### PR TITLE
Implement links and event attributes in SpanData

### DIFF
--- a/ext/include/opentelemetry/ext/zpages/threadsafe_span_data.h
+++ b/ext/include/opentelemetry/ext/zpages/threadsafe_span_data.h
@@ -179,8 +179,7 @@ public:
           trace_api::KeyValueIterableView<std::map<std::string, int>>({})) noexcept override
   {
     std::lock_guard<std::mutex> lock(mutex_);
-    events_.push_back(SpanDataEvent(std::string(name), timestamp));
-    // TODO: handle attributes
+    events_.push_back(SpanDataEvent(std::string(name), timestamp, attributes));
   }
 
   ThreadsafeSpanData() {}

--- a/sdk/include/opentelemetry/sdk/trace/attribute_utils.h
+++ b/sdk/include/opentelemetry/sdk/trace/attribute_utils.h
@@ -91,11 +91,11 @@ public:
   // Contruct attribute map and populate with attributes
   AttributeMap(const opentelemetry::trace::KeyValueIterable &attributes)
   {
-    attributes.ForEachKeyValue(
-        [&](nostd::string_view key, opentelemetry::common::AttributeValue value) noexcept {
-          SetAttribute(key, value);
-          return true;
-        });
+    attributes.ForEachKeyValue([&](nostd::string_view key,
+                                   opentelemetry::common::AttributeValue value) noexcept {
+      SetAttribute(key, value);
+      return true;
+    });
   }
 
   const std::unordered_map<std::string, SpanDataAttributeValue> &GetAttributes() const noexcept

--- a/sdk/include/opentelemetry/sdk/trace/attribute_utils.h
+++ b/sdk/include/opentelemetry/sdk/trace/attribute_utils.h
@@ -1,0 +1,118 @@
+#pragma once
+
+#include <unordered_map>
+#include <vector>
+#include "opentelemetry/common/attribute_value.h"
+#include "opentelemetry/trace/key_value_iterable_view.h"
+
+OPENTELEMETRY_BEGIN_NAMESPACE
+namespace sdk
+{
+namespace trace
+{
+/**
+ * A counterpart to AttributeValue that makes sure a value is owned. This
+ * replaces all non-owning references with owned copies.
+ */
+using SpanDataAttributeValue = nostd::variant<bool,
+                                              int64_t,
+                                              uint64_t,
+                                              double,
+                                              std::string,
+                                              std::vector<bool>,
+                                              std::vector<int64_t>,
+                                              std::vector<uint64_t>,
+                                              std::vector<double>,
+                                              std::vector<std::string>>;
+
+/**
+ * Creates an owned copy (SpanDataAttributeValue) of a non-owning AttributeValue.
+ */
+struct AttributeConverter
+{
+  SpanDataAttributeValue operator()(bool v) { return SpanDataAttributeValue(v); }
+  SpanDataAttributeValue operator()(int v)
+  {
+    return SpanDataAttributeValue(static_cast<int64_t>(v));
+  }
+  SpanDataAttributeValue operator()(int64_t v) { return SpanDataAttributeValue(v); }
+  SpanDataAttributeValue operator()(unsigned int v)
+  {
+    return SpanDataAttributeValue(static_cast<uint64_t>(v));
+  }
+  SpanDataAttributeValue operator()(uint64_t v) { return SpanDataAttributeValue(v); }
+  SpanDataAttributeValue operator()(double v) { return SpanDataAttributeValue(v); }
+  SpanDataAttributeValue operator()(nostd::string_view v)
+  {
+    return SpanDataAttributeValue(std::string(v));
+  }
+  SpanDataAttributeValue operator()(nostd::span<const bool> v) { return convertSpan<bool>(v); }
+  SpanDataAttributeValue operator()(nostd::span<const int64_t> v)
+  {
+    return convertSpan<int64_t>(v);
+  }
+  SpanDataAttributeValue operator()(nostd::span<const unsigned int> v)
+  {
+    return convertSpan<uint64_t>(v);
+  }
+  SpanDataAttributeValue operator()(nostd::span<const uint64_t> v)
+  {
+    return convertSpan<uint64_t>(v);
+  }
+  SpanDataAttributeValue operator()(nostd::span<const double> v) { return convertSpan<double>(v); }
+  SpanDataAttributeValue operator()(nostd::span<const int> v) { return convertSpan<int64_t>(v); }
+  SpanDataAttributeValue operator()(nostd::span<const nostd::string_view> v)
+  {
+    return convertSpan<std::string>(v);
+  }
+
+  template <typename T, typename U = T>
+  SpanDataAttributeValue convertSpan(nostd::span<const U> vals)
+  {
+    std::vector<T> copy;
+    for (auto &val : vals)
+    {
+      copy.push_back(T(val));
+    }
+
+    return SpanDataAttributeValue(std::move(copy));
+  }
+};
+
+/**
+ * Class for storing attributes.
+ */
+class AttributeMap
+{
+public:
+  // Contruct empty attribute map
+  AttributeMap(){};
+
+  // Contruct attribute map and populate with attributes
+  AttributeMap(const opentelemetry::trace::KeyValueIterable &attributes)
+  {
+    attributes.ForEachKeyValue(
+        [&](nostd::string_view key, opentelemetry::common::AttributeValue value) noexcept {
+          SetAttribute(key, value);
+          return true;
+        });
+  }
+
+  const std::unordered_map<std::string, SpanDataAttributeValue> &GetAttributes() const noexcept
+  {
+    return attributes_;
+  }
+
+  void SetAttribute(nostd::string_view key,
+                    const opentelemetry::common::AttributeValue &value) noexcept
+  {
+    attributes_[std::string(key)] = nostd::visit(converter_, value);
+  }
+
+private:
+  std::unordered_map<std::string, SpanDataAttributeValue> attributes_;
+  AttributeConverter converter_;
+};
+}  // namespace trace
+}  // namespace sdk
+OPENTELEMETRY_END_NAMESPACE

--- a/sdk/include/opentelemetry/sdk/trace/attribute_utils.h
+++ b/sdk/include/opentelemetry/sdk/trace/attribute_utils.h
@@ -69,12 +69,7 @@ struct AttributeConverter
   template <typename T, typename U = T>
   SpanDataAttributeValue convertSpan(nostd::span<const U> vals)
   {
-    std::vector<T> copy;
-    for (auto &val : vals)
-    {
-      copy.push_back(T(val));
-    }
-
+    const std::vector<T> copy(vals.begin(), vals.end());
     return SpanDataAttributeValue(std::move(copy));
   }
 };

--- a/sdk/include/opentelemetry/sdk/trace/span_data.h
+++ b/sdk/include/opentelemetry/sdk/trace/span_data.h
@@ -28,6 +28,7 @@ public:
                 const trace_api::KeyValueIterable &attributes)
       : name_(name), timestamp_(timestamp), attribute_map_(attributes)
   {}
+
   /**
    * Get the name for this event
    * @return the name for this event

--- a/sdk/include/opentelemetry/sdk/trace/span_data.h
+++ b/sdk/include/opentelemetry/sdk/trace/span_data.h
@@ -58,12 +58,15 @@ private:
 
 /**
  * Class for storing links in SpanData.
- * TODO: Add trace_id, span_id and trace_state when these are supported by SpanContext
+ * TODO: Add getters for trace id, span id and trace state when these are supported by SpanContext
  */
 class SpanDataLink
 {
 public:
-  SpanDataLink(const trace_api::KeyValueIterable &attributes) : attribute_map_(attributes) {}
+  SpanDataLink(opentelemetry::trace::SpanContext span_context,
+               const trace_api::KeyValueIterable &attributes)
+      : span_context_(span_context), attribute_map_(attributes)
+  {}
 
   /**
    * Get the attributes for this link
@@ -75,6 +78,7 @@ public:
   }
 
 private:
+  opentelemetry::trace::SpanContext span_context_;
   AttributeMap attribute_map_;
 };
 
@@ -179,9 +183,8 @@ public:
   void AddLink(opentelemetry::trace::SpanContext span_context,
                const trace_api::KeyValueIterable &attributes) noexcept override
   {
-    SpanDataLink link(attributes);
+    SpanDataLink link(span_context, attributes);
     links_.push_back(link);
-    // TODO: Populate trace_id, span_id and trace_state when these are supported by SpanContext
   }
 
   void SetStatus(trace_api::CanonicalCode code, nostd::string_view description) noexcept override

--- a/sdk/include/opentelemetry/sdk/trace/span_data.h
+++ b/sdk/include/opentelemetry/sdk/trace/span_data.h
@@ -58,7 +58,7 @@ private:
 
 /**
  * Class for storing links in SpanData.
- * TODO: Add getters for trace id, span id and trace state when these are supported by SpanContext
+ * TODO: Add getters for trace_id, span_id and trace_state when these are supported by SpanContext
  */
 class SpanDataLink
 {

--- a/sdk/test/trace/BUILD
+++ b/sdk/test/trace/BUILD
@@ -100,6 +100,17 @@ cc_test(
     ],
 )
 
+cc_test(
+    name = "attribute_utils_test",
+    srcs = [
+        "attribute_utils_test.cc",
+    ],
+    deps = [
+        "//sdk/src/trace",
+        "@com_google_googletest//:gtest_main",
+    ],
+)
+
 otel_cc_benchmark(
     name = "sampler_benchmark",
     srcs = ["sampler_benchmark.cc"],

--- a/sdk/test/trace/attribute_utils_test.cc
+++ b/sdk/test/trace/attribute_utils_test.cc
@@ -1,5 +1,4 @@
 #include "opentelemetry/sdk/trace/attribute_utils.h"
-#include "opentelemetry/trace/key_value_iterable_view.h"
 
 #include <gtest/gtest.h>
 
@@ -13,7 +12,7 @@ TEST(AttributeMapTest, AttributesContruction)
 {
   const int kNumAttributes              = 3;
   std::string keys[kNumAttributes]      = {"attr1", "attr2", "attr3"};
-  int values[kNumAttributes]            = {4, 12, 33};
+  int values[kNumAttributes]            = {15, 24, 37};
   std::map<std::string, int> attributes = {
       {keys[0], values[0]}, {keys[1], values[1]}, {keys[2], values[2]}};
 

--- a/sdk/test/trace/attribute_utils_test.cc
+++ b/sdk/test/trace/attribute_utils_test.cc
@@ -1,0 +1,27 @@
+#include "opentelemetry/sdk/trace/attribute_utils.h"
+#include "opentelemetry/trace/key_value_iterable_view.h"
+
+#include <gtest/gtest.h>
+
+TEST(AttributeMapTest, DefaultContruction)
+{
+  opentelemetry::sdk::trace::AttributeMap map;
+  EXPECT_EQ(map.GetAttributes().size(), 0);
+}
+
+TEST(AttributeMapTest, AttributesContruction)
+{
+  const int kNumAttributes              = 3;
+  std::string keys[kNumAttributes]      = {"attr1", "attr2", "attr3"};
+  int values[kNumAttributes]            = {4, 12, 33};
+  std::map<std::string, int> attributes = {
+      {keys[0], values[0]}, {keys[1], values[1]}, {keys[2], values[2]}};
+
+  opentelemetry::trace::KeyValueIterableView<std::map<std::string, int>> iterable(attributes);
+  opentelemetry::sdk::trace::AttributeMap map(iterable);
+
+  for (int i = 0; i < kNumAttributes; i++)
+  {
+    EXPECT_EQ(opentelemetry::nostd::get<int64_t>(map.GetAttributes().at(keys[i])), values[i]);
+  }
+}

--- a/sdk/test/trace/attribute_utils_test.cc
+++ b/sdk/test/trace/attribute_utils_test.cc
@@ -2,13 +2,13 @@
 
 #include <gtest/gtest.h>
 
-TEST(AttributeMapTest, DefaultContruction)
+TEST(AttributeMapTest, DefaultConstruction)
 {
   opentelemetry::sdk::trace::AttributeMap map;
   EXPECT_EQ(map.GetAttributes().size(), 0);
 }
 
-TEST(AttributeMapTest, AttributesContruction)
+TEST(AttributeMapTest, AttributesConstruction)
 {
   const int kNumAttributes              = 3;
   std::string keys[kNumAttributes]      = {"attr1", "attr2", "attr3"};

--- a/sdk/test/trace/span_data_test.cc
+++ b/sdk/test/trace/span_data_test.cc
@@ -53,3 +53,42 @@ TEST(SpanData, Set)
   ASSERT_EQ(data.GetEvents().at(0).GetName(), "event1");
   ASSERT_EQ(data.GetEvents().at(0).GetTimestamp(), now);
 }
+
+TEST(SpanData, EventAttributes)
+{
+  SpanData data;
+  const int kNumAttributes              = 3;
+  std::string keys[kNumAttributes]      = {"attr1", "attr2", "attr3"};
+  int values[kNumAttributes]            = {4, 7, 23};
+  std::map<std::string, int> attributes = {
+      {keys[0], values[0]}, {keys[1], values[1]}, {keys[2], values[2]}};
+
+  data.AddEvent("Test Event", std::chrono::system_clock::now(),
+                opentelemetry::trace::KeyValueIterableView<std::map<std::string, int>>(attributes));
+
+  for (int i = 0; i < kNumAttributes; i++)
+  {
+    EXPECT_EQ(
+        opentelemetry::nostd::get<int64_t>(data.GetEvents().at(0).GetAttributes().at(keys[i])),
+        values[i]);
+  }
+}
+
+TEST(SpanData, Links)
+{
+  SpanData data;
+  const int kNumAttributes              = 3;
+  std::string keys[kNumAttributes]      = {"attr1", "attr2", "attr3"};
+  int values[kNumAttributes]            = {4, 7, 23};
+  std::map<std::string, int> attributes = {
+      {keys[0], values[0]}, {keys[1], values[1]}, {keys[2], values[2]}};
+
+  data.AddLink(opentelemetry::trace::SpanContext(false, false),
+               opentelemetry::trace::KeyValueIterableView<std::map<std::string, int>>(attributes));
+
+  for (int i = 0; i < kNumAttributes; i++)
+  {
+    EXPECT_EQ(opentelemetry::nostd::get<int64_t>(data.GetLinks().at(0).GetAttributes().at(keys[i])),
+              values[i]);
+  }
+}

--- a/sdk/test/trace/span_data_test.cc
+++ b/sdk/test/trace/span_data_test.cc
@@ -59,7 +59,7 @@ TEST(SpanData, EventAttributes)
   SpanData data;
   const int kNumAttributes              = 3;
   std::string keys[kNumAttributes]      = {"attr1", "attr2", "attr3"};
-  int values[kNumAttributes]            = {4, 7, 23};
+  int values[kNumAttributes]            = {3, 5, 20};
   std::map<std::string, int> attributes = {
       {keys[0], values[0]}, {keys[1], values[1]}, {keys[2], values[2]}};
 
@@ -79,7 +79,7 @@ TEST(SpanData, Links)
   SpanData data;
   const int kNumAttributes              = 3;
   std::string keys[kNumAttributes]      = {"attr1", "attr2", "attr3"};
-  int values[kNumAttributes]            = {4, 7, 23};
+  int values[kNumAttributes]            = {4, 12, 33};
   std::map<std::string, int> attributes = {
       {keys[0], values[0]}, {keys[1], values[1]}, {keys[2], values[2]}};
 


### PR DESCRIPTION
Add support for links and event attributes to `SpanData`. Note that since `SpanContext` is not yet fully implemented, support for populating `trace_id`, `span_id` and `trace_state` will have to be added later (see issue https://github.com/open-telemetry/opentelemetry-cpp/issues/214).

This PR refactors functionality related to attributes into an `attribute_utils.h` file, simplifying `span_data.h`. The `attribute_utils` includes an  `AttributeMap` class that is used to store attributes in `SpanData`, `SpanDataEvent` and `SpanDataLink`. `AttributeMap` wraps `std::unordered_map` under the hood.