### PR TITLE
fix compile time warnings

### DIFF
--- a/api/include/opentelemetry/context/context.h
+++ b/api/include/opentelemetry/context/context.h
@@ -98,9 +98,9 @@ private:
   class DataList
   {
   public:
-    nostd::shared_ptr<DataList> next_;
-
     char *key_;
+
+    nostd::shared_ptr<DataList> next_;
 
     size_t key_length_;
 

--- a/exporters/ostream/include/opentelemetry/exporters/ostream/metrics_exporter.h
+++ b/exporters/ostream/include/opentelemetry/exporters/ostream/metrics_exporter.h
@@ -85,7 +85,7 @@ private:
         {
           auto vec    = agg->get_checkpoint();
           size_t size = vec.size();
-          int i       = 1;
+          size_t i    = 1;
 
           sout_ << "\n  values      : " << '[';
 
@@ -110,7 +110,7 @@ private:
 
         sout_ << "\n  buckets     : " << '[';
 
-        for (int i = 0; i < boundaries_size; i++)
+        for (size_t i = 0; i < boundaries_size; i++)
         {
           sout_ << boundaries[i];
 
@@ -120,7 +120,7 @@ private:
         sout_ << ']';
 
         sout_ << "\n  counts      : " << '[';
-        for (int i = 0; i < counts_size; i++)
+        for (size_t i = 0; i < counts_size; i++)
         {
           sout_ << counts[i];
 
@@ -140,7 +140,7 @@ private:
 
         sout_ << "\n  buckets     : " << '[';
 
-        for (int i = 0; i < boundaries_size; i++)
+        for (size_t i = 0; i < boundaries_size; i++)
         {
           sout_ << boundaries[i];
 
@@ -150,7 +150,7 @@ private:
         sout_ << ']';
 
         sout_ << "\n  counts      : " << '[';
-        for (int i = 0; i < counts_size; i++)
+        for (size_t i = 0; i < counts_size; i++)
         {
           sout_ << counts[i];
 

--- a/exporters/prometheus/include/opentelemetry/exporters/prometheus/prometheus_collector.h
+++ b/exporters/prometheus/include/opentelemetry/exporters/prometheus/prometheus_collector.h
@@ -45,7 +45,7 @@ public:
    * This constructor initializes the collection for metrics to export
    * in this class with default capacity
    */
-  explicit PrometheusCollector(int max_collection_size = 2048);
+  explicit PrometheusCollector(size_t max_collection_size = 2048);
 
   /**
    * Collects all metrics data from metricsToCollect collection.
@@ -88,7 +88,7 @@ private:
   /**
    * Maximum size of the metricsToCollect collection.
    */
-  int max_collection_size_;
+  size_t max_collection_size_;
 
   /*
    * Lock when operating the metricsToCollect collection

--- a/exporters/prometheus/src/prometheus_collector.cc
+++ b/exporters/prometheus/src/prometheus_collector.cc
@@ -29,7 +29,7 @@ namespace prometheus
  * This constructor initializes the collection for metrics to export
  * in this class with default capacity
  */
-PrometheusCollector::PrometheusCollector(int max_collection_size)
+PrometheusCollector::PrometheusCollector(size_t max_collection_size)
     : max_collection_size_(max_collection_size)
 {
   metrics_to_collect_ =

--- a/exporters/prometheus/src/prometheus_exporter_utils.cc
+++ b/exporters/prometheus/src/prometheus_exporter_utils.cc
@@ -284,7 +284,7 @@ void PrometheusExporterUtils::SetMetricBasic(prometheus_client::ClientMetric &me
   if (!label_pairs.empty())
   {
     metric.label.resize(label_pairs.size());
-    for (int i = 0; i < label_pairs.size(); ++i)
+    for (size_t i = 0; i < label_pairs.size(); ++i)
     {
       auto origin_name      = label_pairs[i].first;
       auto sanitized        = SanitizeNames(origin_name);
@@ -396,7 +396,7 @@ void PrometheusExporterUtils::SetValue(std::vector<T> values,
   metric->histogram.sample_count = values[1];
   int cumulative                 = 0;
   std::vector<prometheus_client::ClientMetric::Bucket> buckets;
-  for (int i = 0; i < boundaries.size() + 1; i++)
+  for (size_t i = 0; i < boundaries.size() + 1; i++)
   {
     prometheus_client::ClientMetric::Bucket bucket;
     cumulative += counts[i];
@@ -444,7 +444,7 @@ void PrometheusExporterUtils::SetValue(std::vector<T> values,
   if (do_quantile)
   {
     std::vector<prometheus_client::ClientMetric::Quantile> prometheus_quantiles;
-    for (int i = 0; i < quantiles.size(); i++)
+    for (size_t i = 0; i < quantiles.size(); i++)
     {
       prometheus_client::ClientMetric::Quantile quantile;
       quantile.quantile = quantile_points[i];

--- a/exporters/prometheus/test/prometheus_collector_test.cc
+++ b/exporters/prometheus/test/prometheus_collector_test.cc
@@ -215,7 +215,7 @@ TEST(PrometheusCollector, AddMetricDataWithCounterRecordsSuccessfully)
     auto after_agg     = nostd::get<std::shared_ptr<metric_sdk::Aggregator<double>>>(after_agg_var);
 
     ASSERT_EQ(before_agg->get_checkpoint().size(), after_agg->get_checkpoint().size());
-    for (int i = 0; i < before_agg->get_checkpoint().size(); i++)
+    for (size_t i = 0; i < before_agg->get_checkpoint().size(); i++)
     {
       ASSERT_EQ(before_agg->get_checkpoint()[i], after_agg->get_checkpoint()[i]);
     }
@@ -267,7 +267,7 @@ TEST(PrometheusCollector, AddMetricDataWithMinMaxSumCountRecordsSuccessfully)
     auto after_agg     = nostd::get<std::shared_ptr<metric_sdk::Aggregator<short>>>(after_agg_var);
 
     ASSERT_EQ(before_agg->get_checkpoint().size(), after_agg->get_checkpoint().size());
-    for (int i = 0; i < before_agg->get_checkpoint().size(); i++)
+    for (size_t i = 0; i < before_agg->get_checkpoint().size(); i++)
     {
       ASSERT_EQ(before_agg->get_checkpoint()[i], after_agg->get_checkpoint()[i]);
     }
@@ -319,7 +319,7 @@ TEST(PrometheusCollector, AddMetricDataWithGaugeRecordsSuccessfully)
     auto after_agg     = nostd::get<std::shared_ptr<metric_sdk::Aggregator<int>>>(after_agg_var);
 
     ASSERT_EQ(before_agg->get_checkpoint().size(), after_agg->get_checkpoint().size());
-    for (int i = 0; i < before_agg->get_checkpoint().size(); i++)
+    for (size_t i = 0; i < before_agg->get_checkpoint().size(); i++)
     {
       ASSERT_EQ(before_agg->get_checkpoint()[i], after_agg->get_checkpoint()[i]);
     }
@@ -372,15 +372,15 @@ TEST(PrometheusCollector, AddMetricDataWithSketchRecordsSuccessfully)
     auto after_agg     = nostd::get<std::shared_ptr<metric_sdk::Aggregator<double>>>(after_agg_var);
 
     ASSERT_EQ(before_agg->get_checkpoint().size(), after_agg->get_checkpoint().size());
-    for (int i = 0; i < before_agg->get_checkpoint().size(); i++)
+    for (size_t i = 0; i < before_agg->get_checkpoint().size(); i++)
     {
       ASSERT_EQ(before_agg->get_checkpoint()[i], after_agg->get_checkpoint()[i]);
     }
-    for (int i = 0; i < before_agg->get_boundaries().size(); i++)
+    for (size_t i = 0; i < before_agg->get_boundaries().size(); i++)
     {
       ASSERT_EQ(before_agg->get_boundaries()[i], after_agg->get_boundaries()[i]);
     }
-    for (int i = 0; i < before_agg->get_counts().size(); i++)
+    for (size_t i = 0; i < before_agg->get_counts().size(); i++)
     {
       ASSERT_EQ(before_agg->get_counts()[i], after_agg->get_counts()[i]);
     }
@@ -433,15 +433,15 @@ TEST(PrometheusCollector, AddMetricDataWithHistogramRecordsSuccessfully)
     auto after_agg     = nostd::get<std::shared_ptr<metric_sdk::Aggregator<float>>>(after_agg_var);
 
     ASSERT_EQ(before_agg->get_checkpoint().size(), after_agg->get_checkpoint().size());
-    for (int i = 0; i < before_agg->get_checkpoint().size(); i++)
+    for (size_t i = 0; i < before_agg->get_checkpoint().size(); i++)
     {
       ASSERT_EQ(before_agg->get_checkpoint()[i], after_agg->get_checkpoint()[i]);
     }
-    for (int i = 0; i < before_agg->get_boundaries().size(); i++)
+    for (size_t i = 0; i < before_agg->get_boundaries().size(); i++)
     {
       ASSERT_EQ(before_agg->get_boundaries()[i], after_agg->get_boundaries()[i]);
     }
-    for (int i = 0; i < before_agg->get_counts().size(); i++)
+    for (size_t i = 0; i < before_agg->get_counts().size(); i++)
     {
       ASSERT_EQ(before_agg->get_counts()[i], after_agg->get_counts()[i]);
     }
@@ -512,7 +512,7 @@ TEST(PrometheusCollector, AddMetricDataWithExactRecordsSuccessfully)
     else
     {
       ASSERT_EQ(before_agg->get_checkpoint().size(), after_agg->get_checkpoint().size());
-      for (int i = 0; i < before_agg->get_checkpoint().size(); i++)
+      for (size_t i = 0; i < before_agg->get_checkpoint().size(); i++)
       {
         ASSERT_EQ(before_agg->get_checkpoint()[i], after_agg->get_checkpoint()[i]);
       }

--- a/exporters/prometheus/test/prometheus_exporter_utils_test.cc
+++ b/exporters/prometheus/test/prometheus_exporter_utils_test.cc
@@ -87,7 +87,7 @@ void assert_histogram(prometheus_client::MetricFamily &metric,
 {
   int cumulative_count = 0;
   auto buckets         = metric.metric[0].histogram.bucket;
-  for (int i = 0; i < buckets.size(); i++)
+  for (size_t i = 0; i < buckets.size(); i++)
   {
     auto bucket = buckets[i];
     if (i != buckets.size() - 1)

--- a/sdk/src/metrics/meter.cc
+++ b/sdk/src/metrics/meter.cc
@@ -547,7 +547,7 @@ void Meter::RecordShortBatch(const trace::KeyValueIterable &labels,
                              nostd::span<metrics_api::SynchronousInstrument<short> *> instruments,
                              nostd::span<const short> values) noexcept
 {
-  for (int i = 0; i < instruments.size(); ++i)
+  for (size_t i = 0; i < instruments.size(); ++i)
   {
     instruments[i]->update(values[i], labels);
   }
@@ -557,7 +557,7 @@ void Meter::RecordIntBatch(const trace::KeyValueIterable &labels,
                            nostd::span<metrics_api::SynchronousInstrument<int> *> instruments,
                            nostd::span<const int> values) noexcept
 {
-  for (int i = 0; i < instruments.size(); ++i)
+  for (size_t i = 0; i < instruments.size(); ++i)
   {
     instruments[i]->update(values[i], labels);
   }
@@ -567,7 +567,7 @@ void Meter::RecordFloatBatch(const trace::KeyValueIterable &labels,
                              nostd::span<metrics_api::SynchronousInstrument<float> *> instruments,
                              nostd::span<const float> values) noexcept
 {
-  for (int i = 0; i < instruments.size(); ++i)
+  for (size_t i = 0; i < instruments.size(); ++i)
   {
     instruments[i]->update(values[i], labels);
   }
@@ -577,7 +577,7 @@ void Meter::RecordDoubleBatch(const trace::KeyValueIterable &labels,
                               nostd::span<metrics_api::SynchronousInstrument<double> *> instruments,
                               nostd::span<const double> values) noexcept
 {
-  for (int i = 0; i < instruments.size(); ++i)
+  for (size_t i = 0; i < instruments.size(); ++i)
   {
     instruments[i]->update(values[i], labels);
   }
@@ -738,7 +738,7 @@ bool Meter::IsValidName(nostd::string_view name)
     return false;
   else
   {
-    for (int i = 0; i < name.size(); ++i)
+    for (size_t i = 0; i < name.size(); ++i)
     {
       if (!isalnum(name[i]) && name[i] != '_' && name[i] != '.' && name[i] != '-')
         return false;

--- a/sdk/test/metrics/sketch_aggregator_test.cc
+++ b/sdk/test/metrics/sketch_aggregator_test.cc
@@ -58,7 +58,7 @@ TEST(Sketch, NormalValues)
   EXPECT_EQ(alpha.get_counts(), correct);
 
   std::vector<double> captured_bounds = alpha.get_boundaries();
-  for (int i = 0; i < captured_bounds.size(); i++)
+  for (size_t i = 0; i < captured_bounds.size(); i++)
   {
     captured_bounds[i] = round(captured_bounds[i]);
   }


### PR DESCRIPTION
As indicated in subject, quick fix to eliminate compile time warnings originating from `-Wsign-compare` and `-Wreorder` flags.