### PR TITLE
Use bazel build relative to this repository

### DIFF
--- a/bazel/repository.bzl
+++ b/bazel/repository.bzl
@@ -47,7 +47,7 @@ def opentelemetry_cpp_deps():
     maybe(
         http_archive,
         name = "com_github_opentelemetry_proto",
-        build_file = "//bazel:opentelemetry_proto.BUILD",
+        build_file = "@io_opentelemetry_cpp//bazel:opentelemetry_proto.BUILD",
         sha256 = "08f090570e0a112bfae276ba37e9c45bf724b64d902a7a001db33123b840ebd6",
         strip_prefix = "opentelemetry-proto-0.6.0",
         urls = [
@@ -59,7 +59,7 @@ def opentelemetry_cpp_deps():
     maybe(
         http_archive,
         name = "github_nlohmann_json",
-        build_file = "//bazel:nlohmann_json.BUILD",
+        build_file = "@io_opentelemetry_cpp//bazel:nlohmann_json.BUILD",
         sha256 = "69cc88207ce91347ea530b227ff0776db82dcb8de6704e1a3d74f4841bc651cf",
         urls = [
             "https://github.com/nlohmann/json/releases/download/v3.6.1/include.zip",


### PR DESCRIPTION
The problem is that when using in third-party bazel complains that the there needs to be a "//bazel:opentelemetry_proto.BUILD" file in the dependent project, which there is not. This way we setup bazel to use the build file from the dependency project. This was a mistake in the previous PR I submitted. I tested this now and it works.

Signed-off-by: Bogdan Drutu <bogdandrutu@gmail.com>