### PR TITLE
Install protobuf generated header file for OTLP

### DIFF
--- a/cmake/opentelemetry-proto.cmake
+++ b/cmake/opentelemetry-proto.cmake
@@ -141,6 +141,12 @@ install(
   LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
   ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR})
 
+install(
+  DIRECTORY ${GENERATED_PROTOBUF_PATH}/opentelemetry
+  DESTINATION include
+  FILES_MATCHING
+  PATTERN "*.h")
+
 if(TARGET protobuf::libprotobuf)
   target_link_libraries(opentelemetry_proto PUBLIC protobuf::libprotobuf)
 else() # cmake 3.8 or lower


### PR DESCRIPTION
The protobuf generated header files are not installed in CMake script so the OTLP header files cannot included from the installed package. This PR installs the generated header files to the correct location.