### PR TITLE
Update maintainers/approvers

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,4 +2,4 @@
 # This file controls who is tagged for review for any given pull request.
 
 # For anything not explicitly taken by someone else:
-*       @g-easy @jmacd @maxgolov @reyang @rnburn @tigrannajaryan
+*       @g-easy @jmacd @maxgolov @pyohannes @reyang @rnburn @tigrannajaryan

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,9 +24,9 @@ Code is formatted automatically and enforced by CI.
 
 Note: these instructions apply to examples configured with Bazel, see example-specific documentation for other build automation tools.
 
-Install the latest bazel version by following the steps listed <a href="https://docs.bazel.build/versions/master/install.html">here</a>
+Install the latest bazel version by following the steps listed [here](https://docs.bazel.build/versions/master/install.html).
 
-Select an example of interest from the <a href="https://github.com/open-telemetry/opentelemetry-cpp/tree/master/examples"> examples folder </a>.  Inside each example directory is a `BUILD` file containing instructions for Bazel.  Find the binary name of your example by inspecting the contents of this `BUILD` file.
+Select an example of interest from the [examples folder](https://github.com/open-telemetry/opentelemetry-cpp/tree/master/examples).  Inside each example directory is a `BUILD` file containing instructions for Bazel.  Find the binary name of your example by inspecting the contents of this `BUILD` file.
 
 Build the example from the root of the opentelemetry-cpp directory using Bazel.  Replace  `<binary name>` with the identifier found in the previous step:
 
@@ -57,23 +57,23 @@ requests (PRs).
 To create a new PR, fork the project in GitHub and clone the upstream repo:
 
 ```sh
-$ git clone https://github.com/open-telemetry/opentelemetry-cpp.git
+git clone https://github.com/open-telemetry/opentelemetry-cpp.git
 ```
 
 Add your fork as a remote:
 
 ```sh
-$ git remote add fork https://github.com/YOUR_GITHUB_USERNAME/opentelemetry-cpp.git
+git remote add fork https://github.com/YOUR_GITHUB_USERNAME/opentelemetry-cpp.git
 ```
 
 Check out a new branch, make modifications and push the branch to your fork:
 
 ```sh
-$ git checkout -b feature
+git checkout -b feature
 # edit files
-$ tools/format.sh
-$ git commit
-$ git push fork feature
+tools/format.sh
+git commit
+git push fork feature
 ```
 
 Open a pull request against the main `opentelemetry-cpp` repo.
@@ -89,6 +89,7 @@ To run tests locally, please read the [CI instructions](ci/README.md).
 ### How to Get PRs Merged
 
 A PR is considered to be **ready to merge** when:
+
 * It has received two approvals from [Approvers](https://github.com/open-telemetry/community/blob/master/community-membership.md#approver)
   / [Maintainers](https://github.com/open-telemetry/community/blob/master/community-membership.md#maintainer)
   (at different companies).
@@ -102,30 +103,29 @@ Any Approver / Maintainer can merge the PR once it is **ready to merge**.
 
 ## Useful Resources
 
-Hi! If you’re looking at this document, these resources will provide you the knowledge to get started as a newcomer to the Open Telemetry project. They will help you understand the Open Telemetry Project, its components, and specifically the C++ repository.
+Hi! If you’re looking at this document, these resources will provide you the knowledge to get started as a newcomer to the OpenTelemetry project. They will help you understand the OpenTelemetry Project, its components, and specifically the C++ repository.
 
 ### Reading Resources
 
-* Medium [article](https://medium.com/opentelemetry/how-to-start-contributing-to-opentelemetry-b23991ad91f4) (October 2019) on how to start contributing to the Open Telemetry project.
-* Medium [article](https://medium.com/opentelemetry/opentelemetry-beyond-getting-started-5ac43cd0fe26) (January 2020) describing the overarching goals and use cases for Open Telemetry.
+* Medium [article](https://medium.com/opentelemetry/how-to-start-contributing-to-opentelemetry-b23991ad91f4) (October 2019) on how to start contributing to the OpenTelemetry project.
+* Medium [article](https://medium.com/opentelemetry/opentelemetry-beyond-getting-started-5ac43cd0fe26) (January 2020) describing the overarching goals and use cases for OpenTelemetry.
 
 ### Relevant Documentation
 
-* Open Telemetry [Specification](https://github.com/open-telemetry/opentelemetry-specification)
-    * The Open Telemetry Specification describes the requirements and expectations of for all Open Telemetry implementations.
+* [OpenTelemetry Specification](https://github.com/open-telemetry/opentelemetry-specification)
+  * The OpenTelemetry Specification describes the requirements and expectations of for all OpenTelemetry implementations.
 
-* Read through the [Open Telemetry Collector](https://github.com/open-telemetry/opentelemetry-collector) GitHub repository
-    * This repository has a lot of good information surrounding the Open Telemetry ecosystem. At the top of the **[readme](https://github.com/open-telemetry/opentelemetry-collector/blob/master/README.md)**, there are multiple links that give newcomers a good idea of what the project is about and how to get involved in it.
-* Read through the Open Telemetry Python documentation
-    * The [API](https://opentelemetry-python.readthedocs.io/en/stable/api/api.html) and [SDK](https://opentelemetry-python.readthedocs.io/en/stable/sdk/sdk.html) documentation provides a lot of information on what the classes and their functions are used for. Since there is currently minimal documentation for C++, use the Python repository’s extensive documentation to learn more about how the API and SDK work.
+* Read through the [OpenTelemetry Collector](https://github.com/open-telemetry/opentelemetry-collector) GitHub repository
+  * This repository has a lot of good information surrounding the OpenTelemetry ecosystem. At the top of the **[readme](https://github.com/open-telemetry/opentelemetry-collector/blob/master/README.md)**, there are multiple links that give newcomers a good idea of what the project is about and how to get involved in it.
+* Read through the OpenTelemetry Python documentation
+  * The [API](https://opentelemetry-python.readthedocs.io/en/stable/api/api.html) and [SDK](https://opentelemetry-python.readthedocs.io/en/stable/sdk/sdk.html) documentation provides a lot of information on what the classes and their functions are used for. Since there is currently minimal documentation for C++, use the Python repository’s extensive documentation to learn more about how the API and SDK work.
 
 ### Code Examples
 
-* Follow the [simple trace example](https://github.com/open-telemetry/opentelemetry-cpp/pull/92) for an introduction to basic Open Telemetry functionality in C++.  Currently the example can be found in [PR #94](https://github.com/open-telemetry/opentelemetry-cpp/pull/94)
+* Follow the [simple trace example](https://github.com/open-telemetry/opentelemetry-cpp/pull/92) for an introduction to basic OpenTelemetry functionality in C++.  Currently the example can be found in [PR #94](https://github.com/open-telemetry/opentelemetry-cpp/pull/94).
 
-* Read through the [Java Quick-Start Guide](https://github.com/open-telemetry/opentelemetry-java/blob/master/QUICKSTART.md)
-    * This shows you how the classes and functions will interact in simple and easy to digest examples.
-* Take a look at this [Java SDK example.](https://github.com/open-telemetry/opentelemetry-java/tree/master/examples/sdk-usage) This shows a good use case of the SDK using stdout exporter.
-* Take a look at the [Java Jaeger example.](https://github.com/open-telemetry/opentelemetry-java/tree/master/examples/jaeger) This provides a brief introduction to the Jaeger exporter, its interface, and how to interact with the service.
+* Read through the [Java Quick-Start Guide](https://github.com/open-telemetry/opentelemetry-java/blob/master/QUICKSTART.md). This shows you how the classes and functions will interact in simple and easy to digest examples.
+* Take a look at this [Java SDK example.](https://github.com/open-telemetry/opentelemetry-java/tree/master/examples/sdk-usage). This shows a good use case of the SDK using stdout exporter.
+* Take a look at the [Java Jaeger example.](https://github.com/open-telemetry/opentelemetry-java/tree/master/examples/jaeger). This provides a brief introduction to the Jaeger exporter, its interface, and how to interact with the service.
 
 Please contribute! You’re welcome to add more information if you come across any helpful resources.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,19 +22,26 @@ Code is formatted automatically and enforced by CI.
 
 ### Build and Run Code Examples
 
-Note: these instructions apply to examples configured with Bazel, see example-specific documentation for other build automation tools.
+Note: these instructions apply to examples configured with Bazel, see
+example-specific documentation for other build automation tools.
 
-Install the latest bazel version by following the steps listed [here](https://docs.bazel.build/versions/master/install.html).
+Install the latest bazel version by following the steps listed
+[here](https://docs.bazel.build/versions/master/install.html).
 
-Select an example of interest from the [examples folder](https://github.com/open-telemetry/opentelemetry-cpp/tree/master/examples).  Inside each example directory is a `BUILD` file containing instructions for Bazel.  Find the binary name of your example by inspecting the contents of this `BUILD` file.
+Select an example of interest from the [examples folder](https://github.com/open-telemetry/opentelemetry-cpp/tree/master/examples).
+Inside each example directory is a `BUILD` file containing instructions for
+Bazel. Find the binary name of your example by inspecting the contents of this
+`BUILD` file.
 
-Build the example from the root of the opentelemetry-cpp directory using Bazel.  Replace  `<binary name>` with the identifier found in the previous step:
+Build the example from the root of the opentelemetry-cpp directory using Bazel.
+Replace `<binary name>` with the identifier found in the previous step:
 
 ```sh
 bazel build //examples/<example directory name>:<binary name>
 ```
 
-Run the resulting executable to see telemetry from the application as it calls the instrumented library: </li>
+Run the resulting executable to see telemetry from the application as it calls
+the instrumented library: </li>
 
 ```sh
 bazel-bin/examples/<example directory name>/<binary name>
@@ -84,7 +91,8 @@ To run tests locally, please read the [CI instructions](ci/README.md).
 
 * If the PR is not ready for review, please put `[WIP]` in the title, tag it
   as `work-in-progress`, or mark it as [`draft`](https://github.blog/2019-02-14-introducing-draft-pull-requests/).
-* Make sure [CLA](https://identity.linuxfoundation.org/projects/cncf) is signed and CI is clear.
+* Make sure [CLA](https://identity.linuxfoundation.org/projects/cncf) is
+  signed and CI is clear.
 
 ### How to Get PRs Merged
 
@@ -103,29 +111,54 @@ Any Approver / Maintainer can merge the PR once it is **ready to merge**.
 
 ## Useful Resources
 
-Hi! If you’re looking at this document, these resources will provide you the knowledge to get started as a newcomer to the OpenTelemetry project. They will help you understand the OpenTelemetry Project, its components, and specifically the C++ repository.
+Hi! If you’re looking at this document, these resources will provide you the
+knowledge to get started as a newcomer to the OpenTelemetry project. They will
+help you understand the OpenTelemetry Project, its components, and
+specifically the C++ repository.
 
 ### Reading Resources
 
-* Medium [article](https://medium.com/opentelemetry/how-to-start-contributing-to-opentelemetry-b23991ad91f4) (October 2019) on how to start contributing to the OpenTelemetry project.
-* Medium [article](https://medium.com/opentelemetry/opentelemetry-beyond-getting-started-5ac43cd0fe26) (January 2020) describing the overarching goals and use cases for OpenTelemetry.
+* Medium [article](https://medium.com/opentelemetry/how-to-start-contributing-to-opentelemetry-b23991ad91f4)
+  (October 2019) on how to start contributing to the OpenTelemetry project.
+* Medium [article](https://medium.com/opentelemetry/opentelemetry-beyond-getting-started-5ac43cd0fe26)
+  (January 2020) describing the overarching goals and use cases for OpenTelemetry.
 
 ### Relevant Documentation
 
 * [OpenTelemetry Specification](https://github.com/open-telemetry/opentelemetry-specification)
-  * The OpenTelemetry Specification describes the requirements and expectations of for all OpenTelemetry implementations.
+  * The OpenTelemetry Specification describes the requirements and
+    expectations of for all OpenTelemetry implementations.
 
-* Read through the [OpenTelemetry Collector](https://github.com/open-telemetry/opentelemetry-collector) GitHub repository
-  * This repository has a lot of good information surrounding the OpenTelemetry ecosystem. At the top of the **[readme](https://github.com/open-telemetry/opentelemetry-collector/blob/master/README.md)**, there are multiple links that give newcomers a good idea of what the project is about and how to get involved in it.
+* Read through the [OpenTelemetry Collector](https://github.com/open-telemetry/opentelemetry-collector)
+  GitHub repository.
+  * This repository has a lot of good information surrounding the
+    OpenTelemetry ecosystem. At the top of the **[readme](https://github.com/open-telemetry/opentelemetry-collector/blob/master/README.md)**,
+    there are multiple links that give newcomers a good idea of what the
+    project is about and how to get involved in it.
 * Read through the OpenTelemetry Python documentation
-  * The [API](https://opentelemetry-python.readthedocs.io/en/stable/api/api.html) and [SDK](https://opentelemetry-python.readthedocs.io/en/stable/sdk/sdk.html) documentation provides a lot of information on what the classes and their functions are used for. Since there is currently minimal documentation for C++, use the Python repository’s extensive documentation to learn more about how the API and SDK work.
+  * The [API](https://opentelemetry-python.readthedocs.io/en/stable/api/api.html)
+    and [SDK](https://opentelemetry-python.readthedocs.io/en/stable/sdk/sdk.html)
+    documentation provides a lot of information on what the classes and their
+    functions are used for. Since there is currently minimal documentation for
+    C++, use the Python repository’s extensive documentation to learn more
+    about how the API and SDK work.
 
 ### Code Examples
 
-* Follow the [simple trace example](https://github.com/open-telemetry/opentelemetry-cpp/pull/92) for an introduction to basic OpenTelemetry functionality in C++.  Currently the example can be found in [PR #94](https://github.com/open-telemetry/opentelemetry-cpp/pull/94).
+* Follow the [simple trace example](https://github.com/open-telemetry/opentelemetry-cpp/pull/92)
+  for an introduction to basic OpenTelemetry functionality in C++. Currently
+  the example can be found in [PR #94](https://github.com/open-telemetry/opentelemetry-cpp/pull/94).
 
-* Read through the [Java Quick-Start Guide](https://github.com/open-telemetry/opentelemetry-java/blob/master/QUICKSTART.md). This shows you how the classes and functions will interact in simple and easy to digest examples.
-* Take a look at this [Java SDK example.](https://github.com/open-telemetry/opentelemetry-java/tree/master/examples/sdk-usage). This shows a good use case of the SDK using stdout exporter.
-* Take a look at the [Java Jaeger example.](https://github.com/open-telemetry/opentelemetry-java/tree/master/examples/jaeger). This provides a brief introduction to the Jaeger exporter, its interface, and how to interact with the service.
+* Read through the [Java Quick-Start
+  Guide](https://github.com/open-telemetry/opentelemetry-java/blob/master/QUICKSTART.md).
+  This shows you how the classes and functions will interact in simple and
+  easy to digest examples.
+* Take a look at this [Java SDK
+  example](https://github.com/open-telemetry/opentelemetry-java/tree/master/examples/sdk-usage).
+  This shows a good use case of the SDK using stdout exporter.
+* Take a look at the [Java Jaeger
+  example](https://github.com/open-telemetry/opentelemetry-java/tree/master/examples/jaeger).
+  This provides a brief introduction to the Jaeger exporter, its interface,
+  and how to interact with the service.
 
 Please contribute! You’re welcome to add more information if you come across any helpful resources.

--- a/README.md
+++ b/README.md
@@ -1,10 +1,11 @@
-# OpenTelemetry C/C++
+# OpenTelemetry C++
+
 [![Gitter chat][gitter-image]][gitter-url]
 
 [gitter-image]: https://badges.gitter.im/open-telemetry/opentelemetry-cpp.svg
 [gitter-url]: https://gitter.im/open-telemetry/opentelemetry-cpp?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge
 
-The C/C++ [OpenTelemetry](https://opentelemetry.io/) client.
+The C++ [OpenTelemetry](https://opentelemetry.io/) client.
 
 ## Installation
 
@@ -18,10 +19,44 @@ TBD
 
 See [CONTRIBUTING.md](CONTRIBUTING.md)
 
+We meet weekly on Mondays at 3:00PM PT. Check the [OpenTelemetry community calendar](https://calendar.google.com/calendar/embed?src=google.com_b79e3e90j7bbsa2n2p5an5lf60%40group.calendar.google.com) for specific dates.
+
+Meetings take place via [Zoom video conference](https://zoom.us/j/8287234601).
+
+Meeting notes are available as a public [Google doc](https://docs.google.com/document/d/1i1E4-_y4uJ083lCutKGDhkpi3n4_e774SBLi9hPLocw/edit?usp=sharing). For edit access, get in touch on [Gitter](https://gitter.im/open-telemetry/opentelemetry-cpp).
+
+Approvers ([@open-telemetry/dotnet-approvers](https://github.com/orgs/open-telemetry/teams/dotnet-approvers)):
+
+- [Max Golovanov](https://github.com/maxgolov), Microsoft
+- [Johannes Tax](https://github.com/pyohannes), New Relic
+- [Josh MacDonald](https://github.com/jmacd), Lightstep
+- [Ryan Burn](https://github.com/rnburn), Lightstep
+- [Tigran Najaryan](https://github.com/tigrannajaryan), Splunk
+
+*Find more about the approver role in [community repository](https://github.com/open-telemetry/community/blob/master/community-membership.md#approver).*
+
+Maintainers ([@open-telemetry/dotnet-maintainers](https://github.com/orgs/open-telemetry/teams/dotnet-maintainers)):
+
+- [Emil Mikulic](https://github.com/g-easy), Google
+- [Reiley Yang](https://github.com/reyang), Microsoft
+
+*Find more about the maintainer role in [community repository](https://github.com/open-telemetry/community/blob/master/community-membership.md#maintainer).*
+
 ## Release Schedule
 
-OpenTelemetry C/C++ is under active development.
+OpenTelemetry C++ is under active development.
 
 The library is not yet _generally available_, and releases aren't guaranteed to
-conform to a specific version of the specification.  Future releases will not
-attempt to maintain backwards compatibility with current releases.
+conform to a specific version of the specification. Future releases will not
+attempt to maintain backwards compatibility with previous releases. Each alpha
+and beta release includes significant changes to the API and SDK packages,
+making them incompatible with each other.
+
+See the [release
+notes](https://github.com/open-telemetry/opentelemetry-cpp/releases)
+for existing releases.
+
+See the [project
+milestones](https://github.com/open-telemetry/opentelemetry-cpp/milestones)
+for details on upcoming releases. The dates and features described in issues
+and milestones are estimates, and subject to change.

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ See [CONTRIBUTING.md](CONTRIBUTING.md)
 
 We meet weekly on Mondays at 3:00PM PT. Check the [OpenTelemetry community calendar](https://calendar.google.com/calendar/embed?src=google.com_b79e3e90j7bbsa2n2p5an5lf60%40group.calendar.google.com) for specific dates.
 
-Meetings take place via [Zoom video conference](https://zoom.us/j/8287234601).
+Meetings take place via [Zoom video conference](https://zoom.us/j/8203130519).
 
 Meeting notes are available as a public [Google doc](https://docs.google.com/document/d/1i1E4-_y4uJ083lCutKGDhkpi3n4_e774SBLi9hPLocw/edit?usp=sharing). For edit access, get in touch on [Gitter](https://gitter.im/open-telemetry/opentelemetry-cpp).
 

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Meetings take place via [Zoom video conference](https://zoom.us/j/8203130519).
 
 Meeting notes are available as a public [Google doc](https://docs.google.com/document/d/1i1E4-_y4uJ083lCutKGDhkpi3n4_e774SBLi9hPLocw/edit?usp=sharing). For edit access, get in touch on [Gitter](https://gitter.im/open-telemetry/opentelemetry-cpp).
 
-Approvers ([@open-telemetry/dotnet-approvers](https://github.com/orgs/open-telemetry/teams/dotnet-approvers)):
+Approvers ([@open-telemetry/cpp-approvers](https://github.com/orgs/open-telemetry/teams/cpp-approvers)):
 
 - [Max Golovanov](https://github.com/maxgolov), Microsoft
 - [Johannes Tax](https://github.com/pyohannes), New Relic
@@ -35,7 +35,7 @@ Approvers ([@open-telemetry/dotnet-approvers](https://github.com/orgs/open-telem
 
 *Find more about the approver role in [community repository](https://github.com/open-telemetry/community/blob/master/community-membership.md#approver).*
 
-Maintainers ([@open-telemetry/dotnet-maintainers](https://github.com/orgs/open-telemetry/teams/dotnet-maintainers)):
+Maintainers ([@open-telemetry/cpp-maintainers](https://github.com/orgs/open-telemetry/teams/cpp-maintainers)):
 
 - [Emil Mikulic](https://github.com/g-easy), Google
 - [Reiley Yang](https://github.com/reyang), Microsoft


### PR DESCRIPTION
* Updated the maintainers/approvers.
  * Moved @rnburn from maintainer to approver as Ryan has switched focus.
  * Added @pyohannes as an approver:
    * Actively driving the exporter design, becoming mentor for two intern projects.
    * Actively contributing to the overall API/SDK strategy and design.
    * Very active on PRs: https://github.com/open-telemetry/opentelemetry-cpp/pulls?q=is%3Apr+author%3Apyohannes
    * Very active on code review.
* Aligned the doc structure with other SDK repo which is aligned with the overall guidance.
* Fixed all the obvious GFM issues.
* Changed the wording from `C/C++` to `C++` based on our decision that we're not going to provide C interface in this repo.

I will update the community repo after this PR.