### PR TITLE
add docfx check

### DIFF
--- a/.markdown_link_check_config.json
+++ b/.markdown_link_check_config.json
@@ -1,0 +1,7 @@
+{
+  "ignorePatterns": [
+      {
+          "pattern": "^https://github\\.com"
+      }
+  ]
+}

--- a/.markdownlint.yaml
+++ b/.markdownlint.yaml
@@ -1,0 +1,9 @@
+{
+  "default": true,
+  "MD024": { "allow_different_nesting": true },
+  "MD029": { "style": "ordered" },
+  "ul-style": false,  # MD004
+  "line-length": false,  # MD013
+  "no-inline-html": false,  # MD033
+  "fenced-code-language": false  # MD040
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,12 @@
+{
+    "rewrap.wrappingColumn": 80,
+    "editor.rulers": [80],
+    "markdownlint.config": {
+        "MD004": false,
+        "MD013": false,
+        "MD024": {"allow_different_nesting": true},
+        "MD029": {"style": "ordered"},
+        "MD033": false,
+        "MD040": false,
+    },
+}

--- a/docfx.cmd
+++ b/docfx.cmd
@@ -1,0 +1,15 @@
+SETLOCAL
+SETLOCAL ENABLEEXTENSIONS
+
+docfx.exe build docfx.json > docfx.log
+@IF NOT %ERRORLEVEL% == 0 (
+  type docfx.log
+  ECHO Error: docfx build failed. 1>&2
+  EXIT /B %ERRORLEVEL%
+)
+@type docfx.log
+@type docfx.log | findstr /C:"Build succeeded."
+@IF NOT %ERRORLEVEL% == 0 (
+  ECHO Error: you have introduced build warnings. 1>&2
+  EXIT /B %ERRORLEVEL%
+)

--- a/docfx.json
+++ b/docfx.json
@@ -1,0 +1,28 @@
+{
+  "build": {
+    "content": [
+      {
+        "files": [
+          "**.md",
+          "toc.yml"
+        ]
+      }
+    ],
+    "resource": [
+      {
+        "files": [
+          ".github/CODEOWNERS",
+          ".markdownlint.yaml",
+          ".vscode/settings.json"
+        ]
+      }
+    ],
+    "dest": "_site",
+    "globalMetadataFiles": [],
+    "fileMetadataFiles": [],
+    "noLangKeyword": false,
+    "keepFileLink": false,
+    "cleanupCacheHistory": true,
+    "disableGitFeatures": true
+  }
+}

--- a/toc.yml
+++ b/toc.yml
@@ -1,0 +1,2 @@
+- name: OpenTelemetry CPP Markdown Files 
+  href: ./README.md


### PR DESCRIPTION
This PR adds DocFX sanity check for issue #304, to see whether the build for the links for all the markdown (**.md) files in the repository are valid or not. Changes were added based off changes from a similar issue, [#742](https://github.com/open-telemetry/opentelemetry-specification/pull/742)

**The log file, docfx.log, generated after running the docfx.cmd file shows there are invalid file links.**

**Instructions to replicate results:**

- On Mac, running docfx build docfx.json > docfx.log in Terminal in the root directory will generate an error message showing a comprehensive list of broken links/missing files.
- On Windows, you can achieve a similar result by running the docfx.cmd file, which will print whether there were build warnings/errors generated due to missing links.

Refer to https://dotnet.github.io/docfx/tutorial/docfx.exe_user_manual.html for future DocFX additions/modifications.