### PR TITLE
Update OpenTelemetry protobuf definitions

### DIFF
--- a/exporters/otlp/recordable.cc
+++ b/exporters/otlp/recordable.cc
@@ -41,13 +41,13 @@ void Recordable::SetName(nostd::string_view name) noexcept
 void Recordable::SetStartTime(opentelemetry::core::SystemTimestamp start_time) noexcept
 {
   const uint64_t nano_unix_time = start_time.time_since_epoch().count();
-  span_.set_start_time_unixnano(nano_unix_time);
+  span_.set_start_time_unix_nano(nano_unix_time);
 }
 
 void Recordable::SetDuration(std::chrono::nanoseconds duration) noexcept
 {
-  const uint64_t unix_end_time = span_.start_time_unixnano() + duration.count();
-  span_.set_end_time_unixnano(unix_end_time);
+  const uint64_t unix_end_time = span_.start_time_unix_nano() + duration.count();
+  span_.set_end_time_unix_nano(unix_end_time);
 }
 }  // namespace otlp
 }  // namespace exporter

--- a/exporters/otlp/recordable_test.cc
+++ b/exporters/otlp/recordable_test.cc
@@ -51,7 +51,7 @@ TEST(Recordable, SetStartTime)
       std::chrono::duration_cast<std::chrono::nanoseconds>(start_time.time_since_epoch()).count();
 
   rec.SetStartTime(start_timestamp);
-  EXPECT_EQ(rec.span().start_time_unixnano(), unix_start);
+  EXPECT_EQ(rec.span().start_time_unix_nano(), unix_start);
 }
 
 TEST(Recordable, SetDuration)
@@ -66,7 +66,7 @@ TEST(Recordable, SetDuration)
   rec.SetStartTime(start_timestamp);
   rec.SetDuration(duration);
 
-  EXPECT_EQ(rec.span().end_time_unixnano(), unix_end);
+  EXPECT_EQ(rec.span().end_time_unix_nano(), unix_end);
 }
 }  // namespace otlp
 }  // namespace exporter

--- a/ext/src/zpages/README.md
+++ b/ext/src/zpages/README.md
@@ -1,0 +1,46 @@
+# zPages
+> Last updated 6/26/20
+
+# Table of Contents
+- [Summary](#summary)
+  - [TraceZ](#tracez)
+  - [RPCz](#rpcz)
+- [Usage](#usage)
+- [Links of Interest](#links-of-interest)
+
+## Summary
+zPages allow easy viewing of tracing information. When included for a process, zPages will display basic information about that process on a webpage. There are currently two types of zPages: TraceZ and RPCz.
+
+Including a zPage within a page is useful for developers because it's quicker to get running than adding extra code and installing external exporters like Jaeger and Zipkin. zPages tend to be more lightweight than these external exporters, but are also helpful for debugging latency issues and deadlocks.
+
+The idea of "zPages" originates from one of OpenTelemetry's predecessors, [OpenCensus](https://opencensus.io/). You can read more about it [here](https://opencensus.io/zpages). OpenCensus has different zPage implementations in [Java](https://opencensus.io/zpages/java/), [Go](https://opencensus.io/zpages/go/), and [Node](https://opencensus.io/zpages/node/) and there has been similar internal solutions developed at companies like Uber, but *this is the first major open-source implementation of zPages in C++*. Within OpenTelemetry, zPages are also being developed in [Java](https://github.com/open-telemetry/opentelemetry-java).
+
+#### How It Works
+On a high level, zPages work by reading a process' spans using a SpanProcessor, which exports spans to the appropriate DataAggregator that a HttpServer uses.
+
+> TODO: Add picture examples for span overview and individual span view
+
+### TraceZ
+TraceZ is a type of zPage that shows information on tracing spans, and allows users to look closer at specific and individual spans. Details a user would view include span id, name, status, and timestamps. The individual components of TraceZ are as follows:
+
+- TracezSpanProcessor (TSP)
+  - Contact point for TraceZ to connect with a process, which collects tracing information and provides an interface for TDA.
+- TracezDataAggregator (TDA)
+  - Intermediary between the TSP and THS, which also performs various functions and calculations to send the correct tracing information to the THS.
+- TracezHttpServer (THS)
+  - User-facing web page generator, which creates HTML pages using TDA that display 1) overall information on all of the process's spans and 2) more detailed information on specific spans when clicked.
+
+### RPCz
+RPCz is a type of zPage that provides details on instrumented sent and received RPC messages. Although there is currently no ongoing development of RPCz for OpenTelemetry, OpenCensus zPages have implementations of RPCz (linked above).
+
+# Usage
+
+> TODO: Add instructions to add zPages
+
+## Links of Interest
+- [TracezSpanProcessor Design Doc](https://docs.google.com/document/d/1kO4iZARYyr-EGBlY2VNM3ELU3iw6ZrC58Omup_YT-fU/edit#) (pending review)
+- [TracezDataAggregator Design Doc](https://docs.google.com/document/d/1ziKFgvhXFfRXZjOlAHQRR-TzcNcTXzg1p2I9oPCEIoU/edit?ts=5ef0d177#heading=h.5irk4csrpu0y) (pending review)
+- [TracezHttpServer Design Doc](https://docs.google.com/document/d/1U1V8QZ5LtGl4Mich-aJ6KZGLHrMIE8pWyspmzvnIefI/edit#) (draft)
+- [Contribution Guidelines](https://github.com/open-telemetry/opentelemetry-cpp/blob/master/CONTRIBUTING.md)
+
+

--- a/third_party/opentelemetry-proto/README
+++ b/third_party/opentelemetry-proto/README
@@ -1,2 +1,2 @@
 From: https://github.com/open-telemetry/opentelemetry-proto
-Commit: d496c80b353bc4a4f754ae686b59ca3c41de0946
+Commit: e43e1abc40428a6ee98e3bfd79bec1dfa2ed18cd

--- a/third_party/opentelemetry-proto/opentelemetry/proto/collector/metrics/v1/metrics_service_http.yaml
+++ b/third_party/opentelemetry-proto/opentelemetry/proto/collector/metrics/v1/metrics_service_http.yaml
@@ -4,6 +4,6 @@ type: google.api.Service
 config_version: 3
 http:
  rules:
- - selector: opentelemetry.proto.collector.trace.v1.TraceService.Export
-   post: /v1/trace
+ - selector: opentelemetry.proto.collector.metrics.v1.MetricsService.Export
+   post: /v1/metrics
    body: "*"

--- a/third_party/opentelemetry-proto/opentelemetry/proto/common/v1/common.proto
+++ b/third_party/opentelemetry-proto/opentelemetry/proto/common/v1/common.proto
@@ -21,35 +21,57 @@ option java_package = "io.opentelemetry.proto.common.v1";
 option java_outer_classname = "CommonProto";
 option go_package = "github.com/open-telemetry/opentelemetry-proto/gen/go/common/v1";
 
-// AttributeKeyValue is a key-value pair that is used to store Span attributes, Link
+// AnyValue is used to represent any type of attribute value. AnyValue may contain a
+// primitive value such as a string or integer or it may contain an arbitrary nested
+// object containing arrays, key-value lists and primitives.
+message AnyValue {
+  // The value is one of the listed fields. It is valid for all values to be unspecified
+  // in which case this AnyValue is considered to be "null".
+  oneof value {
+    string string_value = 1;
+    bool bool_value = 2;
+    int64 int_value = 3;
+    double double_value = 4;
+    ArrayValue array_value = 5;
+    KeyValueList kvlist_value = 6;
+  }
+}
+
+// ArrayValue is a list of AnyValue messages. We need ArrayValue as a message
+// since oneof in AnyValue does not allow repeated fields.
+message ArrayValue {
+  // Array of values. The array may be empty (contain 0 elements).
+  repeated AnyValue values = 1;
+}
+
+// KeyValueList is a list of KeyValue messages. We need KeyValueList as a message
+// since `oneof` in AnyValue does not allow repeated fields. Everywhere else where we need
+// a list of KeyValue messages (e.g. in Span) we use `repeated KeyValue` directly to
+// avoid unnecessary extra wrapping (which slows down the protocol). The 2 approaches
+// are semantically equivalent.
+message KeyValueList {
+  // A collection of key/value pairs of key-value pairs. The list may be empty (may
+  // contain 0 elements).
+  repeated KeyValue values = 1;
+}
+
+// KeyValue is a key-value pair that is used to store Span attributes, Link
 // attributes, etc.
-message AttributeKeyValue {
-  // ValueType is the enumeration of possible types that value can have.
-  enum ValueType {
-    STRING  = 0;
-    INT     = 1;
-    DOUBLE  = 2;
-    BOOL    = 3;
-  };
-
-  // key part of the key-value pair.
+message KeyValue {
   string key = 1;
-
-  // type of the value.
-  ValueType type = 2;
-
-  // Only one of the following fields is supposed to contain data (determined by `type` field).
-  // This is deliberately not using Protobuf `oneof` for performance reasons (verified by benchmarks).
-
-  string string_value = 3;
-  int64 int_value = 4;
-  double double_value = 5;
-  bool bool_value = 6;
+  AnyValue value = 2;
 }
 
 // StringKeyValue is a pair of key/value strings. This is the simpler (and faster) version
-// of AttributeKeyValue that only supports string values.
+// of KeyValue that only supports string values.
 message StringKeyValue {
   string key = 1;
   string value = 2;
+}
+
+// InstrumentationLibrary is a message representing the instrumentation library information
+// such as the fully qualified name and version.
+message InstrumentationLibrary {
+  string name = 1;
+  string version = 2;
 }

--- a/third_party/opentelemetry-proto/opentelemetry/proto/metrics/v1/metrics.proto
+++ b/third_party/opentelemetry-proto/opentelemetry/proto/metrics/v1/metrics.proto
@@ -24,14 +24,24 @@ option java_package = "io.opentelemetry.proto.metrics.v1";
 option java_outer_classname = "MetricsProto";
 option go_package = "github.com/open-telemetry/opentelemetry-proto/gen/go/metrics/v1";
 
-// A collection of metrics from a Resource.
+// A collection of InstrumentationLibraryMetrics from a Resource.
 message ResourceMetrics {
-  // A list of metrics that originate from a resource.
-  repeated Metric metrics = 1;
-
   // The resource for the metrics in this message.
   // If this field is not set then no resource info is known.
-  opentelemetry.proto.resource.v1.Resource resource = 2;
+  opentelemetry.proto.resource.v1.Resource resource = 1;
+
+  // A list of metrics that originate from a resource.
+  repeated InstrumentationLibraryMetrics instrumentation_library_metrics = 2;
+}
+
+// A collection of Metrics produced by an InstrumentationLibrary.
+message InstrumentationLibraryMetrics {
+  // The instrumentation library information for the metrics in this message.
+  // If this field is not set then no library info is known.
+  opentelemetry.proto.common.v1.InstrumentationLibrary instrumentation_library = 1;
+
+  // A list of metrics that originate from an instrumentation library.
+  repeated Metric metrics = 2;
 }
 
 // Defines a Metric which has one or more timeseries.
@@ -90,10 +100,10 @@ message Metric {
   // Data is a list of one or more DataPoints for a single metric. Only one of the
   // following fields is used for the data, depending on the type of the metric defined
   // by MetricDescriptor.type field.
-  repeated Int64DataPoint int64_datapoints = 2;
-  repeated DoubleDataPoint double_datapoints = 3;
-  repeated HistogramDataPoint histogram_datapoints = 4;
-  repeated SummaryDataPoint summary_datapoints = 5;
+  repeated Int64DataPoint int64_data_points = 2;
+  repeated DoubleDataPoint double_data_points = 3;
+  repeated HistogramDataPoint histogram_data_points = 4;
+  repeated SummaryDataPoint summary_data_points = 5;
 }
 
 // Defines a metric type and its schema.
@@ -108,49 +118,36 @@ message MetricDescriptor {
   // described by http://unitsofmeasure.org/ucum.html.
   string unit = 3;
 
-  // Type of the metric. It describes how the data is reported.
-  //
-  // A gauge is an instantaneous measurement of a value.
-  //
-  // A counter/cumulative measurement is a value accumulated over a time
-  // interval. In a time series, cumulative measurements should have the same
-  // start time, increasing values, until an event resets the cumulative value
-  // to zero and sets a new start time for the subsequent points.
+  // Type is the type of values a metric has.
   enum Type {
-    // Do not use this default value.
-    UNSPECIFIED = 0;
+    // INVALID_TYPE is the default Type, it MUST not be used.
+    INVALID_TYPE = 0;
 
-    // Integer gauge. The value can go both up and down over time.
-    // Corresponding values are stored in Int64DataPoint.
-    GAUGE_INT64 = 1;
+    // INT64 values are signed 64-bit integers.
+    //
+    // A Metric of this Type MUST store its values as Int64DataPoint.
+    INT64 = 1;
 
-    // Floating point gauge. The value can go both up and down over time.
-    // Corresponding values are stored in DoubleDataPoint.
-    GAUGE_DOUBLE = 2;
+    // MONOTONIC_INT64 values are monotonically increasing signed 64-bit
+    // integers.
+    //
+    // A Metric of this Type MUST store its values as Int64DataPoint.
+    MONOTONIC_INT64 = 2;
 
-    // Histogram gauge measurement.
-    // Used in scenarios like a snapshot of time that current items in a queue
-    // have spent there.
-    // Corresponding values are stored in HistogramDataPoint. The count and sum of the
-    // histogram can go both up and down over time. Recorded values are always >= 0.
-    GAUGE_HISTOGRAM = 3;
+    // DOUBLE values are double-precision floating-point numbers.
+    //
+    // A Metric of this Type MUST store its values as DoubleDataPoint.
+    DOUBLE = 3;
 
-    // Integer counter measurement. The value cannot decrease; if value is reset then
-    // start_time_unixnano should also be reset.
-    // Corresponding values are stored in Int64DataPoint.
-    COUNTER_INT64 = 4;
+    // MONOTONIC_DOUBLE values are monotonically increasing double-precision
+    // floating-point numbers.
+    //
+    // A Metric of this Type MUST store its values as DoubleDataPoint.
+    MONOTONIC_DOUBLE = 4;
 
-    // Floating point counter measurement. The value cannot decrease, if
-    // resets then the start_time_unixnano should also be reset.
-    // Recorded values are always >= 0.
-    // Corresponding values are stored in DoubleDataPoint.
-    COUNTER_DOUBLE = 5;
-
-    // Histogram cumulative measurement.
-    // Corresponding values are stored in HistogramDataPoint. The count and sum of the
-    // histogram cannot decrease; if values are reset then start_time_unixnano
-    // should also be reset to the new start timestamp.
-    CUMULATIVE_HISTOGRAM = 6;
+    // Histogram measurement.
+    // Corresponding values are stored in HistogramDataPoint.
+    HISTOGRAM = 5;
 
     // Summary value. Some frameworks implemented Histograms as a summary of observations
     // (usually things like request durations and response sizes). While it
@@ -158,13 +155,88 @@ message MetricDescriptor {
     // values, it calculates configurable percentiles over a sliding time
     // window.
     // Corresponding values are stored in SummaryDataPoint.
-    SUMMARY = 7;
+    SUMMARY = 6;
   }
+
+  // type is the type of values this metric has.
   Type type = 4;
 
-  // The set of labels associated with the metric descriptor. Labels in this list apply to
-  // all data points.
-  repeated opentelemetry.proto.common.v1.StringKeyValue labels = 5;
+  // Temporality is the temporal quality values of a metric have. It
+  // describes how those values relate to the time interval over which they
+  // are reported.
+  enum Temporality {
+    // INVALID_TEMPORALITY is the default Temporality, it MUST not be
+    // used.
+    INVALID_TEMPORALITY = 0;
+
+    // INSTANTANEOUS is a metric whose values are measured at a particular
+    // instant. The values are not aggregated over any time interval and are
+    // unique per timestamp. As such, these metrics are not expected to have
+    // an associated start time.
+    INSTANTANEOUS = 1;
+
+    // DELTA is a metric whose values are the aggregation of measurements
+    // made over a time interval. Successive metrics contain aggregation of
+    // values from continuous and non-overlapping intervals.
+    //
+    // The values for a DELTA metric are based only on the time interval
+    // associated with one measurement cycle. There is no dependency on
+    // previous measurements like is the case for CUMULATIVE metrics.
+    //
+    // For example, consider a system measuring the number of requests that
+    // it receives and reports the sum of these requests every second as a
+    // DELTA metric:
+    //
+    //   1. The system starts receiving at time=t_0.
+    //   2. A request is received, the system measures 1 request.
+    //   3. A request is received, the system measures 1 request.
+    //   4. A request is received, the system measures 1 request.
+    //   5. The 1 second collection cycle ends. A metric is exported for the
+    //      number of requests received over the interval of time t_0 to
+    //      t_0+1 with a value of 3.
+    //   6. A request is received, the system measures 1 request.
+    //   7. A request is received, the system measures 1 request.
+    //   8. The 1 second collection cycle ends. A metric is exported for the
+    //      number of requests received over the interval of time t_0+1 to
+    //      t_0+2 with a value of 2.
+    DELTA = 2;
+
+    // CUMULATIVE is a metric whose values are the aggregation of
+    // successively made measurements from a fixed start time until the last
+    // reported measurement. This means that current values of a CUMULATIVE
+    // metric depend on all previous measurements since the start time.
+    // Because of this, the sender is required to retain this state in some
+    // form. If this state is lost or invalidated, the CUMULATIVE metric
+    // values MUST be reset and a new fixed start time following the last
+    // reported measurement time sent MUST be used.
+    //
+    // For example, consider a system measuring the number of requests that
+    // it receives and reports the sum of these requests every second as a
+    // CUMULATIVE metric:
+    //
+    //   1. The system starts receiving at time=t_0.
+    //   2. A request is received, the system measures 1 request.
+    //   3. A request is received, the system measures 1 request.
+    //   4. A request is received, the system measures 1 request.
+    //   5. The 1 second collection cycle ends. A metric is exported for the
+    //      number of requests received over the interval of time t_0 to
+    //      t_0+1 with a value of 3.
+    //   6. A request is received, the system measures 1 request.
+    //   7. A request is received, the system measures 1 request.
+    //   8. The 1 second collection cycle ends. A metric is exported for the
+    //      number of requests received over the interval of time t_0 to
+    //      t_0+2 with a value of 5.
+    //   9. The system experiences a fault and loses state.
+    //   10. The system recovers and resumes receiving at time=t_1.
+    //   11. A request is received, the system measures 1 request.
+    //   12. The 1 second collection cycle ends. A metric is exported for the
+    //      number of requests received over the interval of time t_1 to
+    //      t_0+1 with a value of 1.
+    CUMULATIVE = 3;
+  }
+
+  // temporality is the Temporality of values this metric has.
+  Temporality temporality = 5;
 }
 
 // Int64DataPoint is a single data point in a timeseries that describes the time-varying
@@ -173,20 +245,20 @@ message Int64DataPoint {
   // The set of labels that uniquely identify this timeseries.
   repeated opentelemetry.proto.common.v1.StringKeyValue labels = 1;
 
-  // start_time_unixnano is the time when the cumulative value was reset to zero.
+  // start_time_unix_nano is the time when the cumulative value was reset to zero.
   // This is used for Counter type only. For Gauge the value is not specified and
   // defaults to 0.
   //
-  // The cumulative value is over the time interval (start_time_unixnano, timestamp_unixnano].
+  // The cumulative value is over the time interval (start_time_unix_nano, time_unix_nano].
   // Value is UNIX Epoch time in nanoseconds since 00:00:00 UTC on 1 January 1970.
   //
   // Value of 0 indicates that the timestamp is unspecified. In that case the timestamp
   // may be decided by the backend.
-  fixed64 start_time_unixnano = 2;
+  fixed64 start_time_unix_nano = 2;
 
-  // timestamp_unixnano is the moment when this value was recorded.
+  // time_unix_nano is the moment when this value was recorded.
   // Value is UNIX Epoch time in nanoseconds since 00:00:00 UTC on 1 January 1970.
-  fixed64 timestamp_unixnano = 3;
+  fixed64 time_unix_nano = 3;
 
   // value itself.
   int64 value = 4;
@@ -198,20 +270,20 @@ message DoubleDataPoint {
   // The set of labels that uniquely identify this timeseries.
   repeated opentelemetry.proto.common.v1.StringKeyValue labels = 1;
 
-  // start_time_unixnano is the time when the cumulative value was reset to zero.
+  // start_time_unix_nano is the time when the cumulative value was reset to zero.
   // This is used for Counter type only. For Gauge the value is not specified and
   // defaults to 0.
   //
-  // The cumulative value is over the time interval (start_time_unixnano, timestamp_unixnano].
+  // The cumulative value is over the time interval (start_time_unix_nano, time_unix_nano].
   // Value is UNIX Epoch time in nanoseconds since 00:00:00 UTC on 1 January 1970.
   //
   // Value of 0 indicates that the timestamp is unspecified. In that case the timestamp
   // may be decided by the backend.
-  fixed64 start_time_unixnano = 2;
+  fixed64 start_time_unix_nano = 2;
 
-  // timestamp_unixnano is the moment when this value was recorded.
+  // time_unix_nano is the moment when this value was recorded.
   // Value is UNIX Epoch time in nanoseconds since 00:00:00 UTC on 1 January 1970.
-  fixed64 timestamp_unixnano = 3;
+  fixed64 time_unix_nano = 3;
 
   // value itself.
   double value = 4;
@@ -224,19 +296,19 @@ message HistogramDataPoint {
   // The set of labels that uniquely identify this timeseries.
   repeated opentelemetry.proto.common.v1.StringKeyValue labels = 1;
 
-  // start_time_unixnano is the time when the cumulative value was reset to zero.
+  // start_time_unix_nano is the time when the cumulative value was reset to zero.
   //
-  // The cumulative value is over the time interval (start_time_unixnano, timestamp_unixnano].
+  // The cumulative value is over the time interval (start_time_unix_nano, time_unix_nano].
   // Value is UNIX Epoch time in nanoseconds since 00:00:00 UTC on 1 January 1970.
   //
   // Value of 0 indicates that the timestamp is unspecified. In that case the timestamp
   // may be decided by the backend.
   // Note: this field is always unspecified and ignored if MetricDescriptor.type==GAUGE_HISTOGRAM.
-  fixed64 start_time_unixnano = 2;
+  fixed64 start_time_unix_nano = 2;
 
-  // timestamp_unixnano is the moment when this value was recorded.
+  // time_unix_nano is the moment when this value was recorded.
   // Value is UNIX Epoch time in nanoseconds since 00:00:00 UTC on 1 January 1970.
-  fixed64 timestamp_unixnano = 3;
+  fixed64 time_unix_nano = 3;
 
   // count is the number of values in the population. Must be non-negative. This value
   // must be equal to the sum of the "count" fields in buckets if a histogram is provided.
@@ -262,9 +334,9 @@ message HistogramDataPoint {
       // the defined bounds.
       double value = 1;
 
-      // timestamp_unixnano is the moment when this exemplar was recorded.
+      // time_unix_nano is the moment when this exemplar was recorded.
       // Value is UNIX Epoch time in nanoseconds since 00:00:00 UTC on 1 January 1970.
-      fixed64 timestamp_unixnano = 2;
+      fixed64 time_unix_nano = 2;
 
       // exemplar_attachments are contextual information about the example value.
       // Keys in this list must be unique.
@@ -318,18 +390,18 @@ message SummaryDataPoint {
   // The set of labels that uniquely identify this timeseries.
   repeated opentelemetry.proto.common.v1.StringKeyValue labels = 1;
 
-  // start_time_unixnano is the time when the cumulative value was reset to zero.
+  // start_time_unix_nano is the time when the cumulative value was reset to zero.
   //
-  // The cumulative value is over the time interval (start_time_unixnano, timestamp_unixnano].
+  // The cumulative value is over the time interval (start_time_unix_nano, time_unix_nano].
   // Value is UNIX Epoch time in nanoseconds since 00:00:00 UTC on 1 January 1970.
   //
   // Value of 0 indicates that the timestamp is unspecified. In that case the timestamp
   // may be decided by the backend.
-  fixed64 start_time_unixnano = 2;
+  fixed64 start_time_unix_nano = 2;
 
-  // timestamp_unixnano is the moment when this value was recorded.
+  // time_unix_nano is the moment when this value was recorded.
   // Value is UNIX Epoch time in nanoseconds since 00:00:00 UTC on 1 January 1970.
-  fixed64 timestamp_unixnano = 3;
+  fixed64 time_unix_nano = 3;
 
   // The total number of recorded values since start_time. Optional since
   // some systems don't expose this.
@@ -340,6 +412,13 @@ message SummaryDataPoint {
   double sum = 5;
 
   // Represents the value at a given percentile of a distribution.
+  //
+  // To record Min and Max values following conventions are used:
+  // - The 100th percentile is equivalent to the maximum value observed.
+  // - The 0th percentile is equivalent to the minimum value observed.
+  //
+  // See the following issue for more context:
+  // https://github.com/open-telemetry/opentelemetry-proto/issues/125
   message ValueAtPercentile {
     // The percentile of a distribution. Must be in the interval
     // [0.0, 100.0].

--- a/third_party/opentelemetry-proto/opentelemetry/proto/resource/v1/resource.proto
+++ b/third_party/opentelemetry-proto/opentelemetry/proto/resource/v1/resource.proto
@@ -26,7 +26,7 @@ option go_package = "github.com/open-telemetry/opentelemetry-proto/gen/go/resour
 // Resource information.
 message Resource {
   // Set of labels that describe the resource.
-  repeated opentelemetry.proto.common.v1.AttributeKeyValue attributes = 1;
+  repeated opentelemetry.proto.common.v1.KeyValue attributes = 1;
 
   // dropped_attributes_count is the number of dropped attributes. If the value is 0, then
   // no attributes were dropped.

--- a/third_party/opentelemetry-proto/opentelemetry/proto/trace/v1/trace.proto
+++ b/third_party/opentelemetry-proto/opentelemetry/proto/trace/v1/trace.proto
@@ -24,13 +24,23 @@ option java_package = "io.opentelemetry.proto.trace.v1";
 option java_outer_classname = "TraceProto";
 option go_package = "github.com/open-telemetry/opentelemetry-proto/gen/go/trace/v1";
 
-// A collection of spans from a Resource.
+// A collection of InstrumentationLibrarySpans from a Resource.
 message ResourceSpans {
   // The resource for the spans in this message.
   // If this field is not set then no resource info is known.
   opentelemetry.proto.resource.v1.Resource resource = 1;
 
-  // A list of Spans that originate from a resource.
+  // A list of InstrumentationLibrarySpans that originate from a resource.
+  repeated InstrumentationLibrarySpans instrumentation_library_spans = 2;
+}
+
+// A collection of Spans produced by an InstrumentationLibrary.
+message InstrumentationLibrarySpans {
+  // The instrumentation library information for the spans in this message.
+  // If this field is not set then no library info is known.
+  opentelemetry.proto.common.v1.InstrumentationLibrary instrumentation_library = 1;
+
+  // A list of Spans that originate from an instrumentation library.
   repeated Span spans = 2;
 }
 
@@ -123,21 +133,21 @@ message Span {
   // and `SERVER` (callee) to identify queueing latency associated with the span.
   SpanKind kind = 6;
 
-  // start_time_unixnano is the start time of the span. On the client side, this is the time
+  // start_time_unix_nano is the start time of the span. On the client side, this is the time
   // kept by the local machine where the span execution starts. On the server side, this
   // is the time when the server's application handler starts running.
   // Value is UNIX Epoch time in nanoseconds since 00:00:00 UTC on 1 January 1970.
   //
   // This field is semantically required and it is expected that end_time >= start_time.
-  fixed64 start_time_unixnano = 7;
+  fixed64 start_time_unix_nano = 7;
 
-  // end_time_unixnano is the end time of the span. On the client side, this is the time
+  // end_time_unix_nano is the end time of the span. On the client side, this is the time
   // kept by the local machine where the span execution ends. On the server side, this
   // is the time when the server application handler stops running.
   // Value is UNIX Epoch time in nanoseconds since 00:00:00 UTC on 1 January 1970.
   //
   // This field is semantically required and it is expected that end_time >= start_time.
-  fixed64 end_time_unixnano = 8;
+  fixed64 end_time_unix_nano = 8;
 
   // attributes is a collection of key/value pairs. The value can be a string,
   // an integer, a double or the Boolean values `true` or `false`. Note, global attributes
@@ -147,7 +157,7 @@ message Span {
   //     "/http/server_latency": 300
   //     "abc.com/myattribute": true
   //     "abc.com/score": 10.239
-  repeated opentelemetry.proto.common.v1.AttributeKeyValue attributes = 9;
+  repeated opentelemetry.proto.common.v1.KeyValue attributes = 9;
 
   // dropped_attributes_count is the number of attributes that were discarded. Attributes
   // can be discarded because their keys are too long or because there are too many
@@ -157,15 +167,15 @@ message Span {
   // Event is a time-stamped annotation of the span, consisting of user-supplied
   // text description and key-value pairs.
   message Event {
-    // time_unixnano is the time the event occurred.
-    fixed64 time_unixnano = 1;
+    // time_unix_nano is the time the event occurred.
+    fixed64 time_unix_nano = 1;
 
     // name of the event.
     // This field is semantically required to be set to non-empty string.
     string name = 2;
 
     // attributes is a collection of attribute key/value pairs on the event.
-    repeated opentelemetry.proto.common.v1.AttributeKeyValue attributes = 3;
+    repeated opentelemetry.proto.common.v1.KeyValue attributes = 3;
 
     // dropped_attributes_count is the number of dropped attributes. If the value is 0,
     // then no attributes were dropped.
@@ -195,7 +205,7 @@ message Span {
     string trace_state = 3;
 
     // attributes is a collection of attribute key/value pairs on the link.
-    repeated opentelemetry.proto.common.v1.AttributeKeyValue attributes = 4;
+    repeated opentelemetry.proto.common.v1.KeyValue attributes = 4;
 
     // dropped_attributes_count is the number of dropped attributes. If the value is 0,
     // then no attributes were dropped.


### PR DESCRIPTION
Our vendored version of `opentelemetry-proto` is out of date with https://github.com/open-telemetry/opentelemetry-proto. This PR updates it with the most recent version. This update is required for the OTLP exporter.