### PR TITLE
Set span start and end timestamps

### DIFF
--- a/api/include/opentelemetry/core/timestamp.h
+++ b/api/include/opentelemetry/core/timestamp.h
@@ -47,6 +47,11 @@ public:
     return nanos_since_epoch_ == other.nanos_since_epoch_;
   }
 
+  bool operator!=(const SystemTimestamp &other) const noexcept
+  {
+    return nanos_since_epoch_ != other.nanos_since_epoch_;
+  }
+
 private:
   int64_t nanos_since_epoch_;
 };
@@ -87,6 +92,11 @@ public:
   bool operator==(const SteadyTimestamp &other) const noexcept
   {
     return nanos_since_epoch_ == other.nanos_since_epoch_;
+  }
+
+  bool operator!=(const SteadyTimestamp &other) const noexcept
+  {
+    return nanos_since_epoch_ != other.nanos_since_epoch_;
   }
 
 private:

--- a/api/include/opentelemetry/plugin/tracer.h
+++ b/api/include/opentelemetry/plugin/tracer.h
@@ -39,7 +39,7 @@ public:
 
   void UpdateName(nostd::string_view name) noexcept override { span_->UpdateName(name); }
 
-  void End(const trace::EndSpanOptions &options = {}) noexcept override { span_->End(); }
+  void End(const trace::EndSpanOptions &options = {}) noexcept override { span_->End(options); }
 
   bool IsRecording() const noexcept override { return span_->IsRecording(); }
 

--- a/api/include/opentelemetry/trace/noop.h
+++ b/api/include/opentelemetry/trace/noop.h
@@ -38,7 +38,7 @@ public:
 
   void UpdateName(nostd::string_view /*name*/) noexcept override {}
 
-  void End(const EndSpanOptions &options = {}) noexcept override {}
+  void End(const EndSpanOptions & /*options*/) noexcept override {}
 
   bool IsRecording() const noexcept override { return false; }
 

--- a/api/include/opentelemetry/trace/span.h
+++ b/api/include/opentelemetry/trace/span.h
@@ -43,9 +43,13 @@ struct StartSpanOptions
   // Attributes
   SpanKind kind = SpanKind::kInternal;
 };
-
+/**
+ * StartEndOptions provides options to set properties of a Span when it is
+ * ended.
+ */
 struct EndSpanOptions
 {
+  // Optionally sets the end time of a Span.
   core::SteadyTimestamp end_steady_time;
 };
 
@@ -135,8 +139,13 @@ public:
   // during creation.
   virtual void UpdateName(nostd::string_view name) noexcept = 0;
 
-  // Mark the end of the Span. Only the timing of the first End call for a given Span will
-  // be recorded, and implementations are free to ignore all further calls.
+  /**
+   * Mark the end of the Span.
+   * Only the timing of the first End call for a given Span will be recorded,
+   * and implementations are free to ignore all further calls.
+   * @param options can be used to manually define span properties like the end
+   * timestamp
+   */
   virtual void End(const EndSpanOptions &options = {}) noexcept = 0;
 
   // TODO

--- a/api/test/core/timestamp_test.cc
+++ b/api/test/core/timestamp_test.cc
@@ -24,6 +24,19 @@ TEST(SystemTimestampTest, Construction)
             t2.time_since_epoch());
 }
 
+TEST(SystemTimestampTest, Comparison)
+{
+  SystemTimestamp t1;
+  SystemTimestamp t2;
+  SystemTimestamp t3{std::chrono::nanoseconds{2}};
+
+  EXPECT_EQ(t1, t1);
+  EXPECT_EQ(t1, t2);
+  EXPECT_EQ(t2, t1);
+  EXPECT_NE(t1, t3);
+  EXPECT_NE(t3, t1);
+}
+
 TEST(SteadyTimestampTest, Construction)
 {
   auto now_steady = std::chrono::steady_clock::now();
@@ -35,4 +48,17 @@ TEST(SteadyTimestampTest, Construction)
   EXPECT_TRUE(AreNearlyEqual(now_steady, static_cast<std::chrono::steady_clock::time_point>(t2)));
   EXPECT_EQ(std::chrono::duration_cast<std::chrono::nanoseconds>(now_steady.time_since_epoch()),
             t2.time_since_epoch());
+}
+
+TEST(SteadyTimestampTest, Comparison)
+{
+  SteadyTimestamp t1;
+  SteadyTimestamp t2;
+  SteadyTimestamp t3{std::chrono::nanoseconds{2}};
+
+  EXPECT_EQ(t1, t1);
+  EXPECT_EQ(t1, t2);
+  EXPECT_EQ(t2, t1);
+  EXPECT_NE(t1, t3);
+  EXPECT_NE(t3, t1);
 }

--- a/examples/plugin/plugin/tracer.cc
+++ b/examples/plugin/plugin/tracer.cc
@@ -13,7 +13,7 @@ class Span final : public trace::Span
 public:
   Span(std::shared_ptr<Tracer> &&tracer,
        nostd::string_view name,
-       const trace::StartSpanOptions &options) noexcept
+       const trace::StartSpanOptions & /*options*/) noexcept
       : tracer_{std::move(tracer)}, name_{name}
   {
     std::cout << "StartSpan: " << name << "\n";
@@ -38,7 +38,7 @@ public:
 
   void UpdateName(nostd::string_view /*name*/) noexcept override {}
 
-  void End(const trace::EndSpanOptions &options) noexcept override {}
+  void End(const trace::EndSpanOptions & /*options*/) noexcept override {}
 
   bool IsRecording() const noexcept override { return true; }
 

--- a/sdk/src/trace/span.cc
+++ b/sdk/src/trace/span.cc
@@ -13,7 +13,7 @@ using opentelemetry::core::SystemTimestamp;
 
 namespace
 {
-SystemTimestamp NowOrGiven(const SystemTimestamp &system)
+SystemTimestamp NowOr(const SystemTimestamp &system)
 {
   if (system == SystemTimestamp())
   {
@@ -25,7 +25,7 @@ SystemTimestamp NowOrGiven(const SystemTimestamp &system)
   }
 }
 
-SteadyTimestamp NowOrGiven(const SteadyTimestamp &steady)
+SteadyTimestamp NowOr(const SteadyTimestamp &steady)
 {
   if (steady == SteadyTimestamp())
   {
@@ -55,8 +55,8 @@ Span::Span(std::shared_ptr<Tracer> &&tracer,
   processor_->OnStart(*recordable_);
   recordable_->SetName(name);
 
-  recordable_->SetStartTime(NowOrGiven(options.start_system_time));
-  start_steady_time = NowOrGiven(options.start_steady_time);
+  recordable_->SetStartTime(NowOr(options.start_system_time));
+  start_steady_time = NowOr(options.start_steady_time);
 }
 
 Span::~Span()
@@ -112,9 +112,10 @@ void Span::End(const trace_api::EndSpanOptions &options) noexcept
     return;
   }
 
-  recordable_->SetDuration(
-      std::chrono::steady_clock::time_point(NowOrGiven(options.end_steady_time)) -
-      std::chrono::steady_clock::time_point(start_steady_time));
+  auto end_steady_time = NowOr(options.end_steady_time);
+  recordable_->SetDuration(std::chrono::steady_clock::time_point(end_steady_time) -
+                           std::chrono::steady_clock::time_point(start_steady_time));
+
   processor_->OnEnd(std::move(recordable_));
   recordable_.reset();
 }

--- a/sdk/test/trace/tracer_test.cc
+++ b/sdk/test/trace/tracer_test.cc
@@ -91,7 +91,7 @@ TEST(Tracer, StartSpan)
   ASSERT_LT(std::chrono::nanoseconds(0), span_data->GetDuration());
 }
 
-TEST(Tracer, StartSpanWithTime)
+TEST(Tracer, StartSpanWithOptions)
 {
   std::shared_ptr<std::vector<std::unique_ptr<SpanData>>> spans_received(
       new std::vector<std::unique_ptr<SpanData>>);


### PR DESCRIPTION
This adds SDK support for setting start and end timestamps on spans.

1. The API is extended to allow for specifying end timestamps manually.
2. Comparison operators to `SystemTimestamp` and `SteadyTimestamp` are added.
3. The `Span` implementation in the SDK is updated to use given timestamps or calculate timestamps based on the current time.