### PR TITLE
Correct type of size_t - size_t to be size_t in tracez_processor_test

### DIFF
--- a/ext/test/zpages/tracez_processor_test.cc
+++ b/ext/test/zpages/tracez_processor_test.cc
@@ -55,7 +55,7 @@ bool ContainsNames(const std::vector<std::string> &names,
   if (name_end == 0)
     name_end = names.size();
 
-  unsigned int num_names = name_end - name_start;
+  size_t num_names = name_end - name_start;
 
   if (num_names > running.size() ||  // More names than spans, can't have all names
       (one_to_one_correspondence && num_names != running.size()))


### PR DESCRIPTION
A minor fix of the result type of `size_t - size_t`.