### PR TITLE
Document the supported C++ versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,17 @@
 
 The C++ [OpenTelemetry](https://opentelemetry.io/) client.
 
+## Supported C++ Versions
+
+Code shipped from this repository generally supports the following versions of
+C++ standards:
+
+* ISO/IEC 14882:2011 (C++11, C++0x)
+* ISO/IEC 14882:2014 (C++14, C++1y)
+* ISO/IEC 14882:2017 (C++17, C++1z)
+
+Any exceptions to this are noted in the individual `README.md` files.
+
 ## Installation
 
 TBD


### PR DESCRIPTION
As discussed in the Oct. 12th, 2020 SIG meeting, I added the supported C++ standard versions to the README.