### PR TITLE
fix namespace scoping for TraceState

### DIFF
--- a/api/include/opentelemetry/trace/trace_state.h
+++ b/api/include/opentelemetry/trace/trace_state.h
@@ -21,8 +21,7 @@
 #include "opentelemetry/nostd/string_view.h"
 #include "opentelemetry/nostd/unique_ptr.h"
 
-namespace opentelemetry
-{
+OPENTELEMETRY_BEGIN_NAMESPACE
 namespace trace
 {
 
@@ -193,4 +192,4 @@ private:
 };
 
 }  // namespace trace
-}  // namespace opentelemetry
+OPENTELEMETRY_END_NAMESPACE


### PR DESCRIPTION
small fix for namespace scoping of `TraceState`.