### PR TITLE
Add OTLP exporter example

### DIFF
--- a/examples/otlp/BUILD
+++ b/examples/otlp/BUILD
@@ -19,7 +19,7 @@ cc_binary(
     deps = [
         ":foo_library",
         "//api",
+        "//exporters/otlp:otlp_exporter",
         "//sdk/src/trace",
-        "//exporters/otlp:otlp_exporter"
     ],
 )

--- a/examples/otlp/BUILD
+++ b/examples/otlp/BUILD
@@ -1,0 +1,25 @@
+cc_library(
+    name = "foo_library",
+    srcs = [
+        "foo_library/foo_library.cc",
+    ],
+    hdrs = [
+        "foo_library/foo_library.h",
+    ],
+    deps = [
+        "//api",
+    ],
+)
+
+cc_binary(
+    name = "example_otlp",
+    srcs = [
+        "main.cc",
+    ],
+    deps = [
+        ":foo_library",
+        "//api",
+        "//sdk/src/trace",
+        "//exporters/otlp:otlp_exporter"
+    ],
+)

--- a/examples/otlp/CMakeLists.txt
+++ b/examples/otlp/CMakeLists.txt
@@ -1,0 +1,6 @@
+add_library(foo_library foo_library/foo_library.cc)
+target_link_libraries(foo_library ${CMAKE_THREAD_LIBS_INIT} opentelemetry_api)
+
+add_executable(example_otlp main.cc)
+target_link_libraries(example_otlp ${CMAKE_THREAD_LIBS_INIT} foo_library
+                      opentelemetry_trace)

--- a/examples/otlp/README.md
+++ b/examples/otlp/README.md
@@ -1,0 +1,31 @@
+# OTLP Exporter Example
+
+This is an example of how to use the OTLP exporter.
+
+The application in `main.cc` initializes an `OtlpExporter` instance, and uses it to register a tracer provider from the [OpenTelemetry SDK](https://github.com/open-telemetry/opentelemetry-cpp). The application then calls a `foo_library` which has been instrumented using the [OpenTelemetry API](https://github.com/open-telemetry/opentelemetry-cpp/tree/master/api).
+
+Resulting spans are exported to the OpenTelemetry Collector using the OTLP exporter. The OpenTelemetry Collector can be configured to export to other backends (see list of [supported backends](https://github.com/open-telemetry/opentelemetry-collector/blob/master/exporter/README.md)).
+
+For instructions on downloading and running the OpenTelemetry Collector, see [OpenTelemetry Collector Getting Started](https://opentelemetry.io/docs/collector/about/).
+
+Here is an example of a Collector `config.yaml` file to export to [Zipkin](https://zipkin.io/) using the OTLP exporter:
+
+```
+receivers:
+  otlp:
+    protocols:
+      grpc:
+        endpoint: localhost:55680
+exporters:
+  zipkin:
+    endpoint: "http://localhost:9411/api/v2/spans"
+service:
+  pipelines:
+    traces:
+      receivers: [otlp]
+      exporters: [zipkin]
+```
+
+Note that the OTLP exporter connects to the Collector at `localhost:55680` by default.
+
+Once you have the Collector running, see [CONTRIBUTING.md](../../CONTRIBUTING.md) for instructions on building and running the example.

--- a/examples/otlp/README.md
+++ b/examples/otlp/README.md
@@ -1,14 +1,14 @@
 # OTLP Exporter Example
 
-This is an example of how to use the OTLP exporter.
+This is an example of how to use the [OpenTelemetry Protocol](https://github.com/open-telemetry/opentelemetry-specification/blob/master/specification/protocol/README.md) (OTLP) exporter.
 
-The application in `main.cc` initializes an `OtlpExporter` instance, and uses it to register a tracer provider from the [OpenTelemetry SDK](https://github.com/open-telemetry/opentelemetry-cpp). The application then calls a `foo_library` which has been instrumented using the [OpenTelemetry API](https://github.com/open-telemetry/opentelemetry-cpp/tree/master/api).
+The application in `main.cc` initializes an `OtlpExporter` instance and uses it to register a tracer provider from the [OpenTelemetry SDK](https://github.com/open-telemetry/opentelemetry-cpp). The application then calls a `foo_library` which has been instrumented using the [OpenTelemetry API](https://github.com/open-telemetry/opentelemetry-cpp/tree/master/api).
 
-Resulting spans are exported to the OpenTelemetry Collector using the OTLP exporter. The OpenTelemetry Collector can be configured to export to other backends (see list of [supported backends](https://github.com/open-telemetry/opentelemetry-collector/blob/master/exporter/README.md)).
+Resulting spans are exported to the **OpenTelemetry Collector** using the OTLP exporter. The OpenTelemetry Collector can be configured to export to other backends (see list of [supported backends](https://github.com/open-telemetry/opentelemetry-collector/blob/master/exporter/README.md)).
 
-For instructions on downloading and running the OpenTelemetry Collector, see [OpenTelemetry Collector Getting Started](https://opentelemetry.io/docs/collector/about/).
+For instructions on downloading and running the OpenTelemetry Collector, see [Getting Started](https://opentelemetry.io/docs/collector/about/).
 
-Here is an example of a Collector `config.yaml` file to export to [Zipkin](https://zipkin.io/) using the OTLP exporter:
+Here is an example of a Collector `config.yaml` file that can be used to export to [Zipkin](https://zipkin.io/) via the Collector using the OTLP exporter:
 
 ```
 receivers:

--- a/examples/otlp/foo_library/foo_library.cc
+++ b/examples/otlp/foo_library/foo_library.cc
@@ -1,0 +1,37 @@
+#include "opentelemetry/context/threadlocal_context.h"
+#include "opentelemetry/trace/provider.h"
+
+namespace trace = opentelemetry::trace;
+namespace nostd = opentelemetry::nostd;
+
+namespace
+{
+nostd::shared_ptr<trace::Tracer> get_tracer()
+{
+  auto provider = trace::Provider::GetTracerProvider();
+  return provider->GetTracer("foo_library");
+}
+
+void f1()
+{
+  auto span = get_tracer()->StartSpan("f1");
+  span->End();
+}
+
+void f2()
+{
+  auto span = get_tracer()->StartSpan("f2");
+
+  f1();
+  f1();
+  span->End();
+}
+}  // namespace
+
+void foo_library()
+{
+  auto span = get_tracer()->StartSpan("library");
+
+  f2();
+  span->End();
+}

--- a/examples/otlp/foo_library/foo_library.cc
+++ b/examples/otlp/foo_library/foo_library.cc
@@ -12,6 +12,9 @@ nostd::shared_ptr<trace::Tracer> get_tracer()
   return provider->GetTracer("foo_library");
 }
 
+// TODO: Remove all calls to span->End() once context memory issue is fixed
+// (https://github.com/open-telemetry/opentelemetry-cpp/issues/287)
+
 void f1()
 {
   auto span = get_tracer()->StartSpan("f1");

--- a/examples/otlp/foo_library/foo_library.h
+++ b/examples/otlp/foo_library/foo_library.h
@@ -1,0 +1,3 @@
+#pragma once
+
+void foo_library();

--- a/examples/otlp/main.cc
+++ b/examples/otlp/main.cc
@@ -1,0 +1,34 @@
+#include "opentelemetry/exporters/otlp/otlp_exporter.h"
+#include "opentelemetry/sdk/trace/simple_processor.h"
+#include "opentelemetry/sdk/trace/tracer_provider.h"
+#include "opentelemetry/trace/provider.h"
+
+#include "foo_library/foo_library.h"
+
+namespace trace    = opentelemetry::trace;
+namespace nostd    = opentelemetry::nostd;
+namespace sdktrace = opentelemetry::sdk::trace;
+namespace otlp     = opentelemetry::exporter::otlp;
+
+namespace
+{
+void initTracer()
+{
+  // Create OTLP exporter instance
+  auto exporter = std::unique_ptr<sdktrace::SpanExporter>(new otlp::OtlpExporter);
+
+  auto processor = std::shared_ptr<sdktrace::SpanProcessor>(
+      new sdktrace::SimpleSpanProcessor(std::move(exporter)));
+  auto provider = nostd::shared_ptr<trace::TracerProvider>(new sdktrace::TracerProvider(processor));
+  // Set the global trace provider
+  trace::Provider::SetTracerProvider(provider);
+}
+}  // namespace
+
+int main()
+{
+  // Removing this line will leave the default noop TracerProvider in place.
+  initTracer();
+
+  foo_library();
+}


### PR DESCRIPTION
Add an example application using the OTLP exporter. The example includes a detailed README with instructions on how to configure the OpenTelemetry Collector to use the OTLP exporter.

Currently, `foo_library` makes explicit calls to `span->End()` to work around https://github.com/open-telemetry/opentelemetry-cpp/issues/287. These calls should be removed once the issue is resolved. I've added a TODO in the code for this.