### PR TITLE
Lint and reformat markdown

### DIFF
--- a/.markdownlint.yml
+++ b/.markdownlint.yml
@@ -1,8 +1,0 @@
-{
-  "default": true,
-  "MD029": { "style": "ordered" },
-  "ul-style": false,  # MD004
-  "line-length": false,  # MD013
-  "no-inline-html": false,  # MD033
-  "fenced-code-language": false  # MD040
-}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,14 +4,19 @@ The OpenTelemetry C/C++ special interest group (SIG) meets regularly. See the
 OpenTelemetry [community](https://github.com/open-telemetry/community#cc-sdk)
 repo for information on this and other language SIGs.
 
-See the [public meeting notes](https://docs.google.com/document/d/1i1E4-_y4uJ083lCutKGDhkpi3n4_e774SBLi9hPLocw/edit)
+See the [public meeting
+notes](https://docs.google.com/document/d/1i1E4-_y4uJ083lCutKGDhkpi3n4_e774SBLi9hPLocw/edit)
 for a summary description of past meetings. To request edit access, join the
-meeting or get in touch on [Gitter](https://gitter.im/open-telemetry/opentelemetry-cpp).
+meeting or get in touch on
+[Gitter](https://gitter.im/open-telemetry/opentelemetry-cpp).
 
-See the [community membership document](https://github.com/open-telemetry/community/blob/main/community-membership.md)
-on how to become a [**Member**](https://github.com/open-telemetry/community/blob/main/community-membership.md#member),
+See the [community membership
+document](https://github.com/open-telemetry/community/blob/main/community-membership.md)
+on how to become a
+[**Member**](https://github.com/open-telemetry/community/blob/main/community-membership.md#member),
 [**Approver**](https://github.com/open-telemetry/community/blob/main/community-membership.md#approver)
-and [**Maintainer**](https://github.com/open-telemetry/community/blob/main/community-membership.md#maintainer).
+and
+[**Maintainer**](https://github.com/open-telemetry/community/blob/main/community-membership.md#maintainer).
 
 ## Development
 
@@ -28,7 +33,8 @@ example-specific documentation for other build automation tools.
 Install the latest bazel version by following the steps listed
 [here](https://docs.bazel.build/versions/master/install.html).
 
-Select an example of interest from the [examples folder](https://github.com/open-telemetry/opentelemetry-cpp/tree/main/examples).
+Select an example of interest from the [examples
+folder](https://github.com/open-telemetry/opentelemetry-cpp/tree/main/examples).
 Inside each example directory is a `BUILD` file containing instructions for
 Bazel. Find the binary name of your example by inspecting the contents of this
 `BUILD` file.
@@ -73,7 +79,8 @@ Add your fork as a remote:
 git remote add fork https://github.com/YOUR_GITHUB_USERNAME/opentelemetry-cpp.git
 ```
 
-If you haven't, make sure you are loading the submodules required to build OpenTelemetry
+If you haven't, make sure you are loading the submodules required to build
+OpenTelemetry
 
 ```sh
 git submodule init
@@ -96,85 +103,108 @@ To run tests locally, please read the [CI instructions](ci/README.md).
 
 ### How to Receive Comments
 
-* If the PR is not ready for review, please put `[WIP]` in the title, tag it
-  as `work-in-progress`, or mark it as [`draft`](https://github.blog/2019-02-14-introducing-draft-pull-requests/).
-* Make sure [CLA](https://identity.linuxfoundation.org/projects/cncf) is
-  signed and CI is clear.
+* If the PR is not ready for review, please put `[WIP]` in the title, tag it as
+  `work-in-progress`, or mark it as
+  [`draft`](https://github.blog/2019-02-14-introducing-draft-pull-requests/).
+* Make sure [CLA](https://identity.linuxfoundation.org/projects/cncf) is signed
+  and CI is clear.
 * For non-trivial changes, please update the [CHANGELOG](./CHANGELOG.md).
 
 ### How to Get PRs Merged
 
 A PR is considered to be **ready to merge** when:
 
-* It has received two approvals with at least one approval from [Approver](https://github.com/open-telemetry/community/blob/main/community-membership.md#approver)
-  / [Maintainer](https://github.com/open-telemetry/community/blob/main/community-membership.md#maintainer)
+* It has received two approvals with at least one approval from
+  [Approver](https://github.com/open-telemetry/community/blob/main/community-membership.md#approver)
+  /
+  [Maintainer](https://github.com/open-telemetry/community/blob/main/community-membership.md#maintainer)
   (at different company).
-* A pull reqeust opened by an Approver / Maintainer can be merged with only one approval from  Approver / Maintainer (at different company).
+* A pull reqeust opened by an Approver / Maintainer can be merged with only one
+  approval from  Approver / Maintainer (at different company).
 * Major feedback items/points are resolved.
 * It has been open for review for at least one working day. This gives people
   reasonable time to review.
 * Trivial changes (typo, cosmetic, doc, etc.) don't have to wait for one day.
 * Urgent fixes can take exceptions as long as it has been actively communicated.
 
-Any Maintainer can merge the PR once it is **ready to merge**. Maintainer can make conscious judgement to merge pull requests which have not strictly met above mentioned requirements.
+Any Maintainer can merge the PR once it is **ready to merge**. Maintainer can
+make conscious judgement to merge pull requests which have not strictly met
+above mentioned requirements.
 
-If a PR has been stuck (e.g. there are lots of debates and people couldn't agree on each other), the owner should try to get people aligned by:
+If a PR has been stuck (e.g. there are lots of debates and people couldn't agree
+on each other), the owner should try to get people aligned by:
 
-* Consolidating the perspectives and putting a summary in the PR. It is recommended to add a link into the PR description, which points to a comment with a summary in the PR conversation
-* Stepping back to see if it makes sense to narrow down the scope of the PR or split it up.
+* Consolidating the perspectives and putting a summary in the PR. It is
+  recommended to add a link into the PR description, which points to a comment
+  with a summary in the PR conversation
+* Stepping back to see if it makes sense to narrow down the scope of the PR or
+  split it up.
 
-If none of the above worked and the PR has been stuck for more than 2 weeks, the owner should bring it to the [OpenTelemetry C++ SIG meeting](https://zoom.us/j/8203130519). The meeting passcode is _77777_.
+If none of the above worked and the PR has been stuck for more than 2 weeks, the
+owner should bring it to the [OpenTelemetry C++ SIG
+meeting](https://zoom.us/j/8203130519). The meeting passcode is _77777_.
 
 ## Useful Resources
 
 Hi! If you’re looking at this document, these resources will provide you the
 knowledge to get started as a newcomer to the OpenTelemetry project. They will
-help you understand the OpenTelemetry Project, its components, and
-specifically the C++ repository.
+help you understand the OpenTelemetry Project, its components, and specifically
+the C++ repository.
 
 ### Reading Resources
 
-* Medium [article](https://medium.com/opentelemetry/how-to-start-contributing-to-opentelemetry-b23991ad91f4)
+* Medium
+  [article](https://medium.com/opentelemetry/how-to-start-contributing-to-opentelemetry-b23991ad91f4)
   (October 2019) on how to start contributing to the OpenTelemetry project.
-* Medium [article](https://medium.com/opentelemetry/opentelemetry-beyond-getting-started-5ac43cd0fe26)
-  (January 2020) describing the overarching goals and use cases for OpenTelemetry.
+* Medium
+  [article](https://medium.com/opentelemetry/opentelemetry-beyond-getting-started-5ac43cd0fe26)
+  (January 2020) describing the overarching goals and use cases for
+  OpenTelemetry.
 
 ### Relevant Documentation
 
-* [OpenTelemetry Specification](https://github.com/open-telemetry/opentelemetry-specification)
-  * The OpenTelemetry Specification describes the requirements and
-    expectations of for all OpenTelemetry implementations.
+* [OpenTelemetry
+  Specification](https://github.com/open-telemetry/opentelemetry-specification)
+  * The OpenTelemetry Specification describes the requirements and expectations
+    of for all OpenTelemetry implementations.
 
-* Read through the [OpenTelemetry Collector](https://github.com/open-telemetry/opentelemetry-collector)
-  GitHub repository.
-  * This repository has a lot of good information surrounding the
-    OpenTelemetry ecosystem. At the top of the **[readme](https://github.com/open-telemetry/opentelemetry-collector/blob/main/README.md)**,
-    there are multiple links that give newcomers a good idea of what the
-    project is about and how to get involved in it.
+* Read through the [OpenTelemetry
+  Collector](https://github.com/open-telemetry/opentelemetry-collector) GitHub
+  repository.
+  * This repository has a lot of good information surrounding the OpenTelemetry
+    ecosystem. At the top of the
+    **[readme](https://github.com/open-telemetry/opentelemetry-collector/blob/main/README.md)**,
+    there are multiple links that give newcomers a good idea of what the project
+    is about and how to get involved in it.
 * Read through the OpenTelemetry Python documentation
-  * The [API](https://opentelemetry-python.readthedocs.io/en/stable/api/api.html)
-    and [SDK](https://opentelemetry-python.readthedocs.io/en/stable/sdk/sdk.html)
+  * The
+    [API](https://opentelemetry-python.readthedocs.io/en/stable/api/api.html)
+    and
+    [SDK](https://opentelemetry-python.readthedocs.io/en/stable/sdk/sdk.html)
     documentation provides a lot of information on what the classes and their
     functions are used for. Since there is currently minimal documentation for
-    C++, use the Python repository’s extensive documentation to learn more
-    about how the API and SDK work.
+    C++, use the Python repository’s extensive documentation to learn more about
+    how the API and SDK work.
 
 ### Code Examples
 
-* Follow the [simple trace example](https://github.com/open-telemetry/opentelemetry-cpp/pull/92)
-  for an introduction to basic OpenTelemetry functionality in C++. Currently
-  the example can be found in [PR #94](https://github.com/open-telemetry/opentelemetry-cpp/pull/94).
+* Follow the [simple trace
+  example](https://github.com/open-telemetry/opentelemetry-cpp/pull/92) for an
+  introduction to basic OpenTelemetry functionality in C++. Currently the
+  example can be found in [PR
+  #94](https://github.com/open-telemetry/opentelemetry-cpp/pull/94).
 
 * Read through the [Java Quick-Start
   Guide](https://github.com/open-telemetry/opentelemetry-java/blob/main/QUICKSTART.md).
-  This shows you how the classes and functions will interact in simple and
-  easy to digest examples.
+  This shows you how the classes and functions will interact in simple and easy
+  to digest examples.
 * Take a look at this [Java SDK
   example](https://github.com/open-telemetry/opentelemetry-java/tree/main/examples/sdk-usage).
   This shows a good use case of the SDK using stdout exporter.
 * Take a look at the [Java Jaeger
   example](https://github.com/open-telemetry/opentelemetry-java/tree/main/examples/jaeger).
-  This provides a brief introduction to the Jaeger exporter, its interface,
-  and how to interact with the service.
+  This provides a brief introduction to the Jaeger exporter, its interface, and
+  how to interact with the service.
 
-Please contribute! You’re welcome to add more information if you come across any helpful resources.
+Please contribute! You’re welcome to add more information if you come across any
+helpful resources.

--- a/README.md
+++ b/README.md
@@ -1,8 +1,10 @@
 # OpenTelemetry C++
 
-[![Gitter chat](https://badges.gitter.im/open-telemetry/opentelemetry-cpp.svg)](https://gitter.im/open-telemetry/opentelemetry-cpp?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
+[![Gitter
+chat](https://badges.gitter.im/open-telemetry/opentelemetry-cpp.svg)](https://gitter.im/open-telemetry/opentelemetry-cpp?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 [![codecov.io](https://codecov.io/gh/open-telemetry/opentelemetry-cpp/branch/main/graphs/badge.svg?)](https://codecov.io/gh/open-telemetry/opentelemetry-cpp/)
-[![Build Status](https://action-badges.now.sh/open-telemetry/opentelemetry-cpp)](https://github.com/open-telemetry/opentelemetry-cpp/actions)
+[![Build
+Status](https://action-badges.now.sh/open-telemetry/opentelemetry-cpp)](https://github.com/open-telemetry/opentelemetry-cpp/actions)
 [![Release](https://img.shields.io/github/v/release/open-telemetry/opentelemetry-cpp?include_prereleases&style=)](https://github.com/open-telemetry/opentelemetry-cpp/releases/)
 
 The C++ [OpenTelemetry](https://opentelemetry.io/) client.
@@ -33,7 +35,8 @@ of the current project.
 * macOS 10.15 (Xcode 12.2)
 * Windows Server 2019 (Visual Studio Enterprise 2019)
 
-In general, the code shipped from this repository should build on all platforms having C++ compiler with [supported C++ standards](#supported-c-versions).
+In general, the code shipped from this repository should build on all platforms
+having C++ compiler with [supported C++ standards](#supported-c-versions).
 
 ## Installation
 
@@ -41,8 +44,9 @@ Please refer to [INSTALL.md](./INSTALL.md).
 
 ## Quick Start
 
-The `examples/simple` directory contains a minimal program demonstrating
-how to instrument a small library using a simple `processor` and console `exporter`, along with build files for CMake and Bazel.
+The `examples/simple` directory contains a minimal program demonstrating how to
+instrument a small library using a simple `processor` and console `exporter`,
+along with build files for CMake and Bazel.
 
 ## Contributing
 
@@ -54,11 +58,16 @@ contributors' availability. Check the [OpenTelemetry community
 calendar](https://calendar.google.com/calendar/embed?src=google.com_b79e3e90j7bbsa2n2p5an5lf60%40group.calendar.google.com)
 for specific dates.
 
-Meetings take place via [Zoom video conference](https://zoom.us/j/8203130519). The passcode is _77777_.
+Meetings take place via [Zoom video conference](https://zoom.us/j/8203130519).
+The passcode is _77777_.
 
-Meeting notes are available as a public [Google doc](https://docs.google.com/document/d/1i1E4-_y4uJ083lCutKGDhkpi3n4_e774SBLi9hPLocw/edit?usp=sharing). For edit access, get in touch on [Gitter](https://gitter.im/open-telemetry/opentelemetry-cpp).
+Meeting notes are available as a public [Google
+doc](https://docs.google.com/document/d/1i1E4-_y4uJ083lCutKGDhkpi3n4_e774SBLi9hPLocw/edit?usp=sharing).
+For edit access, get in touch on
+[Gitter](https://gitter.im/open-telemetry/opentelemetry-cpp).
 
-Approvers ([@open-telemetry/cpp-approvers](https://github.com/orgs/open-telemetry/teams/cpp-approvers)):
+Approvers
+([@open-telemetry/cpp-approvers](https://github.com/orgs/open-telemetry/teams/cpp-approvers)):
 
 * [Johannes Tax](https://github.com/pyohannes), Microsoft
 * [Josh Suereth](https://github.com/jsuereth), Google
@@ -66,22 +75,27 @@ Approvers ([@open-telemetry/cpp-approvers](https://github.com/orgs/open-telemetr
 * [Ryan Burn](https://github.com/rnburn), Lightstep
 * [Tom Tan](https://github.com/ThomsonTan), Microsoft
 
-*Find more about the approver role in [community repository](https://github.com/open-telemetry/community/blob/main/community-membership.md#approver).*
+*Find more about the approver role in [community
+repository](https://github.com/open-telemetry/community/blob/main/community-membership.md#approver).*
 
-Maintainers ([@open-telemetry/cpp-maintainers](https://github.com/orgs/open-telemetry/teams/cpp-maintainers)):
+Maintainers
+([@open-telemetry/cpp-maintainers](https://github.com/orgs/open-telemetry/teams/cpp-maintainers)):
 
 * [Emil Mikulic](https://github.com/g-easy), Google
 * [Lalit Kumar Bhasin](https://github.com/lalitb), Microsoft
 * [Reiley Yang](https://github.com/reyang), Microsoft
 
-*Find more about the maintainer role in [community repository](https://github.com/open-telemetry/community/blob/main/community-membership.md#maintainer).*
+*Find more about the maintainer role in [community
+repository](https://github.com/open-telemetry/community/blob/main/community-membership.md#maintainer).*
 
-Triagers ([@open-telemetry/cpp-triagers](https://github.com/orgs/open-telemetry/teams/cpp-triagers)):
+Triagers
+([@open-telemetry/cpp-triagers](https://github.com/orgs/open-telemetry/teams/cpp-triagers)):
 
 * [Alolita Sharma](https://github.com/alolita), Amazon
 * [Jodee Varney](https://github.com/jodeev), New Relic
 
-*Find more about the triager role in [community repository](https://github.com/open-telemetry/community/blob/main/community-membership.md#triager).*
+*Find more about the triager role in [community
+repository](https://github.com/open-telemetry/community/blob/main/community-membership.md#triager).*
 
 ## Release Schedule
 
@@ -94,10 +108,10 @@ releases. Each alpha and beta release could include significant changes to the
 API and SDK packages, making them incompatible with each other.
 
 See the [release
-notes](https://github.com/open-telemetry/opentelemetry-cpp/releases)
-for existing releases.
+notes](https://github.com/open-telemetry/opentelemetry-cpp/releases) for
+existing releases.
 
 See the [project
-milestones](https://github.com/open-telemetry/opentelemetry-cpp/milestones)
-for details on upcoming releases. The dates and features described in issues
-and milestones are estimates, and subject to change.
+milestones](https://github.com/open-telemetry/opentelemetry-cpp/milestones) for
+details on upcoming releases. The dates and features described in issues and
+milestones are estimates, and subject to change.

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -2,9 +2,12 @@
 
 ## Pre Release
 
-1: Make sure all relevant changes for this release are included under `Unreleased` section in `CHANGELOG.md` and are in language that non-contributors to the project can understand.
+1: Make sure all relevant changes for this release are included under
+`Unreleased` section in `CHANGELOG.md` and are in language that non-contributors
+to the project can understand.
 
-2: Run the pre-release script. It creates a branch `pre_release_<new-tag>` and updates `CHANGELOG.md` with the `<new-tag>`:
+2: Run the pre-release script. It creates a branch `pre_release_<new-tag>` and
+updates `CHANGELOG.md` with the `<new-tag>`:
 
 ```sh
 ./buildscripts/pre_release.sh -t <new-tag>
@@ -16,17 +19,20 @@
 git diff main
 ```
 
-4: Push the changes to upstream and create a Pull Request on GitHub.
-Be sure to include the curated changes from the [Changelog](./CHANGELOG.md) in the description.
+4: Push the changes to upstream and create a Pull Request on GitHub. Be sure to
+include the curated changes from the [Changelog](./CHANGELOG.md) in the
+description.
 
 ## Tag
 
-Once the above Pull Request has been approved and merged it is time to tag the merged commit.
+Once the above Pull Request has been approved and merged it is time to tag the
+merged commit.
 
-***IMPORTANT***: It is critical you use the same tag that you used in the Pre-Release step!
-Failure to do so will leave things in a broken state.
+***IMPORTANT***: It is critical you use the same tag that you used in the
+Pre-Release step! Failure to do so will leave things in a broken state.
 
-1: Note down the commit hash of the master branch after above PR request is merged : <commit-hash>
+1: Note down the commit hash of the master branch after above PR request is
+merged: `<commit-hash>`
 
 ```sh
 git show -s --format=%H
@@ -48,7 +54,8 @@ git push upstream
 
 Once tag is created, it's time to use that tag for Runtime Versioning
 
-1: Create a new brach for updating version information in `./sdk/src/version.cc`.
+1: Create a new brach for updating version information in
+`./sdk/src/version.cc`.
 
 ```sh
 git checkout -b update_version_${tag} master
@@ -60,11 +67,14 @@ git checkout -b update_version_${tag} master
 ./buildscripts/pre-commit
 ```
 
-3: Check if any changes made since last release broke ABI compatibility. If yes, update `OPENTELEMETRY_ABI_VERSION_NO` in [version.h](api/include/opentelemetry/version.h).
+3: Check if any changes made since last release broke ABI compatibility. If yes,
+update `OPENTELEMETRY_ABI_VERSION_NO` in
+[version.h](api/include/opentelemetry/version.h).
 
 4: Push the changes to upstream and create a Pull Request on GitHub.
 
-5: Once changes are merged, move the tag created earlier to the new commit hash from step 4.
+5: Once changes are merged, move the tag created earlier to the new commit hash
+from step 4.
 
 ```sh
 git tag -f <previous-tag> <new-commit-hash>
@@ -73,4 +83,5 @@ git push --tags --force
 
 ## Release
 
-Finally create a Release for the new <new-tag> on GitHub. The release body should include all the release notes from the Changelog for this release.
+Finally create a Release for the new `<new-tag>` on GitHub. The release body
+should include all the release notes from the Changelog for this release.

--- a/Versioning.md
+++ b/Versioning.md
@@ -6,11 +6,13 @@ This document describes the versioning policy for this repository.
 
 ### API Stability
 
-Once the API for a given signal (spans, logs, metrics, baggage) has been officially released, that API module will function with any SDK that has the same MAJOR version and equal or greater MINOR or PATCH version. For example, application compiled with API v1.1 is compatible with SDK v1.1.2, v1.2.0, etc.
+Once the API for a given signal (spans, logs, metrics, baggage) has been
+officially released, that API module will function with any SDK that has the
+same MAJOR version and equal or greater MINOR or PATCH version. For example,
+application compiled with API v1.1 is compatible with SDK v1.1.2, v1.2.0, etc.
 
 For example, libraries that are instrumented with `opentelemetry 1.0.1` will
-function in applications using `opentelemetry 1.11.33` or `opentelemetry
-1.3.4`.
+function in applications using `opentelemetry 1.11.33` or `opentelemetry 1.3.4`.
 
 ### SDK Stability
 
@@ -22,14 +24,22 @@ must remain backwards compatible. Internal types are allowed to break.
 Refer to the [ABI Policy](./docs/abi-policy.md) for more details. To summarise:
 
 * ABI stability is guaranteed for the API.
-* ABI stability is not guaranteed for the SDK. In case of ABI breaking changes, instead of bumping up the major version, a new `inline namespace` version will be created, and both old API and new API would be made available simultaneously.
+* ABI stability is not guaranteed for the SDK. In case of ABI breaking changes,
+  instead of bumping up the major version, a new `inline namespace` version will
+  be created, and both old API and new API would be made available
+  simultaneously.
 
 ## Policy
 
 * Release versions will follow [SemVer 2.0](https://semver.org/).
-* Only a single source package containing both the api and sdk for all signals will be released as part of each GitHub release.
-* There will be source package releases for api and sdk. There won't be separate releases for the signals. The release version numbers for api and sdk will not be in sync with each other. As there would be more frequent changes expected in sdk than in the api.
-* Experimental releases: New (unstable) telemetry signals and features will be introduced behind feature flag protected by a preprocessor macro.
+* Only a single source package containing both the api and sdk for all signals
+  will be released as part of each GitHub release.
+* There will be source package releases for api and sdk. There won't be separate
+  releases for the signals. The release version numbers for api and sdk will not
+  be in sync with each other. As there would be more frequent changes expected
+  in sdk than in the api.
+* Experimental releases: New (unstable) telemetry signals and features will be
+  introduced behind feature flag protected by a preprocessor macro.
 
   ```cpp
   #ifdef FEATURE_FLAG
@@ -37,19 +47,28 @@ Refer to the [ABI Policy](./docs/abi-policy.md) for more details. To summarise:
   #endif
   ```
 
-  As we deliver the package in source form, and the user is responsible to build it for their platform, the user must be
-  aware of these feature flags (documented in the [CHANGELOG.md](CHANGELOG.md) file).
-  The user must enable them explicitly through their build system (CMake, Bazel or others) to use any preview features.
+  As we deliver the package in source form, and the user is responsible to build
+  it for their platform, the user must be aware of these feature flags
+  (documented in the [CHANGELOG.md](CHANGELOG.md) file). The user must enable
+  them explicitly through their build system (CMake, Bazel or others) to use any
+  preview features.
 
   The guidelines in creating feature flag would be:
 
   * Naming:
-    * `ENABLE_<SIGNAL>_PREVIEW` : For experimental release of signal api/sdks eg, `METRICS_PREVIEW`, `LOGGING_PREVIEW`,
-    * `ENABLE_<SIGNAL>_<FEATURE_NAME>_PREVIEW` : For experimental release for any feature within stable signal. For example, `TRACING_JAEGER_PREVIEW` to release the experimental Jaeger exporter for tracing.
-  * Cleanup: It is good practice to keep feature-flags as shortlived as possible. And, also important to keep the number of them low. They should be used such that it is easy to remove/cleanup them once the experimental feature is stable.
+    * `ENABLE_<SIGNAL>_PREVIEW` : For experimental release of signal api/sdks
+      eg, `METRICS_PREVIEW`, `LOGGING_PREVIEW`,
+    * `ENABLE_<SIGNAL>_<FEATURE_NAME>_PREVIEW` : For experimental release for
+      any feature within stable signal. For example, `TRACING_JAEGER_PREVIEW` to
+      release the experimental Jaeger exporter for tracing.
+  * Cleanup: It is good practice to keep feature-flags as shortlived as
+    possible. And, also important to keep the number of them low. They should be
+    used such that it is easy to remove/cleanup them once the experimental
+    feature is stable.
 
-* New signals will be stabilized via a **minor version bump**, and are not allowed to break existing stable interfaces.
-Feature flags will be removed once we have a stable implementation for the signal.
+* New signals will be stabilized via a **minor version bump**, and are not
+  allowed to break existing stable interfaces. Feature flags will be removed
+  once we have a stable implementation for the signal.
 
 * GitHub releases will be made for all released versions.
 
@@ -59,10 +78,12 @@ Purely for illustration purposes, not intended to represent actual releases:
 
 * v0.0.1 release:
   * `opentelemetry-api 0.0.1`
-    * Contains experimental api's of trace, resouce ( no feature flag as major version is 0 )
+    * Contains experimental api's of trace, resouce ( no feature flag as major
+      version is 0 )
     * No api's of logging and metrics available
   * `opentelemetry-sdk 0.0.1`
-    * Contains experimental implementation of trace, resouce ( no feature flag as major version is 0 )
+    * Contains experimental implementation of trace, resouce ( no feature flag
+      as major version is 0 )
     * No implemtation of logging and metrics available
 * v1.0.0 release: ( with traces )
   * `opentelemetry-api 1.0.0`
@@ -73,17 +94,22 @@ Purely for illustration purposes, not intended to represent actual releases:
     * experimental metrics api's behind feature flag
 * v1.5.0 release (with metrics)
   * `opentelemetry-api 1.5.0`
-    * Contains stable api's of metrics, trace, baggage, resource, context modules
+    * Contains stable api's of metrics, trace, baggage, resource, context
+      modules
     * experimental logging api still only behind feature flag
   * `opentelemetry-sdk 1.5.0`
-    * Contains stable implementation of metrics, trace, baggage, resource, context modules
+    * Contains stable implementation of metrics, trace, baggage, resource,
+      context modules
     * experimental logging implementation still only behind feature flag
 * v1.10.0 release (with logging)
   * `opentelemetry-api 1.10.0`
-    * Contains stable api's of logging, metrics, trace, baggage, resource, context modules
+    * Contains stable api's of logging, metrics, trace, baggage, resource,
+      context modules
   * `opentelemetry-sdk 1.10.0`
-    * Contains stable sdk of logging, metrics, trace, baggage, resource, context modules
+    * Contains stable sdk of logging, metrics, trace, baggage, resource, context
+      modules
 
 ### Before moving to version 1.0.0
 
-* Major version zero (0.y.z) is for initial development. Anything MAY change at any time. The public API SHOULD NOT be considered stable.
+* Major version zero (0.y.z) is for initial development. Anything MAY change at
+  any time. The public API SHOULD NOT be considered stable.

--- a/api/include/opentelemetry/nostd/absl/README.md
+++ b/api/include/opentelemetry/nostd/absl/README.md
@@ -1,9 +1,14 @@
 # Notes on Abseil Variant implementation
 
-This is a snapshot of Abseil Variant `absl::variant` from Abseil `v2020-03-03#8`.
+This is a snapshot of Abseil Variant `absl::variant` from Abseil
+`v2020-03-03#8`.
 
-This code is required to compile OpenTelemetry code in vs2015 because MPark Variant implementation is not compatible with vs2015.
+This code is required to compile OpenTelemetry code in vs2015 because MPark
+Variant implementation is not compatible with vs2015.
 
-Build option `HAVE_ABSEIL_VARIANT` allows to enable the build with `absl::variant`, `absl::get` and `absl::visit` as defalt implementation for `nostd::` classes.
+Build option `HAVE_ABSEIL_VARIANT` allows to enable the build with
+`absl::variant`, `absl::get` and `absl::visit` as defalt implementation for
+`nostd::` classes.
 
-Going forward it makes sense to use `absl::variant` as default implementation for Windows OS and vs2015, vs2017, vs2019 and newer compilers.
+Going forward it makes sense to use `absl::variant` as default implementation
+for Windows OS and vs2015, vs2017, vs2019 and newer compilers.

--- a/ci/README.md
+++ b/ci/README.md
@@ -1,6 +1,7 @@
 # Building and running tests as a developer
 
-CI tests can be run on docker by invoking the script `./ci/run_docker.sh ./ci/do_ci.sh <TARGET>` where the targets are:
+CI tests can be run on docker by invoking the script `./ci/run_docker.sh
+./ci/do_ci.sh {TARGET}` where the targets are:
 
 * `cmake.test`: build cmake targets and run tests.
 * `cmake.legacy.test`: build cmake targets with gcc 4.8 and run tests.
@@ -8,14 +9,17 @@ CI tests can be run on docker by invoking the script `./ci/run_docker.sh ./ci/do
 * `cmake.test_example_plugin`: build and test an example OpenTelemetry plugin.
 * `cmake.exporter.otprotocol.test`: build and test the otprotocol exporter
 * `bazel.test`: build bazel targets and run tests.
-* `bazel.legacy.test`: build bazel targets and run tests for the targets meant to work with older compilers.
+* `bazel.legacy.test`: build bazel targets and run tests for the targets meant
+  to work with older compilers.
 * `bazel.noexcept`: build bazel targets and run tests with exceptions disabled.
 * `bazel.asan`: build bazel targets and run tests with AddressSanitizer.
 * `bazel.tsan`: build bazel targets and run tests with ThreadSanitizer.
-* `bazel.valgrind`: build bazel targets and run tests under the valgrind memory checker.
+* `bazel.valgrind`: build bazel targets and run tests under the valgrind memory
+  checker.
 * `benchmark`: run all benchmarks.
 * `format`: use `tools/format.sh` to enforce text formatting.
-* `code.coverage`: build cmake targets with CXX option `--coverage` and run tests.
+* `code.coverage`: build cmake targets with CXX option `--coverage` and run
+  tests.
 
-Additionally, `./ci/run_docker.sh` can be invoked with no arguments to get a docker shell where tests
-can be run manually.
+Additionally, `./ci/run_docker.sh` can be invoked with no arguments to get a
+docker shell where tests can be run manually.

--- a/docs/abi-compatibility.md
+++ b/docs/abi-compatibility.md
@@ -2,17 +2,38 @@
 
 ## Visual Studio 2015, 2017, 2019
 
-The Microsoft C++ (MSVC) compiler toolsets in Visual Studio 2013 and earlier don't guarantee binary compatibility across versions. You can't link object files, static libraries, dynamic libraries, and executables built by different versions. The ABIs, object formats, and runtime libraries are incompatible.
+The Microsoft C++ (MSVC) compiler toolsets in Visual Studio 2013 and earlier
+don't guarantee binary compatibility across versions. You can't link object
+files, static libraries, dynamic libraries, and executables built by different
+versions. The ABIs, object formats, and runtime libraries are incompatible.
 
-We've changed this behavior in Visual Studio 2015, 2017, and 2019. The runtime libraries and apps compiled by any of these versions of the compiler are binary-compatible. It's reflected in the C++ toolset major number, which is 14 for all three versions. (The toolset version is v140 for Visual Studio 2015, v141 for 2017, and v142 for 2019). Say you have third-party libraries built by Visual Studio 2015. You can still use them in an application built by Visual Studio 2017 or 2019. There's no need to recompile with a matching toolset. The latest version of the Microsoft Visual C++ Redistributable package (the Redistributable) works for all of them.
+We've changed this behavior in Visual Studio 2015, 2017, and 2019. The runtime
+libraries and apps compiled by any of these versions of the compiler are
+binary-compatible. It's reflected in the C++ toolset major number, which is 14
+for all three versions. (The toolset version is v140 for Visual Studio 2015,
+v141 for 2017, and v142 for 2019). Say you have third-party libraries built by
+Visual Studio 2015. You can still use them in an application built by Visual
+Studio 2017 or 2019. There's no need to recompile with a matching toolset. The
+latest version of the Microsoft Visual C++ Redistributable package (the
+Redistributable) works for all of them.
 
 There are three important restrictions on binary compatibility:
 
-- You can mix binaries built by different versions of the toolset. However, you must use a toolset at least as recent as the most recent binary to link your app. Here's an example: you can link an app compiled using the 2017 toolset to a static library compiled using 2019, if they're linked using the 2019 toolset.
+- You can mix binaries built by different versions of the toolset. However, you
+  must use a toolset at least as recent as the most recent binary to link your
+  app. Here's an example: you can link an app compiled using the 2017 toolset to
+  a static library compiled using 2019, if they're linked using the 2019
+  toolset.
 
-- The Redistributable your app uses has a similar binary-compatibility restriction. When you mix binaries built by different supported versions of the toolset, the Redistributable version must be at least as new as the latest toolset used by any app component.
+- The Redistributable your app uses has a similar binary-compatibility
+  restriction. When you mix binaries built by different supported versions of
+  the toolset, the Redistributable version must be at least as new as the latest
+  toolset used by any app component.
 
-- Static libraries or object files compiled using the /GL (Whole program optimization) compiler switch aren't binary-compatible across versions. All object files and libraries compiled using /GL must use exactly the same toolset for the compile and the final link.
+- Static libraries or object files compiled using the /GL (Whole program
+  optimization) compiler switch aren't binary-compatible across versions. All
+  object files and libraries compiled using /GL must use exactly the same
+  toolset for the compile and the final link.
 
 [Reference](https://docs.microsoft.com/en-us/cpp/porting/binary-compat-2015-2017?view=vs-2019)
 
@@ -20,16 +41,22 @@ There are three important restrictions on binary compatibility:
 
 ### Exceptions
 
-- [__CxxFrameHandler4](https://devblogs.microsoft.com/cppblog/making-cpp-exception-handling-smaller-x64/) - static library built with Visual Studio 2019 wont link to executable compiled with Visual Studio 2017
+- [__CxxFrameHandler4](https://devblogs.microsoft.com/cppblog/making-cpp-exception-handling-smaller-x64/)
+  - static library built with Visual Studio 2019 wont link to executable
+  compiled with Visual Studio 2017
 
 ### Release vs Debug libraries on Windows
 
-- [\_SECURE_SCL](https://docs.microsoft.com/en-us/cpp/standard-library/secure-scl?view=vs-2019) - checked iterators (old)
+- [\_SECURE_SCL](https://docs.microsoft.com/en-us/cpp/standard-library/secure-scl?view=vs-2019)
+  - checked iterators (old)
 
-- [\_ITERATOR_DEBUG_LEVEL](https://docs.microsoft.com/en-us/cpp/standard-library/iterator-debug-level?view=vs-2019) - checked iterators (new)
+- [\_ITERATOR_DEBUG_LEVEL](https://docs.microsoft.com/en-us/cpp/standard-library/iterator-debug-level?view=vs-2019)
+  - checked iterators (new)
 
 ### Spectre Mitigation
 
-- [Runtime Libraries for Spectre Mitigation](https://docs.microsoft.com/en-us/cpp/build/reference/qspectre?view=vs-2019)
+- [Runtime Libraries for Spectre
+  Mitigation](https://docs.microsoft.com/en-us/cpp/build/reference/qspectre?view=vs-2019)
 
-- [New Spectre Mitigations in Visual Studio 2019](https://devblogs.microsoft.com/cppblog/more-spectre-mitigations-in-msvc/)
+- [New Spectre Mitigations in Visual Studio
+  2019](https://devblogs.microsoft.com/cppblog/more-spectre-mitigations-in-msvc/)

--- a/docs/abi-policy.md
+++ b/docs/abi-policy.md
@@ -32,11 +32,14 @@ class Tracer {
 public:
   ...
 
-  virtual void f(const std::string& s); // Bad: std::string doesn't have a well-defined ABI.
+  // Bad: std::string doesn't have a well-defined ABI.
+  virtual void f(const std::string& s);
 
-  virtual void f(nostd::string_view s); // OK: We provide a ABI stable string_view type.
+  // OK: We provide a ABI stable string_view type.
+  virtual void f(nostd::string_view s);
 
-  void g(const std::vector<int>& v); // OK: g is non-virtual function.
+  // OK: g is non-virtual function.
+  void g(const std::vector<int>& v);
   ...
 };
 ```

--- a/docs/building-with-stdlib.md
+++ b/docs/building-with-stdlib.md
@@ -4,13 +4,13 @@ Standard Library build flavor works best for statically linking the SDK in a
 process (environment where ABI compat is not a requirement), or for
 "header-only" implementation of SDK.
 
-Proposed approach cannot be employed for shared libs in environments where
-ABI compatibility is required. OpenTelemetry SDK binary compiled with
-`compiler A + STL B` will not be ABI -compatible with the main executable
-compiled with `compiler C + STL D`.
+Proposed approach cannot be employed for shared libs in environments where ABI
+compatibility is required. OpenTelemetry SDK binary compiled with `compiler A +
+STL B` will not be ABI -compatible with the main executable compiled with
+`compiler C + STL D`.
 
-In addition to standard library, similar approach can be reused to implement
-the API surface classes with [Abseil classes](https://abseil.io/) instead of
+In addition to standard library, similar approach can be reused to implement the
+API surface classes with [Abseil classes](https://abseil.io/) instead of
 `nostd`, in products that prefer Abseil.
 
 ## Motivation
@@ -18,7 +18,7 @@ the API surface classes with [Abseil classes](https://abseil.io/) instead of
 `nostd` classes in OpenTelemetry API were introduced for the following reasons:
 
 * ABI stability: scenario where different modules are compiled with different
-compiler and incompatible standard library.
+  compiler and incompatible standard library.
 * backport of C++17 and above features to C++11 compiler.
 
 The need for custom `nostd` classes is significantly diminished when the SDK is
@@ -31,25 +31,25 @@ is the case when SDK is compiled into product itself, with no runtime loadable
 components.
 
 Compiling OpenTelemetry SDK from source using standard library classes:
-`std::map`, `std::string_view`, `std::span`, `std::variant`
-instead of `nostd::` yields better performance and debugability at expense
-of potentially losing ABI compatibility. However, the standard library built
-for Release is guaranteed to be compatible across Visual Studio 2015, 2017 and
-2019 compilers on Windows with vc14x runtime. Thus, ABI stability requirement
-introduces an additional unnecessary runtime complexity and overhead.
+`std::map`, `std::string_view`, `std::span`, `std::variant` instead of `nostd::`
+yields better performance and debugability at expense of potentially losing ABI
+compatibility. However, the standard library built for Release is guaranteed to
+be compatible across Visual Studio 2015, 2017 and 2019 compilers on Windows with
+vc14x runtime. Thus, ABI stability requirement introduces an additional
+unnecessary runtime complexity and overhead.
 
 While we are committed to support `nostd` classes for those environments where
 ABI compatibility is a requirement, we would also like to add flexibility to
-build system to optimize the SDK for the case where ABI compatibility is NOT
-a requirement.
+build system to optimize the SDK for the case where ABI compatibility is NOT a
+requirement.
 
 Implementation of this feature can be subsequently be used as a foundation for
 further work - allow bindings to [Abseil](https://github.com/abseil/abseil-cpp)
 "backport" implementation of the standard library.
 
 Implementation is completely opaque from SDK code / SDK developer perspective:
-mapping / aliasing from `nostd::` classes back to their `std::` counterparts
-is done in a corresponding `opentelemetry/nostd/*.h` header. Users still use
+mapping / aliasing from `nostd::` classes back to their `std::` counterparts is
+done in a corresponding `opentelemetry/nostd/*.h` header. Users still use
 `nostd` classes, but the most optimal implementation is picked up depending on
 whether users require ABI stability or not.
 
@@ -58,7 +58,8 @@ Example environments that contain the full set of standard classes:
 * C++17 or above compiler, with Microsoft GSL backport of `gsl::span`
 * C++20 compilers: Visual Studio 2019+, latest LLVM clang, latest gcc
 
-We continue fully supporting both models (`nostd`, `stdlib`) by running CI for both.
+We continue fully supporting both models (`nostd`, `stdlib`) by running CI for
+both.
 
 ## Implementation
 
@@ -66,17 +67,18 @@ Allow to alias from `nostd::` to `std::` classes for C++17 and above.
 
 Consistent handling of `std::variant` across various OS:
 
-- backport of a few missing variant features, e.g. `std::get` and `std::visit`
+* backport of a few missing variant features, e.g. `std::get` and `std::visit`
   for older version of Mac OS X. Patches that enable proper handling of
-  `std::visit` and `std::variant` irrespective of OS version to resolve
-  [this quirk](https://stackoverflow.com/questions/52310835/xcode-10-call-to-unavailable-function-stdvisit).
+  `std::visit` and `std::variant` irrespective of OS version to resolve [this
+  quirk](https://stackoverflow.com/questions/52310835/xcode-10-call-to-unavailable-function-stdvisit).
 
-- ability to borrow implementation of C++20 `gsl::span` from
-  [Microsoft Guidelines Support Library](https://github.com/microsoft/GSL).
-  This is necessary for C++17 and above compiler.
+* ability to borrow implementation of C++20 `gsl::span` from [Microsoft
+  Guidelines Support Library](https://github.com/microsoft/GSL). This is
+  necessary for C++17 and above compiler.
 
-- ability to use Abseil classes for Visual Studio 2015 :`nostd::variant` does
-  not compile with Visual Studio 2010. Please refer to [this issue](https://github.com/open-telemetry/opentelemetry-cpp/issues/314)
+* ability to use Abseil classes for Visual Studio 2015 :`nostd::variant` does
+  not compile with Visual Studio 2010. Please refer to [this
+  issue](https://github.com/open-telemetry/opentelemetry-cpp/issues/314)
 
 ## Pros and Cons
 
@@ -91,11 +93,11 @@ runtime-checks for Debug builds that use Standard containers.
 
 ### Minimizing binary size
 
-No need to marshal types from standard to `nostd`, then back to standard
-library across ABI boundary - means less code involved and less memcpy. We use
-Standard Library classes used elsewhere in the app. We can optimize the
-event passing by avoiding `KeyValueIterable` transform (and, thus, unnecessary memcpy)
-when we know that the incoming container type matches that one used by SDK.
+No need to marshal types from standard to `nostd`, then back to standard library
+across ABI boundary - means less code involved and less memcpy. We use Standard
+Library classes used elsewhere in the app. We can optimize the event passing by
+avoiding `KeyValueIterable` transform (and, thus, unnecessary memcpy) when we
+know that the incoming container type matches that one used by SDK.
 
 ### Avoiding unnecessary extra memcpy (perf improvements)
 
@@ -118,15 +120,17 @@ older runtime library. In this case the SDK must be compiled with `nostd`.
 Note that for most scenarios with modern Windows compilers, STL library is
 ABI-safe across Visual Studio 2015, 2017 and 2019 with vc14x runtime.
 
-Quote from [official documentation](https://docs.microsoft.com/en-us/cpp/porting/binary-compat-2015-2017?view=msvc-160) :
+Quote from [official
+documentation](https://docs.microsoft.com/en-us/cpp/porting/binary-compat-2015-2017?view=msvc-160)
+:
 
 Visual Studio 2015, 2017, and 2019: the runtime libraries and apps compiled by
 any of these versions of the compiler are binary-compatible. It's reflected in
 the C++ toolset major number, which is 14 for all three versions. The toolset
-version is v140 for Visual Studio 2015, v141 for 2017, and v142 for 2019.
-Say you have third-party libraries built by Visual Studio 2015. You can still
-use them in an application built by Visual Studio 2017 or 2019. There's no need
-to recompile with a matching toolset. The latest version of the Microsoft Visual
+version is v140 for Visual Studio 2015, v141 for 2017, and v142 for 2019. Say
+you have third-party libraries built by Visual Studio 2015. You can still use
+them in an application built by Visual Studio 2017 or 2019. There's no need to
+recompile with a matching toolset. The latest version of the Microsoft Visual
 C++ Redistributable package (the Redistributable) works for all of them.
 
 Visual Studio provides 1st class debug experience for the standard library.
@@ -137,14 +141,14 @@ Visual Studio provides 1st class debug experience for the standard library.
 
 Supported build flavors:
 
-- `nostd` - OpenTelemetry backport of classes for C++11. Not using standard lib.
-- `stdlib`   - Standard Library. Full native experience with C++20 compiler.
-  C++17 works but with additional dependencies, e.g. either MS-GSL or Abseil
-  for `std::span` implementation (`gsl::span` or `absl::Span`).
-- `absl`  - TODO: this should allow using Abseil C++ library only (no MS-GSL).
+* `nostd` - OpenTelemetry backport of classes for C++11. Not using standard lib.
+* `stdlib`   - Standard Library. Full native experience with C++20 compiler.
+  C++17 works but with additional dependencies, e.g. either MS-GSL or Abseil for
+  `std::span` implementation (`gsl::span` or `absl::Span`).
+* `absl`  - TODO: this should allow using Abseil C++ library only (no MS-GSL).
 
-Currently only `nostd` and `stdlib` configurations are implemented in CMake build.
-`absl` is reserved for future use. Build systems other than CMake need to
+Currently only `nostd` and `stdlib` configurations are implemented in CMake
+build. `absl` is reserved for future use. Build systems other than CMake need to
 `#define HAVE_CPP_STDLIB` to enable the Standard Library classes.
 
 ### Build matrix
@@ -163,24 +167,25 @@ gcc-9+             | C++20             |
 
 C++20 `std::span` -compatible implementation is needed for C++17 compilers.
 
-Other modern C++ language features used by OpenTelemetry, e.g. `std::string_view`
-and `std::variant` are available in C++17 standard library. Minor customization
-needed for Apple LLVM clang in `std::variant` exception handling due to the fact
-that the variant exception handler presence depends on what OS version developer
-is targeting. This exception on Apple systems is implemented inside the OS system
-library. This idiosyncrasy is now handled by OpenTelemetry API in opaque manner:
-support `nostd::variant` exception handling even on older Mac OS X and iOS by
-providing implementation of it in OpenTelemetry SDK: if exceptions are enabled,
-then throw `nostd::bad_variant_access` exception old OS where `std::bad_variant_access`
-is unavailable.
+Other modern C++ language features used by OpenTelemetry, e.g.
+`std::string_view` and `std::variant` are available in C++17 standard library.
+Minor customization needed for Apple LLVM clang in `std::variant` exception
+handling due to the fact that the variant exception handler presence depends on
+what OS version developer is targeting. This exception on Apple systems is
+implemented inside the OS system library. This idiosyncrasy is now handled by
+OpenTelemetry API in opaque manner: support `nostd::variant` exception handling
+even on older Mac OS X and iOS by providing implementation of it in
+OpenTelemetry SDK: if exceptions are enabled, then throw
+`nostd::bad_variant_access` exception old OS where `std::bad_variant_access` is
+unavailable.
 
 #### Note on `gsl::span` vs `absl::Span`
 
 It is important to note that, while `absl::Span` is similar in design and
 purpose to the `std::span` (and existing `gsl::span` reference implementation),
 `absl::Span` is not currently guaranteeing to be a drop-in replacement for any
-eventual standard. Instead, `absl::Span` aims to have an interface as similar
-as possible to `absl::string_view`, without the string-specific functionality.
+eventual standard. Instead, `absl::Span` aims to have an interface as similar as
+possible to `absl::string_view`, without the string-specific functionality.
 
 Thus, OpenTelemetry built with standard library prefers `gsl::span` as it is
 fully compatible with standard `std::span`. It may become possible to use Abseil

--- a/docs/building-with-vcpkg.md
+++ b/docs/building-with-vcpkg.md
@@ -1,6 +1,12 @@
 # Building OpenTelemetry C++ SDK with vcpkg
 
-vcpkg is a Microsoft cross-platform open source C++ package manager. Onboarding instructions for Windows, Linux and Mac OS X [available here](https://docs.microsoft.com/en-us/cpp/build/vcpkg). This document assumes that the customer build system is already configured to use vcpkg. OpenTelemetry C++ SDK maintainers provide a build recipe, `opentelemetry` port or CONTROL file for vcpkg. Mainline vcpkg repo is refreshed to point to latest stable open source release of OpenTelemetry C++ SDK.
+vcpkg is a Microsoft cross-platform open source C++ package manager. Onboarding
+instructions for Windows, Linux and Mac OS X [available
+here](https://docs.microsoft.com/en-us/cpp/build/vcpkg). This document assumes
+that the customer build system is already configured to use vcpkg. OpenTelemetry
+C++ SDK maintainers provide a build recipe, `opentelemetry` port or CONTROL file
+for vcpkg. Mainline vcpkg repo is refreshed to point to latest stable open
+source release of OpenTelemetry C++ SDK.
 
 ## Installing opentelemetry package
 
@@ -12,7 +18,8 @@ vcpkg install opentelemetry
 
 That's it! The package should be compiled for the current OS.
 
-See instructions below to build the SDK with additional Microsoft-proprietary modules.
+See instructions below to build the SDK with additional Microsoft-proprietary
+modules.
 
 ## Testing custom dev OpenTelemetry build on Windows
 
@@ -36,7 +43,9 @@ vcpkg install --head --overlay-ports=`pwd`/tools/ports opentelemetry
 
 ## Using response files to specify dependencies
 
-vcpkg allows to consolidate parameters passed to vcpkg in a response file. All 3rd party dependencies needed for OpenTelemetry SDK can be described and installed via response file.
+vcpkg allows to consolidate parameters passed to vcpkg in a response file. All
+3rd party dependencies needed for OpenTelemetry SDK can be described and
+installed via response file.
 
 Example for Mac:
 
@@ -50,11 +59,22 @@ Example for Linux:
 vcpkg install @tools/ports/opentelemetry/response_file_linux.txt
 ```
 
-vcpkg build log files are created in `${VCPKG_INSTALL_DIR}/buildtrees/opentelemetry/build-[err|out].log` . Review the logs in case if you encounter package installation failures.
+vcpkg build log files are created in
+`${VCPKG_INSTALL_DIR}/buildtrees/opentelemetry/build-[err|out].log` . Review the
+logs in case if you encounter package installation failures.
 
 ## Using triplets
 
-In order to enable custom build flags - vcpkg triplets and custom environment variables may be used. Please see [triplets instruction here](https://vcpkg.readthedocs.io/en/latest/users/triplets/). Response file for a custom build, e.g. `response_file_linux_PRODUCTNAME.txt` may specify a custom triplet. For example, custom triplet controls if the library is built as static or dynamic. Default triplets may also be overridden with [custom triplets](https://vcpkg.readthedocs.io/en/latest/examples/overlay-triplets-linux-dynamic/#overlay-triplets-example). Custom triplets specific to various products must be maintained by product teams. Product teams may optionally decide to integrate their triplets in the mainline OpenTelemetry C++ SDK repo as-needed.
+In order to enable custom build flags - vcpkg triplets and custom environment
+variables may be used. Please see [triplets instruction
+here](https://vcpkg.readthedocs.io/en/latest/users/triplets/). Response file for
+a custom build, e.g. `response_file_linux_PRODUCTNAME.txt` may specify a custom
+triplet. For example, custom triplet controls if the library is built as static
+or dynamic. Default triplets may also be overridden with [custom
+triplets](https://vcpkg.readthedocs.io/en/latest/examples/overlay-triplets-linux-dynamic/#overlay-triplets-example).
+Custom triplets specific to various products must be maintained by product
+teams. Product teams may optionally decide to integrate their triplets in the
+mainline OpenTelemetry C++ SDK repo as-needed.
 
 ## Using Feature Packages
 
@@ -72,13 +92,16 @@ vcpkg install opentelemetry[abseil]
 
 ## Build with vcpkg dependencies
 
-`CMakeLists.txt` in top-level directory lists the following package dependencies:
+`CMakeLists.txt` in top-level directory lists the following package
+dependencies:
 
 - `Protobuf` - required for OTLP exporter. Not required otherwise.
 - `GTest` - required when building with tests enabled.
 - `Benchmark` - required when building with tests enabled.
-- `ms-gsl` - required for `gsl::span` when building with Standard Library with C++14 or C++17 compiler.
+- `ms-gsl` - required for `gsl::span` when building with Standard Library with
+  C++14 or C++17 compiler.
 - `nlohmann-json` - required when building with zPages module.
 - `prometheus-cpp` - required for Prometheus exporter.
 
-It is possible to adjust the build system to use either vcpkg-installed dependencies or OS-provided dependencies, e.g. `brew` or `deb` packages.
+It is possible to adjust the build system to use either vcpkg-installed
+dependencies or OS-provided dependencies, e.g. `brew` or `deb` packages.

--- a/docs/cpp-metrics-api-design.md
+++ b/docs/cpp-metrics-api-design.md
@@ -1,41 +1,91 @@
 # Metrics API Design
 
-This document outlines a proposed implementation of the OpenTelemetry Metrics API in C++.  The design conforms to the current versions of the [Metrics API Specification](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/metrics/api.md) though it is currently under development and subject to change.
+This document outlines a proposed implementation of the OpenTelemetry Metrics
+API in C++.  The design conforms to the current versions of the [Metrics API
+Specification](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/metrics/api.md)
+though it is currently under development and subject to change.
 
-The design supports a minimal implementation for the library to be used by an application. However, without the reference SDK or another implementation, no metric data will be collected.
+The design supports a minimal implementation for the library to be used by an
+application. However, without the reference SDK or another implementation, no
+metric data will be collected.
 
 ## Use Cases
 
-A *metric* is some raw measurement about a service, captured at run-time. Logically, the moment of capturing one of these measurements is known as a *metric event* which consists not only of the measurement itself, but the time that it was captured as well as contextual annotations which tie it to the event being measured. Users can inject instruments which facilitate the collection of these measurements into their services or systems which may be running locally, in containers, or on distributed platforms.  The data collected are then used by monitoring and alerting systems to provide statistical performance data.
+A *metric* is some raw measurement about a service, captured at run-time.
+Logically, the moment of capturing one of these measurements is known as a
+*metric event* which consists not only of the measurement itself, but the time
+that it was captured as well as contextual annotations which tie it to the event
+being measured. Users can inject instruments which facilitate the collection of
+these measurements into their services or systems which may be running locally,
+in containers, or on distributed platforms.  The data collected are then used by
+monitoring and alerting systems to provide statistical performance data.
 
-Monitoring and alerting systems commonly use the data provided through metric events, after applying various aggregations and converting into various exposition formats. However, we find that there are many other uses for metric events, such as to record aggregated or raw measurements in tracing and logging systems. For this reason, OpenTelemetry requires a separation of the API from the SDK, so that different SDKs can be configured at run time.
+Monitoring and alerting systems commonly use the data provided through metric
+events, after applying various aggregations and converting into various
+exposition formats. However, we find that there are many other uses for metric
+events, such as to record aggregated or raw measurements in tracing and logging
+systems. For this reason, OpenTelemetry requires a separation of the API from
+the SDK, so that different SDKs can be configured at run time.
 
-Various instruments also allow for more optimized capture of certain types of measurements.  `Counter` instruments, for example, are monotonic and can therefore be used to capture rate information.  Other potential uses for the `Counter` include tracking the number of bytes received, requests completed, accounts created, etc.
+Various instruments also allow for more optimized capture of certain types of
+measurements.  `Counter` instruments, for example, are monotonic and can
+therefore be used to capture rate information.  Other potential uses for the
+`Counter` include tracking the number of bytes received, requests completed,
+accounts created, etc.
 
-A `ValueRecorder` is commonly used to capture latency measurements. Latency measurements are not additive in the sense that there is little need to know the latency-sum of all processed requests. We use a `ValueRecorder` instrument to capture latency measurements typically because we are interested in knowing mean, median, and other summary statistics about individual events.
+A `ValueRecorder` is commonly used to capture latency measurements. Latency
+measurements are not additive in the sense that there is little need to know the
+latency-sum of all processed requests. We use a `ValueRecorder` instrument to
+capture latency measurements typically because we are interested in knowing
+mean, median, and other summary statistics about individual events.
 
-`Observers` are a good choice in situations where a measurement is expensive to compute, such that it would be wasteful to compute on every request. For example, a system call is needed to capture process CPU usage, therefore it should be done periodically, not on each request.
+`Observers` are a good choice in situations where a measurement is expensive to
+compute, such that it would be wasteful to compute on every request. For
+example, a system call is needed to capture process CPU usage, therefore it
+should be done periodically, not on each request.
 
 ## Design Tenets
 
 * Reliability
-  * The Metrics API and SDK should be “reliable,” meaning that metrics data will always be accounted for. It will get back to the user or an error will be logged.  Reliability also entails that the end-user application will never be blocked.  Error handling will therefore not interfere with the execution of the instrumented program.
+  * The Metrics API and SDK should be “reliable,” meaning that metrics data will
+    always be accounted for. It will get back to the user or an error will be
+    logged.  Reliability also entails that the end-user application will never
+    be blocked.  Error handling will therefore not interfere with the execution
+    of the instrumented program.
   * Thread Safety
-    * As with the Tracer API and SDK, thread safety is not guaranteed on all functions and will be explicitly mentioned in documentation for functions that support concurrent calling.  Generally, the goal is to lock functions which change the state of library objects (incrementing the value of a Counter or adding a new Observer for example) or access global memory.  As a performance consideration, the library strives to hold locks for as short a duration as possible to avoid lock contention concerns.  Calls to create instrumentation may not be thread-safe as this is expected to occur during initialization of the program.
+    * As with the Tracer API and SDK, thread safety is not guaranteed on all
+      functions and will be explicitly mentioned in documentation for functions
+      that support concurrent calling.  Generally, the goal is to lock functions
+      which change the state of library objects (incrementing the value of a
+      Counter or adding a new Observer for example) or access global memory.  As
+      a performance consideration, the library strives to hold locks for as
+      short a duration as possible to avoid lock contention concerns.  Calls to
+      create instrumentation may not be thread-safe as this is expected to occur
+      during initialization of the program.
 * Scalability
-  * As OpenTelemetry is a distributed tracing system, it must be able to operate on sizeable systems with predictable overhead growth.  A key requirement of this is that the library does not consume unbounded memory resource.
+  * As OpenTelemetry is a distributed tracing system, it must be able to operate
+    on sizeable systems with predictable overhead growth.  A key requirement of
+    this is that the library does not consume unbounded memory resource.
 * Security
-  * Currently security is not a key consideration but may be addressed at a later date.
+  * Currently security is not a key consideration but may be addressed at a
+    later date.
 
 ## **Meter Interface (`MeterProvider` Class)**
 
-The singleton global `MeterProvider` can be used to obtain a global Meter by calling `global.GetMeter(name,version)` which calls `GetMeter()` on the initialized global `MeterProvider`
+The singleton global `MeterProvider` can be used to obtain a global Meter by
+calling `global.GetMeter(name,version)` which calls `GetMeter()` on the
+initialized global `MeterProvider`
 
 **Global Meter Provider:**
 
-The API should support a global `MeterProvider`.  When a global instance is supported, the API must ensure that `Meter` instances derived from the global `MeterProvider` are initialized after the global SDK implementation is first initialized.
+The API should support a global `MeterProvider`.  When a global instance is
+supported, the API must ensure that `Meter` instances derived from the global
+`MeterProvider` are initialized after the global SDK implementation is first
+initialized.
 
-A `MeterProvider` interface must support a  `global.SetMeterProvider(MeterProvider)` function which installs the SDK implementation of the `MeterProvider` into the API
+A `MeterProvider` interface must support a
+`global.SetMeterProvider(MeterProvider)` function which installs the SDK
+implementation of the `MeterProvider` into the API
 
 **Obtaining a Meter from MeterProvider:**
 
@@ -43,7 +93,8 @@ A `MeterProvider` interface must support a  `global.SetMeterProvider(MeterProvid
 
 * Expects 2 string arguments:
   * name (required): identifies the instrumentation library.
-  * version (optional): specifies the version of the instrumenting library (the library injecting OpenTelemetry calls into the code)
+  * version (optional): specifies the version of the instrumenting library (the
+    library injecting OpenTelemetry calls into the code)
 
 ```cpp
 # meter_provider.h
@@ -88,6 +139,7 @@ private:
 };
 ```
 
+<!-- markdownlint-disable MD013 -->
 ```cpp
 # meter_provider.h
 class MeterProvider
@@ -108,13 +160,15 @@ public:
 };
 ```
 
-Using this MeterProvider, users can obtain new Meters through the GetMeter function.
+Using this MeterProvider, users can obtain new Meters through the GetMeter
+function.
 
 ## Metric Instruments (`Meter` Class)
 
 **Metric Events:**
 
-This interface consists of a set of **instrument constructors**, and a **facility for capturing batches of measurements.**
+This interface consists of a set of **instrument constructors**, and a
+**facility for capturing batches of measurements.**
 
 ```cpp
 # meter.h
@@ -204,59 +258,103 @@ private:
   InstrumentationInfo instrumentationInfo_;
 }
 ```
+<!-- markdownlint-enable MD013 -->
 
 ### Meter API Class Design Considerations
 
-According to the specification, both signed integer and floating point value types must be supported.  This implementation will use short, int, float, and double types. Different constructors are used for the different metric instruments and even for different value types due to C++ being a strongly typed language. This is similar to Java’s implementation of the meter class. Python gets around this by passing the value type and metric type to a single function called `create_metric`.
+According to the specification, both signed integer and floating point value
+types must be supported.  This implementation will use short, int, float, and
+double types. Different constructors are used for the different metric
+instruments and even for different value types due to C++ being a strongly typed
+language. This is similar to Java’s implementation of the meter class. Python
+gets around this by passing the value type and metric type to a single function
+called `create_metric`.
 
 ## Instrument Types (`Metric` Class)
 
-Metric instruments capture raw measurements of designated quantities in instrumented applications.  All measurements captured by the Metrics API are associated with the instrument which collected that measurement.  These instruments are also templated allowing users to decide which data type to capture.  This enhances user control over the memory used by their instrument set and provides greater precision when necessary.
+Metric instruments capture raw measurements of designated quantities in
+instrumented applications.  All measurements captured by the Metrics API are
+associated with the instrument which collected that measurement.  These
+instruments are also templated allowing users to decide which data type to
+capture.  This enhances user control over the memory used by their instrument
+set and provides greater precision when necessary.
 
 ### Metric Instrument Data Model
 
-Each instrument must have enough information to meaningfully attach its measured values with a process in the instrumented application.  As such, metric instruments contain the following information:
+Each instrument must have enough information to meaningfully attach its measured
+values with a process in the instrumented application.  As such, metric
+instruments contain the following information:
 
 * name (string) — Identifier for this metric instrument.
 * description (string) — Short description of what this instrument is capturing.
-* value_type (string or enum) — Determines whether the value tracked is an int64 or double.
+* value_type (string or enum) — Determines whether the value tracked is an int64
+  or double.
 * meter (Meter) — The Meter instance from which this instrument was derived.
-* label_keys (KeyValueIterable) — A nostd class acting as a map from nostd::string_view to nostd::string_view
-* enabled (boolean) — Determines whether the instrument is currently collecting data.
-* bound_instruments (key value container) — Contains the bound instruments derived from this instrument.
+* label_keys (KeyValueIterable) — A nostd class acting as a map from
+  nostd::string_view to nostd::string_view
+* enabled (boolean) — Determines whether the instrument is currently collecting
+  data.
+* bound_instruments (key value container) — Contains the bound instruments
+  derived from this instrument.
 
-Metric instruments are created through instances of the `Meter` class and each type of instrument can be described with the following properties:
+Metric instruments are created through instances of the `Meter` class and each
+type of instrument can be described with the following properties:
 
-* Synchronicity:  A synchronous instrument is called by the user in a distributed [Context](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/context/context.md) (i.e., Span context, Correlation context) and is updated once per request. An asynchronous instrument is called by the SDK once per collection interval and only one value from the interval is kept.
-* Additivity:  An additive instrument is one that records additive measurements, meaning the final sum of updates is the only useful value.  Non-additive instruments should be used when the intent is to capture information about the distribution of values.
-* Monotonicity: A monotonic instrument is an additive instrument, where the progression of each sum is non-decreasing. Monotonic instruments are useful for monitoring rate information.
+* Synchronicity:  A synchronous instrument is called by the user in a
+  distributed
+  [Context](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/context/context.md)
+  (i.e., Span context, Correlation context) and is updated once per request. An
+  asynchronous instrument is called by the SDK once per collection interval and
+  only one value from the interval is kept.
+* Additivity:  An additive instrument is one that records additive measurements,
+  meaning the final sum of updates is the only useful value.  Non-additive
+  instruments should be used when the intent is to capture information about the
+  distribution of values.
+* Monotonicity: A monotonic instrument is an additive instrument, where the
+  progression of each sum is non-decreasing. Monotonic instruments are useful
+  for monitoring rate information.
 
 The following instrument types will be supported:
 <!-- [//]: # ![Metric Instrument Table](../images/MetricInstrumentsTable.png) -->
 
 ### Metric Event Data Model
 
-Each measurement taken by a Metric instrument is a Metric event which must contain the following information:
+Each measurement taken by a Metric instrument is a Metric event which must
+contain the following information:
 
 * timestamp (implicit) — System time when measurement was captured.
-* instrument definition(strings) — Name of instrument, kind, description, and unit of measure
-* label set (key value pairs) — Labels associated with the capture, described further below.
+* instrument definition(strings) — Name of instrument, kind, description, and
+  unit of measure
+* label set (key value pairs) — Labels associated with the capture, described
+  further below.
 * resources associated with the SDK at startup
 
 **Label Set:**
 
-A key:value mapping of some kind MUST be supported as annotation each metric event.  Labels must be represented the same way throughout the API (i.e. using the same idiomatic data structure) and duplicates are dealt with by taking the last value mapping.
+A key:value mapping of some kind MUST be supported as annotation each metric
+event.  Labels must be represented the same way throughout the API (i.e. using
+the same idiomatic data structure) and duplicates are dealt with by taking the
+last value mapping.
 
-To maintain ABI stability, we have chosen to implement this as a KeyValueIterable type. However, due to performance concerns, we may convert to a std::string internally.
+To maintain ABI stability, we have chosen to implement this as a
+KeyValueIterable type. However, due to performance concerns, we may convert to a
+std::string internally.
 
 **Calling Conventions:**
 
-Metric instruments must support bound instrument calling where the labels for each capture remain the same.  After a call to  `instrument.Bind(labels)` , all subsequent calls to `instrument.add()` will include the labels implicitly in their capture.
+Metric instruments must support bound instrument calling where the labels for
+each capture remain the same.  After a call to  `instrument.Bind(labels)` , all
+subsequent calls to `instrument.add()` will include the labels implicitly in
+their capture.
 
-Direct calling must also be supported.  The user can specify labels with the capture rather than binding beforehand by including the labels in the update call: `instrument.Add(x, labels)`.
+Direct calling must also be supported.  The user can specify labels with the
+capture rather than binding beforehand by including the labels in the update
+call: `instrument.Add(x, labels)`.
 
-MUST support `RecordBatch` calling (where a single set of labels is applied to several metric instruments).
+MUST support `RecordBatch` calling (where a single set of labels is applied to
+several metric instruments).
 
+<!-- markdownlint-disable MD013 -->
 ```cpp
 # metric.h
 
@@ -418,9 +516,15 @@ private:
     void (*callback_)(ObserverResult<T>);
 };
 ```
+<!-- markdownlint-enable MD013 -->
 
-The Counter below is an example of one Metric instrument.  It is important to note that in the Counter’s add function, it binds the labels to the instrument before calling add, then unbinds.  Therefore all interactions with the aggregator take place through bound instruments and by extension, the BaseBoundInstrument Class.
+The Counter below is an example of one Metric instrument.  It is important to
+note that in the Counter’s add function, it binds the labels to the instrument
+before calling add, then unbinds.  Therefore all interactions with the
+aggregator take place through bound instruments and by extension, the
+BaseBoundInstrument Class.
 
+<!-- markdownlint-disable MD013 -->
 ```cpp
 template <class T>
 class BoundCounter: public BoundSynchronousInstrument{ //override bind?
@@ -495,9 +599,23 @@ class BoundUpDownSumObserver: public AsynchronousInstrument;
 class ValueObserver: public AsynchronousInstrument;
 class BoundValueObserver: public AsynchronousInstrument;
 ```
+<!-- markdownlint-enable MD013 -->
 
 ### Metric Class Design Considerations
 
-OpenTelemetry requires several types of metric instruments with very similar core usage, but slightly different tracking schemes.  As such, a base Metric class defines the necessary functions for each instrument leaving the implementation for the specific instrument type.  Each instrument then inherits from this base class making the necessary modifications.  In order to facilitate efficient aggregation of labeled data, a complementary BoundInstrument class is included which attaches the same set of labels to each capture.  Knowing that all data in an instrument has the same labels enhances the efficiency of any post-collection calculations as there is no need for filtering or separation.  In the above code examples, a Counter instrument is shown but all 6 mandated by the specification will be supported.
+OpenTelemetry requires several types of metric instruments with very similar
+core usage, but slightly different tracking schemes.  As such, a base Metric
+class defines the necessary functions for each instrument leaving the
+implementation for the specific instrument type.  Each instrument then inherits
+from this base class making the necessary modifications.  In order to facilitate
+efficient aggregation of labeled data, a complementary BoundInstrument class is
+included which attaches the same set of labels to each capture.  Knowing that
+all data in an instrument has the same labels enhances the efficiency of any
+post-collection calculations as there is no need for filtering or separation.
+In the above code examples, a Counter instrument is shown but all 6 mandated by
+the specification will be supported.
 
-A base BoundInstrument class also serves as the foundation for more specific bound instruments.  It also facilitates the practice of reference counting which can determine when an instrument is unused and can improve memory optimization as inactive bound instruments can be removed for performance.
+A base BoundInstrument class also serves as the foundation for more specific
+bound instruments.  It also facilitates the practice of reference counting which
+can determine when an instrument is unused and can improve memory optimization
+as inactive bound instruments can be removed for performance.

--- a/docs/cpp-metrics-sdk-design.md
+++ b/docs/cpp-metrics-sdk-design.md
@@ -3,31 +3,56 @@
 ## Design Tenets
 
 * Reliability
-  * The Metrics API and SDK should be “reliable,” meaning that metrics data will always be accounted for. It will get back to the user or an error will be logged.  Reliability also entails that the end-user application will never be blocked.  Error handling will therefore not interfere with the execution of the instrumented program.  The library may “fail fast” during the initialization or configuration path however.
+  * The Metrics API and SDK should be “reliable,” meaning that metrics data will
+    always be accounted for. It will get back to the user or an error will be
+    logged.  Reliability also entails that the end-user application will never
+    be blocked.  Error handling will therefore not interfere with the execution
+    of the instrumented program.  The library may “fail fast” during the
+    initialization or configuration path however.
   * Thread Safety
-    * As with the Tracer API and SDK, thread safety is not guaranteed on all functions and will be explicitly mentioned in documentation for functions that support concurrent calling.  Generally, the goal is to lock functions which change the state of library objects (incrementing the value of a Counter or adding a new Observer for example) or access global memory.  As a performance consideration, the library strives to hold locks for as short a duration as possible to avoid lock contention concerns.  Calls to create instrumentation may not be thread-safe as this is expected to occur during initialization of the program.
+    * As with the Tracer API and SDK, thread safety is not guaranteed on all
+      functions and will be explicitly mentioned in documentation for functions
+      that support concurrent calling.  Generally, the goal is to lock functions
+      which change the state of library objects (incrementing the value of a
+      Counter or adding a new Observer for example) or access global memory.  As
+      a performance consideration, the library strives to hold locks for as
+      short a duration as possible to avoid lock contention concerns.  Calls to
+      create instrumentation may not be thread-safe as this is expected to occur
+      during initialization of the program.
 * Scalability
-  * As OpenTelemetry is a distributed tracing system, it must be able to operate on sizeable systems with predictable overhead growth.  A key requirement of this is that the library does not consume unbounded memory resource.
+  * As OpenTelemetry is a distributed tracing system, it must be able to operate
+    on sizeable systems with predictable overhead growth.  A key requirement of
+    this is that the library does not consume unbounded memory resource.
 * Security
-  * Currently security is not a key consideration but may be addressed at a later date.
+  * Currently security is not a key consideration but may be addressed at a
+    later date.
 
 ## SDK Data Path Diagram
 
 <!-- [//]: # ![Data Path Diagram](../images/DataPath.png) -->
 
-This is the control path our implementation of the metrics SDK will follow. There are five main components: The controller, accumulator, aggregators, processor, and exporter. Each of these components will be further elaborated on.
+This is the control path our implementation of the metrics SDK will follow.
+There are five main components: The controller, accumulator, aggregators,
+processor, and exporter. Each of these components will be further elaborated on.
 
 ## API Class Implementations
 
 ### MeterProvider Class
 
-The singleton global `MeterProvider` can be used to obtain a global Meter by calling `global.GetMeter(name,version)` which calls `GetMeter()` on the initialized global `MeterProvider`.
+The singleton global `MeterProvider` can be used to obtain a global Meter by
+calling `global.GetMeter(name,version)` which calls `GetMeter()` on the
+initialized global `MeterProvider`.
 
 **Global Meter Provider:**
 
-The API should support a global `MeterProvider`. When a global instance is supported, the API must ensure that `Meter` instances derived from the global `MeterProvider` are initialized after the global SDK implementation is first initialized.
+The API should support a global `MeterProvider`. When a global instance is
+supported, the API must ensure that `Meter` instances derived from the global
+`MeterProvider` are initialized after the global SDK implementation is first
+initialized.
 
-A `MeterProvider` interface must support a  `global.SetMeterProvider(MeterProvider)` function which installs the SDK implementation of the `MeterProvider` into the API.
+A `MeterProvider` interface must support a
+`global.SetMeterProvider(MeterProvider)` function which installs the SDK
+implementation of the `MeterProvider` into the API.
 
 **Obtaining a Meter from MeterProvider:**
 
@@ -35,11 +60,16 @@ A `MeterProvider` interface must support a  `global.SetMeterProvider(MeterProvid
 
 * Expects 2 string arguments:
   * name (required): identifies the instrumentation library.
-  * version (optional): specifies the version of the instrumenting library (the library injecting OpenTelemetry calls into the code).
+  * version (optional): specifies the version of the instrumenting library (the
+    library injecting OpenTelemetry calls into the code).
 
 #### Implementation
 
-The Provider class offers static functions to both get and set the global MeterProvider. Once a user sets the MeterProvider, it will replace the default No-op implementation stored as a private variable and persist for the remainder of the program’s execution. This pattern imitates the TracerProvider used in the Tracing portion of this SDK.
+The Provider class offers static functions to both get and set the global
+MeterProvider. Once a user sets the MeterProvider, it will replace the default
+No-op implementation stored as a private variable and persist for the remainder
+of the program’s execution. This pattern imitates the TracerProvider used in the
+Tracing portion of this SDK.
 
 ```cpp
 # meter_provider.cc
@@ -74,23 +104,36 @@ public:
 
 **Metric Events:**
 
-Metric instruments are primarily defined by their name.  Names MUST conform to the following syntax:
+Metric instruments are primarily defined by their name.  Names MUST conform to
+the following syntax:
 
 * Non-empty string
 * case-insensitive
 * first character non-numeric, non-space, non-punctuation
 * subsequent characters alphanumeric, ‘_’, ‘.’ , and ‘-’
 
-`Meter` instances MUST return an error when multiple instruments with the same name are registered
+`Meter` instances MUST return an error when multiple instruments with the same
+name are registered
 
-**The meter implementation will throw an illegal argument exception if the user-passed `name` for a metric instrument either conflicts with the name of another metric instrument created from the same `meter` or violates the `name` syntax outlined above.**
+**The meter implementation will throw an illegal argument exception if the
+user-passed `name` for a metric instrument either conflicts with the name of
+another metric instrument created from the same `meter` or violates the `name`
+syntax outlined above.**
 
-Each distinctly named Meter (i.e. Meters derived from different instrumentation libraries) MUST create a new namespace for metric instruments descending from them.  Thus, the same instrument name can be used in an application provided they come from different Meter instances.
+Each distinctly named Meter (i.e. Meters derived from different instrumentation
+libraries) MUST create a new namespace for metric instruments descending from
+them.  Thus, the same instrument name can be used in an application provided
+they come from different Meter instances.
 
-**In order to achieve this, each instance of the `Meter` class will have a container storing all metric instruments that were created using that meter. This way, metric instruments created from different instantiations of the `Meter` class will never be compared to one another and will never result in an error.**
+**In order to achieve this, each instance of the `Meter` class will have a
+container storing all metric instruments that were created using that meter.
+This way, metric instruments created from different instantiations of the
+`Meter` class will never be compared to one another and will never result in an
+error.**
 
 **Implementation:**
 
+<!-- markdownlint-disable MD013 -->
 ```cpp
 # meter.h / meter.cc
 class Meter : public API::Meter {
@@ -228,7 +271,9 @@ private:
   InstrumentationInfo instrumentationInfo_;
 };
 ```
+<!-- markdownlint-enable MD013 -->
 
+<!-- markdownlint-disable MD013 -->
 ```cpp
 # record.h
 /*
@@ -271,85 +316,157 @@ private:
   nostd::variant<Aggregator<short>, Aggregator<int>, Aggregator<float>, Aggregator<Double>> aggregator_;
 };
 ```
+<!-- markdownlint-enable MD013 -->
 
-Metric instruments created from this Meter class will be stored in a map (or another, similar container [needs to be nostd]) called “metrics.” This is identical to the Python implementation and makes sense because the SDK implementation of the `Meter` class should have a function titled `collect_all()` that collects metrics for every instrument created from this meter. In contrast, Java’s implementation has a `MeterSharedState` class that contains a registry (hash map) of all metric instruments spawned from this meter. However, since each `Meter` has its own unique instruments it is easier to store the instruments in the meter itself.
+Metric instruments created from this Meter class will be stored in a map (or
+another, similar container [needs to be nostd]) called “metrics.” This is
+identical to the Python implementation and makes sense because the SDK
+implementation of the `Meter` class should have a function titled
+`collect_all()` that collects metrics for every instrument created from this
+meter. In contrast, Java’s implementation has a `MeterSharedState` class that
+contains a registry (hash map) of all metric instruments spawned from this
+meter. However, since each `Meter` has its own unique instruments it is easier
+to store the instruments in the meter itself.
 
-The SDK implementation of the `Meter` class will contain a function called `collect_all()` that will collect the measurements from each metric stored in the `metrics` container. The implementation of this class acts as the accumulator in the SDK specification.
+The SDK implementation of the `Meter` class will contain a function called
+`collect_all()` that will collect the measurements from each metric stored in
+the `metrics` container. The implementation of this class acts as the
+accumulator in the SDK specification.
 
 **Pros of this implementation:**
 
-* Different constructors and overloaded template calls to those constructors for the various metric instruments allows us to forego much of the code duplication involved in supporting various types.
-* Storing the metric instruments created from this meter directly in the meter object itself allows us to implement the collect_all method without creating a new class that contains the meter state and instrument registry.
+* Different constructors and overloaded template calls to those constructors for
+  the various metric instruments allows us to forego much of the code
+  duplication involved in supporting various types.
+* Storing the metric instruments created from this meter directly in the meter
+  object itself allows us to implement the collect_all method without creating a
+  new class that contains the meter state and instrument registry.
 
 **Cons of this implementation:**
 
-* Different constructors for the different metric instruments means less duplicated code but still a lot.
-* Storing the metric instruments in the Meter class means that if we have multiple meters, metric instruments are stored in various objects. Using an instrument registry that maps meters to metric instruments resolves this. However, we have designed our SDK to only support one Meter instance.
-* Storing 8 maps in the meter class is costly. However, we believe that this is ok because these maps will only need to be created once, at the instantiation of the meter class. **We believe that these maps will not slow down the pipeline in any meaningful way**
+* Different constructors for the different metric instruments means less
+  duplicated code but still a lot.
+* Storing the metric instruments in the Meter class means that if we have
+  multiple meters, metric instruments are stored in various objects. Using an
+  instrument registry that maps meters to metric instruments resolves this.
+  However, we have designed our SDK to only support one Meter instance.
+* Storing 8 maps in the meter class is costly. However, we believe that this is
+  ok because these maps will only need to be created once, at the instantiation
+  of the meter class. **We believe that these maps will not slow down the
+  pipeline in any meaningful way**
 
-**The SDK implementation of the `Meter` class will act as the Accumulator mentioned in the SDK specification.**
+**The SDK implementation of the `Meter` class will act as the Accumulator
+mentioned in the SDK specification.**
 
 ## **Metric Instrument Class**
 
-Metric instruments capture raw measurements of designated quantities in instrumented applications. All measurements captured by the Metrics API are associated with the instrument which collected that measurement.
+Metric instruments capture raw measurements of designated quantities in
+instrumented applications. All measurements captured by the Metrics API are
+associated with the instrument which collected that measurement.
 
 ### Metric Instrument Data Model
 
-Each instrument must have enough information to meaningfully attach its measured values with a process in the instrumented application. As such, metric instruments contain the following fields
+Each instrument must have enough information to meaningfully attach its measured
+values with a process in the instrumented application. As such, metric
+instruments contain the following fields
 
 * name (string) — Identifier for this metric instrument.
 * description (string) — Short description of what this instrument is capturing.
-* value_type (string or enum) — Determines whether the value tracked is an int64 or double.
+* value_type (string or enum) — Determines whether the value tracked is an int64
+  or double.
 * meter (Meter) — The Meter instance from which this instrument was derived.
-* label_keys (KeyValueIterable) — A nostd class acting as map from nostd::string_view to nostd::string_view.
-* enabled (boolean) — Determines whether the instrument is currently collecting data.
-* bound_instruments (key value container) — Contains the bound instruments derived from this instrument.
+* label_keys (KeyValueIterable) — A nostd class acting as map from
+  nostd::string_view to nostd::string_view.
+* enabled (boolean) — Determines whether the instrument is currently collecting
+  data.
+* bound_instruments (key value container) — Contains the bound instruments
+  derived from this instrument.
 
 ### Metric Event Data Model
 
-Each measurement taken by a Metric instrument is a Metric event which must contain the following information:
+Each measurement taken by a Metric instrument is a Metric event which must
+contain the following information:
 
 * timestamp (implicit) — System time when measurement was captured.
-* instrument definition(strings) — Name of instrument, kind, description, and unit of measure
-* label set (key value pairs) — Labels associated with the capture, described further below.
+* instrument definition(strings) — Name of instrument, kind, description, and
+  unit of measure
+* label set (key value pairs) — Labels associated with the capture, described
+  further below.
 * resources associated with the SDK at startup
 
 **Label Set:**
 
-A key:value mapping of some kind MUST be supported as annotation each metric event. Labels must be represented the same way throughout the API (i.e. using the same idiomatic data structure) and duplicates are dealt with by taking the last value mapping.
+A key:value mapping of some kind MUST be supported as annotation each metric
+event. Labels must be represented the same way throughout the API (i.e. using
+the same idiomatic data structure) and duplicates are dealt with by taking the
+last value mapping.
 
-Due to the requirement to maintain ABI stability we have chosen to implement labels as type KeyValueIterable. Though, due to performance reasons, we may convert to std::string internally.
+Due to the requirement to maintain ABI stability we have chosen to implement
+labels as type KeyValueIterable. Though, due to performance reasons, we may
+convert to std::string internally.
 
 **Implementation:**
 
-A base Metric class defines the constructor and binding functions which each metric instrument will need. Once an instrument is bound, it becomes a BoundInstrument which extends the BaseBoundInstrument class. The BaseBoundInstrument is what communicates with the aggregator and performs the actual updating of values. An enum helps to organize the numerous types of metric instruments that will be supported.
+A base Metric class defines the constructor and binding functions which each
+metric instrument will need. Once an instrument is bound, it becomes a
+BoundInstrument which extends the BaseBoundInstrument class. The
+BaseBoundInstrument is what communicates with the aggregator and performs the
+actual updating of values. An enum helps to organize the numerous types of
+metric instruments that will be supported.
 
-The only addition to the SDK metric instrument classes from their API counterparts is the function GetRecords() and the private variables std::map<std::string, BoundSynchronousInstrument> to hold bound instruments and Aggregator<T> to hold the instrument's aggregator.
+The only addition to the SDK metric instrument classes from their API
+counterparts is the function GetRecords() and the private variables
+std::map<std::string, BoundSynchronousInstrument> to hold bound instruments and
+`Aggregator<T>` to hold the instrument's aggregator.
 
-**For more information about the structure of metric instruments, refer to the Metrics API Design document.**
+**For more information about the structure of metric instruments, refer to the
+Metrics API Design document.**
 
 ## Metrics SDK Data Path Implementation
 
-Note: these requirements come from a specification currently under development. Changes and feedback are in [PR #347](https://github.com/open-telemetry/opentelemetry-specification/pull/347) and the current document is linked [here](https://github.com/open-telemetry/opentelemetry-specification/blob/64bbb0c611d849b90916005d7714fa2a7132d0bf/specification/metrics/sdk.md).
+Note: these requirements come from a specification currently under development.
+Changes and feedback are in [PR
+347](https://github.com/open-telemetry/opentelemetry-specification/pull/347)
+and the current document is linked
+[here](https://github.com/open-telemetry/opentelemetry-specification/blob/64bbb0c611d849b90916005d7714fa2a7132d0bf/specification/metrics/sdk.md).
 
 <!-- [//]: # ![Data Path Diagram](../images/DataPath.png) -->
 
 ### Accumulator
 
-The Accumulator is responsible for computing aggregation over a fixed unit of time. It essentially takes a set of captures and turns them into a quantity that can be collected and used for meaningful analysis by maintaining aggregators for each active instrument and each distinct label set. For example, the aggregator for a counter must combine multiple calls to Add(increment) into a single sum.
+The Accumulator is responsible for computing aggregation over a fixed unit of
+time. It essentially takes a set of captures and turns them into a quantity that
+can be collected and used for meaningful analysis by maintaining aggregators for
+each active instrument and each distinct label set. For example, the aggregator
+for a counter must combine multiple calls to Add(increment) into a single sum.
 
-Accumulators MUST support a `Checkpoint()` operation which saves a snapshot of the current state for collection and a `Merge()` operation which combines the state from multiple aggregators into one.
+Accumulators MUST support a `Checkpoint()` operation which saves a snapshot of
+the current state for collection and a `Merge()` operation which combines the
+state from multiple aggregators into one.
 
-Calls to the Accumulator's  `Collect()` sweep through metric instruments with un-exported updates, checkpoints their aggregators, and submits them to the processor/exporter. This and all other accumulator operations should be extremely efficient and follow the shortest code path possible.
+Calls to the Accumulator's  `Collect()` sweep through metric instruments with
+un-exported updates, checkpoints their aggregators, and submits them to the
+processor/exporter. This and all other accumulator operations should be
+extremely efficient and follow the shortest code path possible.
 
-Design choice: We have chosen to implement the Accumulator as the SDK implementation of the Meter interface shown above.
+Design choice: We have chosen to implement the Accumulator as the SDK
+implementation of the Meter interface shown above.
 
 ### Aggregator
 
-The term *aggregator* refers to an implementation that can combine multiple metric updates into a single, combined state for a specific function. Aggregators MUST support `Update()`, `Checkpoint()`, and `Merge()` operations. `Update()` is called directly from the Metric instrument in response to a metric event, and may be called concurrently.  The `Checkpoint()` operation is called to atomically save a snapshot of the Aggregator. The `Merge()` operation supports dimensionality reduction by combining state from multiple aggregators into a single Aggregator state.
+The term *aggregator* refers to an implementation that can combine multiple
+metric updates into a single, combined state for a specific function.
+Aggregators MUST support `Update()`, `Checkpoint()`, and `Merge()` operations.
+`Update()` is called directly from the Metric instrument in response to a metric
+event, and may be called concurrently.  The `Checkpoint()` operation is called
+to atomically save a snapshot of the Aggregator. The `Merge()` operation
+supports dimensionality reduction by combining state from multiple aggregators
+into a single Aggregator state.
 
-The SDK must include the Counter aggregator which maintains a sum and the gauge aggregator which maintains last value and timestamp. In addition, the SDK should include MinMaxSumCount, Sketch, Histogram, and Exact aggregators
-All operations should be atomic in languages that support them.
+The SDK must include the Counter aggregator which maintains a sum and the gauge
+aggregator which maintains last value and timestamp. In addition, the SDK should
+include MinMaxSumCount, Sketch, Histogram, and Exact aggregators All operations
+should be atomic in languages that support them.
 
 ```cpp
 # aggregator.cc
@@ -432,24 +549,52 @@ public:
 };
 ```
 
-This Counter is an example Aggregator. We plan on implementing all the Aggregators in the specification: Counter, Gauge, MinMaxSumCount, Sketch, Histogram, and Exact.
+This Counter is an example Aggregator. We plan on implementing all the
+Aggregators in the specification: Counter, Gauge, MinMaxSumCount, Sketch,
+Histogram, and Exact.
 
 ### Processor
 
-The Processor SHOULD act as the primary source of configuration for exporting metrics from the SDK. The two kinds of configuration are:
+The Processor SHOULD act as the primary source of configuration for exporting
+metrics from the SDK. The two kinds of configuration are:
 
-1. Given a metric instrument, choose which concrete aggregator type to apply for in-process aggregation.
-2. Given a metric instrument, choose which dimensions to export by (i.e., the "grouping" function).
+1. Given a metric instrument, choose which concrete aggregator type to apply for
+   in-process aggregation.
+2. Given a metric instrument, choose which dimensions to export by (i.e., the
+   "grouping" function).
 
-During the collection pass, the Processor receives a full set of check-pointed aggregators corresponding to each (Instrument, LabelSet) pair with an active record managed by the Accumulator. According to its own configuration, the Processor at this point determines which dimensions to aggregate for export; it computes a checkpoint of (possibly) reduced-dimension export records ready for export. It can be thought of as the business logic or processing phase in the pipeline.
+During the collection pass, the Processor receives a full set of check-pointed
+aggregators corresponding to each (Instrument, LabelSet) pair with an active
+record managed by the Accumulator. According to its own configuration, the
+Processor at this point determines which dimensions to aggregate for export; it
+computes a checkpoint of (possibly) reduced-dimension export records ready for
+export. It can be thought of as the business logic or processing phase in the
+pipeline.
 
-Change of dimensions: The user-facing metric API allows users to supply LabelSets containing an unlimited number of labels for any metric update. Some metric exporters will restrict the set of labels when exporting metric data, either to reduce cost or because of system-imposed requirements. A *change of dimensions* maps input LabelSets with potentially many labels into a LabelSet with a fixed set of label keys. A change of dimensions eliminates labels with keys not in the output LabelSet and fills in empty values for label keys that are not in the input LabelSet. This can be used for different filtering options, rate limiting, and alternate aggregation schemes. Additionally, it will be used to prevent unbounded memory growth through capping collected data. The community is still deciding exactly how metrics data will be pruned and this document will be updated when a decision is made.
+Change of dimensions: The user-facing metric API allows users to supply
+LabelSets containing an unlimited number of labels for any metric update. Some
+metric exporters will restrict the set of labels when exporting metric data,
+either to reduce cost or because of system-imposed requirements. A *change of
+dimensions* maps input LabelSets with potentially many labels into a LabelSet
+with a fixed set of label keys. A change of dimensions eliminates labels with
+keys not in the output LabelSet and fills in empty values for label keys that
+are not in the input LabelSet. This can be used for different filtering options,
+rate limiting, and alternate aggregation schemes. Additionally, it will be used
+to prevent unbounded memory growth through capping collected data. The community
+is still deciding exactly how metrics data will be pruned and this document will
+be updated when a decision is made.
 
 The following is a pseudo code implementation of a ‘simple’ Processor.
 
-Note: Josh MacDonald is working on implementing a [‘basic’ Processor](https://github.com/jmacd/opentelemetry-go/blob/jmacd/mexport/sdk/metric/processor/simple/simple.go) which allows for further Configuration that lines up with the specification in Go. He will be finishing the implementation and updating the specification within the next few weeks.
+Note: Josh MacDonald is working on implementing a [‘basic’
+Processor](https://github.com/jmacd/opentelemetry-go/blob/jmacd/mexport/sdk/metric/processor/simple/simple.go)
+which allows for further Configuration that lines up with the specification in
+Go. He will be finishing the implementation and updating the specification
+within the next few weeks.
 
-Design choice: We recommend that we implement the ‘simple’ Processor first as apart of the MVP and then will also implement the ‘basic’ Processor later on. Josh recommended having both for doing different processes.
+Design choice: We recommend that we implement the ‘simple’ Processor first as
+apart of the MVP and then will also implement the ‘basic’ Processor later on.
+Josh recommended having both for doing different processes.
 
 ```cpp
 #processor.cc
@@ -513,15 +658,28 @@ private:
 
 ### Controller
 
-Controllers generally are responsible for binding the Accumulator, the Processor, and the Exporter. The controller initiates the collection and export pipeline and manages all the moving parts within it. It also governs the flow of data through the SDK components. Users interface with the controller to begin collection process.
+Controllers generally are responsible for binding the Accumulator, the
+Processor, and the Exporter. The controller initiates the collection and export
+pipeline and manages all the moving parts within it. It also governs the flow of
+data through the SDK components. Users interface with the controller to begin
+collection process.
 
-Once the decision has been made to export, the controller must call `Collect()` on the Accumulator, then read the checkpoint from the Processor, then invoke the Exporter.
+Once the decision has been made to export, the controller must call `Collect()`
+on the Accumulator, then read the checkpoint from the Processor, then invoke the
+Exporter.
 
-Java’s IntervalMetricReader class acts as a parallel to the controller. The user gets an instance of this class, sets the configuration options (like the tick rate) and then the controller takes care of the collection and exporting of metric data from instruments the user defines.
+Java’s IntervalMetricReader class acts as a parallel to the controller. The user
+gets an instance of this class, sets the configuration options (like the tick
+rate) and then the controller takes care of the collection and exporting of
+metric data from instruments the user defines.
 
-There are two different controllers: Push and Pull. The “Push” Controller will establish a periodic timer to regularly collect and export metrics. A “Pull” Controller will await a pull request before initiating metric collection.
+There are two different controllers: Push and Pull. The “Push” Controller will
+establish a periodic timer to regularly collect and export metrics. A “Pull”
+Controller will await a pull request before initiating metric collection.
 
-We recommend implementing the PushController as the initial implementation of the Controller. This Controller is the base controller in the specification. We may also implement the PullController if we have the time to do it.
+We recommend implementing the PushController as the initial implementation of
+the Controller. This Controller is the base controller in the specification. We
+may also implement the PullController if we have the time to do it.
 
 ```cpp
 #push_controller.cc
@@ -595,11 +753,21 @@ private:
 
 ### Exporter
 
-The exporter SHOULD be called with a checkpoint of finished (possibly dimensionally reduced) export records. Most configuration decisions have been made before the exporter is invoked, including which instruments are enabled, which concrete aggregator types to use, and which dimensions to aggregate by.
+The exporter SHOULD be called with a checkpoint of finished (possibly
+dimensionally reduced) export records. Most configuration decisions have been
+made before the exporter is invoked, including which instruments are enabled,
+which concrete aggregator types to use, and which dimensions to aggregate by.
 
-There is very little left for the exporter to do other than format the metric updates into the desired format and send them on their way.
+There is very little left for the exporter to do other than format the metric
+updates into the desired format and send them on their way.
 
-Design choice: Our idea is to take the simple trace example [OStreamSpanExporter](https://github.com/open-telemetry/opentelemetry-cpp/blob/main/examples/simple/main.cc) and add Metric functionality to it. This will allow us to verify that what we are implementing in the API and SDK works as intended. The exporter will go through the different metric instruments and print the value stored in their aggregators to stdout, **for simplicity only Sum is shown here, but all aggregators will be implemented**.
+Design choice: Our idea is to take the simple trace example
+[OStreamSpanExporter](https://github.com/open-telemetry/opentelemetry-cpp/blob/main/examples/simple/main.cc)
+and add Metric functionality to it. This will allow us to verify that what we
+are implementing in the API and SDK works as intended. The exporter will go
+through the different metric instruments and print the value stored in their
+aggregators to stdout, **for simplicity only Sum is shown here, but all
+aggregators will be implemented**.
 
 ```cpp
 # stdout_exporter.cc
@@ -635,6 +803,19 @@ enum class ExportResult {
 
 ## Test Strategy / Plan
 
-Since there is a specification we will be following, we will not have to write out user stories for testing. We will generally only be writing functional unit tests for this project. The C++ Open Telemetry repository uses [Googletest](https://github.com/google/googletest) because it provides test coverage reports, also allows us to easily integrate code coverage tools such as [codecov.io](http://codecov.io/) with the project. A required coverage target of 90% will help to ensure that our code is fully tested.
+Since there is a specification we will be following, we will not have to write
+out user stories for testing. We will generally only be writing functional unit
+tests for this project. The C++ Open Telemetry repository uses
+[Googletest](https://github.com/google/googletest) because it provides test
+coverage reports, also allows us to easily integrate code coverage tools such as
+[codecov.io](http://codecov.io/) with the project. A required coverage target of
+90% will help to ensure that our code is fully tested.
 
-An open-source header-only testing framework called [Catch2](https://github.com/catchorg/Catch2) is an alternate option which would satisfy our testing needs. It is easy to use, supports behavior driven development, and does not need to be embedded in the project as source files to operate (unlike Googletest). Code coverage would still be possible using this testing framework but would require us to integrate additional tools. This framework may be preferred as an agnostic replacement for Googletest and is widely used in open source projects.
+An open-source header-only testing framework called
+[Catch2](https://github.com/catchorg/Catch2) is an alternate option which would
+satisfy our testing needs. It is easy to use, supports behavior driven
+development, and does not need to be embedded in the project as source files to
+operate (unlike Googletest). Code coverage would still be possible using this
+testing framework but would require us to integrate additional tools. This
+framework may be preferred as an agnostic replacement for Googletest and is
+widely used in open source projects.

--- a/docs/cpp-ostream-exporter-design.md
+++ b/docs/cpp-ostream-exporter-design.md
@@ -1,62 +1,107 @@
 # OStreamExporter Design
 
-In strongly typed languages typically there will be 2 separate `Exporter` interfaces, one that accepts spans from a tracer (SpanExporter) and one that accepts metrics (MetricsExporter)
+In strongly typed languages typically there will be 2 separate `Exporter`
+interfaces, one that accepts spans from a tracer (SpanExporter) and one that
+accepts metrics (MetricsExporter)
 
-The exporter SHOULD be called with a checkpoint of finished (possibly dimensionally reduced) export records. Most configuration decisions have been made before the exporter is invoked, including which instruments are enabled, which concrete aggregator types to use, and which dimensions to aggregate by.
+The exporter SHOULD be called with a checkpoint of finished (possibly
+dimensionally reduced) export records. Most configuration decisions have been
+made before the exporter is invoked, including which instruments are enabled,
+which concrete aggregator types to use, and which dimensions to aggregate by.
 
 ## Use Cases
 
-Monitoring and alerting systems commonly use the data provided through metric events or tracers, after applying various aggregations and converting into various exposition format. After getting the data, the systems need to be able to see the data. The OStreamExporter will be used here to print data through an ostream, this is seen as a simple exporter where the user doesn’t have the burden of implementing or setting up a protocol dependent exporter.
+Monitoring and alerting systems commonly use the data provided through metric
+events or tracers, after applying various aggregations and converting into
+various exposition format. After getting the data, the systems need to be able
+to see the data. The OStreamExporter will be used here to print data through an
+ostream, this is seen as a simple exporter where the user doesn’t have the
+burden of implementing or setting up a protocol dependent exporter.
 
-The OStreamExporter will also be used as a debugging tool for the Metrics API/SDK and Tracing API/SDK which are currently work in progress projects. This exporter will allow contributors to easily diagnose problems when working on the project.
+The OStreamExporter will also be used as a debugging tool for the Metrics
+API/SDK and Tracing API/SDK which are currently work in progress projects. This
+exporter will allow contributors to easily diagnose problems when working on the
+project.
 
 ## Push vs Pull Exporter
 
-There are two different versions of exporters: Push and Pull. A Push Exporter pushes the data outwards towards a system, in the case of the OStreamExporter it sends its data into an ostream. A Pull Exporter exposes data to some endpoint for another system to grab the data.
+There are two different versions of exporters: Push and Pull. A Push Exporter
+pushes the data outwards towards a system, in the case of the OStreamExporter it
+sends its data into an ostream. A Pull Exporter exposes data to some endpoint
+for another system to grab the data.
 
 The OStreamExporter will only be implementing a Push Exporter framework.
 
 ## Design Tenets
 
 * Reliability
-  * The Exporter should be reliable; data exported should always be accounted for. The data will either all be successfully exported to the destination server, or in the case of failure, the data is dropped. `Export` will always return failure or success to notify the user of the result.
+  * The Exporter should be reliable; data exported should always be accounted
+    for. The data will either all be successfully exported to the destination
+    server, or in the case of failure, the data is dropped. `Export` will always
+    return failure or success to notify the user of the result.
   * Thread Safety
-    * The OStreamExporter can be called simultaneously, however we do not handle this in the Exporter. Synchronization should be done at a lower level.
+    * The OStreamExporter can be called simultaneously, however we do not handle
+      this in the Exporter. Synchronization should be done at a lower level.
 * Scalability
-  * The Exporter must be able to operate on sizeable systems with predictable overhead growth.  A key requirement of this is that the library does not consume unbounded memory resource.
+  * The Exporter must be able to operate on sizeable systems with predictable
+    overhead growth.  A key requirement of this is that the library does not
+    consume unbounded memory resource.
 * Security
-  * OStreamExporter should only be used for development and testing purpose, where security and privacy is less a concern as it doesn't communicate to external systems.
+  * OStreamExporter should only be used for development and testing purpose,
+    where security and privacy is less a concern as it doesn't communicate to
+    external systems.
 
 ## SpanExporter
 
-`Span Exporter` defines the interface that protocol-specific exporters must implement so that they can be plugged into OpenTelemetry SDK and support sending of telemetry data.
+`Span Exporter` defines the interface that protocol-specific exporters must
+implement so that they can be plugged into OpenTelemetry SDK and support sending
+of telemetry data.
 
-The goal of the interface is to minimize burden of implementation for protocol-dependent telemetry exporters. The protocol exporter is expected to be primarily a simple telemetry data encoder and transmitter.
+The goal of the interface is to minimize burden of implementation for
+protocol-dependent telemetry exporters. The protocol exporter is expected to be
+primarily a simple telemetry data encoder and transmitter.
 
-The SpanExporter is called through the SpanProcessor, which passes finished spans to the configured SpanExporter, as soon as they are finished. The SpanProcessor also shutdown the exporter by the Shutdown function within the SpanProcessor.
+The SpanExporter is called through the SpanProcessor, which passes finished
+spans to the configured SpanExporter, as soon as they are finished. The
+SpanProcessor also shutdown the exporter by the Shutdown function within the
+SpanProcessor.
 
 <!-- [//]: # ![SDK Data Path](./images/SpanDataPath.png) -->
 
-The specification states: exporter must support two functions: Export and Shutdown.
+The specification states: exporter must support two functions: Export and
+Shutdown.
 
 ### SpanExporter.Export(span of recordables)
 
-Exports a batch of telemetry data. Protocol exporters that will implement this function are typically expected to serialize and transmit the data to the destination.
+Exports a batch of telemetry data. Protocol exporters that will implement this
+function are typically expected to serialize and transmit the data to the
+destination.
 
-Export() must not block indefinitely. We can rely on printing to an ostream is reasonably performant and doesn't block.
+Export() must not block indefinitely. We can rely on printing to an ostream is
+reasonably performant and doesn't block.
 
-The specification states: Any retry logic that is required by the exporter is the responsibility of the exporter. The default SDK SHOULD NOT implement retry logic, as the required logic is likely to depend heavily on the specific protocol and backend the spans are being sent to.
+The specification states: Any retry logic that is required by the exporter is
+the responsibility of the exporter. The default SDK SHOULD NOT implement retry
+logic, as the required logic is likely to depend heavily on the specific
+protocol and backend the spans are being sent to.
 
 ### SpanExporter.Shutdown()
 
-Shuts down the exporter. Called when SDK is shut down. This is an opportunity for exporter to do any cleanup required.
+Shuts down the exporter. Called when SDK is shut down. This is an opportunity
+for exporter to do any cleanup required.
 
-`Shutdown` should be called only once for each `Exporter` instance. After the call to `Shutdown` subsequent calls to `Export` are not allowed and should return a `Failure` result.
+`Shutdown` should be called only once for each `Exporter` instance. After the
+call to `Shutdown` subsequent calls to `Export` are not allowed and should
+return a `Failure` result.
 
-`Shutdown` should not block indefinitely (e.g. if it attempts to flush the data and the destination is unavailable). Language library authors can decide if they want to make the shutdown timeout configurable.
+`Shutdown` should not block indefinitely (e.g. if it attempts to flush the data
+and the destination is unavailable). Language library authors can decide if they
+want to make the shutdown timeout configurable.
 
-In the OStreamExporter there is no cleanup to be done, so there is no need to use the timeout within the `Shutdown` function as it will never be blocking.
+In the OStreamExporter there is no cleanup to be done, so there is no need to
+use the timeout within the `Shutdown` function as it will never be blocking.
 
+<!-- markdownlint-disable MD013 -->
 ```cpp
 class StreamSpanExporter final : public sdktrace::SpanExporter
 {
@@ -117,22 +162,35 @@ public:
     }
 };
 ```
+<!-- markdownlint-enable MD013 -->
 
 ## MetricsExporter
 
-The MetricsExporter has the same requirements as the SpanExporter. The exporter will go through the different metric instruments and send the value stored in their aggregators to an ostream, for simplicity only Counter is shown here, but all aggregators will be implemented. Counter, Gauge, MinMaxSumCount, Sketch, Histogram and Exact Aggregators will be supported.
+The MetricsExporter has the same requirements as the SpanExporter. The exporter
+will go through the different metric instruments and send the value stored in
+their aggregators to an ostream, for simplicity only Counter is shown here, but
+all aggregators will be implemented. Counter, Gauge, MinMaxSumCount, Sketch,
+Histogram and Exact Aggregators will be supported.
 
-Exports a batch of telemetry data. Protocol exporters that will implement this function are typically expected to serialize and transmit the data to the destination.
+Exports a batch of telemetry data. Protocol exporters that will implement this
+function are typically expected to serialize and transmit the data to the
+destination.
 
 <!-- [//]: # ![SDK Data Path](./images/DataPath.png) -->
 
 ### MetricsExporter.Export(batch of Records)
 
-Export() must not block indefinitely. We can rely on printing to an ostream is reasonably performant and doesn't block.
+Export() must not block indefinitely. We can rely on printing to an ostream is
+reasonably performant and doesn't block.
 
-The specification states: Any retry logic that is required by the exporter is the responsibility of the exporter. The default SDK SHOULD NOT implement retry logic, as the required logic is likely to depend heavily on the specific protocol and backend the spans are being sent to.
+The specification states: Any retry logic that is required by the exporter is
+the responsibility of the exporter. The default SDK SHOULD NOT implement retry
+logic, as the required logic is likely to depend heavily on the specific
+protocol and backend the spans are being sent to.
 
-The MetricsExporter is called through the Controller in the SDK data path. The exporter will either be called on a regular interval in the case of a push controller or through manual calls in the case of a pull controller.
+The MetricsExporter is called through the Controller in the SDK data path. The
+exporter will either be called on a regular interval in the case of a push
+controller or through manual calls in the case of a pull controller.
 
 ### MetricsExporter.Shutdown()
 
@@ -180,9 +238,19 @@ public:
 
 ## Test Strategy / Plan
 
-In this project, we will follow the TDD rules, and write enough functional unit tests before implementing production code. We will design exhaustive test cases for normal and abnormal inputs, and tests for edge cases.
+In this project, we will follow the TDD rules, and write enough functional unit
+tests before implementing production code. We will design exhaustive test cases
+for normal and abnormal inputs, and tests for edge cases.
 
-In terms of test framework, as is described in the [Metrics API/SDK design document](https://quip-amazon.com/UBXyAuqRzkIj/Metrics-APISDK-C-Design-Document-External), the OStreamExporter will use [Googletest](https://github.com/google/googletest) framework because it provides test coverage reports, and it also integrate code coverage tools such as [codecov.io](http://codecov.io/) in the project. There are already many reference tests such as MockExporter tests written in GoogleTest, making it a clear choice to stick with it as the testing framework. A required coverage target of 90% will help to ensure that our code is fully tested.
+In terms of test framework, as is described in the [Metrics API/SDK design
+document](https://quip-amazon.com/UBXyAuqRzkIj/Metrics-APISDK-C-Design-Document-External),
+the OStreamExporter will use [Googletest](https://github.com/google/googletest)
+framework because it provides test coverage reports, and it also integrate code
+coverage tools such as [codecov.io](http://codecov.io/) in the project. There
+are already many reference tests such as MockExporter tests written in
+GoogleTest, making it a clear choice to stick with it as the testing framework.
+A required coverage target of 90% will help to ensure that our code is fully
+tested.
 
 ## Future Features
 

--- a/docs/library-distribution.md
+++ b/docs/library-distribution.md
@@ -11,8 +11,8 @@ The OpenTelemetry-cpp libraries (API and SDK) and any library that depends on
 them are expected to be distributed as either "source" or "binary" artifacts.
 This document defines these distribution models as:
 
-- **Source** - The source code is shipped as-is and can be built as desired.
-- **Binary** - The library and/or its dependants may be distributed as pre-built
+* **Source** - The source code is shipped as-is and can be built as desired.
+* **Binary** - The library and/or its dependants may be distributed as pre-built
   binaries which can be built using different toolchains or compilers.
 
 This document will focus on the specific challenges of the "binary" distribution
@@ -23,13 +23,13 @@ model.
 The library and its dependants can be distributed and bound (loaded) in multiple
 ways which are defined as follows:
 
-- **Static Linkage** - The library is distributed as a compiled artifact (`.a`
+* **Static Linkage** - The library is distributed as a compiled artifact (`.a`
   extension on Unix-like systems) which is linked and bound at compile-time.
-- **Dynamic Linkage with Early Binding** - The library is distributed as a
+* **Dynamic Linkage with Early Binding** - The library is distributed as a
   compiled artifact (`.so` on Unix-like systems), and its binding is defined at
   compile-time. It is loaded by the dynamic linker when the application/library
   depending on it is started/loaded.
-- **Dynamic Linkage with Late Binding** - The library is distributed as a
+* **Dynamic Linkage with Late Binding** - The library is distributed as a
   compiled artifact (`.so` on Unix-like systems), only its interface is known at
   compile-time. It is loaded dynamically (using `dlopen` on POSIX).
 
@@ -40,20 +40,21 @@ _NOTE: A library may itself link in other libraries based on any of the above._
 The following components will be considered for analysing the impact of
 different binding models and the recommendations.
 
-- **OpenTelemetry Libraries** - The libraries produced from this project, the
+* **OpenTelemetry Libraries** - The libraries produced from this project, the
   API library will contain a minimal implementation including some compiled
   globals/singletons such as `TracerProvider`.
-- **OpenTelemetry Instrumented Libraries** - A library that depends on the
+* **OpenTelemetry Instrumented Libraries** - A library that depends on the
   OpenTelemetry API library to generate telemetry.
-- **OpenTelemetry Implementations or Exporters** - A specific implementation of
+* **OpenTelemetry Implementations or Exporters** - A specific implementation of
   the OpenTelemetry API or the `exporters` may be provided externally (e.g.
   distributed by a vendor).
-- **Binary Executable** - The compiled binary that has `main()`, this also
+* **Binary Executable** - The compiled binary that has `main()`, this also
   includes interpreters such as Python which will be considered. This binary may
   itself instrument using OpenTelemetry or register a specific implementation.
 
-For more information on language-agnostic library, please see:
-[OpenTelemetry Specification Library Guidelines](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/library-guidelines.md).
+For more information on language-agnostic library, please see: [OpenTelemetry
+Specification Library
+Guidelines](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/library-guidelines.md).
 
 ### ABI Compatibility
 
@@ -103,8 +104,8 @@ vendor's implementation by using it as a plugin.
 For example, a C++ database server might add support for the OpenTelemetry API
 and exposes configuration options that let a user point to a vendor's plugin and
 load it with a JSON config. (With OpenTracing, Ceph explored a deployment
-scenario similar to this. See
-this [link](https://www.spinics.net/lists/ceph-devel/msg41007.html))
+scenario similar to this. See this
+[link](https://www.spinics.net/lists/ceph-devel/msg41007.html))
 
 ### Non OpenTelemetry aware application with OpenTelemetry capability library
 
@@ -113,13 +114,13 @@ OpenTelemetry via extensions.
 
 Examples:
 
-- The core NGINX application has no knowledge of tracing. However, through
+* The core NGINX application has no knowledge of tracing. However, through
   NGINX's dynamic module capability, tracing can be supported as a plugin. For
-  instance, the
-  [nginx-opentracing module](https://github.com/opentracing-contrib/nginx-opentracing)
-  provides this type of extension and is used by projects such as Kubernete's
-  [ingress controller](https://kubernetes.github.io/ingress-nginx/user-guide/third-party-addons/opentracing/).
-- The CPython binary also has no knowledge of OpenTelemetry, but C++ Python
+  instance, the [nginx-opentracing
+  module](https://github.com/opentracing-contrib/nginx-opentracing) provides
+  this type of extension and is used by projects such as Kubernete's [ingress
+  controller](https://kubernetes.github.io/ingress-nginx/user-guide/third-party-addons/opentracing/).
+* The CPython binary also has no knowledge of OpenTelemetry, but C++ Python
   extension modules can be instrumented for OpenTelemetry.
 
 Additionally, when multiple OpenTelemetry-aware extensions co-exist in the same

--- a/docs/requirements.md
+++ b/docs/requirements.md
@@ -8,7 +8,7 @@ the build or adding a dependency.
 * The SDK should have minimal dependencies.
 
 * Exporters can bring in transport dependencies, e.g. Stackdriver exporter
-depends on gRPC.
+  depends on gRPC.
 
 * Support both static linking and dynamic loading.
 
@@ -20,4 +20,4 @@ This also requires a stable C++ ABI. There is quite a bit of interest in this.
 This means STL types can't be used in the interface.
 
 * OpenTelemetry should not _require_ a dedicated thread for background work and
-exporters.
+  exporters.

--- a/docs/using-clang-format.md
+++ b/docs/using-clang-format.md
@@ -2,7 +2,8 @@
 
 ## Command-line use
 
-To format a file according to Coding style using command line, please setup the build tools environment first.
+To format a file according to Coding style using command line, please setup the
+build tools environment first.
 
 For Windows - cmd.exe command:
 
@@ -12,14 +13,17 @@ For Linux and Mac:
 
 ```. tools/setup-devenv.sh```
 
-Command will add the tools from repo *tools* directory to PATH environment variable.
+Command will add the tools from repo *tools* directory to PATH environment
+variable.
 
 Then run:
 
 ```git cl format <filename>```
 
-At the moment the tool requires you to specify the path to file you want to format.
-Long-term goal is to integrate the [clang-format from Chromium](https://chromium.googlesource.com/chromium/src/+/master/docs/clang_format.md) to automatically format all source code files being changed.
+At the moment the tool requires you to specify the path to file you want to
+format. Long-term goal is to integrate the [clang-format from
+Chromium](https://chromium.googlesource.com/chromium/src/+/master/docs/clang_format.md)
+to automatically format all source code files being changed.
 
 ## Alternative
 
@@ -31,14 +35,19 @@ Or, via Docker: `./ci/run_docker.sh ./ci/do_ci.sh format`
 
 For further guidance on editor integration, see these specific pages:
 
-* [Download link for LLVM tools for Windows](https://releases.llvm.org/9.0.0/LLVM-9.0.0-win64.exe)
-* [LLVM tools extension for Visual Studio](https://marketplace.visualstudio.com/items?itemName=LLVMExtensions.llvm-toolchain)
-* [Visual Studio code extension](https://marketplace.visualstudio.com/items?itemName=xaver.clang-format)
-* [CppStyle Eclipse CDT extension](https://marketplace.eclipse.org/content/cppstyle)
+* [Download link for LLVM tools for
+  Windows](https://releases.llvm.org/9.0.0/LLVM-9.0.0-win64.exe)
+* [LLVM tools extension for Visual
+  Studio](https://marketplace.visualstudio.com/items?itemName=LLVMExtensions.llvm-toolchain)
+* [Visual Studio code
+  extension](https://marketplace.visualstudio.com/items?itemName=xaver.clang-format)
+* [CppStyle Eclipse CDT
+  extension](https://marketplace.eclipse.org/content/cppstyle)
 
 ## Are robots taking over my freedom to choose where newlines go
 
-No. For the project as a whole, using clang-format is just one optional way to format your code.
-While it will produce style-guide conformant code, other formattings would also satisfy the style
-guide. For certain modules it may be appropriate to use alternate coding style. In those scenarios
-a local directory *.clang-format* settings file takes precedence over the one at top-level.
+No. For the project as a whole, using clang-format is just one optional way to
+format your code. While it will produce style-guide conformant code, other
+formattings would also satisfy the style guide. For certain modules it may be
+appropriate to use alternate coding style. In those scenarios a local directory
+*.clang-format* settings file takes precedence over the one at top-level.

--- a/examples/metrics_simple/README.md
+++ b/examples/metrics_simple/README.md
@@ -1,35 +1,56 @@
 # Simple Metrics Example
 
-In this example, the application in `main.cc` initializes the metrics pipeline and shows 3 different ways of updating instrument values. Here are more detailed explanations of each part.
+In this example, the application in `main.cc` initializes the metrics pipeline
+and shows 3 different ways of updating instrument values. Here are more detailed
+explanations of each part.
 
-1: Initialize a MeterProvider. We will use this to obtain Meter objects in the future.
+1: Initialize a MeterProvider. We will use this to obtain Meter objects in the
+future.
 
 `auto provider = shared_ptr<MeterProvider>(new MeterProvider);`
 
-2: Set the MeterProvider as the default instance for the library. This ensures that we will have access to the same MeterProvider across our application.
+2: Set the MeterProvider as the default instance for the library. This ensures
+that we will have access to the same MeterProvider across our application.
 
 `Provider::SetMeterProvider(provider);`
 
-3: Obtain a meter from this meter provider. Every Meter pointer returned by the MeterProvider points to the same Meter. This means that the Meter will be able to combine metrics captured from different functions without having to constantly pass the Meter around the library.
+3: Obtain a meter from this meter provider. Every Meter pointer returned by the
+MeterProvider points to the same Meter. This means that the Meter will be able
+to combine metrics captured from different functions without having to
+constantly pass the Meter around the library.
 
 `shared_ptr<Meter> meter = provider→GetMeter("Test");`
 
-4: Initialize an exporter and processor. In this case, we initialize an OStream Exporter which will print to stdout by default. The Processor is an UngroupedProcessor which doesn’t filter or group captured metrics in any way. The false parameter indicates that this processor will send metric deltas rather than metric cumulatives.
+4: Initialize an exporter and processor. In this case, we initialize an OStream
+Exporter which will print to stdout by default. The Processor is an
+UngroupedProcessor which doesn’t filter or group captured metrics in any way.
+The false parameter indicates that this processor will send metric deltas rather
+than metric cumulatives.
 
-```
+```cpp
 unique_ptr<MetricsExporter> exporter = unique_ptr<MetricsExporter>(new OStreamMetricsExporter);
 shared_ptr<MetricsProcessor> processor = shared_ptr<MetricsProcessor>(new UngroupedMetricsProcessor(false));
 ```
 
-5: Pass the meter, exporter, and processor into the controller. Since this is a push controller, a collection interval parameter (in seconds) is also taken. At each collection interval, the controller will request data from all of the instruments in the code and export them. Start the controller to begin the metrics pipeline.
+5: Pass the meter, exporter, and processor into the controller. Since this is a
+push controller, a collection interval parameter (in seconds) is also taken. At
+each collection interval, the controller will request data from all of the
+instruments in the code and export them. Start the controller to begin the
+metrics pipeline.
 
-`metrics_sdk::PushController controller(meter, std::move(exporter), processor, 5);`
-`controller.start();`
+`metrics_sdk::PushController controller(meter, std::move(exporter), processor,
+5);` `controller.start();`
 
-6: Instrument code with synchronous and asynchronous instrument. These instruments can be placed in areas of interest to collect metrics and are created by the meter. Synchronous instruments are updated whenever the user desires with a value and label set. Calling add on a counter instrument for example will increase its value.  Asynchronous instruments can be updated the same way, but are intended to receive updates from a callback function. The callback below observes a value of 1. The user never has to call this function as it is automatically called by the controller.
+6: Instrument code with synchronous and asynchronous instrument. These
+instruments can be placed in areas of interest to collect metrics and are
+created by the meter. Synchronous instruments are updated whenever the user
+desires with a value and label set. Calling add on a counter instrument for
+example will increase its value.  Asynchronous instruments can be updated the
+same way, but are intended to receive updates from a callback function. The
+callback below observes a value of 1. The user never has to call this function
+as it is automatically called by the controller.
 
-```
-
+```cpp
 // Observer callback function
 void SumObserverCallback(metrics_api::ObserverResult<int> result){
     std::map<std::string, std::string> labels = {{"key", "value"}};
@@ -52,18 +73,25 @@ ctr->add(5, labelkv);
 
 ```
 
-7: Stop the controller once the program finished. This ensures that any metrics inside the pipeline are properly exported. Otherwise, some metrics may be destroyed in cleanup.
+7: Stop the controller once the program finished. This ensures that any metrics
+inside the pipeline are properly exported. Otherwise, some metrics may be
+destroyed in cleanup.
 
 `controller.stop();`
 
-See [CONTRIBUTING.md](../../CONTRIBUTING.md) for instructions on building and running the example.
+See [CONTRIBUTING.md](../../CONTRIBUTING.md) for instructions on building and
+running the example.
 
 ## Additional Documentation
 
-[API Design](https://github.com/open-o11y/docs/blob/master/cpp-metrics/api-design.md)
+[API
+Design](https://github.com/open-o11y/docs/blob/master/cpp-metrics/api-design.md)
 
-[SDK Design](https://github.com/open-o11y/docs/blob/master/cpp-metrics/sdk-design.md)
+[SDK
+Design](https://github.com/open-o11y/docs/blob/master/cpp-metrics/sdk-design.md)
 
-[OStreamExporters Design](https://github.com/open-o11y/docs/blob/master/cpp-ostream/ostream-exporter-design.md)
+[OStreamExporters
+Design](https://github.com/open-o11y/docs/blob/master/cpp-ostream/ostream-exporter-design.md)
 
-[OpenTelemetry C++ Metrics Overview](https://github.com/open-o11y/docs/blob/master/cpp-metrics/README.md)
+[OpenTelemetry C++ Metrics
+Overview](https://github.com/open-o11y/docs/blob/master/cpp-metrics/README.md)

--- a/examples/otlp/README.md
+++ b/examples/otlp/README.md
@@ -1,16 +1,27 @@
 # OTLP Exporter Example
 
-This is an example of how to use the [OpenTelemetry Protocol](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/protocol/README.md) (OTLP) exporter.
+This is an example of how to use the [OpenTelemetry
+Protocol](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/protocol/README.md)
+(OTLP) exporter.
 
-The application in `main.cc` initializes an `OtlpExporter` instance and uses it to register a tracer provider from the [OpenTelemetry SDK](https://github.com/open-telemetry/opentelemetry-cpp). The application then calls a `foo_library` which has been instrumented using the [OpenTelemetry API](https://github.com/open-telemetry/opentelemetry-cpp/tree/main/api).
+The application in `main.cc` initializes an `OtlpExporter` instance and uses it
+to register a tracer provider from the [OpenTelemetry
+SDK](https://github.com/open-telemetry/opentelemetry-cpp). The application then
+calls a `foo_library` which has been instrumented using the [OpenTelemetry
+API](https://github.com/open-telemetry/opentelemetry-cpp/tree/main/api).
 
-Resulting spans are exported to the **OpenTelemetry Collector** using the OTLP exporter. The OpenTelemetry Collector can be configured to export to other backends (see list of [supported backends](https://github.com/open-telemetry/opentelemetry-collector/blob/main/exporter/README.md)).
+Resulting spans are exported to the **OpenTelemetry Collector** using the OTLP
+exporter. The OpenTelemetry Collector can be configured to export to other
+backends (see list of [supported
+backends](https://github.com/open-telemetry/opentelemetry-collector/blob/main/exporter/README.md)).
 
-For instructions on downloading and running the OpenTelemetry Collector, see [Getting Started](https://opentelemetry.io/docs/collector/about/).
+For instructions on downloading and running the OpenTelemetry Collector, see
+[Getting Started](https://opentelemetry.io/docs/collector/about/).
 
-Here is an example of a Collector `config.yaml` file that can be used to export to [Zipkin](https://zipkin.io/) via the Collector using the OTLP exporter:
+Here is an example of a Collector `config.yaml` file that can be used to export
+to [Zipkin](https://zipkin.io/) via the Collector using the OTLP exporter:
 
-```
+```yml
 receivers:
   otlp:
     protocols:
@@ -26,6 +37,10 @@ service:
       exporters: [zipkin]
 ```
 
-Note that the OTLP exporter connects to the Collector at `localhost:4317` by default. This can be changed with first argument from command-line, for example: `./example_otlp gateway.docker.internal:4317`.
+Note that the OTLP exporter connects to the Collector at `localhost:4317` by
+default. This can be changed with first argument from command-line, for example:
+`./example_otlp gateway.docker.internal:4317`.
 
-Once you have the Collector running, see [CONTRIBUTING.md](../../CONTRIBUTING.md) for instructions on building and running the example.
+Once you have the Collector running, see
+[CONTRIBUTING.md](../../CONTRIBUTING.md) for instructions on building and
+running the example.

--- a/examples/simple/README.md
+++ b/examples/simple/README.md
@@ -2,9 +2,11 @@
 # Simple Trace Example
 
 In this example, the application in `main.cc` initializes and registers a tracer
-provider from the [OpenTelemetry SDK](https://github.com/open-telemetry/opentelemetry-cpp).
-The application then calls a `foo_library` which has been instrumented using
-the [OpenTelemetry API](https://github.com/open-telemetry/opentelemetry-cpp/tree/main/api).
+provider from the [OpenTelemetry
+SDK](https://github.com/open-telemetry/opentelemetry-cpp). The application then
+calls a `foo_library` which has been instrumented using the [OpenTelemetry
+API](https://github.com/open-telemetry/opentelemetry-cpp/tree/main/api).
 Resulting telemetry is directed to stdout through the StdoutSpanExporter.
 
-See [CONTRIBUTING.md](../../CONTRIBUTING.md) for instructions on building and running the example.
+See [CONTRIBUTING.md](../../CONTRIBUTING.md) for instructions on building and
+running the example.

--- a/exporters/otlp/README.md
+++ b/exporters/otlp/README.md
@@ -1,16 +1,30 @@
 # OTLP Exporter
 
-The [OpenTelemetry Protocol](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/protocol/README.md) (OTLP) is a vendor-agnostic protocol designed as part of the OpenTelemetry project. The OTLP exporter can be used to export to any backend that supports OTLP.
+The [OpenTelemetry
+Protocol](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/protocol/README.md)
+(OTLP) is a vendor-agnostic protocol designed as part of the OpenTelemetry
+project. The OTLP exporter can be used to export to any backend that supports
+OTLP.
 
-The [OpenTelemetry Collector](https://github.com/open-telemetry/opentelemetry-collector) is a reference implementation of an OTLP backend. The Collector can be configured to export to many other backends, such as Zipkin and Jaegar.
+The [OpenTelemetry
+Collector](https://github.com/open-telemetry/opentelemetry-collector) is a
+reference implementation of an OTLP backend. The Collector can be configured to
+export to many other backends, such as Zipkin and Jaegar.
 
-For a full list of backends supported by the Collector, see the [main Collector repo](https://github.com/open-telemetry/opentelemetry-collector/tree/main/exporter) and [Collector contributions](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/exporter).
+For a full list of backends supported by the Collector, see the [main Collector
+repo](https://github.com/open-telemetry/opentelemetry-collector/tree/main/exporter)
+and [Collector
+contributions](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/exporter).
 
 ## Configuration
 
-The OTLP exporter offers some configuration options. To configure the exporter, create an `OtlpExporterOptions` struct (defined in [exporter.h](https://github.com/open-telemetry/opentelemetry-cpp/blob/main/exporters/otlp/include/opentelemetry/exporters/otlp/otlp_exporter.h)), set the options inside, and pass the struct to the `OtlpExporter` constructor, like so:
+The OTLP exporter offers some configuration options. To configure the exporter,
+create an `OtlpExporterOptions` struct (defined in
+[exporter.h](https://github.com/open-telemetry/opentelemetry-cpp/blob/main/exporters/otlp/include/opentelemetry/exporters/otlp/otlp_exporter.h)),
+set the options inside, and pass the struct to the `OtlpExporter` constructor,
+like so:
 
-```
+```cpp
 OtlpExporterOptions options;
 options.endpoint = "localhost:12345";
 auto exporter = std::unique_ptr<sdktrace::SpanExporter>(new otlp::OtlpExporter(options));
@@ -24,4 +38,5 @@ auto exporter = std::unique_ptr<sdktrace::SpanExporter>(new otlp::OtlpExporter(o
 
 ## Example
 
-For a complete example demonstrating how to use the OTLP exporter, see [examples/otlp](https://github.com/open-telemetry/opentelemetry-cpp/blob/main/examples/otlp/).
+For a complete example demonstrating how to use the OTLP exporter, see
+[examples/otlp](https://github.com/open-telemetry/opentelemetry-cpp/blob/main/examples/otlp/).

--- a/ext/src/zpages/README.md
+++ b/ext/src/zpages/README.md
@@ -2,7 +2,13 @@
 
 ## Overview
 
-zPages are a quick and light way to view tracing and metrics information on standard OpenTelemetry C++ instrumented applications. It requires no external dependencies or backend setup. See more information in the OTel zPages experimental [spec](https://github.com/open-telemetry/opentelemetry-specification/blob/5b86d4b6c42e6d1e47d9155ac1e2e27f0f0b7769/experimental/trace/zpages.md). OTel C++ currently only offers Tracez; future zPages to potentially add include TraceConfigz, RPCz, and Statsz. Events and links need to be added to Tracez.
+zPages are a quick and light way to view tracing and metrics information on
+standard OpenTelemetry C++ instrumented applications. It requires no external
+dependencies or backend setup. See more information in the OTel zPages
+experimental
+[spec](https://github.com/open-telemetry/opentelemetry-specification/blob/5b86d4b6c42e6d1e47d9155ac1e2e27f0f0b7769/experimental/trace/zpages.md).
+OTel C++ currently only offers Tracez; future zPages to potentially add include
+TraceConfigz, RPCz, and Statsz. Events and links need to be added to Tracez.
 
 ## Usage
 
@@ -11,26 +17,37 @@ zPages are a quick and light way to view tracing and metrics information on stan
 1: Add the following 2 lines of code
 
 * `#include opentelemetry/ext/zpages/zpages.h // include zPages`
-* `zpages::Initialize; // start up zPages in your app, before any tracing/span code`
+* `zpages::Initialize; // start up zPages in your app, before any tracing/span
+  code`
 
 2: Build and run your application normally
 
-For example, you can do this for the zPages example while at the root `opentelemetry-cpp` directory with:
+For example, you can do this for the zPages example while at the root
+`opentelemetry-cpp` directory with:
 
 ```sh
 bazel build //examples/zpages:zpages_example
 bazel-bin/examples/zpages/zpages_example
 ```
 
-If you look at the [zPages example's source code](https://github.com/open-telemetry/opentelemetry-cpp/blob/main/examples/zpages/zpages_example.cc), it demonstrates adding zPages, manual application instrumentation (which sends data to zPages for viewing), and simulated use cases for zPages.
+If you look at the [zPages example's source
+code](https://github.com/open-telemetry/opentelemetry-cpp/blob/main/examples/zpages/zpages_example.cc),
+it demonstrates adding zPages, manual application instrumentation (which sends
+data to zPages for viewing), and simulated use cases for zPages.
 
 3: View zPages at `http://localhost:3000/tracez`
 
 ## More Information
 
-* OTel zPages experimental [spec](https://github.com/open-telemetry/opentelemetry-specification/blob/5b86d4b6c42e6d1e47d9155ac1e2e27f0f0b7769/experimental/trace/zpages.md)
-* [zPages General Direction Spec (OTEP)](https://github.com/open-telemetry/oteps/blob/main/text/0110-z-pages.md)
+* OTel zPages experimental
+  [spec](https://github.com/open-telemetry/opentelemetry-specification/blob/5b86d4b6c42e6d1e47d9155ac1e2e27f0f0b7769/experimental/trace/zpages.md)
+* [zPages General Direction Spec
+  (OTEP)](https://github.com/open-telemetry/oteps/blob/main/text/0110-z-pages.md)
 * OTel C++ Design Docs
-  * [Tracez Span Processor](https://docs.google.com/document/d/1kO4iZARYyr-EGBlY2VNM3ELU3iw6ZrC58Omup_YT-fU/edit#)
-  * [Tracez Data Aggregator](https://docs.google.com/document/d/1ziKFgvhXFfRXZjOlAHQRR-TzcNcTXzg1p2I9oPCEIoU/edit?ts=5ef0d177#heading=h.5irk4csrpu0y)
-  * [Tracez Http Server](https://docs.google.com/document/d/1U1V8QZ5LtGl4Mich-aJ6KZGLHrMIE8pWyspmzvnIefI/edit#) - includes reference pictures of the zPages/Tracez UI
+  * [Tracez Span
+    Processor](https://docs.google.com/document/d/1kO4iZARYyr-EGBlY2VNM3ELU3iw6ZrC58Omup_YT-fU/edit#)
+  * [Tracez Data
+    Aggregator](https://docs.google.com/document/d/1ziKFgvhXFfRXZjOlAHQRR-TzcNcTXzg1p2I9oPCEIoU/edit?ts=5ef0d177#heading=h.5irk4csrpu0y)
+  * [Tracez Http
+    Server](https://docs.google.com/document/d/1U1V8QZ5LtGl4Mich-aJ6KZGLHrMIE8pWyspmzvnIefI/edit#)
+    * includes reference pictures of the zPages/Tracez UI

--- a/ext/test/w3c_tracecontext_test/README.md
+++ b/ext/test/w3c_tracecontext_test/README.md
@@ -1,7 +1,10 @@
 # Test service endpoint for W3C validation
 
-This test application is intended to be used as a test service for the [W3C Distributed Tracing Validation Service](https://github.com/w3c/trace-context/tree/master/test).
-It is implemented according to [this instructions](https://github.com/w3c/trace-context/tree/master/test#implement-test-service).
+This test application is intended to be used as a test service for the [W3C
+Distributed Tracing Validation
+Service](https://github.com/w3c/trace-context/tree/master/test). It is
+implemented according to [this
+instructions](https://github.com/w3c/trace-context/tree/master/test#implement-test-service).
 
 ## Usage
 
@@ -21,22 +24,27 @@ A custom port number for the test service to listen to can be specified:
 Listening to http://localhost:31339/test
 ```
 
-The test service will print the full URI that the validation service can connect to.
+The test service will print the full URI that the validation service can connect
+to.
 
-2: In a different terminal, set up and start the validation service according to the [instructions](https://github.com/w3c/trace-context/tree/master/test#run-test-cases), giving the address of the test service endpoint as argument:
+2: In a different terminal, set up and start the validation service according to
+the
+[instructions](https://github.com/w3c/trace-context/tree/master/test#run-test-cases),
+giving the address of the test service endpoint as argument:
 
 ```sh
 python test.py http://localhost:31339/test
 ```
 
-One can also use the `Dockerfile` provided in this folder to conveniently
-run the validation service:
+One can also use the `Dockerfile` provided in this folder to conveniently run
+the validation service:
 
 ```sh
 docker build --tag w3c_driver .
 docker run --network host w3c_driver http://localhost:31339/test
 ```
 
-3: The validation service will run the test suite and print detailed test results.
+3: The validation service will run the test suite and print detailed test
+results.
 
 4: Stop the test service by pressing enter.

--- a/tools/ports/opentelemetry/TODO.md
+++ b/tools/ports/opentelemetry/TODO.md
@@ -1,7 +1,7 @@
 # TODO
 
-- Consider adding the following line to portfile.cmake
+* Consider adding the following line to portfile.cmake
 
-```
+```text
 Build-Depends: curl[ssl], nlohmann-json
 ```


### PR DESCRIPTION
Follow up #578.
No content change, just reformatted markdown files and enforce all markdownlint policy in CI.