### PR TITLE
Disable flaky patch coverage checks

### DIFF
--- a/.github/.codecov.yaml
+++ b/.github/.codecov.yaml
@@ -6,6 +6,8 @@ coverage:
   precision: 2
   round: down
   range: "80...100"
+  status:
+    patch: off
 
 parsers:
   gcov:


### PR DESCRIPTION
This disables the flaky patch coverage check (documented [here](https://docs.codecov.io/docs/commit-status#disabling-a-status)).