### PR TITLE
Add Prometheus Collector - PrometheusCollector header and source files

### DIFF
--- a/exporters/prometheus/include/opentelemetry/exporters/prometheus/prometheus_collector.h
+++ b/exporters/prometheus/include/opentelemetry/exporters/prometheus/prometheus_collector.h
@@ -1,0 +1,84 @@
+#pragma once
+
+#include <memory>
+#include <mutex>
+#include <vector>
+
+#include "prometheus_exporter_utils.h"
+#include "opentelemetry/sdk/metrics/record.h"
+#include "prometheus/collectable.h"
+#include "prometheus/metric_family.h"
+
+namespace prometheus_client = ::prometheus;
+namespace metric_sdk        = opentelemetry::sdk::metrics;
+
+OPENTELEMETRY_BEGIN_NAMESPACE
+namespace exporter
+{
+namespace prometheus
+{
+/**
+ * The Prometheus Collector maintains the intermediate collection in Prometheus Exporter
+ */
+class PrometheusCollector : public prometheus_client::Collectable
+{
+public:
+  /**
+   * Default Constructor.
+   *
+   * This constructor initializes the collection for metrics to export
+   * in this class with default capacity
+   */
+  explicit PrometheusCollector(int max_collection_size = 2048);
+
+  /**
+   * Collects all metrics data from metricsToCollect collection.
+   *
+   * @return all metrics in the metricsToCollect snapshot
+   */
+  std::vector<prometheus_client::MetricFamily> Collect() const override;
+
+  /**
+   * This function is called by export() function and add the collection of
+   * records to the metricsToCollect collection
+   *
+   * @param records a collection of records to add to the metricsToCollect collection
+   */
+  void AddMetricData(const std::vector<metric_sdk::Record> &records);
+
+  /**
+   * Get the current collection in the collector.
+   *
+   * @return the current metricsToCollect collection
+   */
+  std::vector<metric_sdk::Record> GetCollection();
+
+  /**
+   * Gets the maximum size of the collection.
+   *
+   * @return max collection size
+   */
+  int GetMaxCollectionSize() const;
+
+private:
+  /**
+   * Collection of metrics data from the export() function, and to be export
+   * to user when they send a pull request. This collection is a pointer
+   * to a collection so Collect() is able to clear the collection, even
+   * though it is a const function.
+   */
+  std::unique_ptr<std::vector<metric_sdk::Record>> metrics_to_collect_;
+
+  /**
+   * Maximum size of the metricsToCollect collection.
+   */
+  int max_collection_size_;
+
+  /*
+   * Lock when operating the metricsToCollect collection
+   */
+  mutable std::mutex collection_lock_;
+};
+}  // namespace prometheus
+}  // namespace exporter
+OPENTELEMETRY_END_NAMESPACE

--- a/exporters/prometheus/include/opentelemetry/exporters/prometheus/prometheus_collector.h
+++ b/exporters/prometheus/include/opentelemetry/exporters/prometheus/prometheus_collector.h
@@ -1,13 +1,29 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 #pragma once
 
 #include <memory>
 #include <mutex>
 #include <vector>
 
-#include "prometheus_exporter_utils.h"
 #include "opentelemetry/sdk/metrics/record.h"
 #include "prometheus/collectable.h"
 #include "prometheus/metric_family.h"
+#include "prometheus_exporter_utils.h"
 
 namespace prometheus_client = ::prometheus;
 namespace metric_sdk        = opentelemetry::sdk::metrics;

--- a/exporters/prometheus/src/prometheus_collector.cc
+++ b/exporters/prometheus/src/prometheus_collector.cc
@@ -1,0 +1,152 @@
+#include <iostream>
+
+#include "opentelemetry/exporters/prometheus/prometheus_collector.h"
+
+OPENTELEMETRY_BEGIN_NAMESPACE
+namespace exporter
+{
+namespace prometheus
+{
+/**
+ * Default Constructor.
+ *
+ * This constructor initializes the collection for metrics to export
+ * in this class with default capacity
+ */
+PrometheusCollector::PrometheusCollector(int max_collection_size)
+    : max_collection_size_(max_collection_size)
+{
+  metrics_to_collect_ =
+      std::unique_ptr<std::vector<metric_sdk::Record>>(new std::vector<metric_sdk::Record>);
+}
+
+/**
+ * Collects all metrics data from metricsToCollect collection.
+ *
+ * @return all metrics in the metricsToCollect snapshot
+ */
+std::vector<prometheus_client::MetricFamily> PrometheusCollector::Collect() const
+{
+  if (metrics_to_collect_->empty())
+  {
+    return {};
+  }
+
+  std::vector<prometheus_client::MetricFamily> result;
+
+  // copy the intermediate collection, and then clear it
+  std::vector<metric_sdk::Record> copied_data;
+
+  collection_lock_.lock();
+  copied_data = std::vector<metric_sdk::Record>(*metrics_to_collect_);
+  metrics_to_collect_->clear();
+  collection_lock_.unlock();
+
+  result = PrometheusExporterUtils::TranslateToPrometheus(copied_data);
+  return result;
+}
+
+/**
+ * This function is called by export() function and add the collection of
+ * records to the metricsToCollect collection
+ *
+ * @param records a collection of records to add to the metricsToCollect collection
+ */
+void PrometheusCollector::AddMetricData(const std::vector<sdk::metrics::Record> &records)
+{
+  if (metrics_to_collect_->size() + records.size() <= max_collection_size_ && !records.empty())
+  {
+    /**
+     *  ValidAggregator is a lambda that checks a Record to see if its
+     *  Aggregator is a valid nostd::shared_ptr and not a nullptr.
+     */
+    auto ValidAggregator = [](sdk::metrics::Record record) {
+      auto aggregator_variant = record.GetAggregator();
+      if (nostd::holds_alternative<nostd::shared_ptr<metric_sdk::Aggregator<int>>>(
+              aggregator_variant))
+      {
+        auto aggregator =
+            nostd::get<nostd::shared_ptr<metric_sdk::Aggregator<int>>>(aggregator_variant);
+        if (!aggregator)
+        {
+          return false;
+        }
+      }
+      else if (nostd::holds_alternative<nostd::shared_ptr<metric_sdk::Aggregator<short>>>(
+                   aggregator_variant))
+      {
+        auto aggregator =
+            nostd::get<nostd::shared_ptr<metric_sdk::Aggregator<short>>>(aggregator_variant);
+        if (!aggregator)
+        {
+          return false;
+        }
+      }
+      else if (nostd::holds_alternative<nostd::shared_ptr<metric_sdk::Aggregator<float>>>(
+                   aggregator_variant))
+      {
+        auto aggregator =
+            nostd::get<nostd::shared_ptr<metric_sdk::Aggregator<float>>>(aggregator_variant);
+        if (!aggregator)
+        {
+          return false;
+        }
+      }
+      else if (nostd::holds_alternative<nostd::shared_ptr<metric_sdk::Aggregator<double>>>(
+                   aggregator_variant))
+      {
+        auto aggregator =
+            nostd::get<nostd::shared_ptr<metric_sdk::Aggregator<double>>>(aggregator_variant);
+        if (!aggregator)
+        {
+          return false;
+        }
+      }
+
+      return true;
+    };
+
+    collection_lock_.lock();
+
+    for (auto &r : records)
+    {
+      if (ValidAggregator(r))
+      {
+        metrics_to_collect_->push_back(r);
+      }
+      // Drop the record and write to std::cout
+      else
+      {
+        // Cannot call non const functions on const Record r
+        sdk::metrics::Record c = r;
+        std::cout << "Dropped Record containing invalid aggregator with name: " + c.GetName() << std::endl;
+      }
+    }
+
+    collection_lock_.unlock();
+  }
+}
+
+/**
+ * Get the current collection in the collector.
+ *
+ * @return the current metrics_to_collect collection
+ */
+std::vector<sdk::metrics::Record> PrometheusCollector::GetCollection()
+{
+  return *metrics_to_collect_;
+}
+
+/**
+ * Gets the maximum size of the collection.
+ *
+ * @return max collection size
+ */
+int PrometheusCollector::GetMaxCollectionSize() const
+{
+  return max_collection_size_;
+}
+
+}  // namespace prometheus
+}  // namespace exporter
+OPENTELEMETRY_END_NAMESPACE

--- a/exporters/prometheus/src/prometheus_collector.cc
+++ b/exporters/prometheus/src/prometheus_collector.cc
@@ -1,3 +1,19 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 #include <iostream>
 
 #include "opentelemetry/exporters/prometheus/prometheus_collector.h"
@@ -119,7 +135,8 @@ void PrometheusCollector::AddMetricData(const std::vector<sdk::metrics::Record> 
       {
         // Cannot call non const functions on const Record r
         sdk::metrics::Record c = r;
-        std::cout << "Dropped Record containing invalid aggregator with name: " + c.GetName() << std::endl;
+        std::cout << "Dropped Record containing invalid aggregator with name: " + c.GetName()
+                  << std::endl;
       }
     }
 

--- a/exporters/prometheus/src/prometheus_collector.cc
+++ b/exporters/prometheus/src/prometheus_collector.cc
@@ -74,45 +74,45 @@ void PrometheusCollector::AddMetricData(const std::vector<sdk::metrics::Record> 
   {
     /**
      *  ValidAggregator is a lambda that checks a Record to see if its
-     *  Aggregator is a valid nostd::shared_ptr and not a nullptr.
+     *  Aggregator is a valid std::shared_ptr and not a nullptr.
      */
     auto ValidAggregator = [](sdk::metrics::Record record) {
       auto aggregator_variant = record.GetAggregator();
-      if (nostd::holds_alternative<nostd::shared_ptr<metric_sdk::Aggregator<int>>>(
+      if (nostd::holds_alternative<std::shared_ptr<metric_sdk::Aggregator<int>>>(
               aggregator_variant))
       {
         auto aggregator =
-            nostd::get<nostd::shared_ptr<metric_sdk::Aggregator<int>>>(aggregator_variant);
+            nostd::get<std::shared_ptr<metric_sdk::Aggregator<int>>>(aggregator_variant);
         if (!aggregator)
         {
           return false;
         }
       }
-      else if (nostd::holds_alternative<nostd::shared_ptr<metric_sdk::Aggregator<short>>>(
+      else if (nostd::holds_alternative<std::shared_ptr<metric_sdk::Aggregator<short>>>(
                    aggregator_variant))
       {
         auto aggregator =
-            nostd::get<nostd::shared_ptr<metric_sdk::Aggregator<short>>>(aggregator_variant);
+            nostd::get<std::shared_ptr<metric_sdk::Aggregator<short>>>(aggregator_variant);
         if (!aggregator)
         {
           return false;
         }
       }
-      else if (nostd::holds_alternative<nostd::shared_ptr<metric_sdk::Aggregator<float>>>(
+      else if (nostd::holds_alternative<std::shared_ptr<metric_sdk::Aggregator<float>>>(
                    aggregator_variant))
       {
         auto aggregator =
-            nostd::get<nostd::shared_ptr<metric_sdk::Aggregator<float>>>(aggregator_variant);
+            nostd::get<std::shared_ptr<metric_sdk::Aggregator<float>>>(aggregator_variant);
         if (!aggregator)
         {
           return false;
         }
       }
-      else if (nostd::holds_alternative<nostd::shared_ptr<metric_sdk::Aggregator<double>>>(
+      else if (nostd::holds_alternative<std::shared_ptr<metric_sdk::Aggregator<double>>>(
                    aggregator_variant))
       {
         auto aggregator =
-            nostd::get<nostd::shared_ptr<metric_sdk::Aggregator<double>>>(aggregator_variant);
+            nostd::get<std::shared_ptr<metric_sdk::Aggregator<double>>>(aggregator_variant);
         if (!aggregator)
         {
           return false;


### PR DESCRIPTION
This PR implements the PrometheusCollector class and its header and source files. Test files will be added in another PR. This class is derived from the Collectable class in the C++ Prometheus client and allows for data translated from OpenTelemetry for Prometheus to be collected by an end user.

This PR is one in a series of PRs that aims to add a full implementation of a Prometheus Exporter within the OpenTelemetry C++ library.

Note to reviewers: Please keep in mind that this PR is dependent on the Prometheus Exporter Utils PRs(#245 and #250) so codecov tests may not fully pass.
