### PR TITLE
Rename SpanContext.HasRemoteParent to SpanContext.IsRemote

### DIFF
--- a/api/include/opentelemetry/trace/span_context.h
+++ b/api/include/opentelemetry/trace/span_context.h
@@ -26,7 +26,7 @@ namespace trace_api = opentelemetry::trace;
 
 /* SpanContext contains the state that must propagate to child Spans and across
  * process boundaries. It contains the identifiers TraceId and SpanId,
- * TraceFlags, TraceState, and whether it was propagateda from a remote parent.
+ * TraceFlags, TraceState, and whether it was propagated from a remote parent.
  *
  * TODO: This is currently a placeholder class and requires revisiting
  */

--- a/api/include/opentelemetry/trace/span_context.h
+++ b/api/include/opentelemetry/trace/span_context.h
@@ -26,7 +26,7 @@ namespace trace_api = opentelemetry::trace;
 
 /* SpanContext contains the state that must propagate to child Spans and across
  * process boundaries. It contains the identifiers TraceId and SpanId,
- * TraceFlags, TraceState, and whether it represents a remote context.
+ * TraceFlags, TraceState, and whether it was propagateda from a remote parent.
  *
  * TODO: This is currently a placeholder class and requires revisiting
  */
@@ -38,7 +38,7 @@ public:
    *
    * @param sampled_flag a required parameter specifying if child spans should be
    * sampled
-   * @param is_remote true if this context represents a remote context.
+   * @param is_remote true if this context was propagated from a remote parent.
    */
   SpanContext(bool sampled_flag, bool is_remote)
       : trace_id_(),

--- a/api/include/opentelemetry/trace/span_context.h
+++ b/api/include/opentelemetry/trace/span_context.h
@@ -26,7 +26,7 @@ namespace trace_api = opentelemetry::trace;
 
 /* SpanContext contains the state that must propagate to child Spans and across
  * process boundaries. It contains the identifiers TraceId and SpanId,
- * TraceFlags, TraceState, and whether it has a remote parent.
+ * TraceFlags, TraceState, and whether it represents a remote context.
  *
  * TODO: This is currently a placeholder class and requires revisiting
  */
@@ -38,14 +38,13 @@ public:
    *
    * @param sampled_flag a required parameter specifying if child spans should be
    * sampled
-   * @param has_remote_parent a required parameter specifying if this context has
-   * a remote parent
+   * @param is_remote true if this context represents a remote context.
    */
-  SpanContext(bool sampled_flag, bool has_remote_parent)
+  SpanContext(bool sampled_flag, bool is_remote)
       : trace_id_(),
         span_id_(),
         trace_flags_(trace_api::TraceFlags((uint8_t)sampled_flag)),
-        remote_parent_(has_remote_parent){};
+        is_remote_(is_remote) {}
 
   // @returns whether this context is valid
   bool IsValid() const noexcept { return trace_id_.IsValid() && span_id_.IsValid(); }
@@ -60,11 +59,11 @@ public:
   SpanContext(TraceId trace_id,
               SpanId span_id,
               TraceFlags trace_flags,
-              bool has_remote_parent) noexcept
+              bool is_remote) noexcept
       : trace_id_(trace_id),
         span_id_(span_id),
         trace_flags_(trace_flags),
-        remote_parent_(has_remote_parent)
+        is_remote_(is_remote)
   {}
 
   SpanContext(const SpanContext &ctx) = default;
@@ -77,7 +76,7 @@ public:
            trace_flags() == that.trace_flags();
   }
 
-  bool HasRemoteParent() const noexcept { return remote_parent_; }
+  bool IsRemote() const noexcept { return is_remote_; }
 
   static SpanContext GetInvalid() { return SpanContext(false, false); }
 
@@ -87,7 +86,7 @@ private:
   trace_api::TraceId trace_id_;
   trace_api::SpanId span_id_;
   trace_api::TraceFlags trace_flags_;
-  bool remote_parent_ = false;
+  bool is_remote_ = false;
 };
 }  // namespace trace
 OPENTELEMETRY_END_NAMESPACE

--- a/api/include/opentelemetry/trace/span_context.h
+++ b/api/include/opentelemetry/trace/span_context.h
@@ -44,7 +44,8 @@ public:
       : trace_id_(),
         span_id_(),
         trace_flags_(trace_api::TraceFlags((uint8_t)sampled_flag)),
-        is_remote_(is_remote) {}
+        is_remote_(is_remote)
+  {}
 
   // @returns whether this context is valid
   bool IsValid() const noexcept { return trace_id_.IsValid() && span_id_.IsValid(); }
@@ -56,14 +57,8 @@ public:
 
   const trace_api::SpanId &span_id() const noexcept { return span_id_; }
 
-  SpanContext(TraceId trace_id,
-              SpanId span_id,
-              TraceFlags trace_flags,
-              bool is_remote) noexcept
-      : trace_id_(trace_id),
-        span_id_(span_id),
-        trace_flags_(trace_flags),
-        is_remote_(is_remote)
+  SpanContext(TraceId trace_id, SpanId span_id, TraceFlags trace_flags, bool is_remote) noexcept
+      : trace_id_(trace_id), span_id_(span_id), trace_flags_(trace_flags), is_remote_(is_remote)
   {}
 
   SpanContext(const SpanContext &ctx) = default;

--- a/api/test/trace/propagation/http_text_format_test.cc
+++ b/api/test/trace/propagation/http_text_format_test.cc
@@ -111,7 +111,7 @@ TEST(HTTPTextFormatTest, SetRemoteSpan)
   EXPECT_EQ(Hex(span->GetContext().trace_id()), "4bf92f3577b34da6a3ce929d0e0e4736");
   EXPECT_EQ(Hex(span->GetContext().span_id()), "0102030405060708");
   EXPECT_EQ(span->GetContext().IsSampled(), true);
-  EXPECT_EQ(span->GetContext().HasRemoteParent(), true);
+  EXPECT_EQ(span->GetContext().IsRemote(), true);
 }
 
 TEST(HTTPTextFormatTest, GetCurrentSpan)

--- a/api/test/trace/span_context_test.cc
+++ b/api/test/trace/span_context_test.cc
@@ -17,15 +17,15 @@ TEST(SpanContextTest, IsSampled)
   ASSERT_EQ(s2.IsSampled(), false);
 }
 
-TEST(SpanContextTest, HasRemoteParent)
+TEST(SpanContextTest, IsRemote)
 {
   SpanContext s1(true, true);
 
-  ASSERT_EQ(s1.HasRemoteParent(), true);
+  ASSERT_EQ(s1.IsRemote(), true);
 
   SpanContext s2(true, false);
 
-  ASSERT_EQ(s2.HasRemoteParent(), false);
+  ASSERT_EQ(s2.IsRemote(), false);
 }
 
 TEST(SpanContextTest, TraceFlags)


### PR DESCRIPTION
As defined in the [spec](https://github.com/open-telemetry/opentelemetry-specification/blob/master/specification/trace/api.md#isremote), the `SpanContext` should have a method `IsRemote`, and not `HasRemoteParent`.