### PR TITLE
Add alolita as a Triager

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ Maintainers ([@open-telemetry/cpp-maintainers](https://github.com/orgs/open-tele
 
 Triagers ([@open-telemetry/cpp-triagers](https://github.com/orgs/open-telemetry/teams/cpp-triagers)):
 
+* [Alolita Sharma](https://github.com/alolita), Amazon
 * [Jodee Varney](https://github.com/jodeev), New Relic
 
 *Find more about the maintainer role in [community repository](https://github.com/open-telemetry/community/blob/master/community-membership.md#maintainer).*


### PR DESCRIPTION
@alolita has been helping multiple projects across the OpenTelemetry community. She has been one of the key stakeholders of the OpenTelemetry C++ metrics prototype, and now driving the C++ logging prototype.

Related to #410.

https://github.com/open-telemetry/community/blob/master/community-membership.md#triager