### PR TITLE
Simplify walking the values in SpanDataAttributeValue

### DIFF
--- a/exporters/ostream/include/opentelemetry/exporters/ostream/span_exporter.h
+++ b/exporters/ostream/include/opentelemetry/exporters/ostream/span_exporter.h
@@ -62,19 +62,24 @@ private:
                                        {16, "UNAUTHENTICATED"}};
 
   /*
-    print_array and print_value are used to print out the value of an attribute within a vector.
+    print_value is used to print out the value of an attribute within a vector.
     These values are held in a variant which makes the process of printing them much more
     complicated.
   */
 
   template <typename T>
-  void print_array(sdktrace::SpanDataAttributeValue &value)
+  void print_value(const T &item)
+  {
+    sout_ << item;
+  }
+
+  template <typename T>
+  void print_value(const std::vector<T> &vec)
   {
     sout_ << '[';
-    auto s    = nostd::get<std::vector<T>>(value);
     size_t i  = 1;
-    size_t sz = s.size();
-    for (auto v : s)
+    size_t sz = vec.size();
+    for (auto v : vec)
     {
       sout_ << v;
       if (i != sz)
@@ -86,62 +91,7 @@ private:
 
   void print_value(sdktrace::SpanDataAttributeValue &value)
   {
-    if (nostd::holds_alternative<bool>(value))
-    {
-      sout_ << nostd::get<bool>(value);
-    }
-    else if (nostd::holds_alternative<int32_t>(value))
-    {
-      sout_ << nostd::get<int32_t>(value);
-    }
-    else if (nostd::holds_alternative<uint32_t>(value))
-    {
-      sout_ << nostd::get<uint32_t>(value);
-    }
-    else if (nostd::holds_alternative<int64_t>(value))
-    {
-      sout_ << nostd::get<int64_t>(value);
-    }
-    else if (nostd::holds_alternative<uint64_t>(value))
-    {
-      sout_ << nostd::get<uint64_t>(value);
-    }
-    else if (nostd::holds_alternative<double>(value))
-    {
-      sout_ << nostd::get<double>(value);
-    }
-    else if (nostd::holds_alternative<std::string>(value))
-    {
-      sout_ << nostd::get<std::string>(value);
-    }
-    else if (nostd::holds_alternative<std::vector<bool>>(value))
-    {
-      print_array<bool>(value);
-    }
-    else if (nostd::holds_alternative<std::vector<int32_t>>(value))
-    {
-      print_array<int32_t>(value);
-    }
-    else if (nostd::holds_alternative<std::vector<uint32_t>>(value))
-    {
-      print_array<uint32_t>(value);
-    }
-    else if (nostd::holds_alternative<std::vector<int64_t>>(value))
-    {
-      print_array<int64_t>(value);
-    }
-    else if (nostd::holds_alternative<std::vector<uint64_t>>(value))
-    {
-      print_array<uint64_t>(value);
-    }
-    else if (nostd::holds_alternative<std::vector<double>>(value))
-    {
-      print_array<double>(value);
-    }
-    else if (nostd::holds_alternative<std::vector<std::string>>(value))
-    {
-      print_array<std::string>(value);
-    }
+    nostd::visit([this](auto &&arg) { print_value(arg); }, value);
   }
 
   void printAttributes(std::unordered_map<std::string, sdktrace::SpanDataAttributeValue> map)

--- a/exporters/ostream/include/opentelemetry/exporters/ostream/span_exporter.h
+++ b/exporters/ostream/include/opentelemetry/exporters/ostream/span_exporter.h
@@ -89,9 +89,24 @@ private:
     sout_ << ']';
   }
 
+  class SpanDataAttributeValueVisitor
+  {
+  public:
+    SpanDataAttributeValueVisitor(OStreamSpanExporter &exporter) : exporter_(exporter) {}
+
+    template <typename T>
+    void operator()(T &&arg)
+    {
+      exporter_.print_value(arg);
+    }
+
+  private:
+    OStreamSpanExporter &exporter_;
+  };
+
   void print_value(sdktrace::SpanDataAttributeValue &value)
   {
-    nostd::visit([this](auto &&arg) { print_value(arg); }, value);
+    nostd::visit(SpanDataAttributeValueVisitor(*this), value);
   }
 
   void printAttributes(std::unordered_map<std::string, sdktrace::SpanDataAttributeValue> map)


### PR DESCRIPTION
In `OStreamSpanExporter` class, it prints the value of `SpanDataAttributeValue` which is in type `nostd::variant`. The print function enumerates (`if/else if/...`) all the types in this `nostd::variant`, but the output of the value is almost the same (categorized into vector and primitive types) and it needs to be updated for any change in the associated `nostd::variant` type.

The PR replaces the type enumeration by `nostd::visit` which visits the variant with correct type, and dispatches to right overloaded `print_value` function.