### PR TITLE
Add jodeev as a triager

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,10 @@ Maintainers ([@open-telemetry/cpp-maintainers](https://github.com/orgs/open-tele
 - [Emil Mikulic](https://github.com/g-easy), Google
 - [Reiley Yang](https://github.com/reyang), Microsoft
 
+Triagers ([@open-telemetry/cpp-triagers](https://github.com/orgs/open-telemetry/teams/cpp-triagers)):
+
+- [Jodee Varney](https://github.com/jodeev), New Relic
+
 *Find more about the maintainer role in [community repository](https://github.com/open-telemetry/community/blob/master/community-membership.md#maintainer).*
 
 ## Release Schedule


### PR DESCRIPTION
I'll need to submit a request to get the triager team created. For now I'll add @jodeev to the approvers list to unblock the access issue.