### PR TITLE
Add Bazel tests from a test list

### DIFF
--- a/api/test/nostd/BUILD
+++ b/api/test/nostd/BUILD
@@ -1,54 +1,8 @@
-cc_test(
-    name = "string_view_test",
-    srcs = [
-        "string_view_test.cc",
-    ],
+[cc_test(
+    name = f[:-3],
+    srcs = [f],
     deps = [
         "//api",
         "@com_google_googletest//:gtest_main",
     ],
-)
-
-cc_test(
-    name = "unique_ptr_test",
-    srcs = [
-        "unique_ptr_test.cc",
-    ],
-    deps = [
-        "//api",
-        "@com_google_googletest//:gtest_main",
-    ],
-)
-
-cc_test(
-    name = "utility_test",
-    srcs = [
-        "utility_test.cc",
-    ],
-    deps = [
-        "//api",
-        "@com_google_googletest//:gtest_main",
-    ],
-)
-
-cc_test(
-    name = "span_test",
-    srcs = [
-        "span_test.cc",
-    ],
-    deps = [
-        "//api",
-        "@com_google_googletest//:gtest_main",
-    ],
-)
-
-cc_test(
-    name = "shared_ptr_test",
-    srcs = [
-        "shared_ptr_test.cc",
-    ],
-    deps = [
-        "//api",
-        "@com_google_googletest//:gtest_main",
-    ],
-)
+) for f in glob(["*_test.cc"])]

--- a/api/test/trace/BUILD
+++ b/api/test/trace/BUILD
@@ -1,51 +1,16 @@
 load("//bazel:otel_cc_benchmark.bzl", "otel_cc_benchmark")
 
-cc_test(
-    name = "noop_test",
-    srcs = [
-        "noop_test.cc",
-    ],
-    deps = [
-        "//api",
-        "@com_google_googletest//:gtest_main",
-    ],
-)
-
 otel_cc_benchmark(
     name = "span_id_benchmark",
     srcs = ["span_id_benchmark.cc"],
     deps = ["//api"],
 )
 
-cc_test(
-    name = "span_id_test",
-    srcs = [
-        "span_id_test.cc",
-    ],
+[cc_test(
+    name = f[:-3],
+    srcs = [f],
     deps = [
         "//api",
         "@com_google_googletest//:gtest_main",
     ],
-)
-
-cc_test(
-    name = "trace_flags_test",
-    srcs = [
-        "trace_flags_test.cc",
-    ],
-    deps = [
-        "//api",
-        "@com_google_googletest//:gtest_main",
-    ],
-)
-
-cc_test(
-    name = "trace_id_test",
-    srcs = [
-        "trace_id_test.cc",
-    ],
-    deps = [
-        "//api",
-        "@com_google_googletest//:gtest_main",
-    ],
-)
+) for f in glob(["*_test.cc"])]


### PR DESCRIPTION
Similar to the CMake modification, this also adds Bazel tests from a test list created from a wildcard. I didn't add this to the CMake PR because I only now found out that list comprehensions can be used in Bazel files.