### PR TITLE
std::result_of removed in C++20

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,7 +21,9 @@ include(CTest)
 find_package(Threads)
 
 if(CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
-  # Options for Visual C++ compiler
+  # Options for Visual C++ compiler:
+  # /Zc:__cplusplus - report an updated value for recent C++ language standards.
+  # Without this option MSVC returns the value of __cplusplus="199711L"
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /Zc:__cplusplus")
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,6 +20,11 @@ include(CTest)
 
 find_package(Threads)
 
+if(CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
+  # Options for Visual C++ compiler
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /Zc:__cplusplus")
+endif()
+
 if(WITH_PROTOBUF)
   set(protobuf_MODULE_COMPATIBLE ON)
   find_package(Protobuf CONFIG NAMES protobuf)

--- a/api/include/opentelemetry/nostd/function_ref.h
+++ b/api/include/opentelemetry/nostd/function_ref.h
@@ -63,7 +63,13 @@ public:
       typename std::enable_if<!std::is_same<function_ref, typename std::decay<F>::type>::value,
                               int>::type = 0,
       typename std::enable_if<
+#if (__cplusplus >= 201703L)
+          // std::result_of deprecated in C++17, removed in C++20
+          std::is_convertible<typename std::invoke_result<F, Args...>::type, R>::value,
+#else
+          // std::result_of since C++11
           std::is_convertible<typename std::result_of<F &(Args...)>::type, R>::value,
+#endif
           int>::type = 0>
   function_ref(F &&f)
   {


### PR DESCRIPTION
Fix for #104 : when OpenTelemetry is compiled with latest update of Visual Studio 2019 in C++17 mode - it'd generate a warning, and in C++20 it won't compile because std::result_of has been removed in C++20. Adjust the header to stop using a compiler feature that's been removed from standard.