### PR TITLE
TraceState implementation as per spec

### DIFF
--- a/api/include/opentelemetry/trace/trace_state.h
+++ b/api/include/opentelemetry/trace/trace_state.h
@@ -132,7 +132,7 @@ public:
       else
       {
         // `end` points to end of current list member
-        end = end - 1;
+        end--;
       }
       auto list_member = TrimString(header, begin, end);  // OWS handling
       if (list_member.size() == 0)
@@ -179,11 +179,11 @@ public:
       {
         header_s.append(",");
       }
-      
+
       auto entry = (entries_.get())[count];
-      header_s.append(entry.GetKey());
-      header_s.append(kKeyValueSeparator);
-      header_s.append(entry.GetValue());
+      header_s.append(std::string(entry.GetKey()));
+      header_s.append(std::string(1, kKeyValueSeparator));
+      header_s.append(std::string(entry.GetValue()));
     }
     return header_s;
   }
@@ -220,15 +220,18 @@ public:
   TraceState Set(const nostd::string_view &key, const nostd::string_view &value)
   {
     TraceState ts;
-    if ((!IsValidKey(key) || !IsValidValue(value)) || num_entries_ == kMaxKeyValuePairs)
+    if ((!IsValidKey(key) || !IsValidValue(value)))
     {
       // max size reached or invalid key/value. Returning empty tracestate
       return ts;  // empty instance
     }
 
-    // add new key-value pair at beginning
-    Entry e(key, value);
-    (ts.entries_.get())[ts.num_entries_++] = e;
+    // add new key-value pair at beginning if list is not reached to its limit
+    if (num_entries_ < kMaxKeyValuePairs)
+    {
+      Entry e(key, value);
+      (ts.entries_.get())[ts.num_entries_++] = e;
+    }
     for (size_t i = 0; i < num_entries_; i++)
     {
       auto entry = (entries_.get())[i];

--- a/api/include/opentelemetry/trace/trace_state.h
+++ b/api/include/opentelemetry/trace/trace_state.h
@@ -16,10 +16,14 @@
 
 #include <cstdint>
 #include <cstring>
-#include <regex>
 #include <string>
 
-#include <iostream>
+#include <regex>
+#if (__GNUC__ == 4 && (__GNUC_MINOR__ == 8))
+#  define HAVE_WORKING_REGEX 0
+#else
+#  define HAVE_WORKING_REGEX 1
+#endif
 
 #include "opentelemetry/nostd/span.h"
 #include "opentelemetry/nostd/string_view.h"
@@ -196,7 +200,7 @@ public:
         return std::string(entry.GetValue());
       }
     }
-    return "";
+    return std::string();
   }
 
   /**
@@ -274,8 +278,11 @@ public:
    */
   static bool IsValidKey(nostd::string_view key)
   {
-    // return IsValidKeyRegEx(key); // uncomment me for non-GCC4.8 C++11 compiler
+#if HAVE_WORKING_REGEX
+    return IsValidKeyRegEx(key);
+#else
     return IsValidKeyNonRegEx(key);
+#endif
   }
 
   /** Returns whether value is a valid value. See https://www.w3.org/TR/trace-context/#value
@@ -284,8 +291,11 @@ public:
    */
   static bool IsValidValue(nostd::string_view value)
   {
-    // return IsValidValueRegEx(value); // uncomment me for non-GCC4.8 C++11 compiler
+#if HAVE_WORKING_REGEX
+    return IsValidValueRegEx(value);
+#else
     return IsValidValueNonRegEx(value);
+#endif
   }
 
 private:

--- a/api/include/opentelemetry/trace/trace_state.h
+++ b/api/include/opentelemetry/trace/trace_state.h
@@ -113,7 +113,7 @@ public:
    * the W3C Trace Context specification https://www.w3.org/TR/trace-context/
    *  @return Tracestate A new Tracestate instance or DEFAULT
    */
-  static TraceState FromHeader(const nostd::string_view &header)
+  static TraceState FromHeader(nostd::string_view header)
   {
     TraceState ts;
 

--- a/api/include/opentelemetry/trace/trace_state.h
+++ b/api/include/opentelemetry/trace/trace_state.h
@@ -17,7 +17,7 @@
 #include <cstdint>
 #include <cstring>
 #include <regex>
-#include<string>
+#include <string>
 
 #include "opentelemetry/nostd/span.h"
 #include "opentelemetry/nostd/string_view.h"
@@ -38,11 +38,11 @@ namespace trace
 class TraceState
 {
 public:
-  static constexpr int kKeyMaxSize       = 256;
-  static constexpr int kValueMaxSize     = 256;
-  static constexpr int kMaxKeyValuePairs = 32;
-  static constexpr auto kKeyValueSeparator =  '=' ; 
-  static constexpr auto kMembersSeparator = ',';
+  static constexpr int kKeyMaxSize         = 256;
+  static constexpr int kValueMaxSize       = 256;
+  static constexpr int kMaxKeyValuePairs   = 32;
+  static constexpr auto kKeyValueSeparator = '=';
+  static constexpr auto kMembersSeparator  = ',';
 
   // Class to store key-value pairs.
   class Entry
@@ -101,82 +101,92 @@ public:
     }
   };
 
-    /**
-     * Returns a newly created Tracestate parsed from the header provided. 
-     * @param header Encoding of the tracestate header defined by
-     * the W3C Trace Context specification https://www.w3.org/TR/trace-context/
-     *  @return Tracestate A new Tracestate instance or DEFAULT
-    */ 
-    static TraceState FromHeader( const nostd::string_view& header){
-        TraceState ts;
+  /**
+   * Returns a newly created Tracestate parsed from the header provided.
+   * @param header Encoding of the tracestate header defined by
+   * the W3C Trace Context specification https://www.w3.org/TR/trace-context/
+   *  @return Tracestate A new Tracestate instance or DEFAULT
+   */
+  static TraceState FromHeader(const nostd::string_view &header)
+  {
+    TraceState ts;
 
-        std::size_t begin{0};
-        std::size_t end{0};
-        bool invalid_header = false;
-        while (begin < header.size() && ts.num_entries_ < kMaxKeyValuePairs ) {
-            //find list-member
-            end = header.find(kMembersSeparator, begin);
-            if (end == std::string::npos ){
-                // last list member. `end` points to end of it.
-                end = header.size() - 1;
-            } else {
-                // `end` points to end of current list member
-                end = end  - 1; 
-            }
-            auto list_member = TrimString(header, begin, end ); // OWS handling
-            if (list_member.size() == 0) {
-              // empty list member, move to next in list
-              begin = end + 2; // begin points to start of next member
-              continue;
-            }
-            auto key_end_pos = list_member.find(kKeyValueSeparator) ;
-            if (key_end_pos == std::string::npos ) {
-              // Error: invalid list member, return empty TraceState
-              ts.entries_.reset(nullptr);
-              ts.num_entries_ = 0;          
-              break;
-            }
-            auto key = list_member.substr(0, key_end_pos);
-            auto value = list_member.substr(key_end_pos + 1);
-            if ( !IsValidKey(key) || !IsValidValue(value))
-            {
-              //invalid header. return empty TraceState
-              ts.entries_.reset(nullptr);
-              ts.num_entries_ = 0;
-              break;
-            }
-            Entry entry(key, value);
-            (ts.entries_.get())[ts.num_entries_] = entry;
-            ts.num_entries_++;
-
-            begin = end + 2;
-        }
-        return ts;
-    }
-
-    /**
-     * Creates a w3c tracestate header from TraceState object
-    */
-    std::string ToHeader() {
-      std::string header_s;
-      size_t count = num_entries_;
-      while(count) {
-        auto entry = (entries_.get())[num_entries_ - count];
-        auto kv  = std::string(entry.GetKey()) + kKeyValueSeparator + std::string(entry.GetValue());
-        if (--count) {
-          // append "," if not last member
-          kv +=",";
-        }
-        header_s = header_s + kv;
+    std::size_t begin{0};
+    std::size_t end{0};
+    bool invalid_header = false;
+    while (begin < header.size() && ts.num_entries_ < kMaxKeyValuePairs)
+    {
+      // find list-member
+      end = header.find(kMembersSeparator, begin);
+      if (end == std::string::npos)
+      {
+        // last list member. `end` points to end of it.
+        end = header.size() - 1;
       }
-      return header_s;
+      else
+      {
+        // `end` points to end of current list member
+        end = end - 1;
+      }
+      auto list_member = TrimString(header, begin, end);  // OWS handling
+      if (list_member.size() == 0)
+      {
+        // empty list member, move to next in list
+        begin = end + 2;  // begin points to start of next member
+        continue;
+      }
+      auto key_end_pos = list_member.find(kKeyValueSeparator);
+      if (key_end_pos == std::string::npos)
+      {
+        // Error: invalid list member, return empty TraceState
+        ts.entries_.reset(nullptr);
+        ts.num_entries_ = 0;
+        break;
+      }
+      auto key   = list_member.substr(0, key_end_pos);
+      auto value = list_member.substr(key_end_pos + 1);
+      if (!IsValidKey(key) || !IsValidValue(value))
+      {
+        // invalid header. return empty TraceState
+        ts.entries_.reset(nullptr);
+        ts.num_entries_ = 0;
+        break;
+      }
+      Entry entry(key, value);
+      (ts.entries_.get())[ts.num_entries_] = entry;
+      ts.num_entries_++;
+
+      begin = end + 2;
     }
+    return ts;
+  }
+
+  /**
+   * Creates a w3c tracestate header from TraceState object
+   */
+  std::string ToHeader()
+  {
+    std::string header_s;
+    size_t count = num_entries_;
+    while (count)
+    {
+      auto entry = (entries_.get())[num_entries_ - count];
+      auto kv    = std::string(entry.GetKey()) + kKeyValueSeparator + std::string(entry.GetValue());
+      if (--count)
+      {
+        // append "," if not last member
+        kv += ",";
+      }
+      header_s = header_s + kv;
+    }
+    return header_s;
+  }
 
   // Returns false if no such key, otherwise returns true and populates the value parameter with the
   // associated value.
   std::string Get(nostd::string_view key) const noexcept
   {
-    for (int i = 0 ; i < num_entries_; i++)
+    for (int i = 0; i < num_entries_; i++)
     {
       auto entry = (entries_.get())[i];
       if (key == entry.GetKey())
@@ -187,56 +197,62 @@ public:
     return "";
   }
 
-    /**
-     * Returns `new` TransState object with following mutations applied to the existing instance:
-     *  Update Key value: The updated value must be moved to beginning of List
-     *  Add : The new key-value pair SHOULD be added to beginning of List
-     * 
-     * If the provided key-value pair is invalid, or results in transtate that violates the 
-     * tracecontext specification, they are discarded and same tracestate will be returned.
-    */
-    TraceState Set(const nostd::string_view& key, const nostd::string_view &value)
+  /**
+   * Returns `new` TransState object with following mutations applied to the existing instance:
+   *  Update Key value: The updated value must be moved to beginning of List
+   *  Add : The new key-value pair SHOULD be added to beginning of List
+   *
+   * If the provided key-value pair is invalid, or results in transtate that violates the
+   * tracecontext specification, they are discarded and same tracestate will be returned.
+   */
+  TraceState Set(const nostd::string_view &key, const nostd::string_view &value)
+  {
+    TraceState ts;
+    if ((!IsValidKey(key) || !IsValidValue(value)) || num_entries_ == kMaxKeyValuePairs)
     {
-        TraceState ts;
-        if (( !IsValidKey(key) || !IsValidValue(value)) || num_entries_ == kMaxKeyValuePairs ) {
-            // max size reached. No more entry can be added. Returning empty tracestate
-            return ts ; // empty instance
-        }
+      // max size reached. No more entry can be added. Returning empty tracestate
+      return ts;  // empty instance
+    }
 
-        //add new key-value pair at beginning
+    // add new key-value pair at beginning
+    Entry e(key, value);
+    (ts.entries_.get())[ts.num_entries_++] = e;
+    for (int i = 0; i < num_entries_; i++)
+    {
+      auto entry = (entries_.get())[i];
+      auto key   = entry.GetKey();
+      auto value = entry.GetValue();
+      Entry e(key, value);
+      (ts.entries_.get())[ts.num_entries_++] = e;
+    }
+    return ts;
+  }
+
+  /**
+   * Returns `new` TransState object after removing the attribute with given key ( if present )
+   * @returns empty TransState object if invalid key
+   * @returns copy of original TransState object if key is not present (??)
+   */
+  TraceState Delete(const nostd::string_view &key)
+  {
+    TraceState ts;
+    if (!IsValidKey(key))
+    {
+      return ts;
+    }
+    for (int i = 0; i < num_entries_; i++)
+    {
+      auto entry = (entries_.get())[i];
+      if ((entries_.get())[i].GetKey() != key)
+      {
+        auto key   = (entries_.get())[i].GetKey();
+        auto value = (entries_.get())[i].GetValue();
         Entry e(key, value);
         (ts.entries_.get())[ts.num_entries_++] = e;
-        for (int i = 0 ; i < num_entries_; i++){
-          auto entry = (entries_.get())[i];
-          auto key = entry.GetKey();
-          auto value = entry.GetValue();
-          Entry e(key, value);
-          (ts.entries_.get())[ts.num_entries_++] = e;
-        }
-        return ts;
+      }
     }
-
-    /**
-     * Returns `new` TransState object after removing the attribute with given key ( if present )
-     * @returns empty TransState object if invalid key
-     * @returns copy of original TransState object if key is not present (??)
-     */
-    TraceState Delete(const nostd::string_view &key){
-        TraceState ts;
-        if ( !IsValidKey(key)) {
-          return ts;
-        }
-        for (int i = 0 ; i < num_entries_; i++){
-          auto entry = (entries_.get())[i];
-          if ((entries_.get())[i].GetKey() != key ) {
-            auto key = (entries_.get())[i].GetKey();
-            auto value = (entries_.get())[i].GetValue();
-            Entry e(key, value);
-            (ts.entries_.get())[ts.num_entries_++] = e;          
-          }
-        }
-        return ts;
-    }
+    return ts;
+  }
 
   // Returns true if there are no keys, false otherwise.
   bool Empty() const noexcept { return num_entries_ == 0; }
@@ -248,32 +264,37 @@ public:
   }
 
   /** Returns whether key is a valid key. See https://www.w3.org/TR/trace-context/#key
-   * Identifiers MUST begin with a lowercase letter or a digit, and can only contain 
-   * lowercase letters (a-z), digits (0-9), underscores (_), dashes (-), asterisks (*), 
+   * Identifiers MUST begin with a lowercase letter or a digit, and can only contain
+   * lowercase letters (a-z), digits (0-9), underscores (_), dashes (-), asterisks (*),
    * and forward slashes (/).
-   * For multi-tenant vendor scenarios, an at sign (@) can be used to prefix the vendor name. 
-   * 
+   * For multi-tenant vendor scenarios, an at sign (@) can be used to prefix the vendor name.
+   *
    */
   static bool IsValidKey(nostd::string_view key)
   {
 
     std::regex reg_key("^[a-z0-9][a-z0-9_\\-*/]{0,255}$");
-    std::regex reg_key_multitenant("^[a-z0-9][a-z0-9_\\-*/]{0,240}(@)[a-z0-9][a-z0-9_\\-*/]{0,13}$");  
-    if (std::regex_match(std::string(key), reg_key ) || std::regex_match(std::string(key), reg_key_multitenant)) {
+    std::regex reg_key_multitenant(
+        "^[a-z0-9][a-z0-9_\\-*/]{0,240}(@)[a-z0-9][a-z0-9_\\-*/]{0,13}$");
+    if (std::regex_match(std::string(key), reg_key) ||
+        std::regex_match(std::string(key), reg_key_multitenant))
+    {
       return true;
     }
     return false;
   }
 
   /** Returns whether value is a valid value. See https://www.w3.org/TR/trace-context/#value
-   * The value is an opaque string containing up to 256 printable ASCII (RFC0020) 
+   * The value is an opaque string containing up to 256 printable ASCII (RFC0020)
    *  characters ((i.e., the range 0x20 to 0x7E) except comma , and equal =)
    */
   static bool IsValidValue(nostd::string_view value)
   {
-    // Hex 0x20 to 0x2B, 0x2D to 0x3C, 0x3E to 0x7E 
-    std::regex reg_value("^[\\x20-\\x2B\\x2D-\\x3C\\x3E-\\x7E]{0,255}[\\x21-\\x2B\\x2D-\\x3C\\x3E-\\x7E]$");
-    if (std::regex_match(std::string(value), reg_value)) {
+    // Hex 0x20 to 0x2B, 0x2D to 0x3C, 0x3E to 0x7E
+    std::regex reg_value(
+        "^[\\x20-\\x2B\\x2D-\\x3C\\x3E-\\x7E]{0,255}[\\x21-\\x2B\\x2D-\\x3C\\x3E-\\x7E]$");
+    if (std::regex_match(std::string(value), reg_value))
+    {
       return true;
     }
     return false;
@@ -289,9 +310,16 @@ private:
   // An empty TraceState.
   TraceState() noexcept : entries_(new Entry[kMaxKeyValuePairs]), num_entries_(0) {}
 
- static nostd::string_view TrimString(nostd::string_view str, size_t left, size_t right) {
-    while (str[ (std::size_t) right ]  == ' ' ) { right--; }
-    while (str[ (std::size_t) left] == ' ') { left ++;}
+  static nostd::string_view TrimString(nostd::string_view str, size_t left, size_t right)
+  {
+    while (str[(std::size_t)right] == ' ')
+    {
+      right--;
+    }
+    while (str[(std::size_t)left] == ' ')
+    {
+      left++;
+    }
     return str.substr(left, right - left + 1);
   }
 };

--- a/api/include/opentelemetry/trace/trace_state.h
+++ b/api/include/opentelemetry/trace/trace_state.h
@@ -108,10 +108,10 @@ public:
   };
 
   /**
-   * Returns a newly created Tracestate parsed from the header provided.
+   * Returns a newly created TraceState parsed from the header provided.
    * @param header Encoding of the tracestate header defined by
    * the W3C Trace Context specification https://www.w3.org/TR/trace-context/
-   *  @return Tracestate A new Tracestate instance or DEFAULT
+   *  @return Tracestate A new TraceState instance or DEFAULT
    */
   static TraceState FromHeader(nostd::string_view header)
   {
@@ -215,7 +215,7 @@ public:
    *  Add : The new key-value pair SHOULD be added to beginning of List
    *
    * If the provided key-value pair is invalid, or results in transtate that violates the
-   * tracecontext specification, empty tracestate will be returned.
+   * tracecontext specification, empty TraceState instance will be returned.
    *
    * If the existing object has maximum list members, it's copy is returned.
    */
@@ -224,7 +224,7 @@ public:
     TraceState ts;
     if ((!IsValidKey(key) || !IsValidValue(value)))
     {
-      // max size reached or invalid key/value. Returning empty tracestate
+      // max size reached or invalid key/value. Returning empty TraceState
       return ts;  // empty instance
     }
 

--- a/api/include/opentelemetry/trace/trace_state.h
+++ b/api/include/opentelemetry/trace/trace_state.h
@@ -251,8 +251,8 @@ public:
       auto entry = (entries_.get())[i];
       if ((entries_.get())[i].GetKey() != key)
       {
-        auto key   = (entries_.get())[i].GetKey();
-        auto value = (entries_.get())[i].GetValue();
+        auto key   = entry.GetKey();
+        auto value = entry.GetValue();
         Entry e(key, value);
         (ts.entries_.get())[ts.num_entries_++] = e;
       }

--- a/api/include/opentelemetry/trace/trace_state.h
+++ b/api/include/opentelemetry/trace/trace_state.h
@@ -173,17 +173,17 @@ public:
   std::string ToHeader()
   {
     std::string header_s;
-    size_t count = num_entries_;
-    while (count)
+    for (size_t count = 0; count < num_entries_; count++)
     {
-      auto entry = (entries_.get())[num_entries_ - count];
-      auto kv    = std::string(entry.GetKey()) + kKeyValueSeparator + std::string(entry.GetValue());
-      if (--count)
+      if (count != 0)
       {
-        // append "," if not last member
-        kv += ",";
+        header_s.append(",");
       }
-      header_s = header_s + kv;
+      
+      auto entry = (entries_.get())[count];
+      header_s.append(entry.GetKey());
+      header_s.append(kKeyValueSeparator);
+      header_s.append(entry.GetValue());
     }
     return header_s;
   }

--- a/api/include/opentelemetry/trace/trace_state.h
+++ b/api/include/opentelemetry/trace/trace_state.h
@@ -340,11 +340,7 @@ private:
     std::regex reg_value(
         "^[\\x20-\\x2B\\x2D-\\x3C\\x3E-\\x7E]{0,255}[\\x21-\\x2B\\x2D-\\x3C\\x3E-\\x7E]$");
     // Need to benchmark without regex, as a string object is created here.
-    if (std::regex_match(std::string(value), reg_value))
-    {
-      return true;
-    }
-    return false;
+    return std::regex_match(std::string(value), reg_value);
   }
 
   static bool IsValidKeyNonRegEx(nostd::string_view key)

--- a/api/include/opentelemetry/trace/trace_state.h
+++ b/api/include/opentelemetry/trace/trace_state.h
@@ -124,6 +124,12 @@ public:
     {
       // find list-member
       end = header.find(kMembersSeparator, begin);
+      if (end == 0)
+      {
+        // special case where "," is first char, move to next list member
+        begin = 1;
+        continue;
+      }
       if (end == std::string::npos)
       {
         // last list member. `end` points to end of it.
@@ -182,7 +188,7 @@ public:
 
       auto entry = (entries_.get())[count];
       header_s.append(std::string(entry.GetKey()));
-      header_s.append(std::string(1, kKeyValueSeparator));
+      header_s.append(1, kKeyValueSeparator);
       header_s.append(std::string(entry.GetValue()));
     }
     return header_s;

--- a/api/include/opentelemetry/trace/trace_state.h
+++ b/api/include/opentelemetry/trace/trace_state.h
@@ -242,7 +242,7 @@ public:
     {
       return ts;
     }
-    for (int i = 0; i < num_entries_; i++)
+    for (size_t i = 0; i < num_entries_; i++)
     {
       auto entry = (entries_.get())[i];
       if ((entries_.get())[i].GetKey() != key)

--- a/api/include/opentelemetry/trace/trace_state.h
+++ b/api/include/opentelemetry/trace/trace_state.h
@@ -188,10 +188,16 @@ public:
     return header_s;
   }
 
-  // Returns false if no such key, otherwise returns true and populates the value parameter with the
-  // associated value.
+  /**
+   *  Returns `value` associated with `key` passed as argument
+   *  Returns empty string if key is invalid  or not found
+   */
   std::string Get(nostd::string_view key) const noexcept
   {
+    if (!IsValidKey(key))
+    {
+      return std::string();
+    }
     for (size_t i = 0; i < num_entries_; i++)
     {
       auto entry = (entries_.get())[i];
@@ -323,8 +329,8 @@ private:
 
   static bool IsValidKeyRegEx(nostd::string_view key)
   {
-    std::regex reg_key("^[a-z0-9][a-z0-9*_\\-/]{0,255}$");
-    std::regex reg_key_multitenant(
+    static std::regex reg_key("^[a-z0-9][a-z0-9*_\\-/]{0,255}$");
+    static std::regex reg_key_multitenant(
         "^[a-z0-9][a-z0-9*_\\-/]{0,240}(@)[a-z0-9][a-z0-9*_\\-/]{0,13}$");
     std::string key_s(key);
     if (std::regex_match(key_s, reg_key) || std::regex_match(key_s, reg_key_multitenant))

--- a/api/include/opentelemetry/trace/trace_state.h
+++ b/api/include/opentelemetry/trace/trace_state.h
@@ -210,7 +210,7 @@ public:
   }
 
   /**
-   * Returns `new` TransState object with following mutations applied to the existing instance:
+   * Returns `new` TraceState object with following mutations applied to the existing instance:
    *  Update Key value: The updated value must be moved to beginning of List
    *  Add : The new key-value pair SHOULD be added to beginning of List
    *
@@ -246,9 +246,9 @@ public:
   }
 
   /**
-   * Returns `new` TransState object after removing the attribute with given key ( if present )
-   * @returns empty TransState object if key is invalid
-   * @returns copy of original TransState object if key is not present (??)
+   * Returns `new` TraceState object after removing the attribute with given key ( if present )
+   * @returns empty TraceState object if key is invalid
+   * @returns copy of original TraceState object if key is not present (??)
    */
   TraceState Delete(const nostd::string_view &key)
   {

--- a/api/include/opentelemetry/trace/trace_state.h
+++ b/api/include/opentelemetry/trace/trace_state.h
@@ -217,7 +217,7 @@ public:
    * If the provided key-value pair is invalid, or results in transtate that violates the
    * tracecontext specification, empty tracestate will be returned.
    *
-   * If the exising object has maximum list members, it's copy is returned.
+   * If the existing object has maximum list members, it's copy is returned.
    */
   TraceState Set(const nostd::string_view &key, const nostd::string_view &value)
   {
@@ -321,11 +321,11 @@ private:
 
   static nostd::string_view TrimString(nostd::string_view str, size_t left, size_t right)
   {
-    while (str[(std::size_t)right] == ' ' && left < right)
+    while (str[static_cast<std::size_t>(right)] == ' ' && left < right)
     {
       right--;
     }
-    while (str[(std::size_t)left] == ' ' && left < right)
+    while (str[static_cast<std::size_t>(left)] == ' ' && left < right)
     {
       left++;
     }

--- a/api/include/opentelemetry/trace/trace_state.h
+++ b/api/include/opentelemetry/trace/trace_state.h
@@ -216,6 +216,8 @@ public:
    *
    * If the provided key-value pair is invalid, or results in transtate that violates the
    * tracecontext specification, empty tracestate will be returned.
+   *
+   * If the exising object has maximum list members, it's copy is returned.
    */
   TraceState Set(const nostd::string_view &key, const nostd::string_view &value)
   {

--- a/api/include/opentelemetry/trace/trace_state.h
+++ b/api/include/opentelemetry/trace/trace_state.h
@@ -188,7 +188,7 @@ public:
   // associated value.
   std::string Get(nostd::string_view key) const noexcept
   {
-    for (int i = 0; i < num_entries_; i++)
+    for (size_t i = 0; i < num_entries_; i++)
     {
       auto entry = (entries_.get())[i];
       if (key == entry.GetKey())
@@ -219,7 +219,7 @@ public:
     // add new key-value pair at beginning
     Entry e(key, value);
     (ts.entries_.get())[ts.num_entries_++] = e;
-    for (int i = 0; i < num_entries_; i++)
+    for (size_t i = 0; i < num_entries_; i++)
     {
       auto entry = (entries_.get())[i];
       auto key   = entry.GetKey();
@@ -300,11 +300,11 @@ private:
 
   static nostd::string_view TrimString(nostd::string_view str, size_t left, size_t right)
   {
-    while (str[(std::size_t)right] == ' ')
+    while (str[(std::size_t)right] == ' ' && left < right)
     {
       right--;
     }
-    while (str[(std::size_t)left] == ' ')
+    while (str[(std::size_t)left] == ' ' && left < right)
     {
       left++;
     }

--- a/api/include/opentelemetry/trace/trace_state.h
+++ b/api/include/opentelemetry/trace/trace_state.h
@@ -343,7 +343,7 @@ private:
   static bool IsValidValueRegEx(nostd::string_view value)
   {
     // Hex 0x20 to 0x2B, 0x2D to 0x3C, 0x3E to 0x7E
-    std::regex reg_value(
+    static std::regex reg_value(
         "^[\\x20-\\x2B\\x2D-\\x3C\\x3E-\\x7E]{0,255}[\\x21-\\x2B\\x2D-\\x3C\\x3E-\\x7E]$");
     // Need to benchmark without regex, as a string object is created here.
     return std::regex_match(std::string(value), reg_value);

--- a/api/test/trace/CMakeLists.txt
+++ b/api/test/trace/CMakeLists.txt
@@ -10,6 +10,7 @@ foreach(
   span_context_test
   scope_test
   noop_test
+  trace_state_test
   tracer_test)
   add_executable(api_${testname} "${testname}.cc")
   target_link_libraries(

--- a/api/test/trace/trace_state_test.cc
+++ b/api/test/trace/trace_state_test.cc
@@ -99,7 +99,7 @@ TEST(TraceStateTest, ValidateHeaderParsing)
                    {"k1=v1,k2=v2,invalidmember", ""},
                    {"1a-2f@foo=bar1,a*/foo-_/bar=bar4", "1a-2f@foo=bar1,a*/foo-_/bar=bar4"},
                    {"1a-2f@foo=bar1,*/foo-_/bar=bar4", ""},
-                   {",", ""},
+                   {",k1=v1", "k1=v1"},
                    {"", ""},
                    {max_trace_state_header.data(), max_trace_state_header.data()}};
   for (auto &testcase : testcases)

--- a/api/test/trace/trace_state_test.cc
+++ b/api/test/trace/trace_state_test.cc
@@ -100,6 +100,8 @@ TEST(TraceStateTest, ValidateHeaderParsing)
                    {"1a-2f@foo=bar1,a*/foo-_/bar=bar4", "1a-2f@foo=bar1,a*/foo-_/bar=bar4"},
                    {"1a-2f@foo=bar1,*/foo-_/bar=bar4", ""},
                    {",k1=v1", "k1=v1"},
+                   {",", ""},
+                   {",=,", ""},
                    {"", ""},
                    {max_trace_state_header.data(), max_trace_state_header.data()}};
   for (auto &testcase : testcases)

--- a/api/test/trace/trace_state_test.cc
+++ b/api/test/trace/trace_state_test.cc
@@ -159,8 +159,8 @@ TEST(TraceStateTest, TraceStateDelete)
   EXPECT_EQ(ts2_new.ToHeader(), "");
 
   trace_state_header = "k1=v1";  // single list member, delete invalid entry
-  auto ts3     = TraceState::FromHeader(trace_state_header);
-  auto ts3_new = ts3.Delete(std::string("InvalidKey"));
+  auto ts3           = TraceState::FromHeader(trace_state_header);
+  auto ts3_new       = ts3.Delete(std::string("InvalidKey"));
   EXPECT_EQ(ts3_new.ToHeader(), "");
 }
 
@@ -226,7 +226,6 @@ TEST(TraceStateTest, MemorySafe)
   auto ts1 = ts.Set(keys[2], values[2]);
   auto ts2 = ts1.Set(keys[1], values[1]);
   auto ts3 = ts2.Set(keys[0], values[0]);
-  ;
 
   opentelemetry::nostd::span<TraceState::Entry> entries = ts3.Entries();
   for (int i = 0; i < kNumPairs; i++)

--- a/api/test/trace/trace_state_test.cc
+++ b/api/test/trace/trace_state_test.cc
@@ -86,12 +86,21 @@ std::string header_with_max_members()
 
 TEST(TraceStateTest, ValidateHeaderParsing)
 {
-  std::string trace_state_header = "k1=v1";  // valid header
-  EXPECT_EQ(create_ts_return_header(trace_state_header), trace_state_header);
+  struct {
+    const char* input;
+    const char* expected;
+  } testcases[] = {
+    { "k1=v1", "k1=v1" },
+    { "K1=V1", "" },
+    { "k1=v1,k2=v2,k3=v3", "k1=v1,k2=v2,k3=v3" },
+    { "k1=v1,k2=v2,,", "k1=v1,k2=v24" }
+    // not all cases covered
+  };
 
-  trace_state_header = "K1=V1";  // invalid header, key can't start with uppercase.
-  EXPECT_EQ(create_ts_return_header(trace_state_header), "");
-
+  for (auto& testcase : testcases)
+  {
+    EXPECT_EQ(TraceState::FromHeader(testcase.input).ToHeader(), testcase.expected);
+  }
   trace_state_header = "k1=v1,k2=v2,k3=v3";
   EXPECT_EQ(create_ts_return_header(trace_state_header), trace_state_header);
 

--- a/api/test/trace/trace_state_test.cc
+++ b/api/test/trace/trace_state_test.cc
@@ -1,5 +1,6 @@
 #include "opentelemetry/trace/trace_state.h"
 
+#include "opentelemetry/nostd/string_view.h"
 #include <gtest/gtest.h>
 
 namespace
@@ -60,81 +61,126 @@ TEST(EntryTest, SetValue)
 
 // -------------------------- TraceState class tests ---------------------------
 
-TEST(TraceStateTest, DefaultConstruction)
+std::string create_ts_return_header(std::string header)
 {
-  TraceState s;
-  opentelemetry::nostd::string_view return_val = "";
-  EXPECT_FALSE(s.Get("missing_key", return_val));
-  EXPECT_EQ(return_val, "");
-  EXPECT_TRUE(s.Empty());
-  EXPECT_EQ(s.Entries().size(), 0);
+  TraceState ts = TraceState::FromHeader(header);
+  return ts.ToHeader();
 }
 
-TEST(TraceStateTest, Set)
-{
-  TraceState s;
-  opentelemetry::nostd::string_view key = "test_key";
-  opentelemetry::nostd::string_view val = "test_value";
-  s.Set(key, val);
-
-  opentelemetry::nostd::string_view bad_key = "bad_key";
-  opentelemetry::nostd::string_view null_val;
-  // Since string_view data is null by default, this should be a no-op
-  s.Set(bad_key, null_val);
-
-  opentelemetry::nostd::span<TraceState::Entry> entries = s.Entries();
-  EXPECT_EQ(entries.size(), 1);
-  EXPECT_EQ(entries[0].GetKey(), key);
-  EXPECT_EQ(entries[0].GetValue(), val);
+std::string header_with_max_members(){
+  std::string header = "";
+  auto max_members = opentelemetry::trace::TraceState::kMaxKeyValuePairs;
+  for (int i = 0 ; i < max_members; i++ ){
+    std::string key = "key" + std::to_string(i);
+    std::string value = "value" + std::to_string(i);
+    header += key +"=" + value;
+    if (i != max_members - 1) {
+      header += ",";
+    }
+  }
+  return header;
 }
 
-TEST(TraceStateTest, Get)
+TEST(TraceStateTest, ValidateHeaderParsing)
 {
-  TraceState s;
-  const int kNumPairs                                 = 3;
-  opentelemetry::nostd::string_view keys[kNumPairs]   = {"test_key_1", "test_key_2", "test_key_3"};
-  opentelemetry::nostd::string_view values[kNumPairs] = {"test_val_1", "test_val_2", "test_val_3"};
+  std::string trace_state_header = "k1=v1"; // valid header
+  EXPECT_EQ(create_ts_return_header(trace_state_header), trace_state_header);
 
-  for (int i = 0; i < kNumPairs; i++)
-  {
-    s.Set(keys[i], values[i]);
-  }
+  trace_state_header = "K1=V1"; // invalid header, key can't start with uppercase.
+  EXPECT_EQ(create_ts_return_header(trace_state_header), "");
 
-  opentelemetry::nostd::string_view return_val = "";
+  trace_state_header = "k1=v1,k2=v2,k3=v3";
+  EXPECT_EQ(create_ts_return_header(trace_state_header), trace_state_header);
 
-  for (int i = 0; i < kNumPairs; i++)
-  {
-    EXPECT_TRUE(s.Get(keys[i], return_val));
-    EXPECT_EQ(return_val, values[i]);
-    return_val = "";
-  }
+  trace_state_header = "k1=v1,k2=v2,k3=v3";
+  EXPECT_EQ(create_ts_return_header(trace_state_header), trace_state_header);
 
-  EXPECT_FALSE(s.Get("fake_key", return_val));
-  EXPECT_EQ(return_val, "");
+  trace_state_header = "k1=v1,k2=v2,,";
+  auto expected_state_header =  "k1=v1,k2=v2";
+  EXPECT_EQ(create_ts_return_header(trace_state_header), expected_state_header);
+
+  trace_state_header = "k1=v1,k2=v2,sd"; // invalid list member
+  EXPECT_EQ(create_ts_return_header(trace_state_header), ""); // empty header
+
+  trace_state_header = "1a-2f@foo=bar1,a*/foo-_/bar=bar4" ;// valid list
+  EXPECT_EQ(create_ts_return_header(trace_state_header), trace_state_header);
+
+  trace_state_header = "1a-2f@foo=bar1,*/foo-_/bar=bar4" ;// invalid list member, key `*/foo-_/bar` must begin with [a-z,0-9]
+  EXPECT_EQ(create_ts_return_header(trace_state_header), "");
+
+  trace_state_header = header_with_max_members();
+  EXPECT_EQ(create_ts_return_header(trace_state_header), trace_state_header);
+
+}
+
+TEST(TraceStateTest, TraceStateGet){
+
+  std::string trace_state_header = header_with_max_members();
+  TraceState ts = TraceState::FromHeader(trace_state_header);
+
+  EXPECT_EQ(ts.Get("key0"),"value0");
+  EXPECT_EQ(ts.Get("key16"),"value16");
+  EXPECT_EQ(ts.Get("key31"),"value31");
+  EXPECT_EQ(ts.Get("key32"),""); // key not found
+
+}
+
+TEST(TraceStateTest, TraceStateSet){
+  std::string trace_state_header = "k1=v1,k2=v2";
+  auto ts1 = TraceState::FromHeader(trace_state_header);
+  auto ts1_new = ts1.Set("k3","v3");
+  EXPECT_EQ(ts1_new.ToHeader(), "k3=v3,k1=v1,k2=v2");
+
+  trace_state_header = header_with_max_members();
+  auto ts2 = TraceState::FromHeader(trace_state_header);
+  auto ts2_new = ts2.Set("n_k1","n_v1"); // adding to max list, should fail and return empty
+  EXPECT_EQ(ts2_new.ToHeader(), "");
+
+  trace_state_header = "k1=v1,k2=v2";
+  auto ts3 = TraceState::FromHeader(trace_state_header);
+  auto ts3_new = ts3.Set("*n_k1","n_v1"); // adding invalid key, should return empty
+  EXPECT_EQ(ts3_new.ToHeader(), "");  
+}
+
+
+TEST(TraceStateTest, TraceStateDelete){
+  std::string trace_state_header = "k1=v1,k2=v2,k3=v3";
+  auto ts1 = TraceState::FromHeader(trace_state_header);
+  auto ts1_new = ts1.Delete(std::string("k1"));
+  EXPECT_EQ(ts1_new.ToHeader(), "k2=v2,k3=v3");
+
+  trace_state_header = "k1=v1"; //single list member
+  auto ts2 = TraceState::FromHeader(trace_state_header);
+  auto ts2_new = ts2.Delete(std::string("k1"));
+  EXPECT_EQ(ts2_new.ToHeader(), "");
+
+  trace_state_header = "k1=v1"; //single list member, delete invalid entry
+  auto ts3 = TraceState::FromHeader(trace_state_header);
+  auto ts3_new = ts3.Delete(std::string("InvalidKey"));
+  EXPECT_EQ(ts3_new.ToHeader(), "");
+
 }
 
 TEST(TraceStateTest, Empty)
 {
-  TraceState s;
-  EXPECT_TRUE(s.Empty());
+  std::string trace_state_header = "";
+  auto ts = TraceState::FromHeader(trace_state_header);
+  EXPECT_TRUE(ts.Empty());
 
-  s.Set("test_key", "test_value");
-  EXPECT_FALSE(s.Empty());
+  trace_state_header = "k1=v1,k2=v2";
+  auto ts1 = TraceState::FromHeader(trace_state_header);
+  EXPECT_FALSE(ts1.Empty());
 }
 
 TEST(TraceStateTest, Entries)
 {
-  TraceState s;
+  std::string trace_state_header = "k1=v1,k2=v2,k3=v3";
+  auto ts1 = TraceState::FromHeader(trace_state_header);
   const int kNumPairs                                 = 3;
-  opentelemetry::nostd::string_view keys[kNumPairs]   = {"test_key_1", "test_key_2", "test_key_3"};
-  opentelemetry::nostd::string_view values[kNumPairs] = {"test_val_1", "test_val_2", "test_val_3"};
+  opentelemetry::nostd::string_view keys[kNumPairs]   = {"k1", "k2", "k3"};
+  opentelemetry::nostd::string_view values[kNumPairs] = {"v1", "v2", "v3"};
 
-  for (int i = 0; i < kNumPairs; i++)
-  {
-    s.Set(keys[i], values[i]);
-  }
-
-  opentelemetry::nostd::span<TraceState::Entry> entries = s.Entries();
+  opentelemetry::nostd::span<TraceState::Entry> entries = ts1.Entries();
   for (int i = 0; i < kNumPairs; i++)
   {
     EXPECT_EQ(entries[i].GetKey(), keys[i]);
@@ -164,7 +210,8 @@ TEST(TraceStateTest, IsValidValue)
 // Tests that keys and values don't depend on null terminators
 TEST(TraceStateTest, MemorySafe)
 {
-  TraceState s;
+  std::string trace_state_header = "";
+  auto ts = TraceState::FromHeader(trace_state_header);  
   const int kNumPairs                               = 3;
   opentelemetry::nostd::string_view key_string      = "test_key_1test_key_2test_key_3";
   opentelemetry::nostd::string_view val_string      = "test_val_1test_val_2test_val_3";
@@ -173,12 +220,11 @@ TEST(TraceStateTest, MemorySafe)
   opentelemetry::nostd::string_view values[kNumPairs] = {
       val_string.substr(0, 10), val_string.substr(10, 10), val_string.substr(20, 10)};
 
-  for (int i = 0; i < kNumPairs; i++)
-  {
-    s.Set(keys[i], values[i]);
-  }
+  auto ts1 = ts.Set(keys[2], values[2]);
+  auto ts2 = ts1.Set(keys[1], values[1]);
+  auto ts3 = ts2.Set(keys[0], values[0]);;
 
-  opentelemetry::nostd::span<TraceState::Entry> entries = s.Entries();
+  opentelemetry::nostd::span<TraceState::Entry> entries = ts3.Entries();
   for (int i = 0; i < kNumPairs; i++)
   {
     EXPECT_EQ(entries[i].GetKey(), keys[i]);


### PR DESCRIPTION
Current tracestate api is not compliant to `opentelemetry` and `w3c trace` specs. Attempt to fix in this PR. 
To Summaries the changes

- As per the opentelemetry specs (https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/api.md#tracestate), TraceState object is immutable, and `add`, `update` and `delete` methds should return newly created object. Added/updated needed methods.

- Methods to serialize and de-serialize TraceState object to/from w3c trace header ( as defined here: https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/api.md#tracestate)

- Much accurate validation check for tracestate list members using regex in non-gcc4.8 compiler.

#537 