### PR TITLE
Update StatusCode as per specs

### DIFF
--- a/api/include/opentelemetry/plugin/tracer.h
+++ b/api/include/opentelemetry/plugin/tracer.h
@@ -38,7 +38,7 @@ public:
     span_->AddEvent(name, timestamp, attributes);
   }
 
-  void SetStatus(trace::CanonicalCode code, nostd::string_view description) noexcept override
+  void SetStatus(trace::StatusCode code, nostd::string_view description) noexcept override
   {
     span_->SetStatus(code, description);
   }

--- a/api/include/opentelemetry/trace/default_span.h
+++ b/api/include/opentelemetry/trace/default_span.h
@@ -33,7 +33,7 @@ public:
     this->AddEvent(name, std::chrono::system_clock::now(), attributes);
   }
 
-  void SetStatus(CanonicalCode status, nostd::string_view description) noexcept {}
+  void SetStatus(StatusCode status, nostd::string_view description) noexcept {}
 
   void UpdateName(nostd::string_view name) noexcept {}
 

--- a/api/include/opentelemetry/trace/noop.h
+++ b/api/include/opentelemetry/trace/noop.h
@@ -43,7 +43,7 @@ public:
                 const common::KeyValueIterable & /*attributes*/) noexcept override
   {}
 
-  void SetStatus(CanonicalCode /*code*/, nostd::string_view /*description*/) noexcept override {}
+  void SetStatus(StatusCode /*code*/, nostd::string_view /*description*/) noexcept override {}
 
   void UpdateName(nostd::string_view /*name*/) noexcept override {}
 

--- a/api/include/opentelemetry/trace/span.h
+++ b/api/include/opentelemetry/trace/span.h
@@ -34,9 +34,9 @@ enum class SpanKind
 
 enum class StatusCode
 {
-  Unset,  // default status
-  Ok,     // Operation has completed successfully.
-  Error   // The operation contains an error
+  kUnset,  // default status
+  kOk,     // Operation has completed successfully.
+  kError   // The operation contains an error
 };
 
 /**

--- a/api/include/opentelemetry/trace/span.h
+++ b/api/include/opentelemetry/trace/span.h
@@ -29,6 +29,16 @@ enum class SpanKind
   kProducer,
   kConsumer,
 };
+
+// StatusCode - Represents the canonical set of status codes of a finished Span.
+
+enum class StatusCode
+{
+  Unset,  // default status
+  Ok,     // Operation has completed successfully.
+  Error   // The operation contains an error
+};
+
 /**
  * StartSpanOptions provides options to set properties of a Span at the time of
  * its creation
@@ -147,10 +157,10 @@ public:
                        attributes.begin(), attributes.end()});
   }
 
-  // Sets the status of the span. The default status is OK. Only the value of
+  // Sets the status of the span. The default status is Unset. Only the value of
   // the last call will be
   // recorded, and implementations are free to ignore previous calls.
-  virtual void SetStatus(CanonicalCode code, nostd::string_view description) noexcept = 0;
+  virtual void SetStatus(StatusCode code, nostd::string_view description) noexcept = 0;
 
   // Updates the name of the Span. If used, this will override the name provided
   // during creation.

--- a/api/include/opentelemetry/trace/span.h
+++ b/api/include/opentelemetry/trace/span.h
@@ -160,7 +160,7 @@ public:
   // Sets the status of the span. The default status is Unset. Only the value of
   // the last call will be
   // recorded, and implementations are free to ignore previous calls.
-  virtual void SetStatus(StatusCode code, nostd::string_view description) noexcept = 0;
+  virtual void SetStatus(StatusCode code, nostd::string_view description = "") noexcept = 0;
 
   // Updates the name of the Span. If used, this will override the name provided
   // during creation.

--- a/api/test/trace/noop_test.cc
+++ b/api/test/trace/noop_test.cc
@@ -34,7 +34,7 @@ TEST(NoopTest, UseNoopTracers)
 
   EXPECT_EQ(s1->IsRecording(), false);
 
-  s1->SetStatus(opentelemetry::trace::StatusCode::Unset, "span unset");
+  s1->SetStatus(opentelemetry::trace::StatusCode::kUnset, "span unset");
 
   s1->UpdateName("test_name");
 

--- a/api/test/trace/noop_test.cc
+++ b/api/test/trace/noop_test.cc
@@ -34,7 +34,7 @@ TEST(NoopTest, UseNoopTracers)
 
   EXPECT_EQ(s1->IsRecording(), false);
 
-  s1->SetStatus(opentelemetry::trace::CanonicalCode::INVALID_ARGUMENT, "span unavailable");
+  s1->SetStatus(opentelemetry::trace::StatusCode::Unset, "span unset");
 
   s1->UpdateName("test_name");
 

--- a/examples/plugin/plugin/tracer.cc
+++ b/examples/plugin/plugin/tracer.cc
@@ -42,8 +42,7 @@ public:
                 const common::KeyValueIterable & /*attributes*/) noexcept override
   {}
 
-  void SetStatus(trace::CanonicalCode /*code*/,
-                 nostd::string_view /*description*/) noexcept override
+  void SetStatus(trace::StatusCode /*code*/, nostd::string_view /*description*/) noexcept override
   {}
 
   void UpdateName(nostd::string_view /*name*/) noexcept override {}

--- a/examples/zpages/zpages_example.cc
+++ b/examples/zpages/zpages_example.cc
@@ -30,7 +30,7 @@ int main(int argc, char *argv[])
   std::map<std::string, opentelemetry::common::AttributeValue> attribute_map;
   attribute_map["completed_search_for"] = "Unknown user";
   tracer->StartSpan("find user", attribute_map)
-      ->SetStatus(opentelemetry::trace::CanonicalCode::NOT_FOUND, "User not found");
+      ->SetStatus(opentelemetry::trace::StatusCode::Error, "User not found");
 
   // Long time duration span
   std::map<std::string, opentelemetry::common::AttributeValue> attribute_map2;

--- a/examples/zpages/zpages_example.cc
+++ b/examples/zpages/zpages_example.cc
@@ -30,7 +30,7 @@ int main(int argc, char *argv[])
   std::map<std::string, opentelemetry::common::AttributeValue> attribute_map;
   attribute_map["completed_search_for"] = "Unknown user";
   tracer->StartSpan("find user", attribute_map)
-      ->SetStatus(opentelemetry::trace::StatusCode::Error, "User not found");
+      ->SetStatus(opentelemetry::trace::StatusCode::kError, "User not found");
 
   // Long time duration span
   std::map<std::string, opentelemetry::common::AttributeValue> attribute_map2;

--- a/exporters/etw/include/opentelemetry/exporters/etw/etw_data.h
+++ b/exporters/etw/include/opentelemetry/exporters/etw/etw_data.h
@@ -426,7 +426,7 @@ public:
    * Get the status for this span
    * @return the status for this span
    */
-  opentelemetry::trace::CanonicalCode GetStatus() const noexcept { return status_code_; }
+  opentelemetry::trace::StatusCode GetStatus() const noexcept { return status_code_; }
 
   /**
    * Get the status description for this span
@@ -520,7 +520,7 @@ private:
   core::SystemTimestamp start_time_;
   std::chrono::nanoseconds duration_{0};
   std::string name_;
-  opentelemetry::trace::CanonicalCode status_code_{opentelemetry::trace::CanonicalCode::OK};
+  opentelemetry::trace::StatusCode status_code_{opentelemetry::trace::StatusCode::Unset};
   std::string status_desc_;
   sdk::common::AttributeMap attribute_map_;
   opentelemetry::trace::SpanKind span_kind_{opentelemetry::trace::SpanKind::kInternal};

--- a/exporters/etw/include/opentelemetry/exporters/etw/etw_data.h
+++ b/exporters/etw/include/opentelemetry/exporters/etw/etw_data.h
@@ -520,7 +520,7 @@ private:
   core::SystemTimestamp start_time_;
   std::chrono::nanoseconds duration_{0};
   std::string name_;
-  opentelemetry::trace::StatusCode status_code_{opentelemetry::trace::StatusCode::Unset};
+  opentelemetry::trace::StatusCode status_code_{opentelemetry::trace::StatusCode::kUnset};
   std::string status_desc_;
   sdk::common::AttributeMap attribute_map_;
   opentelemetry::trace::SpanKind span_kind_{opentelemetry::trace::SpanKind::kInternal};

--- a/exporters/etw/include/opentelemetry/exporters/etw/etw_data.h
+++ b/exporters/etw/include/opentelemetry/exporters/etw/etw_data.h
@@ -267,8 +267,7 @@ public:
   /// <param name="code"></param>
   /// <param name="description"></param>
   /// <returns></returns>
-  virtual void SetStatus(trace::CanonicalCode code,
-                         nostd::string_view description) noexcept override
+  virtual void SetStatus(trace::StatusCode code, nostd::string_view description) noexcept override
   {
     // TODO: not implemented
     UNREFERENCED_PARAMETER(code);
@@ -485,7 +484,7 @@ public:
     // TODO: Link Implementation for the Span to be implemented
   }
 
-  void SetStatus(opentelemetry::trace::CanonicalCode code,
+  void SetStatus(opentelemetry::trace::StatusCode code,
                  nostd::string_view description) noexcept override
   {
     status_code_ = code;

--- a/exporters/ostream/include/opentelemetry/exporters/ostream/span_exporter.h
+++ b/exporters/ostream/include/opentelemetry/exporters/ostream/span_exporter.h
@@ -45,23 +45,7 @@ private:
   bool isShutdown_ = false;
 
   // Mapping status number to the string from api/include/opentelemetry/trace/canonical_code.h
-  std::map<int, std::string> statusMap{{0, "OK"},
-                                       {1, "CANCELLED"},
-                                       {2, "UNKNOWN"},
-                                       {3, "INVALID_ARGUMENT"},
-                                       {4, "DEADLINE_EXCEEDED"},
-                                       {5, "NOT_FOUND"},
-                                       {6, "ALREADY_EXISTS"},
-                                       {7, "PERMISSION_DENIED"},
-                                       {8, "RESOURCE_EXHAUSTED"},
-                                       {9, "FAILED_PRECONDITION"},
-                                       {10, "ABORTED"},
-                                       {11, "OUT_OF_RANGE"},
-                                       {12, "UNIMPLEMENTED"},
-                                       {13, "INTERNAL"},
-                                       {14, "UNAVAILABLE"},
-                                       {15, "DATA_LOSS"},
-                                       {16, "UNAUTHENTICATED"}};
+  std::map<int, std::string> statusMap{{0, "Unset"}, {1, "Ok"}, {2, "Error"}};
 
   /*
     print_value is used to print out the value of an attribute within a vector.

--- a/exporters/ostream/test/ostream_span_test.cc
+++ b/exporters/ostream/test/ostream_span_test.cc
@@ -84,7 +84,7 @@ TEST(OStreamSpanExporter, PrintDefaultSpan)
       "  duration      : 0\n"
       "  description   : \n"
       "  span kind     : Internal\n"
-      "  status        : OK\n"
+      "  status        : Unset\n"
       "  attributes    : \n"
       "}\n";
   ASSERT_EQ(stdoutOutput.str(), expectedOutput);
@@ -112,7 +112,7 @@ TEST(OStreamSpanExporter, PrintChangedSpanCout)
 
   recordable->SetStartTime(now);
   recordable->SetDuration(std::chrono::nanoseconds(100));
-  recordable->SetStatus(opentelemetry::trace::CanonicalCode::UNIMPLEMENTED, "Test Description");
+  recordable->SetStatus(opentelemetry::trace::StatusCode::Ok, "Test Description");
   recordable->SetSpanKind(opentelemetry::trace::SpanKind::kClient);
 
   recordable->SetAttribute("attr1", "string");
@@ -144,7 +144,7 @@ TEST(OStreamSpanExporter, PrintChangedSpanCout)
       "  duration      : 100\n"
       "  description   : Test Description\n"
       "  span kind     : Client\n"
-      "  status        : UNIMPLEMENTED\n"
+      "  status        : Ok\n"
       "  attributes    : attr1: string\n"
       "}\n";
   ASSERT_EQ(stdoutOutput.str(), expectedOutput);
@@ -173,7 +173,7 @@ TEST(OStreamSpanExporter, PrintChangedSpanCerr)
 
   recordable->SetStartTime(now);
   recordable->SetDuration(std::chrono::nanoseconds(100));
-  recordable->SetStatus(opentelemetry::trace::CanonicalCode::UNIMPLEMENTED, "Test Description");
+  recordable->SetStatus(opentelemetry::trace::StatusCode::Ok, "Test Description");
   recordable->SetSpanKind(opentelemetry::trace::SpanKind::kConsumer);
 
   std::array<bool, 3> array2 = {false, true, false};
@@ -207,7 +207,7 @@ TEST(OStreamSpanExporter, PrintChangedSpanCerr)
       "  duration      : 100\n"
       "  description   : Test Description\n"
       "  span kind     : Consumer\n"
-      "  status        : UNIMPLEMENTED\n"
+      "  status        : Ok\n"
       "  attributes    : attr1: [0,1,0]\n"
       "}\n";
   ASSERT_EQ(stdcerrOutput.str(), expectedOutput);
@@ -235,7 +235,7 @@ TEST(OStreamSpanExporter, PrintChangedSpanClog)
 
   recordable->SetStartTime(now);
   recordable->SetDuration(std::chrono::nanoseconds(100));
-  recordable->SetStatus(opentelemetry::trace::CanonicalCode::UNIMPLEMENTED, "Test Description");
+  recordable->SetStatus(opentelemetry::trace::StatusCode::Ok, "Test Description");
   recordable->SetSpanKind(opentelemetry::trace::SpanKind::kInternal);
 
   std::array<int, 3> array1 = {1, 2, 3};
@@ -269,7 +269,7 @@ TEST(OStreamSpanExporter, PrintChangedSpanClog)
       "  duration      : 100\n"
       "  description   : Test Description\n"
       "  span kind     : Internal\n"
-      "  status        : UNIMPLEMENTED\n"
+      "  status        : Ok\n"
       "  attributes    : attr1: [1,2,3]\n"
       "}\n";
   ASSERT_EQ(stdclogOutput.str(), expectedOutput);

--- a/exporters/ostream/test/ostream_span_test.cc
+++ b/exporters/ostream/test/ostream_span_test.cc
@@ -112,7 +112,7 @@ TEST(OStreamSpanExporter, PrintChangedSpanCout)
 
   recordable->SetStartTime(now);
   recordable->SetDuration(std::chrono::nanoseconds(100));
-  recordable->SetStatus(opentelemetry::trace::StatusCode::Ok, "Test Description");
+  recordable->SetStatus(opentelemetry::trace::StatusCode::kOk, "Test Description");
   recordable->SetSpanKind(opentelemetry::trace::SpanKind::kClient);
 
   recordable->SetAttribute("attr1", "string");
@@ -173,7 +173,7 @@ TEST(OStreamSpanExporter, PrintChangedSpanCerr)
 
   recordable->SetStartTime(now);
   recordable->SetDuration(std::chrono::nanoseconds(100));
-  recordable->SetStatus(opentelemetry::trace::StatusCode::Ok, "Test Description");
+  recordable->SetStatus(opentelemetry::trace::StatusCode::kOk, "Test Description");
   recordable->SetSpanKind(opentelemetry::trace::SpanKind::kConsumer);
 
   std::array<bool, 3> array2 = {false, true, false};
@@ -235,7 +235,7 @@ TEST(OStreamSpanExporter, PrintChangedSpanClog)
 
   recordable->SetStartTime(now);
   recordable->SetDuration(std::chrono::nanoseconds(100));
-  recordable->SetStatus(opentelemetry::trace::StatusCode::Ok, "Test Description");
+  recordable->SetStatus(opentelemetry::trace::StatusCode::kOk, "Test Description");
   recordable->SetSpanKind(opentelemetry::trace::SpanKind::kInternal);
 
   std::array<int, 3> array1 = {1, 2, 3};

--- a/exporters/otlp/include/opentelemetry/exporters/otlp/recordable.h
+++ b/exporters/otlp/include/opentelemetry/exporters/otlp/recordable.h
@@ -28,7 +28,7 @@ public:
   void AddLink(const opentelemetry::trace::SpanContext &span_context,
                const common::KeyValueIterable &attributes) noexcept override;
 
-  void SetStatus(trace::CanonicalCode code, nostd::string_view description) noexcept override;
+  void SetStatus(trace::StatusCode code, nostd::string_view description) noexcept override;
 
   void SetName(nostd::string_view name) noexcept override;
 

--- a/exporters/otlp/src/recordable.cc
+++ b/exporters/otlp/src/recordable.cc
@@ -154,7 +154,7 @@ void Recordable::AddLink(const opentelemetry::trace::SpanContext &span_context,
   // TODO: Populate trace_state when it is supported by SpanContext
 }
 
-void Recordable::SetStatus(trace::CanonicalCode code, nostd::string_view description) noexcept
+void Recordable::SetStatus(trace::StatusCode code, nostd::string_view description) noexcept
 {
   span_.mutable_status()->set_code(opentelemetry::proto::trace::v1::Status_StatusCode(code));
   span_.mutable_status()->set_message(description.data(), description.size());

--- a/exporters/otlp/test/recordable_test.cc
+++ b/exporters/otlp/test/recordable_test.cc
@@ -77,7 +77,7 @@ TEST(Recordable, SetDuration)
 TEST(Recordable, SetStatus)
 {
   Recordable rec;
-  trace::StatusCode code(trace::StatusCode::Ok);
+  trace::StatusCode code(trace::StatusCode::kOk);
   nostd::string_view description = "For test";
   rec.SetStatus(code, description);
 

--- a/exporters/otlp/test/recordable_test.cc
+++ b/exporters/otlp/test/recordable_test.cc
@@ -77,7 +77,7 @@ TEST(Recordable, SetDuration)
 TEST(Recordable, SetStatus)
 {
   Recordable rec;
-  trace::CanonicalCode code(trace::CanonicalCode::OK);
+  trace::StatusCode code(trace::StatusCode::Ok);
   nostd::string_view description = "For test";
   rec.SetStatus(code, description);
 

--- a/ext/include/opentelemetry/ext/zpages/threadsafe_span_data.h
+++ b/ext/include/opentelemetry/ext/zpages/threadsafe_span_data.h
@@ -70,7 +70,7 @@ public:
    * Get the status for this span
    * @return the status for this span
    */
-  opentelemetry::trace::CanonicalCode GetStatus() const noexcept
+  opentelemetry::trace::StatusCode GetStatus() const noexcept
   {
     std::lock_guard<std::mutex> lock(mutex_);
     return status_code_;
@@ -133,7 +133,7 @@ public:
     attributes_[std::string(key)] = nostd::visit(converter_, value);
   }
 
-  void SetStatus(opentelemetry::trace::CanonicalCode code,
+  void SetStatus(opentelemetry::trace::StatusCode code,
                  nostd::string_view description) noexcept override
   {
     std::lock_guard<std::mutex> lock(mutex_);
@@ -216,7 +216,7 @@ private:
   std::chrono::nanoseconds duration_{0};
   std::string name_;
   opentelemetry::trace::SpanKind span_kind_;
-  opentelemetry::trace::CanonicalCode status_code_{opentelemetry::trace::CanonicalCode::OK};
+  opentelemetry::trace::StatusCode status_code_{opentelemetry::trace::StatusCode::Unset};
   std::string status_desc_;
   std::unordered_map<std::string, opentelemetry::sdk::common::OwnedAttributeValue> attributes_;
   std::vector<opentelemetry::sdk::trace::SpanDataEvent> events_;

--- a/ext/include/opentelemetry/ext/zpages/threadsafe_span_data.h
+++ b/ext/include/opentelemetry/ext/zpages/threadsafe_span_data.h
@@ -216,7 +216,7 @@ private:
   std::chrono::nanoseconds duration_{0};
   std::string name_;
   opentelemetry::trace::SpanKind span_kind_;
-  opentelemetry::trace::StatusCode status_code_{opentelemetry::trace::StatusCode::Unset};
+  opentelemetry::trace::StatusCode status_code_{opentelemetry::trace::StatusCode::kUnset};
   std::string status_desc_;
   std::unordered_map<std::string, opentelemetry::sdk::common::OwnedAttributeValue> attributes_;
   std::vector<opentelemetry::sdk::trace::SpanDataEvent> events_;

--- a/ext/src/zpages/tracez_data_aggregator.cc
+++ b/ext/src/zpages/tracez_data_aggregator.cc
@@ -124,8 +124,8 @@ void TracezDataAggregator::AggregateCompletedSpans(
       aggregated_tracez_data_[span_name] = TracezData();
     }
 
-    if (completed_span->GetStatus() == trace::StatusCode::Ok ||
-        completed_span->GetStatus() == trace::StatusCode::Unset)
+    if (completed_span->GetStatus() == trace::StatusCode::kOk ||
+        completed_span->GetStatus() == trace::StatusCode::kUnset)
       AggregateStatusOKSpan(completed_span);
     else
       AggregateStatusErrorSpan(completed_span);

--- a/ext/src/zpages/tracez_data_aggregator.cc
+++ b/ext/src/zpages/tracez_data_aggregator.cc
@@ -124,7 +124,8 @@ void TracezDataAggregator::AggregateCompletedSpans(
       aggregated_tracez_data_[span_name] = TracezData();
     }
 
-    if (completed_span->GetStatus() == CanonicalCode::OK)
+    if (completed_span->GetStatus() == trace::StatusCode::Ok ||
+        completed_span->GetStatus() == trace::StatusCode::Unset)
       AggregateStatusOKSpan(completed_span);
     else
       AggregateStatusErrorSpan(completed_span);

--- a/ext/test/zpages/threadsafe_span_data_test.cc
+++ b/ext/test/zpages/threadsafe_span_data_test.cc
@@ -20,7 +20,7 @@ TEST(ThreadsafeSpanData, DefaultValues)
   ASSERT_EQ(data.GetSpanId(), zero_span_id);
   ASSERT_EQ(data.GetParentSpanId(), zero_span_id);
   ASSERT_EQ(data.GetName(), "");
-  ASSERT_EQ(data.GetStatus(), opentelemetry::trace::CanonicalCode::OK);
+  ASSERT_EQ(data.GetStatus(), opentelemetry::trace::StatusCode::Unset);
   ASSERT_EQ(data.GetDescription(), "");
   ASSERT_EQ(data.GetStartTime().time_since_epoch(), std::chrono::nanoseconds(0));
   ASSERT_EQ(data.GetDuration(), std::chrono::nanoseconds(0));
@@ -37,7 +37,7 @@ TEST(ThreadsafeSpanData, Set)
   ThreadsafeSpanData data;
   data.SetIds(trace_id, span_id, parent_span_id);
   data.SetName("span name");
-  data.SetStatus(opentelemetry::trace::CanonicalCode::UNKNOWN, "description");
+  data.SetStatus(opentelemetry::trace::StatusCode::Ok, "description");
   data.SetStartTime(now);
   data.SetDuration(std::chrono::nanoseconds(1000000));
   data.SetAttribute("attr1", 314159);
@@ -47,7 +47,7 @@ TEST(ThreadsafeSpanData, Set)
   ASSERT_EQ(data.GetSpanId(), span_id);
   ASSERT_EQ(data.GetParentSpanId(), parent_span_id);
   ASSERT_EQ(data.GetName(), "span name");
-  ASSERT_EQ(data.GetStatus(), opentelemetry::trace::CanonicalCode::UNKNOWN);
+  ASSERT_EQ(data.GetStatus(), opentelemetry::trace::StatusCode::Ok);
   ASSERT_EQ(data.GetDescription(), "description");
   ASSERT_EQ(data.GetStartTime().time_since_epoch(), now.time_since_epoch());
   ASSERT_EQ(data.GetDuration(), std::chrono::nanoseconds(1000000));

--- a/ext/test/zpages/threadsafe_span_data_test.cc
+++ b/ext/test/zpages/threadsafe_span_data_test.cc
@@ -20,7 +20,7 @@ TEST(ThreadsafeSpanData, DefaultValues)
   ASSERT_EQ(data.GetSpanId(), zero_span_id);
   ASSERT_EQ(data.GetParentSpanId(), zero_span_id);
   ASSERT_EQ(data.GetName(), "");
-  ASSERT_EQ(data.GetStatus(), opentelemetry::trace::StatusCode::Unset);
+  ASSERT_EQ(data.GetStatus(), opentelemetry::trace::StatusCode::kUnset);
   ASSERT_EQ(data.GetDescription(), "");
   ASSERT_EQ(data.GetStartTime().time_since_epoch(), std::chrono::nanoseconds(0));
   ASSERT_EQ(data.GetDuration(), std::chrono::nanoseconds(0));
@@ -37,7 +37,7 @@ TEST(ThreadsafeSpanData, Set)
   ThreadsafeSpanData data;
   data.SetIds(trace_id, span_id, parent_span_id);
   data.SetName("span name");
-  data.SetStatus(opentelemetry::trace::StatusCode::Ok, "description");
+  data.SetStatus(opentelemetry::trace::StatusCode::kOk, "description");
   data.SetStartTime(now);
   data.SetDuration(std::chrono::nanoseconds(1000000));
   data.SetAttribute("attr1", 314159);
@@ -47,7 +47,7 @@ TEST(ThreadsafeSpanData, Set)
   ASSERT_EQ(data.GetSpanId(), span_id);
   ASSERT_EQ(data.GetParentSpanId(), parent_span_id);
   ASSERT_EQ(data.GetName(), "span name");
-  ASSERT_EQ(data.GetStatus(), opentelemetry::trace::StatusCode::Ok);
+  ASSERT_EQ(data.GetStatus(), opentelemetry::trace::StatusCode::kOk);
   ASSERT_EQ(data.GetDescription(), "description");
   ASSERT_EQ(data.GetStartTime().time_since_epoch(), now.time_since_epoch());
   ASSERT_EQ(data.GetDuration(), std::chrono::nanoseconds(1000000));

--- a/ext/test/zpages/tracez_data_aggregator_test.cc
+++ b/ext/test/zpages/tracez_data_aggregator_test.cc
@@ -156,7 +156,7 @@ TEST_F(TracezDataAggregatorTest, SingleErrorSpan)
 {
   // Start and end a single error span
   auto span = tracer->StartSpan(span_name1);
-  span->SetStatus(opentelemetry::trace::CanonicalCode::CANCELLED, "span cancelled");
+  span->SetStatus(opentelemetry::trace::StatusCode::Error, "span cancelled");
   span->End();
   std::this_thread::sleep_for(milliseconds(500));
   auto data = tracez_data_aggregator->GetAggregatedTracezData();
@@ -320,7 +320,7 @@ TEST_F(TracezDataAggregatorTest, MultipleErrorSpans)
     for (auto error_desc : span_error.second)
     {
       auto span = tracer->StartSpan(span_error.first);
-      span->SetStatus(opentelemetry::trace::CanonicalCode::CANCELLED, error_desc);
+      span->SetStatus(opentelemetry::trace::StatusCode::Error, error_desc);
       span->End();
     }
   }
@@ -400,7 +400,7 @@ TEST_F(TracezDataAggregatorTest, ErrorSampleSpansOverCapacity)
   for (auto span_error_description : span_error_descriptions)
   {
     auto span = tracer->StartSpan(span_name1);
-    span->SetStatus(opentelemetry::trace::CanonicalCode::CANCELLED, span_error_description);
+    span->SetStatus(opentelemetry::trace::StatusCode::Error, span_error_description);
     span->End();
   }
 
@@ -490,7 +490,7 @@ TEST_F(TracezDataAggregatorTest, SpanNameInAlphabeticalOrder)
   auto span_first = tracer->StartSpan(span_name2);
   tracer->StartSpan(span_name1)->End();
   auto span_third = tracer->StartSpan(span_name3);
-  span_third->SetStatus(opentelemetry::trace::CanonicalCode::CANCELLED, "span cancelled");
+  span_third->SetStatus(opentelemetry::trace::StatusCode::Error, "span cancelled");
   span_third->End();
   std::this_thread::sleep_for(milliseconds(500));
   // Get data and check if span name exists in aggregation
@@ -670,7 +670,7 @@ TEST_F(TracezDataAggregatorTest, NoChangeInBetweenCallsToAggregator)
   tracer->StartSpan(span_name1, start)->End(end);
   auto running_span = tracer->StartSpan(span_name2);
   auto span         = tracer->StartSpan(span_name3);
-  span->SetStatus(opentelemetry::trace::CanonicalCode::CANCELLED, "span cancelled");
+  span->SetStatus(opentelemetry::trace::StatusCode::Error, "span cancelled");
   span->End();
   std::this_thread::sleep_for(milliseconds(500));
   auto data = tracez_data_aggregator->GetAggregatedTracezData();

--- a/ext/test/zpages/tracez_data_aggregator_test.cc
+++ b/ext/test/zpages/tracez_data_aggregator_test.cc
@@ -156,7 +156,7 @@ TEST_F(TracezDataAggregatorTest, SingleErrorSpan)
 {
   // Start and end a single error span
   auto span = tracer->StartSpan(span_name1);
-  span->SetStatus(opentelemetry::trace::StatusCode::Error, "span cancelled");
+  span->SetStatus(opentelemetry::trace::StatusCode::kError, "span cancelled");
   span->End();
   std::this_thread::sleep_for(milliseconds(500));
   auto data = tracez_data_aggregator->GetAggregatedTracezData();
@@ -320,7 +320,7 @@ TEST_F(TracezDataAggregatorTest, MultipleErrorSpans)
     for (auto error_desc : span_error.second)
     {
       auto span = tracer->StartSpan(span_error.first);
-      span->SetStatus(opentelemetry::trace::StatusCode::Error, error_desc);
+      span->SetStatus(opentelemetry::trace::StatusCode::kError, error_desc);
       span->End();
     }
   }
@@ -400,7 +400,7 @@ TEST_F(TracezDataAggregatorTest, ErrorSampleSpansOverCapacity)
   for (auto span_error_description : span_error_descriptions)
   {
     auto span = tracer->StartSpan(span_name1);
-    span->SetStatus(opentelemetry::trace::StatusCode::Error, span_error_description);
+    span->SetStatus(opentelemetry::trace::StatusCode::kError, span_error_description);
     span->End();
   }
 
@@ -490,7 +490,7 @@ TEST_F(TracezDataAggregatorTest, SpanNameInAlphabeticalOrder)
   auto span_first = tracer->StartSpan(span_name2);
   tracer->StartSpan(span_name1)->End();
   auto span_third = tracer->StartSpan(span_name3);
-  span_third->SetStatus(opentelemetry::trace::StatusCode::Error, "span cancelled");
+  span_third->SetStatus(opentelemetry::trace::StatusCode::kError, "span cancelled");
   span_third->End();
   std::this_thread::sleep_for(milliseconds(500));
   // Get data and check if span name exists in aggregation
@@ -670,7 +670,7 @@ TEST_F(TracezDataAggregatorTest, NoChangeInBetweenCallsToAggregator)
   tracer->StartSpan(span_name1, start)->End(end);
   auto running_span = tracer->StartSpan(span_name2);
   auto span         = tracer->StartSpan(span_name3);
-  span->SetStatus(opentelemetry::trace::StatusCode::Error, "span cancelled");
+  span->SetStatus(opentelemetry::trace::StatusCode::kError, "span cancelled");
   span->End();
   std::this_thread::sleep_for(milliseconds(500));
   auto data = tracez_data_aggregator->GetAggregatedTracezData();

--- a/sdk/include/opentelemetry/sdk/trace/recordable.h
+++ b/sdk/include/opentelemetry/sdk/trace/recordable.h
@@ -101,7 +101,7 @@ public:
    * @param code the status code
    * @param description a description of the status
    */
-  virtual void SetStatus(opentelemetry::trace::CanonicalCode code,
+  virtual void SetStatus(opentelemetry::trace::StatusCode code,
                          nostd::string_view description) noexcept = 0;
 
   /**

--- a/sdk/include/opentelemetry/sdk/trace/span_data.h
+++ b/sdk/include/opentelemetry/sdk/trace/span_data.h
@@ -227,7 +227,7 @@ private:
   core::SystemTimestamp start_time_;
   std::chrono::nanoseconds duration_{0};
   std::string name_;
-  opentelemetry::trace::StatusCode status_code_{opentelemetry::trace::StatusCode::Unset};
+  opentelemetry::trace::StatusCode status_code_{opentelemetry::trace::StatusCode::kUnset};
   std::string status_desc_;
   common::AttributeMap attribute_map_;
   std::vector<SpanDataEvent> events_;

--- a/sdk/include/opentelemetry/sdk/trace/span_data.h
+++ b/sdk/include/opentelemetry/sdk/trace/span_data.h
@@ -125,7 +125,7 @@ public:
    * Get the status for this span
    * @return the status for this span
    */
-  opentelemetry::trace::CanonicalCode GetStatus() const noexcept { return status_code_; }
+  opentelemetry::trace::StatusCode GetStatus() const noexcept { return status_code_; }
 
   /**
    * Get the status description for this span
@@ -196,7 +196,7 @@ public:
     links_.push_back(link);
   }
 
-  void SetStatus(opentelemetry::trace::CanonicalCode code,
+  void SetStatus(opentelemetry::trace::StatusCode code,
                  nostd::string_view description) noexcept override
   {
     status_code_ = code;
@@ -227,7 +227,7 @@ private:
   core::SystemTimestamp start_time_;
   std::chrono::nanoseconds duration_{0};
   std::string name_;
-  opentelemetry::trace::CanonicalCode status_code_{opentelemetry::trace::CanonicalCode::OK};
+  opentelemetry::trace::StatusCode status_code_{opentelemetry::trace::StatusCode::Unset};
   std::string status_desc_;
   common::AttributeMap attribute_map_;
   std::vector<SpanDataEvent> events_;

--- a/sdk/src/trace/span.cc
+++ b/sdk/src/trace/span.cc
@@ -158,8 +158,7 @@ void Span::AddEvent(nostd::string_view name,
   recordable_->AddEvent(name, timestamp, attributes);
 }
 
-void Span::SetStatus(opentelemetry::trace::CanonicalCode code,
-                     nostd::string_view description) noexcept
+void Span::SetStatus(opentelemetry::trace::StatusCode code, nostd::string_view description) noexcept
 {
   std::lock_guard<std::mutex> lock_guard{mu_};
   if (recordable_ == nullptr)

--- a/sdk/src/trace/span.h
+++ b/sdk/src/trace/span.h
@@ -38,7 +38,7 @@ public:
                 core::SystemTimestamp timestamp,
                 const opentelemetry::common::KeyValueIterable &attributes) noexcept override;
 
-  void SetStatus(trace_api::CanonicalCode code, nostd::string_view description) noexcept override;
+  void SetStatus(trace_api::StatusCode code, nostd::string_view description) noexcept override;
 
   void UpdateName(nostd::string_view name) noexcept override;
 

--- a/sdk/test/trace/span_data_test.cc
+++ b/sdk/test/trace/span_data_test.cc
@@ -18,7 +18,7 @@ TEST(SpanData, DefaultValues)
   ASSERT_EQ(data.GetSpanId(), zero_span_id);
   ASSERT_EQ(data.GetParentSpanId(), zero_span_id);
   ASSERT_EQ(data.GetName(), "");
-  ASSERT_EQ(data.GetStatus(), opentelemetry::trace::StatusCode::Unset);
+  ASSERT_EQ(data.GetStatus(), opentelemetry::trace::StatusCode::kUnset);
   ASSERT_EQ(data.GetDescription(), "");
   ASSERT_EQ(data.GetStartTime().time_since_epoch(), std::chrono::nanoseconds(0));
   ASSERT_EQ(data.GetDuration(), std::chrono::nanoseconds(0));
@@ -37,7 +37,7 @@ TEST(SpanData, Set)
   data.SetIds(trace_id, span_id, parent_span_id);
   data.SetName("span name");
   data.SetSpanKind(opentelemetry::trace::SpanKind::kServer);
-  data.SetStatus(opentelemetry::trace::StatusCode::Ok, "description");
+  data.SetStatus(opentelemetry::trace::StatusCode::kOk, "description");
   data.SetStartTime(now);
   data.SetDuration(std::chrono::nanoseconds(1000000));
   data.SetAttribute("attr1", (int64_t)314159);
@@ -48,7 +48,7 @@ TEST(SpanData, Set)
   ASSERT_EQ(data.GetParentSpanId(), parent_span_id);
   ASSERT_EQ(data.GetName(), "span name");
   ASSERT_EQ(data.GetSpanKind(), opentelemetry::trace::SpanKind::kServer);
-  ASSERT_EQ(data.GetStatus(), opentelemetry::trace::StatusCode::Ok);
+  ASSERT_EQ(data.GetStatus(), opentelemetry::trace::StatusCode::kOk);
   ASSERT_EQ(data.GetDescription(), "description");
   ASSERT_EQ(data.GetStartTime().time_since_epoch(), now.time_since_epoch());
   ASSERT_EQ(data.GetDuration(), std::chrono::nanoseconds(1000000));

--- a/sdk/test/trace/span_data_test.cc
+++ b/sdk/test/trace/span_data_test.cc
@@ -18,7 +18,7 @@ TEST(SpanData, DefaultValues)
   ASSERT_EQ(data.GetSpanId(), zero_span_id);
   ASSERT_EQ(data.GetParentSpanId(), zero_span_id);
   ASSERT_EQ(data.GetName(), "");
-  ASSERT_EQ(data.GetStatus(), opentelemetry::trace::CanonicalCode::OK);
+  ASSERT_EQ(data.GetStatus(), opentelemetry::trace::StatusCode::Unset);
   ASSERT_EQ(data.GetDescription(), "");
   ASSERT_EQ(data.GetStartTime().time_since_epoch(), std::chrono::nanoseconds(0));
   ASSERT_EQ(data.GetDuration(), std::chrono::nanoseconds(0));
@@ -37,7 +37,7 @@ TEST(SpanData, Set)
   data.SetIds(trace_id, span_id, parent_span_id);
   data.SetName("span name");
   data.SetSpanKind(opentelemetry::trace::SpanKind::kServer);
-  data.SetStatus(opentelemetry::trace::CanonicalCode::UNKNOWN, "description");
+  data.SetStatus(opentelemetry::trace::StatusCode::Ok, "description");
   data.SetStartTime(now);
   data.SetDuration(std::chrono::nanoseconds(1000000));
   data.SetAttribute("attr1", (int64_t)314159);
@@ -48,7 +48,7 @@ TEST(SpanData, Set)
   ASSERT_EQ(data.GetParentSpanId(), parent_span_id);
   ASSERT_EQ(data.GetName(), "span name");
   ASSERT_EQ(data.GetSpanKind(), opentelemetry::trace::SpanKind::kServer);
-  ASSERT_EQ(data.GetStatus(), opentelemetry::trace::CanonicalCode::UNKNOWN);
+  ASSERT_EQ(data.GetStatus(), opentelemetry::trace::StatusCode::Ok);
   ASSERT_EQ(data.GetDescription(), "description");
   ASSERT_EQ(data.GetStartTime().time_since_epoch(), now.time_since_epoch());
   ASSERT_EQ(data.GetDuration(), std::chrono::nanoseconds(1000000));


### PR DESCRIPTION
update StatusCode as per specs.  Permitted values : `Unset`, `Ok`, `Error` , and NOT the grpc values.

Specs: https://github.com/open-telemetry/opentelemetry-specification/blob/master/specification/trace/api.md

--clip--

**Set Status**
Sets the Status of the Span. If used, this will override the default Span status, which is Unset.

Status is structurally defined by the following properties:

StatusCode, one of the values listed below.
Optional Description that provides a descriptive message of the Status. Description MUST only be used with the Error StatusCode value.
StatusCode is one of the following values:

_Unset_
The default status.
_Ok_
The operation has been validated by an Application developer or Operator to have completed successfully.
_Error_
The operation contains an error.
The Span interface MUST provide:

An API to set the Status. This SHOULD be called SetStatus. This API takes the StatusCode, and an optional Description, either as individual parameters or as an immutable object encapsulating them, whichever is most appropriate for the language. Description MUST be IGNORED for StatusCode Ok & Unset values.



