### PR TITLE
Build gRPC with CMake for OLTP exporter

### DIFF
--- a/exporters/otlp/CMakeLists.txt
+++ b/exporters/otlp/CMakeLists.txt
@@ -1,6 +1,9 @@
 include_directories(include)
 
 add_library(opentelemetry_exporter_otprotocol src/recordable.cc)
+target_include_directories(
+  opentelemetry_exporter_otprotocol
+  PUBLIC $<TARGET_PROPERTY:opentelemetry_proto,INTERFACE_INCLUDE_DIRECTORIES>)
 target_link_libraries(opentelemetry_exporter_otprotocol
                       $<TARGET_OBJECTS:opentelemetry_proto>)
 

--- a/third_party/opentelemetry-proto/Protobuf.cmake
+++ b/third_party/opentelemetry-proto/Protobuf.cmake
@@ -1,48 +1,68 @@
+include(FetchContent)
+FetchContent_Declare(
+  gRPC
+  GIT_REPOSITORY https://github.com/grpc/grpc
+  GIT_TAG v1.32.0)
+FetchContent_MakeAvailable(gRPC)
+
 set(PROTO_PATH "${CMAKE_SOURCE_DIR}/third_party/opentelemetry-proto")
 
 set(COMMON_PROTO "${PROTO_PATH}/opentelemetry/proto/common/v1/common.proto")
-set(RESOURCE_PROTO "${PROTO_PATH}/opentelemetry/proto/resource/v1/resource.proto")
+set(RESOURCE_PROTO
+    "${PROTO_PATH}/opentelemetry/proto/resource/v1/resource.proto")
 set(TRACE_PROTO "${PROTO_PATH}/opentelemetry/proto/trace/v1/trace.proto")
 
-set(GENERATED_PROTOBUF_PATH "${CMAKE_BINARY_DIR}/generated/third_party/opentelemetry-proto")
+set(GENERATED_PROTOBUF_PATH
+    "${CMAKE_BINARY_DIR}/generated/third_party/opentelemetry-proto")
 
 file(MAKE_DIRECTORY "${GENERATED_PROTOBUF_PATH}")
 
-set(COMMON_PB_CPP_FILE "${GENERATED_PROTOBUF_PATH}/opentelemetry/proto/common/v1/common.pb.cc")
-set(COMMON_PB_H_FILE "${GENERATED_PROTOBUF_PATH}/opentelemetry/proto/common/v1/common.pb.h")
-set(RESOURCE_PB_CPP_FILE "${GENERATED_PROTOBUF_PATH}/opentelemetry/proto/resource/v1/resource.pb.cc")
-set(RESOURCE_PB_H_FILE "${GENERATED_PROTOBUF_PATH}/opentelemetry/proto/resource/v1/resource.pb.h")
-set(TRACE_PB_CPP_FILE "${GENERATED_PROTOBUF_PATH}/opentelemetry/proto/trace/v1/trace.pb.cc")
-set(TRACE_PB_H_FILE "${GENERATED_PROTOBUF_PATH}/opentelemetry/proto/trace/v1/trace.pb.h")
+set(COMMON_PB_CPP_FILE
+    "${GENERATED_PROTOBUF_PATH}/opentelemetry/proto/common/v1/common.pb.cc")
+set(COMMON_PB_H_FILE
+    "${GENERATED_PROTOBUF_PATH}/opentelemetry/proto/common/v1/common.pb.h")
+set(RESOURCE_PB_CPP_FILE
+    "${GENERATED_PROTOBUF_PATH}/opentelemetry/proto/resource/v1/resource.pb.cc")
+set(RESOURCE_PB_H_FILE
+    "${GENERATED_PROTOBUF_PATH}/opentelemetry/proto/resource/v1/resource.pb.h")
+set(TRACE_PB_CPP_FILE
+    "${GENERATED_PROTOBUF_PATH}/opentelemetry/proto/trace/v1/trace.pb.cc")
+set(TRACE_PB_H_FILE
+    "${GENERATED_PROTOBUF_PATH}/opentelemetry/proto/trace/v1/trace.pb.h")
+set(TRACE_GRPC_PB_CPP_FILE
+    "${GENERATED_PROTOBUF_PATH}/opentelemetry/proto/trace/v1/trace.grpc.pb.cc")
+set(TRACE_GRPC_PB_H_FILE
+    "${GENERATED_PROTOBUF_PATH}/opentelemetry/proto/trace/v1/trace.grpc.pb.h")
 
 foreach(IMPORT_DIR ${PROTOBUF_IMPORT_DIRS})
   list(APPEND PROTOBUF_INCLUDE_FLAGS "-I${IMPORT_DIR}")
 endforeach()
 
 add_custom_command(
-  OUTPUT
-    ${COMMON_PB_H_FILE}
-    ${COMMON_PB_CPP_FILE}
-    ${RESOURCE_PB_H_FILE}
-    ${RESOURCE_PB_CPP_FILE}
-    ${TRACE_PB_H_FILE}
-    ${TRACE_PB_CPP_FILE}
-  COMMAND ${PROTOBUF_PROTOC_EXECUTABLE}
-  ARGS
-    "--proto_path=${PROTO_PATH}"
-    ${PROTOBUF_INCLUDE_FLAGS}
+  OUTPUT ${COMMON_PB_H_FILE}
+         ${COMMON_PB_CPP_FILE}
+         ${RESOURCE_PB_H_FILE}
+         ${RESOURCE_PB_CPP_FILE}
+         ${TRACE_PB_H_FILE}
+         ${TRACE_PB_CPP_FILE}
+         ${TRACE_GRPC_PB_H_FILE}
+         ${TRACE_GRPC_PB_CPP_FILE}
+  COMMAND
+    ${PROTOBUF_PROTOC_EXECUTABLE} ARGS "--grpc_out=${GENERATED_PROTOBUF_PATH}"
+    "--proto_path=${PROTO_PATH}" ${PROTOBUF_INCLUDE_FLAGS}
     "--cpp_out=${GENERATED_PROTOBUF_PATH}"
-    ${COMMON_PROTO}
-    ${RESOURCE_PROTO}
-    ${TRACE_PROTO}
-)
+    --plugin=protoc-gen-grpc=$<TARGET_FILE:grpc_cpp_plugin> ${COMMON_PROTO}
+    ${RESOURCE_PROTO} ${TRACE_PROTO})
 
-include_directories(SYSTEM "${CMAKE_BINARY_DIR}/generated/third_party/opentelemetry-proto")
+include_directories(${GENERATED_PROTOBUF_PATH})
 
-add_library(opentelemetry_proto OBJECT
-    ${COMMON_PB_CPP_FILE}
-    ${RESOURCE_PB_CPP_FILE}
-    ${TRACE_PB_CPP_FILE})
-if (BUILD_SHARED_LIBS)
+add_library(
+  opentelemetry_proto OBJECT ${COMMON_PB_CPP_FILE} ${RESOURCE_PB_CPP_FILE}
+                             ${TRACE_PB_CPP_FILE} ${TRACE_GRPC_PB_CPP_FILE})
+set_target_properties(
+  opentelemetry_proto
+  PROPERTIES INTERFACE_INCLUDE_DIRECTORIES ${GENERATED_PROTOBUF_PATH}
+             INTERFACE_LINK_LIBRARIES gRPC::grpc)
+if(BUILD_SHARED_LIBS)
   set_property(TARGET opentelemetry_proto PROPERTY POSITION_INDEPENDENT_CODE ON)
 endif()


### PR DESCRIPTION
Uses FetchContent to fetch gRPC. Adds the gRPC plugin to the protoc
command to generate gRPC files. Finally, adds the path for the generated
gRPC and protobuf files to the target include directory property.

Fixes #154 