### PR TITLE
Add logic to refrain from exporting un-updated metric instruments

### DIFF
--- a/sdk/include/opentelemetry/sdk/metrics/aggregator/aggregator.h
+++ b/sdk/include/opentelemetry/sdk/metrics/aggregator/aggregator.h
@@ -97,6 +97,14 @@ public:
    */
   virtual AggregatorKind get_aggregator_kind() final { return agg_kind_; }
 
+  /**
+   * Getter function for updated_ protected var
+   *
+   * @return A bool indicating wether or not this aggregator has been updated
+   * in the most recent collection interval.
+   */
+  bool is_updated() final { return updated_;  }
+
   // virtual function to be overriden for the Histogram Aggregator
   virtual std::vector<double> get_boundaries() { return std::vector<double>(); }
 
@@ -134,6 +142,7 @@ protected:
   opentelemetry::metrics::InstrumentKind kind_;
   std::mutex mu_;
   AggregatorKind agg_kind_;
+  bool updated_;
 };
 
 }  // namespace metrics

--- a/sdk/include/opentelemetry/sdk/metrics/aggregator/aggregator.h
+++ b/sdk/include/opentelemetry/sdk/metrics/aggregator/aggregator.h
@@ -103,7 +103,7 @@ public:
    * @return A bool indicating wether or not this aggregator has been updated
    * in the most recent collection interval.
    */
-  virtual bool is_updated() final { return updated_;  }
+  virtual bool is_updated() final { return updated_; }
 
   // virtual function to be overriden for the Histogram Aggregator
   virtual std::vector<double> get_boundaries() { return std::vector<double>(); }

--- a/sdk/include/opentelemetry/sdk/metrics/aggregator/aggregator.h
+++ b/sdk/include/opentelemetry/sdk/metrics/aggregator/aggregator.h
@@ -103,7 +103,7 @@ public:
    * @return A bool indicating wether or not this aggregator has been updated
    * in the most recent collection interval.
    */
-  bool is_updated() final { return updated_;  }
+  virtual bool is_updated() final { return updated_;  }
 
   // virtual function to be overriden for the Histogram Aggregator
   virtual std::vector<double> get_boundaries() { return std::vector<double>(); }

--- a/sdk/include/opentelemetry/sdk/metrics/aggregator/counter_aggregator.h
+++ b/sdk/include/opentelemetry/sdk/metrics/aggregator/counter_aggregator.h
@@ -36,6 +36,7 @@ public:
   void update(T val) override
   {
     this->mu_.lock();
+    this->updated_ = true;
     this->values_[0] += val;  // atomic operation
     this->mu_.unlock();
   }
@@ -50,6 +51,7 @@ public:
   void checkpoint() override
   {
     this->mu_.lock();
+    this->updated_    = false;
     this->checkpoint_ = this->values_;
     this->values_[0]  = 0;
     this->mu_.unlock();

--- a/sdk/include/opentelemetry/sdk/metrics/aggregator/exact_aggregator.h
+++ b/sdk/include/opentelemetry/sdk/metrics/aggregator/exact_aggregator.h
@@ -62,6 +62,7 @@ public:
   void update(T val) override
   {
     this->mu_.lock();
+    this->updated_ = true;
     this->values_.push_back(val);
     this->mu_.unlock();
   }
@@ -74,6 +75,7 @@ public:
   void checkpoint() override
   {
     this->mu_.lock();
+    this->updated_ = false;
     if (quant_estimation_)
     {
       std::sort(this->values_.begin(), this->values_.end());

--- a/sdk/include/opentelemetry/sdk/metrics/aggregator/gauge_aggregator.h
+++ b/sdk/include/opentelemetry/sdk/metrics/aggregator/gauge_aggregator.h
@@ -59,7 +59,7 @@ public:
   void update(T val) override
   {
     this->mu_.lock();
-    this->updated_ = true;
+    this->updated_     = true;
     this->values_[0]   = val;
     current_timestamp_ = core::SystemTimestamp(std::chrono::system_clock::now());
     this->mu_.unlock();

--- a/sdk/include/opentelemetry/sdk/metrics/aggregator/gauge_aggregator.h
+++ b/sdk/include/opentelemetry/sdk/metrics/aggregator/gauge_aggregator.h
@@ -59,6 +59,7 @@ public:
   void update(T val) override
   {
     this->mu_.lock();
+    this->updated_ = true;
     this->values_[0]   = val;
     current_timestamp_ = core::SystemTimestamp(std::chrono::system_clock::now());
     this->mu_.unlock();
@@ -75,6 +76,7 @@ public:
   {
     this->mu_.lock();
 
+    this->updated_    = false;
     this->checkpoint_ = this->values_;
 
     // Reset the values to default

--- a/sdk/include/opentelemetry/sdk/metrics/aggregator/histogram_aggregator.h
+++ b/sdk/include/opentelemetry/sdk/metrics/aggregator/histogram_aggregator.h
@@ -63,7 +63,8 @@ public:
   void update(T val) override
   {
     this->mu_.lock();
-    int bucketID = boundaries_.size();
+    this->updated_ = true;
+    int bucketID   = boundaries_.size();
     for (size_t i = 0; i < boundaries_.size(); i++)
     {
       if (val < boundaries_[i])  // concurrent read is thread-safe
@@ -93,6 +94,7 @@ public:
   void checkpoint() override
   {
     this->mu_.lock();
+    this->updated_     = false;
     this->checkpoint_  = this->values_;
     this->values_[0]   = 0;
     this->values_[1]   = 0;

--- a/sdk/include/opentelemetry/sdk/metrics/aggregator/min_max_sum_count_aggregator.h
+++ b/sdk/include/opentelemetry/sdk/metrics/aggregator/min_max_sum_count_aggregator.h
@@ -60,6 +60,7 @@ public:
   void update(T val) override
   {
     this->mu_.lock();
+    this->updated_ = true;
 
     if (this->values_[CountValueIndex] == 0 || val < this->values_[MinValueIndex])  // set min
       this->values_[MinValueIndex] = val;
@@ -80,6 +81,7 @@ public:
   void checkpoint() override
   {
     this->mu_.lock();
+    this->updated_    = false;
     this->checkpoint_ = this->values_;
     // Reset the values
     this->values_[MinValueIndex]   = 0;

--- a/sdk/include/opentelemetry/sdk/metrics/aggregator/sketch_aggregator.h
+++ b/sdk/include/opentelemetry/sdk/metrics/aggregator/sketch_aggregator.h
@@ -64,6 +64,7 @@ public:
   void update(T val) override
   {
     this->mu_.lock();
+    this->updated_ = true;
     int idx;
     if (val == 0)
     {
@@ -130,6 +131,7 @@ public:
   void checkpoint() override
   {
     this->mu_.lock();
+    this->updated_    = false;
     this->checkpoint_ = this->values_;
     checkpoint_raw_   = raw_;
     this->values_[0]  = 0;

--- a/sdk/include/opentelemetry/sdk/metrics/sync_instruments.h
+++ b/sdk/include/opentelemetry/sdk/metrics/sync_instruments.h
@@ -149,7 +149,7 @@ public:
         toDelete.push_back(x.first);
       }
       auto agg_ptr = dynamic_cast<BoundCounter<T> *>(x.second.get())->GetAggregator();
-      if (x.second->is_updated())
+      if (agg_ptr->is_updated())
       {
         agg_ptr->checkpoint();
         ret.push_back(Record(x.second->GetName(), x.second->GetDescription(), x.first, agg_ptr));
@@ -276,7 +276,7 @@ public:
         toDelete.push_back(x.first);
       }
       auto agg_ptr = dynamic_cast<BoundUpDownCounter<T> *>(x.second.get())->GetAggregator();
-      if (x.second->is_updated())
+      if (agg_ptr->is_updated())
       {
         agg_ptr->checkpoint();
         ret.push_back(Record(x.second->GetName(), x.second->GetDescription(), x.first, agg_ptr));
@@ -402,7 +402,7 @@ public:
         toDelete.push_back(x.first);
       }
       auto agg_ptr = dynamic_cast<BoundValueRecorder<T> *>(x.second.get())->GetAggregator();
-      if (x.second->is_updated())
+      if (agg_ptr->is_updated())
       {
         agg_ptr->checkpoint();
         ret.push_back(Record(x.second->GetName(), x.second->GetDescription(), x.first, agg_ptr));

--- a/sdk/include/opentelemetry/sdk/metrics/sync_instruments.h
+++ b/sdk/include/opentelemetry/sdk/metrics/sync_instruments.h
@@ -149,8 +149,11 @@ public:
         toDelete.push_back(x.first);
       }
       auto agg_ptr = dynamic_cast<BoundCounter<T> *>(x.second.get())->GetAggregator();
-      agg_ptr->checkpoint();
-      ret.push_back(Record(x.second->GetName(), x.second->GetDescription(), x.first, agg_ptr));
+      if (x.second->is_updated())
+      {
+        agg_ptr->checkpoint();
+        ret.push_back(Record(x.second->GetName(), x.second->GetDescription(), x.first, agg_ptr));
+      }
     }
     for (const auto &x : toDelete)
     {
@@ -273,8 +276,11 @@ public:
         toDelete.push_back(x.first);
       }
       auto agg_ptr = dynamic_cast<BoundUpDownCounter<T> *>(x.second.get())->GetAggregator();
-      agg_ptr->checkpoint();
-      ret.push_back(Record(x.second->GetName(), x.second->GetDescription(), x.first, agg_ptr));
+      if (x.second->is_updated())
+      {
+        agg_ptr->checkpoint();
+        ret.push_back(Record(x.second->GetName(), x.second->GetDescription(), x.first, agg_ptr));
+      }
     }
     for (const auto &x : toDelete)
     {
@@ -396,8 +402,11 @@ public:
         toDelete.push_back(x.first);
       }
       auto agg_ptr = dynamic_cast<BoundValueRecorder<T> *>(x.second.get())->GetAggregator();
-      agg_ptr->checkpoint();
-      ret.push_back(Record(x.second->GetName(), x.second->GetDescription(), x.first, agg_ptr));
+      if (x.second->is_updated())
+      {
+        agg_ptr->checkpoint();
+        ret.push_back(Record(x.second->GetName(), x.second->GetDescription(), x.first, agg_ptr));
+      }
     }
     for (const auto &x : toDelete)
     {

--- a/sdk/test/metrics/metric_instrument_test.cc
+++ b/sdk/test/metrics/metric_instrument_test.cc
@@ -248,6 +248,7 @@ TEST(Counter, getAggsandnewupdate)
 
   auto labelkv = trace::KeyValueIterableView<decltype(labels)>{labels};
   auto beta    = alpha.bindCounter(labelkv);
+  beta->add(1, labelkv)
   beta->unbind();
 
   EXPECT_EQ(alpha.boundInstruments_[KvToString(labelkv)]->get_ref(), 0);

--- a/sdk/test/metrics/metric_instrument_test.cc
+++ b/sdk/test/metrics/metric_instrument_test.cc
@@ -248,7 +248,7 @@ TEST(Counter, getAggsandnewupdate)
 
   auto labelkv = trace::KeyValueIterableView<decltype(labels)>{labels};
   auto beta    = alpha.bindCounter(labelkv);
-  beta->add(1)
+  beta->add(1);
   beta->unbind();
 
   EXPECT_EQ(alpha.boundInstruments_[KvToString(labelkv)]->get_ref(), 0);

--- a/sdk/test/metrics/metric_instrument_test.cc
+++ b/sdk/test/metrics/metric_instrument_test.cc
@@ -442,8 +442,10 @@ TEST(Instruments, NoUpdateNoRecord)
   // in the last collection period are not made into records for export.
 
   Counter<int> alpha("alpha", "no description", "unitless", true);
-  std::map<std::string, std::string> labels  = {{"key", "value"}};
-  auto labelkv  = trace::KeyValueIterableView<decltype(labels)>{labels};
+
+  std::map<std::string, std::string> labels = {{"key", "value"}};
+
+  auto labelkv = trace::KeyValueIterableView<decltype(labels)>{labels};
 
   EXPECT_EQ(alpha.GetRecords().size(), 0);
   alpha.add(1, labelkv);

--- a/sdk/test/metrics/metric_instrument_test.cc
+++ b/sdk/test/metrics/metric_instrument_test.cc
@@ -435,6 +435,36 @@ TEST(IntValueRecorder, StressRecord)
       125);  // count
 }
 
+TEST(Instruments, NoUpdateNoRecord)
+{
+  // This test verifies that instruments that have received no updates
+  // in the last collection period are not made into records for export.
+
+  Counter<int> alpha("alpha", "no description", "unitless", true);
+  std::map<std::string, std::string> labels  = {{"key", "value"}};
+  auto labelkv  = trace::KeyValueIterableView<decltype(labels)>{labels};
+
+  EXPECT_EQ(alpha->GetRecords().size(), 0);
+  alpha->add(1, labelkv);
+  EXPECT_EQ(alpha->GetRecords().size(), 1);
+
+  UpDownCounter<int> beta("beta", "no description", "unitless", true);
+  std::map<std::string, std::string> labels = {{"key", "value"}};
+  auto labelkv                              = trace::KeyValueIterableView<decltype(labels)>{labels};
+
+  EXPECT_EQ(alpha->GetRecords().size(), 0);
+  beta->add(1, labelkv);
+  EXPECT_EQ(alpha->GetRecords().size(), 1);
+
+  ValueRecorder<int> gamma("gamma", "no description", "unitless", true);
+  std::map<std::string, std::string> labels = {{"key", "value"}};
+  auto labelkv                              = trace::KeyValueIterableView<decltype(labels)>{labels};
+
+  EXPECT_EQ(alpha->GetRecords().size(), 0);
+  beta->record(1, labelkv);
+  EXPECT_EQ(alpha->GetRecords().size(), 1);
+}
+
 }  // namespace metrics
 }  // namespace sdk
 

--- a/sdk/test/metrics/metric_instrument_test.cc
+++ b/sdk/test/metrics/metric_instrument_test.cc
@@ -467,5 +467,4 @@ TEST(Instruments, NoUpdateNoRecord)
 
 }  // namespace metrics
 }  // namespace sdk
-
 OPENTELEMETRY_END_NAMESPACE

--- a/sdk/test/metrics/metric_instrument_test.cc
+++ b/sdk/test/metrics/metric_instrument_test.cc
@@ -449,16 +449,12 @@ TEST(Instruments, NoUpdateNoRecord)
   EXPECT_EQ(alpha.GetRecords().size(), 1);
 
   UpDownCounter<int> beta("beta", "no description", "unitless", true);
-  std::map<std::string, std::string> labels = {{"key", "value"}};
-  auto labelkv                              = trace::KeyValueIterableView<decltype(labels)>{labels};
 
   EXPECT_EQ(alpha.GetRecords().size(), 0);
   beta.add(1, labelkv);
   EXPECT_EQ(alpha.GetRecords().size(), 1);
 
   ValueRecorder<int> gamma("gamma", "no description", "unitless", true);
-  std::map<std::string, std::string> labels = {{"key", "value"}};
-  auto labelkv                              = trace::KeyValueIterableView<decltype(labels)>{labels};
 
   EXPECT_EQ(alpha.GetRecords().size(), 0);
   gamma.record(1, labelkv);

--- a/sdk/test/metrics/metric_instrument_test.cc
+++ b/sdk/test/metrics/metric_instrument_test.cc
@@ -248,7 +248,7 @@ TEST(Counter, getAggsandnewupdate)
 
   auto labelkv = trace::KeyValueIterableView<decltype(labels)>{labels};
   auto beta    = alpha.bindCounter(labelkv);
-  beta->add(1, labelkv)
+  beta->add(1)
   beta->unbind();
 
   EXPECT_EQ(alpha.boundInstruments_[KvToString(labelkv)]->get_ref(), 0);

--- a/sdk/test/metrics/metric_instrument_test.cc
+++ b/sdk/test/metrics/metric_instrument_test.cc
@@ -450,15 +450,15 @@ TEST(Instruments, NoUpdateNoRecord)
 
   UpDownCounter<int> beta("beta", "no description", "unitless", true);
 
-  EXPECT_EQ(alpha.GetRecords().size(), 0);
+  EXPECT_EQ(beta.GetRecords().size(), 0);
   beta.add(1, labelkv);
-  EXPECT_EQ(alpha.GetRecords().size(), 1);
+  EXPECT_EQ(beta.GetRecords().size(), 1);
 
   ValueRecorder<int> gamma("gamma", "no description", "unitless", true);
 
-  EXPECT_EQ(alpha.GetRecords().size(), 0);
+  EXPECT_EQ(gamma.GetRecords().size(), 0);
   gamma.record(1, labelkv);
-  EXPECT_EQ(alpha.GetRecords().size(), 1);
+  EXPECT_EQ(gamma.GetRecords().size(), 1);
 }
 
 }  // namespace metrics

--- a/sdk/test/metrics/metric_instrument_test.cc
+++ b/sdk/test/metrics/metric_instrument_test.cc
@@ -444,25 +444,25 @@ TEST(Instruments, NoUpdateNoRecord)
   std::map<std::string, std::string> labels  = {{"key", "value"}};
   auto labelkv  = trace::KeyValueIterableView<decltype(labels)>{labels};
 
-  EXPECT_EQ(alpha->GetRecords().size(), 0);
-  alpha->add(1, labelkv);
-  EXPECT_EQ(alpha->GetRecords().size(), 1);
+  EXPECT_EQ(alpha.GetRecords().size(), 0);
+  alpha.add(1, labelkv);
+  EXPECT_EQ(alpha.GetRecords().size(), 1);
 
   UpDownCounter<int> beta("beta", "no description", "unitless", true);
   std::map<std::string, std::string> labels = {{"key", "value"}};
   auto labelkv                              = trace::KeyValueIterableView<decltype(labels)>{labels};
 
-  EXPECT_EQ(alpha->GetRecords().size(), 0);
-  beta->add(1, labelkv);
-  EXPECT_EQ(alpha->GetRecords().size(), 1);
+  EXPECT_EQ(alpha.GetRecords().size(), 0);
+  beta.add(1, labelkv);
+  EXPECT_EQ(alpha.GetRecords().size(), 1);
 
   ValueRecorder<int> gamma("gamma", "no description", "unitless", true);
   std::map<std::string, std::string> labels = {{"key", "value"}};
   auto labelkv                              = trace::KeyValueIterableView<decltype(labels)>{labels};
 
-  EXPECT_EQ(alpha->GetRecords().size(), 0);
-  beta->record(1, labelkv);
-  EXPECT_EQ(alpha->GetRecords().size(), 1);
+  EXPECT_EQ(alpha.GetRecords().size(), 0);
+  beta.record(1, labelkv);
+  EXPECT_EQ(alpha.GetRecords().size(), 1);
 }
 
 }  // namespace metrics

--- a/sdk/test/metrics/metric_instrument_test.cc
+++ b/sdk/test/metrics/metric_instrument_test.cc
@@ -461,7 +461,7 @@ TEST(Instruments, NoUpdateNoRecord)
   auto labelkv                              = trace::KeyValueIterableView<decltype(labels)>{labels};
 
   EXPECT_EQ(alpha.GetRecords().size(), 0);
-  beta.record(1, labelkv);
+  gamma.record(1, labelkv);
   EXPECT_EQ(alpha.GetRecords().size(), 1);
 }
 


### PR DESCRIPTION
This PR is meant to resolve Issue #255.

I have added a new bool variable to the aggregator base class to track whether or not the aggregator has been updated in the most recent collection cycle. Some additional logic was then added to the SDK sync instrument classes to refrain from creating records from aggregators that have received no recent updates. Since there are no records created from these un-updated (stale) instruments, they will not be exported.

I did not implement the same logic for the SDK async instrument classes as I don't believe it would make sense there. Asynchronous instruments are supposed to be exported by interval rather than by request: Therefore they are never stale.