### PR TITLE
Add method to get currently active span

### DIFF
--- a/api/include/opentelemetry/trace/tracer.h
+++ b/api/include/opentelemetry/trace/tracer.h
@@ -3,6 +3,7 @@
 #include "opentelemetry/nostd/shared_ptr.h"
 #include "opentelemetry/nostd/string_view.h"
 #include "opentelemetry/nostd/unique_ptr.h"
+#include "opentelemetry/trace/default_span.h"
 #include "opentelemetry/trace/scope.h"
 #include "opentelemetry/trace/span.h"
 #include "opentelemetry/version.h"

--- a/api/include/opentelemetry/trace/tracer.h
+++ b/api/include/opentelemetry/trace/tracer.h
@@ -70,6 +70,11 @@ public:
     return nostd::unique_ptr<Scope>(new Scope{span});
   }
 
+  /**
+   * Get the currently active span.
+   * @return the currently active span, or an invalid default span if no span
+   * is active.
+   */
   nostd::shared_ptr<Span> GetCurrentSpan() noexcept
   {
     context::ContextValue active_span = context::RuntimeContext::GetValue(SpanKey);

--- a/api/include/opentelemetry/trace/tracer.h
+++ b/api/include/opentelemetry/trace/tracer.h
@@ -70,6 +70,16 @@ public:
     return nostd::unique_ptr<Scope>(new Scope{span});
   }
 
+  nostd::shared_ptr<Span> GetCurrentSpan() noexcept 
+  {
+  context::ContextValue active_span = context::RuntimeContext::GetValue(SpanKey);
+  if (nostd::holds_alternative<nostd::shared_ptr<Span>>(active_span)) {
+  return nostd::get<nostd::shared_ptr<Span>>(active_span);
+  } else {
+      return nostd::shared_ptr<Span>(new DefaultSpan(SpanContext::GetInvalid()));
+  }
+  }
+
   /**
    * Force any buffered spans to flush.
    * @param timeout to complete the flush

--- a/api/include/opentelemetry/trace/tracer.h
+++ b/api/include/opentelemetry/trace/tracer.h
@@ -70,14 +70,17 @@ public:
     return nostd::unique_ptr<Scope>(new Scope{span});
   }
 
-  nostd::shared_ptr<Span> GetCurrentSpan() noexcept 
+  nostd::shared_ptr<Span> GetCurrentSpan() noexcept
   {
-  context::ContextValue active_span = context::RuntimeContext::GetValue(SpanKey);
-  if (nostd::holds_alternative<nostd::shared_ptr<Span>>(active_span)) {
-  return nostd::get<nostd::shared_ptr<Span>>(active_span);
-  } else {
+    context::ContextValue active_span = context::RuntimeContext::GetValue(SpanKey);
+    if (nostd::holds_alternative<nostd::shared_ptr<Span>>(active_span))
+    {
+      return nostd::get<nostd::shared_ptr<Span>>(active_span);
+    }
+    else
+    {
       return nostd::shared_ptr<Span>(new DefaultSpan(SpanContext::GetInvalid()));
-  }
+    }
   }
 
   /**

--- a/api/test/trace/BUILD
+++ b/api/test/trace/BUILD
@@ -115,3 +115,14 @@ cc_test(
         "@com_google_googletest//:gtest_main",
     ],
 )
+
+cc_test(
+    name = "tracer_test",
+    srcs = [
+        "tracer_test.cc",
+    ],
+    deps = [
+        "//api",
+        "@com_google_googletest//:gtest_main",
+    ],
+)

--- a/api/test/trace/CMakeLists.txt
+++ b/api/test/trace/CMakeLists.txt
@@ -7,11 +7,12 @@ foreach(
   trace_flags_test
   span_context_test
   scope_test
-  noop_test)
-  add_executable(${testname} "${testname}.cc")
-  target_link_libraries(${testname} ${GTEST_BOTH_LIBRARIES}
+  noop_test
+  tracer_test)
+  add_executable(api_${testname} "${testname}.cc")
+  target_link_libraries(api_${testname} ${GTEST_BOTH_LIBRARIES}
                         ${CMAKE_THREAD_LIBS_INIT} opentelemetry_api)
-  gtest_add_tests(TARGET ${testname} TEST_PREFIX trace. TEST_LIST ${testname})
+  gtest_add_tests(TARGET api_${testname} TEST_PREFIX trace. TEST_LIST api_${testname})
 endforeach()
 
 add_executable(span_id_benchmark span_id_benchmark.cc)

--- a/api/test/trace/CMakeLists.txt
+++ b/api/test/trace/CMakeLists.txt
@@ -12,7 +12,8 @@ foreach(
   add_executable(api_${testname} "${testname}.cc")
   target_link_libraries(api_${testname} ${GTEST_BOTH_LIBRARIES}
                         ${CMAKE_THREAD_LIBS_INIT} opentelemetry_api)
-  gtest_add_tests(TARGET api_${testname} TEST_PREFIX trace. TEST_LIST api_${testname})
+  gtest_add_tests(TARGET api_${testname} TEST_PREFIX trace. TEST_LIST
+                  api_${testname})
 endforeach()
 
 add_executable(span_id_benchmark span_id_benchmark.cc)

--- a/api/test/trace/tracer_test.cc
+++ b/api/test/trace/tracer_test.cc
@@ -1,0 +1,38 @@
+#include "opentelemetry/trace/scope.h"
+#include "opentelemetry/context/threadlocal_context.h"
+#include "opentelemetry/nostd/shared_ptr.h"
+#include "opentelemetry/trace/noop.h"
+
+#include <gtest/gtest.h>
+
+using opentelemetry::trace::NoopSpan;
+using opentelemetry::trace::Scope;
+using opentelemetry::trace::Span;
+namespace nostd   = opentelemetry::nostd;
+namespace context = opentelemetry::context;
+
+TEST(TracerTest, GetCurrentSpan)
+{
+  std::unique_ptr<Tracer> tracer(new NoopTracer());
+  nostd::shared_ptr<Span> span_first(new NoopSpan(nullptr));
+  nostd::shared_ptr<Span> span_second(new NoopSpan(nullptr));
+
+  auto current = tracer->GetCurrentSpan();
+  ASSERT_TRUE(current->IsInvalid());
+
+  auto scope_first = tracer->WithCurrentSpan(span_first);
+  current = tracer->GetCurrentSpan();
+  ASSERT_EQ(current, span_first);  
+
+  auto scope_second = tracer->WithCurrentSpan(span_second);
+  current = tracer->GetCurrentSpan();
+  ASSERT_EQ(current, span_second);  
+
+  scope_second.reset(nullptr);
+  current = tracer->GetCurrentSpan();
+  ASSERT_EQ(current, span_first);  
+
+  scope_firstt.reset(nullptr);
+  current = tracer->GetCurrentSpan();
+  ASSERT_TRUE(current->IsInvalid());
+}

--- a/api/test/trace/tracer_test.cc
+++ b/api/test/trace/tracer_test.cc
@@ -1,30 +1,27 @@
-#include "opentelemetry/context/threadlocal_context.h"
 #include "opentelemetry/nostd/shared_ptr.h"
 #include "opentelemetry/trace/noop.h"
 #include "opentelemetry/trace/scope.h"
 
 #include <gtest/gtest.h>
 
-using opentelemetry::trace::NoopSpan;
-using opentelemetry::trace::Scope;
-using opentelemetry::trace::Span;
-namespace nostd   = opentelemetry::nostd;
-namespace context = opentelemetry::context;
+namespace trace_api = opentelemetry::trace;
+namespace nostd     = opentelemetry::nostd;
+namespace context   = opentelemetry::context;
 
 TEST(TracerTest, GetCurrentSpan)
 {
-  std::unique_ptr<Tracer> tracer(new NoopTracer());
-  nostd::shared_ptr<Span> span_first(new NoopSpan(nullptr));
-  nostd::shared_ptr<Span> span_second(new NoopSpan(nullptr));
+  std::unique_ptr<trace_api::Tracer> tracer(new trace_api::NoopTracer());
+  nostd::shared_ptr<trace_api::Span> span_first(new trace_api::NoopSpan(nullptr));
+  nostd::shared_ptr<trace_api::Span> span_second(new trace_api::NoopSpan(nullptr));
 
   auto current = tracer->GetCurrentSpan();
-  ASSERT_TRUE(current->IsInvalid());
+  ASSERT_FALSE(current->GetContext().IsValid());
 
-  auto scope_first = tracer->WithCurrentSpan(span_first);
+  auto scope_first = tracer->WithActiveSpan(span_first);
   current          = tracer->GetCurrentSpan();
   ASSERT_EQ(current, span_first);
 
-  auto scope_second = tracer->WithCurrentSpan(span_second);
+  auto scope_second = tracer->WithActiveSpan(span_second);
   current           = tracer->GetCurrentSpan();
   ASSERT_EQ(current, span_second);
 
@@ -32,7 +29,7 @@ TEST(TracerTest, GetCurrentSpan)
   current = tracer->GetCurrentSpan();
   ASSERT_EQ(current, span_first);
 
-  scope_firstt.reset(nullptr);
+  scope_first.reset(nullptr);
   current = tracer->GetCurrentSpan();
-  ASSERT_TRUE(current->IsInvalid());
+  ASSERT_FALSE(current->GetContext().IsValid());
 }

--- a/api/test/trace/tracer_test.cc
+++ b/api/test/trace/tracer_test.cc
@@ -1,7 +1,7 @@
-#include "opentelemetry/trace/scope.h"
 #include "opentelemetry/context/threadlocal_context.h"
 #include "opentelemetry/nostd/shared_ptr.h"
 #include "opentelemetry/trace/noop.h"
+#include "opentelemetry/trace/scope.h"
 
 #include <gtest/gtest.h>
 
@@ -21,16 +21,16 @@ TEST(TracerTest, GetCurrentSpan)
   ASSERT_TRUE(current->IsInvalid());
 
   auto scope_first = tracer->WithCurrentSpan(span_first);
-  current = tracer->GetCurrentSpan();
-  ASSERT_EQ(current, span_first);  
+  current          = tracer->GetCurrentSpan();
+  ASSERT_EQ(current, span_first);
 
   auto scope_second = tracer->WithCurrentSpan(span_second);
-  current = tracer->GetCurrentSpan();
-  ASSERT_EQ(current, span_second);  
+  current           = tracer->GetCurrentSpan();
+  ASSERT_EQ(current, span_second);
 
   scope_second.reset(nullptr);
   current = tracer->GetCurrentSpan();
-  ASSERT_EQ(current, span_first);  
+  ASSERT_EQ(current, span_first);
 
   scope_firstt.reset(nullptr);
   current = tracer->GetCurrentSpan();


### PR DESCRIPTION
This adds a method `GetCurrentSpan` on the tracer, which returns the currently active span.

This is defined in the [specification](https://github.com/open-telemetry/opentelemetry-specification/blob/master/specification/trace/api.md#tracer-operations) as an optional operation on the tracer.

Fixes #317.