### PR TITLE
Fix branch name to main in links

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,10 +8,10 @@ See the [public meeting notes](https://docs.google.com/document/d/1i1E4-_y4uJ083
 for a summary description of past meetings. To request edit access, join the
 meeting or get in touch on [Gitter](https://gitter.im/open-telemetry/opentelemetry-cpp).
 
-See the [community membership document](https://github.com/open-telemetry/community/blob/master/community-membership.md)
-on how to become a [**Member**](https://github.com/open-telemetry/community/blob/master/community-membership.md#member),
-[**Approver**](https://github.com/open-telemetry/community/blob/master/community-membership.md#approver)
-and [**Maintainer**](https://github.com/open-telemetry/community/blob/master/community-membership.md#maintainer).
+See the [community membership document](https://github.com/open-telemetry/community/blob/main/community-membership.md)
+on how to become a [**Member**](https://github.com/open-telemetry/community/blob/main/community-membership.md#member),
+[**Approver**](https://github.com/open-telemetry/community/blob/main/community-membership.md#approver)
+and [**Maintainer**](https://github.com/open-telemetry/community/blob/main/community-membership.md#maintainer).
 
 ## Development
 
@@ -106,8 +106,8 @@ To run tests locally, please read the [CI instructions](ci/README.md).
 
 A PR is considered to be **ready to merge** when:
 
-* It has received two approvals with at least one approval from [Approver](https://github.com/open-telemetry/community/blob/master/community-membership.md#approver)
-  / [Maintainer](https://github.com/open-telemetry/community/blob/master/community-membership.md#maintainer)
+* It has received two approvals with at least one approval from [Approver](https://github.com/open-telemetry/community/blob/main/community-membership.md#approver)
+  / [Maintainer](https://github.com/open-telemetry/community/blob/main/community-membership.md#maintainer)
   (at different company).
 * A pull reqeust opened by an Approver / Maintainer can be merged with only one approval from  Approver / Maintainer (at different company).
 * Major feedback items/points are resolved.
@@ -148,7 +148,7 @@ specifically the C++ repository.
 * Read through the [OpenTelemetry Collector](https://github.com/open-telemetry/opentelemetry-collector)
   GitHub repository.
   * This repository has a lot of good information surrounding the
-    OpenTelemetry ecosystem. At the top of the **[readme](https://github.com/open-telemetry/opentelemetry-collector/blob/master/README.md)**,
+    OpenTelemetry ecosystem. At the top of the **[readme](https://github.com/open-telemetry/opentelemetry-collector/blob/main/README.md)**,
     there are multiple links that give newcomers a good idea of what the
     project is about and how to get involved in it.
 * Read through the OpenTelemetry Python documentation
@@ -166,14 +166,14 @@ specifically the C++ repository.
   the example can be found in [PR #94](https://github.com/open-telemetry/opentelemetry-cpp/pull/94).
 
 * Read through the [Java Quick-Start
-  Guide](https://github.com/open-telemetry/opentelemetry-java/blob/master/QUICKSTART.md).
+  Guide](https://github.com/open-telemetry/opentelemetry-java/blob/main/QUICKSTART.md).
   This shows you how the classes and functions will interact in simple and
   easy to digest examples.
 * Take a look at this [Java SDK
-  example](https://github.com/open-telemetry/opentelemetry-java/tree/master/examples/sdk-usage).
+  example](https://github.com/open-telemetry/opentelemetry-java/tree/main/examples/sdk-usage).
   This shows a good use case of the SDK using stdout exporter.
 * Take a look at the [Java Jaeger
-  example](https://github.com/open-telemetry/opentelemetry-java/tree/master/examples/jaeger).
+  example](https://github.com/open-telemetry/opentelemetry-java/tree/main/examples/jaeger).
   This provides a brief introduction to the Jaeger exporter, its interface,
   and how to interact with the service.
 

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ Approvers ([@open-telemetry/cpp-approvers](https://github.com/orgs/open-telemetr
 * [Ryan Burn](https://github.com/rnburn), Lightstep
 * [Tom Tan](https://github.com/ThomsonTan), Microsoft
 
-*Find more about the approver role in [community repository](https://github.com/open-telemetry/community/blob/master/community-membership.md#approver).*
+*Find more about the approver role in [community repository](https://github.com/open-telemetry/community/blob/main/community-membership.md#approver).*
 
 Maintainers ([@open-telemetry/cpp-maintainers](https://github.com/orgs/open-telemetry/teams/cpp-maintainers)):
 
@@ -74,14 +74,14 @@ Maintainers ([@open-telemetry/cpp-maintainers](https://github.com/orgs/open-tele
 * [Lalit Kumar Bhasin](https://github.com/lalitb), Microsoft
 * [Reiley Yang](https://github.com/reyang), Microsoft
 
-*Find more about the maintainer role in [community repository](https://github.com/open-telemetry/community/blob/master/community-membership.md#maintainer).*
+*Find more about the maintainer role in [community repository](https://github.com/open-telemetry/community/blob/main/community-membership.md#maintainer).*
 
 Triagers ([@open-telemetry/cpp-triagers](https://github.com/orgs/open-telemetry/teams/cpp-triagers)):
 
 * [Alolita Sharma](https://github.com/alolita), Amazon
 * [Jodee Varney](https://github.com/jodeev), New Relic
 
-*Find more about the triager role in [community repository](https://github.com/open-telemetry/community/blob/master/community-membership.md#triager).*
+*Find more about the triager role in [community repository](https://github.com/open-telemetry/community/blob/main/community-membership.md#triager).*
 
 ## Release Schedule
 

--- a/api/include/opentelemetry/trace/propagation/b3_propagator.h
+++ b/api/include/opentelemetry/trace/propagation/b3_propagator.h
@@ -44,7 +44,7 @@ static const int kTraceFlagHexStrLength = 1;
 // The B3PropagatorExtractor class provides an interface that enables extracting context from
 // headers of HTTP requests. HTTP frameworks and clients can integrate with B3Propagator by
 // providing the object containing the headers, and a getter function for the extraction. Based on:
-// https://github.com/open-telemetry/opentelemetry-specification/blob/master/specification/context/api-propagators.md#b3-extract
+// https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/context/api-propagators.md#b3-extract
 template <typename T>
 class B3PropagatorExtractor : public HTTPTextFormat<T>
 {

--- a/docs/cpp-metrics-api-design.md
+++ b/docs/cpp-metrics-api-design.md
@@ -1,6 +1,6 @@
 # Metrics API Design
 
-This document outlines a proposed implementation of the OpenTelemetry Metrics API in C++.  The design conforms to the current versions of the [Metrics API Specification](https://github.com/open-telemetry/opentelemetry-specification/blob/master/specification/metrics/api.md) though it is currently under development and subject to change.
+This document outlines a proposed implementation of the OpenTelemetry Metrics API in C++.  The design conforms to the current versions of the [Metrics API Specification](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/metrics/api.md) though it is currently under development and subject to change.
 
 The design supports a minimal implementation for the library to be used by an application. However, without the reference SDK or another implementation, no metric data will be collected.
 
@@ -243,7 +243,7 @@ Each instrument must have enough information to meaningfully attach its measured
 Metric instruments are created through instances of the `Meter` class and each type of instrument can be described with the following properties:
 
 
-* Synchronicity:  A synchronous instrument is called by the user in a distributed [Context](https://github.com/open-telemetry/opentelemetry-specification/blob/master/specification/context/context.md) (i.e., Span context, Correlation context) and is updated once per request. An asynchronous instrument is called by the SDK once per collection interval and only one value from the interval is kept.
+* Synchronicity:  A synchronous instrument is called by the user in a distributed [Context](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/context/context.md) (i.e., Span context, Correlation context) and is updated once per request. An asynchronous instrument is called by the SDK once per collection interval and only one value from the interval is kept.
 * Additivity:  An additive instrument is one that records additive measurements, meaning the final sum of updates is the only useful value.  Non-additive instruments should be used when the intent is to capture information about the distribution of values.
 * Monotonicity: A monotonic instrument is an additive instrument, where the progression of each sum is non-decreasing. Monotonic instruments are useful for monitoring rate information.
 

--- a/docs/cpp-metrics-sdk-design.md
+++ b/docs/cpp-metrics-sdk-design.md
@@ -633,7 +633,7 @@ The exporter SHOULD be called with a checkpoint of finished (possibly dimensiona
 
 There is very little left for the exporter to do other than format the metric updates into the desired format and send them on their way.
 
-Design choice: Our idea is to take the simple trace example [StdoutExporter](https://github.com/open-telemetry/opentelemetry-cpp/blob/master/examples/simple/stdout_exporter.h) and add Metric functionality to it. This will allow us to verify that what we are implementing in the API and SDK works as intended. The exporter will go through the different metric instruments and print the value stored in their aggregators to stdout, **for simplicity only Sum is shown here, but all aggregators will be implemented**.
+Design choice: Our idea is to take the simple trace example [OStreamSpanExporter](https://github.com/open-telemetry/opentelemetry-cpp/blob/main/examples/simple/main.cc) and add Metric functionality to it. This will allow us to verify that what we are implementing in the API and SDK works as intended. The exporter will go through the different metric instruments and print the value stored in their aggregators to stdout, **for simplicity only Sum is shown here, but all aggregators will be implemented**.
 
 
 ```cc

--- a/docs/library-distribution.md
+++ b/docs/library-distribution.md
@@ -53,7 +53,7 @@ different binding models and the recommendations.
   itself instrument using OpenTelemetry or register a specific implementation.
 
 For more information on language-agnostic library, please see:
-[OpenTelemetry Specification Library Guidelines](https://github.com/open-telemetry/opentelemetry-specification/blob/master/specification/library-guidelines.md).
+[OpenTelemetry Specification Library Guidelines](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/library-guidelines.md).
 
 ### ABI Compatibility
 

--- a/examples/otlp/README.md
+++ b/examples/otlp/README.md
@@ -1,10 +1,10 @@
 # OTLP Exporter Example
 
-This is an example of how to use the [OpenTelemetry Protocol](https://github.com/open-telemetry/opentelemetry-specification/blob/master/specification/protocol/README.md) (OTLP) exporter.
+This is an example of how to use the [OpenTelemetry Protocol](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/protocol/README.md) (OTLP) exporter.
 
 The application in `main.cc` initializes an `OtlpExporter` instance and uses it to register a tracer provider from the [OpenTelemetry SDK](https://github.com/open-telemetry/opentelemetry-cpp). The application then calls a `foo_library` which has been instrumented using the [OpenTelemetry API](https://github.com/open-telemetry/opentelemetry-cpp/tree/main/api).
 
-Resulting spans are exported to the **OpenTelemetry Collector** using the OTLP exporter. The OpenTelemetry Collector can be configured to export to other backends (see list of [supported backends](https://github.com/open-telemetry/opentelemetry-collector/blob/master/exporter/README.md)).
+Resulting spans are exported to the **OpenTelemetry Collector** using the OTLP exporter. The OpenTelemetry Collector can be configured to export to other backends (see list of [supported backends](https://github.com/open-telemetry/opentelemetry-collector/blob/main/exporter/README.md)).
 
 For instructions on downloading and running the OpenTelemetry Collector, see [Getting Started](https://opentelemetry.io/docs/collector/about/).
 

--- a/exporters/otlp/README.md
+++ b/exporters/otlp/README.md
@@ -1,10 +1,10 @@
 # OTLP Exporter
 
-The [OpenTelemetry Protocol](https://github.com/open-telemetry/opentelemetry-specification/blob/master/specification/protocol/README.md) (OTLP) is a vendor-agnostic protocol designed as part of the OpenTelemetry project. The OTLP exporter can be used to export to any backend that supports OTLP.
+The [OpenTelemetry Protocol](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/protocol/README.md) (OTLP) is a vendor-agnostic protocol designed as part of the OpenTelemetry project. The OTLP exporter can be used to export to any backend that supports OTLP.
 
 The [OpenTelemetry Collector](https://github.com/open-telemetry/opentelemetry-collector) is a reference implementation of an OTLP backend. The Collector can be configured to export to many other backends, such as Zipkin and Jaegar.
 
-For a full list of backends supported by the Collector, see the [main Collector repo](https://github.com/open-telemetry/opentelemetry-collector/tree/master/exporter) and [Collector contributions](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/master/exporter).
+For a full list of backends supported by the Collector, see the [main Collector repo](https://github.com/open-telemetry/opentelemetry-collector/tree/main/exporter) and [Collector contributions](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/exporter).
 
 ## Configuration
 

--- a/ext/src/zpages/README.md
+++ b/ext/src/zpages/README.md
@@ -20,7 +20,7 @@ zPages are a quick and light way to view tracing and metrics information on stan
 
 ## More Information
 - OTel zPages experimental [spec](https://github.com/open-telemetry/opentelemetry-specification/blob/5b86d4b6c42e6d1e47d9155ac1e2e27f0f0b7769/experimental/trace/zpages.md)
-- [zPages General Direction Spec (OTEP)](https://github.com/open-telemetry/oteps/blob/master/text/0110-z-pages.md)
+- [zPages General Direction Spec (OTEP)](https://github.com/open-telemetry/oteps/blob/main/text/0110-z-pages.md)
 - OTel C++ Design Docs
   - [Tracez Span Processor](https://docs.google.com/document/d/1kO4iZARYyr-EGBlY2VNM3ELU3iw6ZrC58Omup_YT-fU/edit#)
   - [Tracez Data Aggregator](https://docs.google.com/document/d/1ziKFgvhXFfRXZjOlAHQRR-TzcNcTXzg1p2I9oPCEIoU/edit?ts=5ef0d177#heading=h.5irk4csrpu0y)

--- a/sdk/include/opentelemetry/sdk/logs/log_record.h
+++ b/sdk/include/opentelemetry/sdk/logs/log_record.h
@@ -31,7 +31,7 @@ namespace logs
 /**
  * A default Recordable implemenation to be passed in log statements,
  * matching the 10 fields of the Log Data Model.
- * (https://github.com/open-telemetry/opentelemetry-specification/blob/master/specification/logs/data-model.md#log-and-event-record-definition)
+ * (https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/logs/data-model.md#log-and-event-record-definition)
  *
  */
 class LogRecord final : public Recordable


### PR DESCRIPTION
Changed the branch to main in all links to OpenTelemetry repos.