### PR TITLE
Test gcc-4.8 as part of CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,7 +23,7 @@ jobs:
       - run: ./ci/setup_ci_environment.sh
       - run: ./ci/install_bazelisk.sh
       - run: ./ci/install_gcc48.sh
-      - run: CXX=/usr/bin/g++-4.8 ./ci/do_ci.sh bazel.test
+      - run: CC=/usr/bin/g++-4.8 ./ci/do_ci.sh bazel.test
 
   bazel_test:
     resource_class: xlarge

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,7 +21,7 @@ jobs:
     steps:
       - checkout
       - run: ./ci/setup_ci_environment.sh
-      - run: ./ci/setup_cmake.sh
+      - run: ./ci/install_bazelisk.sh
       - run: ./ci/install_gcc48.sh
       - run: CXX=/usr/bin/g++-4.8 ./ci/do_ci.sh bazel.test
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,10 +23,7 @@ jobs:
       - run: ./ci/setup_ci_environment.sh
       - run: ./ci/setup_cmake.sh
       - run: ./ci/install_gcc48.sh
-      - run: CXX=/usr/bin/g++-4.8 ./ci/do_ci.sh cmake.test
-      - store_artifacts:
-          path: /build/Testing/Temporary/LastTest.log
-          destination: Test.log
+      - run: CXX=/usr/bin/g++-4.8 ./ci/do_ci.sh bazel.test
 
   bazel_test:
     resource_class: xlarge

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -44,4 +44,5 @@ workflows:
   build_and_test:
     jobs:
       - cmake_test
+      - gcc_48_test
       - bazel_test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,6 +14,20 @@ jobs:
           path: /build/Testing/Temporary/LastTest.log
           destination: Test.log
 
+  gcc_48_test:
+    resource_class: xlarge
+    docker:
+      - image: ubuntu:18.04
+    steps:
+      - checkout
+      - run: ./ci/setup_ci_environment.sh
+      - run: ./ci/setup_cmake.sh
+      - run: ./ci/install_gcc48.sh
+      - run: CXX=/usr/bin/g++-4.8 ./ci/do_ci.sh cmake.test
+      - store_artifacts:
+          path: /build/Testing/Temporary/LastTest.log
+          destination: Test.log
+
   bazel_test:
     resource_class: xlarge
     docker:

--- a/ci/Dockerfile
+++ b/ci/Dockerfile
@@ -8,4 +8,5 @@ ADD install_bazelisk.sh /setup-ci
 
 RUN /setup-ci/setup_ci_environment.sh \
   && /setup-ci/setup_cmake.sh \
+  && /setup-ci/install_gcc48.sh \
   && /setup-ci/install_bazelisk.sh

--- a/ci/install_gcc48.sh
+++ b/ci/install_gcc48.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+set -e
+apt-get update 
+apt-get install --no-install-recommends --no-install-suggests -y \
+  g++-4.8


### PR DESCRIPTION
gcc-4.8 is the oldest compiler we've discussed supporting for the API.