### PR TITLE
Add thread safety to SimpleSpanProcessor

### DIFF
--- a/api/include/opentelemetry/common/spin_lock_mutex.h
+++ b/api/include/opentelemetry/common/spin_lock_mutex.h
@@ -1,0 +1,54 @@
+#pragma once
+
+#include <atomic>
+
+#include "opentelemetry/version.h"
+
+OPENTELEMETRY_BEGIN_NAMESPACE
+namespace common
+{
+
+/**
+ * A Mutex which uses atomic flags and spin-locks instead of halting threads.
+ *
+ * This class implements the `BasicLockable` specification:
+ * https://en.cppreference.com/w/cpp/named_req/BasicLockable
+ */
+class SpinLockMutex
+{
+public:
+  SpinLockMutex() noexcept {}
+  ~SpinLockMutex() noexcept            = default;
+  SpinLockMutex(const SpinLockMutex &) = delete;
+  SpinLockMutex &operator=(const SpinLockMutex &) = delete;
+  SpinLockMutex &operator=(const SpinLockMutex &) volatile = delete;
+
+  /**
+   * Blocks until a lock can be obtained for the current thread.
+   *
+   * This mutex will spin the current CPU waiting for the lock to be available.  This can have
+   * decent performance in scenarios where there is low lock contention and lock-holders acheive
+   * their work quickly.  It degrades in scenarios where locked tasks take a long time.
+   */
+  void lock() noexcept
+  {
+    /* Note: We expect code protected by this lock to be "fast", i.e. we do NOT incrementally
+     * back-off and wait/notify here, we just loop until we have access, then try again.
+     *
+     * This has the downside that we could be spinning a long time if the exporter is slow.
+     * Note: in C++20x we could use `.wait` to make this slightly better. This should move to
+     * an exponential-back-off / wait strategy.
+     */
+    while (flag_.test_and_set(std::memory_order_acquire))
+      /** TODO - We should immmediately yield if the machine is single processor. */
+      ;
+  }
+  /** Releases the lock held by the execution agent. Throws no exceptions. */
+  void unlock() noexcept { flag_.clear(std::memory_order_release); }
+
+private:
+  std::atomic_flag flag_{ATOMIC_FLAG_INIT};
+};
+
+}  // namespace common
+OPENTELEMETRY_END_NAMESPACE

--- a/api/include/opentelemetry/metrics/provider.h
+++ b/api/include/opentelemetry/metrics/provider.h
@@ -1,7 +1,8 @@
 #pragma once
 
-#include <atomic>
+#include <mutex>
 
+#include "opentelemetry/common/spin_lock_mutex.h"
 #include "opentelemetry/metrics/meter_provider.h"
 #include "opentelemetry/metrics/noop.h"
 #include "opentelemetry/nostd/shared_ptr.h"
@@ -23,12 +24,8 @@ public:
    */
   static nostd::shared_ptr<MeterProvider> GetMeterProvider() noexcept
   {
-    while (GetLock().test_and_set(std::memory_order_acquire))
-      ;
-    auto provider = nostd::shared_ptr<MeterProvider>(GetProvider());
-    GetLock().clear(std::memory_order_release);
-
-    return provider;
+    std::lock_guard<common::SpinLockMutex> guard(GetLock());
+    return nostd::shared_ptr<MeterProvider>(GetProvider());
   }
 
   /**
@@ -36,10 +33,8 @@ public:
    */
   static void SetMeterProvider(nostd::shared_ptr<MeterProvider> tp) noexcept
   {
-    while (GetLock().test_and_set(std::memory_order_acquire))
-      ;
+    std::lock_guard<common::SpinLockMutex> guard(GetLock());
     GetProvider() = tp;
-    GetLock().clear(std::memory_order_release);
   }
 
 private:
@@ -49,9 +44,9 @@ private:
     return provider;
   }
 
-  static std::atomic_flag &GetLock() noexcept
+  static common::SpinLockMutex &GetLock() noexcept
   {
-    static std::atomic_flag lock = ATOMIC_FLAG_INIT;
+    static common::SpinLockMutex lock;
     return lock;
   }
 };

--- a/api/include/opentelemetry/trace/provider.h
+++ b/api/include/opentelemetry/trace/provider.h
@@ -1,7 +1,8 @@
 #pragma once
 
-#include <atomic>
+#include <mutex>
 
+#include "opentelemetry/common/spin_lock_mutex.h"
 #include "opentelemetry/nostd/shared_ptr.h"
 #include "opentelemetry/trace/noop.h"
 #include "opentelemetry/trace/tracer_provider.h"
@@ -23,12 +24,8 @@ public:
    */
   static nostd::shared_ptr<TracerProvider> GetTracerProvider() noexcept
   {
-    while (GetLock().test_and_set(std::memory_order_acquire))
-      ;
-    auto provider = nostd::shared_ptr<TracerProvider>(GetProvider());
-    GetLock().clear(std::memory_order_release);
-
-    return provider;
+    std::lock_guard<common::SpinLockMutex> guard(GetLock());
+    return nostd::shared_ptr<TracerProvider>(GetProvider());
   }
 
   /**
@@ -36,10 +33,8 @@ public:
    */
   static void SetTracerProvider(nostd::shared_ptr<TracerProvider> tp) noexcept
   {
-    while (GetLock().test_and_set(std::memory_order_acquire))
-      ;
+    std::lock_guard<common::SpinLockMutex> guard(GetLock());
     GetProvider() = tp;
-    GetLock().clear(std::memory_order_release);
   }
 
 private:
@@ -49,9 +44,9 @@ private:
     return provider;
   }
 
-  static std::atomic_flag &GetLock() noexcept
+  static common::SpinLockMutex &GetLock() noexcept
   {
-    static std::atomic_flag lock = ATOMIC_FLAG_INIT;
+    static common::SpinLockMutex lock;
     return lock;
   }
 };

--- a/sdk/include/opentelemetry/sdk/trace/exporter.h
+++ b/sdk/include/opentelemetry/sdk/trace/exporter.h
@@ -39,6 +39,8 @@ public:
    * custom recordables or use the default SpanData recordable provided by the
    * SDK.
    * @return a newly initialized Recordable object
+   *
+   * Note: This method must be callable from multiple threads.
    */
   virtual std::unique_ptr<Recordable> MakeRecordable() noexcept = 0;
 

--- a/sdk/include/opentelemetry/sdk/trace/processor.h
+++ b/sdk/include/opentelemetry/sdk/trace/processor.h
@@ -24,6 +24,8 @@ public:
    * Create a span recordable. This requests a new span recordable from the
    * associated exporter.
    * @return a newly initialized recordable
+   *
+   * Note: This method must be callable from multiple threads.
    */
   virtual std::unique_ptr<Recordable> MakeRecordable() noexcept = 0;
 


### PR DESCRIPTION
Changes:
- Ensure calls to the configured `Exporter` are locked behind an atomic_flag.
- We use a spin-lock for now, under the assumption that Exporter calls are fast.

Notes:

1. I tried really really hard to write a test that would fail if the locking wasn't in place, and was unable to make anything consistent/worthwhile, so that's dropped.  If you have a good idea to how to write a test to ensure locking is done properly and failure to lock causes an issue, more than happy to add it.
2. I thought spin-lock usage was "ok" given two assumptions: (a) Exporter calls will be 'fast' and (b) "simple" processor is not likely to be used over the buffering processor.   If either of these are wrong, please let me know.
3. The spin-lock itself could easily be improved w/ C++20x mechanisms or by pulling in some helpful utilities to better do exponential-back-off and provide better processor instructions instead of just looping.   I think that this code would also benefit the `*Provider` classes that do similar spin-locking.
     