### PR TITLE
Add Metrics Controller

### DIFF
--- a/sdk/include/opentelemetry/sdk/metrics/aggregator/counter_aggregator.h
+++ b/sdk/include/opentelemetry/sdk/metrics/aggregator/counter_aggregator.h
@@ -49,8 +49,10 @@ public:
    */
   void checkpoint() override
   {
+    this->mu_.lock();
     this->checkpoint_ = this->values_;
     this->values_[0]  = 0;
+    this->mu_.unlock();
   }
 
   /**

--- a/sdk/include/opentelemetry/sdk/metrics/aggregator/histogram_aggregator.h
+++ b/sdk/include/opentelemetry/sdk/metrics/aggregator/histogram_aggregator.h
@@ -62,6 +62,7 @@ public:
    */
   void update(T val) override
   {
+    this->mu_.lock();
     int bucketID = boundaries_.size();
     for (size_t i = 0; i < boundaries_.size(); i++)
     {
@@ -76,7 +77,6 @@ public:
     // auto pos = std::lower_bound (boundaries_.begin(), boundaries_.end(), val);
     // bucketCounts_[pos-boundaries_.begin()] += 1;
 
-    this->mu_.lock();
     this->values_[0] += val;
     this->values_[1] += 1;
     bucketCounts_[bucketID] += 1;
@@ -92,11 +92,13 @@ public:
    */
   void checkpoint() override
   {
+    this->mu_.lock();
     this->checkpoint_  = this->values_;
     this->values_[0]   = 0;
     this->values_[1]   = 0;
     bucketCounts_ckpt_ = bucketCounts_;
     std::fill(bucketCounts_.begin(), bucketCounts_.end(), 0);
+    this->mu_.unlock();
   }
 
   /**

--- a/sdk/include/opentelemetry/sdk/metrics/aggregator/sketch_aggregator.h
+++ b/sdk/include/opentelemetry/sdk/metrics/aggregator/sketch_aggregator.h
@@ -148,7 +148,6 @@ public:
    */
   void merge(SketchAggregator other)
   {
-    this->mu_.lock();
     if (gamma != other.gamma)
     {
 #if __EXCEPTIONS
@@ -166,6 +165,7 @@ public:
 #endif
     }
 
+    this->mu_.lock();
     this->values_[0] += other.values_[0];
     this->values_[1] += other.values_[1];
     this->checkpoint_[0] += other.checkpoint_[0];

--- a/sdk/include/opentelemetry/sdk/metrics/controller.h
+++ b/sdk/include/opentelemetry/sdk/metrics/controller.h
@@ -98,7 +98,7 @@ public:
      */
     void run()
     {
-        if (!running){
+        if (!running_){
             running_ = true;
             while (active_)
             {

--- a/sdk/include/opentelemetry/sdk/metrics/controller.h
+++ b/sdk/include/opentelemetry/sdk/metrics/controller.h
@@ -1,5 +1,10 @@
 #pragma once
 
+#include <iostream>
+#include <sstream>
+#include <thread>
+#include <unistd.h>
+#include <vector>
 #include "opentelemetry/metrics/instrument.h"
 #include "opentelemetry/nostd/unique_ptr.h"
 #include "opentelemetry/sdk/metrics/meter.h"
@@ -8,11 +13,6 @@
 #include "opentelemetry/exporters/ostream/metrics_exporter.h"
 #include "opentelemetry/version.h"
 #include "opentelemetry/sdk/metrics/processor.h"
-
-#include <sstream>
-#include <thread>
-#include <unistd.h>
-#include <vector>
 
 namespace metrics_api = opentelemetry::metrics;
 namespace trace_api   = opentelemetry::trace;
@@ -25,90 +25,102 @@ namespace metrics
 
 class PushController
 {
-
+    
 public:
-  PushController(nostd::shared_ptr<metrics_api::Meter> meter,
-                 nostd::unique_ptr<MetricsExporter> exporter,
-                 nostd::shared_ptr<MetricsProcessor> processor,
-                 double period,
-                 int timeout = 30)
-  {
-    meter_     = meter;
-    exporter_  = std::move(exporter);
-    processor_ = processor;
-    timeout_   = (unsigned int)(timeout * 1000000);  // convert seconds to microseconds
-    period_    = (unsigned int)(period * 1000000);
-  }
-
-  /*
-   * Used to check if the metrics pipeline is currecntly active
-   *
-   * @param none
-   * @return true when active, false when on standby
-   */
-  bool isActive() { return active_; }
-
-  /*
-   * Begins the data processing and export pipeline.  The function first ensures that the pipeline
-   * is not already running.  If not, it begins and detaches a new thread for the Controller's run
-   * function which periodically polls the instruments for their data.
-   *
-   * @param none
-   * @return a boolean which is true when the pipeline is successfully started and false when
-   * already active
-   */
-  bool start()
-  {
-    if (!active_)
+    PushController(nostd::shared_ptr<metrics_api::Meter> meter,
+                   nostd::unique_ptr<MetricsExporter> exporter,
+                   nostd::shared_ptr<MetricsProcessor> processor,
+                   double period,
+                   int timeout = 30)
     {
-      active_ = true;
-      std::thread runner(&PushController::run, this);
-      runner.detach();
-      return true;
+        meter_     = meter;
+        exporter_  = std::move(exporter);
+        processor_ = processor;
+        timeout_   = (unsigned int)(timeout * 1000000);  // convert seconds to microseconds
+        period_    = (unsigned int)(period * 1000000);
     }
-    return false;
-  }
-
-  /*
-   * Ends the processing and export pipeline then exports metrics one last time
-   * before returning.
-   *
-   * @param none
-   * @return none
-   */
-  void stop()
-  {
-    active_ = false;
-    usleep(period_);
-    tick();  // flush metrics sitting in the processor
-  }
-
-  /*
-   * Run the tick function at a regular interval. This function
-   * should be run in its own thread.
-   *
-   * Used to wait between collection intervals.
-   */
-  void run()
-  {
-    while (active_)
+    
+    /*
+     * Used to check if the metrics pipeline is currecntly active
+     *
+     * @param none
+     * @return true when active, false when on standby
+     */
+    bool isActive() { return active_; }
+    
+    /*
+     * Begins the data processing and export pipeline.  The function first ensures that the pipeline
+     * is not already running.  If not, it begins and detaches a new thread for the Controller's run
+     * function which periodically polls the instruments for their data.
+     *
+     * @param none
+     * @return a boolean which is true when the pipeline is successfully started and false when
+     * already active
+     */
+    bool start()
     {
-      tick();
-      usleep(period_);
+        mu_.lock();
+        if (!active_)
+        {
+            active_ = true;
+            std::thread runner(&PushController::run, this);
+            runner.detach();
+            mu_.unlock();
+            return true;
+        }
+        mu_.unlock();
+        return false;
     }
-  }
-
-  /*
-   * Tick
-   *
-   * Called at regular intervals, this function collects all values from the
-   * member variable meter_, then sends them to the processor_ for
-   * processing. After the records have been processed they are sent to the
-   * exporter_ to be exported.
-   *
-   */
+    
+    /*
+     * Ends the processing and export pipeline then exports metrics one last time
+     * before returning.
+     *
+     * @param none
+     * @return none
+     */
+    void stop()
+    {
+        if (active_){
+            active_ = false;
+            while (running_){
+                usleep(period_/100); // wait until the runner thread concludes
+            }
+            tick();  // flush metrics sitting in the processor
+        }
+    }
+    
+    /*
+     * Run the tick function at a regular interval. This function
+     * should be run in its own thread.
+     *
+     * Used to wait between collection intervals.
+     */
+    void run()
+    {
+        if (!running){
+            running_ = true;
+            while (active_)
+            {
+                tick();
+                usleep(period_);
+            }
+            running_ = false;
+        }
+    }
+    
+    /*
+     * Tick
+     *
+     * Called at regular intervals, this function collects all values from the
+     * member variable meter_, then sends them to the processor_ for
+     * processing. After the records have been processed they are sent to the
+     * exporter_ to be exported.
+     *
+     */
     void tick()
     {
+        mu_.lock();
         std::vector<Record> collected = dynamic_cast<Meter*>(meter_.get())->Collect();
         for (const auto &rec: collected){
             processor_->process(rec);
@@ -116,14 +128,17 @@ public:
         collected = processor_->CheckpointSelf();
         processor_->FinishedCollection();
         exporter_->Export(collected);
+        mu_.unlock();
     }
-
-  nostd::shared_ptr<metrics_api::Meter> meter_;
-  std::unique_ptr<MetricsExporter> exporter_;
-  nostd::shared_ptr<MetricsProcessor> processor_;
-  bool active_ = false;
-  unsigned int period_;
-  unsigned int timeout_;
+    
+    nostd::shared_ptr<metrics_api::Meter> meter_;
+    nostd::unique_ptr<MetricsExporter> exporter_;
+    nostd::shared_ptr<MetricsProcessor> processor_;
+    std::mutex mu_;
+    bool active_ = false;
+    bool running_ = true;
+    unsigned int period_;
+    unsigned int timeout_;
 };
 
 }  // namespace metrics

--- a/sdk/include/opentelemetry/sdk/metrics/controller.h
+++ b/sdk/include/opentelemetry/sdk/metrics/controller.h
@@ -85,7 +85,8 @@ public:
       active_ = false;
       while (running_)
       {
-        std::this_thread::sleep_for(std::chrono::microseconds(period_ / 100)); // wait until the runner thread concludes
+        std::this_thread::sleep_for(
+            std::chrono::microseconds(period_ / 100));  // wait until the runner thread concludes
       }
       tick();  // flush metrics sitting in the processor
     }

--- a/sdk/include/opentelemetry/sdk/metrics/controller.h
+++ b/sdk/include/opentelemetry/sdk/metrics/controller.h
@@ -1,18 +1,18 @@
 #pragma once
 
+#include <unistd.h>
 #include <iostream>
 #include <sstream>
 #include <thread>
-#include <unistd.h>
 #include <vector>
+#include "opentelemetry/exporters/ostream/metrics_exporter.h"
 #include "opentelemetry/metrics/instrument.h"
 #include "opentelemetry/nostd/unique_ptr.h"
-#include "opentelemetry/sdk/metrics/meter.h"
-#include "opentelemetry/sdk/metrics/record.h"
 #include "opentelemetry/sdk/metrics/exporter.h"
-#include "opentelemetry/exporters/ostream/metrics_exporter.h"
-#include "opentelemetry/version.h"
+#include "opentelemetry/sdk/metrics/meter.h"
 #include "opentelemetry/sdk/metrics/processor.h"
+#include "opentelemetry/sdk/metrics/record.h"
+#include "opentelemetry/version.h"
 
 namespace metrics_api = opentelemetry::metrics;
 namespace trace_api   = opentelemetry::trace;
@@ -25,120 +25,124 @@ namespace metrics
 
 class PushController
 {
-    
+
 public:
-    PushController(nostd::shared_ptr<metrics_api::Meter> meter,
-                   nostd::unique_ptr<MetricsExporter> exporter,
-                   nostd::shared_ptr<MetricsProcessor> processor,
-                   double period,
-                   int timeout = 30)
+  PushController(nostd::shared_ptr<metrics_api::Meter> meter,
+                 nostd::unique_ptr<MetricsExporter> exporter,
+                 nostd::shared_ptr<MetricsProcessor> processor,
+                 double period,
+                 int timeout = 30)
+  {
+    meter_     = meter;
+    exporter_  = std::move(exporter);
+    processor_ = processor;
+    timeout_   = (unsigned int)(timeout * 1000000);  // convert seconds to microseconds
+    period_    = (unsigned int)(period * 1000000);
+  }
+
+  /*
+   * Used to check if the metrics pipeline is currecntly active
+   *
+   * @param none
+   * @return true when active, false when on standby
+   */
+  bool isActive() { return active_; }
+
+  /*
+   * Begins the data processing and export pipeline.  The function first ensures that the pipeline
+   * is not already running.  If not, it begins and detaches a new thread for the Controller's run
+   * function which periodically polls the instruments for their data.
+   *
+   * @param none
+   * @return a boolean which is true when the pipeline is successfully started and false when
+   * already active
+   */
+  bool start()
+  {
+    mu_.lock();
+    if (!active_)
     {
-        meter_     = meter;
-        exporter_  = std::move(exporter);
-        processor_ = processor;
-        timeout_   = (unsigned int)(timeout * 1000000);  // convert seconds to microseconds
-        period_    = (unsigned int)(period * 1000000);
+      active_ = true;
+      std::thread runner(&PushController::run, this);
+      runner.detach();
+      mu_.unlock();
+      return true;
     }
-    
-    /*
-     * Used to check if the metrics pipeline is currecntly active
-     *
-     * @param none
-     * @return true when active, false when on standby
-     */
-    bool isActive() { return active_; }
-    
-    /*
-     * Begins the data processing and export pipeline.  The function first ensures that the pipeline
-     * is not already running.  If not, it begins and detaches a new thread for the Controller's run
-     * function which periodically polls the instruments for their data.
-     *
-     * @param none
-     * @return a boolean which is true when the pipeline is successfully started and false when
-     * already active
-     */
-    bool start()
+    mu_.unlock();
+    return false;
+  }
+
+  /*
+   * Ends the processing and export pipeline then exports metrics one last time
+   * before returning.
+   *
+   * @param none
+   * @return none
+   */
+  void stop()
+  {
+    if (active_)
     {
-        mu_.lock();
-        if (!active_)
-        {
-            active_ = true;
-            std::thread runner(&PushController::run, this);
-            runner.detach();
-            mu_.unlock();
-            return true;
-        }
-        mu_.unlock();
-        return false;
+      active_ = false;
+      while (running_)
+      {
+        usleep(period_ / 100);  // wait until the runner thread concludes
+      }
+      tick();  // flush metrics sitting in the processor
     }
-    
-    /*
-     * Ends the processing and export pipeline then exports metrics one last time
-     * before returning.
-     *
-     * @param none
-     * @return none
-     */
-    void stop()
+  }
+
+  /*
+   * Run the tick function at a regular interval. This function
+   * should be run in its own thread.
+   *
+   * Used to wait between collection intervals.
+   */
+  void run()
+  {
+    if (!running_)
     {
-        if (active_){
-            active_ = false;
-            while (running_){
-                usleep(period_/100); // wait until the runner thread concludes
-            }
-            tick();  // flush metrics sitting in the processor
-        }
+      running_ = true;
+      while (active_)
+      {
+        tick();
+        usleep(period_);
+      }
+      running_ = false;
     }
-    
-    /*
-     * Run the tick function at a regular interval. This function
-     * should be run in its own thread.
-     *
-     * Used to wait between collection intervals.
-     */
-    void run()
+  }
+
+  /*
+   * Tick
+   *
+   * Called at regular intervals, this function collects all values from the
+   * member variable meter_, then sends them to the processor_ for
+   * processing. After the records have been processed they are sent to the
+   * exporter_ to be exported.
+   *
+   */
+  void tick()
+  {
+    mu_.lock();
+    std::vector<Record> collected = dynamic_cast<Meter *>(meter_.get())->Collect();
+    for (const auto &rec : collected)
     {
-        if (!running_){
-            running_ = true;
-            while (active_)
-            {
-                tick();
-                usleep(period_);
-            }
-            running_ = false;
-        }
+      processor_->process(rec);
     }
-    
-    /*
-     * Tick
-     *
-     * Called at regular intervals, this function collects all values from the
-     * member variable meter_, then sends them to the processor_ for
-     * processing. After the records have been processed they are sent to the
-     * exporter_ to be exported.
-     *
-     */
-    void tick()
-    {
-        mu_.lock();
-        std::vector<Record> collected = dynamic_cast<Meter*>(meter_.get())->Collect();
-        for (const auto &rec: collected){
-            processor_->process(rec);
-        }
-        collected = processor_->CheckpointSelf();
-        processor_->FinishedCollection();
-        exporter_->Export(collected);
-        mu_.unlock();
-    }
-    
-    nostd::shared_ptr<metrics_api::Meter> meter_;
-    nostd::unique_ptr<MetricsExporter> exporter_;
-    nostd::shared_ptr<MetricsProcessor> processor_;
-    std::mutex mu_;
-    bool active_ = false;
-    bool running_ = true;
-    unsigned int period_;
-    unsigned int timeout_;
+    collected = processor_->CheckpointSelf();
+    processor_->FinishedCollection();
+    exporter_->Export(collected);
+    mu_.unlock();
+  }
+
+  nostd::shared_ptr<metrics_api::Meter> meter_;
+  nostd::unique_ptr<MetricsExporter> exporter_;
+  nostd::shared_ptr<MetricsProcessor> processor_;
+  std::mutex mu_;
+  bool active_  = false;
+  bool running_ = false;
+  unsigned int period_;
+  unsigned int timeout_;
 };
 
 }  // namespace metrics

--- a/sdk/include/opentelemetry/sdk/metrics/controller.h
+++ b/sdk/include/opentelemetry/sdk/metrics/controller.h
@@ -1,0 +1,139 @@
+#pragma once
+
+#include "opentelemetry/metrics/instrument.h"
+#include "opentelemetry/nostd/unique_ptr.h"
+#include "opentelemetry/sdk/metrics/meter.h"
+#include "opentelemetry/sdk/metrics/record.h"
+#include "opentelemetry/sdk/metrics/exporter.h"
+#include "opentelemetry/exporters/ostream/metrics_exporter.h"
+#include "opentelemetry/version.h"
+
+#include <unistd.h>
+#include <iostream>
+#include <sstream>
+#include <thread>
+#include <vector>
+
+namespace metrics_api = opentelemetry::metrics;
+namespace trace_api   = opentelemetry::trace;
+
+OPENTELEMETRY_BEGIN_NAMESPACE
+namespace sdk
+{
+namespace metrics
+{
+
+class Processor {
+public:
+    Processor() = default;
+    
+    void process(std::vector<Record> alpha){}
+    
+    std::vector<Record> CheckpointSelf() {
+        return std::vector<Record>();
+    }
+};
+
+class PushController
+{
+
+public:
+  PushController(nostd::shared_ptr<metrics_api::Meter> meter,
+                 nostd::unique_ptr<MetricsExporter> exporter,
+                 nostd::shared_ptr<Processor> processor,
+                 double period,
+                 int timeout = 30)
+  {
+    meter_     = meter;
+    exporter_  = std::move(exporter);
+    processor_ = processor;
+    timeout_   = (unsigned int)(timeout * 1000000);  // convert seconds to microseconds
+    period_    = (unsigned int)(period * 1000000);
+  }
+
+  /*
+   * Used to check if the metrics pipeline is currecntly active
+   *
+   * @param none
+   * @return true when active, false when on standby
+   */
+  bool isActive() { return active_; }
+
+  /*
+   * Begins the data processing and export pipeline.  The function first ensures that the pipeline
+   * is not already running.  If not, it begins and detaches a new thread for the Controller's run
+   * function which periodically polls the instruments for their data.
+   *
+   * @param none
+   * @return a boolean which is true when the pipeline is successfully started and false when
+   * already active
+   */
+  bool start()
+  {
+    if (!active_)
+    {
+      active_ = true;
+      std::thread runner(&PushController::run, this);
+      runner.detach();
+      return true;
+    }
+    return false;
+  }
+
+  /*
+   * Ends the processing and export pipeline then exports metrics one last time
+   * before returning.
+   *
+   * @param none
+   * @return none
+   */
+  void stop()
+  {
+    active_ = false;
+    usleep(period_);
+    tick();  // flush metrics sitting in the processor
+  }
+
+  /*
+   * Run the tick function at a regular interval. This function
+   * should be run in its own thread.
+   *
+   * Used to wait between collection intervals.
+   */
+  void run()
+  {
+    while (active_)
+    {
+      tick();
+      usleep(period_);
+    }
+  }
+
+  /*
+   * Tick
+   *
+   * Called at regular intervals, this function collects all values from the
+   * member variable meter_, then sends them to the processor_ for
+   * processing. After the records have been processed they are sent to the
+   * exporter_ to be exported.
+   *
+   */
+  void tick()
+  {
+    std::cout << "tick" << std::endl;
+    processor_->process(dynamic_cast<Meter*>(meter_.get())->Collect());
+    std::vector<Record> checkpointed = processor_->CheckpointSelf();
+    exporter_->Export(checkpointed);
+  }
+
+  nostd::shared_ptr<metrics_api::Meter> meter_;
+  nostd::unique_ptr<MetricsExporter> exporter_;
+  nostd::shared_ptr<Processor> processor_;
+  bool active_ = false;
+  unsigned int period_;
+  unsigned int timeout_;
+};
+
+}  // namespace metrics
+}  // namespace sdk
+OPENTELEMETRY_END_NAMESPACE

--- a/sdk/include/opentelemetry/sdk/metrics/controller.h
+++ b/sdk/include/opentelemetry/sdk/metrics/controller.h
@@ -1,6 +1,5 @@
 #pragma once
 
-#include <unistd.h>
 #include <iostream>
 #include <sstream>
 #include <thread>
@@ -86,7 +85,7 @@ public:
       active_ = false;
       while (running_)
       {
-        usleep(period_ / 100);  // wait until the runner thread concludes
+        std::this_thread::sleep_for(std::chrono::microseconds(period_ / 100)); // wait until the runner thread concludes
       }
       tick();  // flush metrics sitting in the processor
     }
@@ -106,7 +105,7 @@ public:
       while (active_)
       {
         tick();
-        usleep(period_);
+        std::this_thread::sleep_for(std::chrono::microseconds(period_));
       }
       running_ = false;
     }

--- a/sdk/include/opentelemetry/sdk/metrics/controller.h
+++ b/sdk/include/opentelemetry/sdk/metrics/controller.h
@@ -25,123 +25,124 @@ namespace metrics
 
 class PushController
 {
-    
+
 public:
-    PushController(nostd::shared_ptr<metrics_api::Meter> meter,
-                   nostd::unique_ptr<MetricsExporter> exporter,
-                   nostd::shared_ptr<MetricsProcessor> processor,
-                   double period,
-                   int timeout = 30)
+  PushController(nostd::shared_ptr<metrics_api::Meter> meter,
+                 nostd::unique_ptr<MetricsExporter> exporter,
+                 nostd::shared_ptr<MetricsProcessor> processor,
+                 double period,
+                 int timeout = 30)
+  {
+    meter_     = meter;
+    exporter_  = std::move(exporter);
+    processor_ = processor;
+    timeout_   = (unsigned int)(timeout * 1000000);  // convert seconds to microseconds
+    period_    = (unsigned int)(period * 1000000);
+  }
+
+  /*
+   * Used to check if the metrics pipeline is currecntly active
+   *
+   * @param none
+   * @return true when active, false when on standby
+   */
+  bool isActive() { return active_.load(); }
+
+  /*
+   * Begins the data processing and export pipeline.  The function first ensures that the pipeline
+   * is not already running.  If not, it begins and detaches a new thread for the Controller's run
+   * function which periodically polls the instruments for their data.
+   *
+   * @param none
+   * @return a boolean which is true when the pipeline is successfully started and false when
+   * already active
+   */
+  bool start()
+  {
+    if (!active_.load())
     {
-        meter_     = meter;
-        exporter_  = std::move(exporter);
-        processor_ = processor;
-        timeout_   = (unsigned int)(timeout * 1000000);  // convert seconds to microseconds
-        period_    = (unsigned int)(period * 1000000);
+      active_ = true;
+      std::thread runner(&PushController::run, this);
+      runner.detach();
+      return true;
     }
-    
-    /*
-     * Used to check if the metrics pipeline is currecntly active
-     *
-     * @param none
-     * @return true when active, false when on standby
-     */
-    bool isActive() { return active_.load(); }
-    
-    /*
-     * Begins the data processing and export pipeline.  The function first ensures that the pipeline
-     * is not already running.  If not, it begins and detaches a new thread for the Controller's run
-     * function which periodically polls the instruments for their data.
-     *
-     * @param none
-     * @return a boolean which is true when the pipeline is successfully started and false when
-     * already active
-     */
-    bool start()
+    return false;
+  }
+
+  /*
+   * Ends the processing and export pipeline then exports metrics one last time
+   * before returning.
+   *
+   * @param none
+   * @return none
+   */
+  void stop()
+  {
+    if (active_.load())
     {
-        if (!active_.load())
-        {
-            active_ = true;
-            std::thread runner(&PushController::run, this);
-            runner.detach();
-            return true;
-        }
-        return false;
+      active_ = false;
+      while (running_.load())
+      {
+        std::this_thread::sleep_for(
+            std::chrono::microseconds(period_ / 100));  // wait until the runner thread concludes
+      }
+      tick();  // flush metrics sitting in the processor
     }
-    
-    /*
-     * Ends the processing and export pipeline then exports metrics one last time
-     * before returning.
-     *
-     * @param none
-     * @return none
-     */
-    void stop()
-    {
-        if (active_.load())
-        {
-            active_ = false;
-            while (running_.load())
-            {
-                std::this_thread::sleep_for(
-                                            std::chrono::microseconds(period_ / 100));  // wait until the runner thread concludes
-            }
-            tick();  // flush metrics sitting in the processor
-        }
-    }
-    
+  }
+
 private:
-    /*
-     * Run the tick function at a regular interval. This function
-     * should be run in its own thread.
-     *
-     * Used to wait between collection intervals.
-     */
-    void run()
+  /*
+   * Run the tick function at a regular interval. This function
+   * should be run in its own thread.
+   *
+   * Used to wait between collection intervals.
+   */
+  void run()
+  {
+    if (!running_.load())
     {
-        if (!running_.load())
-        {
-            running_= true;
-            while (active_.load())
-            {
-                tick();
-                std::this_thread::sleep_for(std::chrono::microseconds(period_));
-            }
-            running_ = false;;
-        }
+      running_ = true;
+      while (active_.load())
+      {
+        tick();
+        std::this_thread::sleep_for(std::chrono::microseconds(period_));
+      }
+      running_ = false;
+      ;
     }
-    
-    /*
-     * Tick
-     *
-     * Called at regular intervals, this function collects all values from the
-     * member variable meter_, then sends them to the processor_ for
-     * processing. After the records have been processed they are sent to the
-     * exporter_ to be exported.
-     *
-     */
-    void tick()
+  }
+
+  /*
+   * Tick
+   *
+   * Called at regular intervals, this function collects all values from the
+   * member variable meter_, then sends them to the processor_ for
+   * processing. After the records have been processed they are sent to the
+   * exporter_ to be exported.
+   *
+   */
+  void tick()
+  {
+    this->mu_.lock();
+    std::vector<Record> collected = dynamic_cast<Meter *>(meter_.get())->Collect();
+    for (const auto &rec : collected)
     {
-        this->mu_.lock();
-        std::vector<Record> collected = dynamic_cast<Meter *>(meter_.get())->Collect();
-        for (const auto &rec : collected)
-        {
-            processor_->process(rec);
-        }
-        collected = processor_->CheckpointSelf();
-        processor_->FinishedCollection();
-        exporter_->Export(collected);
-        this->mu_.unlock();
+      processor_->process(rec);
     }
-    
-    nostd::shared_ptr<metrics_api::Meter> meter_;
-    nostd::unique_ptr<MetricsExporter> exporter_;
-    nostd::shared_ptr<MetricsProcessor> processor_;
-    std::mutex mu_;
-    std::atomic<bool> active_ = ATOMIC_VAR_INIT(false);
-    std::atomic<bool> running_ = ATOMIC_VAR_INIT(false);
-    unsigned int period_;
-    unsigned int timeout_;
+    collected = processor_->CheckpointSelf();
+    processor_->FinishedCollection();
+    exporter_->Export(collected);
+    this->mu_.unlock();
+  }
+
+  nostd::shared_ptr<metrics_api::Meter> meter_;
+  nostd::unique_ptr<MetricsExporter> exporter_;
+  nostd::shared_ptr<MetricsProcessor> processor_;
+  std::mutex mu_;
+  std::atomic<bool> active_  = ATOMIC_VAR_INIT(false);
+  std::atomic<bool> running_ = ATOMIC_VAR_INIT(false);
+  unsigned int period_;
+  unsigned int timeout_;
 };
 
 }  // namespace metrics

--- a/sdk/include/opentelemetry/sdk/metrics/instrument.h
+++ b/sdk/include/opentelemetry/sdk/metrics/instrument.h
@@ -111,7 +111,12 @@ public:
    * @param none
    * @return current ref count of the instrument
    */
-  virtual int get_ref() override { return ref_; }
+  virtual int get_ref() override
+  {
+    this->mu_.lock();
+    return ref_;
+    this->mu_.unlock();
+  }
 
   /**
    * Records a single synchronous metric event via a call to the aggregator.

--- a/sdk/include/opentelemetry/sdk/metrics/instrument.h
+++ b/sdk/include/opentelemetry/sdk/metrics/instrument.h
@@ -113,7 +113,10 @@ public:
    */
   virtual int get_ref() override
   {
-    return ref_;
+      this->mu_.lock();
+      auto ret = ref_;
+      this->mu_.unlock();
+      return ret;
   }
 
   /**

--- a/sdk/include/opentelemetry/sdk/metrics/instrument.h
+++ b/sdk/include/opentelemetry/sdk/metrics/instrument.h
@@ -113,9 +113,7 @@ public:
    */
   virtual int get_ref() override
   {
-    this->mu_.lock();
     return ref_;
-    this->mu_.unlock();
   }
 
   /**

--- a/sdk/include/opentelemetry/sdk/metrics/instrument.h
+++ b/sdk/include/opentelemetry/sdk/metrics/instrument.h
@@ -113,10 +113,10 @@ public:
    */
   virtual int get_ref() override
   {
-      this->mu_.lock();
-      auto ret = ref_;
-      this->mu_.unlock();
-      return ret;
+    this->mu_.lock();
+    auto ret = ref_;
+    this->mu_.unlock();
+    return ret;
   }
 
   /**

--- a/sdk/test/metrics/BUILD
+++ b/sdk/test/metrics/BUILD
@@ -1,4 +1,16 @@
 cc_test(
+    name = "controller_test",
+    srcs = [
+        "controller_test.cc",
+    ],
+    deps = [
+        "//sdk/src/metrics",
+	"//exporters/ostream:ostream_metrics_exporter",
+        "@com_google_googletest//:gtest_main",
+    ],
+)
+
+cc_test(
     name = "gauge_aggregator_test",
     srcs = [
         "gauge_aggregator_test.cc",

--- a/sdk/test/metrics/BUILD
+++ b/sdk/test/metrics/BUILD
@@ -4,8 +4,8 @@ cc_test(
         "controller_test.cc",
     ],
     deps = [
+        "//exporters/ostream:ostream_metrics_exporter",
         "//sdk/src/metrics",
-	"//exporters/ostream:ostream_metrics_exporter",
         "@com_google_googletest//:gtest_main",
     ],
 )

--- a/sdk/test/metrics/controller_test.cc
+++ b/sdk/test/metrics/controller_test.cc
@@ -3,8 +3,8 @@
 #include "opentelemetry/sdk/metrics/ungrouped_processor.h"
 
 #include <gtest/gtest.h>
-#include <thread>
 #include <numeric>
+#include <thread>
 // #include <chrono>
 
 namespace metrics_api = opentelemetry::metrics;
@@ -17,26 +17,29 @@ namespace metrics
 
 TEST(Controller, Constructor)
 {
-    
-    std::shared_ptr<metrics_api::Meter> meter = std::shared_ptr<metrics_api::Meter>(new Meter("Test"));
-    PushController alpha(meter,
-                         std::unique_ptr<MetricsExporter>(new opentelemetry::exporter::metrics::OStreamMetricsExporter),
-                         std::shared_ptr<MetricsProcessor>(new opentelemetry::sdk::metrics::UngroupedMetricsProcessor(false)),
-                         .05);
-    
-    auto instr = meter->NewIntCounter("test","none","none",true);
-    std::map<std::string, std::string> labels = {{"key", "value"}};
-    auto labelkv = trace::KeyValueIterableView<decltype(labels)>{labels};
-    
-    alpha.start();
-    
-    for (int i=0; i<20; i++){
-        instr->add(i, labelkv);
-    }
-    alpha.stop();
+
+  std::shared_ptr<metrics_api::Meter> meter =
+      std::shared_ptr<metrics_api::Meter>(new Meter("Test"));
+  PushController alpha(meter,
+                       std::unique_ptr<MetricsExporter>(
+                           new opentelemetry::exporter::metrics::OStreamMetricsExporter),
+                       std::shared_ptr<MetricsProcessor>(
+                           new opentelemetry::sdk::metrics::UngroupedMetricsProcessor(false)),
+                       .05);
+
+  auto instr                                = meter->NewIntCounter("test", "none", "none", true);
+  std::map<std::string, std::string> labels = {{"key", "value"}};
+  auto labelkv                              = trace::KeyValueIterableView<decltype(labels)>{labels};
+
+  alpha.start();
+
+  for (int i = 0; i < 20; i++)
+  {
+    instr->add(i, labelkv);
+  }
+  alpha.stop();
 }
 
-
-}  // namespace sdk
 }  // namespace metrics
+}  // namespace sdk
 OPENTELEMETRY_END_NAMESPACE

--- a/sdk/test/metrics/controller_test.cc
+++ b/sdk/test/metrics/controller_test.cc
@@ -58,15 +58,14 @@ namespace metrics
 // Test updating with a uniform set of updates
 TEST(Controller, Constructor)
 {
-//    std::shared_ptr<metrics_api::Meter> meter = std::shared_ptr<metrics_api::Meter>(new Meter("Test"));
-    auto beta = new Meter("Test");
-//    PushController alpha(meter,
-//                         std::unique_ptr<MetricsExporter>(new opentelemetry::exporter::metrics::OStreamMetricsExporter),
-//                         std::shared_ptr<Processor>(new Processor()),
-//                         .01);
-//    alpha.start();
-//    sleep(1);
-//    alpha.stop();
+    std::shared_ptr<metrics_api::Meter> meter = std::shared_ptr<metrics_api::Meter>(new Meter("Test"));
+    PushController alpha(meter,
+                         std::unique_ptr<MetricsExporter>(new opentelemetry::exporter::metrics::OStreamMetricsExporter),
+                         std::shared_ptr<Processor>(new Processor()),
+                         .01);
+    alpha.start();
+    sleep(1);
+    alpha.stop();
 }
 
 

--- a/sdk/test/metrics/controller_test.cc
+++ b/sdk/test/metrics/controller_test.cc
@@ -1,5 +1,6 @@
 #include "opentelemetry/sdk/metrics/controller.h"
 #include "opentelemetry/sdk/metrics/meter.h"
+#include "opentelemetry/sdk/metrics/ungrouped_processor.h"
 
 #include <gtest/gtest.h>
 #include <thread>
@@ -14,57 +15,24 @@ namespace sdk
 namespace metrics
 {
 
-//// Test updating with a uniform set of updates
-//TEST(Controller, Constructor)
-//{
-//    Record r(std::vector<int>{1}, "first", "only instrument", "unitless");
-//    Record r1(std::vector<int>{2}, "first", "only instrument", "unitless");
-//    Record r2(std::vector<int>{3}, "first", "only instrument", "unitless");
-//    Record r3(std::vector<int>{4}, "first", "only instrument", "unitless");
-//    Record r4(std::vector<int>{5}, "first", "only instrument", "unitless");
-//    Record r5(std::vector<int>{6}, "first", "only instrument", "unitless");
-//    Record r6(std::vector<int>{7}, "first", "only instrument", "unitless");
-//    std::vector<Record> fabricated;
-//    fabricated.push_back(r);
-//    Meter m(fabricated);
-//    Exporter e;
-//    Processor p;
-//
-//    PushController pc(m, e, p, 1, 30);
-//    pc.start();
-//
-//    fabricated.push_back(r1);
-//    pc.meter_.collected_ = fabricated;
-//    sleep(1);
-//    fabricated.push_back(r2);
-//    pc.meter_.collected_ = fabricated;
-//    sleep(1);
-//    fabricated.push_back(r3);
-//    pc.meter_.collected_ = fabricated;
-//    sleep(1);
-//    fabricated.push_back(r4);
-//    pc.meter_.collected_ = fabricated;
-//    sleep(1);
-//    fabricated.push_back(r5);
-//    pc.meter_.collected_ = fabricated;
-//    sleep(1);
-//    fabricated.push_back(r6);
-//    pc.meter_.collected_ = fabricated;
-//    sleep(1);
-//    pc.stop(); //blocking
-//    std::cout <<"test complete" <<std::endl;
-//}
-
-// Test updating with a uniform set of updates
 TEST(Controller, Constructor)
 {
+    
     std::shared_ptr<metrics_api::Meter> meter = std::shared_ptr<metrics_api::Meter>(new Meter("Test"));
     PushController alpha(meter,
                          std::unique_ptr<MetricsExporter>(new opentelemetry::exporter::metrics::OStreamMetricsExporter),
-                         std::shared_ptr<Processor>(new Processor()),
-                         .01);
+                         std::shared_ptr<MetricsProcessor>(new opentelemetry::sdk::metrics::UngroupedMetricsProcessor(false)),
+                         .05);
+    
+    auto instr = meter->NewIntCounter("test","none","none",true);
+    std::map<std::string, std::string> labels = {{"key", "value"}};
+    auto labelkv = trace::KeyValueIterableView<decltype(labels)>{labels};
+    
     alpha.start();
-    sleep(1);
+    for (int i=0; i<20; i++){
+        instr->add(i, labelkv);
+        usleep(.01*1000000);
+    }
     alpha.stop();
 }
 

--- a/sdk/test/metrics/controller_test.cc
+++ b/sdk/test/metrics/controller_test.cc
@@ -1,0 +1,75 @@
+#include "opentelemetry/sdk/metrics/controller.h"
+#include "opentelemetry/sdk/metrics/meter.h"
+
+#include <gtest/gtest.h>
+#include <thread>
+#include <numeric>
+// #include <chrono>
+
+namespace metrics_api = opentelemetry::metrics;
+
+OPENTELEMETRY_BEGIN_NAMESPACE
+namespace sdk
+{
+namespace metrics
+{
+
+//// Test updating with a uniform set of updates
+//TEST(Controller, Constructor)
+//{
+//    Record r(std::vector<int>{1}, "first", "only instrument", "unitless");
+//    Record r1(std::vector<int>{2}, "first", "only instrument", "unitless");
+//    Record r2(std::vector<int>{3}, "first", "only instrument", "unitless");
+//    Record r3(std::vector<int>{4}, "first", "only instrument", "unitless");
+//    Record r4(std::vector<int>{5}, "first", "only instrument", "unitless");
+//    Record r5(std::vector<int>{6}, "first", "only instrument", "unitless");
+//    Record r6(std::vector<int>{7}, "first", "only instrument", "unitless");
+//    std::vector<Record> fabricated;
+//    fabricated.push_back(r);
+//    Meter m(fabricated);
+//    Exporter e;
+//    Processor p;
+//
+//    PushController pc(m, e, p, 1, 30);
+//    pc.start();
+//
+//    fabricated.push_back(r1);
+//    pc.meter_.collected_ = fabricated;
+//    sleep(1);
+//    fabricated.push_back(r2);
+//    pc.meter_.collected_ = fabricated;
+//    sleep(1);
+//    fabricated.push_back(r3);
+//    pc.meter_.collected_ = fabricated;
+//    sleep(1);
+//    fabricated.push_back(r4);
+//    pc.meter_.collected_ = fabricated;
+//    sleep(1);
+//    fabricated.push_back(r5);
+//    pc.meter_.collected_ = fabricated;
+//    sleep(1);
+//    fabricated.push_back(r6);
+//    pc.meter_.collected_ = fabricated;
+//    sleep(1);
+//    pc.stop(); //blocking
+//    std::cout <<"test complete" <<std::endl;
+//}
+
+// Test updating with a uniform set of updates
+TEST(Controller, Constructor)
+{
+//    std::shared_ptr<metrics_api::Meter> meter = std::shared_ptr<metrics_api::Meter>(new Meter("Test"));
+    auto beta = new Meter("Test");
+//    PushController alpha(meter,
+//                         std::unique_ptr<MetricsExporter>(new opentelemetry::exporter::metrics::OStreamMetricsExporter),
+//                         std::shared_ptr<Processor>(new Processor()),
+//                         .01);
+//    alpha.start();
+//    sleep(1);
+//    alpha.stop();
+}
+
+
+}  // namespace sdk
+}  // namespace metrics
+OPENTELEMETRY_END_NAMESPACE

--- a/sdk/test/metrics/controller_test.cc
+++ b/sdk/test/metrics/controller_test.cc
@@ -29,9 +29,9 @@ TEST(Controller, Constructor)
     auto labelkv = trace::KeyValueIterableView<decltype(labels)>{labels};
     
     alpha.start();
+    
     for (int i=0; i<20; i++){
         instr->add(i, labelkv);
-        usleep(.01*1000000);
     }
     alpha.stop();
 }


### PR DESCRIPTION
This PR adds the Controller class to the metrics SDK.  The requirements for this class can be found in the current version of the [SDK specification](https://github.com/jmacd/opentelemetry-specification/blob/jmacd/draft_metric_sdk_spec/specification/metrics/sdk.md#controller-implementation).

The component oversees the entire metric pipeline by collecting data from the Accumulator and exporting it at regular intervals.  This is a push controller, meaning it will automatically send data to the exporter with fixed frequency.  The controller is also where the user can customize aspects of the pipeline.  Specifically, users can define the collection interval, timeout, Processor, and Exporter of their choice.  In the current design, a controller owns the Exporter passed into it, meaning that a multiple controller pipeline cannot share an Exporter.  

Note: This PR is dependent on the Processor (PR #229) and Ostream Exporter (PR #218).  It will not compile without these files. 
