### PR TITLE
Improve invalid span Id check

### DIFF
--- a/api/include/opentelemetry/trace/span_id.h
+++ b/api/include/opentelemetry/trace/span_id.h
@@ -58,7 +58,11 @@ public:
   bool operator!=(const SpanId &that) const noexcept { return !(*this == that); }
 
   // Returns false if the SpanId is all zeros.
-  bool IsValid() const noexcept { return *this != SpanId(); }
+  bool IsValid() const noexcept
+  {
+    static_assert(kSize == 8, "update is needed if kSize is not 8");
+    return *reinterpret_cast<const uint64_t *>(&rep_) != 0ull;
+  }
 
   // Copies the opaque SpanId data to dest.
   void CopyBytesTo(nostd::span<uint8_t, kSize> dest) const noexcept


### PR DESCRIPTION
The current check of `SpanId::IsValid` constructs a default instance of `SpanId` and then make comparison between the 2 instance. Improve this by assuming the 8 bytes `SpanId` as unsigned 64-bit integer and comparing it with 0 directly.