### PR TITLE
Add explicit conversion from size_t to int for shared_ptr_test

### DIFF
--- a/api/test/nostd/shared_ptr_test.cc
+++ b/api/test/nostd/shared_ptr_test.cc
@@ -163,7 +163,7 @@ static void SharedPtrTest_Sort(size_t size = 10)
 {
   std::vector<shared_ptr<const int>> nums;
 
-  for (int i = size; i > 0; i--)
+  for (int i = static_cast<int>(size); i > 0; i--)
   {
     nums.push_back(shared_ptr<int>(new int(i)));
   }


### PR DESCRIPTION
`size_t` could be wider than `int` could make the conversion explicit.