### PR TITLE
Moving a temporary object prevents copy elision.

### DIFF
--- a/api/include/opentelemetry/context/context.h
+++ b/api/include/opentelemetry/context/context.h
@@ -116,7 +116,7 @@ private:
       {
         if (first)
         {
-          *node = std::move(DataList(iter.first, iter.second));
+          *node = DataList(iter.first, iter.second);
           first = false;
         }
         else


### PR DESCRIPTION
Caught by: -Wpessimizing-move