### PR TITLE
Change strategy for detaching contexts

### DIFF
--- a/api/include/opentelemetry/context/runtime_context.h
+++ b/api/include/opentelemetry/context/runtime_context.h
@@ -175,8 +175,9 @@ public:
   // Return the current context.
   Context GetCurrent() noexcept override { return GetStack().Top(); }
 
-  // Resets the context to a previous value stored in the
-  // passed in token. Returns true if successful, false otherwise
+  // Resets the context to the value previous to the passed in token. This will
+  // also detach all child contexts of the passed in token.
+  // Returns true if successful, false otherwise.
   bool Detach(Token &token) noexcept override
   {
     if (!GetStack().Contains(token))

--- a/api/include/opentelemetry/context/runtime_context.h
+++ b/api/include/opentelemetry/context/runtime_context.h
@@ -179,11 +179,18 @@ public:
   // passed in token. Returns true if successful, false otherwise
   bool Detach(Token &token) noexcept override
   {
-    if (!(token == GetStack().Top()))
+    if (!GetStack().Contains(token))
     {
       return false;
     }
+
+    while (!(token == GetStack().Top()))
+    {
+      GetStack().Pop();
+    }
+
     GetStack().Pop();
+
     return true;
   }
 
@@ -212,6 +219,19 @@ private:
       }
       size_ -= 1;
       return base_[size_];
+    }
+
+    bool Contains(const Token &token) const noexcept
+    {
+      for (size_t pos = size_; pos > 0; --pos)
+      {
+        if (token == base_[pos - 1])
+        {
+          return true;
+        }
+      }
+
+      return false;
     }
 
     // Returns the Context at the top of the stack.

--- a/api/include/opentelemetry/context/runtime_context.h
+++ b/api/include/opentelemetry/context/runtime_context.h
@@ -180,6 +180,13 @@ public:
   // Returns true if successful, false otherwise.
   bool Detach(Token &token) noexcept override
   {
+    // In most cases, the context to be detached is on the top of the stack.
+    if (token == GetStack().Top())
+    {
+      GetStack().Pop();
+      return true;
+    }
+
     if (!GetStack().Contains(token))
     {
       return false;


### PR DESCRIPTION
With the existing solution, users had to make sure that they always detached contexts in exactly the reverse orders they were attached. So, for attaching contexts in the order `A - B - C`, they have to be detached in the order `C - B - A`. If a user would try to detach `B` before `C`, this would lead to an error (which the user doesn't notice if they don't explicitly check the return code of `Detach`). This can lead problems if a user forgets to detach a context (in this case, this context would never be detached).

With this PR the strategy is changed so that if a context is detached, all it's active child contexts are detached too. So if a user attaches contexts in the order `A - B - C`, and then detached `B`, both `B` and `C` will be detached. This is a much more robust solution that will avoid dangling contexts.

Fixes #219.