### PR TITLE
fix context data structure to support multiple attributes

### DIFF
--- a/api/include/opentelemetry/context/context.h
+++ b/api/include/opentelemetry/context/context.h
@@ -40,7 +40,7 @@ public:
   Context SetValues(T &values) noexcept
   {
     Context context                   = Context(values);
-    nostd::shared_ptr<DataList> &last = context.head_;
+    nostd::shared_ptr<DataList> last = context.head_;
     while (last->next_ != nullptr)
     {
       last = last->next_;

--- a/api/include/opentelemetry/context/context.h
+++ b/api/include/opentelemetry/context/context.h
@@ -39,7 +39,7 @@ public:
   template <class T>
   Context SetValues(T &values) noexcept
   {
-    Context context                   = Context(values);
+    Context context                  = Context(values);
     nostd::shared_ptr<DataList> last = context.head_;
     while (last->next_ != nullptr)
     {

--- a/api/include/opentelemetry/context/context.h
+++ b/api/include/opentelemetry/context/context.h
@@ -110,7 +110,7 @@ private:
 
     // Builds a data list off of a key and value iterable and returns the head
     template <class T>
-    DataList(const T &keys_and_vals) : key_{nullptr}
+    DataList(const T &keys_and_vals) : key_{nullptr}, next_(nostd::shared_ptr<DataList>{nullptr})
     {
       bool first = true;
       auto *node = this;

--- a/api/test/context/context_test.cc
+++ b/api/test/context/context_test.cc
@@ -78,14 +78,16 @@ TEST(ContextTest, ContextInheritance)
 {
   using M = std::map<std::string, context::ContextValue>;
 
-  M m1 = {{"test_key", (int64_t)123}, {"foo_key", (int64_t)456}};
-  M m2 = {{"other_key", (int64_t)789}};
+  M m1 = {{"test_key", (int64_t)123}, {"foo_key", (int64_t)321}};
+  M m2 = {{"other_key", (int64_t)789}, {"another_key", (int64_t)987}};
 
   context::Context test_context = context::Context(m1);
   context::Context foo_context  = test_context.SetValues(m2);
 
   EXPECT_EQ(nostd::get<int64_t>(foo_context.GetValue("test_key")), 123);
-  EXPECT_EQ(nostd::get<int64_t>(foo_context.GetValue("foo_key")), 456);
+  EXPECT_EQ(nostd::get<int64_t>(foo_context.GetValue("foo_key")), 321);
+  EXPECT_EQ(nostd::get<int64_t>(foo_context.GetValue("other_key")),789);
+  EXPECT_EQ(nostd::get<int64_t>(foo_context.GetValue("another_key")),987);
 }
 
 // Tests that copying a context copies the key value pairs as expected.

--- a/api/test/context/context_test.cc
+++ b/api/test/context/context_test.cc
@@ -88,6 +88,11 @@ TEST(ContextTest, ContextInheritance)
   EXPECT_EQ(nostd::get<int64_t>(foo_context.GetValue("foo_key")), 321);
   EXPECT_EQ(nostd::get<int64_t>(foo_context.GetValue("other_key")),789);
   EXPECT_EQ(nostd::get<int64_t>(foo_context.GetValue("another_key")),987);
+
+  EXPECT_EQ(nostd::get<int64_t>(test_context.GetValue("other_key")),0);
+  EXPECT_EQ(nostd::get<int64_t>(test_context.GetValue("another_key")),0);
+
+
 }
 
 // Tests that copying a context copies the key value pairs as expected.

--- a/api/test/context/context_test.cc
+++ b/api/test/context/context_test.cc
@@ -86,13 +86,11 @@ TEST(ContextTest, ContextInheritance)
 
   EXPECT_EQ(nostd::get<int64_t>(foo_context.GetValue("test_key")), 123);
   EXPECT_EQ(nostd::get<int64_t>(foo_context.GetValue("foo_key")), 321);
-  EXPECT_EQ(nostd::get<int64_t>(foo_context.GetValue("other_key")),789);
-  EXPECT_EQ(nostd::get<int64_t>(foo_context.GetValue("another_key")),987);
+  EXPECT_EQ(nostd::get<int64_t>(foo_context.GetValue("other_key")), 789);
+  EXPECT_EQ(nostd::get<int64_t>(foo_context.GetValue("another_key")), 987);
 
-  EXPECT_EQ(nostd::get<int64_t>(test_context.GetValue("other_key")),0);
-  EXPECT_EQ(nostd::get<int64_t>(test_context.GetValue("another_key")),0);
-
-
+  EXPECT_EQ(nostd::get<int64_t>(test_context.GetValue("other_key")), 0);
+  EXPECT_EQ(nostd::get<int64_t>(test_context.GetValue("another_key")), 0);
 }
 
 // Tests that copying a context copies the key value pairs as expected.


### PR DESCRIPTION
A tiny(est) of fixes to prevent crash while creating new context from existing context properties. The reference variable was used to store list head and later to iterate over the context list (at line 46), which eventually crashes. Changed it to non-reference variable, and added test case to validate the scenario.