### PR TITLE
Fix calling target_include_directories on library

### DIFF
--- a/cmake/opentelemetry-proto.cmake
+++ b/cmake/opentelemetry-proto.cmake
@@ -152,8 +152,8 @@ if(TARGET protobuf::libprotobuf)
 else() # cmake 3.8 or lower
   target_include_directories(opentelemetry_proto
                              PUBLIC ${Protobuf_INCLUDE_DIRS})
-  target_include_directories(opentelemetry_proto
-                             INTERFACE ${Protobuf_LIBRARIES})
+  target_link_libraries(opentelemetry_proto
+                        INTERFACE ${Protobuf_LIBRARIES})
 endif()
 
 if(BUILD_SHARED_LIBS)


### PR DESCRIPTION
CMake `target_link_libraries()` should be called instead of `target_include_directories()` to link to library like protobuf.