### PR TITLE
Add OTLP exporter configuration

### DIFF
--- a/exporters/otlp/include/opentelemetry/exporters/otlp/otlp_exporter.h
+++ b/exporters/otlp/include/opentelemetry/exporters/otlp/otlp_exporter.h
@@ -31,7 +31,7 @@ public:
   /**
    * Create an OtlpExporter using the given options.
    */
-  OtlpExporter(OtlpExporterOptions options);
+  OtlpExporter(const OtlpExporterOptions &options);
 
   /**
    * Create a span recordable.

--- a/exporters/otlp/include/opentelemetry/exporters/otlp/otlp_exporter.h
+++ b/exporters/otlp/include/opentelemetry/exporters/otlp/otlp_exporter.h
@@ -9,16 +9,29 @@ namespace exporter
 namespace otlp
 {
 /**
+ * Struct to hold OTLP exporter options.
+ */
+struct OtlpExporterOptions
+{
+  // The endpoint to export to. By default the OpenTelemetry Collector's default endpoint.
+  std::string endpoint = "localhost:55680";
+};
+
+/**
  * The OTLP exporter exports span data in OpenTelemetry Protocol (OTLP) format.
  */
 class OtlpExporter final : public opentelemetry::sdk::trace::SpanExporter
 {
 public:
   /**
-   * Create an OtlpExporter. This constructor initializes a service stub to be
-   * used for exporting.
+   * Create an OtlpExporter using all default options.
    */
   OtlpExporter();
+
+  /**
+   * Create an OtlpExporter using the given options.
+   */
+  OtlpExporter(OtlpExporterOptions options);
 
   /**
    * Create a span recordable.
@@ -42,6 +55,9 @@ public:
       std::chrono::microseconds timeout = std::chrono::microseconds(0)) noexcept override{};
 
 private:
+  // The configuration options associated with this exporter.
+  const OtlpExporterOptions options_;
+
   // For testing
   friend class OtlpExporterTestPeer;
 

--- a/exporters/otlp/src/otlp_exporter.cc
+++ b/exporters/otlp/src/otlp_exporter.cc
@@ -44,7 +44,7 @@ std::unique_ptr<proto::collector::trace::v1::TraceService::Stub> MakeServiceStub
 
 OtlpExporter::OtlpExporter() : OtlpExporter(OtlpExporterOptions()) {}
 
-OtlpExporter::OtlpExporter(OtlpExporterOptions options)
+OtlpExporter::OtlpExporter(const OtlpExporterOptions &options)
     : options_(options), trace_service_stub_(MakeServiceStub(options.endpoint))
 {}
 

--- a/exporters/otlp/src/otlp_exporter.cc
+++ b/exporters/otlp/src/otlp_exporter.cc
@@ -44,10 +44,9 @@ std::unique_ptr<proto::collector::trace::v1::TraceService::Stub> MakeServiceStub
 
 OtlpExporter::OtlpExporter() : OtlpExporter(OtlpExporterOptions()) {}
 
-OtlpExporter::OtlpExporter(OtlpExporterOptions options) : options_(std::move(options))
-{
-  trace_service_stub_ = MakeServiceStub(options_.endpoint);
-}
+OtlpExporter::OtlpExporter(OtlpExporterOptions options)
+    : options_(std::move(options)), trace_service_stub_(MakeServiceStub(options.endpoint))
+{}
 
 OtlpExporter::OtlpExporter(
     std::unique_ptr<proto::collector::trace::v1::TraceService::StubInterface> stub)

--- a/exporters/otlp/src/otlp_exporter.cc
+++ b/exporters/otlp/src/otlp_exporter.cc
@@ -45,7 +45,7 @@ std::unique_ptr<proto::collector::trace::v1::TraceService::Stub> MakeServiceStub
 OtlpExporter::OtlpExporter() : OtlpExporter(OtlpExporterOptions()) {}
 
 OtlpExporter::OtlpExporter(OtlpExporterOptions options)
-    : options_(std::move(options)), trace_service_stub_(MakeServiceStub(options.endpoint))
+    : options_(options), trace_service_stub_(MakeServiceStub(options.endpoint))
 {}
 
 OtlpExporter::OtlpExporter(

--- a/exporters/otlp/src/otlp_exporter.cc
+++ b/exporters/otlp/src/otlp_exporter.cc
@@ -10,7 +10,10 @@ namespace exporter
 namespace otlp
 {
 
-const std::string kCollectorAddress = "localhost:55678";
+// Environment variable to configure endpoint for OTLP exporter
+constexpr char kConfiguredEndpoint[] = "OTEL_EXPORTER_OTLP_ENDPOINT";
+// Default endpoint is the OpenTelemetry Collector default address
+std::string kDefaultEndpoint = "localhost:55678";
 
 // ----------------------------- Helper functions ------------------------------
 
@@ -37,7 +40,15 @@ void PopulateRequest(const nostd::span<std::unique_ptr<sdk::trace::Recordable>> 
  */
 std::unique_ptr<proto::collector::trace::v1::TraceService::Stub> MakeServiceStub()
 {
-  auto channel = grpc::CreateChannel(kCollectorAddress, grpc::InsecureChannelCredentials());
+  std::string endpoint      = kDefaultEndpoint;
+  char *configured_endpoint = getenv(kConfiguredEndpoint);
+
+  if (configured_endpoint != NULL)
+  {
+    endpoint = configured_endpoint;
+  }
+
+  auto channel = grpc::CreateChannel(endpoint, grpc::InsecureChannelCredentials());
   return proto::collector::trace::v1::TraceService::NewStub(channel);
 }
 

--- a/exporters/otlp/test/otlp_exporter_test.cc
+++ b/exporters/otlp/test/otlp_exporter_test.cc
@@ -23,6 +23,12 @@ public:
   {
     return std::unique_ptr<sdk::trace::SpanExporter>(new OtlpExporter(std::move(stub_interface)));
   }
+
+  // Get the options associated with the given exporter.
+  OtlpExporterOptions GetOptions(std::unique_ptr<OtlpExporter> &exporter)
+  {
+    return exporter->options_;
+  }
 };
 
 // Call Export() directly
@@ -76,6 +82,15 @@ TEST_F(OtlpExporterTestPeer, ExportIntegrationTest)
   auto child_span  = tracer->StartSpan("Test child span");
   child_span->End();
   parent_span->End();
+}
+
+// Test exporter configuration options
+TEST_F(OtlpExporterTestPeer, ConfigTest)
+{
+  OtlpExporterOptions opts;
+  opts.endpoint = "localhost:45454";
+  std::unique_ptr<OtlpExporter> exporter(new OtlpExporter(opts));
+  EXPECT_EQ(GetOptions(exporter).endpoint, "localhost:45454");
 }
 }  // namespace otlp
 }  // namespace exporter

--- a/exporters/otlp/test/otlp_exporter_test.cc
+++ b/exporters/otlp/test/otlp_exporter_test.cc
@@ -25,7 +25,7 @@ public:
   }
 
   // Get the options associated with the given exporter.
-  OtlpExporterOptions GetOptions(std::unique_ptr<OtlpExporter> &exporter)
+  const OtlpExporterOptions &GetOptions(std::unique_ptr<OtlpExporter> &exporter)
   {
     return exporter->options_;
   }


### PR DESCRIPTION
Add an `options` struct to the OTLP exporter to allow exporter configuration (see [OTLP exporter spec](https://github.com/open-telemetry/opentelemetry-specification/blob/master/specification/protocol/exporter.md)). Add a new OTLP exporter constructor that accepts and sets these options.

This PR adds an `endpoint` configuration, with a default of `localhost:55680`. In the future, other configuration options will be added, such as `timeout`.

Note that this PR changes the default port used to connect to the OpenTelemetry Collector from `55678` to `55680`, in accordance with https://github.com/open-telemetry/opentelemetry-cpp/issues/239.