### PR TITLE
Add Simple Metrics example

### DIFF
--- a/examples/metrics_simple/BUILD
+++ b/examples/metrics_simple/BUILD
@@ -1,0 +1,11 @@
+cc_binary(
+    name = "metrics_simple_example",
+    srcs = [
+        "main.cc",
+    ],
+    deps = [
+        "//api",
+        "//sdk/src/metrics",
+        "//exporters/ostream:ostream_metrics_exporter",
+    ],
+)

--- a/examples/metrics_simple/BUILD
+++ b/examples/metrics_simple/BUILD
@@ -3,10 +3,10 @@ cc_binary(
     srcs = [
         "main.cc",
     ],
+    linkopts = ["-pthread"],
     deps = [
         "//api",
         "//exporters/ostream:ostream_metrics_exporter",
         "//sdk/src/metrics",
     ],
-    linkopts = ["-pthread"],
 )

--- a/examples/metrics_simple/BUILD
+++ b/examples/metrics_simple/BUILD
@@ -5,7 +5,8 @@ cc_binary(
     ],
     deps = [
         "//api",
-        "//sdk/src/metrics",
         "//exporters/ostream:ostream_metrics_exporter",
+        "//sdk/src/metrics",
     ],
+    linkopts = ["-pthread"],
 )

--- a/examples/metrics_simple/README.md
+++ b/examples/metrics_simple/README.md
@@ -1,0 +1,67 @@
+# Simple Metrics Example
+
+In this example, the application in `main.cc` initializes the metrics pipeline and shows 3 different ways of updating instrument values. Here are more detailed explanations of each part.
+
+1. Initialize a MeterProvider. We will use this to obtain Meter objects in the future.  
+
+`auto provider = shared_ptr<MeterProvider>(new MeterProvider);`
+
+2. Set the MeterProvider as the default instance for the library. This ensures that we will have access to the same MeterProvider across our application.
+
+`Provider::SetMeterProvider(provider);`
+
+3. Obtain a meter from this meter provider. Every Meter pointer returned by the MeterProvider points to the same Meter. This means that the Meter will be able to combine metrics captured from different functions without having to constantly pass the Meter around the library.
+
+`shared_ptr<Meter> meter = provider→GetMeter("Test");`
+
+4. Initialize an exporter and processor. In this case, we initialize an OStream Exporter which will print to stdout by default. The Processor is an UngroupedProcessor which doesn’t filter or group captured metrics in any way. The false parameter indicates that this processor will send metric deltas rather than metric cumulatives.
+
+```
+unique_ptr<MetricsExporter> exporter = unique_ptr<MetricsExporter>(new OStreamMetricsExporter);  
+shared_ptr<MetricsProcessor> processor = shared_ptr<MetricsProcessor>(new UngroupedMetricsProcessor(false));
+```
+
+5. Pass the meter, exporter, and processor into the controller. Since this is a push controller, a collection interval parameter (in seconds) is also taken. At each collection interval, the controller will request data from all of the instruments in the code and export them. Start the controller to begin the metrics pipeline.
+
+`metrics_sdk::PushController controller(meter, std::move(exporter), processor, 5);`
+`controller.start();`
+
+6. Instrument code with synchronous and asynchronous instrument. These instruments can be placed in areas of interest to collect metrics and are created by the meter. Synchronous instruments are updated whenever the user desires with a value and label set. Calling add on a counter instrument for example will increase its value.  Asynchronous instruments can be updated the same way, but are intended to recieve updates from a callback function. The callback below observes a value of 1. The user never has to call this function as it is automatically called by the controller. 
+
+```
+
+// Observer callback function
+void SumObserverCallback(metrics_api::ObserverResult<int> result){
+    std::map<std::string, std::string> labels = {{"key", "value"}};
+    auto labelkv = trace::KeyValueIterableView<decltype(labels)>{labels};
+    result.observe(1,labelkv);
+}
+
+// Create new instruments
+auto ctr= meter->NewIntCounter("Counter","none", "none", true);
+auto obs= meter->NewIntSumObserver("Counter","none", "none", true, &SumObserverCallback);
+
+// Create a label set which annotates metric values
+std::map<std::string, std::string> labels = {{"key", "value"}};
+auto labelkv = trace::KeyValueIterableView<decltype(labels)>{labels};
+
+// Capture data from instruments.  Note that the asynchronous instrument is updates 
+// automatically though its callback at the collection interval.  Additional measurments
+// can be made through calls to its observe function.
+ctr->add(5, labelkv);
+
+```
+
+7. Stop the controller once the program finished. This ensures that any metrics inside the pipeline are properly exported. Otherwise, some metrics may be destroyed in cleanup.
+
+`controller.stop();`
+
+See [CONTRIBUTING.md](../../CONTRIBUTING.md) for instructions on building and running the example.
+
+## Additional Documentation
+
+[API Design](https://github.com/open-o11y/otel-docs/blob/master/cpp-metrics/api-design.md)
+
+[SDK Design](https://github.com/open-o11y/otel-docs/blob/master/cpp-metrics/sdk-design.md)
+
+[OStreamExporters Design](https://github.com/open-o11y/otel-docs/blob/master/exporter/ostream/ostream-exporter-design.md)

--- a/examples/metrics_simple/README.md
+++ b/examples/metrics_simple/README.md
@@ -2,7 +2,7 @@
 
 In this example, the application in `main.cc` initializes the metrics pipeline and shows 3 different ways of updating instrument values. Here are more detailed explanations of each part.
 
-1. Initialize a MeterProvider. We will use this to obtain Meter objects in the future.  
+1. Initialize a MeterProvider. We will use this to obtain Meter objects in the future.
 
 `auto provider = shared_ptr<MeterProvider>(new MeterProvider);`
 
@@ -17,7 +17,7 @@ In this example, the application in `main.cc` initializes the metrics pipeline a
 4. Initialize an exporter and processor. In this case, we initialize an OStream Exporter which will print to stdout by default. The Processor is an UngroupedProcessor which doesn’t filter or group captured metrics in any way. The false parameter indicates that this processor will send metric deltas rather than metric cumulatives.
 
 ```
-unique_ptr<MetricsExporter> exporter = unique_ptr<MetricsExporter>(new OStreamMetricsExporter);  
+unique_ptr<MetricsExporter> exporter = unique_ptr<MetricsExporter>(new OStreamMetricsExporter);
 shared_ptr<MetricsProcessor> processor = shared_ptr<MetricsProcessor>(new UngroupedMetricsProcessor(false));
 ```
 
@@ -26,7 +26,7 @@ shared_ptr<MetricsProcessor> processor = shared_ptr<MetricsProcessor>(new Ungrou
 `metrics_sdk::PushController controller(meter, std::move(exporter), processor, 5);`
 `controller.start();`
 
-6. Instrument code with synchronous and asynchronous instrument. These instruments can be placed in areas of interest to collect metrics and are created by the meter. Synchronous instruments are updated whenever the user desires with a value and label set. Calling add on a counter instrument for example will increase its value.  Asynchronous instruments can be updated the same way, but are intended to recieve updates from a callback function. The callback below observes a value of 1. The user never has to call this function as it is automatically called by the controller. 
+6. Instrument code with synchronous and asynchronous instrument. These instruments can be placed in areas of interest to collect metrics and are created by the meter. Synchronous instruments are updated whenever the user desires with a value and label set. Calling add on a counter instrument for example will increase its value.  Asynchronous instruments can be updated the same way, but are intended to recieve updates from a callback function. The callback below observes a value of 1. The user never has to call this function as it is automatically called by the controller.
 
 ```
 
@@ -45,7 +45,7 @@ auto obs= meter->NewIntSumObserver("Counter","none", "none", true, &SumObserverC
 std::map<std::string, std::string> labels = {{"key", "value"}};
 auto labelkv = trace::KeyValueIterableView<decltype(labels)>{labels};
 
-// Capture data from instruments.  Note that the asynchronous instrument is updates 
+// Capture data from instruments.  Note that the asynchronous instrument is updates
 // automatically though its callback at the collection interval.  Additional measurments
 // can be made through calls to its observe function.
 ctr->add(5, labelkv);

--- a/examples/metrics_simple/main.cc
+++ b/examples/metrics_simple/main.cc
@@ -1,8 +1,8 @@
+#include "opentelemetry/metrics/provider.h"
 #include "opentelemetry/sdk/metrics/controller.h"
 #include "opentelemetry/sdk/metrics/meter.h"
-#include "opentelemetry/sdk/metrics/ungrouped_processor.h"
 #include "opentelemetry/sdk/metrics/meter_provider.h"
-#include "opentelemetry/metrics/provider.h"
+#include "opentelemetry/sdk/metrics/ungrouped_processor.h"
 
 #include <unistd.h>
 
@@ -10,41 +10,46 @@ namespace sdkmetrics = opentelemetry::sdk::metrics;
 namespace nostd      = opentelemetry::nostd;
 namespace trace      = opentelemetry::trace;
 
-int main() {
+int main()
+{
   // Initialize and set the global MeterProvider
   auto provider = nostd::shared_ptr<metrics_api::MeterProvider>(new sdkmetrics::MeterProvider);
   opentelemetry::metrics::Provider::SetMeterProvider(provider);
 
   // Get the Meter from the MeterProvider
-  nostd::shared_ptr<metrics_api::Meter> meter = provider->GetMeter("Test","0.1.0");
-  
+  nostd::shared_ptr<metrics_api::Meter> meter = provider->GetMeter("Test", "0.1.0");
+
   // Create the controller with Stateless Metrics Processor
-  sdkmetrics::PushController ControllerStateless(meter,
-                        std::unique_ptr<sdkmetrics::MetricsExporter>(new opentelemetry::exporter::metrics::OStreamMetricsExporter),
-                        std::shared_ptr<sdkmetrics::MetricsProcessor>(new opentelemetry::sdk::metrics::UngroupedMetricsProcessor(false)),
-                        .05);
+  sdkmetrics::PushController ControllerStateless(
+      meter,
+      std::unique_ptr<sdkmetrics::MetricsExporter>(
+          new opentelemetry::exporter::metrics::OStreamMetricsExporter),
+      std::shared_ptr<sdkmetrics::MetricsProcessor>(
+          new opentelemetry::sdk::metrics::UngroupedMetricsProcessor(false)),
+      .05);
 
   // Create and instrument
-  auto intupdowncounter = meter->NewIntUpDownCounter("UpDownCounter","None","none",true);
-  auto intcounter = meter->NewIntCounter("Counter","none","none",true);
+  auto intupdowncounter = meter->NewIntUpDownCounter("UpDownCounter", "None", "none", true);
+  auto intcounter       = meter->NewIntCounter("Counter", "none", "none", true);
 
   // Create a labelset
   std::map<std::string, std::string> labels = {{"key", "value"}};
-  auto labelkv = trace::KeyValueIterableView<decltype(labels)>{labels};
-  
+  auto labelkv                              = trace::KeyValueIterableView<decltype(labels)>{labels};
+
   // Create arrays of instrument and values to add to them
-  metrics_api::SynchronousInstrument<int>* iinstr_arr[] = {intupdowncounter.get(), intcounter.get()};
-  int ivalues_arr[] = {10, 5};
+  metrics_api::SynchronousInstrument<int> *iinstr_arr[] = {intupdowncounter.get(),
+                                                           intcounter.get()};
+  int ivalues_arr[]                                     = {10, 5};
 
   // Change the arrays to be nostd::spans
-  nostd::span<metrics_api::SynchronousInstrument<int>*> instrument_span {iinstr_arr};
-  nostd::span<const int, 2> instrument_values {ivalues_arr};
+  nostd::span<metrics_api::SynchronousInstrument<int> *> instrument_span{iinstr_arr};
+  nostd::span<const int, 2> instrument_values{ivalues_arr};
 
-  /** 
-  * First way of updating an instrument, RecordBatch. We can update multiple instruments at once by
-  * using a span of instruments and a span of values. This RecordBatch will update the ith
-  * instrument with the ith value.
-  **/
+  /**
+   * First way of updating an instrument, RecordBatch. We can update multiple instruments at once by
+   * using a span of instruments and a span of values. This RecordBatch will update the ith
+   * instrument with the ith value.
+   **/
   std::cout << "Example 1" << std::endl;
   ControllerStateless.start();
 
@@ -52,9 +57,9 @@ int main() {
   meter->RecordIntBatch(labelkv, instrument_span, instrument_values);
 
   ControllerStateless.stop();
-  /** 
-   * Second way of updating an instrument, bind then add. In this method the user binds an instrument to a labelset
-   * Then add to the bounded instrument, then unbind.
+  /**
+   * Second way of updating an instrument, bind then add. In this method the user binds an
+   *instrument to a labelset Then add to the bounded instrument, then unbind.
    **/
   std::cout << "Example 2" << std::endl;
   ControllerStateless.start();
@@ -70,28 +75,35 @@ int main() {
    */
 
   // Start exporting from the Controller with Stateless Processor
-  std::cout << "-----" << " Stateless Processor " << "-----" << std::endl;
+  std::cout << "-----"
+            << " Stateless Processor "
+            << "-----" << std::endl;
   ControllerStateless.start();
   for (int i = 0; i < 20; i++)
   {
     intupdowncounter->add(i, labelkv);
-    usleep(.01*1000000);
+    usleep(.01 * 1000000);
   }
-  ControllerStateless.stop(); 
+  ControllerStateless.stop();
 
   // Do the same thing for stateful to see the difference
-  sdkmetrics::PushController ControllerStateful(meter,
-                      std::unique_ptr<sdkmetrics::MetricsExporter>(new opentelemetry::exporter::metrics::OStreamMetricsExporter),
-                      std::shared_ptr<sdkmetrics::MetricsProcessor>(new opentelemetry::sdk::metrics::UngroupedMetricsProcessor(true)),
-                      .05);
+  sdkmetrics::PushController ControllerStateful(
+      meter,
+      std::unique_ptr<sdkmetrics::MetricsExporter>(
+          new opentelemetry::exporter::metrics::OStreamMetricsExporter),
+      std::shared_ptr<sdkmetrics::MetricsProcessor>(
+          new opentelemetry::sdk::metrics::UngroupedMetricsProcessor(true)),
+      .05);
 
-  // Start exporting from the Controller with Stateful Processor     
-  std::cout << "-----" << " Stateful Processor " << "-----" << std::endl;
+  // Start exporting from the Controller with Stateful Processor
+  std::cout << "-----"
+            << " Stateful Processor "
+            << "-----" << std::endl;
   ControllerStateful.start();
   for (int i = 0; i < 20; i++)
   {
     intupdowncounter->add(i, labelkv);
-    usleep(.01*1000000);
+    usleep(.01 * 1000000);
   }
-  ControllerStateful.stop(); 
+  ControllerStateful.stop();
 }

--- a/examples/metrics_simple/main.cc
+++ b/examples/metrics_simple/main.cc
@@ -1,0 +1,96 @@
+#include "opentelemetry/sdk/metrics/controller.h"
+#include "opentelemetry/sdk/metrics/meter.h"
+#include "opentelemetry/sdk/metrics/ungrouped_processor.h"
+#include "opentelemetry/sdk/metrics/meter_provider.h"
+#include "opentelemetry/metrics/provider.h"
+
+namespace sdkmetrics = opentelemetry::sdk::metrics;
+namespace nostd      = opentelemetry::nostd;
+namespace trace      = opentelemetry::trace;
+
+int main() {
+  // Initialize and set the global MeterProvider
+  auto provider = nostd::shared_ptr<metrics_api::MeterProvider>(new sdkmetrics::MeterProvider);
+  opentelemetry::metrics::Provider::SetMeterProvider(provider);
+
+  // Get the Meter from the MeterProvider
+  nostd::shared_ptr<metrics_api::Meter> meter = provider->GetMeter("Test","0.1.0");
+  
+  // Create the controller with Stateless Metrics Processor
+  sdkmetrics::PushController ControllerStateless(meter,
+                        std::unique_ptr<sdkmetrics::MetricsExporter>(new opentelemetry::exporter::metrics::OStreamMetricsExporter),
+                        std::shared_ptr<sdkmetrics::MetricsProcessor>(new opentelemetry::sdk::metrics::UngroupedMetricsProcessor(false)),
+                        .05);
+
+  // Create and instrument
+  auto intupdowncounter = meter->NewIntUpDownCounter("UpDownCounter","None","none",true);
+  auto intcounter = meter->NewIntCounter("Counter","none","none",true);
+
+  // Create a labelset
+  std::map<std::string, std::string> labels = {{"key", "value"}};
+  auto labelkv = trace::KeyValueIterableView<decltype(labels)>{labels};
+  
+  // Create arrays of instrument and values to add to them
+  metrics_api::SynchronousInstrument<int>* iinstr_arr[] = {intupdowncounter.get(), intcounter.get()};
+  int ivalues_arr[] = {10, 5};
+
+  // Change the arrays to be nostd::spans
+  nostd::span<metrics_api::SynchronousInstrument<int>*> instrument_span {iinstr_arr};
+  nostd::span<const int, 2> instrument_values {ivalues_arr};
+
+  /** 
+  * First way of updating an instrument, RecordBatch. We can update multiple instruments at once by
+  * using a span of instruments and a span of values. This RecordBatch will update the ith
+  * instrument with the ith value.
+  **/
+  ControllerStateless.start();
+
+  // Updating multiple instruments with the same labelset
+  meter->RecordIntBatch(labelkv, instrument_span, instrument_values);
+
+  ControllerStateless.stop();
+  std::cout << std::endl;
+  /** 
+   * Second way of updating an instrument, bind then add. In this method the user binds an instrument to a labelset
+   * Then add to the bounded instrument, then unbind.
+   **/
+
+  ControllerStateless.start();
+
+  auto boundintupdowncounter = intupdowncounter->bindUpDownCounter(labelkv);
+  boundintupdowncounter->add(50);
+  boundintupdowncounter->unbind();
+
+  ControllerStateless.stop();
+  std::cout << std::endl;
+  /**
+   * The Third and final way is to add a value with a labelset at the same time. This also shows
+   * The difference between using a Stateless and Stateful Processor
+   */
+
+  // Start exporting from the Controller with Stateless Processor
+  std::cout << "-----" << " Stateless Processor " << "-----" << std::endl;
+  ControllerStateless.start();
+  for (int i = 0; i < 20; i++)
+  {
+    intupdowncounter->add(i, labelkv);
+    usleep(.01*1000000);
+  }
+  ControllerStateless.stop(); 
+
+  // Do the same thing for stateful to see the difference
+  sdkmetrics::PushController ControllerStateful(meter,
+                      std::unique_ptr<sdkmetrics::MetricsExporter>(new opentelemetry::exporter::metrics::OStreamMetricsExporter),
+                      std::shared_ptr<sdkmetrics::MetricsProcessor>(new opentelemetry::sdk::metrics::UngroupedMetricsProcessor(true)),
+                      .05);
+
+  // Start exporting from the Controller with Stateful Processor     
+  std::cout << "-----" << " Stateful Processor " << "-----" << std::endl;
+  ControllerStateful.start();
+  for (int i = 0; i < 20; i++)
+  {
+    intupdowncounter->add(i, labelkv);
+    usleep(.01*1000000);
+  }
+  ControllerStateful.stop(); 
+}

--- a/examples/metrics_simple/main.cc
+++ b/examples/metrics_simple/main.cc
@@ -4,8 +4,6 @@
 #include "opentelemetry/sdk/metrics/meter_provider.h"
 #include "opentelemetry/sdk/metrics/ungrouped_processor.h"
 
-#include <unistd.h>
-
 namespace sdkmetrics = opentelemetry::sdk::metrics;
 namespace nostd      = opentelemetry::nostd;
 namespace trace      = opentelemetry::trace;
@@ -82,7 +80,7 @@ int main()
   for (int i = 0; i < 20; i++)
   {
     intupdowncounter->add(i, labelkv);
-    usleep(.01 * 1000000);
+    std::this_thread::sleep_for(std::chrono::milliseconds(10));
   }
   ControllerStateless.stop();
 
@@ -103,7 +101,7 @@ int main()
   for (int i = 0; i < 20; i++)
   {
     intupdowncounter->add(i, labelkv);
-    usleep(.01 * 1000000);
+    std::this_thread::sleep_for(std::chrono::milliseconds(10));
   }
   ControllerStateful.stop();
 }

--- a/examples/metrics_simple/main.cc
+++ b/examples/metrics_simple/main.cc
@@ -4,8 +4,6 @@
 #include "opentelemetry/sdk/metrics/meter_provider.h"
 #include "opentelemetry/metrics/provider.h"
 
-#include <unistd.h>
-
 namespace sdkmetrics = opentelemetry::sdk::metrics;
 namespace nostd      = opentelemetry::nostd;
 namespace trace      = opentelemetry::trace;
@@ -75,7 +73,7 @@ int main() {
   for (int i = 0; i < 20; i++)
   {
     intupdowncounter->add(i, labelkv);
-    usleep(.01*1000000);
+    // usleep(.01*1000000);
   }
   ControllerStateless.stop(); 
 
@@ -91,7 +89,7 @@ int main() {
   for (int i = 0; i < 20; i++)
   {
     intupdowncounter->add(i, labelkv);
-    usleep(.01*1000000);
+    // usleep(.01*1000000);
   }
   ControllerStateful.stop(); 
 }

--- a/examples/metrics_simple/main.cc
+++ b/examples/metrics_simple/main.cc
@@ -4,6 +4,10 @@
 #include "opentelemetry/sdk/metrics/meter_provider.h"
 #include "opentelemetry/metrics/provider.h"
 
+#include <stdlib.h>
+#include <unistd.h>
+#include <stdio.h>
+
 namespace sdkmetrics = opentelemetry::sdk::metrics;
 namespace nostd      = opentelemetry::nostd;
 namespace trace      = opentelemetry::trace;
@@ -43,18 +47,18 @@ int main() {
   * using a span of instruments and a span of values. This RecordBatch will update the ith
   * instrument with the ith value.
   **/
+  std::cout << "Example 1" << std::endl;
   ControllerStateless.start();
 
   // Updating multiple instruments with the same labelset
   meter->RecordIntBatch(labelkv, instrument_span, instrument_values);
 
   ControllerStateless.stop();
-  std::cout << std::endl;
   /** 
    * Second way of updating an instrument, bind then add. In this method the user binds an instrument to a labelset
    * Then add to the bounded instrument, then unbind.
    **/
-
+  std::cout << "Example 2" << std::endl;
   ControllerStateless.start();
 
   auto boundintupdowncounter = intupdowncounter->bindUpDownCounter(labelkv);
@@ -62,7 +66,6 @@ int main() {
   boundintupdowncounter->unbind();
 
   ControllerStateless.stop();
-  std::cout << std::endl;
   /**
    * The Third and final way is to add a value with a labelset at the same time. This also shows
    * The difference between using a Stateless and Stateful Processor

--- a/examples/metrics_simple/main.cc
+++ b/examples/metrics_simple/main.cc
@@ -4,6 +4,8 @@
 #include "opentelemetry/sdk/metrics/meter_provider.h"
 #include "opentelemetry/metrics/provider.h"
 
+#include <unistd.h>
+
 namespace sdkmetrics = opentelemetry::sdk::metrics;
 namespace nostd      = opentelemetry::nostd;
 namespace trace      = opentelemetry::trace;
@@ -73,7 +75,7 @@ int main() {
   for (int i = 0; i < 20; i++)
   {
     intupdowncounter->add(i, labelkv);
-    // usleep(.01*1000000);
+    usleep(.01*1000000);
   }
   ControllerStateless.stop(); 
 
@@ -89,7 +91,7 @@ int main() {
   for (int i = 0; i < 20; i++)
   {
     intupdowncounter->add(i, labelkv);
-    // usleep(.01*1000000);
+    usleep(.01*1000000);
   }
   ControllerStateful.stop(); 
 }

--- a/examples/metrics_simple/main.cc
+++ b/examples/metrics_simple/main.cc
@@ -4,9 +4,7 @@
 #include "opentelemetry/sdk/metrics/meter_provider.h"
 #include "opentelemetry/metrics/provider.h"
 
-#include <stdlib.h>
 #include <unistd.h>
-#include <stdio.h>
 
 namespace sdkmetrics = opentelemetry::sdk::metrics;
 namespace nostd      = opentelemetry::nostd;


### PR DESCRIPTION
Simple example for setting up the metrics pipeline and showing the 3 different ways to updating instrument values. Include a README that goes into more detail on each of the different parts. This example uses the OStreamMetricsExporter and shows the difference between stateful / stateless modes for the Processor.