### PR TITLE
Add OTLP exporter README

### DIFF
--- a/examples/otlp/main.cc
+++ b/examples/otlp/main.cc
@@ -28,7 +28,7 @@ void InitTracer()
 int main()
 {
   // Removing this line will leave the default noop TracerProvider in place.
-  initTracer();
+  InitTracer();
 
   foo_library();
 }

--- a/examples/otlp/main.cc
+++ b/examples/otlp/main.cc
@@ -12,7 +12,7 @@ namespace otlp     = opentelemetry::exporter::otlp;
 
 namespace
 {
-void initTracer()
+void InitTracer()
 {
   // Create OTLP exporter instance
   auto exporter = std::unique_ptr<sdktrace::SpanExporter>(new otlp::OtlpExporter);

--- a/exporters/otlp/README.md
+++ b/exporters/otlp/README.md
@@ -1,0 +1,28 @@
+# OTLP Exporter
+
+The [OpenTelemetry Protocol](https://github.com/open-telemetry/opentelemetry-specification/blob/master/specification/protocol/README.md) (OTLP) is a vendor-agnostic protocol designed as part of the
+OpenTelemetry project. The OTLP exporter can be used to export to any backend that supports OTLP.
+
+Currently, the only backend that supports OTLP is the [OpenTelemetry Collector](https://github.com/open-telemetry/opentelemetry-collector). The Collector can be configured to export to many other backends, such as Zipkin and Jaegar.
+
+For a full list of backends supported by the Collector, see the [main Collector repo](https://github.com/open-telemetry/opentelemetry-collector/tree/master/exporter) and [Collector contributions](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/master/exporter).
+
+## Configuration
+The OTLP exporter offers some configuration options. To configure the exporter, create an
+`OtlpExporterOptions` struct (defined in [exporter.h](include/exporter.h)), set the options inside,
+and pass the struct to the `OtlpExporter` constructor, like so:
+
+```
+OtlpExporterOptions options;
+options.endpoint = "localhost:12345";
+auto exporter = std::unique_ptr<sdktrace::SpanExporter>(new otlp::OtlpExporter(options));
+```
+
+### Configuration options
+
+| Option       | Default           |
+| ------------ |------------------ |
+| `endpoint`   | `localhost:55680` |
+
+## Example
+For a complete example demonstrating how to use the OTLP exporter, see [examples/otlp](../../examples/otlp).

--- a/exporters/otlp/README.md
+++ b/exporters/otlp/README.md
@@ -2,11 +2,12 @@
 
 The [OpenTelemetry Protocol](https://github.com/open-telemetry/opentelemetry-specification/blob/master/specification/protocol/README.md) (OTLP) is a vendor-agnostic protocol designed as part of the OpenTelemetry project. The OTLP exporter can be used to export to any backend that supports OTLP.
 
-Currently, the only backend that supports OTLP is the [OpenTelemetry Collector](https://github.com/open-telemetry/opentelemetry-collector). The Collector can be configured to export to many other backends, such as Zipkin and Jaegar.
+The [OpenTelemetry Collector](https://github.com/open-telemetry/opentelemetry-collector) is a reference implementation of an OTLP backend. The Collector can be configured to export to many other backends, such as Zipkin and Jaegar.
 
 For a full list of backends supported by the Collector, see the [main Collector repo](https://github.com/open-telemetry/opentelemetry-collector/tree/master/exporter) and [Collector contributions](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/master/exporter).
 
 ## Configuration
+
 The OTLP exporter offers some configuration options. To configure the exporter, create an `OtlpExporterOptions` struct (defined in [exporter.h](include/exporter.h)), set the options inside, and pass the struct to the `OtlpExporter` constructor, like so:
 
 ```
@@ -22,4 +23,5 @@ auto exporter = std::unique_ptr<sdktrace::SpanExporter>(new otlp::OtlpExporter(o
 | `endpoint`   | `localhost:55680` |
 
 ## Example
+
 For a complete example demonstrating how to use the OTLP exporter, see [examples/otlp](../../examples/otlp).

--- a/exporters/otlp/README.md
+++ b/exporters/otlp/README.md
@@ -1,16 +1,13 @@
 # OTLP Exporter
 
-The [OpenTelemetry Protocol](https://github.com/open-telemetry/opentelemetry-specification/blob/master/specification/protocol/README.md) (OTLP) is a vendor-agnostic protocol designed as part of the
-OpenTelemetry project. The OTLP exporter can be used to export to any backend that supports OTLP.
+The [OpenTelemetry Protocol](https://github.com/open-telemetry/opentelemetry-specification/blob/master/specification/protocol/README.md) (OTLP) is a vendor-agnostic protocol designed as part of the OpenTelemetry project. The OTLP exporter can be used to export to any backend that supports OTLP.
 
 Currently, the only backend that supports OTLP is the [OpenTelemetry Collector](https://github.com/open-telemetry/opentelemetry-collector). The Collector can be configured to export to many other backends, such as Zipkin and Jaegar.
 
 For a full list of backends supported by the Collector, see the [main Collector repo](https://github.com/open-telemetry/opentelemetry-collector/tree/master/exporter) and [Collector contributions](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/master/exporter).
 
 ## Configuration
-The OTLP exporter offers some configuration options. To configure the exporter, create an
-`OtlpExporterOptions` struct (defined in [exporter.h](include/exporter.h)), set the options inside,
-and pass the struct to the `OtlpExporter` constructor, like so:
+The OTLP exporter offers some configuration options. To configure the exporter, create an `OtlpExporterOptions` struct (defined in [exporter.h](include/exporter.h)), set the options inside, and pass the struct to the `OtlpExporter` constructor, like so:
 
 ```
 OtlpExporterOptions options;


### PR DESCRIPTION
Add a README to the OTLP exporter directory to describe the exporter and how it can be used/configured.