### PR TITLE
Add Scope object to control the currently active span

### DIFF
--- a/api/include/opentelemetry/plugin/tracer.h
+++ b/api/include/opentelemetry/plugin/tracer.h
@@ -50,8 +50,6 @@ public:
 
   trace::SpanContext GetContext() const noexcept override { return span_->GetContext(); }
 
-  void SetToken(nostd::unique_ptr<context::Token> &&token) noexcept override {}
-
 private:
   std::shared_ptr<trace::Tracer> tracer_;
   nostd::shared_ptr<trace::Span> span_;

--- a/api/include/opentelemetry/trace/default_span.h
+++ b/api/include/opentelemetry/trace/default_span.h
@@ -41,8 +41,6 @@ public:
 
   nostd::string_view ToString() { return "DefaultSpan"; }
 
-  void SetToken(nostd::unique_ptr<context::Token> &&default_token) noexcept {}
-
   DefaultSpan() = default;
 
   DefaultSpan(SpanContext span_context) : span_context_(span_context) {}

--- a/api/include/opentelemetry/trace/noop.h
+++ b/api/include/opentelemetry/trace/noop.h
@@ -50,8 +50,6 @@ public:
 
   SpanContext GetContext() const noexcept override { return span_context_; }
 
-  void SetToken(nostd::unique_ptr<context::Token> && /* token */) noexcept override {}
-
 private:
   std::shared_ptr<Tracer> tracer_;
   SpanContext span_context_;

--- a/api/include/opentelemetry/trace/scope.h
+++ b/api/include/opentelemetry/trace/scope.h
@@ -1,0 +1,57 @@
+// Copyright 2020, OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include "opentelemetry/context/runtime_context.h"
+#include "opentelemetry/trace/span.h"
+#include "opentelemetry/version.h"
+
+OPENTELEMETRY_BEGIN_NAMESPACE
+namespace trace
+{
+/**
+ * Controls how long a span is active.
+ *
+ * On creation of the Scope object, the given span is set to the currently
+ * active span. On destruction, the given span is ended and the previously
+ * active span will be the currently active span again.
+ */
+class Scope final
+{
+public:
+  /**
+   * Initialize a new scope.
+   * @param span the given span will be set as the currently active span.
+   */
+  Scope(nostd::shared_ptr<Span> span) noexcept
+      : span_(span),
+        token_(context::Token(context::RuntimeContext::Attach(
+            context::RuntimeContext::GetCurrent().SetValue(SpanKey, span))))
+  {}
+
+  /**
+   * Destroy a scope.
+   * The span wrapped by this Scope object will be ended, and the previously
+   * active span will be restored.
+   */
+  ~Scope() { span_->End(); }
+
+private:
+  nostd::shared_ptr<Span> span_;
+  context::Token token_;
+};
+
+}  // namespace trace
+OPENTELEMETRY_END_NAMESPACE

--- a/api/include/opentelemetry/trace/scope.h
+++ b/api/include/opentelemetry/trace/scope.h
@@ -35,21 +35,12 @@ public:
    * Initialize a new scope.
    * @param span the given span will be set as the currently active span.
    */
-  Scope(nostd::shared_ptr<Span> span) noexcept
-      : span_(span),
-        token_(context::Token(context::RuntimeContext::Attach(
+  Scope(nostd::shared_ptr<Span> &span) noexcept
+      : token_(context::Token(context::RuntimeContext::Attach(
             context::RuntimeContext::GetCurrent().SetValue(SpanKey, span))))
   {}
 
-  /**
-   * Destroy a scope.
-   * The span wrapped by this Scope object will be ended, and the previously
-   * active span will be restored.
-   */
-  ~Scope() { span_->End(); }
-
 private:
-  nostd::shared_ptr<Span> span_;
   context::Token token_;
 };
 

--- a/api/include/opentelemetry/trace/span.h
+++ b/api/include/opentelemetry/trace/span.h
@@ -15,10 +15,6 @@
 constexpr char SpanKey[] = "span_key";
 
 OPENTELEMETRY_BEGIN_NAMESPACE
-namespace context
-{
-class Token;
-}
 namespace trace
 {
 enum class SpanKind
@@ -162,8 +158,6 @@ public:
   // Returns true if this Span is recording tracing events (e.g. SetAttribute,
   // AddEvent).
   virtual bool IsRecording() const noexcept = 0;
-
-  virtual void SetToken(nostd::unique_ptr<context::Token> &&token) noexcept = 0;
 };
 }  // namespace trace
 OPENTELEMETRY_END_NAMESPACE

--- a/api/include/opentelemetry/trace/tracer.h
+++ b/api/include/opentelemetry/trace/tracer.h
@@ -3,6 +3,7 @@
 #include "opentelemetry/nostd/shared_ptr.h"
 #include "opentelemetry/nostd/string_view.h"
 #include "opentelemetry/nostd/unique_ptr.h"
+#include "opentelemetry/trace/scope.h"
 #include "opentelemetry/trace/span.h"
 #include "opentelemetry/version.h"
 
@@ -56,6 +57,17 @@ public:
                            nostd::span<const std::pair<nostd::string_view, common::AttributeValue>>{
                                attributes.begin(), attributes.end()},
                            options);
+  }
+
+  /**
+   * Set the active span. The span will remain active until the returned Scope
+   * object is destroyed.
+   * @param span the span that should be set as the new active span.
+   * @return a Scope that controls how long the span will be active.
+   */
+  nostd::unique_ptr<Scope> WithActiveSpan(nostd::shared_ptr<Span> &span) noexcept
+  {
+    return nostd::unique_ptr<Scope>(new Scope{span});
   }
 
   /**

--- a/api/test/trace/BUILD
+++ b/api/test/trace/BUILD
@@ -104,3 +104,14 @@ cc_test(
         "@com_google_googletest//:gtest_main",
     ],
 )
+
+cc_test(
+    name = "scope_test",
+    srcs = [
+        "scope_test.cc",
+    ],
+    deps = [
+        "//api",
+        "@com_google_googletest//:gtest_main",
+    ],
+)

--- a/api/test/trace/CMakeLists.txt
+++ b/api/test/trace/CMakeLists.txt
@@ -6,6 +6,7 @@ foreach(
   trace_id_test
   trace_flags_test
   span_context_test
+  scope_test
   noop_test)
   add_executable(${testname} "${testname}.cc")
   target_link_libraries(${testname} ${GTEST_BOTH_LIBRARIES}

--- a/api/test/trace/noop_test.cc
+++ b/api/test/trace/noop_test.cc
@@ -7,7 +7,6 @@
 
 #include <gtest/gtest.h>
 
-using opentelemetry::context::Token;
 using opentelemetry::core::SystemTimestamp;
 using opentelemetry::trace::NoopTracer;
 using opentelemetry::trace::SpanContext;
@@ -41,8 +40,6 @@ TEST(NoopTest, UseNoopTracers)
 
   SystemTimestamp t1;
   s1->AddEvent("test_time_stamp", t1);
-
-  s1->SetToken(opentelemetry::nostd::unique_ptr<Token>(nullptr));
 
   s1->GetContext();
 }

--- a/api/test/trace/scope_test.cc
+++ b/api/test/trace/scope_test.cc
@@ -1,0 +1,48 @@
+#include "opentelemetry/trace/scope.h"
+#include "opentelemetry/context/context.h"
+#include "opentelemetry/context/threadlocal_context.h"
+#include "opentelemetry/nostd/shared_ptr.h"
+#include "opentelemetry/trace/noop.h"
+
+#include <gtest/gtest.h>
+
+using opentelemetry::trace::NoopSpan;
+using opentelemetry::trace::Scope;
+using opentelemetry::trace::Span;
+namespace nostd   = opentelemetry::nostd;
+namespace context = opentelemetry::context;
+
+TEST(ScopeTest, Construct)
+{
+  nostd::shared_ptr<Span> span(new NoopSpan(nullptr));
+  Scope scope(span);
+
+  context::ContextValue active_span_value = context::RuntimeContext::GetValue(SpanKey);
+  ASSERT_TRUE(nostd::holds_alternative<nostd::shared_ptr<Span>>(active_span_value));
+
+  auto active_span = nostd::get<nostd::shared_ptr<Span>>(active_span_value);
+  ASSERT_EQ(active_span, span);
+}
+
+TEST(ScopeTest, Destruct)
+{
+  nostd::shared_ptr<Span> span(new NoopSpan(nullptr));
+  Scope scope(span);
+
+  {
+    nostd::shared_ptr<Span> span_nested(new NoopSpan(nullptr));
+    Scope scope_nested(span_nested);
+
+    context::ContextValue active_span_value = context::RuntimeContext::GetValue(SpanKey);
+    ASSERT_TRUE(nostd::holds_alternative<nostd::shared_ptr<Span>>(active_span_value));
+
+    auto active_span = nostd::get<nostd::shared_ptr<Span>>(active_span_value);
+    ASSERT_EQ(active_span, span_nested);
+  }
+
+  context::ContextValue active_span_value = context::RuntimeContext::GetValue(SpanKey);
+  ASSERT_TRUE(nostd::holds_alternative<nostd::shared_ptr<Span>>(active_span_value));
+
+  auto active_span = nostd::get<nostd::shared_ptr<Span>>(active_span_value);
+  ASSERT_EQ(active_span, span);
+}

--- a/examples/plugin/plugin/tracer.cc
+++ b/examples/plugin/plugin/tracer.cc
@@ -54,8 +54,6 @@ public:
 
   trace::SpanContext GetContext() const noexcept override { return span_context_; }
 
-  void SetToken(nostd::unique_ptr<context::Token> &&token) noexcept override {}
-
 private:
   std::shared_ptr<Tracer> tracer_;
   std::string name_;

--- a/examples/simple/foo_library/foo_library.cc
+++ b/examples/simple/foo_library/foo_library.cc
@@ -13,24 +13,30 @@ nostd::shared_ptr<trace::Tracer> get_tracer()
 
 void f1()
 {
-  auto span = get_tracer()->StartSpan("f1");
+  auto span  = get_tracer()->StartSpan("f1");
   auto scope = get_tracer()->WithActiveSpan(span);
+
+  span->End();
 }
 
 void f2()
 {
-  auto span = get_tracer()->StartSpan("f2");
+  auto span  = get_tracer()->StartSpan("f2");
   auto scope = get_tracer()->WithActiveSpan(span);
 
   f1();
   f1();
+
+  span->End();
 }
 }  // namespace
 
 void foo_library()
 {
-  auto span = get_tracer()->StartSpan("library");
+  auto span  = get_tracer()->StartSpan("library");
   auto scope = get_tracer()->WithActiveSpan(span);
 
   f2();
+
+  span->End();
 }

--- a/examples/simple/foo_library/foo_library.cc
+++ b/examples/simple/foo_library/foo_library.cc
@@ -14,11 +14,13 @@ nostd::shared_ptr<trace::Tracer> get_tracer()
 void f1()
 {
   auto span = get_tracer()->StartSpan("f1");
+  auto scope = get_tracer()->WithActiveSpan(span);
 }
 
 void f2()
 {
   auto span = get_tracer()->StartSpan("f2");
+  auto scope = get_tracer()->WithActiveSpan(span);
 
   f1();
   f1();
@@ -28,6 +30,7 @@ void f2()
 void foo_library()
 {
   auto span = get_tracer()->StartSpan("library");
+  auto scope = get_tracer()->WithActiveSpan(span);
 
   f2();
 }

--- a/sdk/src/trace/span.cc
+++ b/sdk/src/trace/span.cc
@@ -67,9 +67,7 @@ Span::Span(std::shared_ptr<Tracer> &&tracer,
       processor_{processor},
       recordable_{processor_->MakeRecordable()},
       start_steady_time{options.start_steady_time},
-      has_ended_{false},
-      token_{nullptr}
-
+      has_ended_{false}
 {
   (void)options;
   if (recordable_ == nullptr)
@@ -169,12 +167,6 @@ void Span::End(const trace_api::EndSpanOptions &options) noexcept
   }
   has_ended_ = true;
 
-  if (token_ != nullptr)
-  {
-    context::RuntimeContext::Detach(*token_);
-    token_.reset();
-  }
-
   if (recordable_ == nullptr)
   {
     return;
@@ -193,12 +185,6 @@ bool Span::IsRecording() const noexcept
   std::lock_guard<std::mutex> lock_guard{mu_};
   return recordable_ != nullptr;
 }
-
-void Span::SetToken(nostd::unique_ptr<context::Token> &&token) noexcept
-{
-  token_ = std::move(token);
-}
-
 }  // namespace trace
 }  // namespace sdk
 OPENTELEMETRY_END_NAMESPACE

--- a/sdk/src/trace/span.h
+++ b/sdk/src/trace/span.h
@@ -45,8 +45,6 @@ public:
 
   trace_api::SpanContext GetContext() const noexcept override { return *span_context_.get(); }
 
-  void SetToken(nostd::unique_ptr<context::Token> &&token) noexcept override;
-
 private:
   std::shared_ptr<trace_api::Tracer> tracer_;
   std::shared_ptr<SpanProcessor> processor_;
@@ -55,7 +53,6 @@ private:
   opentelemetry::core::SteadyTimestamp start_steady_time;
   std::unique_ptr<trace_api::SpanContext> span_context_;
   bool has_ended_;
-  nostd::unique_ptr<context::Token> token_;
 };
 }  // namespace trace
 }  // namespace sdk

--- a/sdk/src/trace/tracer.cc
+++ b/sdk/src/trace/tracer.cc
@@ -65,10 +65,6 @@ nostd::shared_ptr<trace_api::Span> Tracer::StartSpan(
         new (std::nothrow) Span{this->shared_from_this(), processor_.load(), name, attributes,
                                 options, GetCurrentSpanContext()}};
 
-    span->SetToken(
-        nostd::unique_ptr<context::Token>(new context::Token(context::RuntimeContext::Attach(
-            context::RuntimeContext::GetCurrent().SetValue(SpanKey, span)))));
-
     // if the attributes is not nullptr, add attributes to the span.
     if (sampling_result.attributes)
     {

--- a/sdk/test/trace/tracer_test.cc
+++ b/sdk/test/trace/tracer_test.cc
@@ -434,10 +434,14 @@ TEST(Tracer, WithActiveSpan)
       auto scope_second = tracer->WithActiveSpan(span_second);
 
       EXPECT_EQ(0, spans_received->size());
+
+      span_second->End();
     }
 
     EXPECT_EQ(1, spans_received->size());
     EXPECT_EQ("span 2", spans_received->at(0)->GetName());
+
+    span_first->End();
   }
   EXPECT_EQ(2, spans_received->size());
   EXPECT_EQ("span 1", spans_received->at(1)->GetName());


### PR DESCRIPTION
Currently, whenever a new span is created, this span is set as the active span. This is not in line with the specification, which asks for the possibility to create spans that are not set to active, and which even asks that this should be the default.

This PR decouples the the span lifetime from the time the span is active, it does so by introducing a `Scope` object, which is very similar to what [OpenTelemetry Java](https://github.com/open-telemetry/opentelemetry-java/blob/master/api/src/main/java/io/opentelemetry/trace/Tracer.java#L140) does:

```c++
auto span = tracer->StartSpan("f1");
/* span is started, but not active */
auto scope = tracer->WithActiveSpan(span);
/* span is started and active */
scope.reset(nullptr);
/* span is started, but not active anymore */
span->End();
/* span is ended */
```

Closes #316 