### PR TITLE
Update PR merge requirement.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -116,7 +116,7 @@ A PR is considered to be **ready to merge** when:
 * Trivial changes (typo, cosmetic, doc, etc.) don't have to wait for one day.
 * Urgent fixes can take exceptions as long as it has been actively communicated.
 
-Any Maintainer can merge the PR once it is **ready to merge**.
+Any Maintainer can merge the PR once it is **ready to merge**. Maintainer can make conscious judgement to merge pull requests which have not strictly met above requirements.
 
 If a PR has been stuck (e.g. there are lots of debates and people couldn't agree on each other), the owner should try to get people aligned by:
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -116,7 +116,7 @@ A PR is considered to be **ready to merge** when:
 * Trivial changes (typo, cosmetic, doc, etc.) don't have to wait for one day.
 * Urgent fixes can take exceptions as long as it has been actively communicated.
 
-Any Maintainer can merge the PR once it is **ready to merge**. Maintainer can make conscious judgement to merge pull requests which have not strictly met above requirements.
+Any Maintainer can merge the PR once it is **ready to merge**. Maintainer can make conscious judgement to merge pull requests which have not strictly met above mentioned requirements.
 
 If a PR has been stuck (e.g. there are lots of debates and people couldn't agree on each other), the owner should try to get people aligned by:
 


### PR DESCRIPTION
As agreed in community meeting dated 13th Jan 2021 ( https://docs.google.com/document/d/1i1E4-_y4uJ083lCutKGDhkpi3n4_e774SBLi9hPLocw/ ) , proposing changes in Contribution Guide to allow maintainers merge PRs which doesn't meet minimum approval requirement. 

We can revisit this again once we are nearing GA release, and/or there are sufficient approvers from multiple companies.