### PR TITLE
GenerateHexFromString http_trace_context.h uses non-standard assignment

### DIFF
--- a/api/include/opentelemetry/trace/propagation/http_trace_context.h
+++ b/api/include/opentelemetry/trace/propagation/http_trace_context.h
@@ -129,7 +129,7 @@ private:
   // Converts the hex numbers stored as strings into bytes stored in a buffer.
   static void GenerateHexFromString(nostd::string_view string, int bytes, uint8_t *buf)
   {
-    const char *str_id = string.begin();
+    const char *str_id = string.data();
     for (int i = 0; i < bytes; i++)
     {
       int tmp = HexToInt(str_id[i]);


### PR DESCRIPTION
When SDK is compiled with STL (standard library) classes flavor, this code won't compile with vs2019 in C++20 mode:

```cpp
nostd::string_view string;
...
const char *str_id = string.begin();
```

with an error `Error	C2440	'initializing': cannot convert from 'std::_String_view_iterator<_Traits>' to 'const char *'	http_text_format_test	6	C:\work\opentelemetry-cpp-etw\api\include\opentelemetry\trace\propagation	C:\work\opentelemetry-cpp-etw\api\include\opentelemetry\trace\propagation\http_trace_context.h	132			CL`

The fix is to use `.data()` instead of `.begin()` . `data()` always points to `const char *` buffer.
