### PR TITLE
Use newest available Go version in CI container

### DIFF
--- a/ci/install_format_tools.sh
+++ b/ci/install_format_tools.sh
@@ -2,10 +2,6 @@
 
 set -e
 
-apt-get install -y software-properties-common
-add-apt-repository -y ppa:longsleep/golang-backports
-apt update
-
-apt install -y clang-format-8 python3-pip golang-go git
+apt install -y clang-format-8 python3-pip git curl
 pip3 install cmake_format==0.6.5
-go get github.com/bazelbuild/buildtools/buildifier
+curl -o /usr/local/bin/buildifier https://github.com/bazelbuild/buildtools/releases/tag/2.2.1/buildifier

--- a/ci/install_format_tools.sh
+++ b/ci/install_format_tools.sh
@@ -3,7 +3,7 @@
 set -e
 
 apt-get install -y software-properties-common
-add-apt-repository ppa:longsleep/golang-backports
+add-apt-repository -y ppa:longsleep/golang-backports
 apt update
 
 apt install -y clang-format-8 python3-pip golang-go git

--- a/ci/install_format_tools.sh
+++ b/ci/install_format_tools.sh
@@ -2,6 +2,10 @@
 
 set -e
 
-apt install -y clang-format-8 python3-pip golang git
+apt-get install -y software-properties-common
+add-apt-repository ppa:longsleep/golang-backports
+apt update
+
+apt install -y clang-format-8 python3-pip golang-go git
 pip3 install cmake_format==0.6.5
 go get github.com/bazelbuild/buildtools/buildifier

--- a/ci/install_format_tools.sh
+++ b/ci/install_format_tools.sh
@@ -4,4 +4,5 @@ set -e
 
 apt install -y clang-format-8 python3-pip git curl
 pip3 install cmake_format==0.6.5
-curl -o /usr/local/bin/buildifier https://github.com/bazelbuild/buildtools/releases/tag/2.2.1/buildifier
+curl -L -o /usr/local/bin/buildifier https://github.com/bazelbuild/buildtools/releases/download/2.2.1/buildifier
+chmod +x /usr/local/bin/buildifier

--- a/tools/format.sh
+++ b/tools/format.sh
@@ -39,6 +39,7 @@ if which cmake-format >/dev/null; then
 else
   echo "Can't find cmake-format. It can be installed with:"
   echo "  pip install --user cmake_format"
+  exit 1
 fi
 
 if [[ -z "$BUILDIFIER" ]]; then
@@ -54,4 +55,5 @@ if which "$BUILDIFIER" >/dev/null; then
 else
   echo "Can't find buildifier. It can be installed with:"
   echo "  go get github.com/bazelbuild/buildtools/buildifier"
+  exit 1
 fi


### PR DESCRIPTION
This downloads a pre-compiled version (2.2.1) of the Bazel buildifier. This fixes the currently broken `format` CI rule and should prevent future regressions.

The `format` CI rule currently fails with a message that `strings.ReplaceAll` is missing. This was added in Go 1.12, but Ubuntu 18 by default comes with Go 1.10.