### PR TITLE
add docfx ci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -215,3 +215,14 @@ jobs:
       uses: codecov/codecov-action@v1
       with:
         file: /home/runner/build/coverage.info
+
+  docfx_check:
+    name: DocFX check
+    runs-on: windows-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: install docfx
+      run: choco install docfx -y
+    - name: run ./ci/docfx.cmd
+      shell: cmd
+      run: ./ci/docfx.cmd

--- a/ci/docfx.cmd
+++ b/ci/docfx.cmd
@@ -1,0 +1,18 @@
+SETLOCAL ENABLEEXTENSIONS
+
+type ci\docfx.json > docfx.json
+type ci\toc.yml > toc.yml
+docfx build docfx.json > docfx.log
+DEL docfx.json 2> NUL
+DEL toc.yml 2> NUL
+@IF NOT %ERRORLEVEL% == 0 (
+  type docfx.log
+  ECHO Error: docfx build failed. 1>&2
+  EXIT /B %ERRORLEVEL%
+)
+@type docfx.log
+@type docfx.log | findstr /C:"Build succeeded."
+@IF NOT %ERRORLEVEL% == 0 (
+  ECHO Error: you have introduced build warnings. 1>&2
+  EXIT /B %ERRORLEVEL%
+)

--- a/ci/docfx.json
+++ b/ci/docfx.json
@@ -1,0 +1,26 @@
+{
+  "build": {
+    "content": [
+      {
+        "files": [
+          "**.md",
+          "toc.yml"
+        ]
+      }
+    ],
+    "resource": [
+      {
+        "files": [
+
+        ]
+      }
+    ],
+    "dest": "_site",
+    "globalMetadataFiles": [],
+    "fileMetadataFiles": [],
+    "noLangKeyword": false,
+    "keepFileLink": false,
+    "cleanupCacheHistory": true,
+    "disableGitFeatures": true
+  }
+}

--- a/ci/toc.yml
+++ b/ci/toc.yml
@@ -1,0 +1,2 @@
+- name: OpenTelemetry CPP
+  href: ./README.md

--- a/docs/cpp-metrics-api-design.md
+++ b/docs/cpp-metrics-api-design.md
@@ -248,7 +248,7 @@ Metric instruments are created through instances of the `Meter` class and each t
 * Monotonicity: A monotonic instrument is an additive instrument, where the progression of each sum is non-decreasing. Monotonic instruments are useful for monitoring rate information.
 
 The following instrument types will be supported:
-![Metric Instrument Table](../images/MetricInstrumentsTable.png)
+<!-- [//]: # ![Metric Instrument Table](../images/MetricInstrumentsTable.png) -->
 
 ### Metric Event Data Model
 

--- a/docs/cpp-metrics-sdk-design.md
+++ b/docs/cpp-metrics-sdk-design.md
@@ -13,7 +13,7 @@
 
 ## SDK Data Path Diagram
 
-![Data Path Diagram](../images/DataPath.png)
+<!-- [//]: # ![Data Path Diagram](../images/DataPath.png) -->
 
 This is the control path our implementation of the metrics SDK will follow. There are five main components: The controller, accumulator, aggregators, processor, and exporter. Each of these components will be further elaborated on.
 
@@ -351,7 +351,7 @@ The only addition to the SDK metric instrument classes from their API counterpar
 
 Note: these requirements come from a specification currently under development. Changes and feedback are in [PR #347](https://github.com/open-telemetry/opentelemetry-specification/pull/347) and the current document is linked [here](https://github.com/open-telemetry/opentelemetry-specification/blob/64bbb0c611d849b90916005d7714fa2a7132d0bf/specification/metrics/sdk.md).
 
-![Data Path Diagram](../images/DataPath.png)
+<!-- [//]: # ![Data Path Diagram](../images/DataPath.png) -->
 
 ## **Accumulator**
 

--- a/docs/cpp-ostream-exporter-design.md
+++ b/docs/cpp-ostream-exporter-design.md
@@ -35,7 +35,7 @@ The goal of the interface is to minimize burden of implementation for protocol-d
 
 The SpanExporter is called through the SpanProcessor, which passes finished spans to the configured SpanExporter, as soon as they are finished. The SpanProcessor also shutdown the exporter by the Shutdown function within the SpanProcessor.
 
-![SDK Data Path](./images/SpanDataPath.png)
+<!-- [//]: # ![SDK Data Path](./images/SpanDataPath.png) -->
 
 The specification states: exporter must support two functions: Export and Shutdown.
 
@@ -127,7 +127,7 @@ The MetricsExporter has the same requirements as the SpanExporter. The exporter 
 
 Exports a batch of telemetry data. Protocol exporters that will implement this function are typically expected to serialize and transmit the data to the destination.
 
-![SDK Data Path](./images/DataPath.png)
+<!-- [//]: # ![SDK Data Path](./images/DataPath.png) -->
 
 ### `Export(batch of Records)`
 

--- a/exporters/otlp/README.md
+++ b/exporters/otlp/README.md
@@ -8,7 +8,7 @@ For a full list of backends supported by the Collector, see the [main Collector 
 
 ## Configuration
 
-The OTLP exporter offers some configuration options. To configure the exporter, create an `OtlpExporterOptions` struct (defined in [exporter.h](include/opentelemetry/exporters/otlp/otlp_exporter.h)), set the options inside, and pass the struct to the `OtlpExporter` constructor, like so:
+The OTLP exporter offers some configuration options. To configure the exporter, create an `OtlpExporterOptions` struct (defined in [exporter.h](https://github.com/open-telemetry/opentelemetry-cpp/blob/master/exporters/otlp/include/opentelemetry/exporters/otlp/otlp_exporter.h)), set the options inside, and pass the struct to the `OtlpExporter` constructor, like so:
 
 ```
 OtlpExporterOptions options;
@@ -24,4 +24,4 @@ auto exporter = std::unique_ptr<sdktrace::SpanExporter>(new otlp::OtlpExporter(o
 
 ## Example
 
-For a complete example demonstrating how to use the OTLP exporter, see [examples/otlp](../../examples/otlp).
+For a complete example demonstrating how to use the OTLP exporter, see [examples/otlp](https://github.com/open-telemetry/opentelemetry-cpp/blob/master/examples/otlp/).


### PR DESCRIPTION
Changes: 
-Added a docfx ci check after existing ci tests (in ci.yml file)
-Changed 2 markdown links from relative to absolute urls (since absolute URLs are used consistently in all READMEs in this repo and docfx CI tests wouldn't recognize relative urls even though it would be linked properly after uploading to  github) 
-Commented out 4 missing .png source files
-Added 3 new files to /ci folder (docfx.json, toc.yml, docfx.cmd) and 1 new file to /build folder (docfx.yml) - nothing new in top level
-Removed SETLOCAL in docfx.cmd