### PR TITLE
Add missing include folders for example OTLP exporter

### DIFF
--- a/examples/otlp/CMakeLists.txt
+++ b/examples/otlp/CMakeLists.txt
@@ -1,6 +1,11 @@
-add_library(foo_library foo_library/foo_library.cc)
-target_link_libraries(foo_library ${CMAKE_THREAD_LIBS_INIT} opentelemetry_api)
+include_directories(${CMAKE_BINARY_DIR}/generated/third_party/opentelemetry-proto)
+include_directories(${CMAKE_SOURCE_DIR}/exporters/otlp/include)
+
+add_library(otlp_foo_library foo_library/foo_library.cc)
+target_link_libraries(otlp_foo_library ${CMAKE_THREAD_LIBS_INIT} opentelemetry_api)
 
 add_executable(example_otlp main.cc)
-target_link_libraries(example_otlp ${CMAKE_THREAD_LIBS_INIT} foo_library
-                      opentelemetry_trace)
+target_link_libraries(example_otlp ${CMAKE_THREAD_LIBS_INIT}
+                      otlp_foo_library
+                      opentelemetry_trace
+                      opentelemetry_exporter_otprotocol)


### PR DESCRIPTION
Added missing included folders and also renamed library target `foo_library` to `otlp_foo_library` in CMakeLists.txt. The name `foo_library` conflicts with the library in [simple](https://github.com/open-telemetry/opentelemetry-cpp/blob/e0a93fd0f0791cdd1e09b4e27048aa0ca299e4e9/examples/simple/CMakeLists.txt#L3) example.

gRPC dependency is still missing so I didn't add this exporter to the parent CMakeLists.txt, will fix it later.