### PR TITLE
Add benchmark tests for OTLP exporter

### DIFF
--- a/exporters/otlp/BUILD
+++ b/exporters/otlp/BUILD
@@ -14,6 +14,8 @@
 
 package(default_visibility = ["//visibility:public"])
 
+load("//bazel:otel_cc_benchmark.bzl", "otel_cc_benchmark")
+
 cc_library(
     name = "recordable",
     srcs = [
@@ -63,5 +65,13 @@ cc_test(
         ":otlp_exporter",
         "//api",
         "@com_google_googletest//:gtest_main",
+    ],
+)
+
+otel_cc_benchmark(
+    name = "otlp_exporter_benchmark",
+    srcs = ["otlp_exporter_benchmark.cc"],
+    deps = [
+        ":otlp_exporter",
     ],
 )

--- a/exporters/otlp/otlp_exporter_benchmark.cc
+++ b/exporters/otlp/otlp_exporter_benchmark.cc
@@ -1,0 +1,81 @@
+#include "otlp_exporter.h"
+
+#include <benchmark/benchmark.h>
+
+OPENTELEMETRY_BEGIN_NAMESPACE
+namespace exporter
+{
+namespace otlp
+{
+
+// OtlpExporterTestPeer is a friend class of OtlpExporter
+class OtlpExporterTestPeer
+{
+public:
+  std::unique_ptr<sdk::trace::SpanExporter> GetExporter(
+      std::unique_ptr<proto::collector::trace::v1::TraceService::StubInterface> &stub_interface)
+  {
+    return std::unique_ptr<sdk::trace::SpanExporter>(
+        new exporter::otlp::OtlpExporter(std::move(stub_interface)));
+  }
+};
+
+class FakeServiceStub : public proto::collector::trace::v1::TraceService::StubInterface
+{
+  grpc::Status Export(grpc::ClientContext *context,
+                      const proto::collector::trace::v1::ExportTraceServiceRequest &request,
+                      proto::collector::trace::v1::ExportTraceServiceResponse *response) override
+  {
+    return grpc::Status::OK;
+  }
+
+  grpc::ClientAsyncResponseReaderInterface<proto::collector::trace::v1::ExportTraceServiceResponse>
+      *AsyncExportRaw(grpc::ClientContext *context,
+                      const proto::collector::trace::v1::ExportTraceServiceRequest &request,
+                      grpc::CompletionQueue *cq) override
+  {
+    return NULL;
+  }
+
+  grpc::ClientAsyncResponseReaderInterface<proto::collector::trace::v1::ExportTraceServiceResponse>
+      *PrepareAsyncExportRaw(grpc::ClientContext *context,
+                             const proto::collector::trace::v1::ExportTraceServiceRequest &request,
+                             grpc::CompletionQueue *cq) override
+  {
+    return NULL;
+  }
+};
+
+void BM_OtlpExporter(benchmark::State &state)
+{
+  std::unique_ptr<OtlpExporterTestPeer> testpeer(new OtlpExporterTestPeer());
+
+  auto mock_stub = new FakeServiceStub();
+  std::unique_ptr<proto::collector::trace::v1::TraceService::StubInterface> stub_interface(
+      mock_stub);
+
+  auto exporter = testpeer->GetExporter(stub_interface);
+
+  while (state.KeepRunning())
+  {
+    const int kBatchSize = 100;
+    std::unique_ptr<sdk::trace::Recordable> batch_arr[kBatchSize];
+
+    for (int i = 0; i < kBatchSize; i++)
+    {
+      auto recordable = exporter->MakeRecordable();
+      recordable->SetName("Hello");
+      batch_arr[i] = std::unique_ptr<sdk::trace::Recordable>(recordable.release());
+    }
+    nostd::span<std::unique_ptr<sdk::trace::Recordable>> batch(batch_arr, kBatchSize);
+
+    exporter->Export(batch);
+  }
+}
+BENCHMARK(BM_OtlpExporter);
+
+}  // namespace otlp
+}  // namespace exporter
+OPENTELEMETRY_END_NAMESPACE
+
+BENCHMARK_MAIN();

--- a/exporters/otlp/otlp_exporter_benchmark.cc
+++ b/exporters/otlp/otlp_exporter_benchmark.cc
@@ -10,6 +10,7 @@ namespace otlp
 
 const int kBatchSize     = 200;
 const int kNumAttributes = 5;
+const int kNumIterations = 1000;
 
 const trace::TraceId kTraceId(std::array<const uint8_t, trace::TraceId::kSize>(
     {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1}));
@@ -118,7 +119,7 @@ void BM_OtlpExporterEmptySpans(benchmark::State &state)
   std::unique_ptr<OtlpExporterTestPeer> testpeer(new OtlpExporterTestPeer());
   auto exporter = testpeer->GetExporter();
 
-  for (auto _ : state)
+  while(state.KeepRunningBatch(kNumIterations))
   {
     std::array<std::unique_ptr<sdk::trace::Recordable>, kBatchSize> recordables;
     CreateEmptySpans(recordables);
@@ -133,7 +134,7 @@ void BM_OtlpExporterSparseSpans(benchmark::State &state)
   std::unique_ptr<OtlpExporterTestPeer> testpeer(new OtlpExporterTestPeer());
   auto exporter = testpeer->GetExporter();
 
-  for (auto _ : state)
+  while(state.KeepRunningBatch(kNumIterations))
   {
     std::array<std::unique_ptr<sdk::trace::Recordable>, kBatchSize> recordables;
     CreateSparseSpans(recordables);
@@ -148,7 +149,7 @@ void BM_OtlpExporterDenseSpans(benchmark::State &state)
   std::unique_ptr<OtlpExporterTestPeer> testpeer(new OtlpExporterTestPeer());
   auto exporter = testpeer->GetExporter();
 
-  for (auto _ : state)
+  while(state.KeepRunningBatch(kNumIterations))
   {
     std::array<std::unique_ptr<sdk::trace::Recordable>, kBatchSize> recordables;
     CreateDenseSpans(recordables);

--- a/exporters/otlp/otlp_exporter_benchmark.cc
+++ b/exporters/otlp/otlp_exporter_benchmark.cc
@@ -8,6 +8,8 @@ namespace exporter
 namespace otlp
 {
 
+const int kBatchSize = 200;
+
 const trace::TraceId kTraceId(std::array<const uint8_t, trace::TraceId::kSize>(
     {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1}));
 const trace::SpanId kSpanId(std::array<const uint8_t, trace::SpanId::kSize>(
@@ -64,8 +66,6 @@ void BM_OtlpExporterFullSpans(benchmark::State &state)
 
   auto exporter = testpeer->GetExporter(stub_interface);
 
-  const int kBatchSize = 200;
-
   while (state.KeepRunning())
   {
     std::unique_ptr<sdk::trace::Recordable> batch_arr[kBatchSize];
@@ -79,7 +79,7 @@ void BM_OtlpExporterFullSpans(benchmark::State &state)
       recordable->SetStartTime(core::SystemTimestamp(std::chrono::system_clock::now()));
       recordable->SetDuration(std::chrono::nanoseconds(10));
 
-      batch_arr[i] = std::unique_ptr<sdk::trace::Recordable>(recordable.release());
+      batch_arr[i] = std::move(recordable);
     }
     nostd::span<std::unique_ptr<sdk::trace::Recordable>> batch(batch_arr, kBatchSize);
 
@@ -99,8 +99,6 @@ void BM_OtlpExporterEmptySpans(benchmark::State &state)
 
   auto exporter = testpeer->GetExporter(stub_interface);
 
-  const int kBatchSize = 200;
-
   while (state.KeepRunning())
   {
     std::unique_ptr<sdk::trace::Recordable> batch_arr[kBatchSize];
@@ -108,7 +106,7 @@ void BM_OtlpExporterEmptySpans(benchmark::State &state)
     for (int i = 0; i < kBatchSize; i++)
     {
       auto recordable = exporter->MakeRecordable();
-      batch_arr[i] = std::unique_ptr<sdk::trace::Recordable>(recordable.release());
+      batch_arr[i] = std::move(recordable);
     }
     nostd::span<std::unique_ptr<sdk::trace::Recordable>> batch(batch_arr, kBatchSize);
 

--- a/exporters/otlp/otlp_exporter_benchmark.cc
+++ b/exporters/otlp/otlp_exporter_benchmark.cc
@@ -118,7 +118,7 @@ void BM_OtlpExporterEmptySpans(benchmark::State &state)
   std::unique_ptr<OtlpExporterTestPeer> testpeer(new OtlpExporterTestPeer());
   auto exporter = testpeer->GetExporter();
 
-  while (state.KeepRunning())
+  for (auto _ : state)
   {
     std::array<std::unique_ptr<sdk::trace::Recordable>, kBatchSize> recordables;
     CreateEmptySpans(recordables);
@@ -133,7 +133,7 @@ void BM_OtlpExporterSparseSpans(benchmark::State &state)
   std::unique_ptr<OtlpExporterTestPeer> testpeer(new OtlpExporterTestPeer());
   auto exporter = testpeer->GetExporter();
 
-  while (state.KeepRunning())
+  for (auto _ : state)
   {
     std::array<std::unique_ptr<sdk::trace::Recordable>, kBatchSize> recordables;
     CreateSparseSpans(recordables);
@@ -148,7 +148,7 @@ void BM_OtlpExporterDenseSpans(benchmark::State &state)
   std::unique_ptr<OtlpExporterTestPeer> testpeer(new OtlpExporterTestPeer());
   auto exporter = testpeer->GetExporter();
 
-  while (state.KeepRunning())
+  for (auto _ : state)
   {
     std::array<std::unique_ptr<sdk::trace::Recordable>, kBatchSize> recordables;
     CreateDenseSpans(recordables);

--- a/exporters/otlp/otlp_exporter_benchmark.cc
+++ b/exporters/otlp/otlp_exporter_benchmark.cc
@@ -75,7 +75,7 @@ void BM_OtlpExporterFullSpans(benchmark::State &state)
       auto recordable = exporter->MakeRecordable();
 
       recordable->SetIds(kTraceId, kSpanId, kParentSpanId);
-      recordable->SetName("Span " + i);
+      recordable->SetName("TestSpan");
       recordable->SetStartTime(core::SystemTimestamp(std::chrono::system_clock::now()));
       recordable->SetDuration(std::chrono::nanoseconds(10));
 

--- a/exporters/otlp/otlp_exporter_benchmark.cc
+++ b/exporters/otlp/otlp_exporter_benchmark.cc
@@ -107,17 +107,17 @@ void CreateDenseSpans(std::array<std::unique_ptr<sdk::trace::Recordable>, kBatch
     recordable->SetStartTime(core::SystemTimestamp(std::chrono::system_clock::now()));
     recordable->SetDuration(std::chrono::nanoseconds(10));
 
-    for (int i = 0; i < kNumAttributes; ++i)
+    for (int i = 0; i < kNumAttributes; i++)
     {
       recordable->SetAttribute("int_key_" + i, static_cast<int64_t>(i));
     }
 
-    for (int i = 0; i < kNumAttributes; ++i)
+    for (int i = 0; i < kNumAttributes; i++)
     {
-      recordable->SetAttribute("str_key_" + i, "string_val_" + std::to_string(i));
+      recordable->SetAttribute("str_key_" + i, "string_val_" + i);
     }
 
-    for (int i = 0; i < kNumAttributes; ++i)
+    for (int i = 0; i < kNumAttributes; i++)
     {
       recordable->SetAttribute("bool_key_" + i, true);
     }

--- a/exporters/otlp/otlp_exporter_benchmark.cc
+++ b/exporters/otlp/otlp_exporter_benchmark.cc
@@ -23,35 +23,26 @@ const trace::SpanId kParentSpanId(std::array<const uint8_t, trace::SpanId::kSize
 // Create a fake service stub to avoid dependency on gmock
 class FakeServiceStub : public proto::collector::trace::v1::TraceService::StubInterface
 {
-  grpc::Status Export(grpc::ClientContext *context,
-                      const proto::collector::trace::v1::ExportTraceServiceRequest &request,
-                      proto::collector::trace::v1::ExportTraceServiceResponse *response) override
+  grpc::Status Export(grpc::ClientContext *,
+                      const proto::collector::trace::v1::ExportTraceServiceRequest &,
+                      proto::collector::trace::v1::ExportTraceServiceResponse *) override
   {
-    (void)context;
-    (void)request;
-    (void)response;
     return grpc::Status::OK;
   }
 
   grpc::ClientAsyncResponseReaderInterface<proto::collector::trace::v1::ExportTraceServiceResponse>
-      *AsyncExportRaw(grpc::ClientContext *context,
-                      const proto::collector::trace::v1::ExportTraceServiceRequest &request,
-                      grpc::CompletionQueue *cq) override
+      *AsyncExportRaw(grpc::ClientContext *,
+                      const proto::collector::trace::v1::ExportTraceServiceRequest &,
+                      grpc::CompletionQueue *) override
   {
-    (void)context;
-    (void)request;
-    (void)cq;
     return nullptr;
   }
 
   grpc::ClientAsyncResponseReaderInterface<proto::collector::trace::v1::ExportTraceServiceResponse>
-      *PrepareAsyncExportRaw(grpc::ClientContext *context,
-                             const proto::collector::trace::v1::ExportTraceServiceRequest &request,
-                             grpc::CompletionQueue *cq) override
+      *PrepareAsyncExportRaw(grpc::ClientContext *,
+                             const proto::collector::trace::v1::ExportTraceServiceRequest &,
+                             grpc::CompletionQueue *) override
   {
-    (void)context;
-    (void)request;
-    (void)cq;
     return nullptr;
   }
 };

--- a/exporters/otlp/otlp_exporter_benchmark.cc
+++ b/exporters/otlp/otlp_exporter_benchmark.cc
@@ -93,6 +93,7 @@ void CreateDenseSpans(std::array<std::unique_ptr<sdk::trace::Recordable>, kBatch
   for (int i = 0; i < kBatchSize; i++)
   {
     auto recordable = std::unique_ptr<sdk::trace::Recordable>(new Recordable);
+
     recordable->SetIds(kTraceId, kSpanId, kParentSpanId);
     recordable->SetName("TestSpan");
     recordable->SetStartTime(core::SystemTimestamp(std::chrono::system_clock::now()));
@@ -101,15 +102,7 @@ void CreateDenseSpans(std::array<std::unique_ptr<sdk::trace::Recordable>, kBatch
     for (int i = 0; i < kNumAttributes; i++)
     {
       recordable->SetAttribute("int_key_" + i, static_cast<int64_t>(i));
-    }
-
-    for (int i = 0; i < kNumAttributes; i++)
-    {
       recordable->SetAttribute("str_key_" + i, "string_val_" + i);
-    }
-
-    for (int i = 0; i < kNumAttributes; i++)
-    {
       recordable->SetAttribute("bool_key_" + i, true);
     }
 


### PR DESCRIPTION
Benchmark `Export()` for the OTLP exporter using both full and empty spans.

**Sample output:**

![benchmark_output_updated](https://user-images.githubusercontent.com/14475923/87083131-f5dda480-c1e0-11ea-90b1-ef09caa49b77.png)

**Output after changing `KeepRunning` to `KeepRunningBatch` and using optimized build:**

![benchmark_output_optimized](https://user-images.githubusercontent.com/14475923/87190227-f3de1900-c2a6-11ea-83ce-c07ea8bc075e.png)
