### PR TITLE
Remove protobuf dependency from bazel, not used anywhere

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -14,9 +14,9 @@
 
 workspace(name = "io_opentelemetry_cpp")
 
+# Load our direct dependencies.
 load("//bazel:repository.bzl", "opentelemetry_cpp_deps")
 
-# Load our direct dependencies.
 opentelemetry_cpp_deps()
 
 # Load gRPC dependencies after load.
@@ -33,14 +33,7 @@ load("@upb//bazel:repository_defs.bzl", "bazel_version_repository")
 
 bazel_version_repository(name = "upb_bazel_version")
 
-# Load protobuf deps
-
-load("@com_google_protobuf//:protobuf_deps.bzl", "protobuf_deps")
-
-protobuf_deps()
-
 # Load prometheus C++ dependencies.
-
 load("@com_github_jupp0r_prometheus_cpp//bazel:repositories.bzl", "prometheus_cpp_repositories")
 
 prometheus_cpp_repositories()

--- a/bazel/repository.bzl
+++ b/bazel/repository.bzl
@@ -31,18 +31,6 @@ def opentelemetry_cpp_deps():
         ],
     )
 
-    # Uses older protobuf version because of
-    # https://github.com/protocolbuffers/protobuf/issues/7179
-    maybe(
-        http_archive,
-        name = "com_google_protobuf",
-        sha256 = "b679cef31102ed8beddc39ecfd6368ee311cbee6f50742f13f21be7278781821",
-        strip_prefix = "protobuf-3.11.2",
-        urls = [
-            "https://github.com/protocolbuffers/protobuf/releases/download/v3.11.2/protobuf-all-3.11.2.tar.gz",
-        ],
-    )
-
     # OTLP Protocol definition
     maybe(
         http_archive,


### PR DESCRIPTION
Split from https://github.com/open-telemetry/opentelemetry-cpp/pull/459, this should be trivial.

Signed-off-by: Bogdan Drutu <bogdandrutu@gmail.com>