### PR TITLE
Http Client API

### DIFF
--- a/api/include/opentelemetry/http/http_client.h
+++ b/api/include/opentelemetry/http/http_client.h
@@ -100,12 +100,12 @@ public:
 class HttpResponseCallback
 {
 public:
-	// Called when an HTTP request completes.
-	// The passed response object contains details about the exact way the
-	// request finished (HTTP status code, headers, content, error codes
-	// etc.). The ownership of the response object is transferred to the
+    // Called when an HTTP request completes.
+    // The passed response object contains details about the exact way the
+    // request finished (HTTP status code, headers, content, error codes
+    // etc.). The ownership of the response object is transferred to the
     // callback object. It can store it for later if necessary. Finally, it
-	// must be deleted using its virtual destructor.
+    // must be deleted using its virtual destructor.
     virtual void OnHttpResponse(HttpResponse* response) = 0;
 };
 

--- a/api/include/opentelemetry/http/http_client.h
+++ b/api/include/opentelemetry/http/http_client.h
@@ -1,4 +1,16 @@
-// Copyright (c) Microsoft. All rights reserved
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 #pragma once
 
@@ -40,9 +52,12 @@ public:
     virtual void add(nostd::string_view const& name, nostd::string_view const& value) = 0;
 
     // Gets a string value given a name
+    // Returns:
+    //      If there are multiple headers with same name, it returns any one of the value (implementation defined)
+    //      Empty string if there is no header with speicfied name..
     virtual nostd::string_view const& get(nostd::string_view const& name) const = 0;
 
-    // Tests whether the headers contains the specified name.
+    // Tests whether the headers contain the specified name.
     virtual bool has(nostd::string_view const& name) const = 0;
 };
 

--- a/api/include/opentelemetry/http/http_client.h
+++ b/api/include/opentelemetry/http/http_client.h
@@ -78,7 +78,7 @@ public:
   virtual void SetUrl(nostd::string_view const &url) = 0;
 
   // Gets the request Headers
-  virtual HttpHeaders *GetHeaders() const = 0;
+  virtual HttpHeaders &GetHeaders() const = 0;
 
   // Sets the request body
   virtual void SetBody(const uint8_t *const body, const size_t len) = 0;
@@ -106,7 +106,7 @@ public:
   virtual unsigned GetStatusCode() = 0;
 
   // Gets the response headers.
-  virtual HttpHeaders *GetHeaders() = 0;
+  virtual const HttpHeaders &GetHeaders() = 0;
 
   // Gets the response body.
   virtual void GetBody(uint8_t *body, size_t &len) = 0;

--- a/api/include/opentelemetry/http/http_client.h
+++ b/api/include/opentelemetry/http/http_client.h
@@ -12,6 +12,13 @@ enum class HttpMethod: uint8_t {
     HTTP_PATCH
 };
 
+enum class HttpResult: uint8_t {
+    HTTP_OK,
+    HTTP_ABORTED,
+    HTTP_LOCALFAILURE,
+    HTTP_REMOTEFAILURE
+};
+
 class IHttpClient
 {
 public:
@@ -58,5 +65,4 @@ public:
     virtual void OnHttpResponse(IHttpResponse* response) = 0;
 };
 } // namespace nostd
-OPENTELEMETRY_END_NAMESPACE
 OPENTELEMETRY_END_NAMESPACE

--- a/api/include/opentelemetry/http/http_client.h
+++ b/api/include/opentelemetry/http/http_client.h
@@ -49,7 +49,7 @@ public:
     virtual HttpResult GetResult() = 0;
     virtual unsigned GetStatusCode() = 0;
     virtual HttpHeaders& GetHeaders() = 0;
-    virtual std::vector<uint8_t>& GetBody() = 0;
+    virtual void GetBody(uint8_t* body, int* len) = 0;
 };
 
 class IHttpResponseCallback

--- a/api/include/opentelemetry/http/http_client.h
+++ b/api/include/opentelemetry/http/http_client.h
@@ -57,7 +57,7 @@ public:
   virtual nostd::string_view const &get(nostd::string_view const &name) const = 0;
 
   // Tests whether the headers contain the specified name.
-  virtual bool has(nostd::string_view const &name) const = 0;
+  virtual bool contains(nostd::string_view const &name) const = 0;
 };
 
 // The HttpRequest class represents a Request object.
@@ -145,16 +145,16 @@ public:
   // latter case, the OnHttpResponse() callback is called before this
   // method returns. You must keep the callback object alive until its
   // OnHttpResponse() callback is called.
-  virtual void SendRequestAsync(HttpRequest *request, HttpResponseCallback *callback) = 0;
+  virtual void SendRequest(HttpRequest *request, HttpResponseCallback *callback) = 0;
 
   // Cancels an HTTP request.
   // The caller must provide a string ID returned earlier by request->GetId().
   // The request is cancelled asynchronously. The caller must still
   // wait for the relevant OnHttpResponse() callback (it can just come
   // earlier with some "aborted" error status).
-  virtual void CancelRequestAsync(nostd::string_view const &id) = 0;
+  virtual void CancelRequest(nostd::string_view const &id) = 0;
 
-  virtual void CancelAllRequests() {}
+  virtual void CancelAllRequestsSync() {}
 };
 
 }  // namespace http

--- a/api/include/opentelemetry/http/http_client.h
+++ b/api/include/opentelemetry/http/http_client.h
@@ -20,24 +20,23 @@ OPENTELEMETRY_BEGIN_NAMESPACE
 namespace http
 {
 
-
-enum class HttpResult: uint8_t
+enum class HttpResult : uint8_t
 {
-    // Response has been received successfully from target server.
-    HttpResult_OK = 0,
+  // Response has been received successfully from target server.
+  HttpResult_OK = 0,
 
-    // Request has been aborted by the caller. The server might or
-    // might not have already received or processed the request.
-    HttpResult_Aborted = 1,
+  // Request has been aborted by the caller. The server might or
+  // might not have already received or processed the request.
+  HttpResult_Aborted = 1,
 
-    // Local conditions have prevented the request from being sent
-    // (invalid request parameters, out of memory, internal error etc.)
-    HttpResult_LocalFailure = 2,
+  // Local conditions have prevented the request from being sent
+  // (invalid request parameters, out of memory, internal error etc.)
+  HttpResult_LocalFailure = 2,
 
-    // Network conditions somewhere between the local machine and
-    // the target server have caused the request to fail
-    // (connection failed, connection dropped abruptly etc.).
-    HttpResult_NetworkFailure = 3
+  // Network conditions somewhere between the local machine and
+  // the target server have caused the request to fail
+  // (connection failed, connection dropped abruptly etc.).
+  HttpResult_NetworkFailure = 3
 
 };
 
@@ -45,20 +44,20 @@ enum class HttpResult: uint8_t
 class HttpHeaders
 {
 public:
-    // Inserts a name/value pair, and removes elements with the same name.
-    virtual void set(nostd::string_view const& name, nostd::string_view const& value) = 0;
+  // Inserts a name/value pair, and removes elements with the same name.
+  virtual void set(nostd::string_view const &name, nostd::string_view const &value) = 0;
 
-    // Inserts a name/value pair
-    virtual void add(nostd::string_view const& name, nostd::string_view const& value) = 0;
+  // Inserts a name/value pair
+  virtual void add(nostd::string_view const &name, nostd::string_view const &value) = 0;
 
-    // Gets a string value given a name
-    // Returns:
-    //      If there are multiple headers with same name, it returns any one of the value (implementation defined)
-    //      Empty string if there is no header with speicfied name..
-    virtual nostd::string_view const& get(nostd::string_view const& name) const = 0;
+  // Gets a string value given a name
+  // Returns:
+  //      If there are multiple headers with same name, it returns any one of the value
+  //      (implementation defined) Empty string if there is no header with speicfied name..
+  virtual nostd::string_view const &get(nostd::string_view const &name) const = 0;
 
-    // Tests whether the headers contain the specified name.
-    virtual bool has(nostd::string_view const& name) const = 0;
+  // Tests whether the headers contain the specified name.
+  virtual bool has(nostd::string_view const &name) const = 0;
 };
 
 // The HttpRequest class represents a Request object.
@@ -69,23 +68,23 @@ public:
 class HttpRequest
 {
 public:
-	// Gets the request ID.
-    virtual const nostd::string_view& GetId() const = 0;
+  // Gets the request ID.
+  virtual const nostd::string_view &GetId() const = 0;
 
-    // Sets the request Method 
-    virtual void SetMethod(nostd::string_view const& method) = 0;
+  // Sets the request Method
+  virtual void SetMethod(nostd::string_view const &method) = 0;
 
-	// Gets the request URI
-    virtual void SetUrl(nostd::string_view const& url) = 0;
+  // Gets the request URI
+  virtual void SetUrl(nostd::string_view const &url) = 0;
 
-	// Gets the request Headers
-    virtual HttpHeaders* GetHeaders() const = 0;
+  // Gets the request Headers
+  virtual HttpHeaders *GetHeaders() const = 0;
 
-	// Sets the request body
-    virtual void SetBody(const uint8_t* const body, const size_t len) = 0;
+  // Sets the request body
+  virtual void SetBody(const uint8_t *const body, const size_t len) = 0;
 
-	// Gets the request body
-    virtual void GetBody(uint8_t* body, size_t& len) = 0;
+  // Gets the request body
+  virtual void GetBody(uint8_t *body, size_t &len) = 0;
 };
 
 // The HttpResponse class represents a Response object.
@@ -97,69 +96,66 @@ public:
 class HttpResponse
 {
 public:
-	// Gets the response ID.
-    virtual const nostd::string_view& GetId() = 0;
+  // Gets the response ID.
+  virtual const nostd::string_view &GetId() = 0;
 
-	// Get the response result code.
-    virtual HttpResult GetResult() = 0;
+  // Get the response result code.
+  virtual HttpResult GetResult() = 0;
 
-	// Gets the response status code.
-    virtual unsigned GetStatusCode() = 0;
+  // Gets the response status code.
+  virtual unsigned GetStatusCode() = 0;
 
-	// Gets the response headers.
-    virtual HttpHeaders* GetHeaders() = 0;
+  // Gets the response headers.
+  virtual HttpHeaders *GetHeaders() = 0;
 
-	// Gets the response body.
-    virtual void GetBody(uint8_t* body, size_t& len) = 0;
+  // Gets the response body.
+  virtual void GetBody(uint8_t *body, size_t &len) = 0;
 };
 
 // The HttpResponseCallback class receives HTTP client responses
 class HttpResponseCallback
 {
 public:
-    // Called when an HTTP request completes.
-    // The passed response object contains details about the exact way the
-    // request finished (HTTP status code, headers, content, error codes
-    // etc.). The ownership of the response object is transferred to the
-    // callback object. It can store it for later if necessary. Finally, it
-    // must be deleted using its virtual destructor.
-    virtual void OnHttpResponse(HttpResponse* response) = 0;
+  // Called when an HTTP request completes.
+  // The passed response object contains details about the exact way the
+  // request finished (HTTP status code, headers, content, error codes
+  // etc.). The ownership of the response object is transferred to the
+  // callback object. It can store it for later if necessary. Finally, it
+  // must be deleted using its virtual destructor.
+  virtual void OnHttpResponse(HttpResponse *response) = 0;
 };
 
 // The HttpClient class is the interface for HTTP client implementations.
 class HttpClient
 {
 public:
+  // Creates an empty HTTP request object.
+  // The created request object has only its ID prepopulated. Other fields
+  // must be set by the caller. The request object can then be sent
+  // using SendRequestAsync(). If you are not going to use the request object
+  // then you can delete it safely using its virtual destructor.
+  virtual HttpRequest *CreateRequest() = 0;
 
-    // Creates an empty HTTP request object.
-    // The created request object has only its ID prepopulated. Other fields
-    // must be set by the caller. The request object can then be sent
-    // using SendRequestAsync(). If you are not going to use the request object
-    // then you can delete it safely using its virtual destructor.
-    virtual HttpRequest* CreateRequest() = 0;
+  // Begins an HTTP request.
+  // The method takes ownership of the passed request, and can destroy it before
+  // returning to the caller. Do not access the request object in any
+  // way after this invocation, and do not delete it.
+  // The callback object is always called, even if the request is
+  // cancelled, or if an error occurs immediately during sending. In the
+  // latter case, the OnHttpResponse() callback is called before this
+  // method returns. You must keep the callback object alive until its
+  // OnHttpResponse() callback is called.
+  virtual void SendRequestAsync(HttpRequest *request, HttpResponseCallback *callback) = 0;
 
-    // Begins an HTTP request.
-    // The method takes ownership of the passed request, and can destroy it before
-    // returning to the caller. Do not access the request object in any
-    // way after this invocation, and do not delete it.
-    // The callback object is always called, even if the request is
-    // cancelled, or if an error occurs immediately during sending. In the
-    // latter case, the OnHttpResponse() callback is called before this
-    // method returns. You must keep the callback object alive until its
-    // OnHttpResponse() callback is called.
-    virtual void SendRequestAsync(HttpRequest* request, HttpResponseCallback* callback) = 0;
+  // Cancels an HTTP request.
+  // The caller must provide a string ID returned earlier by request->GetId().
+  // The request is cancelled asynchronously. The caller must still
+  // wait for the relevant OnHttpResponse() callback (it can just come
+  // earlier with some "aborted" error status).
+  virtual void CancelRequestAsync(nostd::string_view const &id) = 0;
 
-    // Cancels an HTTP request.
-    // The caller must provide a string ID returned earlier by request->GetId().
-    // The request is cancelled asynchronously. The caller must still
-    // wait for the relevant OnHttpResponse() callback (it can just come
-    // earlier with some "aborted" error status).
-    virtual void CancelRequestAsync(nostd::string_view const& id) = 0;
-
-    virtual void CancelAllRequests()
-    {
-    }
+  virtual void CancelAllRequests() {}
 };
 
-} // namespace nostd
+}  // namespace http
 OPENTELEMETRY_END_NAMESPACE

--- a/api/include/opentelemetry/http/http_client.h
+++ b/api/include/opentelemetry/http/http_client.h
@@ -1,68 +1,148 @@
 #pragma once
+
+#include "opentelemetry/nostd/string_view.h"
+
 OPENTELEMETRY_BEGIN_NAMESPACE
 namespace http
 {
 
-enum class HttpMethod: uint8_t {
-    HTTP_GET,
-    HTTP_POST,
-    HTTP_DELETE,
-    HTTP_PUT,
-    HTTP_HEAD,
-    HTTP_PATCH
-};
 
-enum class HttpResult: uint8_t {
-    HTTP_OK,
-    HTTP_ABORTED,
-    HTTP_LOCALFAILURE,
-    HTTP_REMOTEFAILURE
-};
-
-class IHttpClient
+enum class HttpResult: uint8_t
 {
-public:
-    virtual IHttpRequest* CreateRequest() = 0;
-    virtual void SendRequest (IHttpRequest* request, IHttpResponse* response) = 0;
-    virtual void SendRequestAsync(IHttpRequest* request, IHttpResponseCallback* callback) = 0;
-    virtual void CancelRequestAsync(nostd::string_view const& id) = 0;
-    virtual void CancelAllRequests();
+    // Response has been received successfully from target server.
+    HttpResult_OK = 0,
+
+    // Request has been aborted by the caller. The server might or
+    // might not have already received or processed the request.
+    HttpResult_Aborted = 1,
+
+    // Local conditions have prevented the request from being sent
+    // (invalid request parameters, out of memory, internal error etc.)
+    HttpResult_LocalFailure = 2,
+
+    // Network conditions somewhere between the local machine and
+    // the target server have caused the request to fail
+    // (connection failed, connection dropped abruptly etc.).
+    HttpResult_NetworkFailure = 3
+
 };
 
-class IHttpRequest
-{
-public:
-    virtual nostd::string_view& GetId() = 0;
-    virtual void SetMethod(nostd::string_view const& method) = 0;
-    virtual void SetUrl(nostd::string_view const& url) = 0;
-    virtual HttpHeaders& GetHeaders() = 0;
-    virtual void SetBody(uint8_t* body, int len) = 0;
-    virtual void GetBody(uint8_t* body, int* len) = 0;
-};
-
+// The HttpHeaders class contains a set of HTTP headers.
 class HttpHeaders
 {
 public:
+    // Inserts a name/value pair, and removes elements with the same name.
     virtual void set(nostd::string_view const& name, nostd::string_view const& value) = 0;
+
+    // Inserts a name/value pair
     virtual void add(nostd::string_view const& name, nostd::string_view const& value) = 0;
-    virtual nostd::string_view const& get(nostd::string_view const& name) = 0;
-    virtual bool has(nostd::string_view const& name) = 0;
+
+    // Gets a string value given a name
+    virtual nostd::string_view const& get(nostd::string_view const& name) const = 0;
+
+    // Tests whether the headers contains the specified name.
+    virtual bool has(nostd::string_view const& name) const = 0;
 };
 
-class IHttpResponse
+// The HttpRequest class represents a Request object.
+// Individual HTTP client implementations can implement the request object in
+// the most efficient way. Either fill the request first, and then issue
+// the underlying request, or create the real request immediately, and then forward
+// the methods and set the individual parameters directly one by one.
+class HttpRequest
 {
 public:
-    virtual nostd::string_view& GetId() = 0;
+	// Gets the request ID.
+    virtual const nostd::string_view& GetId() const = 0;
+
+    // Sets the request Method 
+    virtual void SetMethod(nostd::string_view const& method) = 0;
+
+	// Gets the request URI
+    virtual void SetUrl(nostd::string_view const& url) = 0;
+
+	// Gets the request Headers
+    virtual HttpHeaders* GetHeaders() const = 0;
+
+	// Sets the request body
+    virtual void SetBody(const uint8_t* const body, const size_t len) = 0;
+
+	// Gets the request body
+    virtual void GetBody(uint8_t* body, size_t& len) = 0;
+};
+
+// The HttpResponse class represents a Response object.
+// Individual HTTP client implementations can implement the response object
+// in the most efficient way. Either copy all of the underlying data to a new
+// structure, and provide it to the callback; or keep the real
+// response data around, forward the methods, and retrieve the individual
+// values directly one by one.
+class HttpResponse
+{
+public:
+	// Gets the response ID.
+    virtual const nostd::string_view& GetId() = 0;
+
+	// Get the response result code.
     virtual HttpResult GetResult() = 0;
+
+	// Gets the response status code.
     virtual unsigned GetStatusCode() = 0;
-    virtual HttpHeaders& GetHeaders() = 0;
-    virtual void GetBody(uint8_t* body, int* len) = 0;
+
+	// Gets the response headers.
+    virtual HttpHeaders* GetHeaders() = 0;
+
+	// Gets the response body.
+    virtual void GetBody(uint8_t* body, size_t& len) = 0;
 };
 
-class IHttpResponseCallback
+// The HttpResponseCallback class receives HTTP client responses
+class HttpResponseCallback
 {
 public:
-    virtual void OnHttpResponse(IHttpResponse* response) = 0;
+	// Called when an HTTP request completes.
+	// The passed response object contains details about the exact way the
+	// request finished (HTTP status code, headers, content, error codes
+	// etc.). The ownership of the response object is transferred to the
+    // callback object. It can store it for later if necessary. Finally, it
+	// must be deleted using its virtual destructor.
+    virtual void OnHttpResponse(HttpResponse* response) = 0;
 };
+
+// The HttpClient class is the interface for HTTP client implementations.
+class HttpClient
+{
+public:
+
+    // Creates an empty HTTP request object.
+    // The created request object has only its ID prepopulated. Other fields
+    // must be set by the caller. The request object can then be sent
+    // using SendRequestAsync(). If you are not going to use the request object
+    // then you can delete it safely using its virtual destructor.
+    virtual HttpRequest* CreateRequest() = 0;
+
+    // Begins an HTTP request.
+    // The method takes ownership of the passed request, and can destroy it before
+    // returning to the caller. Do not access the request object in any
+    // way after this invocation, and do not delete it.
+    // The callback object is always called, even if the request is
+    // cancelled, or if an error occurs immediately during sending. In the
+    // latter case, the OnHttpResponse() callback is called before this
+    // method returns. You must keep the callback object alive until its
+    // OnHttpResponse() callback is called.
+    virtual void SendRequestAsync(HttpRequest* request, HttpResponseCallback* callback) = 0;
+
+    // Cancels an HTTP request.
+    // The caller must provide a string ID returned earlier by request->GetId().
+    // The request is cancelled asynchronously. The caller must still
+    // wait for the relevant OnHttpResponse() callback (it can just come
+    // earlier with some "aborted" error status).
+    virtual void CancelRequestAsync(nostd::string_view const& id) = 0;
+
+    virtual void CancelAllRequests()
+    {
+    }
+};
+
 } // namespace nostd
 OPENTELEMETRY_END_NAMESPACE

--- a/api/include/opentelemetry/http/http_client.h
+++ b/api/include/opentelemetry/http/http_client.h
@@ -1,3 +1,5 @@
+// Copyright (c) Microsoft. All rights reserved
+
 #pragma once
 
 #include "opentelemetry/nostd/string_view.h"

--- a/api/include/opentelemetry/http/http_client.h
+++ b/api/include/opentelemetry/http/http_client.h
@@ -1,0 +1,62 @@
+#pragma once
+OPENTELEMETRY_BEGIN_NAMESPACE
+namespace http
+{
+
+enum class HttpMethod: uint8_t {
+    HTTP_GET,
+    HTTP_POST,
+    HTTP_DELETE,
+    HTTP_PUT,
+    HTTP_HEAD,
+    HTTP_PATCH
+};
+
+class IHttpClient
+{
+public:
+    virtual IHttpRequest* CreateRequest() = 0;
+    virtual void SendRequest (IHttpRequest* request, IHttpResponse* response) = 0;
+    virtual void SendRequestAsync(IHttpRequest* request, IHttpResponseCallback* callback) = 0;
+    virtual void CancelRequestAsync(nostd::string_view const& id) = 0;
+    virtual void CancelAllRequests();
+};
+
+class IHttpRequest
+{
+public:
+    virtual nostd::string_view& GetId() = 0;
+    virtual void SetMethod(nostd::string_view const& method) = 0;
+    virtual void SetUrl(nostd::string_view const& url) = 0;
+    virtual HttpHeaders& GetHeaders() = 0;
+    virtual void SetBody(uint8_t* body, int len) = 0;
+    virtual void GetBody(uint8_t* body, int* len) = 0;
+};
+
+class HttpHeaders
+{
+public:
+    virtual void set(nostd::string_view const& name, nostd::string_view const& value) = 0;
+    virtual void add(nostd::string_view const& name, nostd::string_view const& value) = 0;
+    virtual nostd::string_view const& get(nostd::string_view const& name) = 0;
+    virtual bool has(nostd::string_view const& name) = 0;
+};
+
+class IHttpResponse
+{
+public:
+    virtual nostd::string_view& GetId() = 0;
+    virtual HttpResult GetResult() = 0;
+    virtual unsigned GetStatusCode() = 0;
+    virtual HttpHeaders& GetHeaders() = 0;
+    virtual std::vector<uint8_t>& GetBody() = 0;
+};
+
+class IHttpResponseCallback
+{
+public:
+    virtual void OnHttpResponse(IHttpResponse* response) = 0;
+};
+} // namespace nostd
+OPENTELEMETRY_END_NAMESPACE
+OPENTELEMETRY_END_NAMESPACE

--- a/sdk/include/opentelemetry/sdk/http/http_client.h
+++ b/sdk/include/opentelemetry/sdk/http/http_client.h
@@ -1,3 +1,5 @@
+// Copyright (c) Microsoft. All rights reserved.
+
 #pragma once
 #include "opentelemetry/http/http_client.h"
 #include "opentelemetry/version.h"

--- a/sdk/include/opentelemetry/sdk/http/http_client.h
+++ b/sdk/include/opentelemetry/sdk/http/http_client.h
@@ -1,4 +1,16 @@
-// Copyright (c) Microsoft. All rights reserved.
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 #pragma once
 #include "opentelemetry/http/http_client.h"

--- a/sdk/include/opentelemetry/sdk/http/http_client.h
+++ b/sdk/include/opentelemetry/sdk/http/http_client.h
@@ -99,10 +99,10 @@ public:
 
 private:
     http_api::HttpHeaders* headers_;
-	std::vector<uint8_t> body_;
-	nostd::string_view          method_;
-	nostd::string_view          id_;
-	nostd::string_view          url_;
+    std::vector<uint8_t> body_;
+    nostd::string_view          method_;
+    nostd::string_view          id_;
+    nostd::string_view          url_;
 
 
 };

--- a/sdk/include/opentelemetry/sdk/http/http_client.h
+++ b/sdk/include/opentelemetry/sdk/http/http_client.h
@@ -1,7 +1,9 @@
 #pragma once
 #include "opentelemetry/http/http_client.h"
-
 #include "opentelemetry/version.h"
+
+#include <map>
+#include <vector>
 
 OPENTELEMETRY_BEGIN_NAMESPACE
 namespace sdk
@@ -10,13 +12,14 @@ namespace http
 {
 namespace http_api = opentelemetry::http;
 
+// HttpHeaders implementation
 class HttpHeaders: http_api::HttpHeaders, std::multimap<std::string, std::string>
 {
 
 public:
     virtual void set(nostd::string_view const& name, nostd::string_view const& value) override
     {
-       auto range = equal_range(name);
+       auto range = equal_range(std::string(name.data()));
        auto hint = erase(range.first, range.second);
        insert(hint, std::make_pair(name, value));
     }
@@ -28,47 +31,55 @@ public:
 
     virtual nostd::string_view const& get(nostd::string_view const& name) const override
     {
-        auto it = find(name);
+        auto it = find(std::string(name.data()));
         return (it != end()) ? it->second : m_empty;
     }
 
     virtual bool has(nostd::string_view const& name) const override
     {
-        auto it = find(name);
+        auto it = find(std::string(name.data()));
         return (it != end());
     }
+
 private:
-    nostd::string_view m_empty;
+
+    nostd::string_view m_empty{};
 };
 
-class SimpleHttpRequest:: public http_api::IHttpRequest
+class SimpleHttpRequest: public http_api::HttpRequest
 {
 public:
-    SimpleHttpRequest(std::string const& id): _id(id), method_("GET")
+
+    SimpleHttpRequest(nostd::string_view const& id): id_(id), method_("GET")
     {
     }
-    
-    virtual nostd::string_view& GetId() const override 
+   
+    // Gets the HTTP request ID.
+    virtual const nostd::string_view& GetId() const override 
     {
         return id_;
     }
 
+    // Sets the request method   
     virtual void SetMethod(nostd::string_view const& method) override
     {
         method_ = method;
     }
 
-    virtual void SetUrl(std::string const& url) override
+    // Sets the HTTP request URI.        
+    virtual void SetUrl(nostd::string_view const& url) override
     {
 		url_ = url;
 	}
 
-    virtual HttpHeaders& GetHeaders() override
+    // Gets the HTTP request headers.
+    virtual http_api::HttpHeaders* GetHeaders() const override
     {
         return headers_;
     }
 
-    virtual void SetBody(const uint8_t* const body, int len) override
+    // Sets the request body.
+    virtual void SetBody(const uint8_t* const body, const size_t len) override
     {
 		for (int i = 0; i < len; i++)
         {
@@ -76,36 +87,37 @@ public:
         }
     }
 
-    virtual void GetBody(uint8_t* body, int* len) override
+    virtual void GetBody(uint8_t* body, size_t& len) override
     {
-        int i = 0;
+        len = 0;
         for (auto &e: body_)
         {
-            body_[i++] = e;
+            body[len++] = e;
         }
-        return body_;
+        len = (len > 0 ) ? len - 1 :  len ;
     }
 
 private:
-
+    http_api::HttpHeaders* headers_;
 	std::vector<uint8_t> body_;
-	std::string          method_;
-	std::string          id_;
-	std::string          url_;
+	nostd::string_view          method_;
+	nostd::string_view          id_;
+	nostd::string_view          url_;
+
 
 };
 
-class SimpleHttpResponse: public IHttpResponse
+class SimpleHttpResponse: public http_api::HttpResponse
 {
 public:
     SimpleHttpResponse(nostd::string_view const& id):
-        id_(id), m
-        result_(HTTP_LOCALFAULURE),
+        id_(id),
+        result_(http_api::HttpResult::HttpResult_LocalFailure),
         statusCode_(0)
     {
     }
 
-    virtual HttpResult GetResult() override
+    virtual http_api::HttpResult GetResult() override
     {
         return result_;
     }
@@ -115,33 +127,27 @@ public:
         return statusCode_;
     }
 
-    virtual HttpHeaders& GetHeaders() override
+    virtual http_api::HttpHeaders* GetHeaders() override
     {
         return headers_;
     }
 
-    virtual void GetBody(uint8_t* body, int& len) override
+    virtual void GetBody(uint8_t* body, size_t& len) override
     {
         int i = 0;
         for (auto &e: body_)
         {
             body_[i++] = e;
         }
-        return body_;
     }
 private:
 
     nostd::string_view id_;
     unsigned statusCode_;
-    HttpHeaders headers_;
+    http_api::HttpHeaders* headers_;
+    http_api::HttpResult result_;
     std::vector<uint8_t> body_;
 };
 } //http
 } //sdk 
 OPENTELEMETRY_END_NAMESPACE
-
-
-
-
-
-

--- a/sdk/include/opentelemetry/sdk/http/http_client.h
+++ b/sdk/include/opentelemetry/sdk/http/http_client.h
@@ -27,142 +27,113 @@ namespace http
 namespace http_api = opentelemetry::http;
 
 // HttpHeaders implementation
-class HttpHeaders: http_api::HttpHeaders, std::multimap<std::string, std::string>
+class HttpHeaders : http_api::HttpHeaders, std::multimap<std::string, std::string>
 {
 
 public:
-    virtual void set(nostd::string_view const& name, nostd::string_view const& value) override
-    {
-       auto range = equal_range(std::string(name.data()));
-       auto hint = erase(range.first, range.second);
-       insert(hint, std::make_pair(name, value));
-    }
+  virtual void set(nostd::string_view const &name, nostd::string_view const &value) override
+  {
+    auto range = equal_range(std::string(name.data()));
+    auto hint  = erase(range.first, range.second);
+    insert(hint, std::make_pair(name, value));
+  }
 
-    virtual void add(nostd::string_view const& name, nostd::string_view const& value) override
-    {
-        insert(std::make_pair(name, value));
-    }
+  virtual void add(nostd::string_view const &name, nostd::string_view const &value) override
+  {
+    insert(std::make_pair(name, value));
+  }
 
-    virtual nostd::string_view const& get(nostd::string_view const& name) const override
-    {
-        auto it = find(std::string(name.data()));
-        return (it != end()) ? it->second : m_empty;
-    }
+  virtual nostd::string_view const &get(nostd::string_view const &name) const override
+  {
+    auto it = find(std::string(name.data()));
+    return (it != end()) ? it->second : m_empty;
+  }
 
-    virtual bool has(nostd::string_view const& name) const override
-    {
-        auto it = find(std::string(name.data()));
-        return (it != end());
-    }
+  virtual bool has(nostd::string_view const &name) const override
+  {
+    auto it = find(std::string(name.data()));
+    return (it != end());
+  }
 
 private:
-    nostd::string_view m_empty{};
+  nostd::string_view m_empty{};
 };
 
-class SimpleHttpRequest: public http_api::HttpRequest
+class SimpleHttpRequest : public http_api::HttpRequest
 {
 
 public:
+  SimpleHttpRequest(nostd::string_view const &id) : id_(id), method_("GET") {}
 
-    SimpleHttpRequest(nostd::string_view const& id): id_(id), method_("GET")
-    {
-    }
-   
-    // Gets the HTTP request ID.
-    virtual const nostd::string_view& GetId() const override 
-    {
-        return id_;
-    }
+  // Gets the HTTP request ID.
+  virtual const nostd::string_view &GetId() const override { return id_; }
 
-    // Sets the request method   
-    virtual void SetMethod(nostd::string_view const& method) override
-    {
-        method_ = method;
-    }
+  // Sets the request method
+  virtual void SetMethod(nostd::string_view const &method) override { method_ = method; }
 
-    // Sets the HTTP request URI.        
-    virtual void SetUrl(nostd::string_view const& url) override
-    {
-		url_ = url;
-	}
+  // Sets the HTTP request URI.
+  virtual void SetUrl(nostd::string_view const &url) override { url_ = url; }
 
-    // Gets the HTTP request headers.
-    virtual http_api::HttpHeaders* GetHeaders() const override
-    {
-        return headers_;
-    }
+  // Gets the HTTP request headers.
+  virtual http_api::HttpHeaders *GetHeaders() const override { return headers_; }
 
-    // Sets the request body.
-    virtual void SetBody(const uint8_t* const body, const size_t len) override
+  // Sets the request body.
+  virtual void SetBody(const uint8_t *const body, const size_t len) override
+  {
+    for (int i = 0; i < len; i++)
     {
-		for (int i = 0; i < len; i++)
-        {
-            body_.push_back(body[i]);
-        }
+      body_.push_back(body[i]);
     }
+  }
 
-    virtual void GetBody(uint8_t* body, size_t& len) override
+  virtual void GetBody(uint8_t *body, size_t &len) override
+  {
+    len = 0;
+    for (auto &e : body_)
     {
-        len = 0;
-        for (auto &e: body_)
-        {
-            body[len++] = e;
-        }
-        len = (len > 0 ) ? len - 1 :  len ;
+      body[len++] = e;
     }
+    len = (len > 0) ? len - 1 : len;
+  }
 
 private:
-    http_api::HttpHeaders* headers_;
-    std::vector<uint8_t> body_;
-    nostd::string_view          method_;
-    nostd::string_view          id_;
-    nostd::string_view          url_;
-
-
+  http_api::HttpHeaders *headers_;
+  std::vector<uint8_t> body_;
+  nostd::string_view method_;
+  nostd::string_view id_;
+  nostd::string_view url_;
 };
 
-class SimpleHttpResponse: public http_api::HttpResponse
+class SimpleHttpResponse : public http_api::HttpResponse
 {
 
 public:
-    SimpleHttpResponse(nostd::string_view const& id):
-        id_(id),
-        result_(http_api::HttpResult::HttpResult_LocalFailure),
-        statusCode_(0)
-    {
-    }
+  SimpleHttpResponse(nostd::string_view const &id)
+      : id_(id), result_(http_api::HttpResult::HttpResult_LocalFailure), statusCode_(0)
+  {}
 
-    virtual http_api::HttpResult GetResult() override
-    {
-        return result_;
-    }
+  virtual http_api::HttpResult GetResult() override { return result_; }
 
-    virtual unsigned GetStatusCode() override
-    {
-        return statusCode_;
-    }
+  virtual unsigned GetStatusCode() override { return statusCode_; }
 
-    virtual http_api::HttpHeaders* GetHeaders() override
-    {
-        return headers_;
-    }
+  virtual http_api::HttpHeaders *GetHeaders() override { return headers_; }
 
-    virtual void GetBody(uint8_t* body, size_t& len) override
+  virtual void GetBody(uint8_t *body, size_t &len) override
+  {
+    int i = 0;
+    for (auto &e : body_)
     {
-        int i = 0;
-        for (auto &e: body_)
-        {
-            body_[i++] = e;
-        }
+      body_[i++] = e;
     }
+  }
 
 private:
-    nostd::string_view id_;
-    unsigned statusCode_;
-    http_api::HttpHeaders* headers_;
-    http_api::HttpResult result_;
-    std::vector<uint8_t> body_;
+  nostd::string_view id_;
+  unsigned statusCode_;
+  http_api::HttpHeaders *headers_;
+  http_api::HttpResult result_;
+  std::vector<uint8_t> body_;
 };
-} //http
-} //sdk 
+}  // namespace http
+}  // namespace sdk
 OPENTELEMETRY_END_NAMESPACE

--- a/sdk/include/opentelemetry/sdk/http/http_client.h
+++ b/sdk/include/opentelemetry/sdk/http/http_client.h
@@ -1,0 +1,147 @@
+#pragma once
+#include "opentelemetry/http/http_client.h"
+
+#include "opentelemetry/version.h"
+
+OPENTELEMETRY_BEGIN_NAMESPACE
+namespace sdk
+{
+namespace http
+{
+namespace http_api = opentelemetry::http;
+
+class HttpHeaders: http_api::HttpHeaders, std::multimap<std::string, std::string>
+{
+
+public:
+    virtual void set(nostd::string_view const& name, nostd::string_view const& value) override
+    {
+       auto range = equal_range(name);
+       auto hint = erase(range.first, range.second);
+       insert(hint, std::make_pair(name, value));
+    }
+
+    virtual void add(nostd::string_view const& name, nostd::string_view const& value) override
+    {
+        insert(std::make_pair(name, value));
+    }
+
+    virtual nostd::string_view const& get(nostd::string_view const& name) const override
+    {
+        auto it = find(name);
+        return (it != end()) ? it->second : m_empty;
+    }
+
+    virtual bool has(nostd::string_view const& name) const override
+    {
+        auto it = find(name);
+        return (it != end());
+    }
+private:
+    nostd::string_view m_empty;
+};
+
+class SimpleHttpRequest:: public http_api::IHttpRequest
+{
+public:
+    SimpleHttpRequest(std::string const& id): _id(id), method_("GET")
+    {
+    }
+    
+    virtual nostd::string_view& GetId() const override 
+    {
+        return id_;
+    }
+
+    virtual void SetMethod(nostd::string_view const& method) override
+    {
+        method_ = method;
+    }
+
+    virtual void SetUrl(std::string const& url) override
+    {
+		url_ = url;
+	}
+
+    virtual HttpHeaders& GetHeaders() override
+    {
+        return headers_;
+    }
+
+    virtual void SetBody(const uint8_t* const body, int len) override
+    {
+		for (int i = 0; i < len; i++)
+        {
+            body_.push_back(body[i]);
+        }
+    }
+
+    virtual void GetBody(uint8_t* body, int* len) override
+    {
+        int i = 0;
+        for (auto &e: body_)
+        {
+            body_[i++] = e;
+        }
+        return body_;
+    }
+
+private:
+
+	std::vector<uint8_t> body_;
+	std::string          method_;
+	std::string          id_;
+	std::string          url_;
+
+};
+
+class SimpleHttpResponse: public IHttpResponse
+{
+public:
+    SimpleHttpResponse(nostd::string_view const& id):
+        id_(id), m
+        result_(HTTP_LOCALFAULURE),
+        statusCode_(0)
+    {
+    }
+
+    virtual HttpResult GetResult() override
+    {
+        return result_;
+    }
+
+    virtual unsigned GetStatusCode() override
+    {
+        return statusCode_;
+    }
+
+    virtual HttpHeaders& GetHeaders() override
+    {
+        return headers_;
+    }
+
+    virtual void GetBody(uint8_t* body, int& len) override
+    {
+        int i = 0;
+        for (auto &e: body_)
+        {
+            body_[i++] = e;
+        }
+        return body_;
+    }
+private:
+
+    nostd::string_view id_;
+    unsigned statusCode_;
+    HttpHeaders headers_;
+    std::vector<uint8_t> body_;
+};
+} //http
+} //sdk 
+OPENTELEMETRY_END_NAMESPACE
+
+
+
+
+
+

--- a/sdk/include/opentelemetry/sdk/http/http_client.h
+++ b/sdk/include/opentelemetry/sdk/http/http_client.h
@@ -42,12 +42,12 @@ public:
     }
 
 private:
-
     nostd::string_view m_empty{};
 };
 
 class SimpleHttpRequest: public http_api::HttpRequest
 {
+
 public:
 
     SimpleHttpRequest(nostd::string_view const& id): id_(id), method_("GET")
@@ -109,6 +109,7 @@ private:
 
 class SimpleHttpResponse: public http_api::HttpResponse
 {
+
 public:
     SimpleHttpResponse(nostd::string_view const& id):
         id_(id),
@@ -140,8 +141,8 @@ public:
             body_[i++] = e;
         }
     }
-private:
 
+private:
     nostd::string_view id_;
     unsigned statusCode_;
     http_api::HttpHeaders* headers_;


### PR DESCRIPTION
This PR brings the HTTP client API to be used across various exporters ( eg zipkin, azure monitor ) to communicate with remove telemetry servers. 

- Need to discuss/review on the location of these headers. Not sure if they are right place.

TBD:
 - Documentation on usage
 - Sample implementation. 