### PR TITLE
Fix broken link in OTLP exporter README

### DIFF
--- a/exporters/otlp/README.md
+++ b/exporters/otlp/README.md
@@ -8,7 +8,7 @@ For a full list of backends supported by the Collector, see the [main Collector 
 
 ## Configuration
 
-The OTLP exporter offers some configuration options. To configure the exporter, create an `OtlpExporterOptions` struct (defined in [exporter.h](include/exporter.h)), set the options inside, and pass the struct to the `OtlpExporter` constructor, like so:
+The OTLP exporter offers some configuration options. To configure the exporter, create an `OtlpExporterOptions` struct (defined in [exporter.h](include/opentelemetry/exporters/otlp/otlp_exporter.h)), set the options inside, and pass the struct to the `OtlpExporter` constructor, like so:
 
 ```
 OtlpExporterOptions options;


### PR DESCRIPTION
The link to `otlp_exporter.h` is broken in the current version of the README. Fix it to use the proper path.