### PR TITLE
pass in library_name and library_version into meter

### DIFF
--- a/sdk/include/opentelemetry/sdk/metrics/meter.h
+++ b/sdk/include/opentelemetry/sdk/metrics/meter.h
@@ -3,6 +3,7 @@
 #include "opentelemetry/metrics/meter.h"
 #include "opentelemetry/version.h"
 
+#include <string>
 #include <memory>
 
 OPENTELEMETRY_BEGIN_NAMESPACE
@@ -13,6 +14,14 @@ namespace metrics
 class Meter final : public opentelemetry::metrics::Meter, public std::enable_shared_from_this<Meter>
 {
 public:
+  explicit Meter(std::string library_name, std::string library_version)
+  {
+    library_name_    = library_name;
+    library_version_ = library_version;
+  }
+private:
+  std::string library_name_;
+  std::string library_version_;
 };
 }  // namespace metrics
 }  // namespace sdk

--- a/sdk/include/opentelemetry/sdk/metrics/meter.h
+++ b/sdk/include/opentelemetry/sdk/metrics/meter.h
@@ -3,8 +3,8 @@
 #include "opentelemetry/metrics/meter.h"
 #include "opentelemetry/version.h"
 
-#include <string>
 #include <memory>
+#include <string>
 
 OPENTELEMETRY_BEGIN_NAMESPACE
 namespace sdk
@@ -19,6 +19,7 @@ public:
     library_name_    = library_name;
     library_version_ = library_version;
   }
+
 private:
   std::string library_name_;
   std::string library_version_;

--- a/sdk/include/opentelemetry/sdk/metrics/meter_provider.h
+++ b/sdk/include/opentelemetry/sdk/metrics/meter_provider.h
@@ -4,6 +4,7 @@
 #include "opentelemetry/nostd/shared_ptr.h"
 #include "opentelemetry/sdk/metrics/meter.h"
 
+#include <string>
 #include <memory>
 
 OPENTELEMETRY_BEGIN_NAMESPACE
@@ -17,7 +18,7 @@ public:
   /**
    * Initialize a new meter provider
    */
-  explicit MeterProvider() noexcept;
+  explicit MeterProvider(std::string library_name = "", std::string library_version = "") noexcept;
 
   opentelemetry::nostd::shared_ptr<opentelemetry::metrics::Meter> GetMeter(
       nostd::string_view library_name,

--- a/sdk/include/opentelemetry/sdk/metrics/meter_provider.h
+++ b/sdk/include/opentelemetry/sdk/metrics/meter_provider.h
@@ -4,8 +4,8 @@
 #include "opentelemetry/nostd/shared_ptr.h"
 #include "opentelemetry/sdk/metrics/meter.h"
 
-#include <string>
 #include <memory>
+#include <string>
 
 OPENTELEMETRY_BEGIN_NAMESPACE
 namespace sdk

--- a/sdk/src/metrics/meter_provider.cc
+++ b/sdk/src/metrics/meter_provider.cc
@@ -5,7 +5,8 @@ namespace sdk
 {
 namespace metrics
 {
-MeterProvider::MeterProvider() noexcept : meter_(new Meter) {}
+MeterProvider::MeterProvider(std::string library_name, std::string library_version) noexcept 
+                                  : meter_(new Meter(library_name, library_version)) {}
 
 opentelemetry::nostd::shared_ptr<opentelemetry::metrics::Meter> MeterProvider::GetMeter(
     nostd::string_view library_name,

--- a/sdk/src/metrics/meter_provider.cc
+++ b/sdk/src/metrics/meter_provider.cc
@@ -5,8 +5,9 @@ namespace sdk
 {
 namespace metrics
 {
-MeterProvider::MeterProvider(std::string library_name, std::string library_version) noexcept 
-                                  : meter_(new Meter(library_name, library_version)) {}
+MeterProvider::MeterProvider(std::string library_name, std::string library_version) noexcept
+    : meter_(new Meter(library_name, library_version))
+{}
 
 opentelemetry::nostd::shared_ptr<opentelemetry::metrics::Meter> MeterProvider::GetMeter(
     nostd::string_view library_name,


### PR DESCRIPTION
Simple PR to route library_name and library_version into the Meter constructor.