### PR TITLE
Use lowercase base 16 representation of ids

### DIFF
--- a/api/include/opentelemetry/trace/span_id.h
+++ b/api/include/opentelemetry/trace/span_id.h
@@ -39,7 +39,7 @@ public:
   // Populates the buffer with the lowercase base16 representation of the ID.
   void ToLowerBase16(nostd::span<char, 2 * kSize> buffer) const noexcept
   {
-    constexpr char kHex[] = "0123456789ABCDEF";
+    constexpr char kHex[] = "0123456789abcdef";
     for (int i = 0; i < kSize; ++i)
     {
       buffer[i * 2 + 0] = kHex[(rep_[i] >> 4) & 0xF];

--- a/api/include/opentelemetry/trace/trace_id.h
+++ b/api/include/opentelemetry/trace/trace_id.h
@@ -45,7 +45,7 @@ public:
   // Populates the buffer with the lowercase base16 representation of the ID.
   void ToLowerBase16(nostd::span<char, 2 * kSize> buffer) const noexcept
   {
-    constexpr char kHex[] = "0123456789ABCDEF";
+    constexpr char kHex[] = "0123456789abcdef";
     for (int i = 0; i < kSize; ++i)
     {
       buffer[i * 2 + 0] = kHex[(rep_[i] >> 4) & 0xF];

--- a/api/test/trace/span_id_test.cc
+++ b/api/test/trace/span_id_test.cc
@@ -34,6 +34,16 @@ TEST(SpanIdTest, ValidId)
   EXPECT_EQ(SpanId(buf), id);
 }
 
+TEST(SpanIdTest, LowercaseBase16)
+{
+  constexpr uint8_t buf[] = {1, 2, 0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0xff};
+  SpanId id(buf);
+  EXPECT_TRUE(id.IsValid());
+  EXPECT_EQ("0102aabbccddeeff", Hex(id));
+  EXPECT_NE(SpanId(), id);
+  EXPECT_EQ(SpanId(buf), id);
+}
+
 TEST(SpanIdTest, CopyBytesTo)
 {
   constexpr uint8_t src[] = {1, 2, 3, 4, 5, 6, 7, 8};

--- a/api/test/trace/trace_id_test.cc
+++ b/api/test/trace/trace_id_test.cc
@@ -34,6 +34,16 @@ TEST(TraceIdTest, ValidId)
   EXPECT_EQ(TraceId(buf), id);
 }
 
+TEST(TraceIdTest, LowercaseBase16)
+{
+  constexpr uint8_t buf[] = {1, 2, 3, 4, 5, 6, 7, 8, 8, 7, 0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0xff};
+  TraceId id(buf);
+  EXPECT_TRUE(id.IsValid());
+  EXPECT_EQ("01020304050607080807aabbccddeeff", Hex(id));
+  EXPECT_NE(TraceId(), id);
+  EXPECT_EQ(TraceId(buf), id);
+}
+
 TEST(TraceIdTest, CopyBytesTo)
 {
   constexpr uint8_t src[] = {1, 2, 3, 4, 5, 6, 7, 8, 8, 7, 6, 5, 4, 3, 2, 1};


### PR DESCRIPTION
For trace and span ids, the lowercase base 16 representation should be preferred, as the [W3C TraceContext spec](https://www.w3.org/TR/trace-context/#traceparent-header-field-values) relies on hex digits in ids to be all lowercase.

The documentation of `ToLowerCase16` mentioned a lowercase representation, but the function returned an uppercase representation.