### PR TITLE
Fix unsafe type cast and CRT call

### DIFF
--- a/exporters/etw/include/opentelemetry/exporters/etw/etw_provider_exporter.h
+++ b/exporters/etw/include/opentelemetry/exporters/etw/etw_provider_exporter.h
@@ -408,7 +408,7 @@ public:
     EVENT_DESCRIPTOR evtDescriptor;
     EventDescCreate(&evtDescriptor, 0, 0x1, 0, 0, 0, 0, 0);
     EVENT_DATA_DESCRIPTOR evtData[1];
-    EventDataDescCreate(&evtData[0], v.data(), v.size());
+    EventDataDescCreate(&evtData[0], v.data(), static_cast<ULONG>(v.size()));
 
     auto writeResponse = EventWrite(providerData.providerHandle, &evtDescriptor, 1, evtData);
 

--- a/exporters/etw/include/opentelemetry/exporters/etw/uuid.h
+++ b/exporters/etw/include/opentelemetry/exporters/etw/uuid.h
@@ -99,11 +99,11 @@ struct UUID
     unsigned int p1, p2, p3, p4, p5, p6, p7, p8, p9, p10;
     if (
         // Parse input with dashes
-        (11 == sscanf_s(str, "%08lX-%04X-%04X-%02X%02X-%02X%02X%02X%02X%02X%02X", &p0, &p1, &p2, &p3,
-                      &p4, &p5, &p6, &p7, &p8, &p9, &p10)) ||
+        (11 == sscanf_s(str, "%08lX-%04X-%04X-%02X%02X-%02X%02X%02X%02X%02X%02X", &p0, &p1, &p2,
+                        &p3, &p4, &p5, &p6, &p7, &p8, &p9, &p10)) ||
         // Parse input without dashes
-        (11 == sscanf_s(str, "%08lX%04X%04X%02X%02X%02X%02X%02X%02X%02X%02X", &p0, &p1, &p2, &p3, &p4,
-                      &p5, &p6, &p7, &p8, &p9, &p10)))
+        (11 == sscanf_s(str, "%08lX%04X%04X%02X%02X%02X%02X%02X%02X%02X%02X", &p0, &p1, &p2, &p3,
+                        &p4, &p5, &p6, &p7, &p8, &p9, &p10)))
     {
       Data1    = static_cast<uint32_t>(p0);
       Data2    = static_cast<uint16_t>(p1);

--- a/exporters/etw/include/opentelemetry/exporters/etw/uuid.h
+++ b/exporters/etw/include/opentelemetry/exporters/etw/uuid.h
@@ -99,10 +99,10 @@ struct UUID
     unsigned int p1, p2, p3, p4, p5, p6, p7, p8, p9, p10;
     if (
         // Parse input with dashes
-        (11 == sscanf(str, "%08lX-%04X-%04X-%02X%02X-%02X%02X%02X%02X%02X%02X", &p0, &p1, &p2, &p3,
+        (11 == sscanf_s(str, "%08lX-%04X-%04X-%02X%02X-%02X%02X%02X%02X%02X%02X", &p0, &p1, &p2, &p3,
                       &p4, &p5, &p6, &p7, &p8, &p9, &p10)) ||
         // Parse input without dashes
-        (11 == sscanf(str, "%08lX%04X%04X%02X%02X%02X%02X%02X%02X%02X%02X", &p0, &p1, &p2, &p3, &p4,
+        (11 == sscanf_s(str, "%08lX%04X%04X%02X%02X%02X%02X%02X%02X%02X%02X", &p0, &p1, &p2, &p3, &p4,
                       &p5, &p6, &p7, &p8, &p9, &p10)))
     {
       Data1    = static_cast<uint32_t>(p0);


### PR DESCRIPTION
Do explicit type narrow down cast from `size_t` to `ULONG`, and also change unsafe CRT call `sscanf` to `sscanf_s`.