### PR TITLE
Passing parent context to SpanProcessor::OnStart()

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -123,7 +123,7 @@ If a PR has been stuck (e.g. there are lots of debates and people couldn't agree
 * Consolidating the perspectives and putting a summary in the PR. It is recommended to add a link into the PR description, which points to a comment with a summary in the PR conversation
 * Stepping back to see if it makes sense to narrow down the scope of the PR or split it up.
 
-If none of the above worked and the PR has been stuck for more than 2 weeks, the owner should bring it to the (OpenTelemetry C++ SIG meeting)[https://zoom.us/j/8203130519].
+If none of the above worked and the PR has been stuck for more than 2 weeks, the owner should bring it to the (OpenTelemetry C++ SIG meeting)[https://zoom.us/j/8203130519]. The meeting passcode is _77777_.
 
 ## Useful Resources
 

--- a/ext/include/opentelemetry/ext/zpages/tracez_processor.h
+++ b/ext/include/opentelemetry/ext/zpages/tracez_processor.h
@@ -48,7 +48,9 @@ public:
    * running_spans.
    * @param span a recordable for a span that was just started
    */
-  void OnStart(opentelemetry::sdk::trace::Recordable &span) noexcept override;
+  void OnStart(opentelemetry::sdk::trace::Recordable &span,
+               const opentelemetry::trace::SpanContext &parent_context =
+                   opentelemetry::trace::SpanContext::GetInvalid()) noexcept override;
 
   /*
    * OnEnd is called when a span ends; that span_data is moved from running_spans to

--- a/ext/include/opentelemetry/ext/zpages/tracez_processor.h
+++ b/ext/include/opentelemetry/ext/zpages/tracez_processor.h
@@ -49,8 +49,7 @@ public:
    * @param span a recordable for a span that was just started
    */
   void OnStart(opentelemetry::sdk::trace::Recordable &span,
-               const opentelemetry::trace::SpanContext &parent_context =
-                   opentelemetry::trace::SpanContext::GetInvalid()) noexcept override;
+               const opentelemetry::trace::SpanContext &parent_context) noexcept override;
 
   /*
    * OnEnd is called when a span ends; that span_data is moved from running_spans to

--- a/ext/src/zpages/tracez_processor.cc
+++ b/ext/src/zpages/tracez_processor.cc
@@ -6,7 +6,8 @@ namespace ext
 namespace zpages
 {
 
-void TracezSpanProcessor::OnStart(opentelemetry::sdk::trace::Recordable &span) noexcept
+void TracezSpanProcessor::OnStart(opentelemetry::sdk::trace::Recordable &span,
+                                  const opentelemetry::trace::SpanContext &parent_context) noexcept
 {
   std::lock_guard<std::mutex> lock(mtx_);
   spans_.running.insert(static_cast<ThreadsafeSpanData *>(&span));

--- a/sdk/include/opentelemetry/sdk/trace/batch_span_processor.h
+++ b/sdk/include/opentelemetry/sdk/trace/batch_span_processor.h
@@ -52,8 +52,11 @@ public:
    * NOTE: This method is a no-op.
    *
    * @param span - The span that just started
+   * @param parent_context - The parent context of the span that just started
    */
-  void OnStart(Recordable &span) noexcept override;
+  void OnStart(Recordable &span,
+               const opentelemetry::trace::SpanContext &parent_context =
+                   opentelemetry::trace::SpanContext::GetInvalid()) noexcept override;
 
   /**
    * Called when a span ends.

--- a/sdk/include/opentelemetry/sdk/trace/batch_span_processor.h
+++ b/sdk/include/opentelemetry/sdk/trace/batch_span_processor.h
@@ -55,8 +55,7 @@ public:
    * @param parent_context - The parent context of the span that just started
    */
   void OnStart(Recordable &span,
-               const opentelemetry::trace::SpanContext &parent_context =
-                   opentelemetry::trace::SpanContext::GetInvalid()) noexcept override;
+               const opentelemetry::trace::SpanContext &parent_context) noexcept override;
 
   /**
    * Called when a span ends.

--- a/sdk/include/opentelemetry/sdk/trace/processor.h
+++ b/sdk/include/opentelemetry/sdk/trace/processor.h
@@ -32,8 +32,11 @@ public:
   /**
    * OnStart is called when a span is started.
    * @param span a recordable for a span that was just started
+   * @param parent_context The parent context of the span that just started
    */
-  virtual void OnStart(Recordable &span) noexcept = 0;
+  virtual void OnStart(Recordable &span,
+                       const opentelemetry::trace::SpanContext &parent_context =
+                           opentelemetry::trace::SpanContext::GetInvalid()) noexcept = 0;
 
   /**
    * OnEnd is called when a span is ended.

--- a/sdk/include/opentelemetry/sdk/trace/processor.h
+++ b/sdk/include/opentelemetry/sdk/trace/processor.h
@@ -35,8 +35,7 @@ public:
    * @param parent_context The parent context of the span that just started
    */
   virtual void OnStart(Recordable &span,
-                       const opentelemetry::trace::SpanContext &parent_context =
-                           opentelemetry::trace::SpanContext::GetInvalid()) noexcept = 0;
+                       const opentelemetry::trace::SpanContext &parent_context) noexcept = 0;
 
   /**
    * OnEnd is called when a span is ended.

--- a/sdk/include/opentelemetry/sdk/trace/simple_processor.h
+++ b/sdk/include/opentelemetry/sdk/trace/simple_processor.h
@@ -37,7 +37,10 @@ public:
     return exporter_->MakeRecordable();
   }
 
-  void OnStart(Recordable &span) noexcept override {}
+  void OnStart(Recordable &span,
+               const opentelemetry::trace::SpanContext &parent_context =
+                   opentelemetry::trace::SpanContext::GetInvalid()) noexcept override
+  {}
 
   void OnEnd(std::unique_ptr<Recordable> &&span) noexcept override
   {

--- a/sdk/include/opentelemetry/sdk/trace/simple_processor.h
+++ b/sdk/include/opentelemetry/sdk/trace/simple_processor.h
@@ -38,8 +38,7 @@ public:
   }
 
   void OnStart(Recordable &span,
-               const opentelemetry::trace::SpanContext &parent_context =
-                   opentelemetry::trace::SpanContext::GetInvalid()) noexcept override
+               const opentelemetry::trace::SpanContext &parent_context) noexcept override
   {}
 
   void OnEnd(std::unique_ptr<Recordable> &&span) noexcept override

--- a/sdk/src/trace/batch_span_processor.cc
+++ b/sdk/src/trace/batch_span_processor.cc
@@ -4,6 +4,7 @@
 using opentelemetry::sdk::common::AtomicUniquePtr;
 using opentelemetry::sdk::common::CircularBuffer;
 using opentelemetry::sdk::common::CircularBufferRange;
+using opentelemetry::trace::SpanContext;
 
 OPENTELEMETRY_BEGIN_NAMESPACE
 namespace sdk
@@ -27,7 +28,7 @@ std::unique_ptr<Recordable> BatchSpanProcessor::MakeRecordable() noexcept
   return exporter_->MakeRecordable();
 }
 
-void BatchSpanProcessor::OnStart(Recordable &) noexcept
+void BatchSpanProcessor::OnStart(Recordable &, const SpanContext &) noexcept
 {
   // no-op
 }

--- a/sdk/src/trace/span.cc
+++ b/sdk/src/trace/span.cc
@@ -110,7 +110,7 @@ Span::Span(std::shared_ptr<Tracer> &&tracer,
   recordable_->SetStartTime(NowOr(options.start_system_time));
   start_steady_time = NowOr(options.start_steady_time);
   // recordable_->SetResource(resource_); TODO
-  processor_->OnStart(*recordable_);
+  processor_->OnStart(*recordable_, parent_span_context);
 }
 
 Span::~Span()

--- a/sdk/test/trace/simple_processor_test.cc
+++ b/sdk/test/trace/simple_processor_test.cc
@@ -9,6 +9,7 @@
 using namespace opentelemetry::sdk::trace;
 using opentelemetry::exporter::memory::InMemorySpanData;
 using opentelemetry::exporter::memory::InMemorySpanExporter;
+using opentelemetry::trace::SpanContext;
 
 TEST(SimpleProcessor, ToInMemorySpanExporter)
 {
@@ -18,7 +19,7 @@ TEST(SimpleProcessor, ToInMemorySpanExporter)
 
   auto recordable = processor.MakeRecordable();
 
-  processor.OnStart(*recordable);
+  processor.OnStart(*recordable, SpanContext::GetInvalid());
 
   ASSERT_EQ(0, span_data->GetSpans().size());
 


### PR DESCRIPTION
as per spec https://github.com/open-telemetry/opentelemetry-specification/blob/7e0c10260178b947777cf9c11d7f7ac4d4700725/specification/trace/sdk.md#onstart
`SpanProcessor.onStart()` should have a parent Context as parameter.

fixes: #550 