### PR TITLE
Use a consistent key for the current span in the context

### DIFF
--- a/api/include/opentelemetry/trace/propagation/http_trace_context.h
+++ b/api/include/opentelemetry/trace/propagation/http_trace_context.h
@@ -78,16 +78,14 @@ public:
                            context::Context &context) noexcept override
   {
     SpanContext span_context    = ExtractImpl(getter, carrier);
-    nostd::string_view span_key = "current-span";
     nostd::shared_ptr<Span> sp{new DefaultSpan(span_context)};
-    return context.SetValue(span_key, sp);
+    return context.SetValue(kSpanKey, sp);
   }
 
   static SpanContext GetCurrentSpan(const context::Context &context)
   {
-    const nostd::string_view span_key = "current-span";
     context::Context ctx(context);
-    context::ContextValue span = ctx.GetValue(span_key);
+    context::ContextValue span = ctx.GetValue(kSpanKey);
     if (nostd::holds_alternative<nostd::shared_ptr<Span>>(span))
     {
       return nostd::get<nostd::shared_ptr<Span>>(span).get()->GetContext();

--- a/api/include/opentelemetry/trace/propagation/http_trace_context.h
+++ b/api/include/opentelemetry/trace/propagation/http_trace_context.h
@@ -77,7 +77,7 @@ public:
                            const T &carrier,
                            context::Context &context) noexcept override
   {
-    SpanContext span_context    = ExtractImpl(getter, carrier);
+    SpanContext span_context = ExtractImpl(getter, carrier);
     nostd::shared_ptr<Span> sp{new DefaultSpan(span_context)};
     return context.SetValue(kSpanKey, sp);
   }

--- a/api/include/opentelemetry/trace/scope.h
+++ b/api/include/opentelemetry/trace/scope.h
@@ -37,7 +37,7 @@ public:
    */
   Scope(const nostd::shared_ptr<Span> &span) noexcept
       : token_(context::RuntimeContext::Attach(
-            context::RuntimeContext::GetCurrent().SetValue(SpanKey, span)))
+            context::RuntimeContext::GetCurrent().SetValue(kSpanKey, span)))
   {}
 
 private:

--- a/api/include/opentelemetry/trace/span.h
+++ b/api/include/opentelemetry/trace/span.h
@@ -18,7 +18,7 @@ OPENTELEMETRY_BEGIN_NAMESPACE
 namespace trace
 {
 
-// The key the identifies the active span in the current context.
+// The key identifies the active span in the current context.
 constexpr char kSpanKey[] = "active_span";
 
 enum class SpanKind

--- a/api/include/opentelemetry/trace/span.h
+++ b/api/include/opentelemetry/trace/span.h
@@ -14,11 +14,13 @@
 #include "opentelemetry/trace/span_context.h"
 #include "opentelemetry/version.h"
 
-constexpr char SpanKey[] = "span_key";
-
 OPENTELEMETRY_BEGIN_NAMESPACE
 namespace trace
 {
+
+// The key the identifies the active span in the current context.
+constexpr char kSpanKey[] = "active_span";
+
 enum class SpanKind
 {
   kInternal,

--- a/api/include/opentelemetry/trace/tracer.h
+++ b/api/include/opentelemetry/trace/tracer.h
@@ -144,7 +144,7 @@ public:
    */
   nostd::shared_ptr<Span> GetCurrentSpan() noexcept
   {
-    context::ContextValue active_span = context::RuntimeContext::GetValue(SpanKey);
+    context::ContextValue active_span = context::RuntimeContext::GetValue(kSpanKey);
     if (nostd::holds_alternative<nostd::shared_ptr<Span>>(active_span))
     {
       return nostd::get<nostd::shared_ptr<Span>>(active_span);

--- a/api/test/trace/CMakeLists.txt
+++ b/api/test/trace/CMakeLists.txt
@@ -1,3 +1,5 @@
+add_subdirectory(propagation)
+
 foreach(
   testname
   key_value_iterable_view_test

--- a/api/test/trace/propagation/http_text_format_test.cc
+++ b/api/test/trace/propagation/http_text_format_test.cc
@@ -122,7 +122,7 @@ TEST(HTTPTextFormatTest, GetCurrentSpan)
                                   trace::TraceFlags{true}, false};
   nostd::shared_ptr<trace::Span> sp{new trace::DefaultSpan{span_context}};
 
-  // Set `sp` as the currently active span, which must be usued by `Inject`.
+  // Set `sp` as the currently active span, which must be used by `Inject`.
   trace::Scope scoped_span{sp};
 
   std::map<std::string, std::string> headers = {};

--- a/api/test/trace/propagation/http_text_format_test.cc
+++ b/api/test/trace/propagation/http_text_format_test.cc
@@ -3,10 +3,10 @@
 #include "opentelemetry/nostd/span.h"
 #include "opentelemetry/nostd/string_view.h"
 #include "opentelemetry/trace/default_span.h"
+#include "opentelemetry/trace/noop.h"
 #include "opentelemetry/trace/span.h"
 #include "opentelemetry/trace/span_context.h"
 #include "opentelemetry/trace/trace_id.h"
-#include "opentelemetry/trace/noop.h"
 #include "opentelemetry/trace/tracer.h"
 
 #include <map>
@@ -21,7 +21,7 @@
 
 using namespace opentelemetry;
 
-template<typename T>
+template <typename T>
 static std::string Hex(const T &id_item)
 {
   char buf[T::kSize * 2];
@@ -105,7 +105,7 @@ TEST(HTTPTextFormatTest, SetRemoteSpan)
 
   auto ctx2_span = ctx2.GetValue(trace::kSpanKey);
   EXPECT_TRUE(nostd::holds_alternative<nostd::shared_ptr<trace::Span>>(ctx2_span));
-  
+
   auto span = nostd::get<nostd::shared_ptr<trace::Span>>(ctx2_span);
 
   EXPECT_EQ(Hex(span->GetContext().trace_id()), "4bf92f3577b34da6a3ce929d0e0e4736");
@@ -116,9 +116,10 @@ TEST(HTTPTextFormatTest, SetRemoteSpan)
 
 TEST(HTTPTextFormatTest, GetCurrentSpan)
 {
-  constexpr uint8_t buf_span[] = {1, 2, 3, 4, 5, 6, 7, 8};
+  constexpr uint8_t buf_span[]  = {1, 2, 3, 4, 5, 6, 7, 8};
   constexpr uint8_t buf_trace[] = {1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16};
-  trace::SpanContext span_context{trace::TraceId{buf_trace}, trace::SpanId{buf_span}, trace::TraceFlags{true}, false};
+  trace::SpanContext span_context{trace::TraceId{buf_trace}, trace::SpanId{buf_span},
+                                  trace::TraceFlags{true}, false};
   nostd::shared_ptr<trace::Span> sp{new trace::DefaultSpan{span_context}};
 
   // Set `sp` as the currently active span, which must be usued by `Inject`.

--- a/api/test/trace/scope_test.cc
+++ b/api/test/trace/scope_test.cc
@@ -5,10 +5,10 @@
 
 #include <gtest/gtest.h>
 
+using opentelemetry::trace::kSpanKey;
 using opentelemetry::trace::NoopSpan;
 using opentelemetry::trace::Scope;
 using opentelemetry::trace::Span;
-using opentelemetry::trace::kSpanKey;
 namespace nostd   = opentelemetry::nostd;
 namespace context = opentelemetry::context;
 

--- a/api/test/trace/scope_test.cc
+++ b/api/test/trace/scope_test.cc
@@ -8,6 +8,7 @@
 using opentelemetry::trace::NoopSpan;
 using opentelemetry::trace::Scope;
 using opentelemetry::trace::Span;
+using opentelemetry::trace::kSpanKey;
 namespace nostd   = opentelemetry::nostd;
 namespace context = opentelemetry::context;
 
@@ -16,7 +17,7 @@ TEST(ScopeTest, Construct)
   nostd::shared_ptr<Span> span(new NoopSpan(nullptr));
   Scope scope(span);
 
-  context::ContextValue active_span_value = context::RuntimeContext::GetValue(SpanKey);
+  context::ContextValue active_span_value = context::RuntimeContext::GetValue(kSpanKey);
   ASSERT_TRUE(nostd::holds_alternative<nostd::shared_ptr<Span>>(active_span_value));
 
   auto active_span = nostd::get<nostd::shared_ptr<Span>>(active_span_value);
@@ -32,14 +33,14 @@ TEST(ScopeTest, Destruct)
     nostd::shared_ptr<Span> span_nested(new NoopSpan(nullptr));
     Scope scope_nested(span_nested);
 
-    context::ContextValue active_span_value = context::RuntimeContext::GetValue(SpanKey);
+    context::ContextValue active_span_value = context::RuntimeContext::GetValue(kSpanKey);
     ASSERT_TRUE(nostd::holds_alternative<nostd::shared_ptr<Span>>(active_span_value));
 
     auto active_span = nostd::get<nostd::shared_ptr<Span>>(active_span_value);
     ASSERT_EQ(active_span, span_nested);
   }
 
-  context::ContextValue active_span_value = context::RuntimeContext::GetValue(SpanKey);
+  context::ContextValue active_span_value = context::RuntimeContext::GetValue(kSpanKey);
   ASSERT_TRUE(nostd::holds_alternative<nostd::shared_ptr<Span>>(active_span_value));
 
   auto active_span = nostd::get<nostd::shared_ptr<Span>>(active_span_value);

--- a/sdk/src/trace/tracer.cc
+++ b/sdk/src/trace/tracer.cc
@@ -38,7 +38,7 @@ trace_api::SpanContext GetCurrentSpanContext(const trace_api::SpanContext &expli
   }
 
   // Use the currently active span, if there's one.
-  auto curr_span_context = context::RuntimeContext::GetValue(SpanKey);
+  auto curr_span_context = context::RuntimeContext::GetValue(trace_api::kSpanKey);
 
   if (nostd::holds_alternative<nostd::shared_ptr<trace_api::Span>>(curr_span_context))
   {


### PR DESCRIPTION
The `Extract` call on the W3C propagator used to store the extracted span under the key `current-span` in the context, whereas on other places we rely on the current span being stored under the key `span_key`. This discrepancy will break context propagation.

This PR unifies this to use a constant `kSpanKey` in all relevant places and also adds tests.