### PR TITLE
Updating PR Guidelines

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -99,9 +99,10 @@ To run tests locally, please read the [CI instructions](ci/README.md).
 
 A PR is considered to be **ready to merge** when:
 
-* It has received at least one approval from [Approvers](https://github.com/open-telemetry/community/blob/master/community-membership.md#approver)
-  / [Maintainers](https://github.com/open-telemetry/community/blob/master/community-membership.md#maintainer)
-  (at different companies).
+* It has received two approvals with at least one approval from [Approver](https://github.com/open-telemetry/community/blob/master/community-membership.md#approver)
+  / [Maintainer](https://github.com/open-telemetry/community/blob/master/community-membership.md#maintainer)
+  (at different company).
+* A pull reqeust opened by an Approver / Maintainer can be merged with only one review from  Approver / Maintainer (at different company).
 * Major feedback items/points are resolved.
 * It has been open for review for at least one working day. This gives people
   reasonable time to review.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -102,7 +102,7 @@ A PR is considered to be **ready to merge** when:
 * It has received two approvals with at least one approval from [Approver](https://github.com/open-telemetry/community/blob/master/community-membership.md#approver)
   / [Maintainer](https://github.com/open-telemetry/community/blob/master/community-membership.md#maintainer)
   (at different company).
-* A pull reqeust opened by an Approver / Maintainer can be merged with only one review from  Approver / Maintainer (at different company).
+* A pull reqeust opened by an Approver / Maintainer can be merged with only one approval from  Approver / Maintainer (at different company).
 * Major feedback items/points are resolved.
 * It has been open for review for at least one working day. This gives people
   reasonable time to review.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -99,7 +99,7 @@ To run tests locally, please read the [CI instructions](ci/README.md).
 
 A PR is considered to be **ready to merge** when:
 
-* It has received atleast one approval from [Approvers](https://github.com/open-telemetry/community/blob/master/community-membership.md#approver)
+* It has received at least one approval from [Approvers](https://github.com/open-telemetry/community/blob/master/community-membership.md#approver)
   / [Maintainers](https://github.com/open-telemetry/community/blob/master/community-membership.md#maintainer)
   (at different companies).
 * Major feedback items/points are resolved.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -93,12 +93,13 @@ To run tests locally, please read the [CI instructions](ci/README.md).
   as `work-in-progress`, or mark it as [`draft`](https://github.blog/2019-02-14-introducing-draft-pull-requests/).
 * Make sure [CLA](https://identity.linuxfoundation.org/projects/cncf) is
   signed and CI is clear.
+* For non-trivial changes, please update the [CHANGELOG](./CHANGELOG.md).
 
 ### How to Get PRs Merged
 
 A PR is considered to be **ready to merge** when:
 
-* It has received two approvals from [Approvers](https://github.com/open-telemetry/community/blob/master/community-membership.md#approver)
+* It has received atleast one approval from [Approvers](https://github.com/open-telemetry/community/blob/master/community-membership.md#approver)
   / [Maintainers](https://github.com/open-telemetry/community/blob/master/community-membership.md#maintainer)
   (at different companies).
 * Major feedback items/points are resolved.
@@ -108,6 +109,13 @@ A PR is considered to be **ready to merge** when:
 * Urgent fixes can take exceptions as long as it has been actively communicated.
 
 Any Approver / Maintainer can merge the PR once it is **ready to merge**.
+
+If a PR has been stuck (e.g. there are lots of debates and people couldn't agree on each other), the owner should try to get people aligned by:
+
+* Consolidating the perspectives and putting a summary in the PR. It is recommended to add a link into the PR description, which points to a comment with a summary in the PR conversation
+* Stepping back to see if it makes sense to narrow down the scope of the PR or split it up.
+
+If none of the above worked and the PR has been stuck for more than 2 weeks, the owner should bring it to the (OpenTelemetry C++ SIG meeting)[https://zoom.us/j/8203130519].
 
 ## Useful Resources
 


### PR DESCRIPTION
Trying to update existing PR guidelines to ensure smoother ( and probably faster ) merge process:

 - With current small number of Approvers ( and their distribution across different companies ), making number of required approvals ( from different company ) as 1 ( from existing 2 ). We can review this after course of time once we have good distribution.
- Requirement for Updating the changelog (CHANGELOG.md) for non-trivial changes.
- Handling lots of discussions in given PR.