### PR TITLE
Update shared_ptr_test.cc

### DIFF
--- a/api/test/nostd/shared_ptr_test.cc
+++ b/api/test/nostd/shared_ptr_test.cc
@@ -1,5 +1,6 @@
 #include "opentelemetry/nostd/shared_ptr.h"
 
+#include <algorithm>
 #include <gtest/gtest.h>
 
 using opentelemetry::nostd::shared_ptr;

--- a/api/test/nostd/shared_ptr_test.cc
+++ b/api/test/nostd/shared_ptr_test.cc
@@ -1,7 +1,7 @@
 #include "opentelemetry/nostd/shared_ptr.h"
 
-#include <algorithm>
 #include <gtest/gtest.h>
+#include <algorithm>
 
 using opentelemetry::nostd::shared_ptr;
 

--- a/api/test/nostd/shared_ptr_test.cc
+++ b/api/test/nostd/shared_ptr_test.cc
@@ -1,6 +1,7 @@
 #include "opentelemetry/nostd/shared_ptr.h"
 
 #include <gtest/gtest.h>
+
 #include <algorithm>
 
 using opentelemetry::nostd::shared_ptr;

--- a/ci/do_ci.sh
+++ b/ci/do_ci.sh
@@ -156,6 +156,7 @@ elif [[ "$1" == "format" ]]; then
   if [[ ! -z "$CHANGED" ]]; then
     echo "The following files have changes:"
     echo "$CHANGED"
+    git diff
     exit 1
   fi
   exit 0


### PR DESCRIPTION
`std::sort` and `std::reverse` used in this test both require `#include <algorithm>` [ref](https://en.cppreference.com/w/cpp/algorithm/sort)

However, this include was missing. How found it: I was experimenting with different version of Google Test and gcc-9.x with CMake build and hit the compilation issue. It appears that the header was previously included by the `gtest` header. But this is no longer the case if we upgrade to recent / latest version of Google Test.

Thus, fixing this by adding the proper missing include.