### PR TITLE
Resolve NOMINMAX issues where possible

### DIFF
--- a/api/include/opentelemetry/common/spin_lock_mutex.h
+++ b/api/include/opentelemetry/common/spin_lock_mutex.h
@@ -6,6 +6,17 @@
 
 #include "opentelemetry/version.h"
 
+#if defined(_MSC_VER)
+#  ifndef NOMINMAX
+#    define NOMINMAX
+#  endif
+#  include <Windows.h>
+#elif defined(__i386__) || defined(__x86_64__)
+#  if defined(__clang__)
+#    include <emmintrin.h>
+#  endif
+#endif
+
 OPENTELEMETRY_BEGIN_NAMESPACE
 namespace common
 {

--- a/api/include/opentelemetry/nostd/string_view.h
+++ b/api/include/opentelemetry/nostd/string_view.h
@@ -87,7 +87,7 @@ public:
 
   int compare(string_view v) const noexcept
   {
-    size_type len = std::min(size(), v.size());
+    size_type len = (std::min)(size(), v.size());
     int result    = Traits::compare(data(), v.data(), len);
     if (result == 0)
       result = size() == v.size() ? 0 : (size() < v.size() ? -1 : 1);

--- a/api/include/opentelemetry/plugin/detail/dynamic_load_windows.h
+++ b/api/include/opentelemetry/plugin/detail/dynamic_load_windows.h
@@ -7,10 +7,13 @@
 #include "opentelemetry/plugin/hook.h"
 #include "opentelemetry/version.h"
 
-#include <windows.h>
+#ifndef NOMINMAX
+#  define NOMINMAX
+#endif
+#include <Windows.h>
 
 #include <errhandlingapi.h>
-#include <winbase.h>
+#include <WinBase.h>
 
 OPENTELEMETRY_BEGIN_NAMESPACE
 namespace plugin

--- a/api/include/opentelemetry/plugin/detail/dynamic_load_windows.h
+++ b/api/include/opentelemetry/plugin/detail/dynamic_load_windows.h
@@ -12,8 +12,8 @@
 #endif
 #include <Windows.h>
 
-#include <errhandlingapi.h>
 #include <WinBase.h>
+#include <errhandlingapi.h>
 
 OPENTELEMETRY_BEGIN_NAMESPACE
 namespace plugin

--- a/api/include/opentelemetry/std/span.h
+++ b/api/include/opentelemetry/std/span.h
@@ -67,7 +67,7 @@ OPENTELEMETRY_END_NAMESPACE
 OPENTELEMETRY_BEGIN_NAMESPACE
 namespace nostd
 {
-constexpr std::size_t dynamic_extent = std::numeric_limits<std::size_t>::max();
+constexpr std::size_t dynamic_extent = (std::numeric_limits<std::size_t>::max());
 
 template <class ElementType, std::size_t Extent = nostd::dynamic_extent>
 using span = std::span<ElementType, Extent>;

--- a/ext/include/opentelemetry/ext/http/server/socket_tools.h
+++ b/ext/include/opentelemetry/ext/http/server/socket_tools.h
@@ -207,7 +207,7 @@ struct SocketAddr
     {
       inet4.sin_port = htons(atoi(colon + 1));
       char buf[16];
-      memcpy(buf, addr, std::min<ptrdiff_t>(15, colon - addr));
+      memcpy(buf, addr, (std::min<ptrdiff_t>)(15, colon - addr));
       buf[15] = '\0';
       ::inet_pton(AF_INET, buf, &inet4.sin_addr);
     }

--- a/sdk/include/opentelemetry/sdk/metrics/aggregator/sketch_aggregator.h
+++ b/sdk/include/opentelemetry/sdk/metrics/aggregator/sketch_aggregator.h
@@ -68,7 +68,7 @@ public:
     int idx;
     if (val == 0)
     {
-      idx = std::numeric_limits<int>::min();
+      idx = (std::numeric_limits<int>::min());
     }
     else
     {

--- a/sdk/src/common/fast_random_number_generator.h
+++ b/sdk/src/common/fast_random_number_generator.h
@@ -17,6 +17,17 @@ namespace common
  * std::mt19937_64; and since we don't care about the other beneficial random
  * number properties that std:mt19937_64 provides for this application, it's a
  * entirely appropriate replacement.
+ *
+ * Note for Windows users - please make sure that NOMINMAX is defined, e.g.
+ *
+ * ...
+ * #define NOMINMAX 
+ * #include <Windows.h>
+ * ...
+ *
+ * See:
+ * https://stackoverflow.com/questions/13416418/define-nominmax-using-stdmin-max
+ * 
  */
 class FastRandomNumberGenerator
 {

--- a/sdk/src/common/fast_random_number_generator.h
+++ b/sdk/src/common/fast_random_number_generator.h
@@ -21,13 +21,13 @@ namespace common
  * Note for Windows users - please make sure that NOMINMAX is defined, e.g.
  *
  * ...
- * #define NOMINMAX 
+ * #define NOMINMAX
  * #include <Windows.h>
  * ...
  *
  * See:
  * https://stackoverflow.com/questions/13416418/define-nominmax-using-stdmin-max
- * 
+ *
  */
 class FastRandomNumberGenerator
 {


### PR DESCRIPTION
The issue is that `Windows.h` redefines both `min` and `max` as macros.

There are several fixes possible:
- targeted fix: surround the usage of `std::min` and `std::max` with parenthesis; OR
- globally define `NOMINMAX` for the entire project in CMake; OR
- in those modules where it is known that `std::*` is going to be used, `#define NOMINMAX` right before the inclusion of Windows.h

Since there were two recent hits @mishal23 @jsuereth , I'm applying targeted fix to avoid this issue wherever possible.

Not defining `NOMINMAX` globally, as this may lead to other interesting side-effects inside the bowels of Windows SDK 😁 