### PR TITLE
Populate trace_id and spand_id to Recordable in Recordable::AddLink

### DIFF
--- a/exporters/otlp/include/opentelemetry/exporters/otlp/recordable.h
+++ b/exporters/otlp/include/opentelemetry/exporters/otlp/recordable.h
@@ -25,7 +25,7 @@ public:
                 core::SystemTimestamp timestamp,
                 const common::KeyValueIterable &attributes) noexcept override;
 
-  void AddLink(opentelemetry::trace::SpanContext span_context,
+  void AddLink(const opentelemetry::trace::SpanContext &span_context,
                const common::KeyValueIterable &attributes) noexcept override;
 
   void SetStatus(trace::CanonicalCode code, nostd::string_view description) noexcept override;

--- a/exporters/otlp/src/recordable.cc
+++ b/exporters/otlp/src/recordable.cc
@@ -132,7 +132,7 @@ void Recordable::AddEvent(nostd::string_view name,
   });
 }
 
-void Recordable::AddLink(opentelemetry::trace::SpanContext span_context,
+void Recordable::AddLink(const opentelemetry::trace::SpanContext &span_context,
                          const common::KeyValueIterable &attributes) noexcept
 {
   auto *link = span_.add_links();
@@ -140,7 +140,12 @@ void Recordable::AddLink(opentelemetry::trace::SpanContext span_context,
     PopulateAttribute(link->add_attributes(), key, value);
     return true;
   });
-  // TODO: Populate trace_id, span_id and trace_state when these are supported by SpanContext
+
+  span_.set_trace_id(reinterpret_cast<const char *>(span_context.trace_id().Id().data()),
+                     trace::TraceId::kSize);
+  span_.set_span_id(reinterpret_cast<const char *>(span_context.span_id().Id().data()),
+                    trace::SpanId::kSize);
+  // TODO: Populate trace_state when it is supported by SpanContext
 }
 
 void Recordable::SetStatus(trace::CanonicalCode code, nostd::string_view description) noexcept

--- a/ext/include/opentelemetry/ext/zpages/threadsafe_span_data.h
+++ b/ext/include/opentelemetry/ext/zpages/threadsafe_span_data.h
@@ -165,7 +165,7 @@ public:
     duration_ = duration;
   }
 
-  void AddLink(opentelemetry::trace::SpanContext span_context,
+  void AddLink(const opentelemetry::trace::SpanContext &span_context,
                const opentelemetry::common::KeyValueIterable &attributes =
                    opentelemetry::common::KeyValueIterableView<std::map<std::string, int>>(
                        {})) noexcept override

--- a/sdk/include/opentelemetry/sdk/trace/recordable.h
+++ b/sdk/include/opentelemetry/sdk/trace/recordable.h
@@ -83,7 +83,7 @@ public:
    * @param span_context the span context of the linked span
    * @param attributes the attributes associated with the link
    */
-  virtual void AddLink(opentelemetry::trace::SpanContext span_context,
+  virtual void AddLink(const opentelemetry::trace::SpanContext &span_context,
                        const opentelemetry::common::KeyValueIterable &attributes) noexcept = 0;
 
   /**

--- a/sdk/include/opentelemetry/sdk/trace/span_data.h
+++ b/sdk/include/opentelemetry/sdk/trace/span_data.h
@@ -180,7 +180,7 @@ public:
     events_.push_back(event);
   }
 
-  void AddLink(opentelemetry::trace::SpanContext span_context,
+  void AddLink(const opentelemetry::trace::SpanContext &span_context,
                const opentelemetry::common::KeyValueIterable &attributes) noexcept override
   {
     SpanDataLink link(span_context, attributes);


### PR DESCRIPTION
This covers https://github.com/open-telemetry/opentelemetry-cpp/issues/214.

The `SpanContext` parameter was changed to const reference because `SpanContext` have quite a few Id fields which are heavy for passing by value.