### PR TITLE
Fix build break in protobuf by pinning to older version in our local vcpkg port file

### DIFF
--- a/ci/install_windows_protobuf.ps1
+++ b/ci/install_windows_protobuf.ps1
@@ -2,4 +2,5 @@ $ErrorActionPreference = "Stop"
 trap { $host.SetShouldExit(1) }
 
 cd vcpkg
-./vcpkg install protobuf:x64-windows
+# Lock to specific version of Protobuf port file to avoid build break
+./vcpkg install --overlay-ports="$PSScriptRoot\ports" protobuf:x64-windows

--- a/ci/ports/benchmark/CONTROL
+++ b/ci/ports/benchmark/CONTROL
@@ -1,0 +1,5 @@
+Source: benchmark
+Version: 1.5
+Homepage: https://github.com/google/benchmark
+Description: A library to support the benchmarking of functions, similar to unit-tests.
+Supports: !uwp

--- a/ci/ports/benchmark/portfile.cmake
+++ b/ci/ports/benchmark/portfile.cmake
@@ -1,0 +1,40 @@
+if(VCPKG_CMAKE_SYSTEM_NAME STREQUAL "WindowsStore")
+    message(FATAL_ERROR "${PORT} does not currently support UWP")
+endif()
+
+# Make sure vs2019 compiled binaries are compat with vs2017
+set(VCPKG_CXX_FLAGS "/Zc:__cplusplus /d2FH4-")
+set(VCPKG_C_FLAGS "/Zc:__cplusplus /d2FH4-")
+
+include(vcpkg_common_functions)
+
+vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
+
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO google/benchmark
+    REF v1.5.0
+    SHA512 a0df9aa3d03f676e302c76d83b436de36eea0a8517ab50a8f5a11c74ccc68a1f5128fa02474901002d8e6b5a4d290ef0272a798ff4670eab3e2d78dc86bb6cd3
+    HEAD_REF master
+)
+
+vcpkg_configure_cmake(
+    SOURCE_PATH ${SOURCE_PATH}
+    PREFER_NINJA
+    OPTIONS
+        -DBENCHMARK_ENABLE_TESTING=OFF
+        -DCMAKE_DEBUG_POSTFIX=d
+)
+
+vcpkg_install_cmake()
+
+vcpkg_copy_pdbs()
+
+vcpkg_fixup_cmake_targets(CONFIG_PATH lib/cmake/benchmark)
+
+file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/include)
+file(REMOVE_RECURSE ${CURRENT_PACKAGES_DIR}/debug/share)
+
+# Handle copyright
+file(COPY ${SOURCE_PATH}/LICENSE DESTINATION ${CURRENT_PACKAGES_DIR}/share/benchmark)
+file(RENAME ${CURRENT_PACKAGES_DIR}/share/benchmark/LICENSE ${CURRENT_PACKAGES_DIR}/share/benchmark/copyright)

--- a/ci/ports/protobuf/CONTROL
+++ b/ci/ports/protobuf/CONTROL
@@ -1,0 +1,8 @@
+Source: protobuf
+Version: 3.12.3
+Homepage: https://github.com/google/protobuf
+Description: Protocol Buffers - Google's data interchange format
+
+Feature: zlib
+Description: ZLib based features like Gzip streams
+Build-Depends: zlib

--- a/ci/ports/protobuf/fix-android-log.patch
+++ b/ci/ports/protobuf/fix-android-log.patch
@@ -1,0 +1,28 @@
+diff --git a/cmake/libprotobuf-lite.cmake b/cmake/libprotobuf-lite.cmake
+index 6bf86a277..424854798 100644
+--- a/cmake/libprotobuf-lite.cmake
++++ b/cmake/libprotobuf-lite.cmake
+@@ -67,6 +67,9 @@ target_link_libraries(libprotobuf-lite ${CMAKE_THREAD_LIBS_INIT})
+ if(protobuf_LINK_LIBATOMIC)
+   target_link_libraries(libprotobuf-lite atomic)
+ endif()
++if(${CMAKE_SYSTEM_NAME} STREQUAL "Android")
++       target_link_libraries(libprotobuf-lite log)
++endif()
+ target_include_directories(libprotobuf-lite PUBLIC ${protobuf_source_dir}/src)
+ if(MSVC AND protobuf_BUILD_SHARED_LIBS)
+   target_compile_definitions(libprotobuf-lite
+diff --git a/cmake/libprotobuf.cmake b/cmake/libprotobuf.cmake
+index 0c12596c2..a5be494fb 100644
+--- a/cmake/libprotobuf.cmake
++++ b/cmake/libprotobuf.cmake
+@@ -121,6 +121,9 @@ endif()
+ if(protobuf_LINK_LIBATOMIC)
+   target_link_libraries(libprotobuf atomic)
+ endif()
++if(${CMAKE_SYSTEM_NAME} STREQUAL "Android")
++       target_link_libraries(libprotobuf log)
++endif()
+ target_include_directories(libprotobuf PUBLIC ${protobuf_source_dir}/src)
+ if(MSVC AND protobuf_BUILD_SHARED_LIBS)
+   target_compile_definitions(libprotobuf

--- a/ci/ports/protobuf/fix-static-build.patch
+++ b/ci/ports/protobuf/fix-static-build.patch
@@ -1,0 +1,13 @@
+diff --git a/cmake/install.cmake b/cmake/install.cmake
+index be47c54..8b1bd97 100644
+--- a/cmake/install.cmake
++++ b/cmake/install.cmake
+@@ -31,7 +31,7 @@ endforeach()
+ if (protobuf_BUILD_PROTOC_BINARIES)
+   install(TARGETS protoc EXPORT protobuf-targets
+     RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR} COMPONENT protoc)
+-  if (UNIX AND NOT APPLE)
++  if (UNIX AND NOT APPLE AND NOT protobuf_MSVC_STATIC_RUNTIME)
+     set_property(TARGET protoc
+       PROPERTY INSTALL_RPATH "$ORIGIN/../${CMAKE_INSTALL_LIBDIR}")
+   elseif (APPLE)

--- a/ci/ports/protobuf/fix-uwp.patch
+++ b/ci/ports/protobuf/fix-uwp.patch
@@ -1,0 +1,12 @@
+diff --git a/cmake/CMakeLists.txt b/cmake/CMakeLists.txt
+index 849679995..dba537a68 100644
+--- a/cmake/CMakeLists.txt
++++ b/cmake/CMakeLists.txt
+@@ -198,6 +198,7 @@ if (MSVC)
+     /wd4506 # no definition for inline function 'function'
+     /wd4800 # 'type' : forcing value to bool 'true' or 'false' (performance warning)
+     /wd4996 # The compiler encountered a deprecated declaration.
++    /wd4703 # Potentially uninitialized local pointer variable 'name' used.
+   )
+   # Allow big object
+   add_definitions(/bigobj)

--- a/ci/ports/protobuf/portfile.cmake
+++ b/ci/ports/protobuf/portfile.cmake
@@ -1,0 +1,124 @@
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO protocolbuffers/protobuf
+    REF 31ebe2ac71400344a5db91ffc13c4ddfb7589f92    #v3.12.3
+    SHA512 74e623547bb9448ccea29925172bf13fcbffab80eb02f58d248180000b4ae7249f0dee88bb4ef438857b0e1a96a600ab270ebf3b58568da28cbf97d8a2398297
+    HEAD_REF master
+    PATCHES
+        fix-uwp.patch
+        fix-android-log.patch
+        fix-static-build.patch
+)
+
+if(CMAKE_HOST_WIN32 AND NOT VCPKG_TARGET_ARCHITECTURE MATCHES "x64" AND NOT VCPKG_TARGET_ARCHITECTURE MATCHES "x86")
+    set(protobuf_BUILD_PROTOC_BINARIES OFF)
+elseif(CMAKE_HOST_WIN32 AND VCPKG_CMAKE_SYSTEM_NAME)
+    set(protobuf_BUILD_PROTOC_BINARIES OFF)
+else()
+    set(protobuf_BUILD_PROTOC_BINARIES ON)
+endif()
+
+if(NOT protobuf_BUILD_PROTOC_BINARIES AND NOT EXISTS ${CURRENT_INSTALLED_DIR}/../x86-windows/tools/protobuf)
+    message(FATAL_ERROR "Cross-targetting protobuf requires the x86-windows protoc to be available. Please install protobuf:x86-windows first.")
+endif()
+
+if(VCPKG_LIBRARY_LINKAGE STREQUAL "dynamic")
+  set(VCPKG_BUILD_SHARED_LIBS ON)
+else()
+  set(VCPKG_BUILD_SHARED_LIBS OFF)
+endif()
+
+if(VCPKG_CRT_LINKAGE STREQUAL "dynamic")
+  set(VCPKG_BUILD_STATIC_CRT OFF)
+else()
+  set(VCPKG_BUILD_STATIC_CRT ON)
+endif()
+
+vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
+	zlib	protobuf_WITH_ZLIB
+)
+
+
+vcpkg_configure_cmake(
+    SOURCE_PATH ${SOURCE_PATH}/cmake
+    PREFER_NINJA
+    OPTIONS
+        -Dprotobuf_BUILD_SHARED_LIBS=${VCPKG_BUILD_SHARED_LIBS}
+        -Dprotobuf_MSVC_STATIC_RUNTIME=${VCPKG_BUILD_STATIC_CRT}
+        -Dprotobuf_BUILD_TESTS=OFF
+        -DCMAKE_INSTALL_CMAKEDIR:STRING=share/protobuf
+        -Dprotobuf_BUILD_PROTOC_BINARIES=${protobuf_BUILD_PROTOC_BINARIES}
+         ${FEATURE_OPTIONS}
+)
+
+vcpkg_install_cmake()
+
+# It appears that at this point the build hasn't actually finished. There is probably
+# a process spawned by the build, therefore we need to wait a bit.
+
+function(protobuf_try_remove_recurse_wait PATH_TO_REMOVE)
+    file(REMOVE_RECURSE ${PATH_TO_REMOVE})
+    if (EXISTS "${PATH_TO_REMOVE}")
+        execute_process(COMMAND ${CMAKE_COMMAND} -E sleep 5)
+        file(REMOVE_RECURSE ${PATH_TO_REMOVE})
+    endif()
+endfunction()
+
+protobuf_try_remove_recurse_wait(${CURRENT_PACKAGES_DIR}/debug/include)
+
+if(CMAKE_HOST_WIN32)
+    set(EXECUTABLE_SUFFIX ".exe")
+else()
+    set(EXECUTABLE_SUFFIX "")
+endif()
+
+if(NOT DEFINED VCPKG_BUILD_TYPE OR VCPKG_BUILD_TYPE STREQUAL "release")
+	vcpkg_replace_string(${CURRENT_PACKAGES_DIR}/share/protobuf/protobuf-targets-release.cmake
+		"\${_IMPORT_PREFIX}/bin/protoc${EXECUTABLE_SUFFIX}"
+		"\${_IMPORT_PREFIX}/tools/protobuf/protoc${EXECUTABLE_SUFFIX}"
+)
+endif()
+
+if(NOT DEFINED VCPKG_BUILD_TYPE OR VCPKG_BUILD_TYPE STREQUAL "debug")
+    file(READ ${CURRENT_PACKAGES_DIR}/debug/share/protobuf/protobuf-targets-debug.cmake DEBUG_MODULE)
+    string(REPLACE "\${_IMPORT_PREFIX}" "\${_IMPORT_PREFIX}/debug" DEBUG_MODULE "${DEBUG_MODULE}")
+    string(REPLACE "\${_IMPORT_PREFIX}/debug/bin/protoc${EXECUTABLE_SUFFIX}" "\${_IMPORT_PREFIX}/tools/protobuf/protoc${EXECUTABLE_SUFFIX}" DEBUG_MODULE "${DEBUG_MODULE}")
+    file(WRITE ${CURRENT_PACKAGES_DIR}/share/protobuf/protobuf-targets-debug.cmake "${DEBUG_MODULE}")
+endif()
+
+protobuf_try_remove_recurse_wait(${CURRENT_PACKAGES_DIR}/debug/share)
+
+if(CMAKE_HOST_WIN32)
+    if(protobuf_BUILD_PROTOC_BINARIES)
+        file(INSTALL ${CURRENT_PACKAGES_DIR}/bin/protoc.exe DESTINATION ${CURRENT_PACKAGES_DIR}/tools/${PORT})
+        vcpkg_copy_tool_dependencies(${CURRENT_PACKAGES_DIR}/tools/${PORT})
+    else()
+        file(COPY ${CURRENT_INSTALLED_DIR}/../x86-windows/tools/${PORT} DESTINATION ${CURRENT_PACKAGES_DIR}/tools)
+    endif()
+
+    if(VCPKG_LIBRARY_LINKAGE STREQUAL "static")
+        protobuf_try_remove_recurse_wait(${CURRENT_PACKAGES_DIR}/bin)
+        protobuf_try_remove_recurse_wait(${CURRENT_PACKAGES_DIR}/debug/bin)
+    else()
+        protobuf_try_remove_recurse_wait(${CURRENT_PACKAGES_DIR}/bin/protoc.exe)
+        protobuf_try_remove_recurse_wait(${CURRENT_PACKAGES_DIR}/debug/bin/protoc.exe)
+    endif()
+else()
+    file(GLOB EXECUTABLES ${CURRENT_PACKAGES_DIR}/bin/protoc*)
+    foreach(E IN LISTS EXECUTABLES)
+        file(INSTALL ${E} DESTINATION ${CURRENT_PACKAGES_DIR}/tools/${PORT}
+                PERMISSIONS OWNER_READ OWNER_WRITE OWNER_EXECUTE GROUP_READ GROUP_WRITE GROUP_EXECUTE WORLD_READ)
+    endforeach()
+    protobuf_try_remove_recurse_wait(${CURRENT_PACKAGES_DIR}/debug/bin)
+    protobuf_try_remove_recurse_wait(${CURRENT_PACKAGES_DIR}/bin)
+endif()
+
+if(VCPKG_LIBRARY_LINKAGE STREQUAL "dynamic")
+	vcpkg_replace_string(${CURRENT_PACKAGES_DIR}/include/google/protobuf/stubs/platform_macros.h
+		"\#endif  // GOOGLE_PROTOBUF_PLATFORM_MACROS_H_"
+		"\#ifndef PROTOBUF_USE_DLLS\n\#define PROTOBUF_USE_DLLS\n\#endif // PROTOBUF_USE_DLLS\n\n\#endif  // GOOGLE_PROTOBUF_PLATFORM_MACROS_H_"
+)
+endif()
+
+file(INSTALL ${SOURCE_PATH}/LICENSE DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT} RENAME copyright)
+vcpkg_copy_pdbs()

--- a/ci/setup_windows_ci_environment.ps1
+++ b/ci/setup_windows_ci_environment.ps1
@@ -1,11 +1,15 @@
 $ErrorActionPreference = "Stop"
 trap { $host.SetShouldExit(1) }
 
+# TODO: consider moving this to .gitmodules
 git clone https://github.com/Microsoft/vcpkg.git
 Push-Location -Path vcpkg
 $VCPKG_DIR=(Get-Item -Path ".\").FullName
 ./bootstrap-vcpkg.bat
 ./vcpkg integrate install
-./vcpkg install benchmark:x64-windows
+
+# Patched Google Benchmark can be shared between vs2017 and vs2019 compilers
+./vcpkg install --overlay-ports="$PSScriptRoot\ports" benchmark:x64-windows
+
 ./vcpkg install gtest:x64-windows
 Pop-Location


### PR DESCRIPTION
Our current CI loop `CI / CMake -> exporter proto` is broken due to mainline vcpkg issue.

Solution is to save local copies of vcpkg port files in our repo. That way if mainline vcpkg breaks something in those packages, we're not affected.

Also adding port file for Google Benchmark to be compatible with both vs2017 and vs2019 compilers. So that one library built once can be shared between the two different compilers. Without that patch it is impossible to reuse the library across two different compilers: since vs2019 introduces some new exception handling function that is not available in older runtime - if you build Google Bechmark from vcpkg with vs2019, then try that prebuilt - it is not gonna link in vs2017! This is yet another "LOL" at ABI compat requirement, showing that not everything is controlled by stable class definition. Something we have to keep in mind -- the build flag for that "backwards-compat" mode in vs2019 is `/d2FH4-`. Described here:
https://devblogs.microsoft.com/cppblog/making-cpp-exception-handling-smaller-x64/
I added it to `ci/ports/benchmark/portfile.cmake` - 

Alternate solution: we could start using `.gitmodules` and pin to older version of the mainline vcpkg repo that did not have this issue.