### PR TITLE
Fix missing include dir for configure_package_config_file

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -212,12 +212,13 @@ add_subdirectory(ext)
 
 # Export cmake config and support find_packages(opentelemetry-cpp CONFIG) Write
 # config file for find_packages(opentelemetry-cpp CONFIG)
+set(INCLUDE_INSTALL_DIR "${CMAKE_INSTALL_INCLUDEDIR}")
 configure_package_config_file(
   "${CMAKE_CURRENT_LIST_DIR}/opentelemetry-cpp-config.cmake.in"
   "${CMAKE_CURRENT_BINARY_DIR}/cmake/${PROJECT_NAME}-config.cmake"
   INSTALL_DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake"
   PATH_VARS OPENTELEMETRY_ABI_VERSION_NO OPENTELEMETRY_VERSION PROJECT_NAME
-            CMAKE_INSTALL_LIBDIR
+            INCLUDE_INSTALL_DIR CMAKE_INSTALL_LIBDIR
   NO_CHECK_REQUIRED_COMPONENTS_MACRO)
 
 # Write version file for find_packages(opentelemetry-cpp CONFIG)

--- a/opentelemetry-cpp-config.cmake.in
+++ b/opentelemetry-cpp-config.cmake.in
@@ -82,7 +82,7 @@ foreach(_TEST_TARGET IN LISTS _OPENTELEMETRY_CPP_LIBRARIES_TEST_TARGETS)
 endforeach()
 
 # handle the QUIETLY and REQUIRED arguments and set OPENTELEMETRY_CPP_FOUND to
-# TRUE if all listed variables are TRUE
+# TRUE if all variables list contain valid results, e.g. valid file paths.
 include("FindPackageHandleStandardArgs")
 find_package_handle_standard_args(
   OPENTELEMETRY_CPP

--- a/opentelemetry-cpp-config.cmake.in
+++ b/opentelemetry-cpp-config.cmake.in
@@ -82,7 +82,7 @@ foreach(_TEST_TARGET IN LISTS _OPENTELEMETRY_CPP_LIBRARIES_TEST_TARGETS)
 endforeach()
 
 # handle the QUIETLY and REQUIRED arguments and set OPENTELEMETRY_CPP_FOUND to
-# TRUE if all variables list contain valid results, e.g. valid file paths.
+# TRUE if all variables listed contain valid results, e.g. valid file paths.
 include("FindPackageHandleStandardArgs")
 find_package_handle_standard_args(
   OPENTELEMETRY_CPP


### PR DESCRIPTION
This fixes https://github.com/open-telemetry/opentelemetry-cpp/issues/513 by passing the missing `INCLUDE_INSTALL_DIR` to `configure_package_config_file` as `PATH_VARS`.