### PR TITLE
Remove Josh from the approvers

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,4 +2,4 @@
 # This file controls who is tagged for review for any given pull request.
 
 # For anything not explicitly taken by someone else:
-*       @g-easy @jmacd @maxgolov @pyohannes @reyang @rnburn @tigrannajaryan
+*       @open-telemetry/cpp-approvers

--- a/README.md
+++ b/README.md
@@ -29,7 +29,6 @@ Approvers ([@open-telemetry/cpp-approvers](https://github.com/orgs/open-telemetr
 
 - [Max Golovanov](https://github.com/maxgolov), Microsoft
 - [Johannes Tax](https://github.com/pyohannes), New Relic
-- [Josh MacDonald](https://github.com/jmacd), Lightstep
 - [Ryan Burn](https://github.com/rnburn), Lightstep
 - [Tigran Najaryan](https://github.com/tigrannajaryan), Splunk
 


### PR DESCRIPTION
Per request from @jmacd.
@jmacd was in the original team to kick off this project, now we've started to make steady progress.