### PR TITLE
Build opentelemetry-proto as static instead of object library

### DIFF
--- a/cmake/opentelemetry-proto.cmake
+++ b/cmake/opentelemetry-proto.cmake
@@ -119,7 +119,7 @@ add_custom_command(
 include_directories("${GENERATED_PROTOBUF_PATH}")
 
 add_library(
-  opentelemetry_proto OBJECT
+  opentelemetry_proto STATIC
   ${COMMON_PB_CPP_FILE}
   ${RESOURCE_PB_CPP_FILE}
   ${TRACE_PB_CPP_FILE}


### PR DESCRIPTION
Build protobuf generated files and skeleton as object library could requires adding it directly to `add_executable(...)` or `add_library(...)` instead of linking it via `target_link_libraries(...)`. Build these files as static library to better fit linking as library.