### PR TITLE
Add events in SpanData

### DIFF
--- a/sdk/include/opentelemetry/sdk/trace/span_data.h
+++ b/sdk/include/opentelemetry/sdk/trace/span_data.h
@@ -90,17 +90,15 @@ struct AttributeConverter
 class SpanDataEvent
 {
 public:
-  SpanDataEvent(nostd::string_view name, core::SystemTimestamp timestamp)
-  {
-    name_      = name;
-    timestamp_ = timestamp;
-  }
+  SpanDataEvent(std::string name, core::SystemTimestamp timestamp)
+      : name_(name), timestamp_(timestamp)
+  {}
 
   /**
    * Get the name for this event
    * @return the name for this event
    */
-  nostd::string_view GetName() const noexcept { return name_; }
+  std::string GetName() const noexcept { return name_; }
 
   /**
    * Get the timestamp for this event
@@ -109,7 +107,7 @@ public:
   core::SystemTimestamp GetTimestamp() const noexcept { return timestamp_; }
 
 private:
-  nostd::string_view name_;
+  std::string name_;
   core::SystemTimestamp timestamp_;
 };
 
@@ -198,7 +196,7 @@ public:
 
   void AddEvent(nostd::string_view name, core::SystemTimestamp timestamp) noexcept override
   {
-    events_.push_back(SpanDataEvent(name, timestamp));
+    events_.push_back(SpanDataEvent(std::string(name), timestamp));
   }
 
   void SetStatus(trace_api::CanonicalCode code, nostd::string_view description) noexcept override

--- a/sdk/include/opentelemetry/sdk/trace/span_data.h
+++ b/sdk/include/opentelemetry/sdk/trace/span_data.h
@@ -85,6 +85,22 @@ struct AttributeConverter
 };
 
 /**
+ * Class for storing events in SpanData
+ */
+class SpanDataEvent
+{
+public:
+  SpanDataEvent(nostd::string_view name, core::SystemTimestamp timestamp)
+  {
+    name_      = name;
+    timestamp_ = timestamp;
+  }
+
+  nostd::string_view name_;
+  core::SystemTimestamp timestamp_;
+};
+
+/**
  * SpanData is a representation of all data collected by a span.
  */
 class SpanData final : public Recordable
@@ -147,6 +163,12 @@ public:
     return attributes_;
   }
 
+  /**
+   * Get the events associated with this span
+   * @return the events associated with this span
+   */
+  std::vector<SpanDataEvent> GetEvents() const noexcept { return events_; }
+
   void SetIds(opentelemetry::trace::TraceId trace_id,
               opentelemetry::trace::SpanId span_id,
               opentelemetry::trace::SpanId parent_span_id) noexcept override
@@ -163,8 +185,7 @@ public:
 
   void AddEvent(nostd::string_view name, core::SystemTimestamp timestamp) noexcept override
   {
-    (void)name;
-    (void)timestamp;
+    events_.push_back(SpanDataEvent(name, timestamp));
   }
 
   void SetStatus(trace_api::CanonicalCode code, nostd::string_view description) noexcept override
@@ -192,6 +213,7 @@ private:
   opentelemetry::trace::CanonicalCode status_code_{opentelemetry::trace::CanonicalCode::OK};
   std::string status_desc_;
   std::unordered_map<std::string, SpanDataAttributeValue> attributes_;
+  std::vector<SpanDataEvent> events_;
   AttributeConverter converter_;
 };
 }  // namespace trace

--- a/sdk/include/opentelemetry/sdk/trace/span_data.h
+++ b/sdk/include/opentelemetry/sdk/trace/span_data.h
@@ -180,7 +180,7 @@ public:
    * Get the events associated with this span
    * @return the events associated with this span
    */
-  std::vector<SpanDataEvent> GetEvents() const noexcept { return events_; }
+  const std::vector<SpanDataEvent> &GetEvents() const noexcept { return events_; }
 
   void SetIds(opentelemetry::trace::TraceId trace_id,
               opentelemetry::trace::SpanId span_id,

--- a/sdk/include/opentelemetry/sdk/trace/span_data.h
+++ b/sdk/include/opentelemetry/sdk/trace/span_data.h
@@ -85,7 +85,7 @@ struct AttributeConverter
 };
 
 /**
- * Class for storing events in SpanData
+ * Class for storing events in SpanData.
  */
 class SpanDataEvent
 {
@@ -96,6 +96,19 @@ public:
     timestamp_ = timestamp;
   }
 
+  /**
+   * Get the name for this event
+   * @return the name for this event
+   */
+  nostd::string_view GetName() const noexcept { return name_; }
+
+  /**
+   * Get the timestamp for this event
+   * @return the timestamp for this event
+   */
+  core::SystemTimestamp GetTimestamp() const noexcept { return timestamp_; }
+
+private:
   nostd::string_view name_;
   core::SystemTimestamp timestamp_;
 };

--- a/sdk/test/trace/span_data_test.cc
+++ b/sdk/test/trace/span_data_test.cc
@@ -22,6 +22,7 @@ TEST(SpanData, DefaultValues)
   ASSERT_EQ(data.GetStartTime().time_since_epoch(), std::chrono::nanoseconds(0));
   ASSERT_EQ(data.GetDuration(), std::chrono::nanoseconds(0));
   ASSERT_EQ(data.GetAttributes().size(), 0);
+  ASSERT_EQ(data.GetEvents().size(), 0);
 }
 
 TEST(SpanData, Set)
@@ -49,6 +50,6 @@ TEST(SpanData, Set)
   ASSERT_EQ(data.GetStartTime().time_since_epoch(), now.time_since_epoch());
   ASSERT_EQ(data.GetDuration(), std::chrono::nanoseconds(1000000));
   ASSERT_EQ(opentelemetry::nostd::get<int64_t>(data.GetAttributes().at("attr1")), 314159);
-  ASSERT_EQ(data.GetEvents().at(0).name_, "event1");
-  ASSERT_EQ(data.GetEvents().at(0).timestamp_, now);
+  ASSERT_EQ(data.GetEvents().at(0).GetName(), "event1");
+  ASSERT_EQ(data.GetEvents().at(0).GetTimestamp(), now);
 }

--- a/sdk/test/trace/span_data_test.cc
+++ b/sdk/test/trace/span_data_test.cc
@@ -49,4 +49,6 @@ TEST(SpanData, Set)
   ASSERT_EQ(data.GetStartTime().time_since_epoch(), now.time_since_epoch());
   ASSERT_EQ(data.GetDuration(), std::chrono::nanoseconds(1000000));
   ASSERT_EQ(opentelemetry::nostd::get<int64_t>(data.GetAttributes().at("attr1")), 314159);
+  ASSERT_EQ(data.GetEvents().at(0).name_, "event1");
+  ASSERT_EQ(data.GetEvents().at(0).timestamp_, now);
 }


### PR DESCRIPTION
Implement `AddEvent` for SpanData. Currently only `name` and `timestamp` can be set due to limitations in the `recordable` interface. In the future, attributes should also be supported in events.