### PR TITLE
Change type of Resize capacity from int to size_t

### DIFF
--- a/api/include/opentelemetry/context/runtime_context.h
+++ b/api/include/opentelemetry/context/runtime_context.h
@@ -253,9 +253,9 @@ private:
     }
 
     // Reallocates the storage array to the pass in new capacity size.
-    void Resize(int new_capacity) noexcept
+    void Resize(size_t new_capacity) noexcept
     {
-      int old_size = size_ - 1;
+      size_t old_size = size_ - 1;
       if (new_capacity == 0)
       {
         new_capacity = 2;


### PR DESCRIPTION
Parameter `new_capacity` for `RuntimeContext::Resize()` should be in type `size_t` instead of `int`, to be consistent with `size_`.

This could cause issue because `size_t` could have larger range than `int` (this is the case on Windows 64-bit system which is in LLP64 data model), so convert `size_t` to `int` could cause data loss.