### PR TITLE
Add Sketch Aggregator

### DIFF
--- a/sdk/include/opentelemetry/sdk/metrics/aggregator/sketch_aggregator.h
+++ b/sdk/include/opentelemetry/sdk/metrics/aggregator/sketch_aggregator.h
@@ -82,7 +82,7 @@ public:
      * @param q, the quantile to calculate (for example 0.5 is equivelant to the 50th percentile)
      */
     virtual T get_quantiles(double q) override {
-        if (q < 0 or q > 1){
+        if (q < 0 || q > 1){
 #if __EXCEPTIONS
             throw std::invalid_argument("Quantile values must fall between 0 and 1");
 #else

--- a/sdk/include/opentelemetry/sdk/metrics/aggregator/sketch_aggregator.h
+++ b/sdk/include/opentelemetry/sdk/metrics/aggregator/sketch_aggregator.h
@@ -93,7 +93,6 @@ public:
         int idx = iter->first;
         int count = iter->second;
         
-        // will iterator ever reach the end, think it is a possibility
         while (count < (q * (this->checkpoint_[1]-1)) && iter != checkpoint_raw_.end()){
             iter++;
             idx = iter->first;
@@ -147,6 +146,8 @@ public:
         
         this->values_[0]+=other.values_[0];
         this->values_[1]+=other.values_[1];
+        this->checkpoint_[0]+=other.checkpoint_[0];
+        this->checkpoint_[1]+=other.checkpoint_[1];
         auto other_iter = other.raw_.begin();
         while (other_iter != other.raw_.end()){
             raw_[other_iter->first] += other_iter->second;
@@ -156,6 +157,16 @@ public:
                 raw_[raw_.begin()->first]+=minidxval;
             }
             other_iter++;
+        }
+        auto other_ckpt_iter = other.checkpoint_raw_.begin();
+        while (other_ckpt_iter != other.checkpoint_raw_.end()){
+            checkpoint_raw_[other_ckpt_iter->first] += other_ckpt_iter->second;
+            if (checkpoint_raw_.size() > max_buckets_){
+                int minidx = checkpoint_raw_.begin()->first, minidxval = checkpoint_raw_.begin()->second;
+                checkpoint_raw_.erase(minidx);
+                checkpoint_raw_[checkpoint_raw_.begin()->first]+=minidxval;
+            }
+            other_ckpt_iter++;
         }
         this-> mu_.unlock();
     }

--- a/sdk/include/opentelemetry/sdk/metrics/aggregator/sketch_aggregator.h
+++ b/sdk/include/opentelemetry/sdk/metrics/aggregator/sketch_aggregator.h
@@ -4,11 +4,11 @@
 #include <cmath>
 #include <map>
 #include <mutex>
-#include "opentelemetry/metrics/instrument.h"
-#include "opentelemetry/version.h"
-#include "opentelemetry/sdk/metrics/aggregator/aggregator.h"
-#include <vector>
 #include <stdexcept>
+#include <vector>
+#include "opentelemetry/metrics/instrument.h"
+#include "opentelemetry/sdk/metrics/aggregator/aggregator.h"
+#include "opentelemetry/version.h"
 
 namespace metrics_api = opentelemetry::metrics;
 
@@ -26,230 +26,233 @@ namespace metrics
  *  published by Datadog: http://www.vldb.org/pvldb/vol12/p2195-masson.pdf
  */
 
-template<class T>
+template <class T>
 class SketchAggregator final : public Aggregator<T>
 {
-    
+
 public:
-    
-    /**
-     * Given the distribution of data this aggregator is designed for and its usage, the raw updates are stored in
-     * a map rather than a vector.
-     *
-     *@param kind, the instrument kind creating this aggregator
-     *@param error_bound, what is referred to as "alpha" in the DDSketch algorithm
-     *@param max_buckets, the maximum number of indices in the raw value map
-     */
-    SketchAggregator(metrics_api::InstrumentKind kind, double error_bound, size_t max_buckets = 2048)
+  /**
+   * Given the distribution of data this aggregator is designed for and its usage, the raw updates
+   *are stored in a map rather than a vector.
+   *
+   *@param kind, the instrument kind creating this aggregator
+   *@param error_bound, what is referred to as "alpha" in the DDSketch algorithm
+   *@param max_buckets, the maximum number of indices in the raw value map
+   */
+  SketchAggregator(metrics_api::InstrumentKind kind, double error_bound, size_t max_buckets = 2048)
+  {
+
+    this->kind_       = kind;
+    this->agg_kind_   = AggregatorKind::Sketch;
+    this->values_     = std::vector<T>(2, 0);  // Sum in [0], Count in [1]
+    this->checkpoint_ = std::vector<T>(2, 0);
+    max_buckets_      = max_buckets;
+    error_bound_      = error_bound;
+    gamma             = (1 + error_bound) / (1 - error_bound);
+  }
+
+  /**
+   * Update the aggregator with the new value.  For a DDSketch aggregator, if the addition of this
+   * value creates a new bucket which is in excess of the maximum allowed size, the lowest indexes
+   * buckets are merged.
+   *
+   * @param val, the raw value used in aggregation
+   * @return none
+   */
+  void update(T val) override
+  {
+    this->mu_.lock();
+    double idx = ceil(log(val) / log(gamma));
+    raw_[idx] += 1;
+    this->values_[1] += 1;
+    this->values_[0] += val;
+    if (raw_.size() > max_buckets_)
     {
-        
-        this->kind_ = kind;
-        this->agg_kind_ = AggregatorKind::Sketch;
-        this->values_   = std::vector<T>(2, 0); // Sum in [0], Count in [1]
-        this->checkpoint_ = std::vector<T>(2, 0);
-        max_buckets_ = max_buckets;
-        error_bound_ = error_bound;
-        gamma = (1+error_bound)/(1-error_bound);
+      int minidx = raw_.begin()->first, minidxval = raw_.begin()->second;
+      raw_.erase(minidx);
+      raw_[raw_.begin()->first] += minidxval;
     }
-    
-    /**
-     * Update the aggregator with the new value.  For a DDSketch aggregator, if the addition of this value
-     * creates a new bucket which is in excess of the maximum allowed size, the lowest indexes buckets
-     * are merged.
-     *
-     * @param val, the raw value used in aggregation
-     * @return none
-     */
-    void update(T val) override
+    this->mu_.unlock();
+  }
+
+  /**
+   * Calculate and return the value of a user specified quantile.
+   *
+   * @param q, the quantile to calculate (for example 0.5 is equivelant to the 50th percentile)
+   */
+  virtual T get_quantiles(double q) override
+  {
+    if (q < 0 || q > 1)
     {
-        this-> mu_.lock();
-        double idx = ceil(log(val)/log(gamma));
-        raw_[idx]+=1;
-        this->values_[1] += 1;
-        this->values_[0] += val;
-        if (raw_.size() > max_buckets_){
-            int minidx = raw_.begin()->first, minidxval = raw_.begin()->second;
-            raw_.erase(minidx);
-            raw_[raw_.begin()->first]+=minidxval;
-        }
-        this-> mu_.unlock();
-    }
-    
-    
-    /**
-     * Calculate and return the value of a user specified quantile.
-     *
-     * @param q, the quantile to calculate (for example 0.5 is equivelant to the 50th percentile)
-     */
-    virtual T get_quantiles(double q) override {
-        if (q < 0 || q > 1){
 #if __EXCEPTIONS
-            throw std::invalid_argument("Quantile values must fall between 0 and 1");
+      throw std::invalid_argument("Quantile values must fall between 0 and 1");
 #else
-            std::terminate();
+      std::terminate();
 #endif
-        }
-        auto iter = checkpoint_raw_.begin();
-        int idx = iter->first;
-        int count = iter->second;
-        
-        while (count < (q * (this->checkpoint_[1]-1)) && iter != checkpoint_raw_.end()){
-            iter++;
-            idx = iter->first;
-            count += iter->second;
-        }
-        return round(2*pow(gamma, idx)/(gamma + 1));
     }
-    
-    /**
-     * Checkpoints the current value.  This function will overwrite the current checkpoint with the
-     * current value.
-     *
-     * @param none
-     * @return none
-     */
-    void checkpoint() override
+    auto iter = checkpoint_raw_.begin();
+    int idx   = iter->first;
+    int count = iter->second;
+
+    while (count < (q * (this->checkpoint_[1] - 1)) && iter != checkpoint_raw_.end())
     {
-        this-> mu_.lock();
-        this->checkpoint_ = this->values_;
-        checkpoint_raw_ = raw_;
-        this->values_[0]=0;
-        this->values_[1]=0;
-        raw_.clear();
-        this-> mu_.unlock();
+      iter++;
+      idx = iter->first;
+      count += iter->second;
     }
-    
-    /**
-     * Merges this sketch aggregator with another.  The same bucket compression used when
-     * updating values is employed here to manage bucket size if the merging of aggregators
-     * results in more buckets than allowed.
-     *
-     * @param other, the aggregator with merge with
-     * @return none
-     */
-    void merge(SketchAggregator other)
+    return round(2 * pow(gamma, idx) / (gamma + 1));
+  }
+
+  /**
+   * Checkpoints the current value.  This function will overwrite the current checkpoint with the
+   * current value.
+   *
+   * @param none
+   * @return none
+   */
+  void checkpoint() override
+  {
+    this->mu_.lock();
+    this->checkpoint_ = this->values_;
+    checkpoint_raw_   = raw_;
+    this->values_[0]  = 0;
+    this->values_[1]  = 0;
+    raw_.clear();
+    this->mu_.unlock();
+  }
+
+  /**
+   * Merges this sketch aggregator with another.  The same bucket compression used when
+   * updating values is employed here to manage bucket size if the merging of aggregators
+   * results in more buckets than allowed.
+   *
+   * @param other, the aggregator with merge with
+   * @return none
+   */
+  void merge(SketchAggregator other)
+  {
+    this->mu_.lock();
+    if (gamma != other.gamma)
     {
-        this-> mu_.lock();
-        if (gamma != other.gamma){
 #if __EXCEPTIONS
-            throw std::invalid_argument("Aggregators must have identical error tolerance");
+      throw std::invalid_argument("Aggregators must have identical error tolerance");
 #else
-            std::terminate();
+      std::terminate();
 #endif
-        } else if (max_buckets_ != other.max_buckets_) {
+    }
+    else if (max_buckets_ != other.max_buckets_)
+    {
 #if __EXCEPTIONS
-            throw std::invalid_argument("Aggregators must have the same maximum bucket allowance");
+      throw std::invalid_argument("Aggregators must have the same maximum bucket allowance");
 #else
-            std::terminate();
+      std::terminate();
 #endif
-        }
-        
-        this->values_[0]+=other.values_[0];
-        this->values_[1]+=other.values_[1];
-        this->checkpoint_[0]+=other.checkpoint_[0];
-        this->checkpoint_[1]+=other.checkpoint_[1];
-        auto other_iter = other.raw_.begin();
-        while (other_iter != other.raw_.end()){
-            raw_[other_iter->first] += other_iter->second;
-            if (raw_.size() > max_buckets_){
-                int minidx = raw_.begin()->first, minidxval = raw_.begin()->second;
-                raw_.erase(minidx);
-                raw_[raw_.begin()->first]+=minidxval;
-            }
-            other_iter++;
-        }
-        auto other_ckpt_iter = other.checkpoint_raw_.begin();
-        while (other_ckpt_iter != other.checkpoint_raw_.end()){
-            checkpoint_raw_[other_ckpt_iter->first] += other_ckpt_iter->second;
-            if (checkpoint_raw_.size() > max_buckets_){
-                int minidx = checkpoint_raw_.begin()->first, minidxval = checkpoint_raw_.begin()->second;
-                checkpoint_raw_.erase(minidx);
-                checkpoint_raw_[checkpoint_raw_.begin()->first]+=minidxval;
-            }
-            other_ckpt_iter++;
-        }
-        this-> mu_.unlock();
-    }
-    
-    /**
-     * Returns the checkpointed value
-     *
-     * @param none
-     * @return the value of the checkpoint
-     */
-    std::vector<T> get_checkpoint() override
-    {
-        return this->checkpoint_;
-    }
-    
-    /**
-     * Returns the current values
-     *
-     * @param none
-     * @return the present aggregator values
-     */
-    std::vector<T> get_values() override
-    {
-        return this->values_;
-    }
-    
-    /**
-     * Returns the indices (or values) stored by this sketch aggregator.
-     *
-     * @param none
-     * @return a vector of all values the aggregator is currently tracking
-     */
-    virtual std::vector<double> get_boundaries() override {
-        std::vector<double> ret;
-        for (auto const &x: checkpoint_raw_){
-            ret.push_back(2*pow(gamma, x.first)/(gamma + 1));
-        }
-        return ret;
-    }
-    
-    /**
-    * Returns the error bound
-    *
-    * @param none
-    * @return the error bound specified during construction
-    */
-    virtual double get_error_bound() override {
-        return error_bound_;
     }
 
-    /**
-    * Returns the maximum allowed buckets
-    *
-    * @param none
-    * @return the maximum allowed buckets
-    */
-    virtual size_t get_max_buckets() override {
-        return max_buckets_;
+    this->values_[0] += other.values_[0];
+    this->values_[1] += other.values_[1];
+    this->checkpoint_[0] += other.checkpoint_[0];
+    this->checkpoint_[1] += other.checkpoint_[1];
+    auto other_iter = other.raw_.begin();
+    while (other_iter != other.raw_.end())
+    {
+      raw_[other_iter->first] += other_iter->second;
+      if (raw_.size() > max_buckets_)
+      {
+        int minidx = raw_.begin()->first, minidxval = raw_.begin()->second;
+        raw_.erase(minidx);
+        raw_[raw_.begin()->first] += minidxval;
+      }
+      other_iter++;
     }
-    
-    /**
-     * Returns the count of each value tracked by this sketch aggregator.  These are returned
-     * in the same order as the indices returned by the get_boundaries function.
-     *
-     * @param none
-     * @return a vector of all counts for values tracked by the aggregator
-     */
-    virtual std::vector<int> get_counts() override {
-        std::vector<int> ret;
-        for (auto const &x: checkpoint_raw_){
-            ret.push_back(x.second);
-        }
-        return ret;
+    auto other_ckpt_iter = other.checkpoint_raw_.begin();
+    while (other_ckpt_iter != other.checkpoint_raw_.end())
+    {
+      checkpoint_raw_[other_ckpt_iter->first] += other_ckpt_iter->second;
+      if (checkpoint_raw_.size() > max_buckets_)
+      {
+        int minidx = checkpoint_raw_.begin()->first, minidxval = checkpoint_raw_.begin()->second;
+        checkpoint_raw_.erase(minidx);
+        checkpoint_raw_[checkpoint_raw_.begin()->first] += minidxval;
+      }
+      other_ckpt_iter++;
     }
-    
+    this->mu_.unlock();
+  }
+
+  /**
+   * Returns the checkpointed value
+   *
+   * @param none
+   * @return the value of the checkpoint
+   */
+  std::vector<T> get_checkpoint() override { return this->checkpoint_; }
+
+  /**
+   * Returns the current values
+   *
+   * @param none
+   * @return the present aggregator values
+   */
+  std::vector<T> get_values() override { return this->values_; }
+
+  /**
+   * Returns the indices (or values) stored by this sketch aggregator.
+   *
+   * @param none
+   * @return a vector of all values the aggregator is currently tracking
+   */
+  virtual std::vector<double> get_boundaries() override
+  {
+    std::vector<double> ret;
+    for (auto const &x : checkpoint_raw_)
+    {
+      ret.push_back(2 * pow(gamma, x.first) / (gamma + 1));
+    }
+    return ret;
+  }
+
+  /**
+   * Returns the error bound
+   *
+   * @param none
+   * @return the error bound specified during construction
+   */
+  virtual double get_error_bound() override { return error_bound_; }
+
+  /**
+   * Returns the maximum allowed buckets
+   *
+   * @param none
+   * @return the maximum allowed buckets
+   */
+  virtual size_t get_max_buckets() override { return max_buckets_; }
+
+  /**
+   * Returns the count of each value tracked by this sketch aggregator.  These are returned
+   * in the same order as the indices returned by the get_boundaries function.
+   *
+   * @param none
+   * @return a vector of all counts for values tracked by the aggregator
+   */
+  virtual std::vector<int> get_counts() override
+  {
+    std::vector<int> ret;
+    for (auto const &x : checkpoint_raw_)
+    {
+      ret.push_back(x.second);
+    }
+    return ret;
+  }
+
 private:
-    double gamma;
-    double error_bound_;
-    size_t max_buckets_;
-    std::map<int,int> raw_;
-    std::map<int,int> checkpoint_raw_;
+  double gamma;
+  double error_bound_;
+  size_t max_buckets_;
+  std::map<int, int> raw_;
+  std::map<int, int> checkpoint_raw_;
 };
 
-}
-}
+}  // namespace metrics
+}  // namespace sdk
 OPENTELEMETRY_END_NAMESPACE

--- a/sdk/include/opentelemetry/sdk/metrics/aggregator/sketch_aggregator.h
+++ b/sdk/include/opentelemetry/sdk/metrics/aggregator/sketch_aggregator.h
@@ -82,7 +82,11 @@ public:
      */
     int get_quantiles(double q) override {
         if (q < 0 or q > 1){
+#if __EXCEPTIONS
             throw std::invalid_argument("Quantile values must fall between 0 and 1");
+#else
+            std::terminate();
+#endif
         }
         auto iter = checkpoint_raw_.begin();
         int idx = iter->first;
@@ -127,9 +131,17 @@ public:
     {
         this-> mu_.lock();
         if (gamma != other.gamma){
+#if __EXCEPTIONS
             throw std::invalid_argument("Aggregators must have identical error tolerance");
+#else
+            std::terminate();
+#endif
         } else if (max_buckets_ != other.max_buckets_) {
+#if __EXCEPTIONS
             throw std::invalid_argument("Aggregators must have the same maximum bucket allowance");
+#else
+            std::terminate();
+#endif
         }
         
         this->values_[0]+=other.values_[0];

--- a/sdk/include/opentelemetry/sdk/metrics/aggregator/sketch_aggregator.h
+++ b/sdk/include/opentelemetry/sdk/metrics/aggregator/sketch_aggregator.h
@@ -1,0 +1,211 @@
+#pragma once
+
+#include <algorithm>
+#include <mutex>
+#include "opentelemetry/metrics/instrument.h"
+#include "opentelemetry/version.h"
+#include "opentelemetry/sdk/metrics/aggregator/aggregator.h"
+#include <stdexcept>
+#include <variant>
+#include <vector>
+#include <map>
+#include <cmath>
+
+namespace metrics_api = opentelemetry::metrics;
+
+OPENTELEMETRY_BEGIN_NAMESPACE
+namespace sdk
+{
+namespace metrics
+{
+
+/** Sketch Aggregators implement the DDSketch data type.  Note that data is compressed
+ *  by the DDSketch algorithm and users should be informed about its behavior before
+ *  selecting it as the aggregation type.
+ *
+ *  Detailed information about the algorithm can be found in the following paper
+ *  published by Datadog: http://www.vldb.org/pvldb/vol12/p2195-masson.pdf
+ */
+
+template<class T>
+class SketchAggregator final : public Aggregator<T>
+{
+    
+public:
+    
+    /**
+     * Given the distribution of data this aggregator is designed for and its usage, the raw updates are stored in
+     * a map rather than a vector.
+     *
+     *@param kind, the instrument kind creating this aggregator
+     *@param error_bound, what is referred to as "alpha" in the DDSketch algorithm
+     *@param max_buckets, the maximum number of indices in the raw value map
+     */
+    SketchAggregator(metrics_api::InstrumentKind kind, double error_bound, size_t max_buckets = 2048)
+    {
+        
+        this->kind_ = kind;
+        this->agg_kind_ = AggregatorKind::Sketch;
+        this->values_   = std::vector<T>(2, 0); // Sum in [0], Count in [1]
+        this->checkpoint_ = std::vector<T>(2, 0);
+        max_buckets_ = max_buckets;
+        gamma = (1+error_bound)/(1-error_bound);
+    }
+    
+    /**
+     * Update the aggregator with the new value.  For a DDSketch aggregator, if the addition of this value
+     * creates a new bucket which is in excess of the maximum allowed size, the lowest indexes buckets
+     * are merged.
+     *
+     * @param val, the raw value used in aggregation
+     * @return none
+     */
+    void update(T val) override
+    {
+        this-> mu_.lock();
+        double idx = ceil(log(val)/log(gamma));
+        raw_[idx]+=1;
+        this->values_[1] += 1;
+        this->values_[0] += val;
+        if (raw_.size() > max_buckets_){
+            int minidx = raw_.begin()->first, minidxval = raw_.begin()->second;
+            raw_.erase(minidx);
+            raw_[raw_.begin()->first]+=minidxval;
+        }
+        this-> mu_.unlock();
+    }
+    
+    
+    /**
+     * Calculate and return the value of a user specified quantile.
+     *
+     * @param q, the quantile to calculate (for example 0.5 is equivelant to the 50th percentile)
+     */
+    int get_quantiles(double q) override {
+        if (q < 0 or q > 1){
+            throw std::invalid_argument("Quantile values must fall between 0 and 1");
+        }
+        auto iter = checkpoint_raw_.begin();
+        int idx = iter->first;
+        int count = iter->second;
+        
+        // will iterator ever reach the end, think it is a possibility
+        while (count < (q * (this->checkpoint_[1]-1)) && iter != checkpoint_raw_.end()){
+            iter++;
+            idx = iter->first;
+            count += iter->second;
+        }
+        return round(2*pow(gamma, idx)/(gamma + 1));
+    }
+    
+    /**
+     * Checkpoints the current value.  This function will overwrite the current checkpoint with the
+     * current value.
+     *
+     * @param none
+     * @return none
+     */
+    void checkpoint() override
+    {
+        this-> mu_.lock();
+        this->checkpoint_ = this->values_;
+        checkpoint_raw_ = raw_;
+        this->values_[0]=0;
+        this->values_[1]=0;
+        raw_.clear();
+        this-> mu_.unlock();
+    }
+    
+    /**
+     * Merges this sketch aggregator with another.  The same bucket compression used when
+     * updating values is employed here to manage bucket size if the merging of aggregators
+     * results in more buckets than allowed.
+     *
+     * @param other, the aggregator with merge with
+     * @return none
+     */
+    void merge(SketchAggregator other)
+    {
+        this-> mu_.lock();
+        if (gamma != other.gamma){
+            throw std::invalid_argument("Aggregators must have identical error tolerance");
+        } else if (max_buckets_ != other.max_buckets_) {
+            throw std::invalid_argument("Aggregators must have the same maximum bucket allowance");
+        }
+        
+        this->values_[0]+=other.values_[0];
+        this->values_[1]+=other.values_[1];
+        auto other_iter = other.raw_.begin();
+        while (other_iter != other.raw_.end()){
+            raw_[other_iter->first] += other_iter->second;
+            if (raw_.size() > max_buckets_){
+                int minidx = raw_.begin()->first, minidxval = raw_.begin()->second;
+                raw_.erase(minidx);
+                raw_[raw_.begin()->first]+=minidxval;
+            }
+            other_iter++;
+        }
+        this-> mu_.unlock();
+    }
+    
+    /**
+     * Returns the checkpointed value
+     *
+     * @param none
+     * @return the value of the checkpoint
+     */
+    std::vector<T> get_checkpoint() override
+    {
+        return this->checkpoint_;
+    }
+    
+    /**
+     * Returns the current values
+     *
+     * @param none
+     * @return the present aggregator values
+     */
+    std::vector<T> get_values() override
+    {
+        return this->values_;
+    }
+    
+    /**
+     * Returns the indices (or values) stored by this sketch aggregator.
+     *
+     * @param none
+     * @return a vector of all values the aggregator is currently tracking
+     */
+    virtual std::vector<double> get_boundaries() override {
+        std::vector<double> ret;
+        for (auto const &x: checkpoint_raw_){
+            ret.push_back(2*pow(gamma, x.first)/(gamma + 1));
+        }
+        return ret;
+    }
+    
+    /**
+     * Returns the count of each value tracked by this sketch aggregator.  These are returned
+     * in the same order as the indices returned by the get_boundaries function.
+     *
+     * @param none
+     * @return a vector of all counts for values tracked by the aggregator
+     */
+    virtual std::vector<int> get_counts() override {
+        std::vector<int> ret;
+        for (auto const &x: checkpoint_raw_){
+            ret.push_back(x.second);
+        }
+        return ret;
+    }
+    
+private:
+    double gamma;
+    size_t max_buckets_;
+    std::map<int,int> raw_;
+    std::map<int,int> checkpoint_raw_;
+};
+
+}
+}
+OPENTELEMETRY_END_NAMESPACE

--- a/sdk/include/opentelemetry/sdk/metrics/aggregator/sketch_aggregator.h
+++ b/sdk/include/opentelemetry/sdk/metrics/aggregator/sketch_aggregator.h
@@ -48,6 +48,7 @@ public:
         this->values_   = std::vector<T>(2, 0); // Sum in [0], Count in [1]
         this->checkpoint_ = std::vector<T>(2, 0);
         max_buckets_ = max_buckets;
+        error_bound_ = error_bound;
         gamma = (1+error_bound)/(1-error_bound);
     }
     

--- a/sdk/include/opentelemetry/sdk/metrics/aggregator/sketch_aggregator.h
+++ b/sdk/include/opentelemetry/sdk/metrics/aggregator/sketch_aggregator.h
@@ -201,7 +201,7 @@ public:
     * @param none
     * @return the error bound specified during construction
     */
-    virtual double get_error_bound(double q) override {
+    virtual double get_error_bound() override {
         return error_bound_;
     }
 
@@ -211,7 +211,7 @@ public:
     * @param none
     * @return the maximum allowed buckets
     */
-    virtual size_t get_max_buckets(double q) override {
+    virtual size_t get_max_buckets() override {
         return max_buckets_;
     }
     

--- a/sdk/include/opentelemetry/sdk/metrics/aggregator/sketch_aggregator.h
+++ b/sdk/include/opentelemetry/sdk/metrics/aggregator/sketch_aggregator.h
@@ -1,15 +1,14 @@
 #pragma once
 
 #include <algorithm>
+#include <cmath>
+#include <map>
 #include <mutex>
 #include "opentelemetry/metrics/instrument.h"
 #include "opentelemetry/version.h"
 #include "opentelemetry/sdk/metrics/aggregator/aggregator.h"
-#include <stdexcept>
-#include <variant>
 #include <vector>
-#include <map>
-#include <cmath>
+#include <stdexcept>
 
 namespace metrics_api = opentelemetry::metrics;
 

--- a/sdk/include/opentelemetry/sdk/metrics/aggregator/sketch_aggregator.h
+++ b/sdk/include/opentelemetry/sdk/metrics/aggregator/sketch_aggregator.h
@@ -80,7 +80,7 @@ public:
      *
      * @param q, the quantile to calculate (for example 0.5 is equivelant to the 50th percentile)
      */
-    int get_quantiles(double q) override {
+    virtual T get_quantiles(double q) override {
         if (q < 0 or q > 1){
 #if __EXCEPTIONS
             throw std::invalid_argument("Quantile values must fall between 0 and 1");
@@ -196,6 +196,26 @@ public:
     }
     
     /**
+    * Returns the error bound
+    *
+    * @param none
+    * @return the error bound specified during construction
+    */
+    virtual double get_error_bound(double q) override {
+        return error_bound_;
+    }
+
+    /**
+    * Returns the maximum allowed buckets
+    *
+    * @param none
+    * @return the maximum allowed buckets
+    */
+    virtual size_t get_max_buckets(double q) override {
+        return max_buckets_;
+    }
+    
+    /**
      * Returns the count of each value tracked by this sketch aggregator.  These are returned
      * in the same order as the indices returned by the get_boundaries function.
      *
@@ -212,6 +232,7 @@ public:
     
 private:
     double gamma;
+    double error_bound_;
     size_t max_buckets_;
     std::map<int,int> raw_;
     std::map<int,int> checkpoint_raw_;

--- a/sdk/test/metrics/BUILD
+++ b/sdk/test/metrics/BUILD
@@ -74,3 +74,14 @@ cc_test(
         "@com_google_googletest//:gtest_main",
     ],
 )
+
+cc_test(
+    name = "sketch_aggregator_test",
+    srcs = [
+        "sketch_aggregator_test.cc",
+    ],
+    deps = [
+        "//sdk/src/metrics",
+        "@com_google_googletest//:gtest_main",
+    ],
+)

--- a/sdk/test/metrics/metric_instrument_test.cc
+++ b/sdk/test/metrics/metric_instrument_test.cc
@@ -69,42 +69,20 @@ TEST(Counter, getAggsandnewupdate)
 {
   Counter<int> alpha("test", "none", "unitless", true);
 
-  std::map<std::string, std::string> labels  = {{"key", "value"}};
-  std::map<std::string, std::string> labels1 = {{"key1", "value1"}};
+  std::map<std::string, std::string> labels = {{"key3", "value3"}, {"key2", "value2"}};
 
-  // labels 2 and 3 are actually the same
-  std::map<std::string, std::string> labels2 = {{"key2", "value2"}, {"key3", "value3"}};
-  std::map<std::string, std::string> labels3 = {{"key3", "value3"}, {"key2", "value2"}};
-
-  auto labelkv  = trace::KeyValueIterableView<decltype(labels)>{labels};
-  auto labelkv1 = trace::KeyValueIterableView<decltype(labels1)>{labels1};
-  auto labelkv2 = trace::KeyValueIterableView<decltype(labels2)>{labels2};
-  auto labelkv3 = trace::KeyValueIterableView<decltype(labels3)>{labels3};
-
+  auto labelkv = trace::KeyValueIterableView<decltype(labels)>{labels};
   auto beta    = alpha.bindCounter(labelkv);
-  auto gamma   = alpha.bindCounter(labelkv1);
-  auto delta   = alpha.bindCounter(labelkv1);
-  auto epsilon = alpha.bindCounter(labelkv1);
-  auto zeta    = alpha.bindCounter(labelkv2);
-  auto eta     = alpha.bindCounter(labelkv3);
+  beta->unbind();
 
-  EXPECT_EQ(beta->get_ref(), 1);
-  EXPECT_EQ(gamma->get_ref(), 3);
-  EXPECT_EQ(eta->get_ref(), 2);
-
-  delta->unbind();
-  gamma->unbind();
-  epsilon->unbind();
-
-  EXPECT_EQ(alpha.boundInstruments_[KvToString(labelkv1)]->get_ref(), 0);
-  EXPECT_EQ(alpha.boundInstruments_.size(), 3);
+  EXPECT_EQ(alpha.boundInstruments_[KvToString(labelkv)]->get_ref(), 0);
+  EXPECT_EQ(alpha.boundInstruments_.size(), 1);
 
   auto theta = alpha.GetRecords();
-  EXPECT_EQ(theta.size(), 3);
+  EXPECT_EQ(theta.size(), 1);
   EXPECT_EQ(theta[0].GetName(), "test");
   EXPECT_EQ(theta[0].GetDescription(), "none");
   EXPECT_EQ(theta[0].GetLabels(), "{\"key2\":\"value2\",\"key3\":\"value3\"}");
-  EXPECT_EQ(theta[1].GetLabels(), "{\"key1\":\"value1\"}");
 }
 
 void CounterCallback(std::shared_ptr<Counter<int>> in,

--- a/sdk/test/metrics/sketch_aggregator_test.cc
+++ b/sdk/test/metrics/sketch_aggregator_test.cc
@@ -1,0 +1,226 @@
+#include "opentelemetry/sdk/metrics/aggregator/sketch_aggregator.h"
+
+#include <gtest/gtest.h>
+#include <thread>
+#include <numeric>
+#include <iostream>
+
+namespace metrics_api = opentelemetry::metrics;
+
+OPENTELEMETRY_BEGIN_NAMESPACE
+namespace sdk
+{
+namespace metrics
+{
+
+// Test updating with a uniform set of updates
+TEST(Sketch, UniformValues)
+{
+    std::vector<double> boundaries{10,20,30,40,50};
+    SketchAggregator<int> alpha(metrics_api::InstrumentKind::ValueRecorder, .000005);
+
+    EXPECT_EQ(alpha.get_aggregator_kind(), AggregatorKind::Sketch);
+
+    alpha.checkpoint();
+    EXPECT_EQ(alpha.get_checkpoint().size(),2);
+    EXPECT_EQ(alpha.get_boundaries().size(),0);
+    EXPECT_EQ(alpha.get_counts().size(),0);
+
+    for (int i = 0; i< 60; i++){
+        alpha.update(i);
+    }
+
+    alpha.checkpoint();
+
+    EXPECT_EQ(alpha.get_boundaries().size(),60);
+    EXPECT_EQ(alpha.get_counts().size(),60);
+
+    EXPECT_EQ(alpha.get_checkpoint()[0], 1770);
+    EXPECT_EQ(alpha.get_checkpoint()[1], 60);
+
+}
+
+// Test updating with a normal distribution
+TEST(Sketch, NormalValues)
+{
+    SketchAggregator<int> alpha(metrics_api::InstrumentKind::ValueRecorder, .0005);
+
+    std::vector<int> vals{1,3,3,5,5,5,7,7,7,7,9,9,9,11,11,13};
+    for (int i : vals){
+        alpha.update(i);
+    }
+    alpha.checkpoint();
+
+    EXPECT_EQ(alpha.get_checkpoint()[0], std::accumulate(vals.begin(),vals.end(),0));
+    EXPECT_EQ(alpha.get_checkpoint()[1], vals.size());
+
+    std::vector<int> correct = {1,2,3,4,3,2,1};
+    EXPECT_EQ(alpha.get_counts(), correct);
+
+    std::vector<double> captured_bounds = alpha.get_boundaries();
+    for (int i = 0; i < captured_bounds.size(); i++){
+        captured_bounds[i] = round(captured_bounds[i]);
+    }
+
+    //It is not guaranteed that bounds are correct once the bucket sizes pass 1000
+    std::vector<double> correct_bounds = {1,3,5,7,9,11,13};
+    EXPECT_EQ(captured_bounds, correct_bounds);
+}
+
+int randVal(){
+    return rand() % 100000;
+}
+
+/** Note that in this case, "Large" refers to a number of distinct values which exceed the maximum
+ * number of allowed buckets.
+ */
+TEST(Sketch, QuantileSmall){
+    SketchAggregator<int> alpha(metrics_api::InstrumentKind::ValueRecorder, .00005);
+
+    std::vector<int> vals1(2048);
+    std::generate(vals1.begin(),vals1.end(),randVal);
+
+    std::vector<int> vals2(2048);
+    std::generate(vals1.begin(),vals1.end(),randVal);
+
+    for (int i: vals1){
+        alpha.update(i);
+    }
+    alpha.checkpoint();
+    std::sort(vals1.begin(),vals1.end());
+
+    EXPECT_TRUE(abs(alpha.get_quantiles(.25) - vals1[2048*.25 - 1]) <= 1);
+    EXPECT_TRUE(abs(alpha.get_quantiles(.50) - vals1[2048*.50 - 1]) <= 1);
+    EXPECT_TRUE(abs(alpha.get_quantiles(.75) - vals1[2048*.75 - 1]) <= 1);
+}
+
+TEST(Sketch, UpdateQuantileLarge){
+    SketchAggregator<int> alpha(metrics_api::InstrumentKind::ValueRecorder, .0005, 7);
+    std::vector<int> vals{1,3,3,5,5,5,7,7,7,7,9,9,9,11,11,13};
+    for (int i : vals){
+        alpha.update(i);
+    }
+
+    // This addition should trigger the "1" and "3" buckets to merge
+    alpha.update(15);
+    alpha.checkpoint();
+
+    std::vector<int> correct = {3,3,4,3,2,1,1};
+    EXPECT_EQ(alpha.get_counts(), correct);
+
+    for (int i : vals){
+        alpha.update(i);
+    }
+    alpha.update(15);
+    alpha.update(17);
+    alpha.checkpoint();
+
+    correct = {6,4,3,2,1,1,1};
+    EXPECT_EQ(alpha.get_counts(), correct);
+}
+
+
+TEST(Sketch, MergeSmall){
+    SketchAggregator<int> alpha(metrics_api::InstrumentKind::ValueRecorder, .0005);
+    SketchAggregator<int> beta(metrics_api::InstrumentKind::ValueRecorder, .0005);
+
+    std::vector<int> vals{1,3,3,5,5,5,7,7,7,7,9,9,9,11,11,13};
+    for (int i : vals){
+        alpha.update(i);
+    }
+
+    std::vector<int> otherVals{1,1,1,1,11,11,13,13,13,15};
+    for (int i : otherVals){
+        beta.update(i);
+    }
+
+    alpha.merge(beta);
+    alpha.checkpoint();
+
+    EXPECT_EQ(alpha.get_checkpoint()[0], std::accumulate(vals.begin(),vals.end(),0)+std::accumulate(otherVals.begin(), otherVals.end(), 0));
+    EXPECT_EQ(alpha.get_checkpoint()[1], vals.size()+otherVals.size());
+
+    std::vector<int> correct = {5,2,3,4,3,4,4,1};
+    EXPECT_EQ(alpha.get_counts(), correct);
+}
+
+TEST(Sketch, MergeLarge){
+    SketchAggregator<int> alpha(metrics_api::InstrumentKind::ValueRecorder, .0005, 7);
+    SketchAggregator<int> beta(metrics_api::InstrumentKind::ValueRecorder, .0005, 7);
+
+    std::vector<int> vals{1,3,3,5,5,5,7,7,7,7,9,9,9,11,11,13};
+    for (int i : vals){
+        alpha.update(i);
+    }
+
+    std::vector<int> otherVals{1,1,1,1,11,11,13,13,13,15};
+    for (int i : otherVals){
+        beta.update(i);
+    }
+
+    alpha.merge(beta);
+    alpha.checkpoint();
+
+    EXPECT_EQ(alpha.get_checkpoint()[0], std::accumulate(vals.begin(),vals.end(),0)+std::accumulate(otherVals.begin(), otherVals.end(), 0));
+    EXPECT_EQ(alpha.get_checkpoint()[1], vals.size()+otherVals.size());
+
+    std::vector<int> correct = {7,3,4,3,4,4,1};
+    EXPECT_EQ(alpha.get_counts(), correct);
+}
+
+// Update callback used to validate multi-threaded performance
+void sketchUpdateCallback(Aggregator<int> & agg, std::vector<int> vals){
+    for (int i: vals){
+        agg.update(i);
+    }
+}
+
+TEST(Sketch, Concurrency){
+    SketchAggregator<int> alpha(metrics_api::InstrumentKind::ValueRecorder, .0005, 20);
+
+    std::vector<int> vals1(1000);
+    std::generate(vals1.begin(),vals1.end(),randVal);
+
+    std::vector<int> vals2(1000);
+    std::generate(vals2.begin(),vals2.end(),randVal);
+
+    std::thread first (sketchUpdateCallback, std::ref(alpha), vals1);
+    std::thread second (sketchUpdateCallback, std::ref(alpha), vals2);
+
+    first.join();
+    second.join();
+
+    SketchAggregator<int> beta(metrics_api::InstrumentKind::ValueRecorder, .0005, 20);
+
+    for (int i: vals1){
+        beta.update(i);
+    }
+    for (int i: vals2){
+        beta.update(i);
+    }
+
+    alpha.checkpoint();
+    beta.checkpoint();
+
+    EXPECT_EQ(alpha.get_checkpoint(), beta.get_checkpoint());
+    EXPECT_EQ(alpha.get_counts(), beta.get_counts());
+    EXPECT_EQ(alpha.get_boundaries(), beta.get_boundaries());
+}
+
+TEST(Sketch, Errors){
+
+    SketchAggregator<int> tol1(metrics_api::InstrumentKind::ValueRecorder, .000005);
+    SketchAggregator<int> tol2(metrics_api::InstrumentKind::ValueRecorder, .005);
+    SketchAggregator<int> sz1(metrics_api::InstrumentKind::ValueRecorder, .000005, 2938);
+    SketchAggregator<int> sz2(metrics_api::InstrumentKind::ValueRecorder, .000005);
+
+    EXPECT_ANY_THROW(tol1.merge(tol2));
+    EXPECT_ANY_THROW(sz1.merge(sz2));
+    EXPECT_ANY_THROW(tol1.get_quantiles(-.000001));
+    EXPECT_ANY_THROW(tol1.get_quantiles(1.000001));
+}
+
+
+}  // namespace sdk
+}  // namespace metrics
+OPENTELEMETRY_END_NAMESPACE

--- a/sdk/test/metrics/sketch_aggregator_test.cc
+++ b/sdk/test/metrics/sketch_aggregator_test.cc
@@ -1,9 +1,9 @@
 #include "opentelemetry/sdk/metrics/aggregator/sketch_aggregator.h"
 
 #include <gtest/gtest.h>
-#include <thread>
-#include <numeric>
 #include <iostream>
+#include <numeric>
+#include <thread>
 
 namespace metrics_api = opentelemetry::metrics;
 
@@ -16,217 +16,235 @@ namespace metrics
 // Test updating with a uniform set of updates
 TEST(Sketch, UniformValues)
 {
-    std::vector<double> boundaries{10,20,30,40,50};
-    SketchAggregator<int> alpha(metrics_api::InstrumentKind::ValueRecorder, .000005);
+  std::vector<double> boundaries{10, 20, 30, 40, 50};
+  SketchAggregator<int> alpha(metrics_api::InstrumentKind::ValueRecorder, .000005);
 
-    EXPECT_EQ(alpha.get_aggregator_kind(), AggregatorKind::Sketch);
+  EXPECT_EQ(alpha.get_aggregator_kind(), AggregatorKind::Sketch);
 
-    alpha.checkpoint();
-    EXPECT_EQ(alpha.get_checkpoint().size(),2);
-    EXPECT_EQ(alpha.get_boundaries().size(),0);
-    EXPECT_EQ(alpha.get_counts().size(),0);
+  alpha.checkpoint();
+  EXPECT_EQ(alpha.get_checkpoint().size(), 2);
+  EXPECT_EQ(alpha.get_boundaries().size(), 0);
+  EXPECT_EQ(alpha.get_counts().size(), 0);
 
-    for (int i = 0; i< 60; i++){
-        alpha.update(i);
-    }
+  for (int i = 0; i < 60; i++)
+  {
+    alpha.update(i);
+  }
 
-    alpha.checkpoint();
+  alpha.checkpoint();
 
-    EXPECT_EQ(alpha.get_boundaries().size(),60);
-    EXPECT_EQ(alpha.get_counts().size(),60);
+  EXPECT_EQ(alpha.get_boundaries().size(), 60);
+  EXPECT_EQ(alpha.get_counts().size(), 60);
 
-    EXPECT_EQ(alpha.get_checkpoint()[0], 1770);
-    EXPECT_EQ(alpha.get_checkpoint()[1], 60);
-
+  EXPECT_EQ(alpha.get_checkpoint()[0], 1770);
+  EXPECT_EQ(alpha.get_checkpoint()[1], 60);
 }
 
 // Test updating with a normal distribution
 TEST(Sketch, NormalValues)
 {
-    SketchAggregator<int> alpha(metrics_api::InstrumentKind::ValueRecorder, .0005);
+  SketchAggregator<int> alpha(metrics_api::InstrumentKind::ValueRecorder, .0005);
 
-    std::vector<int> vals{1,3,3,5,5,5,7,7,7,7,9,9,9,11,11,13};
-    for (int i : vals){
-        alpha.update(i);
-    }
-    alpha.checkpoint();
+  std::vector<int> vals{1, 3, 3, 5, 5, 5, 7, 7, 7, 7, 9, 9, 9, 11, 11, 13};
+  for (int i : vals)
+  {
+    alpha.update(i);
+  }
+  alpha.checkpoint();
 
-    EXPECT_EQ(alpha.get_checkpoint()[0], std::accumulate(vals.begin(),vals.end(),0));
-    EXPECT_EQ(alpha.get_checkpoint()[1], vals.size());
+  EXPECT_EQ(alpha.get_checkpoint()[0], std::accumulate(vals.begin(), vals.end(), 0));
+  EXPECT_EQ(alpha.get_checkpoint()[1], vals.size());
 
-    std::vector<int> correct = {1,2,3,4,3,2,1};
-    EXPECT_EQ(alpha.get_counts(), correct);
+  std::vector<int> correct = {1, 2, 3, 4, 3, 2, 1};
+  EXPECT_EQ(alpha.get_counts(), correct);
 
-    std::vector<double> captured_bounds = alpha.get_boundaries();
-    for (int i = 0; i < captured_bounds.size(); i++){
-        captured_bounds[i] = round(captured_bounds[i]);
-    }
+  std::vector<double> captured_bounds = alpha.get_boundaries();
+  for (int i = 0; i < captured_bounds.size(); i++)
+  {
+    captured_bounds[i] = round(captured_bounds[i]);
+  }
 
-    //It is not guaranteed that bounds are correct once the bucket sizes pass 1000
-    std::vector<double> correct_bounds = {1,3,5,7,9,11,13};
-    EXPECT_EQ(captured_bounds, correct_bounds);
+  // It is not guaranteed that bounds are correct once the bucket sizes pass 1000
+  std::vector<double> correct_bounds = {1, 3, 5, 7, 9, 11, 13};
+  EXPECT_EQ(captured_bounds, correct_bounds);
 }
 
-int randVal(){
-    return rand() % 100000;
+int randVal()
+{
+  return rand() % 100000;
 }
 
 /** Note that in this case, "Large" refers to a number of distinct values which exceed the maximum
  * number of allowed buckets.
  */
-TEST(Sketch, QuantileSmall){
-    SketchAggregator<int> alpha(metrics_api::InstrumentKind::ValueRecorder, .00005);
+TEST(Sketch, QuantileSmall)
+{
+  SketchAggregator<int> alpha(metrics_api::InstrumentKind::ValueRecorder, .00005);
 
-    std::vector<int> vals1(2048);
-    std::generate(vals1.begin(),vals1.end(),randVal);
+  std::vector<int> vals1(2048);
+  std::generate(vals1.begin(), vals1.end(), randVal);
 
-    std::vector<int> vals2(2048);
-    std::generate(vals1.begin(),vals1.end(),randVal);
+  std::vector<int> vals2(2048);
+  std::generate(vals1.begin(), vals1.end(), randVal);
 
-    for (int i: vals1){
-        alpha.update(i);
-    }
-    alpha.checkpoint();
-    std::sort(vals1.begin(),vals1.end());
+  for (int i : vals1)
+  {
+    alpha.update(i);
+  }
+  alpha.checkpoint();
+  std::sort(vals1.begin(), vals1.end());
 
-    std::cerr <<abs(alpha.get_quantiles(.25) - vals1[2048*.25 - 1]) <<std::endl;
-    EXPECT_TRUE(abs(alpha.get_quantiles(.25) - vals1[2048*.25 - 1]) <= 1);
-    std::cerr <<abs(alpha.get_quantiles(.50) - vals1[2048*.50 - 1]) <<std::endl;
-    EXPECT_TRUE(abs(alpha.get_quantiles(.50) - vals1[2048*.50 - 1]) <= 1);
-    std::cerr <<abs(alpha.get_quantiles(.75) - vals1[2048*.75 - 1]) <<std::endl;
-    EXPECT_TRUE(abs(alpha.get_quantiles(.75) - vals1[2048*.75 - 1]) <= 1);
+  EXPECT_TRUE(abs(alpha.get_quantiles(.25) - vals1[2048 * .25 - 1]) <= 10);
+  EXPECT_TRUE(abs(alpha.get_quantiles(.50) - vals1[2048 * .50 - 1]) <= 10);
+  EXPECT_TRUE(abs(alpha.get_quantiles(.75) - vals1[2048 * .75 - 1]) <= 10);
 }
 
-TEST(Sketch, UpdateQuantileLarge){
-    SketchAggregator<int> alpha(metrics_api::InstrumentKind::ValueRecorder, .0005, 7);
-    std::vector<int> vals{1,3,3,5,5,5,7,7,7,7,9,9,9,11,11,13};
-    for (int i : vals){
-        alpha.update(i);
-    }
+TEST(Sketch, UpdateQuantileLarge)
+{
+  SketchAggregator<int> alpha(metrics_api::InstrumentKind::ValueRecorder, .0005, 7);
+  std::vector<int> vals{1, 3, 3, 5, 5, 5, 7, 7, 7, 7, 9, 9, 9, 11, 11, 13};
+  for (int i : vals)
+  {
+    alpha.update(i);
+  }
 
-    // This addition should trigger the "1" and "3" buckets to merge
-    alpha.update(15);
-    alpha.checkpoint();
+  // This addition should trigger the "1" and "3" buckets to merge
+  alpha.update(15);
+  alpha.checkpoint();
 
-    std::vector<int> correct = {3,3,4,3,2,1,1};
-    EXPECT_EQ(alpha.get_counts(), correct);
+  std::vector<int> correct = {3, 3, 4, 3, 2, 1, 1};
+  EXPECT_EQ(alpha.get_counts(), correct);
 
-    for (int i : vals){
-        alpha.update(i);
-    }
-    alpha.update(15);
-    alpha.update(17);
-    alpha.checkpoint();
+  for (int i : vals)
+  {
+    alpha.update(i);
+  }
+  alpha.update(15);
+  alpha.update(17);
+  alpha.checkpoint();
 
-    correct = {6,4,3,2,1,1,1};
-    EXPECT_EQ(alpha.get_counts(), correct);
+  correct = {6, 4, 3, 2, 1, 1, 1};
+  EXPECT_EQ(alpha.get_counts(), correct);
 }
 
+TEST(Sketch, MergeSmall)
+{
+  SketchAggregator<int> alpha(metrics_api::InstrumentKind::ValueRecorder, .0005);
+  SketchAggregator<int> beta(metrics_api::InstrumentKind::ValueRecorder, .0005);
 
-TEST(Sketch, MergeSmall){
-    SketchAggregator<int> alpha(metrics_api::InstrumentKind::ValueRecorder, .0005);
-    SketchAggregator<int> beta(metrics_api::InstrumentKind::ValueRecorder, .0005);
+  std::vector<int> vals{1, 3, 3, 5, 5, 5, 7, 7, 7, 7, 9, 9, 9, 11, 11, 13};
+  for (int i : vals)
+  {
+    alpha.update(i);
+  }
 
-    std::vector<int> vals{1,3,3,5,5,5,7,7,7,7,9,9,9,11,11,13};
-    for (int i : vals){
-        alpha.update(i);
-    }
+  std::vector<int> otherVals{1, 1, 1, 1, 11, 11, 13, 13, 13, 15};
+  for (int i : otherVals)
+  {
+    beta.update(i);
+  }
 
-    std::vector<int> otherVals{1,1,1,1,11,11,13,13,13,15};
-    for (int i : otherVals){
-        beta.update(i);
-    }
+  alpha.merge(beta);
+  alpha.checkpoint();
 
-    alpha.merge(beta);
-    alpha.checkpoint();
+  EXPECT_EQ(alpha.get_checkpoint()[0], std::accumulate(vals.begin(), vals.end(), 0) +
+                                           std::accumulate(otherVals.begin(), otherVals.end(), 0));
+  EXPECT_EQ(alpha.get_checkpoint()[1], vals.size() + otherVals.size());
 
-    EXPECT_EQ(alpha.get_checkpoint()[0], std::accumulate(vals.begin(),vals.end(),0)+std::accumulate(otherVals.begin(), otherVals.end(), 0));
-    EXPECT_EQ(alpha.get_checkpoint()[1], vals.size()+otherVals.size());
-
-    std::vector<int> correct = {5,2,3,4,3,4,4,1};
-    EXPECT_EQ(alpha.get_counts(), correct);
+  std::vector<int> correct = {5, 2, 3, 4, 3, 4, 4, 1};
+  EXPECT_EQ(alpha.get_counts(), correct);
 }
 
-TEST(Sketch, MergeLarge){
-    SketchAggregator<int> alpha(metrics_api::InstrumentKind::ValueRecorder, .0005, 7);
-    SketchAggregator<int> beta(metrics_api::InstrumentKind::ValueRecorder, .0005, 7);
+TEST(Sketch, MergeLarge)
+{
+  SketchAggregator<int> alpha(metrics_api::InstrumentKind::ValueRecorder, .0005, 7);
+  SketchAggregator<int> beta(metrics_api::InstrumentKind::ValueRecorder, .0005, 7);
 
-    std::vector<int> vals{1,3,3,5,5,5,7,7,7,7,9,9,9,11,11,13};
-    for (int i : vals){
-        alpha.update(i);
-    }
+  std::vector<int> vals{1, 3, 3, 5, 5, 5, 7, 7, 7, 7, 9, 9, 9, 11, 11, 13};
+  for (int i : vals)
+  {
+    alpha.update(i);
+  }
 
-    std::vector<int> otherVals{1,1,1,1,11,11,13,13,13,15};
-    for (int i : otherVals){
-        beta.update(i);
-    }
+  std::vector<int> otherVals{1, 1, 1, 1, 11, 11, 13, 13, 13, 15};
+  for (int i : otherVals)
+  {
+    beta.update(i);
+  }
 
-    alpha.merge(beta);
-    alpha.checkpoint();
+  alpha.merge(beta);
+  alpha.checkpoint();
 
-    EXPECT_EQ(alpha.get_checkpoint()[0], std::accumulate(vals.begin(),vals.end(),0)+std::accumulate(otherVals.begin(), otherVals.end(), 0));
-    EXPECT_EQ(alpha.get_checkpoint()[1], vals.size()+otherVals.size());
+  EXPECT_EQ(alpha.get_checkpoint()[0], std::accumulate(vals.begin(), vals.end(), 0) +
+                                           std::accumulate(otherVals.begin(), otherVals.end(), 0));
+  EXPECT_EQ(alpha.get_checkpoint()[1], vals.size() + otherVals.size());
 
-    std::vector<int> correct = {7,3,4,3,4,4,1};
-    EXPECT_EQ(alpha.get_counts(), correct);
+  std::vector<int> correct = {7, 3, 4, 3, 4, 4, 1};
+  EXPECT_EQ(alpha.get_counts(), correct);
 }
 
 // Update callback used to validate multi-threaded performance
-void sketchUpdateCallback(Aggregator<int> & agg, std::vector<int> vals){
-    for (int i: vals){
-        agg.update(i);
-    }
+void sketchUpdateCallback(Aggregator<int> &agg, std::vector<int> vals)
+{
+  for (int i : vals)
+  {
+    agg.update(i);
+  }
 }
 
-TEST(Sketch, Concurrency){
-    SketchAggregator<int> alpha(metrics_api::InstrumentKind::ValueRecorder, .0005, 20);
+TEST(Sketch, Concurrency)
+{
+  SketchAggregator<int> alpha(metrics_api::InstrumentKind::ValueRecorder, .0005, 20);
 
-    std::vector<int> vals1(1000);
-    std::generate(vals1.begin(),vals1.end(),randVal);
+  std::vector<int> vals1(1000);
+  std::generate(vals1.begin(), vals1.end(), randVal);
 
-    std::vector<int> vals2(1000);
-    std::generate(vals2.begin(),vals2.end(),randVal);
+  std::vector<int> vals2(1000);
+  std::generate(vals2.begin(), vals2.end(), randVal);
 
-    std::thread first (sketchUpdateCallback, std::ref(alpha), vals1);
-    std::thread second (sketchUpdateCallback, std::ref(alpha), vals2);
+  std::thread first(sketchUpdateCallback, std::ref(alpha), vals1);
+  std::thread second(sketchUpdateCallback, std::ref(alpha), vals2);
 
-    first.join();
-    second.join();
+  first.join();
+  second.join();
 
-    SketchAggregator<int> beta(metrics_api::InstrumentKind::ValueRecorder, .0005, 20);
+  SketchAggregator<int> beta(metrics_api::InstrumentKind::ValueRecorder, .0005, 20);
 
-    for (int i: vals1){
-        beta.update(i);
-    }
-    for (int i: vals2){
-        beta.update(i);
-    }
+  for (int i : vals1)
+  {
+    beta.update(i);
+  }
+  for (int i : vals2)
+  {
+    beta.update(i);
+  }
 
-    alpha.checkpoint();
-    beta.checkpoint();
+  alpha.checkpoint();
+  beta.checkpoint();
 
-    EXPECT_EQ(alpha.get_checkpoint(), beta.get_checkpoint());
-    EXPECT_EQ(alpha.get_counts(), beta.get_counts());
-    EXPECT_EQ(alpha.get_boundaries(), beta.get_boundaries());
+  EXPECT_EQ(alpha.get_checkpoint(), beta.get_checkpoint());
+  EXPECT_EQ(alpha.get_counts(), beta.get_counts());
+  EXPECT_EQ(alpha.get_boundaries(), beta.get_boundaries());
 }
 
 #if __EXCEPTIONS
-            
-TEST(Sketch, Errors){
 
-    SketchAggregator<int> tol1(metrics_api::InstrumentKind::ValueRecorder, .000005);
-    SketchAggregator<int> tol2(metrics_api::InstrumentKind::ValueRecorder, .005);
-    SketchAggregator<int> sz1(metrics_api::InstrumentKind::ValueRecorder, .000005, 2938);
-    SketchAggregator<int> sz2(metrics_api::InstrumentKind::ValueRecorder, .000005);
+TEST(Sketch, Errors)
+{
 
-    EXPECT_ANY_THROW(tol1.merge(tol2));
-    EXPECT_ANY_THROW(sz1.merge(sz2));
-    EXPECT_ANY_THROW(tol1.get_quantiles(-.000001));
-    EXPECT_ANY_THROW(tol1.get_quantiles(1.000001));
+  SketchAggregator<int> tol1(metrics_api::InstrumentKind::ValueRecorder, .000005);
+  SketchAggregator<int> tol2(metrics_api::InstrumentKind::ValueRecorder, .005);
+  SketchAggregator<int> sz1(metrics_api::InstrumentKind::ValueRecorder, .000005, 2938);
+  SketchAggregator<int> sz2(metrics_api::InstrumentKind::ValueRecorder, .000005);
+
+  EXPECT_ANY_THROW(tol1.merge(tol2));
+  EXPECT_ANY_THROW(sz1.merge(sz2));
+  EXPECT_ANY_THROW(tol1.get_quantiles(-.000001));
+  EXPECT_ANY_THROW(tol1.get_quantiles(1.000001));
 }
 
 #endif
 
-}  // namespace sdk
 }  // namespace metrics
+}  // namespace sdk
 OPENTELEMETRY_END_NAMESPACE

--- a/sdk/test/metrics/sketch_aggregator_test.cc
+++ b/sdk/test/metrics/sketch_aggregator_test.cc
@@ -89,8 +89,11 @@ TEST(Sketch, QuantileSmall){
     alpha.checkpoint();
     std::sort(vals1.begin(),vals1.end());
 
+    std::cerr <<abs(alpha.get_quantiles(.25) - vals1[2048*.25 - 1]) <<std::endl;
     EXPECT_TRUE(abs(alpha.get_quantiles(.25) - vals1[2048*.25 - 1]) <= 1);
+    std::cerr <<abs(alpha.get_quantiles(.50) - vals1[2048*.50 - 1]) <<std::endl;
     EXPECT_TRUE(abs(alpha.get_quantiles(.50) - vals1[2048*.50 - 1]) <= 1);
+    std::cerr <<abs(alpha.get_quantiles(.75) - vals1[2048*.75 - 1]) <<std::endl;
     EXPECT_TRUE(abs(alpha.get_quantiles(.75) - vals1[2048*.75 - 1]) <= 1);
 }
 

--- a/sdk/test/metrics/sketch_aggregator_test.cc
+++ b/sdk/test/metrics/sketch_aggregator_test.cc
@@ -16,7 +16,6 @@ namespace metrics
 // Test updating with a uniform set of updates
 TEST(Sketch, UniformValues)
 {
-  std::vector<double> boundaries{10, 20, 30, 40, 50};
   SketchAggregator<int> alpha(metrics_api::InstrumentKind::ValueRecorder, .000005);
 
   EXPECT_EQ(alpha.get_aggregator_kind(), AggregatorKind::Sketch);
@@ -59,7 +58,7 @@ TEST(Sketch, NormalValues)
   EXPECT_EQ(alpha.get_counts(), correct);
 
   std::vector<double> captured_bounds = alpha.get_boundaries();
-  for (size_t i = 0; i < (size_t)captured_bounds.size(); i++)
+  for (int i = 0; i < captured_bounds.size(); i++)
   {
     captured_bounds[i] = round(captured_bounds[i]);
   }

--- a/sdk/test/metrics/sketch_aggregator_test.cc
+++ b/sdk/test/metrics/sketch_aggregator_test.cc
@@ -59,8 +59,7 @@ TEST(Sketch, NormalValues)
   EXPECT_EQ(alpha.get_counts(), correct);
 
   std::vector<double> captured_bounds = alpha.get_boundaries();
-    std::cerr <<"captured bounds size " <<captured_bounds.size() <<std::endl;
-  for (int i = 0; i < captured_bounds.size(); i++)
+  for (size_t i = 0; i < (size_t)captured_bounds.size(); i++)
   {
     captured_bounds[i] = round(captured_bounds[i]);
   }

--- a/sdk/test/metrics/sketch_aggregator_test.cc
+++ b/sdk/test/metrics/sketch_aggregator_test.cc
@@ -59,6 +59,7 @@ TEST(Sketch, NormalValues)
   EXPECT_EQ(alpha.get_counts(), correct);
 
   std::vector<double> captured_bounds = alpha.get_boundaries();
+    std::cerr <<"captured bounds size " <<captured_bounds.size() <<std::endl;
   for (int i = 0; i < captured_bounds.size(); i++)
   {
     captured_bounds[i] = round(captured_bounds[i]);

--- a/sdk/test/metrics/sketch_aggregator_test.cc
+++ b/sdk/test/metrics/sketch_aggregator_test.cc
@@ -207,6 +207,8 @@ TEST(Sketch, Concurrency){
     EXPECT_EQ(alpha.get_boundaries(), beta.get_boundaries());
 }
 
+#if __EXCEPTIONS
+            
 TEST(Sketch, Errors){
 
     SketchAggregator<int> tol1(metrics_api::InstrumentKind::ValueRecorder, .000005);
@@ -220,6 +222,7 @@ TEST(Sketch, Errors){
     EXPECT_ANY_THROW(tol1.get_quantiles(1.000001));
 }
 
+#endif
 
 }  // namespace sdk
 }  // namespace metrics


### PR DESCRIPTION
This PR builds out SDK support for the [Sketch Aggregator](https://github.com/jmacd/opentelemetry-specification/blob/jmacd/draft_metric_sdk_spec/specification/metrics/sdk.md#aggregator-implementations) which combines updates to metric instruments in meaningful values.  This aggregator in particular uses a compression scheme which preserves accuracy when distributions as severely skewed right.  More information about the algorithm can be found in Datadog's paper on [DDSketch](http://www.vldb.org/pvldb/vol12/p2195-masson.pdf).  The aggregator is dependent on the Metric Instruments API  (pending approval in [PR # 161](https://github.com/open-telemetry/opentelemetry-cpp/pull/161)) and the aggregator base classes [PR # 178](https://github.com/open-telemetry/opentelemetry-cpp/pull/178) --  it  **will not compile without those files.**

Also included are tests for which validate the correctness of aggregation in both single-threaded and concurrent situations.
