### PR TITLE
Use gcc-4.8 for GHA legacy tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,6 +55,9 @@ jobs:
         sudo ./ci/install_gcc48.sh
     - name: run tests
       run: ./ci/do_ci.sh bazel.legacy.test
+      env:
+        CC: /usr/bin/gcc-4.8
+        CXX: /usr/bin/g++-4.8
 
   bazel_test:
     name: Bazel

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,7 +57,6 @@ jobs:
       run: ./ci/do_ci.sh bazel.legacy.test
       env:
         CC: /usr/bin/gcc-4.8
-        CXX: /usr/bin/g++-4.8
 
   bazel_test:
     name: Bazel

--- a/exporters/ostream/src/span_exporter.cc
+++ b/exporters/ostream/src/span_exporter.cc
@@ -11,7 +11,7 @@ namespace exporter
 namespace trace
 {
 OStreamSpanExporter::OStreamSpanExporter(std::ostream &sout) noexcept
-                                    : sout_{sout} {}
+                                    : sout_(sout) {}
 
 std::unique_ptr<sdktrace::Recordable> OStreamSpanExporter::MakeRecordable() noexcept 
 {


### PR DESCRIPTION
Setting `CC=/usr/bin/gcc-4.8` was omitted for our GHA legacy test, resulting in the use of the default Ubuntu 18.04 gcc version.

This PR fixes this and makes our legacy tests actually using gcc-4.8 again (and pass). Merging this will fix other PR builder failures.