### PR TITLE
Optimize no-op span creation

### DIFF
--- a/api/include/opentelemetry/trace/noop.h
+++ b/api/include/opentelemetry/trace/noop.h
@@ -68,11 +68,10 @@ public:
   {
     // Don't allocate a no-op span for every StartSpan call, but use a static
     // singleton for this case.
-    static NoopSpan noop_span(this->shared_from_this());
-    static nostd::shared_ptr<trace_api::Span> noop_span_ptr(
-        std::shared_ptr<NoopSpan>(&noop_span, [](NoopSpan *) {}));
+    static nostd::shared_ptr<trace_api::Span> noop_span(
+        new trace_api::NoopSpan{this->shared_from_this()});
 
-    return noop_span_ptr;
+    return noop_span;
   }
 
   void ForceFlushWithMicroseconds(uint64_t /*timeout*/) noexcept override {}

--- a/sdk/src/trace/tracer.cc
+++ b/sdk/src/trace/tracer.cc
@@ -56,11 +56,10 @@ nostd::shared_ptr<trace_api::Span> Tracer::StartSpan(
   {
     // Don't allocate a no-op span for every DROP decision, but use a static
     // singleton for this case.
-    static trace_api::NoopSpan noop_span(this->shared_from_this());
-    static nostd::shared_ptr<trace_api::Span> noop_span_ptr(
-        std::shared_ptr<trace_api::NoopSpan>(&noop_span, [](trace_api::NoopSpan *) {}));
+    static nostd::shared_ptr<trace_api::Span> noop_span(
+        new trace_api::NoopSpan{this->shared_from_this()});
 
-    return noop_span_ptr;
+    return noop_span;
   }
   else
   {


### PR DESCRIPTION
Don't create a `NoopSpan` for each `NoopTracer::StartSpan` call or for each `DROP` sampling decision, but instead use a static singleton in both cases.

This causes a significant performance improvement for the [BM_NoopSpanCreation](https://github.com/open-telemetry/opentelemetry-cpp/blob/master/sdk/test/trace/sampler_benchmark.cc#L173) benchmark.