### PR TITLE
fix cmake error when building without tests

### DIFF
--- a/exporters/ostream/CMakeLists.txt
+++ b/exporters/ostream/CMakeLists.txt
@@ -3,6 +3,7 @@ include_directories(include)
 add_library(opentelemetry_exporter_ostream_metrics src/metrics_exporter.cc)
 add_library(opentelemetry_exporter_ostream_span src/span_exporter.cc)
 
+if(BUILD_TESTING)
 add_executable(ostream_metrics_test test/ostream_metrics_test.cc)
 add_executable(ostream_span_test test/ostream_span_test.cc)
 
@@ -18,3 +19,4 @@ gtest_add_tests(TARGET ostream_metrics_test TEST_PREFIX exporter. TEST_LIST
                 ostream_metrics_test)
 gtest_add_tests(TARGET ostream_span_test TEST_PREFIX exporter. TEST_LIST
                 ostream_span_test)
+endif() # BUILD_TESTING

--- a/exporters/otlp/CMakeLists.txt
+++ b/exporters/otlp/CMakeLists.txt
@@ -4,9 +4,11 @@ add_library(opentelemetry_exporter_otprotocol src/recordable.cc)
 target_link_libraries(opentelemetry_exporter_otprotocol
                       $<TARGET_OBJECTS:opentelemetry_proto>)
 
+if(BUILD_TESTING)
 add_executable(recordable_test test/recordable_test.cc)
 target_link_libraries(
   recordable_test ${GTEST_BOTH_LIBRARIES} ${CMAKE_THREAD_LIBS_INIT}
   opentelemetry_exporter_otprotocol protobuf::libprotobuf)
 gtest_add_tests(TARGET recordable_test TEST_PREFIX exporter. TEST_LIST
                 recordable_test)
+endif() # BUILD_TESTING


### PR DESCRIPTION
Fixes building OpenTelemetry-cpp without tests, as `cmake -DBUILD_TESTING=OFF ../`.

Hope this helps and is in the expected format.