### PR TITLE
Remove incorrection description on code.coverage in CI doc

### DIFF
--- a/ci/README.md
+++ b/ci/README.md
@@ -15,7 +15,7 @@ CI tests can be run on docker by invoking the script `./ci/run_docker.sh ./ci/do
 * `bazel.valgrind`: build bazel targets and run tests under the valgrind memory checker.
 * `benchmark`: run all benchmarks.
 * `format`: use `tools/format.sh` to enforce text formatting.
-* `code.coverage`: build cmake targets and run tests. Then upload coverage report to [codecov.io](https://codecov.io/).
+* `code.coverage`: build cmake targets with CXX option `--coverage` and run tests.
 
 Additionally, `./ci/run_docker.sh` can be invoked with no arguments to get a docker shell where tests
 can be run manually.


### PR DESCRIPTION
The build target `code.coverage` will build target with coverage data and run tests, but it will not upload the result coverage data to https://codecov.io. The latter work is done by GitHub action at
https://github.com/open-telemetry/opentelemetry-cpp/blob/main/.github/workflows/ci.yml#L330.