### PR TITLE
Add explicit type conversion to narrower data type

### DIFF
--- a/ext/test/zpages/tracez_data_aggregator_test.cc
+++ b/ext/test/zpages/tracez_data_aggregator_test.cc
@@ -60,14 +60,14 @@ void VerifySpanCountsInTracezData(
       << " Count of running spans incorrect for " << span_name << "\n";
 
   EXPECT_EQ(aggregated_data.sample_running_spans.size(),
-            std::min<unsigned int>(running_span_count, kMaxNumberOfSampleSpans))
+            std::min<size_t>(running_span_count, kMaxNumberOfSampleSpans))
       << " Size of sample running spans incorrect for " << span_name << "\n";
 
   EXPECT_EQ(aggregated_data.error_span_count, error_span_count)
       << " Count of error spans incorrect for " << span_name << "\n";
 
   EXPECT_EQ(aggregated_data.sample_error_spans.size(),
-            std::min<unsigned int>(error_span_count, kMaxNumberOfSampleSpans))
+            std::min<size_t>(error_span_count, kMaxNumberOfSampleSpans))
       << " Count of running spans incorrect for " << span_name << "\n";
 
   for (unsigned int boundary = 0; boundary < kLatencyBoundaries.size(); boundary++)
@@ -77,7 +77,7 @@ void VerifySpanCountsInTracezData(
         << " Count of completed spans in latency boundary " << boundary << " incorrect for "
         << span_name << "\n";
     EXPECT_EQ(aggregated_data.sample_latency_spans[boundary].size(),
-              std::min<unsigned int>(completed_span_count_per_latency_bucket[boundary],
+              std::min<size_t>(completed_span_count_per_latency_bucket[boundary],
                                      kMaxNumberOfSampleSpans))
         << " Count of sample completed spans in latency boundary " << boundary << " incorrect for "
         << span_name << "\n";

--- a/ext/test/zpages/tracez_data_aggregator_test.cc
+++ b/ext/test/zpages/tracez_data_aggregator_test.cc
@@ -78,7 +78,7 @@ void VerifySpanCountsInTracezData(
         << span_name << "\n";
     EXPECT_EQ(aggregated_data.sample_latency_spans[boundary].size(),
               std::min<size_t>(completed_span_count_per_latency_bucket[boundary],
-                                     kMaxNumberOfSampleSpans))
+                               kMaxNumberOfSampleSpans))
         << " Count of sample completed spans in latency boundary " << boundary << " incorrect for "
         << span_name << "\n";
   }

--- a/sdk/include/opentelemetry/sdk/metrics/aggregator/sketch_aggregator.h
+++ b/sdk/include/opentelemetry/sdk/metrics/aggregator/sketch_aggregator.h
@@ -72,7 +72,7 @@ public:
     }
     else
     {
-      idx = ceil(log(val) / log(gamma));
+      idx = static_cast<int>(ceil(log(val) / log(gamma)));
     }
     if (raw_.find(idx) != raw_.end())
     {

--- a/sdk/test/trace/probability_sampler_test.cc
+++ b/sdk/test/trace/probability_sampler_test.cc
@@ -138,9 +138,9 @@ TEST(ProbabilitySampler, ShouldSampleWithContext)
 TEST(ProbabilitySampler, ProbabilitySamplerHalf)
 {
   double probability = 0.5;
-  int iterations = 100000;
+  int iterations     = 100000;
   int expected_count = static_cast<int>(iterations * probability);
-  int variance = static_cast<int>(iterations * 0.01);
+  int variance       = static_cast<int>(iterations * 0.01);
 
   SpanContext c(true, true);
   ProbabilitySampler s(probability);
@@ -154,9 +154,9 @@ TEST(ProbabilitySampler, ProbabilitySamplerHalf)
 TEST(ProbabilitySampler, ProbabilitySamplerOnePercent)
 {
   double probability = 0.01;
-  int iterations = 100000;
+  int iterations     = 100000;
   int expected_count = static_cast<int>(iterations * probability);
-  int variance = static_cast<int>(iterations * 0.01);
+  int variance       = static_cast<int>(iterations * 0.01);
 
   SpanContext c(true, true);
   ProbabilitySampler s(probability);
@@ -170,7 +170,7 @@ TEST(ProbabilitySampler, ProbabilitySamplerOnePercent)
 TEST(ProbabilitySampler, ProbabilitySamplerAll)
 {
   double probability = 1.0;
-  int iterations = 100000;
+  int iterations     = 100000;
   int expected_count = static_cast<int>(iterations * probability);
 
   SpanContext c(true, true);
@@ -184,7 +184,7 @@ TEST(ProbabilitySampler, ProbabilitySamplerAll)
 TEST(ProbabilitySampler, ProbabilitySamplerNone)
 {
   double probability = 0.0;
-  int iterations = 100000;
+  int iterations     = 100000;
   int expected_count = static_cast<int>(iterations * probability);
 
   SpanContext c(true, true);

--- a/sdk/test/trace/probability_sampler_test.cc
+++ b/sdk/test/trace/probability_sampler_test.cc
@@ -138,7 +138,9 @@ TEST(ProbabilitySampler, ShouldSampleWithContext)
 TEST(ProbabilitySampler, ProbabilitySamplerHalf)
 {
   double probability = 0.5;
-  int iterations = 100000, expected_count = iterations * probability, variance = iterations * 0.01;
+  int iterations = 100000;
+  int expected_count = static_cast<int>(iterations * probability);
+  int variance = static_cast<int>(iterations * 0.01);
 
   SpanContext c(true, true);
   ProbabilitySampler s(probability);
@@ -152,7 +154,9 @@ TEST(ProbabilitySampler, ProbabilitySamplerHalf)
 TEST(ProbabilitySampler, ProbabilitySamplerOnePercent)
 {
   double probability = 0.01;
-  int iterations = 100000, expected_count = iterations * probability, variance = iterations * 0.01;
+  int iterations = 100000;
+  int expected_count = static_cast<int>(iterations * probability);
+  int variance = static_cast<int>(iterations * 0.01);
 
   SpanContext c(true, true);
   ProbabilitySampler s(probability);
@@ -166,7 +170,8 @@ TEST(ProbabilitySampler, ProbabilitySamplerOnePercent)
 TEST(ProbabilitySampler, ProbabilitySamplerAll)
 {
   double probability = 1.0;
-  int iterations = 100000, expected_count = iterations * probability;
+  int iterations = 100000;
+  int expected_count = static_cast<int>(iterations * probability);
 
   SpanContext c(true, true);
   ProbabilitySampler s(probability);
@@ -179,7 +184,8 @@ TEST(ProbabilitySampler, ProbabilitySamplerAll)
 TEST(ProbabilitySampler, ProbabilitySamplerNone)
 {
   double probability = 0.0;
-  int iterations = 100000, expected_count = iterations * probability;
+  int iterations = 100000;
+  int expected_count = static_cast<int>(iterations * probability);
 
   SpanContext c(true, true);
   ProbabilitySampler s(probability);


### PR DESCRIPTION
Add explicit type conversion and more fixes to consistency of using `size_t` and `int`.