### PR TITLE
Assign HTTP status code from cURL to uint16_t type

### DIFF
--- a/ext/include/opentelemetry/ext/http/client/curl/http_operation_curl.h
+++ b/ext/include/opentelemetry/ext/http/client/curl/http_operation_curl.h
@@ -304,7 +304,7 @@ public:
   /**
    * Get HTTP response code. This function returns CURL error code if HTTP response code is invalid.
    */
-  long GetResponseCode() { return res_; }
+  uint16_t GetResponseCode() { return res_; }
 
   /**
    * Get last session state.


### PR DESCRIPTION
cURL defines status code for HTTP response as `enum` (see doc [here](https://curl.se/libcurl/c/libcurl-errors.html)) and our http_client defines it as `uint16_t` as below. This PR changes the cURL wrapper `HttpOperation` to return `uint16_t` as well.

https://github.com/open-telemetry/opentelemetry-cpp/blob/dafd82a417abb85e8271f83d2c632a945c3e4fc9/ext/include/opentelemetry/ext/http/client/http_client.h#L95