### PR TITLE
AddEvent support for Span

### DIFF
--- a/sdk/src/trace/span.cc
+++ b/sdk/src/trace/span.cc
@@ -119,22 +119,34 @@ void Span::SetAttribute(nostd::string_view key,
 
 void Span::AddEvent(nostd::string_view name) noexcept
 {
-  (void)name;
+  std::lock_guard<std::mutex> lock_guard{mu_};
+  if (recordable_ == nullptr)
+  {
+    return;
+  }
+  recordable_->AddEvent(name);
 }
 
 void Span::AddEvent(nostd::string_view name, core::SystemTimestamp timestamp) noexcept
 {
-  (void)name;
-  (void)timestamp;
+  std::lock_guard<std::mutex> lock_guard{mu_};
+  if (recordable_ == nullptr)
+  {
+    return;
+  }
+  recordable_->AddEvent(name, timestamp);
 }
 
 void Span::AddEvent(nostd::string_view name,
                     core::SystemTimestamp timestamp,
                     const trace_api::KeyValueIterable &attributes) noexcept
 {
-  (void)name;
-  (void)timestamp;
-  (void)attributes;
+  std::lock_guard<std::mutex> lock_guard{mu_};
+  if (recordable_ == nullptr)
+  {
+    return;
+  }
+  recordable_->AddEvent(name, timestamp, attributes);
 }
 
 void Span::SetStatus(trace_api::CanonicalCode code, nostd::string_view description) noexcept

--- a/sdk/test/trace/tracer_test.cc
+++ b/sdk/test/trace/tracer_test.cc
@@ -341,6 +341,28 @@ TEST(Tracer, SpanSetAttribute)
   ASSERT_EQ(3.1, nostd::get<double>(span_data->GetAttributes().at("abc")));
 }
 
+TEST(Tracer, SpanSetEvents)
+{
+  std::shared_ptr<std::vector<std::unique_ptr<SpanData>>> spans_received(
+      new std::vector<std::unique_ptr<SpanData>>);
+
+  auto tracer = initTracer(spans_received);
+
+  auto span = tracer->StartSpan("span 1");
+  span->AddEvent("event 1");
+  span->AddEvent("event 2", std::chrono::system_clock::now());
+
+  span->End();
+  ASSERT_EQ(1, spans_received->size());
+
+  auto &span_data_events = spans_received->at(0)->GetEvents();
+  ASSERT_EQ(2, span_data_events.size());
+  ASSERT_EQ("event 1", span_data_events[0].GetName());
+  ASSERT_EQ("event 2", span_data_events[1].GetName());
+  ASSERT_EQ(0, span_data_events[0].GetAttributes().size());
+  ASSERT_EQ(0, span_data_events[1].GetAttributes().size());
+}
+
 TEST(Tracer, TestAlwaysOnSampler)
 {
   std::shared_ptr<std::vector<std::unique_ptr<SpanData>>> spans_received(

--- a/sdk/test/trace/tracer_test.cc
+++ b/sdk/test/trace/tracer_test.cc
@@ -352,15 +352,20 @@ TEST(Tracer, SpanSetEvents)
   span->AddEvent("event 1");
   span->AddEvent("event 2", std::chrono::system_clock::now());
 
+  span->AddEvent("event 3", std::chrono::system_clock::now(),
+                 opentelemetry::sdk::GetEmptyAttributes());
+
   span->End();
   ASSERT_EQ(1, spans_received->size());
 
   auto &span_data_events = spans_received->at(0)->GetEvents();
-  ASSERT_EQ(2, span_data_events.size());
+  ASSERT_EQ(3, span_data_events.size());
   ASSERT_EQ("event 1", span_data_events[0].GetName());
   ASSERT_EQ("event 2", span_data_events[1].GetName());
+  ASSERT_EQ("event 3", span_data_events[2].GetName());
   ASSERT_EQ(0, span_data_events[0].GetAttributes().size());
   ASSERT_EQ(0, span_data_events[1].GetAttributes().size());
+  ASSERT_EQ(0, span_data_events[2].GetAttributes().size());
 }
 
 TEST(Tracer, TestAlwaysOnSampler)

--- a/sdk/test/trace/tracer_test.cc
+++ b/sdk/test/trace/tracer_test.cc
@@ -352,8 +352,7 @@ TEST(Tracer, SpanSetEvents)
   span->AddEvent("event 1");
   span->AddEvent("event 2", std::chrono::system_clock::now());
 
-  span->AddEvent("event 3", std::chrono::system_clock::now(),
-                 opentelemetry::sdk::GetEmptyAttributes());
+  span->AddEvent("event 3", std::chrono::system_clock::now(), {{"attr1", 1}});
 
   span->End();
   ASSERT_EQ(1, spans_received->size());
@@ -365,7 +364,7 @@ TEST(Tracer, SpanSetEvents)
   ASSERT_EQ("event 3", span_data_events[2].GetName());
   ASSERT_EQ(0, span_data_events[0].GetAttributes().size());
   ASSERT_EQ(0, span_data_events[1].GetAttributes().size());
-  ASSERT_EQ(0, span_data_events[2].GetAttributes().size());
+  ASSERT_EQ(1, span_data_events[2].GetAttributes().size());
 }
 
 TEST(Tracer, TestAlwaysOnSampler)


### PR DESCRIPTION
As per the [spec](https://github.com/open-telemetry/opentelemetry-specification/blob/master/specification/trace/api.md#add-events), add events for Span to the field of `Recordable` object.