### PR TITLE
Don't move a constant AttributeValue

### DIFF
--- a/api/include/opentelemetry/plugin/tracer.h
+++ b/api/include/opentelemetry/plugin/tracer.h
@@ -18,9 +18,9 @@ public:
   {}
 
   // trace::Span
-  void SetAttribute(nostd::string_view name, const common::AttributeValue &&value) noexcept override
+  void SetAttribute(nostd::string_view name, const common::AttributeValue &value) noexcept override
   {
-    span_->SetAttribute(name, std::move(value));
+    span_->SetAttribute(name, value);
   }
 
   void AddEvent(nostd::string_view name) noexcept override { span_->AddEvent(name); }

--- a/api/include/opentelemetry/trace/noop.h
+++ b/api/include/opentelemetry/trace/noop.h
@@ -25,7 +25,7 @@ public:
   explicit NoopSpan(const std::shared_ptr<Tracer> &tracer) noexcept : tracer_{tracer} {}
 
   void SetAttribute(nostd::string_view /*key*/,
-                    const common::AttributeValue && /*value*/) noexcept override
+                    const common::AttributeValue & /*value*/) noexcept override
   {}
 
   void AddEvent(nostd::string_view /*name*/) noexcept override {}

--- a/api/include/opentelemetry/trace/span.h
+++ b/api/include/opentelemetry/trace/span.h
@@ -77,7 +77,7 @@ public:
   // Sets an attribute on the Span. If the Span previously contained a mapping for
   // the key, the old value is replaced.
   virtual void SetAttribute(nostd::string_view key,
-                            const common::AttributeValue &&value) noexcept = 0;
+                            const common::AttributeValue &value) noexcept = 0;
 
   // Adds an event to the Span.
   virtual void AddEvent(nostd::string_view name) noexcept = 0;

--- a/api/test/trace/noop_test.cc
+++ b/api/test/trace/noop_test.cc
@@ -25,4 +25,6 @@ TEST(NoopTest, UseNoopTracers)
 
   std::vector<std::pair<std::string, std::vector<int>>> attributes3;
   s1->AddEvent("abc", attributes3);
+
+  s1->SetAttribute("abc", 4);
 }

--- a/examples/plugin/plugin/tracer.cc
+++ b/examples/plugin/plugin/tracer.cc
@@ -25,7 +25,7 @@ public:
 
   // opentelemetry::trace::Span
   void SetAttribute(nostd::string_view /*name*/,
-                    const common::AttributeValue && /*value*/) noexcept override
+                    const common::AttributeValue & /*value*/) noexcept override
   {}
 
   void AddEvent(nostd::string_view /*name*/) noexcept override {}

--- a/exporters/otlp/recordable.cc
+++ b/exporters/otlp/recordable.cc
@@ -16,7 +16,7 @@ void Recordable::SetIds(trace::TraceId trace_id,
 }
 
 void Recordable::SetAttribute(nostd::string_view key,
-                              const opentelemetry::common::AttributeValue &&value) noexcept
+                              const opentelemetry::common::AttributeValue &value) noexcept
 {
   (void)key;
   (void)value;

--- a/exporters/otlp/recordable.h
+++ b/exporters/otlp/recordable.h
@@ -19,7 +19,7 @@ public:
               trace::SpanId parent_span_id) noexcept override;
 
   void SetAttribute(nostd::string_view key,
-                    const opentelemetry::common::AttributeValue &&value) noexcept override;
+                    const opentelemetry::common::AttributeValue &value) noexcept override;
 
   void AddEvent(nostd::string_view name, core::SystemTimestamp timestamp) noexcept override;
 

--- a/sdk/include/opentelemetry/sdk/trace/recordable.h
+++ b/sdk/include/opentelemetry/sdk/trace/recordable.h
@@ -40,7 +40,7 @@ public:
    * @param value the attribute value
    */
   virtual void SetAttribute(nostd::string_view key,
-                            const opentelemetry::common::AttributeValue &&value) noexcept = 0;
+                            const opentelemetry::common::AttributeValue &value) noexcept = 0;
 
   /**
    * Add an event to a span.

--- a/sdk/include/opentelemetry/sdk/trace/span_data.h
+++ b/sdk/include/opentelemetry/sdk/trace/span_data.h
@@ -86,7 +86,7 @@ public:
     parent_span_id_ = parent_span_id;
   }
 
-  void SetAttribute(nostd::string_view key, const common::AttributeValue &&value) noexcept override
+  void SetAttribute(nostd::string_view key, const common::AttributeValue &value) noexcept override
   {
     attributes_[std::string(key)] = value;
   }

--- a/sdk/src/trace/span.cc
+++ b/sdk/src/trace/span.cc
@@ -57,7 +57,7 @@ Span::Span(std::shared_ptr<Tracer> &&tracer,
   recordable_->SetName(name);
 
   attributes.ForEachKeyValue([&](nostd::string_view key, common::AttributeValue value) noexcept {
-    recordable_->SetAttribute(key, std::move(value));
+    recordable_->SetAttribute(key, value);
     return true;
   });
 
@@ -70,11 +70,11 @@ Span::~Span()
   End();
 }
 
-void Span::SetAttribute(nostd::string_view key, const common::AttributeValue &&value) noexcept
+void Span::SetAttribute(nostd::string_view key, const common::AttributeValue &value) noexcept
 {
   std::lock_guard<std::mutex> lock_guard{mu_};
 
-  recordable_->SetAttribute(key, std::move(value));
+  recordable_->SetAttribute(key, value);
 }
 
 void Span::AddEvent(nostd::string_view name) noexcept

--- a/sdk/src/trace/span.h
+++ b/sdk/src/trace/span.h
@@ -24,7 +24,7 @@ public:
   ~Span() override;
 
   // trace_api::Span
-  void SetAttribute(nostd::string_view key, const common::AttributeValue &&value) noexcept override;
+  void SetAttribute(nostd::string_view key, const common::AttributeValue &value) noexcept override;
 
   void AddEvent(nostd::string_view name) noexcept override;
 

--- a/sdk/test/trace/tracer_test.cc
+++ b/sdk/test/trace/tracer_test.cc
@@ -1,7 +1,7 @@
 #include "opentelemetry/sdk/trace/tracer.h"
-#include "opentelemetry/sdk/trace/simple_processor.h"
-#include "opentelemetry/sdk/trace/samplers/always_on.h"
 #include "opentelemetry/sdk/trace/samplers/always_off.h"
+#include "opentelemetry/sdk/trace/samplers/always_on.h"
+#include "opentelemetry/sdk/trace/simple_processor.h"
 #include "opentelemetry/sdk/trace/span_data.h"
 
 #include <gtest/gtest.h>
@@ -142,7 +142,6 @@ TEST(Tracer, StartSpanWithAttributes)
   ASSERT_EQ(3.0, nostd::get<double>(span_data2->GetAttributes().at("attr3")));
 }
 
-
 TEST(Tracer, GetSampler)
 {
   // Create a Tracer with a default AlwaysOnSampler
@@ -154,8 +153,25 @@ TEST(Tracer, GetSampler)
 
   // Create a Tracer with a AlwaysOffSampler
   std::shared_ptr<SpanProcessor> processor_2(new SimpleSpanProcessor(nullptr));
-  std::shared_ptr<Tracer> tracer_off(new Tracer(std::move(processor_2), std::make_shared<AlwaysOffSampler>()));
+  std::shared_ptr<Tracer> tracer_off(
+      new Tracer(std::move(processor_2), std::make_shared<AlwaysOffSampler>()));
 
   auto t2 = tracer_off->GetSampler();
   ASSERT_EQ("AlwaysOffSampler", t2->GetDescription());
+}
+
+TEST(Tracer, SpanSetAttribute)
+{
+  std::shared_ptr<std::vector<std::unique_ptr<SpanData>>> spans_received(
+      new std::vector<std::unique_ptr<SpanData>>);
+  auto tracer = initTracer(spans_received);
+
+  auto span = tracer->StartSpan("span 1");
+
+  span->SetAttribute("abc", 3.1);
+
+  span->End();
+  ASSERT_EQ(1, spans_received->size());
+  auto &span_data = spans_received->at(0);
+  ASSERT_EQ(3.1, nostd::get<double>(span_data->GetAttributes().at("abc")));
 }


### PR DESCRIPTION
Moving a constant object causes a copy to be made. Let's rather pass a reference.

Related to this [comment](https://github.com/open-telemetry/opentelemetry-cpp/pull/117#discussion_r447942171).