### PR TITLE
cmake build with gcc4.8

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,9 @@ jobs:
         sudo ./ci/setup_ci_environment.sh
         sudo ./ci/setup_cmake.sh
         sudo ./ci/install_gcc48.sh
+      env:
+        CC: /usr/bin/gcc-4.8
+        CXX: /usr/bin/g++-4.8
     - name: run tests
       run: ./ci/do_ci.sh cmake.legacy.test
       env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,7 @@ jobs:
         sudo ./ci/install_gcc48.sh
     - name: setup cmake
       run: |
-        sudo CC=usr/bin/gcc-4.8 CXX=/usr/bin/g++-4.8 ./ci/setup_cmake.sh
+        sudo CC=/usr/bin/gcc-4.8 CXX=/usr/bin/g++-4.8 ./ci/setup_cmake.sh
     - name: run tests
       run: ./ci/do_ci.sh cmake.legacy.test
       env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,10 +32,7 @@ jobs:
         sudo ./ci/install_gcc48.sh
     - name: setup cmake
       run: |
-        sudo ./ci/setup_cmake.sh
-      env:
-        CC: /usr/bin/gcc-4.8
-        CXX: /usr/bin/g++-4.8
+        sudo CC=usr/bin/gcc-4.8 CXX=/usr/bin/g++-4.8 ./ci/setup_cmake.sh
     - name: run tests
       run: ./ci/do_ci.sh cmake.legacy.test
       env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
       run: ./ci/do_ci.sh cmake.exporter.prometheus.test
 
   cmake_gcc_48_test:
-    name: Legacy CMake
+    name: CMake gcc 4.8
     runs-on: ubuntu-18.04
     steps:
     - uses: actions/checkout@v2
@@ -38,6 +38,7 @@ jobs:
       env:
         CC: /usr/bin/gcc-4.8
         CXX: /usr/bin/g++-4.8
+
   cmake_test_cxx20:
     name: CMake C++20 test
     runs-on: ubuntu-20.04

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,8 +29,10 @@ jobs:
     - name: setup
       run: |
         sudo ./ci/setup_ci_environment.sh
-        sudo ./ci/setup_cmake.sh
         sudo ./ci/install_gcc48.sh
+    - name: setup cmake
+      run: |
+        sudo ./ci/setup_cmake.sh
       env:
         CC: /usr/bin/gcc-4.8
         CXX: /usr/bin/g++-4.8

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,21 @@ jobs:
     - name: run prometheus exporter tests
       run: ./ci/do_ci.sh cmake.exporter.prometheus.test
 
+  cmake_gcc_48_test:
+    name: Legacy CMake
+    runs-on: ubuntu-18.04
+    steps:
+    - uses: actions/checkout@v2
+    - name: setup
+      run: |
+        sudo ./ci/setup_ci_environment.sh
+        sudo ./ci/setup_cmake.sh
+        sudo ./ci/install_gcc48.sh
+    - name: run tests
+      run: ./ci/do_ci.sh cmake.legacy.test
+      env:
+        CC: /usr/bin/gcc-4.8
+        CXX: /usr/bin/g++-4.8
   cmake_test_cxx20:
     name: CMake C++20 test
     runs-on: ubuntu-20.04

--- a/ci/do_ci.sh
+++ b/ci/do_ci.sh
@@ -39,7 +39,7 @@ elif [[ "$1" == "cmake.legacy.test" ]]; then
         "${SRC_DIR}"
   make
   make test
-  exit 0;
+  exit 0
 elif [[ "$1" == "cmake.exporter.otprotocol.test" ]]; then
   cd "${BUILD_DIR}"
   rm -rf *

--- a/ci/do_ci.sh
+++ b/ci/do_ci.sh
@@ -30,6 +30,16 @@ elif [[ "$1" == "cmake.c++20.test" ]]; then
   make
   make test
   exit 0
+elif [[ "$1" == "cmake.legacy.test" ]]; then
+  cd "${BUILD_DIR}"
+  rm -rf *
+  cmake -DCMAKE_BUILD_TYPE=Debug  \
+        -DCMAKE_CXX_FLAGS="-Werror" \
+	-DCMAKE_CXX_STANDARD=11 \
+	"${SRC_DIR}"
+  make
+  make test
+  exit 0;
 elif [[ "$1" == "cmake.exporter.otprotocol.test" ]]; then
   cd "${BUILD_DIR}"
   rm -rf *

--- a/ci/do_ci.sh
+++ b/ci/do_ci.sh
@@ -35,8 +35,8 @@ elif [[ "$1" == "cmake.legacy.test" ]]; then
   rm -rf *
   cmake -DCMAKE_BUILD_TYPE=Debug  \
         -DCMAKE_CXX_FLAGS="-Werror" \
-	-DCMAKE_CXX_STANDARD=11 \
-	"${SRC_DIR}"
+        -DCMAKE_CXX_STANDARD=11 \
+        "${SRC_DIR}"
   make
   make test
   exit 0;

--- a/ci/setup_cmake.sh
+++ b/ci/setup_cmake.sh
@@ -21,7 +21,6 @@ set -e
 # Follows these instructions for setting up gtest
 # https://www.eriksmistad.no/getting-started-with-google-test-on-ubuntu/
 pushd /usr/src/gtest
-echo $CC." --  ".$CXX
 cmake CMakeLists.txt
 make
 cp *.a /usr/lib || cp lib/*.a /usr/lib

--- a/ci/setup_cmake.sh
+++ b/ci/setup_cmake.sh
@@ -21,6 +21,7 @@ set -e
 # Follows these instructions for setting up gtest
 # https://www.eriksmistad.no/getting-started-with-google-test-on-ubuntu/
 pushd /usr/src/gtest
+echo $CC." --  ".$CXX
 cmake CMakeLists.txt
 make
 cp *.a /usr/lib || cp lib/*.a /usr/lib

--- a/ci/setup_cmake.sh
+++ b/ci/setup_cmake.sh
@@ -20,7 +20,6 @@ set -e
 
 # Follows these instructions for setting up gtest
 # https://www.eriksmistad.no/getting-started-with-google-test-on-ubuntu/
-echo $CC."--"$CXX
 pushd /usr/src/gtest
 cmake CMakeLists.txt
 make

--- a/ci/setup_cmake.sh
+++ b/ci/setup_cmake.sh
@@ -20,6 +20,7 @@ set -e
 
 # Follows these instructions for setting up gtest
 # https://www.eriksmistad.no/getting-started-with-google-test-on-ubuntu/
+echo $CC."--"$CXX
 pushd /usr/src/gtest
 cmake CMakeLists.txt
 make


### PR DESCRIPTION
We support experimental C++11 on gcc4.8 , but cmake build is missing for that. Adding a GitHub action for that.