### PR TITLE
Add a memory check task to the CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,7 +70,7 @@ jobs:
         sudo ./ci/install_bazelisk.sh
     - name: run tests
       run: ./ci/do_ci.sh bazel.test
-      
+
   bazel_valgrind:
     name: Bazel valgrind
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,6 +70,19 @@ jobs:
         sudo ./ci/install_bazelisk.sh
     - name: run tests
       run: ./ci/do_ci.sh bazel.test
+      
+  bazel_valgrind:
+    name: Bazel valgrind
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: setup
+      run: |
+        sudo ./ci/setup_cmake.sh
+        sudo ./ci/setup_ci_environment.sh
+        sudo ./ci/install_bazelisk.sh
+    - name: run tests
+      run: ./ci/do_ci.sh bazel.valgrind
 
   bazel_noexcept:
     name: Bazel noexcept

--- a/ci/README.md
+++ b/ci/README.md
@@ -11,6 +11,7 @@ CI tests can be run on docker by invoking the script `./ci/run_docker.sh ./ci/do
 * `bazel.noexcept`: build bazel targets and run tests with exceptions disabled.
 * `bazel.asan`: build bazel targets and run tests with AddressSanitizer.
 * `bazel.tsan`: build bazel targets and run tests with ThreadSanitizer.
+* `bazel.valgrind`: build bazel targets and run tests under the valgrind memory checker.
 * `benchmark`: run all benchmarks.
 * `format`: use `tools/format.sh` to enforce text formatting.
 * `code.coverage`: build cmake targets and run tests. Then upload coverage report to [codecov.io](https://codecov.io/).

--- a/ci/do_ci.sh
+++ b/ci/do_ci.sh
@@ -92,6 +92,10 @@ elif [[ "$1" == "bazel.asan" ]]; then
 elif [[ "$1" == "bazel.tsan" ]]; then
   bazel test --config=tsan $BAZEL_TEST_OPTIONS //...
   exit 0
+elif [[ "$1" == "bazel.valgrind" ]]; then
+  bazel build $BAZEL_OPTIONS //...
+  bazel test --run_under="/usr/bin/valgrind --leak-check=full --error-exitcode=1" $BAZEL_TEST_OPTIONS //...
+  exit 0
 elif [[ "$1" == "benchmark" ]]; then
   [ -z "${BENCHMARK_DIR}" ] && export BENCHMARK_DIR=$HOME/benchmark
   bazel build $BAZEL_OPTIONS -c opt -- \

--- a/ci/setup_ci_environment.sh
+++ b/ci/setup_ci_environment.sh
@@ -6,5 +6,6 @@ apt-get install --no-install-recommends --no-install-suggests -y \
                 build-essential \
                 ca-certificates \
                 wget \
-                git
-apt-get install -y lcov
+                git \
+                valgrind \
+                lcov

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -1,3 +1,4 @@
 add_subdirectory(plugin)
 add_subdirectory(simple)
 add_subdirectory(batch)
+add_subdirectory(metrics_simple)

--- a/examples/metrics_simple/CMakeLists.txt
+++ b/examples/metrics_simple/CMakeLists.txt
@@ -1,0 +1,6 @@
+include_directories(${CMAKE_SOURCE_DIR}/exporters/ostream/include)
+
+add_executable(simple_metrics main.cc)
+target_link_libraries(
+  simple_metrics ${CMAKE_THREAD_LIBS_INIT} opentelemetry_metrics
+  opentelemetry_exporter_ostream_metrics)

--- a/examples/metrics_simple/main.cc
+++ b/examples/metrics_simple/main.cc
@@ -1,3 +1,4 @@
+#include "opentelemetry/exporters/ostream/metrics_exporter.h"
 #include "opentelemetry/metrics/provider.h"
 #include "opentelemetry/sdk/metrics/controller.h"
 #include "opentelemetry/sdk/metrics/meter.h"

--- a/sdk/test/metrics/CMakeLists.txt
+++ b/sdk/test/metrics/CMakeLists.txt
@@ -7,7 +7,9 @@ foreach(
   counter_aggregator_test
   histogram_aggregator_test
   ungrouped_processor_test
-  meter_test)
+  meter_test
+  metric_instrument_test
+  controller_test)
   add_executable(${testname} "${testname}.cc")
   target_link_libraries(${testname} ${GTEST_BOTH_LIBRARIES}
                         ${CMAKE_THREAD_LIBS_INIT} opentelemetry_metrics)

--- a/sdk/test/metrics/controller_test.cc
+++ b/sdk/test/metrics/controller_test.cc
@@ -14,15 +14,20 @@ namespace sdk
 {
 namespace metrics
 {
+class DummyExporter : public MetricsExporter
+{
+  ExportResult Export(const std::vector<Record> &records) noexcept
+  {
+    return ExportResult::kSuccess;
+  }
+};
 
 TEST(Controller, Constructor)
 {
 
   std::shared_ptr<metrics_api::Meter> meter =
       std::shared_ptr<metrics_api::Meter>(new Meter("Test"));
-  PushController alpha(meter,
-                       std::unique_ptr<MetricsExporter>(
-                           new opentelemetry::exporter::metrics::OStreamMetricsExporter),
+  PushController alpha(meter, std::unique_ptr<MetricsExporter>(new DummyExporter),
                        std::shared_ptr<MetricsProcessor>(
                            new opentelemetry::sdk::metrics::UngroupedMetricsProcessor(false)),
                        .05);

--- a/sdk/test/metrics/metric_instrument_test.cc
+++ b/sdk/test/metrics/metric_instrument_test.cc
@@ -94,24 +94,24 @@ TEST(IntValueObserver, StressObserve)
 
   std::thread first(ObserverCallback, alpha, 25,
                     labelkv);  // spawn new threads that call the callback
-  std::thread second(ObserverCallback, alpha, 50, labelkv);
+  std::thread second(ObserverCallback, alpha, 25, labelkv);
   std::thread third(ObserverCallback, alpha, 25, labelkv1);
-  std::thread fourth(NegObserverCallback, alpha, 100, labelkv1);  // negative values
+  std::thread fourth(NegObserverCallback, alpha, 25, labelkv1);  // negative values
 
   first.join();
   second.join();
   third.join();
   fourth.join();
 
-  EXPECT_EQ(alpha->boundAggregators_[KvToString(labelkv)]->get_values()[0], 0);     // min
-  EXPECT_EQ(alpha->boundAggregators_[KvToString(labelkv)]->get_values()[1], 49);    // max
-  EXPECT_EQ(alpha->boundAggregators_[KvToString(labelkv)]->get_values()[2], 1525);  // sum
-  EXPECT_EQ(alpha->boundAggregators_[KvToString(labelkv)]->get_values()[3], 75);    // count
+  EXPECT_EQ(alpha->boundAggregators_[KvToString(labelkv)]->get_values()[0], 0);    // min
+  EXPECT_EQ(alpha->boundAggregators_[KvToString(labelkv)]->get_values()[1], 24);   // max
+  EXPECT_EQ(alpha->boundAggregators_[KvToString(labelkv)]->get_values()[2], 600);  // sum
+  EXPECT_EQ(alpha->boundAggregators_[KvToString(labelkv)]->get_values()[3], 50);   // count
 
-  EXPECT_EQ(alpha->boundAggregators_[KvToString(labelkv1)]->get_values()[0], -99);    // min
-  EXPECT_EQ(alpha->boundAggregators_[KvToString(labelkv1)]->get_values()[1], 24);     // max
-  EXPECT_EQ(alpha->boundAggregators_[KvToString(labelkv1)]->get_values()[2], -4650);  // sum
-  EXPECT_EQ(alpha->boundAggregators_[KvToString(labelkv1)]->get_values()[3], 125);    // count
+  EXPECT_EQ(alpha->boundAggregators_[KvToString(labelkv1)]->get_values()[0], -24);  // min
+  EXPECT_EQ(alpha->boundAggregators_[KvToString(labelkv1)]->get_values()[1], 24);   // max
+  EXPECT_EQ(alpha->boundAggregators_[KvToString(labelkv1)]->get_values()[2], 0);    // sum
+  EXPECT_EQ(alpha->boundAggregators_[KvToString(labelkv1)]->get_values()[3], 50);   // count
 }
 
 void SumObserverCallback(std::shared_ptr<SumObserver<int>> in,
@@ -176,19 +176,19 @@ TEST(IntUpDownObserver, StressAdd)
   auto labelkv  = trace::KeyValueIterableView<decltype(labels)>{labels};
   auto labelkv1 = trace::KeyValueIterableView<decltype(labels1)>{labels1};
 
-  std::thread first(UpDownSumObserverCallback, alpha, 123400,
+  std::thread first(UpDownSumObserverCallback, alpha, 12340,
                     labelkv);  // spawn new threads that call the callback
-  std::thread second(UpDownSumObserverCallback, alpha, 123400, labelkv);
-  std::thread third(UpDownSumObserverCallback, alpha, 567800, labelkv1);
-  std::thread fourth(NegUpDownSumObserverCallback, alpha, 123400, labelkv1);  // negative values
+  std::thread second(UpDownSumObserverCallback, alpha, 12340, labelkv);
+  std::thread third(UpDownSumObserverCallback, alpha, 56780, labelkv1);
+  std::thread fourth(NegUpDownSumObserverCallback, alpha, 12340, labelkv1);  // negative values
 
   first.join();
   second.join();
   third.join();
   fourth.join();
 
-  EXPECT_EQ(alpha->boundAggregators_[KvToString(labelkv)]->get_values()[0], 123400 * 2);
-  EXPECT_EQ(alpha->boundAggregators_[KvToString(labelkv1)]->get_values()[0], 567800 - 123400);
+  EXPECT_EQ(alpha->boundAggregators_[KvToString(labelkv)]->get_values()[0], 12340 * 2);
+  EXPECT_EQ(alpha->boundAggregators_[KvToString(labelkv1)]->get_values()[0], 56780 - 12340);
 }
 
 TEST(Counter, InstrumentFunctions)
@@ -280,9 +280,9 @@ TEST(Counter, StressAdd)
   auto labelkv  = trace::KeyValueIterableView<decltype(labels)>{labels};
   auto labelkv1 = trace::KeyValueIterableView<decltype(labels1)>{labels1};
 
-  std::thread first(CounterCallback, alpha, 100000, labelkv);
-  std::thread second(CounterCallback, alpha, 100000, labelkv);
-  std::thread third(CounterCallback, alpha, 300000, labelkv1);
+  std::thread first(CounterCallback, alpha, 1000, labelkv);
+  std::thread second(CounterCallback, alpha, 1000, labelkv);
+  std::thread third(CounterCallback, alpha, 3000, labelkv1);
 
   first.join();
   second.join();
@@ -291,11 +291,11 @@ TEST(Counter, StressAdd)
   EXPECT_EQ(dynamic_cast<BoundCounter<int> *>(alpha->boundInstruments_[KvToString(labelkv)].get())
                 ->GetAggregator()
                 ->get_values()[0],
-            200000);
+            2000);
   EXPECT_EQ(dynamic_cast<BoundCounter<int> *>(alpha->boundInstruments_[KvToString(labelkv1)].get())
                 ->GetAggregator()
                 ->get_values()[0],
-            300000);
+            3000);
 }
 
 void UpDownCounterCallback(std::shared_ptr<UpDownCounter<int>> in,
@@ -328,11 +328,11 @@ TEST(IntUpDownCounter, StressAdd)
   auto labelkv  = trace::KeyValueIterableView<decltype(labels)>{labels};
   auto labelkv1 = trace::KeyValueIterableView<decltype(labels1)>{labels1};
 
-  std::thread first(UpDownCounterCallback, alpha, 123400,
+  std::thread first(UpDownCounterCallback, alpha, 12340,
                     labelkv);  // spawn new threads that call the callback
-  std::thread second(UpDownCounterCallback, alpha, 123400, labelkv);
-  std::thread third(UpDownCounterCallback, alpha, 567800, labelkv1);
-  std::thread fourth(NegUpDownCounterCallback, alpha, 123400, labelkv1);  // negative values
+  std::thread second(UpDownCounterCallback, alpha, 12340, labelkv);
+  std::thread third(UpDownCounterCallback, alpha, 56780, labelkv1);
+  std::thread fourth(NegUpDownCounterCallback, alpha, 12340, labelkv1);  // negative values
 
   first.join();
   second.join();
@@ -343,12 +343,12 @@ TEST(IntUpDownCounter, StressAdd)
       dynamic_cast<BoundUpDownCounter<int> *>(alpha->boundInstruments_[KvToString(labelkv)].get())
           ->GetAggregator()
           ->get_values()[0],
-      123400 * 2);
+      12340 * 2);
   EXPECT_EQ(
       dynamic_cast<BoundUpDownCounter<int> *>(alpha->boundInstruments_[KvToString(labelkv1)].get())
           ->GetAggregator()
           ->get_values()[0],
-      567800 - 123400);
+      56780 - 12340);
 }
 
 void RecorderCallback(std::shared_ptr<ValueRecorder<int>> in,


### PR DESCRIPTION
This adds a new task `bazel.valgrind` and adds it to our CI.

This task runs all our test via Bazel under the valgrind memory checker, thus exposing any memory leaks or memory violations.