### PR TITLE
Add missing CI test to README

### DIFF
--- a/ci/README.md
+++ b/ci/README.md
@@ -3,6 +3,7 @@
 CI tests can be run on docker by invoking the script `./ci/run_docker.sh ./ci/do_ci.sh <TARGET>` where the targets are:
 
 * `cmake.test`: build cmake targets and run tests.
+* `cmake.legacy.test`: build cmake targets with gcc 4.8 and run tests.
 * `cmake.c++20.test`: build cmake targets with the C++20 standard and run tests.
 * `cmake.test_example_plugin`: build and test an example OpenTelemetry plugin.
 * `cmake.exporter.otprotocol.test`: build and test the otprotocol exporter


### PR DESCRIPTION
This PR adds the missing Github Actions CI test, `Cmake gcc 4.8`, to the `ci/README.md` file. 

cc @alolita