### PR TITLE
Add functionality to explicitely specify a span parent

### DIFF
--- a/api/include/opentelemetry/trace/default_span.h
+++ b/api/include/opentelemetry/trace/default_span.h
@@ -41,8 +41,6 @@ public:
 
   nostd::string_view ToString() { return "DefaultSpan"; }
 
-  DefaultSpan() = default;
-
   DefaultSpan(SpanContext span_context) : span_context_(span_context) {}
 
   // movable and copiable

--- a/api/include/opentelemetry/trace/noop.h
+++ b/api/include/opentelemetry/trace/noop.h
@@ -24,7 +24,9 @@ namespace trace
 class NoopSpan final : public Span
 {
 public:
-  explicit NoopSpan(const std::shared_ptr<Tracer> &tracer) noexcept : tracer_{tracer} {}
+  explicit NoopSpan(const std::shared_ptr<Tracer> &tracer) noexcept
+      : tracer_{tracer}, span_context_{SpanContext::GetInvalid()}
+  {}
 
   void SetAttribute(nostd::string_view /*key*/,
                     const common::AttributeValue & /*value*/) noexcept override

--- a/api/include/opentelemetry/trace/propagation/http_trace_context.h
+++ b/api/include/opentelemetry/trace/propagation/http_trace_context.h
@@ -92,7 +92,7 @@ public:
     {
       return nostd::get<nostd::shared_ptr<Span>>(span).get()->GetContext();
     }
-    return SpanContext();
+    return SpanContext::GetInvalid();
   }
 
   static TraceId GenerateTraceIdFromString(nostd::string_view trace_id)

--- a/api/include/opentelemetry/trace/span.h
+++ b/api/include/opentelemetry/trace/span.h
@@ -43,8 +43,13 @@ struct StartSpanOptions
   core::SystemTimestamp start_system_time;
   core::SteadyTimestamp start_steady_time;
 
+  // Explicitely set the parent of a Span.
+  //
+  // This defaults to an invalid span context. In this case, the Span is
+  // automatically parented to the currently active span.
+  SpanContext parent;
+
   // TODO:
-  // Span(Context?) parent;
   // SpanContext remote_parent;
   // Links
   SpanKind kind = SpanKind::kInternal;

--- a/api/include/opentelemetry/trace/span.h
+++ b/api/include/opentelemetry/trace/span.h
@@ -47,7 +47,7 @@ struct StartSpanOptions
   //
   // This defaults to an invalid span context. In this case, the Span is
   // automatically parented to the currently active span.
-  SpanContext parent;
+  SpanContext parent = SpanContext::GetInvalid();
 
   // TODO:
   // SpanContext remote_parent;

--- a/api/include/opentelemetry/trace/span_context.h
+++ b/api/include/opentelemetry/trace/span_context.h
@@ -78,24 +78,25 @@ public:
   SpanContext(const SpanContext &ctx)
       : trace_id_(ctx.trace_id()), span_id_(ctx.span_id()), trace_flags_(ctx.trace_flags())
   {}
-  //
-  //  SpanContext &operator=(const SpanContext &ctx)
-  //  {
-  //    SpanContext *spn_ctx =
-  //        new SpanContext(ctx.trace_id(), ctx.span_id(), ctx.trace_flags(),
-  //        ctx.HasRemoteParent());
-  //    this = spn_ctx;
-  //    return *this;
-  //  };
-  //
-  //  SpanContext &operator=(SpanContext &&ctx)
-  //  {
-  //    SpanContext *spn_ctx =
-  //        new SpanContext(ctx.trace_id(), ctx.span_id(), ctx.trace_flags(),
-  //        ctx.HasRemoteParent());
-  //    this = spn_ctx;
-  //    return *this;
-  //  };
+ 
+ /* 
+    SpanContext &operator=(const SpanContext &ctx)
+    {
+  trace_id_ = ctx.trace_id();
+  span_id_ = ctx.span_id();
+  trace_flags_ = ctx.trace_flags();
+  remote_parent_ = ctx.HasRemoteParent();
+      return *this;
+    };
+  
+    SpanContext &operator=(SpanContext &&ctx)
+    {
+  trace_id_ = std::move(ctx.trace_id());
+  span_id_ = std::move(ctx.span_id());
+  trace_flags_ = std::move(ctx.trace_flags());
+  remote_parent_ = ctx.HasRemoteParent();
+      return *this;
+    }; */
 
   bool operator==(const SpanContext &that) const noexcept
   {

--- a/api/include/opentelemetry/trace/span_context.h
+++ b/api/include/opentelemetry/trace/span_context.h
@@ -33,10 +33,6 @@ namespace trace_api = opentelemetry::trace;
 class SpanContext final
 {
 public:
-  // An invalid SpanContext.
-  // SpanContext() noexcept
-  //    : trace_flags_(trace::TraceFlags((uint8_t) false)), remote_parent_(false){};
-
   /* A temporary constructor for an invalid SpanContext.
    * Trace id and span id are set to invalid (all zeros).
    *
@@ -71,9 +67,9 @@ public:
         remote_parent_(has_remote_parent)
   {}
 
-  SpanContext(const SpanContext &ctx)
-      : trace_id_(ctx.trace_id()), span_id_(ctx.span_id()), trace_flags_(ctx.trace_flags())
-  {}
+  SpanContext(const SpanContext &ctx) = default;
+
+  SpanContext &operator=(const SpanContext &ctx) = default;
 
   bool operator==(const SpanContext &that) const noexcept
   {

--- a/api/include/opentelemetry/trace/span_context.h
+++ b/api/include/opentelemetry/trace/span_context.h
@@ -34,8 +34,8 @@ class SpanContext final
 {
 public:
   // An invalid SpanContext.
-  SpanContext() noexcept
-      : trace_flags_(trace::TraceFlags((uint8_t) false)), remote_parent_(false){};
+  // SpanContext() noexcept
+  //    : trace_flags_(trace::TraceFlags((uint8_t) false)), remote_parent_(false){};
 
   /* A temporary constructor for an invalid SpanContext.
    * Trace id and span id are set to invalid (all zeros).
@@ -71,32 +71,9 @@ public:
         remote_parent_(has_remote_parent)
   {}
 
-  SpanContext(SpanContext &&ctx)
-      : trace_id_(ctx.trace_id()), span_id_(ctx.span_id()), trace_flags_(ctx.trace_flags())
-  {}
-
   SpanContext(const SpanContext &ctx)
       : trace_id_(ctx.trace_id()), span_id_(ctx.span_id()), trace_flags_(ctx.trace_flags())
   {}
- 
- /* 
-    SpanContext &operator=(const SpanContext &ctx)
-    {
-  trace_id_ = ctx.trace_id();
-  span_id_ = ctx.span_id();
-  trace_flags_ = ctx.trace_flags();
-  remote_parent_ = ctx.HasRemoteParent();
-      return *this;
-    };
-  
-    SpanContext &operator=(SpanContext &&ctx)
-    {
-  trace_id_ = std::move(ctx.trace_id());
-  span_id_ = std::move(ctx.span_id());
-  trace_flags_ = std::move(ctx.trace_flags());
-  remote_parent_ = ctx.HasRemoteParent();
-      return *this;
-    }; */
 
   bool operator==(const SpanContext &that) const noexcept
   {
@@ -111,10 +88,10 @@ public:
   bool IsSampled() const noexcept { return trace_flags_.IsSampled(); }
 
 private:
-  const trace_api::TraceId trace_id_;
-  const trace_api::SpanId span_id_;
-  const trace_api::TraceFlags trace_flags_;
-  const bool remote_parent_ = false;
+  trace_api::TraceId trace_id_;
+  trace_api::SpanId span_id_;
+  trace_api::TraceFlags trace_flags_;
+  bool remote_parent_ = false;
 };
 }  // namespace trace
 OPENTELEMETRY_END_NAMESPACE

--- a/api/test/trace/propagation/http_text_format_test.cc
+++ b/api/test/trace/propagation/http_text_format_test.cc
@@ -66,8 +66,9 @@ TEST(HTTPTextFormatTest, NoSendEmptyTraceState)
   // If the trace state is empty, do not set the header.
   const std::map<std::string, std::string> carrier = {
       {"traceparent", "00-4bf92f3577b34da6a3ce929d0e0e4736-0102030405060708-01"}};
-  context::Context ctx1 =
-      context::Context("current-span", nostd::shared_ptr<trace::Span>(new trace::DefaultSpan::GetInvalid()));
+  context::Context ctx1 = context::Context{
+      "current-span",
+      nostd::shared_ptr<trace::Span>(new trace::DefaultSpan(trace::SpanContext::GetInvalid()))};
   context::Context ctx2                 = format.Extract(Getter, carrier, ctx1);
   std::map<std::string, std::string> c2 = {};
   format.Inject(Setter, c2, ctx2);

--- a/api/test/trace/propagation/http_text_format_test.cc
+++ b/api/test/trace/propagation/http_text_format_test.cc
@@ -67,7 +67,7 @@ TEST(HTTPTextFormatTest, NoSendEmptyTraceState)
   const std::map<std::string, std::string> carrier = {
       {"traceparent", "00-4bf92f3577b34da6a3ce929d0e0e4736-0102030405060708-01"}};
   context::Context ctx1 =
-      context::Context("current-span", nostd::shared_ptr<trace::Span>(new trace::DefaultSpan()));
+      context::Context("current-span", nostd::shared_ptr<trace::Span>(new trace::DefaultSpan::GetInvalid()));
   context::Context ctx2                 = format.Extract(Getter, carrier, ctx1);
   std::map<std::string, std::string> c2 = {};
   format.Inject(Setter, c2, ctx2);

--- a/api/test/trace/span_context_test.cc
+++ b/api/test/trace/span_context_test.cc
@@ -42,7 +42,7 @@ TEST(SpanContextTest, TraceFlags)
 // Test that SpanContext is invalid
 TEST(SpanContextTest, Invalid)
 {
-  SpanContext s1(false, false);
+  SpanContext s1 = SpanContext::GetInvalid();
   EXPECT_FALSE(s1.IsValid());
 
   // Test that trace id and span id are invalid

--- a/examples/plugin/plugin/tracer.cc
+++ b/examples/plugin/plugin/tracer.cc
@@ -20,7 +20,7 @@ public:
        nostd::string_view name,
        const opentelemetry::trace::KeyValueIterable & /*attributes*/,
        const trace::StartSpanOptions & /*options*/) noexcept
-      : tracer_{std::move(tracer)}, name_{name}
+      : tracer_{std::move(tracer)}, name_{name}, span_context_{trace::SpanContext::GetInvalid()}
   {
     std::cout << "StartSpan: " << name << "\n";
   }

--- a/sdk/src/trace/tracer.cc
+++ b/sdk/src/trace/tracer.cc
@@ -58,6 +58,7 @@ nostd::shared_ptr<trace_api::Span> Tracer::StartSpan(
 {
   trace_api::SpanContext parent = GetCurrentSpanContext(options.parent);
 
+  // TODO: replace nullptr with parent context in span context
   auto sampling_result =
       sampler_->ShouldSample(nullptr, parent.trace_id(), name, options.kind, attributes);
   if (sampling_result.decision == Decision::DROP)

--- a/sdk/test/trace/tracer_test.cc
+++ b/sdk/test/trace/tracer_test.cc
@@ -442,3 +442,38 @@ TEST(Tracer, WithActiveSpan)
   ASSERT_EQ(1, spans.size());
   EXPECT_EQ("span 1", spans.at(0)->GetName());
 }
+
+TEST(Tracer, ExpectParent)
+{
+  std::unique_ptr<InMemorySpanExporter> exporter(new InMemorySpanExporter());
+  std::shared_ptr<InMemorySpanData> span_data = exporter->GetData();
+  auto tracer                                 = initTracer(std::move(exporter));
+  auto spans                                  = span_data.get()->GetSpans();
+
+  ASSERT_EQ(0, spans.size());
+
+  auto span_first = tracer->StartSpan("span 1");
+
+  trace_api::StartSpanOptions options;
+  options.parent   = span_first->GetContext();
+  auto span_second = tracer->StartSpan("span 2", options);
+
+  options.parent  = span_second->GetContext();
+  auto span_third = tracer->StartSpan("span 3", options);
+
+  span_third->End();
+  span_second->End();
+  span_first->End();
+
+  spans = span_data->GetSpans();
+  ASSERT_EQ(3, spans.size());
+  auto spandata_first  = std::move(spans.at(2));
+  auto spandata_second = std::move(spans.at(1));
+  auto spandata_third  = std::move(spans.at(0));
+  EXPECT_EQ("span 1", spandata_first->GetName());
+  EXPECT_EQ("span 2", spandata_second->GetName());
+  EXPECT_EQ("span 3", spandata_third->GetName());
+
+  EXPECT_EQ(spandata_first->GetSpanId(), spandata_second->GetParentSpanId());
+  EXPECT_EQ(spandata_second->GetSpanId(), spandata_third->GetParentSpanId());
+}


### PR DESCRIPTION
This PR extends the `StartSpanOptions` struct by a `parent` SpanContext. If this is given, it will be used as a parent for a given span.

While I was at it, I cleaned up some things in the `SpanContext` implementation.

Closes #318.