### PR TITLE
CMake: fix gRPC_CPP_PLUGIN_EXECUTABLE import

### DIFF
--- a/cmake/opentelemetry-proto.cmake
+++ b/cmake/opentelemetry-proto.cmake
@@ -82,8 +82,7 @@ foreach(IMPORT_DIR ${PROTOBUF_IMPORT_DIRS})
   list(APPEND PROTOBUF_INCLUDE_FLAGS "-I${IMPORT_DIR}")
 endforeach()
 
-get_target_property(gRPC_CPP_PLUGIN_EXECUTABLE gRPC::grpc_cpp_plugin
-                    IMPORTED_LOCATION_RELEASE)
+set(gRPC_CPP_PLUGIN_EXECUTABLE $<TARGET_FILE:gRPC::grpc_cpp_plugin>)
 
 add_custom_command(
   OUTPUT ${COMMON_PB_H_FILE}


### PR DESCRIPTION
When building with `-DWITH_OTLP=ON` then `gRPC_CPP_PLUGIN_EXECUTABLE` can't be imported from a current gRPC build, changing it to `TARGET_FILE` fixes the issue. (gRPC examples use the same method: https://github.com/grpc/grpc/blob/master/examples/cpp/helloworld/CMakeLists.txt#L123)