### PR TITLE
Fix Metrics SDK CMake tests

### DIFF
--- a/sdk/test/metrics/CMakeLists.txt
+++ b/sdk/test/metrics/CMakeLists.txt
@@ -1,6 +1,8 @@
-foreach(testname meter_provider_sdk_test gauge_aggregator_test
-                 min_max_sum_count_aggregator_test exact_aggregator_test
-                 counter_aggregator_test histogram_aggregator_test)
+foreach(
+  testname
+  meter_provider_sdk_test gauge_aggregator_test
+  min_max_sum_count_aggregator_test exact_aggregator_test
+  counter_aggregator_test histogram_aggregator_test)
   add_executable(${testname} "${testname}.cc")
   target_link_libraries(${testname} ${GTEST_BOTH_LIBRARIES}
                         ${CMAKE_THREAD_LIBS_INIT} opentelemetry_metrics)

--- a/sdk/test/metrics/CMakeLists.txt
+++ b/sdk/test/metrics/CMakeLists.txt
@@ -1,5 +1,6 @@
 foreach(testname meter_provider_sdk_test gauge_aggregator_test
-                 min_max_sum_count_aggregator_test exact_aggregator_test)
+                 min_max_sum_count_aggregator_test exact_aggregator_test
+                 counter_aggregator_test histogram_aggregator_test)
   add_executable(${testname} "${testname}.cc")
   target_link_libraries(${testname} ${GTEST_BOTH_LIBRARIES}
                         ${CMAKE_THREAD_LIBS_INIT} opentelemetry_metrics)


### PR DESCRIPTION
In resolving merge conflicts in my Exact aggregator PR I accidentally removed the counter_aggregator and histogram_aggregator tests from sdk/test/metrics/CMakeLists.txt. This PR simply adds those back.
My apologies.