### PR TITLE
Use memcpy in TraceState

### DIFF
--- a/api/include/opentelemetry/trace/trace_state.h
+++ b/api/include/opentelemetry/trace/trace_state.h
@@ -91,10 +91,10 @@ public:
     // This is a workaround for the fact that memcpy doesn't accept a const destination.
     nostd::unique_ptr<const char[]> CopyStringToPointer(nostd::string_view str)
     {
-      nostd::unique_ptr<char[]> temp(new char[str.size() + 1]);
-      memcpy(temp.get(), str.data(), str.size());
-      (temp.get())[str.size()] = '\0';
-      return nostd::unique_ptr<const char[]>(temp.release());
+      char* temp = new char[str.size() + 1];
+      memcpy(temp, str.data(), str.size());
+      temp[str.size()] = '\0';
+      return nostd::unique_ptr<const char[]>(temp);
     }
   };
 

--- a/api/include/opentelemetry/trace/trace_state.h
+++ b/api/include/opentelemetry/trace/trace_state.h
@@ -48,7 +48,7 @@ public:
     Entry() : key_(nullptr), value_(nullptr){};
 
     // Copy constructor
-    Entry(Entry &copy)
+    Entry(const Entry &copy)
     {
       key_   = CopyStringToPointer(copy.key_.get());
       value_ = CopyStringToPointer(copy.value_.get());
@@ -92,7 +92,8 @@ public:
     nostd::unique_ptr<const char[]> CopyStringToPointer(nostd::string_view str)
     {
       nostd::unique_ptr<char[]> temp(new char[str.size() + 1]);
-      strcpy(temp.get(), str.data());
+      memcpy(temp.get(), str.data(), str.size());
+      (temp.get())[str.size()] = '\0';
       return nostd::unique_ptr<const char[]>(temp.release());
     }
   };

--- a/api/include/opentelemetry/trace/trace_state.h
+++ b/api/include/opentelemetry/trace/trace_state.h
@@ -91,7 +91,7 @@ public:
     // This is a workaround for the fact that memcpy doesn't accept a const destination.
     nostd::unique_ptr<const char[]> CopyStringToPointer(nostd::string_view str)
     {
-      char* temp = new char[str.size() + 1];
+      char *temp = new char[str.size() + 1];
       memcpy(temp, str.data(), str.size());
       temp[str.size()] = '\0';
       return nostd::unique_ptr<const char[]>(temp);

--- a/api/include/opentelemetry/trace/trace_state.h
+++ b/api/include/opentelemetry/trace/trace_state.h
@@ -88,7 +88,7 @@ public:
     nostd::unique_ptr<const char[]> value_;
 
     // Copies string into a buffer and returns a unique_ptr to the buffer.
-    // This is a workaround for the fact that strcpy doesn't accept a const char* destination.
+    // This is a workaround for the fact that memcpy doesn't accept a const destination.
     nostd::unique_ptr<const char[]> CopyStringToPointer(nostd::string_view str)
     {
       nostd::unique_ptr<char[]> temp(new char[str.size() + 1]);

--- a/api/test/trace/trace_state_test.cc
+++ b/api/test/trace/trace_state_test.cc
@@ -181,8 +181,8 @@ TEST(TraceStateTest, MemorySafe)
   opentelemetry::nostd::span<TraceState::Entry> entries = s.Entries();
   for (int i = 0; i < kNumPairs; i++)
   {
-    EXPECT_EQ(entries[i].GetKey().data(), keys[i]);
-    EXPECT_EQ(entries[i].GetValue().data(), values[i]);
+    EXPECT_EQ(entries[i].GetKey(), keys[i]);
+    EXPECT_EQ(entries[i].GetValue(), values[i]);
   }
 }
 }  // namespace

--- a/api/test/trace/trace_state_test.cc
+++ b/api/test/trace/trace_state_test.cc
@@ -160,4 +160,29 @@ TEST(TraceStateTest, IsValidValue)
   EXPECT_FALSE(TraceState::IsValidValue(""));
   EXPECT_FALSE(TraceState::IsValidValue(kLongString));
 }
+
+// Tests that keys and values don't depend on null terminators
+TEST(TraceStateTest, MemorySafe)
+{
+  TraceState s;
+  const int kNumPairs                               = 3;
+  opentelemetry::nostd::string_view key_string      = "test_key_1test_key_2test_key_3";
+  opentelemetry::nostd::string_view val_string      = "test_val_1test_val_2test_val_3";
+  opentelemetry::nostd::string_view keys[kNumPairs] = {
+      key_string.substr(0, 10), key_string.substr(10, 10), key_string.substr(20, 10)};
+  opentelemetry::nostd::string_view values[kNumPairs] = {
+      val_string.substr(0, 10), val_string.substr(10, 10), val_string.substr(20, 10)};
+
+  for (int i = 0; i < kNumPairs; i++)
+  {
+    s.Set(keys[i], values[i]);
+  }
+
+  opentelemetry::nostd::span<TraceState::Entry> entries = s.Entries();
+  for (int i = 0; i < kNumPairs; i++)
+  {
+    EXPECT_EQ(entries[i].GetKey().data(), keys[i]);
+    EXPECT_EQ(entries[i].GetValue().data(), values[i]);
+  }
+}
 }  // namespace


### PR DESCRIPTION
Currently we're using `strcpy` to copy keys and values into `TraceState` entries. This causes problems when the keys/values are not null-terminated. Fix this by using `memcpy` with the string_view `size`, instead of `strcpy`.