### PR TITLE
Add -recursive to recommended git clone command line

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -3,6 +3,7 @@
 ## C++ and C source files
 *.c                     text eol=lf diff=cpp
 *.h                     text eol=lf diff=cpp
+*.cc                    text eol=lf diff=cpp
 *.cpp                   text eol=lf diff=cpp
 *.cxx                   text eol=lf diff=cpp
 *.hpp                   text eol=lf diff=cpp

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -64,7 +64,7 @@ requests (PRs).
 To create a new PR, fork the project in GitHub and clone the upstream repo:
 
 ```sh
-git clone https://github.com/open-telemetry/opentelemetry-cpp.git
+git clone --recursive https://github.com/open-telemetry/opentelemetry-cpp.git
 ```
 
 Add your fork as a remote:


### PR DESCRIPTION
`-resursive` is available an option for git since 1.6.5 which clones all submodules. The current version of git is 2.28 or above so I think it is fine to expect `-recursive` for git. This would be very helpful as we added many dependencies as submodule to this repo.

Also add line-ending setting for `.cc` file which is missing.