### PR TITLE
Simplify context implementation

### DIFF
--- a/api/include/opentelemetry/context/context.h
+++ b/api/include/opentelemetry/context/context.h
@@ -91,7 +91,7 @@ public:
     return false;
   }
 
-  bool operator==(const Context &other) { return (head_ == other.head_); }
+  bool operator==(const Context &other) const noexcept { return (head_ == other.head_); }
 
 private:
   // A linked list to contain the keys and values of this context node

--- a/api/include/opentelemetry/context/runtime_context.h
+++ b/api/include/opentelemetry/context/runtime_context.h
@@ -47,6 +47,7 @@ public:
   /**
    * Set the current context.
    * @param the new current context
+   * @return a token for the new current context. This never returns a nullptr.
    */
   virtual nostd::unique_ptr<Token> Attach(Context context) noexcept = 0;
 

--- a/api/include/opentelemetry/context/runtime_context.h
+++ b/api/include/opentelemetry/context/runtime_context.h
@@ -12,37 +12,20 @@ namespace context
 class Token
 {
 public:
-  bool operator==(const Context &other) noexcept { return context_ == other; }
+  bool operator==(const Context &other) const noexcept { return context_ == other; }
+
+  ~Token();
 
 private:
   friend class RuntimeContextStorage;
-
-  // The ContextDetacher object automatically attempts to detach
-  // the Token when all copies of the Token are out of scope.
-  class ContextDetacher
-  {
-  public:
-    ContextDetacher(Context context) : context_(context) {}
-
-    ~ContextDetacher();
-
-  private:
-    Context context_;
-  };
 
   Token() noexcept = default;
 
   // A constructor that sets the token's Context object to the
   // one that was passed in.
-  Token(Context context)
-  {
-    context_ = context;
+  Token(Context context) : context_(context) {}
 
-    detacher_ = nostd::shared_ptr<ContextDetacher>(new ContextDetacher(context_));
-  };
-
-  Context context_;
-  nostd::shared_ptr<ContextDetacher> detacher_;
+  const Context context_;
 };
 
 /**
@@ -65,7 +48,7 @@ public:
    * Set the current context.
    * @param the new current context
    */
-  virtual Token Attach(Context context) noexcept = 0;
+  virtual nostd::unique_ptr<Token> Attach(Context context) noexcept = 0;
 
   /**
    * Detach the context related to the given token.
@@ -75,7 +58,10 @@ public:
   virtual bool Detach(Token &token) noexcept = 0;
 
 protected:
-  Token CreateToken(Context context) noexcept { return Token(context); }
+  nostd::unique_ptr<Token> CreateToken(Context context) noexcept
+  {
+    return nostd::unique_ptr<Token>(new Token(context));
+  }
 };
 
 /**
@@ -95,7 +81,7 @@ public:
 
   // Sets the current 'Context' object. Returns a token
   // that can be used to reset to the previous Context.
-  static Token Attach(Context context) noexcept
+  static nostd::unique_ptr<Token> Attach(Context context) noexcept
   {
     return GetRuntimeContextStorage()->Attach(context);
   }
@@ -171,11 +157,9 @@ private:
   }
 };
 
-inline Token::ContextDetacher::~ContextDetacher()
+inline Token::~Token()
 {
-  context::Token token;
-  token.context_ = context_;
-  context::RuntimeContext::Detach(token);
+  context::RuntimeContext::Detach(*this);
 }
 
 // The ThreadLocalContextStorage class is a derived class from
@@ -204,11 +188,10 @@ public:
 
   // Sets the current 'Context' object. Returns a token
   // that can be used to reset to the previous Context.
-  Token Attach(Context context) noexcept override
+  nostd::unique_ptr<Token> Attach(Context context) noexcept override
   {
     GetStack().Push(context);
-    Token old_context = CreateToken(context);
-    return old_context;
+    return CreateToken(context);
   }
 
 private:

--- a/api/include/opentelemetry/trace/scope.h
+++ b/api/include/opentelemetry/trace/scope.h
@@ -41,7 +41,7 @@ public:
   {}
 
 private:
-  const nostd::unique_ptr<context::Token> token_;
+  nostd::unique_ptr<context::Token> token_;
 };
 
 }  // namespace trace

--- a/api/include/opentelemetry/trace/scope.h
+++ b/api/include/opentelemetry/trace/scope.h
@@ -35,13 +35,13 @@ public:
    * Initialize a new scope.
    * @param span the given span will be set as the currently active span.
    */
-  Scope(nostd::shared_ptr<Span> &span) noexcept
-      : token_(context::Token(context::RuntimeContext::Attach(
-            context::RuntimeContext::GetCurrent().SetValue(SpanKey, span))))
+  Scope(const nostd::shared_ptr<Span> &span) noexcept
+      : token_(context::RuntimeContext::Attach(
+            context::RuntimeContext::GetCurrent().SetValue(SpanKey, span)))
   {}
 
 private:
-  context::Token token_;
+  const nostd::unique_ptr<context::Token> token_;
 };
 
 }  // namespace trace


### PR DESCRIPTION
This PR simplifies the context implementation and fixes some minor glitches:
* `Token` objects are stored on the heap now. They were stored on the stack before, but they included heap-allocated shared pointers of `ContextDetacher` objects. Giving out `Token` objects as `unique_ptr`s greatly simplifies the implementation. It's also more efficient (managing a `unique_ptr` instead of a `shared_ptr`). If there need to be copies of a token, it can be transferred into a `shared_ptr`. With that design, we can get completely rid of the `ContextDetacher` class.
* Some optimizations around making class members `const`.

This relates to #219.