### PR TITLE
Clarify ABI requirements for the SDK vendor hooks

### DIFF
--- a/docs/abi-policy.md
+++ b/docs/abi-policy.md
@@ -14,6 +14,10 @@ consistent ABI (vtable layouts, for example, are specified by the
 can be used across compilers, but don't rely on the ABI stability of the
 C++ standard library classes.
 
+ABI stability is not provided by the interfaces the SDK provides as 
+implementation hooks to vendor implementors, like exporters, processors,
+aggregators and propagators.
+
 These are some of the rules for where ABI stability is required.
 
 Note: This assumes export maps are used to properly control symbol resolution.

--- a/docs/abi-policy.md
+++ b/docs/abi-policy.md
@@ -14,7 +14,7 @@ consistent ABI (vtable layouts, for example, are specified by the
 can be used across compilers, but don't rely on the ABI stability of the
 C++ standard library classes.
 
-ABI stability is not provided by the interfaces the SDK provides as 
+ABI stability is not provided by the interfaces the SDK provides as
 implementation hooks to vendor implementors, like exporters, processors,
 aggregators and propagators.
 


### PR DESCRIPTION
This should conclude the discussions around [vendor stability for SDK vendor hooks](https://github.com/open-telemetry/opentelemetry-cpp/issues/43).