### PR TITLE
Add Resources to Recordable interface.

### DIFF
--- a/exporters/etw/include/opentelemetry/exporters/etw/etw_data.h
+++ b/exporters/etw/include/opentelemetry/exporters/etw/etw_data.h
@@ -500,7 +500,7 @@ public:
   }
 
   void SetResourceAttribute(
-      nostd::string_view key,
+      std::string key,
       const opentelemetry::sdk::common::OwnedAttributeValue &value) noexcept override
   {
     // TODO: not implemented

--- a/exporters/etw/include/opentelemetry/exporters/etw/etw_data.h
+++ b/exporters/etw/include/opentelemetry/exporters/etw/etw_data.h
@@ -17,6 +17,7 @@
 #include "opentelemetry/trace/trace_id.h"
 #include "opentelemetry/trace/tracer_provider.h"
 
+#include "opentelemetry/sdk/resource/resource.h"
 #include "opentelemetry/sdk/trace/exporter.h"
 #include "opentelemetry/sdk/trace/recordable.h"
 #include "opentelemetry/sdk/trace/span_data.h"
@@ -498,6 +499,13 @@ public:
     span_kind_ = span_kind;
   }
 
+  void SetResourceAttribute(
+      nostd::string_view key,
+      const opentelemetry::sdk::common::OwnedAttributeValue &value) noexcept override
+  {
+    // TODO
+  }
+
   void SetStartTime(opentelemetry::core::SystemTimestamp start_time) noexcept override
   {
     start_time_ = start_time;
@@ -524,6 +532,7 @@ private:
   std::string status_desc_;
   sdk::common::AttributeMap attribute_map_;
   opentelemetry::trace::SpanKind span_kind_{opentelemetry::trace::SpanKind::kInternal};
+  opentelemetry::sdk::resource::Resource resource_;
   nostd::shared_ptr<opentelemetry::trace::Tracer> tracer_;
   nostd::shared_ptr<opentelemetry::trace::Span> span_;
 };

--- a/exporters/etw/include/opentelemetry/exporters/etw/etw_data.h
+++ b/exporters/etw/include/opentelemetry/exporters/etw/etw_data.h
@@ -503,7 +503,9 @@ public:
       nostd::string_view key,
       const opentelemetry::sdk::common::OwnedAttributeValue &value) noexcept override
   {
-    // TODO
+    // TODO: not implemented
+    UNREFERENCED_PARAMETER(key);
+    UNREFERENCED_PARAMETER(value);
   }
 
   void SetStartTime(opentelemetry::core::SystemTimestamp start_time) noexcept override
@@ -532,7 +534,6 @@ private:
   std::string status_desc_;
   sdk::common::AttributeMap attribute_map_;
   opentelemetry::trace::SpanKind span_kind_{opentelemetry::trace::SpanKind::kInternal};
-  opentelemetry::sdk::resource::Resource resource_;
   nostd::shared_ptr<opentelemetry::trace::Tracer> tracer_;
   nostd::shared_ptr<opentelemetry::trace::Span> span_;
 };

--- a/exporters/etw/include/opentelemetry/exporters/etw/etw_data.h
+++ b/exporters/etw/include/opentelemetry/exporters/etw/etw_data.h
@@ -503,7 +503,6 @@ public:
       std::string key,
       const opentelemetry::sdk::common::OwnedAttributeValue &value) noexcept override
   {
-    // TODO: not implemented
     UNREFERENCED_PARAMETER(key);
     UNREFERENCED_PARAMETER(value);
   }

--- a/exporters/otlp/include/opentelemetry/exporters/otlp/recordable.h
+++ b/exporters/otlp/include/opentelemetry/exporters/otlp/recordable.h
@@ -1,6 +1,8 @@
 #pragma once
 
+#include "opentelemetry/proto/resource/v1/resource.pb.h"
 #include "opentelemetry/proto/trace/v1/trace.pb.h"
+#include "opentelemetry/sdk/resource/resource.h"
 #include "opentelemetry/sdk/trace/recordable.h"
 #include "opentelemetry/version.h"
 
@@ -34,12 +36,19 @@ public:
 
   void SetSpanKind(opentelemetry::trace::SpanKind span_kind) noexcept override;
 
+  void SetResourceAttribute(
+      nostd::string_view key,
+      const opentelemetry::sdk::common::OwnedAttributeValue &value) noexcept override;
+
   void SetStartTime(opentelemetry::core::SystemTimestamp start_time) noexcept override;
 
   void SetDuration(std::chrono::nanoseconds duration) noexcept override;
 
+  proto::resource::v1::Resource &GetResources() noexcept;
+
 private:
   proto::trace::v1::Span span_;
+  proto::resource::v1::Resource resource_;
 };
 }  // namespace otlp
 }  // namespace exporter

--- a/exporters/otlp/include/opentelemetry/exporters/otlp/recordable.h
+++ b/exporters/otlp/include/opentelemetry/exporters/otlp/recordable.h
@@ -37,7 +37,7 @@ public:
   void SetSpanKind(opentelemetry::trace::SpanKind span_kind) noexcept override;
 
   void SetResourceAttribute(
-      nostd::string_view key,
+      const std::string &key,
       const opentelemetry::sdk::common::OwnedAttributeValue &value) noexcept override;
 
   void SetStartTime(opentelemetry::core::SystemTimestamp start_time) noexcept override;

--- a/exporters/otlp/include/opentelemetry/exporters/otlp/recordable.h
+++ b/exporters/otlp/include/opentelemetry/exporters/otlp/recordable.h
@@ -37,7 +37,7 @@ public:
   void SetSpanKind(opentelemetry::trace::SpanKind span_kind) noexcept override;
 
   void SetResourceAttribute(
-      const std::string &key,
+      std::string key,
       const opentelemetry::sdk::common::OwnedAttributeValue &value) noexcept override;
 
   void SetStartTime(opentelemetry::core::SystemTimestamp start_time) noexcept override;

--- a/exporters/otlp/src/otlp_exporter.cc
+++ b/exporters/otlp/src/otlp_exporter.cc
@@ -23,10 +23,22 @@ void PopulateRequest(const nostd::span<std::unique_ptr<sdk::trace::Recordable>> 
   auto resource_span       = request->add_resource_spans();
   auto instrumentation_lib = resource_span->add_instrumentation_library_spans();
 
+  // TBD -> Group using Resources and Instrumentation Lib ( version and name)
+  bool resource_added = false;
   for (auto &recordable : spans)
   {
     auto rec = std::unique_ptr<Recordable>(static_cast<Recordable *>(recordable.release()));
     *instrumentation_lib->add_spans() = std::move(rec->span());
+
+    if (!resource_added)
+    {
+      auto resource = rec->GetResources();
+      if (resource.attributes_size())
+      {
+        resource_span->set_allocated_resource(&resource);
+        resource_added = true;
+      }
+    }
   }
 }
 

--- a/exporters/otlp/src/otlp_exporter.cc
+++ b/exporters/otlp/src/otlp_exporter.cc
@@ -35,7 +35,8 @@ void PopulateRequest(const nostd::span<std::unique_ptr<sdk::trace::Recordable>> 
       auto resource = rec->GetResources();
       if (resource.attributes_size())
       {
-        resource_span->set_allocated_resource(&resource);
+        // TBD
+        // resource_span->set_allocated_resource(&resource);
         resource_added = true;
       }
     }

--- a/exporters/otlp/src/otlp_exporter.cc
+++ b/exporters/otlp/src/otlp_exporter.cc
@@ -35,7 +35,7 @@ void PopulateRequest(const nostd::span<std::unique_ptr<sdk::trace::Recordable>> 
       auto resource = rec->GetResources();
       if (resource.attributes_size())
       {
-        // TBD
+        // TODO
         // resource_span->set_allocated_resource(&resource);
         resource_added = true;
       }

--- a/exporters/otlp/src/recordable.cc
+++ b/exporters/otlp/src/recordable.cc
@@ -303,7 +303,7 @@ void Recordable::SetSpanKind(opentelemetry::trace::SpanKind span_kind) noexcept
 }
 
 void Recordable::SetResourceAttribute(
-    const std::string &key,
+    std::string key,
     const opentelemetry::sdk::common::OwnedAttributeValue &value) noexcept
 {
   auto attribute = resource_.add_attributes();

--- a/exporters/otlp/src/recordable.cc
+++ b/exporters/otlp/src/recordable.cc
@@ -118,7 +118,7 @@ void PopulateAttribute(opentelemetry::proto::common::v1::KeyValue *attribute,
 }
 
 void PopulateResourceAttribute(opentelemetry::proto::common::v1::KeyValue *attribute,
-                               nostd::string_view key,
+                               const std::string &key,
                                const opentelemetry::sdk::common::OwnedAttributeValue &value)
 {
 
@@ -303,7 +303,7 @@ void Recordable::SetSpanKind(opentelemetry::trace::SpanKind span_kind) noexcept
 }
 
 void Recordable::SetResourceAttribute(
-    nostd::string_view key,
+    const std::string &key,
     const opentelemetry::sdk::common::OwnedAttributeValue &value) noexcept
 {
   auto attribute = resource_.add_attributes();

--- a/exporters/otlp/test/otlp_exporter_test.cc
+++ b/exporters/otlp/test/otlp_exporter_test.cc
@@ -69,10 +69,9 @@ TEST_F(OtlpExporterTestPeer, ExportIntegrationTest)
 
   auto processor = std::shared_ptr<sdk::trace::SpanProcessor>(
       new sdk::trace::SimpleSpanProcessor(std::move(exporter)));
-  auto resource = opentelemetry::sdk::resource::Resource::Create({});
-  auto provider = nostd::shared_ptr<trace::TracerProvider>(
-      new sdk::trace::TracerProvider(processor, std::move(resource)));
-  auto tracer = provider->GetTracer("test");
+  auto provider = nostd::shared_ptr<trace::TracerProvider>(new sdk::trace::TracerProvider(
+      processor, opentelemetry::sdk::resource::Resource::Create({})));
+  auto tracer   = provider->GetTracer("test");
 
   EXPECT_CALL(*mock_stub, Export(_, _, _))
       .Times(AtLeast(1))

--- a/exporters/otlp/test/otlp_exporter_test.cc
+++ b/exporters/otlp/test/otlp_exporter_test.cc
@@ -69,9 +69,10 @@ TEST_F(OtlpExporterTestPeer, ExportIntegrationTest)
 
   auto processor = std::shared_ptr<sdk::trace::SpanProcessor>(
       new sdk::trace::SimpleSpanProcessor(std::move(exporter)));
-  auto provider = nostd::shared_ptr<trace::TracerProvider>(new sdk::trace::TracerProvider(
-      processor, opentelemetry::sdk::resource::Resource::Create({})));
-  auto tracer   = provider->GetTracer("test");
+  auto resource = opentelemetry::sdk::resource::Resource::Create({});
+  auto provider = nostd::shared_ptr<trace::TracerProvider>(
+      new sdk::trace::TracerProvider(processor, std::move(resource)));
+  auto tracer = provider->GetTracer("test");
 
   EXPECT_CALL(*mock_stub, Export(_, _, _))
       .Times(AtLeast(1))

--- a/exporters/otlp/test/otlp_exporter_test.cc
+++ b/exporters/otlp/test/otlp_exporter_test.cc
@@ -69,8 +69,9 @@ TEST_F(OtlpExporterTestPeer, ExportIntegrationTest)
 
   auto processor = std::shared_ptr<sdk::trace::SpanProcessor>(
       new sdk::trace::SimpleSpanProcessor(std::move(exporter)));
-  auto provider =
-      nostd::shared_ptr<trace::TracerProvider>(new sdk::trace::TracerProvider(processor));
+  auto resource = opentelemetry::sdk::resource::Resource::Create({});
+  auto provider = nostd::shared_ptr<trace::TracerProvider>(
+      new sdk::trace::TracerProvider(processor, std::move(resource)));
   auto tracer = provider->GetTracer("test");
 
   EXPECT_CALL(*mock_stub, Export(_, _, _))

--- a/ext/include/opentelemetry/ext/zpages/threadsafe_span_data.h
+++ b/ext/include/opentelemetry/ext/zpages/threadsafe_span_data.h
@@ -164,7 +164,7 @@ public:
   }
 
   void SetResourceAttribute(
-      const std::string &key,
+      std::string key,
       const opentelemetry::sdk::common::OwnedAttributeValue &value) noexcept override
   {
     std::lock_guard<std::mutex> lock(mutex_);

--- a/ext/include/opentelemetry/ext/zpages/threadsafe_span_data.h
+++ b/ext/include/opentelemetry/ext/zpages/threadsafe_span_data.h
@@ -164,7 +164,7 @@ public:
   }
 
   void SetResourceAttribute(
-      nostd::string_view key,
+      const std::string &key,
       const opentelemetry::sdk::common::OwnedAttributeValue &value) noexcept override
   {
     std::lock_guard<std::mutex> lock(mutex_);

--- a/ext/include/opentelemetry/ext/zpages/threadsafe_span_data.h
+++ b/ext/include/opentelemetry/ext/zpages/threadsafe_span_data.h
@@ -47,6 +47,17 @@ public:
   }
 
   /**
+   * Get the resources for this span
+   * @return the resources for this span
+   */
+  const std::unordered_map<std::string, opentelemetry::sdk::common::OwnedAttributeValue>
+  GetResources()
+  {
+    std::lock_guard<std::mutex> lock(mutex_);
+    return resources_;
+  }
+
+  /**
    * Get the parent span id for this span
    * @return the span id for this span's parent
    */
@@ -152,6 +163,15 @@ public:
     span_kind_ = span_kind;
   }
 
+  void SetResourceAttribute(
+      nostd::string_view key,
+      const opentelemetry::sdk::common::OwnedAttributeValue &value) noexcept override
+  {
+    std::lock_guard<std::mutex> lock(mutex_);
+    attributes_.insert(
+        std::pair<std::string, opentelemetry::sdk::common::OwnedAttributeValue>(key, value));
+  }
+
   void SetStartTime(opentelemetry::core::SystemTimestamp start_time) noexcept override
   {
     std::lock_guard<std::mutex> lock(mutex_);
@@ -221,6 +241,7 @@ private:
   std::unordered_map<std::string, opentelemetry::sdk::common::OwnedAttributeValue> attributes_;
   std::vector<opentelemetry::sdk::trace::SpanDataEvent> events_;
   opentelemetry::sdk::common::AttributeConverter converter_;
+  std::unordered_map<std::string, opentelemetry::sdk::common::OwnedAttributeValue> resources_;
 };
 }  // namespace zpages
 }  // namespace ext

--- a/ext/test/zpages/tracez_data_aggregator_test.cc
+++ b/ext/test/zpages/tracez_data_aggregator_test.cc
@@ -35,12 +35,13 @@ protected:
   void SetUp() override
   {
     std::shared_ptr<TracezSpanProcessor> processor(new TracezSpanProcessor());
-    auto resource = opentelemetry::sdk::resource::Resource::Create({});
-    tracer        = std::shared_ptr<opentelemetry::trace::Tracer>(new Tracer(processor, resource));
+    tracer = std::shared_ptr<opentelemetry::trace::Tracer>(new Tracer(processor, resource));
     tracez_data_aggregator = std::unique_ptr<TracezDataAggregator>(
         new TracezDataAggregator(processor, milliseconds(10)));
   }
 
+  opentelemetry::sdk::resource::Resource resource =
+      opentelemetry::sdk::resource::Resource::Create({});
   std::unique_ptr<TracezDataAggregator> tracez_data_aggregator;
   std::shared_ptr<opentelemetry::trace::Tracer> tracer;
 };

--- a/ext/test/zpages/tracez_processor_test.cc
+++ b/ext/test/zpages/tracez_processor_test.cc
@@ -175,9 +175,7 @@ class TracezProcessor : public ::testing::Test
 protected:
   void SetUp() override
   {
-    processor     = std::shared_ptr<TracezSpanProcessor>(new TracezSpanProcessor());
-    auto resource = opentelemetry::sdk::resource::Resource::Create({});
-
+    processor  = std::shared_ptr<TracezSpanProcessor>(new TracezSpanProcessor());
     tracer     = std::shared_ptr<opentelemetry::trace::Tracer>(new Tracer(processor, resource));
     auto spans = processor->GetSpanSnapshot();
     running    = spans.running;
@@ -187,6 +185,9 @@ protected:
   }
 
   std::shared_ptr<TracezSpanProcessor> processor;
+  opentelemetry::sdk::resource::Resource resource =
+      opentelemetry::sdk::resource::Resource::Create({});
+
   std::shared_ptr<opentelemetry::trace::Tracer> tracer;
 
   std::vector<std::string> span_names;

--- a/sdk/include/opentelemetry/sdk/trace/recordable.h
+++ b/sdk/include/opentelemetry/sdk/trace/recordable.h
@@ -14,6 +14,7 @@
 #include "opentelemetry/version.h"
 
 #include <map>
+#include <string>
 
 // TODO: Create generic short pattern for opentelemetry::common and opentelemetry::trace
 
@@ -123,7 +124,7 @@ public:
    * @param value attribute value
    */
   virtual void SetResourceAttribute(
-      nostd::string_view key,
+      const std::string &key,
       const opentelemetry::sdk::common::OwnedAttributeValue &value) noexcept = 0;
 
   /**

--- a/sdk/include/opentelemetry/sdk/trace/recordable.h
+++ b/sdk/include/opentelemetry/sdk/trace/recordable.h
@@ -4,6 +4,7 @@
 #include "opentelemetry/common/key_value_iterable.h"
 #include "opentelemetry/core/timestamp.h"
 #include "opentelemetry/nostd/string_view.h"
+#include "opentelemetry/sdk/common/attribute_utils.h"
 #include "opentelemetry/sdk/common/empty_attributes.h"
 #include "opentelemetry/trace/canonical_code.h"
 #include "opentelemetry/trace/span.h"
@@ -115,6 +116,16 @@ public:
    * @param span_kind the spankind to set
    */
   virtual void SetSpanKind(opentelemetry::trace::SpanKind span_kind) noexcept = 0;
+
+  /**
+   * Set Resource attribute of the span.
+   * @param key attribute key
+   * @param value attribute value
+   */
+  virtual void SetResourceAttribute(
+      nostd::string_view key,
+      const opentelemetry::sdk::common::OwnedAttributeValue &value) noexcept = 0;
+
   /**
    * Set the start time of the span.
    * @param start_time the start time to set

--- a/sdk/include/opentelemetry/sdk/trace/recordable.h
+++ b/sdk/include/opentelemetry/sdk/trace/recordable.h
@@ -124,7 +124,7 @@ public:
    * @param value attribute value
    */
   virtual void SetResourceAttribute(
-      const std::string &key,
+      std::string key,
       const opentelemetry::sdk::common::OwnedAttributeValue &value) noexcept = 0;
 
   /**

--- a/sdk/include/opentelemetry/sdk/trace/span_data.h
+++ b/sdk/include/opentelemetry/sdk/trace/span_data.h
@@ -224,7 +224,7 @@ public:
   }
 
   void SetResourceAttribute(
-      nostd::string_view key,
+      const std::string &key,
       const opentelemetry::sdk::common::OwnedAttributeValue &value) noexcept override
   {
     resources_.insert(std::pair<std::string, opentelemetry::sdk::common::OwnedAttributeValue>(

--- a/sdk/include/opentelemetry/sdk/trace/span_data.h
+++ b/sdk/include/opentelemetry/sdk/trace/span_data.h
@@ -122,6 +122,16 @@ public:
   opentelemetry::trace::SpanKind GetSpanKind() const noexcept { return span_kind_; }
 
   /**
+   * Get Resources.
+   * @return the resource of this span
+   */
+  const std::unordered_map<std::string, opentelemetry::sdk::common::OwnedAttributeValue>
+      &GetResources() const noexcept
+  {
+    return resources_;
+  }
+
+  /**
    * Get the status for this span
    * @return the status for this span
    */
@@ -213,6 +223,14 @@ public:
     span_kind_ = span_kind;
   }
 
+  void SetResourceAttribute(
+      nostd::string_view key,
+      const opentelemetry::sdk::common::OwnedAttributeValue &value) noexcept override
+  {
+    resources_.insert(std::pair<std::string, opentelemetry::sdk::common::OwnedAttributeValue>(
+        std::string(key.data()), value));
+  }
+
   void SetStartTime(opentelemetry::core::SystemTimestamp start_time) noexcept override
   {
     start_time_ = start_time;
@@ -233,6 +251,7 @@ private:
   std::vector<SpanDataEvent> events_;
   std::vector<SpanDataLink> links_;
   opentelemetry::trace::SpanKind span_kind_{opentelemetry::trace::SpanKind::kInternal};
+  std::unordered_map<std::string, opentelemetry::sdk::common::OwnedAttributeValue> resources_;
 };
 }  // namespace trace
 }  // namespace sdk

--- a/sdk/include/opentelemetry/sdk/trace/span_data.h
+++ b/sdk/include/opentelemetry/sdk/trace/span_data.h
@@ -224,7 +224,7 @@ public:
   }
 
   void SetResourceAttribute(
-      const std::string &key,
+      std::string key,
       const opentelemetry::sdk::common::OwnedAttributeValue &value) noexcept override
   {
     resources_.insert(std::pair<std::string, opentelemetry::sdk::common::OwnedAttributeValue>(

--- a/sdk/src/trace/span.cc
+++ b/sdk/src/trace/span.cc
@@ -76,7 +76,6 @@ Span::Span(std::shared_ptr<Tracer> &&tracer,
     return;
   }
   recordable_->SetName(name);
-
   trace_api::TraceId trace_id;
   trace_api::SpanId span_id = GenerateRandomSpanId();
 
@@ -109,7 +108,11 @@ Span::Span(std::shared_ptr<Tracer> &&tracer,
   recordable_->SetSpanKind(options.kind);
   recordable_->SetStartTime(NowOr(options.start_system_time));
   start_steady_time = NowOr(options.start_steady_time);
-  // recordable_->SetResource(resource_); TODO
+  for (auto attribute : resource.GetAttributes())
+  {
+    recordable_->SetResourceAttribute(attribute.first, attribute.second);
+  }
+
   processor_->OnStart(*recordable_);
 }
 

--- a/sdk/src/trace/span.cc
+++ b/sdk/src/trace/span.cc
@@ -112,7 +112,7 @@ Span::Span(std::shared_ptr<Tracer> &&tracer,
   {
     recordable_->SetResourceAttribute(attribute.first, attribute.second);
   }
-  processor_->OnStart(*recordable_, , parent_span_context);
+  processor_->OnStart(*recordable_, parent_span_context);
 }
 
 Span::~Span()

--- a/sdk/src/trace/tracer.cc
+++ b/sdk/src/trace/tracer.cc
@@ -13,7 +13,7 @@ namespace trace
 Tracer::Tracer(std::shared_ptr<SpanProcessor> processor,
                const opentelemetry::sdk::resource::Resource &resource,
                std::shared_ptr<Sampler> sampler) noexcept
-    : processor_{processor}, sampler_{sampler}, resource_{resource}
+    : processor_{processor}, sampler_{sampler}, resource_(resource)
 {}
 
 void Tracer::SetProcessor(std::shared_ptr<SpanProcessor> processor) noexcept


### PR DESCRIPTION
This is second part of initial Resource SDK implementation ( https://github.com/open-telemetry/opentelemetry-cpp/pull/502 ) - to propagate resources to Span exporters through Recordable interface.

TODO -> Modify otlp exporter to export resources. This is dependent on #567 , as the spans need to be grouped on basis on Resources and Instrumentation Library before exporting.

@jsuereth  - It doesn't use alternate approach from processor to exporters, as that would need re-work if Resources are later made as mutable / append-only attributes ( as there are some discussion happening on this (and you are already part of that disucssions :) ) : https://github.com/open-telemetry/opentelemetry-specification/issues/1298 ).

Moving to draft, as per comments from Josh.
