### PR TITLE
Remove unnecessary reference to StartSpanOptions

### DIFF
--- a/sdk/src/trace/span.cc
+++ b/sdk/src/trace/span.cc
@@ -69,7 +69,6 @@ Span::Span(std::shared_ptr<Tracer> &&tracer,
       start_steady_time{options.start_steady_time},
       has_ended_{false}
 {
-  (void)options;
   if (recordable_ == nullptr)
   {
     return;


### PR DESCRIPTION
The no-op reference to input parameter `options` is no longer necessary because it is referenced later in the same function at line 101.