### PR TITLE
Upgrade CMake to 3.15.2 for Linux

### DIFF
--- a/ci/setup_cmake.sh
+++ b/ci/setup_cmake.sh
@@ -5,9 +5,16 @@ set -e
 export DEBIAN_FRONTEND=noninteractive
 apt-get update
 
+export CMAKE_VERSION=3.15.2
+
+pushd /tmp
+wget https://github.com/Kitware/CMake/releases/download/v${CMAKE_VERSION}/cmake-${CMAKE_VERSION}-Linux-x86_64.sh
+chmod +x cmake-${CMAKE_VERSION}-Linux-x86_64.sh
+./cmake-${CMAKE_VERSION}-Linux-x86_64.sh --prefix=/usr/local --skip-license
+popd
+
 set +e
 echo		\
-                cmake \
                 libbenchmark-dev \
                 libgtest-dev \
                 zlib1g-dev \

--- a/ci/setup_cmake.sh
+++ b/ci/setup_cmake.sh
@@ -11,6 +11,7 @@ pushd /tmp
 wget https://github.com/Kitware/CMake/releases/download/v${CMAKE_VERSION}/cmake-${CMAKE_VERSION}-Linux-x86_64.sh
 chmod +x cmake-${CMAKE_VERSION}-Linux-x86_64.sh
 ./cmake-${CMAKE_VERSION}-Linux-x86_64.sh --prefix=/usr/local --skip-license
+rm cmake-${CMAKE_VERSION}-Linux-x86_64.sh
 popd
 
 set +e


### PR DESCRIPTION
The Windows build installs CMake version 3.15.2 (see below link), so upgrade Linux to the same version. This version upgrade for Linux is helpful because the CMake from `apt install` on Ubuntu 18.10 is 3.10, and this version of CMake doesn't support installation from submodule (this affects gRPC installation from source tree, see [here](https://github.com/grpc/grpc/blob/0539a63274cd73288ec13fea16fa855b01c73e61/CMakeLists.txt#L62)).

https://github.com/open-telemetry/opentelemetry-cpp/blob/master/ci/setup_windows_cmake.ps1#L4