### PR TITLE
Switch strerror to strerror_s

### DIFF
--- a/examples/plugin/load/main.cc
+++ b/examples/plugin/load/main.cc
@@ -24,7 +24,9 @@ int main(int argc, char *argv[])
   std::ifstream config_in{argv[2]};
   if (!config_in.good())
   {
-    std::cerr << "Failed to open config file: " << std::strerror(errno) << "\n";
+    char err_msg[256] = {'\0',};
+    strerror_s(err_msg, sizeof(err_msg), errno);
+    std::cerr << "Failed to open config file: " << err_msg << "\n";
     return -1;
   }
   std::string config{std::istreambuf_iterator<char>{config_in}, std::istreambuf_iterator<char>{}};

--- a/examples/plugin/load/main.cc
+++ b/examples/plugin/load/main.cc
@@ -24,11 +24,7 @@ int main(int argc, char *argv[])
   std::ifstream config_in{argv[2]};
   if (!config_in.good())
   {
-    char err_msg[256] = {
-        '\0',
-    };
-    strerror_s(err_msg, sizeof(err_msg), errno);
-    std::cerr << "Failed to open config file: " << err_msg << "\n";
+    std::perror("Failed to open config file");
     return -1;
   }
   std::string config{std::istreambuf_iterator<char>{config_in}, std::istreambuf_iterator<char>{}};

--- a/examples/plugin/load/main.cc
+++ b/examples/plugin/load/main.cc
@@ -24,7 +24,9 @@ int main(int argc, char *argv[])
   std::ifstream config_in{argv[2]};
   if (!config_in.good())
   {
-    char err_msg[256] = {'\0',};
+    char err_msg[256] = {
+        '\0',
+    };
     strerror_s(err_msg, sizeof(err_msg), errno);
     std::cerr << "Failed to open config file: " << err_msg << "\n";
     return -1;


### PR DESCRIPTION
`strerror` triggers  below warning when building by MSVC. Follow the
suggestion and switch to `strerror_s`.

warning C4996: 'strerror': This function or variable may be unsafe.
Consider using strerror_s instead. To disable deprecation, use
_CRT_SECURE_NO_WARNINGS. See online help for details.