### PR TITLE
zPages: Copy constructor for zpages recordable

### DIFF
--- a/ext/include/opentelemetry/ext/zpages/threadsafe_span_data.h
+++ b/ext/include/opentelemetry/ext/zpages/threadsafe_span_data.h
@@ -168,6 +168,24 @@ class ThreadsafeSpanData final : public opentelemetry::sdk::trace::Recordable {
     events_.push_back(SpanDataEvent(std::string(name), timestamp));
     // TODO: handle attributes
   }
+  
+  ThreadsafeSpanData (const ThreadsafeSpanData &threadsafe_span_data)
+  {
+    std::lock_guard<std::mutex> lock(threadsafe_span_data.mutex_);
+    trace_id_ = threadsafe_span_data.trace_id_;
+    span_id_ = threadsafe_span_data.span_id_;
+    parent_span_id_ = threadsafe_span_data.parent_span_id_;
+    start_time_ = threadsafe_span_data.start_time_;
+    duration_ = threadsafe_span_data.duration_;
+    name_ = threadsafe_span_data.name_;
+    status_code_ = threadsafe_span_data.status_code_;
+    status_desc_ = threadsafe_span_data.status_desc_;
+    attributes_ = threadsafe_span_data.attributes_;
+    events_ = threadsafe_span_data.events_;
+    converter_ = threadsafe_span_data.converter_;
+  }
+
+  ThreadsafeSpanData(){};
 
  private:
   mutable std::mutex mutex_;

--- a/ext/include/opentelemetry/ext/zpages/tracez_processor.h
+++ b/ext/include/opentelemetry/ext/zpages/tracez_processor.h
@@ -9,7 +9,7 @@
 
 #include "opentelemetry/sdk/trace/processor.h"
 #include "opentelemetry/sdk/trace/recordable.h"
-#include "opentelemetry/sdk/trace/span_data.h"
+#include "opentelemetry/ext/zpages/threadsafe_span_data.h"
 
 OPENTELEMETRY_BEGIN_NAMESPACE
 namespace ext
@@ -24,8 +24,8 @@ class TracezSpanProcessor : public opentelemetry::sdk::trace::SpanProcessor {
  public:
 
   struct CollectedSpans {
-    std::unordered_set<opentelemetry::sdk::trace::SpanData*> running;
-    std::vector<std::unique_ptr<opentelemetry::sdk::trace::SpanData>> completed;
+    std::unordered_set<ThreadsafeSpanData*> running;
+    std::vector<std::unique_ptr<ThreadsafeSpanData>> completed;
   };
 
   /*
@@ -39,7 +39,7 @@ class TracezSpanProcessor : public opentelemetry::sdk::trace::SpanProcessor {
    */
   std::unique_ptr<opentelemetry::sdk::trace::Recordable> MakeRecordable() noexcept override
   {
-    return std::unique_ptr<opentelemetry::sdk::trace::Recordable>(new opentelemetry::sdk::trace::SpanData);
+    return std::unique_ptr<opentelemetry::sdk::trace::Recordable>(new ThreadsafeSpanData);
   }
 
   /*

--- a/ext/src/zpages/tracez_processor.cc
+++ b/ext/src/zpages/tracez_processor.cc
@@ -6,19 +6,19 @@ namespace zpages {
 
   void TracezSpanProcessor::OnStart(opentelemetry::sdk::trace::Recordable &span) noexcept {
     std::lock_guard<std::mutex> lock(mtx_);
-    spans_.running.insert(static_cast<opentelemetry::sdk::trace::SpanData*>(&span));
+    spans_.running.insert(static_cast<ThreadsafeSpanData*>(&span));
   }
 
   void TracezSpanProcessor::OnEnd(std::unique_ptr<opentelemetry::sdk::trace::Recordable> &&span) noexcept {
     if (span == nullptr) return;
-    auto span_raw = static_cast<opentelemetry::sdk::trace::SpanData*>(span.get());
+    auto span_raw = static_cast<ThreadsafeSpanData*>(span.get());
     std::lock_guard<std::mutex> lock(mtx_);
     auto span_it = spans_.running.find(span_raw);
     if (span_it != spans_.running.end()) {
       spans_.running.erase(span_it);
       spans_.completed.push_back(
-          std::unique_ptr<opentelemetry::sdk::trace::SpanData>(
-              static_cast<opentelemetry::sdk::trace::SpanData*>(span.release())));
+          std::unique_ptr<ThreadsafeSpanData>(
+              static_cast<ThreadsafeSpanData*>(span.release())));
     }
   }
 

--- a/ext/test/zpages/tracez_processor_test.cc
+++ b/ext/test/zpages/tracez_processor_test.cc
@@ -5,7 +5,7 @@
 #include <thread>
 
 #include "opentelemetry/nostd/span.h"
-#include "opentelemetry/sdk/trace/span_data.h"
+#include "opentelemetry/ext/zpages/threadsafe_span_data.h"
 #include "opentelemetry/sdk/trace/tracer.h"
 
 using namespace opentelemetry::sdk::trace;
@@ -18,8 +18,8 @@ using namespace opentelemetry::ext::zpages;
  * and running_spans. completed_spans contains all spans (cumulative), unless marked otherwise
  */
 void UpdateSpans(std::shared_ptr<TracezSpanProcessor>& processor,
-    std::vector<std::unique_ptr<opentelemetry::sdk::trace::SpanData>>& completed,
-    std::unordered_set<opentelemetry::sdk::trace::SpanData*>& running,
+    std::vector<std::unique_ptr<ThreadsafeSpanData>>& completed,
+    std::unordered_set<ThreadsafeSpanData*>& running,
     bool store_only_new_completed = false) {
   auto spans = processor->GetSpanSnapshot();
   running = spans.running;
@@ -44,7 +44,7 @@ void UpdateSpans(std::shared_ptr<TracezSpanProcessor>& processor,
  * no more or less
  */
 bool ContainsNames(const std::vector<std::string>& names,
-    std::unordered_set<opentelemetry::sdk::trace::SpanData*>& running,
+    std::unordered_set<ThreadsafeSpanData*>& running,
     unsigned int name_start = 0, unsigned int name_end = 0,
     bool one_to_one_correspondence = false) {
   if (name_end == 0) name_end = names.size();
@@ -84,7 +84,7 @@ bool ContainsNames(const std::vector<std::string>& names,
  * no more or less
  */
 bool ContainsNames(const std::vector<std::string>& names,
-    std::vector<std::unique_ptr<opentelemetry::sdk::trace::SpanData>>& completed,
+    std::vector<std::unique_ptr<ThreadsafeSpanData>>& completed,
     unsigned int name_start = 0, unsigned int name_end = 0,
     bool one_to_one_correspondence = false) {
 
@@ -162,8 +162,8 @@ class TracezProcessor : public ::testing::Test {
   std::shared_ptr<TracezSpanProcessor> processor;
   std::shared_ptr<opentelemetry::trace::Tracer> tracer;
 
-  std::unordered_set<opentelemetry::sdk::trace::SpanData*> running;
-  std::vector<std::unique_ptr<opentelemetry::sdk::trace::SpanData>> completed;
+  std::unordered_set<ThreadsafeSpanData*> running;
+  std::vector<std::unique_ptr<ThreadsafeSpanData>> completed;
 
   std::vector<std::string> span_names;
   std::vector<opentelemetry::nostd::unique_ptr<opentelemetry::trace::Span>> span_vars;


### PR DESCRIPTION
This PR adds a copy constructor for the zpages recordable. A default copy constructor is not created due to the presence of a mutex within the object. Copies of this object is required to be passed over to the front end to display tracez data.