### PR TITLE
Add utility for generating random 64-bit numbers

### DIFF
--- a/bazel/BUILD
+++ b/bazel/BUILD
@@ -1,1 +1,6 @@
 package(default_visibility = ["//:__subpackages__"])
+
+config_setting(
+    name = "windows",
+    constraint_values = ["@bazel_tools//platforms:windows"],
+)

--- a/sdk/src/CMakeLists.txt
+++ b/sdk/src/CMakeLists.txt
@@ -1,1 +1,2 @@
+add_subdirectory(common)
 add_subdirectory(trace)

--- a/sdk/src/common/BUILD
+++ b/sdk/src/common/BUILD
@@ -16,11 +16,11 @@ package(default_visibility = ["//visibility:public"])
 
 cc_library(
     name = "random",
+    srcs = ["random.cc"],
     hdrs = [
         "random.h",
     ],
     include_prefix = "src/common",
-    srcs = ["random.cc"],
     deps = [
         "//api",
         "//sdk/src/common/platform:fork",

--- a/sdk/src/common/BUILD
+++ b/sdk/src/common/BUILD
@@ -1,0 +1,28 @@
+# Copyright 2020, OpenTelemetry Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+package(default_visibility = ["//visibility:public"])
+
+cc_library(
+    name = "random",
+    hdrs = [
+        "random.h",
+    ],
+    include_prefix = "src/common",
+    srcs = ["random.cc"],
+    deps = [
+        "//api",
+        "//sdk/src/common/platform:fork",
+    ],
+)

--- a/sdk/src/common/BUILD
+++ b/sdk/src/common/BUILD
@@ -18,6 +18,7 @@ cc_library(
     name = "random",
     srcs = ["random.cc"],
     hdrs = [
+        "fast_random_number_generator.h",
         "random.h",
     ],
     include_prefix = "src/common",

--- a/sdk/src/common/CMakeLists.txt
+++ b/sdk/src/common/CMakeLists.txt
@@ -1,5 +1,5 @@
 set(COMMON_SRCS random.cc)
-if (WIN32)
+if(WIN32)
   list(APPEND COMMON_SRCS platform/fork_windows.cc)
 else()
   list(APPEND COMMON_SRCS platform/fork_unix.cc)

--- a/sdk/src/common/CMakeLists.txt
+++ b/sdk/src/common/CMakeLists.txt
@@ -1,0 +1,9 @@
+set(COMMON_SRCS random.cc)
+if (WIN32)
+  list(APPEND COMMON_SRCS platform/fork_windows.cc)
+else()
+  list(APPEND COMMON_SRCS platform/fork_unix.cc)
+endif()
+
+add_library(opentelemetry_common ${COMMON_SRCS})
+target_link_libraries(opentelemetry_common Threads::Threads)

--- a/sdk/src/common/fast_random_number_generator.h
+++ b/sdk/src/common/fast_random_number_generator.h
@@ -1,0 +1,68 @@
+#pragma once
+
+#include <array>
+#include <cstdint>
+#include <limits>
+
+#include "opentelemetry/version.h"
+
+OPENTELEMETRY_BEGIN_NAMESPACE
+namespace sdk
+{
+namespace common
+{
+/**
+ * Profiling shows that random number generation can be a significant cost of
+ * span generation. This provides a faster random number generator than
+ * std::mt19937_64; and since we don't care about the other beneficial random
+ * number properties that std:mt19937_64 provides for this application, it's a
+ * entirely appropriate replacement.
+ */
+class FastRandomNumberGenerator
+{
+public:
+  using result_type = uint64_t;
+
+  FastRandomNumberGenerator() noexcept = default;
+
+  template <class SeedSequence>
+  FastRandomNumberGenerator(SeedSequence &seed_sequence) noexcept
+  {
+    seed(seed_sequence);
+  }
+
+  uint64_t operator()() noexcept
+  {
+    // Uses the xorshift128p random number generation algorithm described in
+    // https://en.wikipedia.org/wiki/Xorshift
+    auto &state_a = state_[0];
+    auto &state_b = state_[1];
+    auto t        = state_a;
+    auto s        = state_b;
+    state_a       = s;
+    t ^= t << 23;        // a
+    t ^= t >> 17;        // b
+    t ^= s ^ (s >> 26);  // c
+    state_b = t;
+    return t + s;
+  }
+
+  // RandomNumberGenerator concept functions required from standard library.
+  // See http://www.cplusplus.com/reference/random/mt19937/
+  template <class SeedSequence>
+  void seed(SeedSequence &seed_sequence) noexcept
+  {
+    seed_sequence.generate(reinterpret_cast<uint32_t *>(state_.data()),
+                           reinterpret_cast<uint32_t *>(state_.data() + state_.size()));
+  }
+
+  static constexpr uint64_t min() noexcept { return 0; }
+
+  static constexpr uint64_t max() noexcept { return std::numeric_limits<uint64_t>::max(); }
+
+private:
+  std::array<uint64_t, 2> state_{};
+};
+}  // namespace common
+}  // namespace sdk
+OPENTELEMETRY_END_NAMESPACE

--- a/sdk/src/common/platform/BUILD
+++ b/sdk/src/common/platform/BUILD
@@ -16,14 +16,14 @@ package(default_visibility = ["//visibility:public"])
 
 cc_library(
     name = "fork",
-    hdrs = [
-        "fork.h",
-    ],
-    include_prefix = "src/common/platform",
     srcs = select({
         "//bazel:windows": ["fork_windows.cc"],
         "//conditions:default": ["fork_unix.cc"],
     }),
+    hdrs = [
+        "fork.h",
+    ],
+    include_prefix = "src/common/platform",
     deps = [
         "//api",
     ],

--- a/sdk/src/common/platform/BUILD
+++ b/sdk/src/common/platform/BUILD
@@ -1,0 +1,30 @@
+# Copyright 2020, OpenTelemetry Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+package(default_visibility = ["//visibility:public"])
+
+cc_library(
+    name = "fork",
+    hdrs = [
+        "fork.h",
+    ],
+    include_prefix = "src/common/platform",
+    srcs = select({
+        "//bazel:windows": ["fork_windows.cc"],
+        "//conditions:default": ["fork_unix.cc"],
+    }),
+    deps = [
+        "//api",
+    ],
+)

--- a/sdk/src/common/platform/fork.h
+++ b/sdk/src/common/platform/fork.h
@@ -3,16 +3,19 @@
 #include "opentelemetry/version.h"
 
 OPENTELEMETRY_BEGIN_NAMESPACE
-namespace sdk {
-namespace common {
-namespace platform {
+namespace sdk
+{
+namespace common
+{
+namespace platform
+{
 /**
  * Portable wrapper for pthread_atfork.
  * See
  * https://pubs.opengroup.org/onlinepubs/009695399/functions/pthread_atfork.html
  */
 int AtFork(void (*prepare)(), void (*parent)(), void (*child)()) noexcept;
-} // namespace platform
-} // namespace common
-} // namespace sdk
+}  // namespace platform
+}  // namespace common
+}  // namespace sdk
 OPENTELEMETRY_END_NAMESPACE

--- a/sdk/src/common/platform/fork.h
+++ b/sdk/src/common/platform/fork.h
@@ -1,0 +1,18 @@
+#pragma once
+
+#include "opentelemetry/version.h"
+
+OPENTELEMETRY_BEGIN_NAMESPACE
+namespace sdk {
+namespace common {
+namespace platform {
+/**
+ * Portable wrapper for pthread_atfork.
+ * See
+ * https://pubs.opengroup.org/onlinepubs/009695399/functions/pthread_atfork.html
+ */
+int AtFork(void (*prepare)(), void (*parent)(), void (*child)()) noexcept;
+} // namespace platform
+} // namespace common
+} // namespace sdk
+OPENTELEMETRY_END_NAMESPACE

--- a/sdk/src/common/platform/fork_unix.cc
+++ b/sdk/src/common/platform/fork_unix.cc
@@ -1,0 +1,15 @@
+#include "src/common/platform/fork.h"
+
+#include <pthread.h>
+
+OPENTELEMETRY_BEGIN_NAMESPACE
+namespace sdk {
+namespace common {
+namespace platform {
+int AtFork(void (*prepare)(), void (*parent)(), void (*child)()) noexcept {
+  return ::pthread_atfork(prepare, parent, child);
+}
+} // namespace platform
+} // namespace common
+} // namespace sdk
+OPENTELEMETRY_END_NAMESPACE

--- a/sdk/src/common/platform/fork_unix.cc
+++ b/sdk/src/common/platform/fork_unix.cc
@@ -3,13 +3,17 @@
 #include <pthread.h>
 
 OPENTELEMETRY_BEGIN_NAMESPACE
-namespace sdk {
-namespace common {
-namespace platform {
-int AtFork(void (*prepare)(), void (*parent)(), void (*child)()) noexcept {
+namespace sdk
+{
+namespace common
+{
+namespace platform
+{
+int AtFork(void (*prepare)(), void (*parent)(), void (*child)()) noexcept
+{
   return ::pthread_atfork(prepare, parent, child);
 }
-} // namespace platform
-} // namespace common
-} // namespace sdk
+}  // namespace platform
+}  // namespace common
+}  // namespace sdk
 OPENTELEMETRY_END_NAMESPACE

--- a/sdk/src/common/platform/fork_windows.cc
+++ b/sdk/src/common/platform/fork_windows.cc
@@ -1,16 +1,20 @@
 #include "src/common/platform/fork.h"
 
 OPENTELEMETRY_BEGIN_NAMESPACE
-namespace sdk {
-namespace common {
-namespace platform {
-int AtFork(void (*prepare)(), void (*parent)(), void (*child)()) noexcept {
+namespace sdk
+{
+namespace common
+{
+namespace platform
+{
+int AtFork(void (*prepare)(), void (*parent)(), void (*child)()) noexcept
+{
   (void)prepare;
   (void)parent;
   (void)child;
   return 0;
 }
-} // namespace platform
-} // namespace common
-} // namespace sdk
+}  // namespace platform
+}  // namespace common
+}  // namespace sdk
 OPENTELEMETRY_BEGIN_NAMESPACE

--- a/sdk/src/common/platform/fork_windows.cc
+++ b/sdk/src/common/platform/fork_windows.cc
@@ -17,4 +17,4 @@ int AtFork(void (*prepare)(), void (*parent)(), void (*child)()) noexcept
 }  // namespace platform
 }  // namespace common
 }  // namespace sdk
-OPENTELEMETRY_BEGIN_NAMESPACE
+OPENTELEMETRY_END_NAMESPACE

--- a/sdk/src/common/platform/fork_windows.cc
+++ b/sdk/src/common/platform/fork_windows.cc
@@ -1,0 +1,16 @@
+#include "src/common/platform/fork.h"
+
+OPENTELEMETRY_BEGIN_NAMESPACE
+namespace sdk {
+namespace common {
+namespace platform {
+int AtFork(void (*prepare)(), void (*parent)(), void (*child)()) noexcept {
+  (void)prepare;
+  (void)parent;
+  (void)child;
+  return 0;
+}
+} // namespace platform
+} // namespace common
+} // namespace sdk
+OPENTELEMETRY_BEGIN_NAMESPACE

--- a/sdk/src/common/random.cc
+++ b/sdk/src/common/random.cc
@@ -1,0 +1,50 @@
+#include "src/common/random.h"
+#include "src/common/platform/fork.h"
+
+OPENTELEMETRY_BEGIN_NAMESPACE
+namespace sdk
+{
+namespace common
+{
+// Wraps a thread_local random number generator, but adds a fork handler so that
+// the generator will be correctly seeded after forking.
+//
+// See https://stackoverflow.com/q/51882689/4447365 and
+//     https://github.com/opentracing-contrib/nginx-opentracing/issues/52
+namespace
+{
+class TlsRandomNumberGenerator
+{
+public:
+  TlsRandomNumberGenerator()
+  {
+    Seed();
+    platform::AtFork(nullptr, nullptr, OnFork);
+  }
+
+  static std::mt19937_64 &engine() noexcept { return engine_; }
+
+private:
+  static thread_local std::mt19937_64 engine_;
+
+  static void OnFork() noexcept { Seed(); }
+
+  static void Seed() noexcept
+  {
+    std::random_device random_device;
+    std::seed_seq seed_seq{random_device(), random_device(), random_device(), random_device()};
+    engine_.seed(seed_seq);
+  }
+};
+
+thread_local std::mt19937_64 TlsRandomNumberGenerator::engine_{};
+}  // namespace
+
+std::mt19937_64 &GetRandomNumberGenerator() noexcept
+{
+  static thread_local TlsRandomNumberGenerator random_number_generator{};
+  return TlsRandomNumberGenerator::engine();
+}
+}  // namespace common
+}  // namespace sdk
+OPENTELEMETRY_END_NAMESPACE

--- a/sdk/src/common/random.cc
+++ b/sdk/src/common/random.cc
@@ -16,7 +16,7 @@ namespace
 class TlsRandomNumberGenerator
 {
 public:
-  TlsRandomNumberGenerator()
+  TlsRandomNumberGenerator() noexcept
   {
     Seed();
     platform::AtFork(nullptr, nullptr, OnFork);

--- a/sdk/src/common/random.cc
+++ b/sdk/src/common/random.cc
@@ -22,10 +22,10 @@ public:
     platform::AtFork(nullptr, nullptr, OnFork);
   }
 
-  static std::mt19937_64 &engine() noexcept { return engine_; }
+  static FastRandomNumberGenerator &engine() noexcept { return engine_; }
 
 private:
-  static thread_local std::mt19937_64 engine_;
+  static thread_local FastRandomNumberGenerator engine_;
 
   static void OnFork() noexcept { Seed(); }
 
@@ -37,10 +37,10 @@ private:
   }
 };
 
-thread_local std::mt19937_64 TlsRandomNumberGenerator::engine_{};
+thread_local FastRandomNumberGenerator TlsRandomNumberGenerator::engine_{};
 }  // namespace
 
-std::mt19937_64 &GetRandomNumberGenerator() noexcept
+FastRandomNumberGenerator &GetRandomNumberGenerator() noexcept
 {
   static thread_local TlsRandomNumberGenerator random_number_generator{};
   return TlsRandomNumberGenerator::engine();

--- a/sdk/src/common/random.h
+++ b/sdk/src/common/random.h
@@ -1,0 +1,18 @@
+#pragma once
+
+#include <random>
+
+#include "opentelemetry/version.h"
+
+OPENTELEMETRY_BEGIN_NAMESPACE
+namespace sdk
+{
+namespace common
+{
+/**
+ * @return a seeded thread-local random number generator.
+ */
+std::mt19937_64 &GetRandomNumberGenerator() noexcept;
+}  // namespace common
+}  // namespace sdk
+OPENTELEMETRY_END_NAMESPACE

--- a/sdk/src/common/random.h
+++ b/sdk/src/common/random.h
@@ -3,6 +3,7 @@
 #include <random>
 
 #include "opentelemetry/version.h"
+#include "src/common/fast_random_number_generator.h"
 
 OPENTELEMETRY_BEGIN_NAMESPACE
 namespace sdk
@@ -12,7 +13,7 @@ namespace common
 /**
  * @return a seeded thread-local random number generator.
  */
-std::mt19937_64 &GetRandomNumberGenerator() noexcept;
+FastRandomNumberGenerator &GetRandomNumberGenerator() noexcept;
 }  // namespace common
 }  // namespace sdk
 OPENTELEMETRY_END_NAMESPACE

--- a/sdk/test/CMakeLists.txt
+++ b/sdk/test/CMakeLists.txt
@@ -1,1 +1,2 @@
+add_subdirectory(common)
 add_subdirectory(trace)

--- a/sdk/test/common/BUILD
+++ b/sdk/test/common/BUILD
@@ -1,7 +1,20 @@
+load("//bazel:otel_cc_benchmark.bzl", "otel_cc_benchmark")
+
 cc_test(
     name = "random_test",
     srcs = [
         "random_test.cc",
+    ],
+    deps = [
+        "//sdk/src/common:random",
+        "@com_google_googletest//:gtest_main",
+    ],
+)
+
+cc_test(
+    name = "fast_random_number_generator_test",
+    srcs = [
+        "fast_random_number_generator_test.cc",
     ],
     deps = [
         "//sdk/src/common:random",
@@ -18,4 +31,10 @@ cc_test(
         "//sdk/src/common:random",
         "@com_google_googletest//:gtest_main",
     ],
+)
+
+otel_cc_benchmark(
+    name = "random_benchmark",
+    srcs = ["random_benchmark.cc"],
+    deps = ["//sdk/src/common:random"],
 )

--- a/sdk/test/common/BUILD
+++ b/sdk/test/common/BUILD
@@ -1,0 +1,21 @@
+cc_test(
+    name = "random_test",
+    srcs = [
+        "random_test.cc",
+    ],
+    deps = [
+        "//sdk/src/common:random",
+        "@com_google_googletest//:gtest_main",
+    ],
+)
+
+cc_test(
+    name = "random_fork_test",
+    srcs = [
+        "random_fork_test.cc",
+    ],
+    deps = [
+        "//sdk/src/common:random",
+        "@com_google_googletest//:gtest_main",
+    ],
+)

--- a/sdk/test/common/CMakeLists.txt
+++ b/sdk/test/common/CMakeLists.txt
@@ -1,0 +1,10 @@
+foreach(testname random_test)
+  add_executable(${testname} "${testname}.cc")
+  target_link_libraries(${testname} ${GTEST_BOTH_LIBRARIES}
+                        ${CMAKE_THREAD_LIBS_INIT} opentelemetry_common)
+  gtest_add_tests(TARGET ${testname} TEST_PREFIX trace. TEST_LIST ${testname})
+endforeach()
+
+add_executable(random_fork_test random_fork_test.cc)
+target_link_libraries(random_fork_test opentelemetry_common)
+add_test(random_fork_test random_fork_test)

--- a/sdk/test/common/CMakeLists.txt
+++ b/sdk/test/common/CMakeLists.txt
@@ -1,4 +1,4 @@
-foreach(testname random_test)
+foreach(testname random_test fast_random_number_generator_test)
   add_executable(${testname} "${testname}.cc")
   target_link_libraries(${testname} ${GTEST_BOTH_LIBRARIES}
                         ${CMAKE_THREAD_LIBS_INIT} opentelemetry_common)
@@ -8,3 +8,7 @@ endforeach()
 add_executable(random_fork_test random_fork_test.cc)
 target_link_libraries(random_fork_test opentelemetry_common)
 add_test(random_fork_test random_fork_test)
+
+add_executable(random_benchmark random_benchmark.cc)
+target_link_libraries(random_benchmark benchmark::benchmark
+                      ${CMAKE_THREAD_LIBS_INIT} opentelemetry_common)

--- a/sdk/test/common/fast_random_number_generator_test.cc
+++ b/sdk/test/common/fast_random_number_generator_test.cc
@@ -1,0 +1,16 @@
+#include "src/common/random.h"
+
+#include <gtest/gtest.h>
+using opentelemetry::sdk::common::FastRandomNumberGenerator;
+
+TEST(FastRandomNumberGeneratorTest, GenerateUniqueNumbers)
+{
+  std::seed_seq seed_sequence{1, 2, 3};
+  FastRandomNumberGenerator random_number_generator;
+  random_number_generator.seed(seed_sequence);
+  std::set<uint64_t> values;
+  for (int i = 0; i < 1000; ++i)
+  {
+    EXPECT_TRUE(values.insert(random_number_generator()).second);
+  }
+}

--- a/sdk/test/common/random_benchmark.cc
+++ b/sdk/test/common/random_benchmark.cc
@@ -1,0 +1,31 @@
+#include "src/common/random.h"
+
+#include <benchmark/benchmark.h>
+#include <cstdint>
+
+namespace
+{
+using opentelemetry::sdk::common::GetRandomNumberGenerator;
+
+void BM_RandomIdGeneration(benchmark::State &state)
+{
+  auto &generator = GetRandomNumberGenerator();
+  while (state.KeepRunning())
+  {
+    benchmark::DoNotOptimize(generator());
+  }
+}
+BENCHMARK(BM_RandomIdGeneration);
+
+void BM_RandomIdStdGeneration(benchmark::State &state)
+{
+  std::mt19937_64 generator{0};
+  while (state.KeepRunning())
+  {
+    benchmark::DoNotOptimize(generator());
+  }
+}
+BENCHMARK(BM_RandomIdStdGeneration);
+
+}  // namespace
+BENCHMARK_MAIN();

--- a/sdk/test/common/random_fork_test.cc
+++ b/sdk/test/common/random_fork_test.cc
@@ -1,0 +1,52 @@
+#ifdef __unix__
+// Verifies that IDs don't clash after forking the process.
+//
+// See https://github.com/opentracing-contrib/nginx-opentracing/issues/52
+#  include "src/common/random.h"
+
+#  include <sys/mman.h>
+#  include <sys/types.h>
+#  include <sys/wait.h>
+#  include <unistd.h>
+#  include <cstdio>
+#  include <cstdlib>
+#  include <iostream>
+using opentelemetry::sdk::common::GetRandomNumberGenerator;
+
+static uint64_t *child_id;
+
+int main()
+{
+  auto &random_number_generator = GetRandomNumberGenerator();
+
+  // Set up shared memory to communicate between parent and child processes.
+  //
+  // See https://stackoverflow.com/a/13274800/4447365
+  child_id = static_cast<uint64_t *>(
+      mmap(nullptr, sizeof(*child_id), PROT_READ | PROT_WRITE, MAP_SHARED | MAP_ANONYMOUS, -1, 0));
+  *child_id = 0;
+  if (fork() == 0)
+  {
+    *child_id = random_number_generator();
+    exit(EXIT_SUCCESS);
+  }
+  else
+  {
+    wait(nullptr);
+    auto parent_id     = random_number_generator();
+    auto child_id_copy = *child_id;
+    munmap(static_cast<void *>(child_id), sizeof(*child_id));
+    if (parent_id == child_id_copy)
+    {
+      std::cerr << "Child and parent ids are the same value " << parent_id << "\n";
+      return -1;
+    }
+  }
+  return 0;
+}
+#else
+int main()
+{
+  return 0;
+}
+#endif

--- a/sdk/test/common/random_test.cc
+++ b/sdk/test/common/random_test.cc
@@ -3,7 +3,8 @@
 #include <gtest/gtest.h>
 using opentelemetry::sdk::common::GetRandomNumberGenerator;
 
-TEST(RandomTest, GenerateRandomNumbers) {
-  auto& random_number_generator = GetRandomNumberGenerator();
+TEST(RandomTest, GenerateRandomNumbers)
+{
+  auto &random_number_generator = GetRandomNumberGenerator();
   EXPECT_NE(random_number_generator(), random_number_generator());
 }

--- a/sdk/test/common/random_test.cc
+++ b/sdk/test/common/random_test.cc
@@ -1,0 +1,9 @@
+#include "src/common/random.h"
+
+#include <gtest/gtest.h>
+using opentelemetry::sdk::common::GetRandomNumberGenerator;
+
+TEST(RandomTest, GenerateRandomNumbers) {
+  auto& random_number_generator = GetRandomNumberGenerator();
+  EXPECT_NE(random_number_generator(), random_number_generator());
+}


### PR DESCRIPTION
The implementation uses thread-local random number generators and sets up a fork handler so that we can continue to generate unique IDs when the process is forked.