### PR TITLE
Add lalitb and ThomsonTan as approvers

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,9 +31,11 @@ Meeting notes are available as a public [Google doc](https://docs.google.com/doc
 
 Approvers ([@open-telemetry/cpp-approvers](https://github.com/orgs/open-telemetry/teams/cpp-approvers)):
 
-- [Max Golovanov](https://github.com/maxgolov), Microsoft
+- [Lalit Kumar Bhasin](https://github.com/lalitb), Microsoft
 - [Johannes Tax](https://github.com/pyohannes), New Relic
+- [Max Golovanov](https://github.com/maxgolov), Microsoft
 - [Ryan Burn](https://github.com/rnburn), Lightstep
+- [Tom Tan](https://github.com/ThomsonTan), Microsoft
 
 *Find more about the approver role in [community repository](https://github.com/open-telemetry/community/blob/master/community-membership.md#approver).*
 


### PR DESCRIPTION
Discussed during the Oct. 7th, 2020 SIG meeting.

@lalitb has been actively contributing to OpenTelemetry C++ across many modules as well as general improvements to the CI and infrastructure. He is also actively driving the better design of OpenTelemetry C++ API/SDK.

PRs @lalitb has authored:
* #354
* #352
* #351 
* #309
* #330

PRs @lalitb has contributed:
* #349
* #211
* #322
* #353
* #54
* #290
* #301
* #315

@ThomsonTan has been activity contributing to the overall OpenTelemetry project, including the specs, .NET client and C++ client.

PRs @ThomsonTan has authored in OpenTelemetry C++:

* #300
* #301
* #327
* #338
* #343
* #346
* #347
* #353

@ThomsonTan has also contributed to several PRs in multiple OpenTelemetry repositories, there are too many to list out here.
