### PR TITLE
Remove unnecessary call on Span::End()

### DIFF
--- a/examples/otlp/foo_library/foo_library.cc
+++ b/examples/otlp/foo_library/foo_library.cc
@@ -13,12 +13,12 @@ nostd::shared_ptr<trace::Tracer> get_tracer()
 
 void f1()
 {
-  auto span = get_tracer()->StartSpan("f1");
+  auto scoped_span = trace::Scope(get_tracer()->StartSpan("f1"));
 }
 
 void f2()
 {
-  auto span = get_tracer()->StartSpan("f2");
+  auto scoped_span = trace::Scope(get_tracer()->StartSpan("f2"));
 
   f1();
   f1();
@@ -27,7 +27,7 @@ void f2()
 
 void foo_library()
 {
-  auto span = get_tracer()->StartSpan("library");
+  auto scoped_span = trace::Scope(get_tracer()->StartSpan("library"));
 
   f2();
 }

--- a/examples/otlp/foo_library/foo_library.cc
+++ b/examples/otlp/foo_library/foo_library.cc
@@ -11,13 +11,9 @@ nostd::shared_ptr<trace::Tracer> get_tracer()
   return provider->GetTracer("foo_library");
 }
 
-// TODO: Remove all calls to span->End() once context memory issue is fixed
-// (https://github.com/open-telemetry/opentelemetry-cpp/issues/287)
-
 void f1()
 {
   auto span = get_tracer()->StartSpan("f1");
-  span->End();
 }
 
 void f2()
@@ -26,7 +22,6 @@ void f2()
 
   f1();
   f1();
-  span->End();
 }
 }  // namespace
 
@@ -35,5 +30,4 @@ void foo_library()
   auto span = get_tracer()->StartSpan("library");
 
   f2();
-  span->End();
 }


### PR DESCRIPTION
`End()` calls are added to Span so explicit call is no longer necessary, see https://github.com/open-telemetry/opentelemetry-cpp/issues/287#issuecomment-699019923