### PR TITLE
Fix AtomicSharedPtr for C++20

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,17 @@ jobs:
     - name: run tests
       run: ./ci/do_ci.sh cmake.test
 
+    name: CMake C++20 test
+    runs-on: ubuntu-20.04
+    steps:
+    - uses: actions/checkout@v2
+    - name: setup
+      run: |
+        sudo ./ci/setup_ci_environment.sh
+        sudo ./ci/setup_cmake.sh
+    - name: run tests
+      run: ./ci/do_ci.sh cmake.c++20.test
+
   plugin_test:
     name: Plugin -> CMake
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,7 @@ jobs:
     - name: run tests
       run: ./ci/do_ci.sh cmake.test
 
+  cmake_test_cxx20:
     name: CMake C++20 test
     runs-on: ubuntu-20.04
     steps:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,7 +6,9 @@ cmake_policy(SET CMP0057 NEW)
 
 project(opentelemetry-cpp)
 
-set(CMAKE_CXX_STANDARD 11)
+if(NOT DEFINED CMAKE_CXX_STANDARD)
+  set(CMAKE_CXX_STANDARD 11)
+endif()
 
 option(WITH_OTPROTOCOL
        "Whether to include the OpenTelemetry Protocol in the SDK" OFF)

--- a/ci/README.md
+++ b/ci/README.md
@@ -3,6 +3,7 @@
 CI tests can be run on docker by invoking the script `./ci/run_docker.sh ./ci/do_ci.sh <TARGET>` where the targets are:
 
 * `cmake.test`: build cmake targets and run tests.
+* `cmake.c++20.test`: build cmake targets with the C++20 standard and run tests.
 * `cmake.test_example_plugin`: build and test an example OpenTelemetry plugin.
 * `cmake.exporter.otprotocol.test`: build and test the otprotocol exporter
 * `bazel.test`: build bazel targets and run tests.

--- a/ci/do_ci.sh
+++ b/ci/do_ci.sh
@@ -20,6 +20,16 @@ if [[ "$1" == "cmake.test" ]]; then
   make
   make test
   exit 0
+elif [[ "$1" == "cmake.c++20.test" ]]; then
+  cd "${BUILD_DIR}"
+  rm -rf *
+  cmake -DCMAKE_BUILD_TYPE=Debug  \
+        -DCMAKE_CXX_FLAGS="-Werror" \
+        -DCMAKE_CXX_STANDARD=20 \
+        "${SRC_DIR}"
+  make
+  make test
+  exit 0
 elif [[ "$1" == "cmake.exporter.otprotocol.test" ]]; then
   cd "${BUILD_DIR}"
   rm -rf *

--- a/ci/setup_cmake.sh
+++ b/ci/setup_cmake.sh
@@ -12,5 +12,5 @@ apt-get install --no-install-recommends --no-install-suggests -y \
 pushd /usr/src/gtest
 cmake CMakeLists.txt
 make
-cp *.a /usr/lib
+cp *.a /usr/lib || cp lib/*.a /usr/lib
 popd

--- a/sdk/include/opentelemetry/sdk/common/atomic_shared_ptr.h
+++ b/sdk/include/opentelemetry/sdk/common/atomic_shared_ptr.h
@@ -11,28 +11,10 @@ namespace sdk
 /**
  * A wrapper to provide atomic shared pointers.
  *
- * This wrapper relies on std::atomic for C++20, a mutex for gcc 4.8, and
- * specializations of std::atomic_store and std::atomic_load for all other
- * instances.
+ * This wrapper relies on a mutex for gcc 4.8, and specializations of
+ * std::atomic_store and std::atomic_load for all other instances.
  */
-#if __cplusplus > 201703L
-template <class T>
-class AtomicSharedPtr
-{
-public:
-  explicit AtomicSharedPtr(std::shared_ptr<T> ptr) noexcept : ptr_{std::move(ptr)} {}
-
-  void store(const std::shared_ptr<T> &other) noexcept
-  {
-    ptr_.store(other, std::memory_order_release);
-  }
-
-  std::shared_ptr<T> load() const noexcept { return ptr_.load(std::memory_order_acquire); }
-
-private:
-  std::atomic<std::shared_ptr<T>> ptr_;
-};
-#elif (__GNUC__ == 4 && (__GNUC_MINOR__ >= 8))
+#if (__GNUC__ == 4 && (__GNUC_MINOR__ >= 8))
 template <class T>
 class AtomicSharedPtr
 {

--- a/sdk/test/common/random_test.cc
+++ b/sdk/test/common/random_test.cc
@@ -20,7 +20,7 @@ TEST(RandomTest, GenerateRandomBuffer)
   EXPECT_FALSE(std::equal(std::begin(buf1), std::end(buf1), std::begin(buf2)));
 
   // Edge cases.
-  for (auto size : {1, 7, 8, 9, 16, 17})
+  for (auto size : {7, 8, 9, 16, 17})
   {
     std::vector<uint8_t> buf1(size);
     std::vector<uint8_t> buf2(size);


### PR DESCRIPTION
This is a fix for #105. Our code was relying on a [template specialization of `std::atomic` for `std::shared_ptr<T>`](https://en.cppreference.com/w/cpp/memory/shared_ptr/atomic2), which isn't provided by `g++`.

Instead we now rely on specializations of `std::atomic_store` and `std::atomic_load` for everything except gcc 4.8.

To guard against similar issues in future, I added a C++20 test to the shiny new GHA CI.