### PR TITLE
Add resource to Recordable, make room for InstrumentationLibrary

### DIFF
--- a/exporters/etw/include/opentelemetry/exporters/etw/etw_data.h
+++ b/exporters/etw/include/opentelemetry/exporters/etw/etw_data.h
@@ -465,7 +465,9 @@ public:
     parent_span_id_ = parent_span_id;
   }
 
-  void SetResourceRef(const opentelemetry::sdk::resource::Resource*const resource) noexcept override {
+  void SetResourceRef(
+      const opentelemetry::sdk::resource::Resource *const resource) noexcept override
+  {
     // TODO
   }
 

--- a/exporters/etw/include/opentelemetry/exporters/etw/etw_data.h
+++ b/exporters/etw/include/opentelemetry/exporters/etw/etw_data.h
@@ -466,7 +466,7 @@ public:
   }
 
   void SetResourceRef(
-      const opentelemetry::sdk::resource::Resource *const resource) noexcept override
+      const opentelemetry::sdk::resource::Resource &resource) noexcept override
   {
     // TODO
   }

--- a/exporters/etw/include/opentelemetry/exporters/etw/etw_data.h
+++ b/exporters/etw/include/opentelemetry/exporters/etw/etw_data.h
@@ -465,6 +465,10 @@ public:
     parent_span_id_ = parent_span_id;
   }
 
+  void SetResourceRef(const opentelemetry::sdk::resource::Resource*const resource) noexcept override {
+    // TODO
+  }
+
   void SetAttribute(nostd::string_view key,
                     const opentelemetry::common::AttributeValue &value) noexcept override
   {

--- a/exporters/otlp/include/opentelemetry/exporters/otlp/recordable.h
+++ b/exporters/otlp/include/opentelemetry/exporters/otlp/recordable.h
@@ -45,7 +45,7 @@ public:
 
 private:
   proto::trace::v1::Span span_;
-  const opentelemetry::sdk::resource::Resource* resource_;
+  const opentelemetry::sdk::resource::Resource* resource_ { nullptr };
 };
 }  // namespace otlp
 }  // namespace exporter

--- a/exporters/otlp/include/opentelemetry/exporters/otlp/recordable.h
+++ b/exporters/otlp/include/opentelemetry/exporters/otlp/recordable.h
@@ -18,6 +18,8 @@ public:
               trace::SpanId span_id,
               trace::SpanId parent_span_id) noexcept override;
 
+  void SetResourceRef(const opentelemetry::sdk::resource::Resource*const resource) noexcept override;
+
   void SetAttribute(nostd::string_view key,
                     const opentelemetry::common::AttributeValue &value) noexcept override;
 

--- a/exporters/otlp/include/opentelemetry/exporters/otlp/recordable.h
+++ b/exporters/otlp/include/opentelemetry/exporters/otlp/recordable.h
@@ -21,7 +21,8 @@ public:
               trace::SpanId span_id,
               trace::SpanId parent_span_id) noexcept override;
 
-  void SetResourceRef(const opentelemetry::sdk::resource::Resource*const resource) noexcept override;
+  void SetResourceRef(
+      const opentelemetry::sdk::resource::Resource *const resource) noexcept override;
 
   void SetAttribute(nostd::string_view key,
                     const opentelemetry::common::AttributeValue &value) noexcept override;
@@ -45,7 +46,7 @@ public:
 
 private:
   proto::trace::v1::Span span_;
-  const opentelemetry::sdk::resource::Resource* resource_ { nullptr };
+  const opentelemetry::sdk::resource::Resource *resource_{nullptr};
 };
 }  // namespace otlp
 }  // namespace exporter

--- a/exporters/otlp/include/opentelemetry/exporters/otlp/recordable.h
+++ b/exporters/otlp/include/opentelemetry/exporters/otlp/recordable.h
@@ -22,7 +22,7 @@ public:
               trace::SpanId parent_span_id) noexcept override;
 
   void SetResourceRef(
-      const opentelemetry::sdk::resource::Resource *const resource) noexcept override;
+      const opentelemetry::sdk::resource::Resource &resource) noexcept override;
 
   void SetAttribute(nostd::string_view key,
                     const opentelemetry::common::AttributeValue &value) noexcept override;
@@ -46,7 +46,7 @@ public:
 
 private:
   proto::trace::v1::Span span_;
-  const opentelemetry::sdk::resource::Resource *resource_{nullptr};
+  opentelemetry::sdk::resource::Resource &resource_{opentelemetry::sdk::resource::Resource::GetEmpty()};
 };
 }  // namespace otlp
 }  // namespace exporter

--- a/exporters/otlp/include/opentelemetry/exporters/otlp/recordable.h
+++ b/exporters/otlp/include/opentelemetry/exporters/otlp/recordable.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "opentelemetry/proto/resource/v1/resource.pb.h"
 #include "opentelemetry/proto/trace/v1/trace.pb.h"
 #include "opentelemetry/sdk/trace/recordable.h"
 #include "opentelemetry/version.h"
@@ -13,6 +14,8 @@ class Recordable final : public sdk::trace::Recordable
 {
 public:
   const proto::trace::v1::Span &span() const noexcept { return span_; }
+  /** Dynamically converts the resource of this span into a proto. */
+  proto::resource::v1::Resource resource() const noexcept;
 
   void SetIds(trace::TraceId trace_id,
               trace::SpanId span_id,
@@ -42,6 +45,7 @@ public:
 
 private:
   proto::trace::v1::Span span_;
+  const opentelemetry::sdk::resource::Resource* resource_;
 };
 }  // namespace otlp
 }  // namespace exporter

--- a/exporters/otlp/src/otlp_exporter.cc
+++ b/exporters/otlp/src/otlp_exporter.cc
@@ -22,15 +22,16 @@ void PopulateRequest(const nostd::span<std::unique_ptr<sdk::trace::Recordable>> 
 {
   auto resource_span       = request->add_resource_spans();
   auto instrumentation_lib = resource_span->add_instrumentation_library_spans();
-  bool has_resource = false;
+  bool has_resource        = false;
   for (auto &recordable : spans)
   {
     auto rec = std::unique_ptr<Recordable>(static_cast<Recordable *>(recordable.release()));
     // We assume all the spans are for the same resource.
-    if (!has_resource) {
+    if (!has_resource)
+    {
       // *resource_span->mutable_resource() = std::move(rec->resource());
       *resource_span->mutable_resource() = rec->resource();
-      has_resource = true;
+      has_resource                       = true;
     }
     *instrumentation_lib->add_spans() = std::move(rec->span());
   }

--- a/exporters/otlp/src/otlp_exporter.cc
+++ b/exporters/otlp/src/otlp_exporter.cc
@@ -22,10 +22,16 @@ void PopulateRequest(const nostd::span<std::unique_ptr<sdk::trace::Recordable>> 
 {
   auto resource_span       = request->add_resource_spans();
   auto instrumentation_lib = resource_span->add_instrumentation_library_spans();
-
+  bool has_resource = false;
   for (auto &recordable : spans)
   {
     auto rec = std::unique_ptr<Recordable>(static_cast<Recordable *>(recordable.release()));
+    // We assume all the spans are for the same resource.
+    if (!has_resource) {
+      // *resource_span->mutable_resource() = std::move(rec->resource());
+      *resource_span->mutable_resource() = rec->resource();
+      has_resource = true;
+    }
     *instrumentation_lib->add_spans() = std::move(rec->span());
   }
 }

--- a/exporters/otlp/src/recordable.cc
+++ b/exporters/otlp/src/recordable.cc
@@ -219,18 +219,15 @@ void PopulateAttribute(opentelemetry::proto::common::v1::KeyValue *attribute,
 proto::resource::v1::Resource Recordable::resource() const noexcept
 {
   proto::resource::v1::Resource proto;
-  if (resource_)
+  for (const auto &kv : resource_.GetAttributes())
   {
-    for (const auto &kv : resource_->GetAttributes())
-    {
-      PopulateAttribute(proto.add_attributes(), kv.first, kv.second);
-    }
+    PopulateAttribute(proto.add_attributes(), kv.first, kv.second);
   }
   return proto;
 }
 
 void Recordable::SetResourceRef(
-    const opentelemetry::sdk::resource::Resource *const resource) noexcept
+    const opentelemetry::sdk::resource::Resource &resource) noexcept
 {
   resource_ = resource;
 };

--- a/exporters/otlp/src/recordable.cc
+++ b/exporters/otlp/src/recordable.cc
@@ -217,6 +217,11 @@ void Recordable::SetDuration(std::chrono::nanoseconds duration) noexcept
   const uint64_t unix_end_time = span_.start_time_unix_nano() + duration.count();
   span_.set_end_time_unix_nano(unix_end_time);
 }
+
+void Recordable::SetResourceRef(const opentelemetry::sdk::resource::Resource*const resource) noexcept {
+  // TODO - Do something.
+}
+
 }  // namespace otlp
 }  // namespace exporter
 OPENTELEMETRY_END_NAMESPACE

--- a/exporters/otlp/src/recordable.cc
+++ b/exporters/otlp/src/recordable.cc
@@ -7,6 +7,7 @@ namespace otlp
 {
 
 const int kAttributeValueSize = 14;
+const int kOwnedAttributeValueSize = 14;
 
 void Recordable::SetIds(trace::TraceId trace_id,
                         trace::SpanId span_id,
@@ -117,6 +118,117 @@ void PopulateAttribute(opentelemetry::proto::common::v1::KeyValue *attribute,
   }
 }
 
+/** Maps from C++ attribute into OTLP proto attribute. */
+void PopulateAttribute(opentelemetry::proto::common::v1::KeyValue *attribute,
+                       nostd::string_view key,
+                       const sdk::common::OwnedAttributeValue &value) {
+  // Assert size of variant to ensure that this method gets updated if the variant
+  // definition changes
+  static_assert(
+      nostd::variant_size<opentelemetry::common::AttributeValue>::value == kOwnedAttributeValueSize,
+      "AttributeValue contains unknown type");
+
+  attribute->set_key(key.data(), key.size());
+
+  if (nostd::holds_alternative<bool>(value))
+  {
+    attribute->mutable_value()->set_bool_value(nostd::get<bool>(value));
+  }
+  else if (nostd::holds_alternative<int32_t>(value))
+  {
+    attribute->mutable_value()->set_int_value(nostd::get<int32_t>(value));
+  }
+  else if (nostd::holds_alternative<int64_t>(value))
+  {
+    attribute->mutable_value()->set_int_value(nostd::get<int64_t>(value));
+  }
+  else if (nostd::holds_alternative<uint32_t>(value))
+  {
+    attribute->mutable_value()->set_int_value(nostd::get<uint32_t>(value));
+  }
+  else if (nostd::holds_alternative<uint64_t>(value))
+  {
+    attribute->mutable_value()->set_int_value(nostd::get<uint64_t>(value));
+  }
+  else if (nostd::holds_alternative<double>(value))
+  {
+    attribute->mutable_value()->set_double_value(nostd::get<double>(value));
+  }
+  else if (nostd::holds_alternative<std::string>(value))
+  {
+    attribute->mutable_value()->set_string_value(nostd::get<std::string>(value));
+  }
+#ifdef HAVE_SPAN_BYTE
+  else if (nostd::holds_alternative<uint8_t>(value))
+  {
+    attribute->mutable_value()->set_int_value(nostd::get<uint8_t>(value));
+  }
+#endif
+  else if (nostd::holds_alternative<std::vector<bool>>(value))
+  {
+    for (const auto &val : nostd::get<std::vector<bool>>(value))
+    {
+      attribute->mutable_value()->mutable_array_value()->add_values()->set_bool_value(val);
+    }
+  }
+  else if (nostd::holds_alternative<std::vector<int32_t>>(value))
+  {
+    for (const auto &val : nostd::get<std::vector<int32_t>>(value))
+    {
+      attribute->mutable_value()->mutable_array_value()->add_values()->set_int_value(val);
+    }
+  }
+  else if (nostd::holds_alternative<std::vector<uint32_t>>(value))
+  {
+    for (const auto &val : nostd::get<std::vector<uint32_t>>(value))
+    {
+      attribute->mutable_value()->mutable_array_value()->add_values()->set_int_value(val);
+    }
+  }  
+  else if (nostd::holds_alternative<std::vector<int64_t>>(value))
+  {
+    for (const auto &val : nostd::get<std::vector<int64_t>>(value))
+    {
+      attribute->mutable_value()->mutable_array_value()->add_values()->set_int_value(val);
+    }
+  }
+  else if (nostd::holds_alternative<std::vector<uint64_t>>(value))
+  {
+    for (const auto &val : nostd::get<std::vector<uint64_t>>(value))
+    {
+      attribute->mutable_value()->mutable_array_value()->add_values()->set_int_value(val);
+    }
+  }
+  else if (nostd::holds_alternative<std::vector<double>>(value))
+  {
+    for (const auto &val : nostd::get<std::vector<double>>(value))
+    {
+      attribute->mutable_value()->mutable_array_value()->add_values()->set_double_value(val);
+    }
+  }
+  else if (nostd::holds_alternative<std::vector<std::string>>(value))
+  {
+    for (const auto &val : nostd::get<std::vector<std::string>>(value))
+    {
+      attribute->mutable_value()->mutable_array_value()->add_values()->set_string_value(val);
+    }
+  }
+}
+
+proto::resource::v1::Resource Recordable::resource() const noexcept {
+  proto::resource::v1::Resource proto;
+  if (resource_) {
+    for (const auto& kv : resource_->GetAttributes()) {
+      PopulateAttribute(proto.add_attributes(), kv.first, kv.second);
+    }
+  }
+  return proto;
+}
+
+void Recordable::SetResourceRef(const opentelemetry::sdk::resource::Resource*const resource) noexcept {
+    resource_ = resource;
+  };
+
 void Recordable::SetAttribute(nostd::string_view key,
                               const opentelemetry::common::AttributeValue &value) noexcept
 {
@@ -216,10 +328,6 @@ void Recordable::SetDuration(std::chrono::nanoseconds duration) noexcept
 {
   const uint64_t unix_end_time = span_.start_time_unix_nano() + duration.count();
   span_.set_end_time_unix_nano(unix_end_time);
-}
-
-void Recordable::SetResourceRef(const opentelemetry::sdk::resource::Resource*const resource) noexcept {
-  // TODO - Do something.
 }
 
 }  // namespace otlp

--- a/exporters/otlp/src/recordable.cc
+++ b/exporters/otlp/src/recordable.cc
@@ -6,7 +6,7 @@ namespace exporter
 namespace otlp
 {
 
-const int kAttributeValueSize = 14;
+const int kAttributeValueSize      = 14;
 const int kOwnedAttributeValueSize = 14;
 
 void Recordable::SetIds(trace::TraceId trace_id,
@@ -121,7 +121,8 @@ void PopulateAttribute(opentelemetry::proto::common::v1::KeyValue *attribute,
 /** Maps from C++ attribute into OTLP proto attribute. */
 void PopulateAttribute(opentelemetry::proto::common::v1::KeyValue *attribute,
                        nostd::string_view key,
-                       const sdk::common::OwnedAttributeValue &value) {
+                       const sdk::common::OwnedAttributeValue &value)
+{
   // Assert size of variant to ensure that this method gets updated if the variant
   // definition changes
   static_assert(
@@ -184,7 +185,7 @@ void PopulateAttribute(opentelemetry::proto::common::v1::KeyValue *attribute,
     {
       attribute->mutable_value()->mutable_array_value()->add_values()->set_int_value(val);
     }
-  }  
+  }
   else if (nostd::holds_alternative<std::vector<int64_t>>(value))
   {
     for (const auto &val : nostd::get<std::vector<int64_t>>(value))
@@ -215,19 +216,24 @@ void PopulateAttribute(opentelemetry::proto::common::v1::KeyValue *attribute,
   }
 }
 
-proto::resource::v1::Resource Recordable::resource() const noexcept {
+proto::resource::v1::Resource Recordable::resource() const noexcept
+{
   proto::resource::v1::Resource proto;
-  if (resource_) {
-    for (const auto& kv : resource_->GetAttributes()) {
+  if (resource_)
+  {
+    for (const auto &kv : resource_->GetAttributes())
+    {
       PopulateAttribute(proto.add_attributes(), kv.first, kv.second);
     }
   }
   return proto;
 }
 
-void Recordable::SetResourceRef(const opentelemetry::sdk::resource::Resource*const resource) noexcept {
-    resource_ = resource;
-  };
+void Recordable::SetResourceRef(
+    const opentelemetry::sdk::resource::Resource *const resource) noexcept
+{
+  resource_ = resource;
+};
 
 void Recordable::SetAttribute(nostd::string_view key,
                               const opentelemetry::common::AttributeValue &value) noexcept

--- a/exporters/otlp/test/otlp_exporter_test.cc
+++ b/exporters/otlp/test/otlp_exporter_test.cc
@@ -80,11 +80,7 @@ TEST_F(OtlpExporterTestPeer, ExportIntegrationTest)
     // TODO: Capture the exported proto and inspect it.
     EXPECT_CALL(*mock_stub, Export(_, _, _))
         .Times(AtLeast(1))
-        .WillRepeatedly(
-          DoAll(
-            SaveArg<1>(&request),
-            Return(grpc::Status::OK)
-          ));
+        .WillRepeatedly(DoAll(SaveArg<1>(&request), Return(grpc::Status::OK)));
 
     auto parent_span = tracer->StartSpan("Test parent span");
     auto child_span  = tracer->StartSpan("Test child span");
@@ -98,7 +94,8 @@ TEST_F(OtlpExporterTestPeer, ExportIntegrationTest)
   // Expect the default resource to have been used.
   EXPECT_EQ(3, request.resource_spans(0).resource().attributes_size());
   // And that the span name is the last span ended.
-  EXPECT_EQ("Test parent span", request.resource_spans(0).instrumentation_library_spans(0).spans(0).name());
+  EXPECT_EQ("Test parent span",
+            request.resource_spans(0).instrumentation_library_spans(0).spans(0).name());
 }
 
 // Test exporter configuration options

--- a/exporters/otlp/test/recordable_test.cc
+++ b/exporters/otlp/test/recordable_test.cc
@@ -205,14 +205,14 @@ TEST(Recordable, SetResourceRef)
   Recordable rec;
   sdk::resource::Resource default_resource = sdk::resource::Resource::GetDefault();
   sdk::resource::Resource empty_resource   = sdk::resource::Resource::GetEmpty();
-  rec.SetResourceRef(&default_resource);
+  rec.SetResourceRef(default_resource);
   auto proto = rec.resource();
   EXPECT_EQ(3, proto.attributes_size());
   // Note: We don't test ALL attribtues, only a few to avoid flaky tests and to
   // make sure we ARE getting attributes passed through.
   EXPECT_EQ("telemetry.sdk.name", proto.attributes(1).key());
   EXPECT_EQ("opentelemetry", proto.attributes(1).value().string_value());
-  rec.SetResourceRef(&empty_resource);
+  rec.SetResourceRef(empty_resource);
   EXPECT_EQ(0, rec.resource().attributes_size());
 }
 

--- a/exporters/otlp/test/recordable_test.cc
+++ b/exporters/otlp/test/recordable_test.cc
@@ -204,7 +204,7 @@ TEST(Recordable, SetResourceRef)
 {
   Recordable rec;
   sdk::resource::Resource default_resource = sdk::resource::Resource::GetDefault();
-  sdk::resource::Resource empty_resource = sdk::resource::Resource::GetEmpty();
+  sdk::resource::Resource empty_resource   = sdk::resource::Resource::GetEmpty();
   rec.SetResourceRef(&default_resource);
   auto proto = rec.resource();
   EXPECT_EQ(3, proto.attributes_size());

--- a/exporters/otlp/test/recordable_test.cc
+++ b/exporters/otlp/test/recordable_test.cc
@@ -200,6 +200,22 @@ TEST(Recordable, SetArrayAtrribute)
   }
 }
 
+TEST(Recordable, SetResourceRef)
+{
+  Recordable rec;
+  sdk::resource::Resource default_resource = sdk::resource::Resource::GetDefault();
+  sdk::resource::Resource empty_resource = sdk::resource::Resource::GetEmpty();
+  rec.SetResourceRef(&default_resource);
+  auto proto = rec.resource();
+  EXPECT_EQ(3, proto.attributes_size());
+  // Note: We don't test ALL attribtues, only a few to avoid flaky tests and to
+  // make sure we ARE getting attributes passed through.
+  EXPECT_EQ("telemetry.sdk.name", proto.attributes(1).key());
+  EXPECT_EQ("opentelemetry", proto.attributes(1).value().string_value());
+  rec.SetResourceRef(&empty_resource);
+  EXPECT_EQ(0, rec.resource().attributes_size());
+}
+
 /**
  * AttributeValue can contain different int types, such as int, int64_t,
  * unsigned int, and uint64_t. To avoid writing test cases for each, we can

--- a/ext/include/opentelemetry/ext/zpages/threadsafe_span_data.h
+++ b/ext/include/opentelemetry/ext/zpages/threadsafe_span_data.h
@@ -127,7 +127,9 @@ public:
     parent_span_id_ = parent_span_id;
   }
 
-  void SetResourceRef(const opentelemetry::sdk::resource::Resource*const resource) noexcept override {
+  void SetResourceRef(
+      const opentelemetry::sdk::resource::Resource *const resource) noexcept override
+  {
     // TODO
   }
 

--- a/ext/include/opentelemetry/ext/zpages/threadsafe_span_data.h
+++ b/ext/include/opentelemetry/ext/zpages/threadsafe_span_data.h
@@ -127,6 +127,10 @@ public:
     parent_span_id_ = parent_span_id;
   }
 
+  void SetResourceRef(const opentelemetry::sdk::resource::Resource*const resource) noexcept override {
+    // TODO
+  }
+
   void SetAttribute(nostd::string_view key, const common::AttributeValue &value) noexcept override
   {
     std::lock_guard<std::mutex> lock(mutex_);

--- a/ext/include/opentelemetry/ext/zpages/threadsafe_span_data.h
+++ b/ext/include/opentelemetry/ext/zpages/threadsafe_span_data.h
@@ -128,7 +128,7 @@ public:
   }
 
   void SetResourceRef(
-      const opentelemetry::sdk::resource::Resource *const resource) noexcept override
+      const opentelemetry::sdk::resource::Resource &resource) noexcept override
   {
     // TODO
   }

--- a/ext/test/zpages/tracez_data_aggregator_test.cc
+++ b/ext/test/zpages/tracez_data_aggregator_test.cc
@@ -37,8 +37,9 @@ protected:
   {
     std::shared_ptr<TracezSpanProcessor> processor(new TracezSpanProcessor());
     auto resource = opentelemetry::sdk::resource::Resource::Create({});
-    tracer_provider = std::shared_ptr<TracerProvider>(new TracerProvider(processor, std::move(resource)));
-    tracer = tracer_provider->GetTracer("test", "1.0");
+    tracer_provider =
+        std::shared_ptr<TracerProvider>(new TracerProvider(processor, std::move(resource)));
+    tracer                 = tracer_provider->GetTracer("test", "1.0");
     tracez_data_aggregator = std::unique_ptr<TracezDataAggregator>(
         new TracezDataAggregator(processor, milliseconds(10)));
   }

--- a/ext/test/zpages/tracez_data_aggregator_test.cc
+++ b/ext/test/zpages/tracez_data_aggregator_test.cc
@@ -6,6 +6,7 @@
 #include "opentelemetry/sdk/resource/resource.h"
 #include "opentelemetry/sdk/trace/recordable.h"
 #include "opentelemetry/sdk/trace/tracer.h"
+#include "opentelemetry/sdk/trace/tracer_provider.h"
 
 using namespace opentelemetry::sdk::trace;
 using namespace opentelemetry::ext::zpages;
@@ -36,13 +37,15 @@ protected:
   {
     std::shared_ptr<TracezSpanProcessor> processor(new TracezSpanProcessor());
     auto resource = opentelemetry::sdk::resource::Resource::Create({});
-    tracer        = std::shared_ptr<opentelemetry::trace::Tracer>(new Tracer(processor, resource));
+    tracer_provider = std::shared_ptr<TracerProvider>(new TracerProvider(processor, std::move(resource)));
+    tracer = tracer_provider->GetTracer("test", "1.0");
     tracez_data_aggregator = std::unique_ptr<TracezDataAggregator>(
         new TracezDataAggregator(processor, milliseconds(10)));
   }
 
   std::unique_ptr<TracezDataAggregator> tracez_data_aggregator;
-  std::shared_ptr<opentelemetry::trace::Tracer> tracer;
+  std::shared_ptr<TracerProvider> tracer_provider;
+  opentelemetry::nostd::shared_ptr<opentelemetry::trace::Tracer> tracer;
 };
 
 /**

--- a/ext/test/zpages/tracez_processor_test.cc
+++ b/ext/test/zpages/tracez_processor_test.cc
@@ -8,6 +8,7 @@
 #include "opentelemetry/nostd/span.h"
 #include "opentelemetry/sdk/resource/resource.h"
 #include "opentelemetry/sdk/trace/tracer.h"
+#include "opentelemetry/sdk/trace/tracer_provider.h"
 
 using namespace opentelemetry::sdk::trace;
 using namespace opentelemetry::ext::zpages;
@@ -148,7 +149,7 @@ void GetManySnapshots(std::shared_ptr<TracezSpanProcessor> &processor, int i)
  */
 void StartManySpans(
     std::vector<opentelemetry::nostd::shared_ptr<opentelemetry::trace::Span>> &spans,
-    std::shared_ptr<opentelemetry::trace::Tracer> tracer,
+    opentelemetry::nostd::shared_ptr<opentelemetry::trace::Tracer> tracer,
     int i)
 {
   for (; i > 0; i--)
@@ -177,8 +178,8 @@ protected:
   {
     processor     = std::shared_ptr<TracezSpanProcessor>(new TracezSpanProcessor());
     auto resource = opentelemetry::sdk::resource::Resource::Create({});
-
-    tracer     = std::shared_ptr<opentelemetry::trace::Tracer>(new Tracer(processor, resource));
+    tracer_provider = std::shared_ptr<TracerProvider>(new TracerProvider(processor, std::move(resource)));
+    tracer     = tracer_provider->GetTracer("test", "1.0");
     auto spans = processor->GetSpanSnapshot();
     running    = spans.running;
     completed  = std::move(spans.completed);
@@ -187,7 +188,8 @@ protected:
   }
 
   std::shared_ptr<TracezSpanProcessor> processor;
-  std::shared_ptr<opentelemetry::trace::Tracer> tracer;
+  std::shared_ptr<opentelemetry::sdk::trace::TracerProvider> tracer_provider;
+  opentelemetry::nostd::shared_ptr<opentelemetry::trace::Tracer> tracer;
 
   std::vector<std::string> span_names;
   std::vector<opentelemetry::nostd::shared_ptr<opentelemetry::trace::Span>> span_vars;

--- a/ext/test/zpages/tracez_processor_test.cc
+++ b/ext/test/zpages/tracez_processor_test.cc
@@ -178,7 +178,8 @@ protected:
   {
     processor     = std::shared_ptr<TracezSpanProcessor>(new TracezSpanProcessor());
     auto resource = opentelemetry::sdk::resource::Resource::Create({});
-    tracer_provider = std::shared_ptr<TracerProvider>(new TracerProvider(processor, std::move(resource)));
+    tracer_provider =
+        std::shared_ptr<TracerProvider>(new TracerProvider(processor, std::move(resource)));
     tracer     = tracer_provider->GetTracer("test", "1.0");
     auto spans = processor->GetSpanSnapshot();
     running    = spans.running;

--- a/sdk/include/opentelemetry/sdk/trace/recordable.h
+++ b/sdk/include/opentelemetry/sdk/trace/recordable.h
@@ -44,14 +44,15 @@ public:
 
   /**
    * Sets the resource associated with a span.
-   * 
+   *
    * <p> The resource is guaranteed to have a lifetime longer than this recordable.  It is
    * owned by the `TracerProvider` which (indirectly) owns the `Exporter` that generates a
    * `Recordable`.
-   * 
+   *
    * @param resource pointer to the Resource for this span.
    */
-  virtual void SetResourceRef(const opentelemetry::sdk::resource::Resource*const resource) noexcept = 0;
+  virtual void SetResourceRef(
+      const opentelemetry::sdk::resource::Resource *const resource) noexcept = 0;
 
   /**
    * Set an attribute of a span.

--- a/sdk/include/opentelemetry/sdk/trace/recordable.h
+++ b/sdk/include/opentelemetry/sdk/trace/recordable.h
@@ -49,10 +49,11 @@ public:
    * owned by the `TracerProvider` which (indirectly) owns the `Exporter` that generates a
    * `Recordable`.
    *
-   * @param resource pointer to the Resource for this span.
+   * @param resource the Resource for this span.
+   *                 Note: this reference will remain stable for the life of the Recordable.
    */
   virtual void SetResourceRef(
-      const opentelemetry::sdk::resource::Resource *const resource) noexcept = 0;
+      const opentelemetry::sdk::resource::Resource &resource) noexcept = 0;
 
   /**
    * Set an attribute of a span.

--- a/sdk/include/opentelemetry/sdk/trace/recordable.h
+++ b/sdk/include/opentelemetry/sdk/trace/recordable.h
@@ -5,6 +5,7 @@
 #include "opentelemetry/core/timestamp.h"
 #include "opentelemetry/nostd/string_view.h"
 #include "opentelemetry/sdk/common/empty_attributes.h"
+#include "opentelemetry/sdk/resource/resource.h"
 #include "opentelemetry/trace/canonical_code.h"
 #include "opentelemetry/trace/span.h"
 #include "opentelemetry/trace/span_context.h"
@@ -40,6 +41,17 @@ public:
   virtual void SetIds(opentelemetry::trace::TraceId trace_id,
                       opentelemetry::trace::SpanId span_id,
                       opentelemetry::trace::SpanId parent_span_id) noexcept = 0;
+
+  /**
+   * Sets the resource associated with a span.
+   * 
+   * <p> The resource is guaranteed to have a lifetime longer than this recordable.  It is
+   * owned by the `TracerProvider` which (indirectly) owns the `Exporter` that generates a
+   * `Recordable`.
+   * 
+   * @param resource pointer to the Resource for this span.
+   */
+  virtual void SetResourceRef(const opentelemetry::sdk::resource::Resource*const resource) noexcept = 0;
 
   /**
    * Set an attribute of a span.

--- a/sdk/include/opentelemetry/sdk/trace/span_data.h
+++ b/sdk/include/opentelemetry/sdk/trace/span_data.h
@@ -7,6 +7,7 @@
 #include "opentelemetry/core/timestamp.h"
 #include "opentelemetry/nostd/string_view.h"
 #include "opentelemetry/sdk/common/attribute_utils.h"
+#include "opentelemetry/sdk/resource/resource.h"
 #include "opentelemetry/sdk/trace/recordable.h"
 #include "opentelemetry/trace/canonical_code.h"
 #include "opentelemetry/trace/span.h"
@@ -219,6 +220,10 @@ public:
   }
 
   void SetDuration(std::chrono::nanoseconds duration) noexcept override { duration_ = duration; }
+
+  void SetResourceRef(const opentelemetry::sdk::resource::Resource*const resource) noexcept override {
+    // TODO
+  }
 
 private:
   opentelemetry::trace::TraceId trace_id_;

--- a/sdk/include/opentelemetry/sdk/trace/span_data.h
+++ b/sdk/include/opentelemetry/sdk/trace/span_data.h
@@ -222,7 +222,7 @@ public:
   void SetDuration(std::chrono::nanoseconds duration) noexcept override { duration_ = duration; }
 
   void SetResourceRef(
-      const opentelemetry::sdk::resource::Resource *const resource) noexcept override
+      const opentelemetry::sdk::resource::Resource &resource) noexcept override
   {
     // TODO
   }

--- a/sdk/include/opentelemetry/sdk/trace/span_data.h
+++ b/sdk/include/opentelemetry/sdk/trace/span_data.h
@@ -221,7 +221,9 @@ public:
 
   void SetDuration(std::chrono::nanoseconds duration) noexcept override { duration_ = duration; }
 
-  void SetResourceRef(const opentelemetry::sdk::resource::Resource*const resource) noexcept override {
+  void SetResourceRef(
+      const opentelemetry::sdk::resource::Resource *const resource) noexcept override
+  {
     // TODO
   }
 

--- a/sdk/include/opentelemetry/sdk/trace/tracer.h
+++ b/sdk/include/opentelemetry/sdk/trace/tracer.h
@@ -26,7 +26,7 @@ public:
    * Initialize a new tracer.
    * @param parent The `TraceProvider` which owns resource + pipeline for traces.
    */
-  explicit Tracer(TracerProvider* provider) noexcept;
+  explicit Tracer(TracerProvider *provider) noexcept;
 
   nostd::shared_ptr<trace_api::Span> StartSpan(
       nostd::string_view name,
@@ -39,10 +39,10 @@ public:
   void CloseWithMicroseconds(uint64_t timeout) noexcept override;
 
   /** Returns the provider that created this Tracer. */
-  const TracerProvider& GetProvider() const { return *provider_; }
+  const TracerProvider &GetProvider() const { return *provider_; }
 
 private:
-  TracerProvider* provider_;
+  TracerProvider *provider_;
 };
 }  // namespace trace
 }  // namespace sdk

--- a/sdk/include/opentelemetry/sdk/trace/tracer.h
+++ b/sdk/include/opentelemetry/sdk/trace/tracer.h
@@ -15,36 +15,18 @@ namespace sdk
 {
 namespace trace
 {
+
+// Forward Declaration due to bidirectional dependency
+class TracerProvider;
+
 class Tracer final : public trace_api::Tracer, public std::enable_shared_from_this<Tracer>
 {
 public:
   /**
    * Initialize a new tracer.
-   * @param processor The span processor for this tracer. This must not be a
-   * nullptr.
+   * @param parent The `TraceProvider` which owns resource + pipeline for traces.
    */
-  explicit Tracer(std::shared_ptr<SpanProcessor> processor,
-                  const opentelemetry::sdk::resource::Resource &resource,
-                  std::shared_ptr<Sampler> sampler = std::make_shared<AlwaysOnSampler>()) noexcept;
-
-  /**
-   * Set the span processor associated with this tracer.
-   * @param processor The new span processor for this tracer. This must not be
-   * a nullptr.
-   */
-  void SetProcessor(std::shared_ptr<SpanProcessor> processor) noexcept;
-
-  /**
-   * Obtain the span processor associated with this tracer.
-   * @return The span processor for this tracer.
-   */
-  std::shared_ptr<SpanProcessor> GetProcessor() const noexcept;
-
-  /**
-   * Obtain the sampler associated with this tracer.
-   * @return The sampler for this tracer.
-   */
-  std::shared_ptr<Sampler> GetSampler() const noexcept;
+  explicit Tracer(const TracerProvider& provider) noexcept;
 
   nostd::shared_ptr<trace_api::Span> StartSpan(
       nostd::string_view name,
@@ -57,9 +39,7 @@ public:
   void CloseWithMicroseconds(uint64_t timeout) noexcept override;
 
 private:
-  opentelemetry::sdk::AtomicSharedPtr<SpanProcessor> processor_;
-  const std::shared_ptr<Sampler> sampler_;
-  const opentelemetry::sdk::resource::Resource &resource_;
+  const TracerProvider& provider_;
 };
 }  // namespace trace
 }  // namespace sdk

--- a/sdk/include/opentelemetry/sdk/trace/tracer.h
+++ b/sdk/include/opentelemetry/sdk/trace/tracer.h
@@ -26,7 +26,7 @@ public:
    * Initialize a new tracer.
    * @param parent The `TraceProvider` which owns resource + pipeline for traces.
    */
-  explicit Tracer(const TracerProvider& provider) noexcept;
+  explicit Tracer(TracerProvider* provider) noexcept;
 
   nostd::shared_ptr<trace_api::Span> StartSpan(
       nostd::string_view name,
@@ -38,8 +38,11 @@ public:
 
   void CloseWithMicroseconds(uint64_t timeout) noexcept override;
 
+  /** Returns the provider that created this Tracer. */
+  const TracerProvider& GetProvider() const { return *provider_; }
+
 private:
-  const TracerProvider& provider_;
+  TracerProvider* provider_;
 };
 }  // namespace trace
 }  // namespace sdk

--- a/sdk/include/opentelemetry/sdk/trace/tracer_provider.h
+++ b/sdk/include/opentelemetry/sdk/trace/tracer_provider.h
@@ -68,9 +68,10 @@ public:
 
 private:
   opentelemetry::sdk::AtomicSharedPtr<SpanProcessor> processor_;
-  std::shared_ptr<opentelemetry::trace::Tracer> tracer_;
   const std::shared_ptr<Sampler> sampler_;
   const opentelemetry::sdk::resource::Resource resource_;
+  // TODO: Tracer should be per-instrumentation library
+  std::shared_ptr<opentelemetry::trace::Tracer> tracer_;
 };
 }  // namespace trace
 }  // namespace sdk

--- a/sdk/src/trace/span.cc
+++ b/sdk/src/trace/span.cc
@@ -108,7 +108,8 @@ Span::Span(std::shared_ptr<Tracer> &&tracer,
   recordable_->SetSpanKind(options.kind);
   recordable_->SetStartTime(NowOr(options.start_system_time));
   start_steady_time = NowOr(options.start_steady_time);
-  // recordable_->SetResourceRef(tracer_->GetProvider().GetResource()); TODO
+  recordable_->SetResourceRef(&tracer_->GetProvider().GetResource());
+  // TODO: recordable->SetInstrumentationLibraryRef(&tracer_->GetInstrumentationLibrary());
   tracer_->GetProvider().GetProcessor()->OnStart(*recordable_, parent_span_context);
 }
 

--- a/sdk/src/trace/span.cc
+++ b/sdk/src/trace/span.cc
@@ -2,8 +2,8 @@
 #include "src/common/random.h"
 
 #include "opentelemetry/context/runtime_context.h"
-#include "opentelemetry/trace/trace_flags.h"
 #include "opentelemetry/sdk/trace/tracer_provider.h"
+#include "opentelemetry/trace/trace_flags.h"
 #include "opentelemetry/version.h"
 
 OPENTELEMETRY_BEGIN_NAMESPACE

--- a/sdk/src/trace/span.cc
+++ b/sdk/src/trace/span.cc
@@ -108,7 +108,7 @@ Span::Span(std::shared_ptr<Tracer> &&tracer,
   recordable_->SetSpanKind(options.kind);
   recordable_->SetStartTime(NowOr(options.start_system_time));
   start_steady_time = NowOr(options.start_steady_time);
-  recordable_->SetResourceRef(&tracer_->GetProvider().GetResource());
+  recordable_->SetResourceRef(tracer_->GetProvider().GetResource());
   // TODO: recordable->SetInstrumentationLibraryRef(&tracer_->GetInstrumentationLibrary());
   tracer_->GetProvider().GetProcessor()->OnStart(*recordable_, parent_span_context);
 }

--- a/sdk/src/trace/span.h
+++ b/sdk/src/trace/span.h
@@ -16,13 +16,11 @@ class Span final : public trace_api::Span
 {
 public:
   explicit Span(std::shared_ptr<Tracer> &&tracer,
-                std::shared_ptr<SpanProcessor> processor,
                 nostd::string_view name,
                 const opentelemetry::common::KeyValueIterable &attributes,
                 const trace_api::SpanContextKeyValueIterable &links,
                 const trace_api::StartSpanOptions &options,
-                const trace_api::SpanContext &parent_span_context,
-                const opentelemetry::sdk::resource::Resource &resource) noexcept;
+                const trace_api::SpanContext &parent_span_context) noexcept;
 
   ~Span() override;
 
@@ -49,8 +47,7 @@ public:
   trace_api::SpanContext GetContext() const noexcept override { return *span_context_.get(); }
 
 private:
-  std::shared_ptr<trace_api::Tracer> tracer_;
-  std::shared_ptr<SpanProcessor> processor_;
+  std::shared_ptr<Tracer> tracer_;
   mutable std::mutex mu_;
   std::unique_ptr<Recordable> recordable_;
   opentelemetry::core::SteadyTimestamp start_steady_time;

--- a/sdk/src/trace/tracer.cc
+++ b/sdk/src/trace/tracer.cc
@@ -1,8 +1,8 @@
 #include "opentelemetry/sdk/trace/tracer.h"
-#include "opentelemetry/sdk/trace/tracer_provider.h"
 #include "opentelemetry/context/runtime_context.h"
 #include "opentelemetry/nostd/shared_ptr.h"
 #include "opentelemetry/sdk/common/atomic_shared_ptr.h"
+#include "opentelemetry/sdk/trace/tracer_provider.h"
 #include "opentelemetry/version.h"
 #include "src/trace/span.h"
 
@@ -11,8 +11,7 @@ namespace sdk
 {
 namespace trace
 {
-Tracer::Tracer(opentelemetry::sdk::trace::TracerProvider* provider) noexcept
-    : provider_ { provider }
+Tracer::Tracer(opentelemetry::sdk::trace::TracerProvider *provider) noexcept : provider_{provider}
 {}
 
 trace_api::SpanContext GetCurrentSpanContext(const trace_api::SpanContext &explicit_parent)
@@ -43,8 +42,8 @@ nostd::shared_ptr<trace_api::Span> Tracer::StartSpan(
     const trace_api::StartSpanOptions &options) noexcept
 {
   trace_api::SpanContext parent = GetCurrentSpanContext(options.parent);
-  auto sampling_result =
-    provider_->GetSampler()->ShouldSample(parent, parent.trace_id(), name, options.kind, attributes, links);
+  auto sampling_result = provider_->GetSampler()->ShouldSample(parent, parent.trace_id(), name,
+                                                               options.kind, attributes, links);
   if (sampling_result.decision == Decision::DROP)
   {
     // Don't allocate a no-op span for every DROP decision, but use a static
@@ -56,8 +55,8 @@ nostd::shared_ptr<trace_api::Span> Tracer::StartSpan(
   }
   else
   {
-    auto span = nostd::shared_ptr<trace_api::Span>{
-        new (std::nothrow) Span{this->shared_from_this(), name, attributes, links, options, parent}};
+    auto span = nostd::shared_ptr<trace_api::Span>{new (std::nothrow) Span{
+        this->shared_from_this(), name, attributes, links, options, parent}};
 
     // if the attributes is not nullptr, add attributes to the span.
     if (sampling_result.attributes)

--- a/sdk/src/trace/tracer_provider.cc
+++ b/sdk/src/trace/tracer_provider.cc
@@ -11,7 +11,7 @@ TracerProvider::TracerProvider(std::shared_ptr<SpanProcessor> processor,
     : processor_{processor},
       sampler_(sampler),
       resource_(resource),
-      tracer_(new Tracer(*this))
+      tracer_(new Tracer(this))
 {}
 
 opentelemetry::nostd::shared_ptr<opentelemetry::trace::Tracer> TracerProvider::GetTracer(

--- a/sdk/src/trace/tracer_provider.cc
+++ b/sdk/src/trace/tracer_provider.cc
@@ -8,10 +8,7 @@ namespace trace
 TracerProvider::TracerProvider(std::shared_ptr<SpanProcessor> processor,
                                opentelemetry::sdk::resource::Resource &&resource,
                                std::shared_ptr<Sampler> sampler) noexcept
-    : processor_{processor},
-      sampler_(sampler),
-      resource_(resource),
-      tracer_(new Tracer(this))
+    : processor_{processor}, sampler_(sampler), resource_(resource), tracer_(new Tracer(this))
 {}
 
 opentelemetry::nostd::shared_ptr<opentelemetry::trace::Tracer> TracerProvider::GetTracer(

--- a/sdk/src/trace/tracer_provider.cc
+++ b/sdk/src/trace/tracer_provider.cc
@@ -9,9 +9,9 @@ TracerProvider::TracerProvider(std::shared_ptr<SpanProcessor> processor,
                                opentelemetry::sdk::resource::Resource &&resource,
                                std::shared_ptr<Sampler> sampler) noexcept
     : processor_{processor},
-      tracer_(new Tracer(std::move(processor), resource, sampler)),
       sampler_(sampler),
-      resource_(resource)
+      resource_(resource),
+      tracer_(new Tracer(*this))
 {}
 
 opentelemetry::nostd::shared_ptr<opentelemetry::trace::Tracer> TracerProvider::GetTracer(
@@ -24,9 +24,6 @@ opentelemetry::nostd::shared_ptr<opentelemetry::trace::Tracer> TracerProvider::G
 void TracerProvider::SetProcessor(std::shared_ptr<SpanProcessor> processor) noexcept
 {
   processor_.store(processor);
-
-  auto sdkTracer = static_cast<Tracer *>(tracer_.get());
-  sdkTracer->SetProcessor(processor);
 }
 
 std::shared_ptr<SpanProcessor> TracerProvider::GetProcessor() const noexcept

--- a/sdk/test/trace/sampler_benchmark.cc
+++ b/sdk/test/trace/sampler_benchmark.cc
@@ -122,7 +122,7 @@ void BenchmarkSpanCreation(std::shared_ptr<Sampler> sampler, benchmark::State &s
   auto processor = std::make_shared<SimpleSpanProcessor>(std::move(exporter));
   auto resource  = opentelemetry::sdk::resource::Resource::Create({});
   auto tracer_provider =
-     std::shared_ptr<TracerProvider>(new TracerProvider(processor, std::move(resource), sampler));
+      std::shared_ptr<TracerProvider>(new TracerProvider(processor, std::move(resource), sampler));
   auto tracer = tracer_provider->GetTracer("test", "1.0");
 
   while (state.KeepRunning())

--- a/sdk/test/trace/sampler_benchmark.cc
+++ b/sdk/test/trace/sampler_benchmark.cc
@@ -8,6 +8,7 @@
 #include "opentelemetry/sdk/trace/simple_processor.h"
 #include "opentelemetry/sdk/trace/span_data.h"
 #include "opentelemetry/sdk/trace/tracer.h"
+#include "opentelemetry/sdk/trace/tracer_provider.h"
 
 #include <cstdint>
 
@@ -120,8 +121,9 @@ void BenchmarkSpanCreation(std::shared_ptr<Sampler> sampler, benchmark::State &s
   std::unique_ptr<SpanExporter> exporter(new InMemorySpanExporter());
   auto processor = std::make_shared<SimpleSpanProcessor>(std::move(exporter));
   auto resource  = opentelemetry::sdk::resource::Resource::Create({});
-  auto tracer =
-      std::shared_ptr<opentelemetry::trace::Tracer>(new Tracer(processor, resource, sampler));
+  auto tracer_provider =
+     std::shared_ptr<TracerProvider>(new TracerProvider(processor, std::move(resource), sampler));
+  auto tracer = tracer_provider->GetTracer("test", "1.0");
 
   while (state.KeepRunning())
   {

--- a/sdk/test/trace/tracer_provider_test.cc
+++ b/sdk/test/trace/tracer_provider_test.cc
@@ -24,17 +24,17 @@ TEST(TracerProvider, GetTracer)
 
   // Should return the same instance each time.
   ASSERT_EQ(t1, t2);
+  // TODO: These should be different, InstrumentationLibrary is different.
   ASSERT_EQ(t1, t3);
 
   // Should be an sdk::trace::Tracer with the processor attached.
   auto sdkTracer1 = dynamic_cast<Tracer *>(t1.get());
   ASSERT_NE(nullptr, sdkTracer1);
-  ASSERT_EQ(processor, sdkTracer1->GetProcessor());
-  ASSERT_EQ("AlwaysOnSampler", sdkTracer1->GetSampler()->GetDescription());
+  // TODO - figure out how to ensure tracer is attached to this instance.
 
   TracerProvider tp2(processor, Resource::Create({}), std::make_shared<AlwaysOffSampler>());
   auto sdkTracer2 = dynamic_cast<Tracer *>(tp2.GetTracer("test").get());
-  ASSERT_EQ("AlwaysOffSampler", sdkTracer2->GetSampler()->GetDescription());
+  // TODO - figure out how to ensure tracer is attached to this instance.
 }
 
 TEST(TracerProvider, GetSampler)

--- a/sdk/test/trace/tracer_test.cc
+++ b/sdk/test/trace/tracer_test.cc
@@ -1,4 +1,5 @@
 #include "opentelemetry/sdk/trace/tracer.h"
+#include "opentelemetry/sdk/trace/tracer_provider.h"
 #include "opentelemetry/exporters/memory/in_memory_span_exporter.h"
 #include "opentelemetry/sdk/resource/resource.h"
 #include "opentelemetry/sdk/trace/samplers/always_off.h"
@@ -47,22 +48,22 @@ public:
 
 namespace
 {
-std::shared_ptr<opentelemetry::trace::Tracer> initTracer(
+std::shared_ptr<TracerProvider> initTracerProvider(
     std::unique_ptr<InMemorySpanExporter> &&exporter)
 {
   auto processor = std::make_shared<SimpleSpanProcessor>(std::move(exporter));
   auto resource  = Resource::Create({});
-  return std::shared_ptr<opentelemetry::trace::Tracer>(new Tracer(processor, resource));
+  return std::shared_ptr<TracerProvider>(new TracerProvider(processor, std::move(resource)));
 }
 
-std::shared_ptr<opentelemetry::trace::Tracer> initTracer(
+std::shared_ptr<TracerProvider> initTracerProvider(
     std::unique_ptr<InMemorySpanExporter> &&exporter,
     std::shared_ptr<Sampler> sampler)
 {
   auto processor = std::make_shared<SimpleSpanProcessor>(std::move(exporter));
   auto resource  = Resource::Create({});
 
-  return std::shared_ptr<opentelemetry::trace::Tracer>(new Tracer(processor, resource, sampler));
+  return std::shared_ptr<TracerProvider>(new TracerProvider(processor, std::move(resource), sampler));
 }
 }  // namespace
 
@@ -70,7 +71,8 @@ TEST(Tracer, ToInMemorySpanExporter)
 {
   std::unique_ptr<InMemorySpanExporter> exporter(new InMemorySpanExporter());
   std::shared_ptr<InMemorySpanData> span_data = exporter->GetData();
-  auto tracer                                 = initTracer(std::move(exporter));
+  auto tracer_provider                        = initTracerProvider(std::move(exporter));
+  auto tracer                                 = tracer_provider->GetTracer("test", "1.0");
 
   auto span_first  = tracer->StartSpan("span 1");
   auto scope_first = tracer->WithActiveSpan(span_first);
@@ -105,7 +107,8 @@ TEST(Tracer, StartSpanSampleOn)
 {
   std::unique_ptr<InMemorySpanExporter> exporter(new InMemorySpanExporter());
   std::shared_ptr<InMemorySpanData> span_data = exporter->GetData();
-  auto tracer_on                              = initTracer(std::move(exporter));
+  auto tracer_provider                        = initTracerProvider(std::move(exporter));
+  auto tracer_on                              = tracer_provider->GetTracer("test", "1.0");
 
   tracer_on->StartSpan("span 1")->End();
 
@@ -121,7 +124,8 @@ TEST(Tracer, StartSpanSampleOff)
 {
   std::unique_ptr<InMemorySpanExporter> exporter(new InMemorySpanExporter());
   std::shared_ptr<InMemorySpanData> span_data = exporter->GetData();
-  auto tracer_off = initTracer(std::move(exporter), std::make_shared<AlwaysOffSampler>());
+  auto tracer_provider                        = initTracerProvider(std::move(exporter), std::make_shared<AlwaysOffSampler>());
+  auto tracer_off                             = tracer_provider->GetTracer("test", "1.0");
 
   // This span will not be recorded.
   tracer_off->StartSpan("span 2")->End();
@@ -135,7 +139,8 @@ TEST(Tracer, StartSpanWithOptionsTime)
 {
   std::unique_ptr<InMemorySpanExporter> exporter(new InMemorySpanExporter());
   std::shared_ptr<InMemorySpanData> span_data = exporter->GetData();
-  auto tracer                                 = initTracer(std::move(exporter));
+  auto tracer_provider                        = initTracerProvider(std::move(exporter));
+  auto tracer                                 = tracer_provider->GetTracer("test", "1.0");
 
   opentelemetry::trace::StartSpanOptions start;
   start.start_system_time = SystemTimestamp(std::chrono::nanoseconds(300));
@@ -158,7 +163,8 @@ TEST(Tracer, StartSpanWithAttributes)
 {
   std::unique_ptr<InMemorySpanExporter> exporter(new InMemorySpanExporter());
   std::shared_ptr<InMemorySpanData> span_data = exporter->GetData();
-  auto tracer                                 = initTracer(std::move(exporter));
+  auto tracer_provider                        = initTracerProvider(std::move(exporter));
+  auto tracer                                 = tracer_provider->GetTracer("test", "1.0");
 
   // Start a span with all supported scalar attribute types.
   tracer
@@ -238,7 +244,8 @@ TEST(Tracer, StartSpanWithAttributesCopy)
 {
   std::unique_ptr<InMemorySpanExporter> exporter(new InMemorySpanExporter());
   std::shared_ptr<InMemorySpanData> span_data = exporter->GetData();
-  auto tracer                                 = initTracer(std::move(exporter));
+  auto tracer_provider                        = initTracerProvider(std::move(exporter));
+  auto tracer                                 = tracer_provider->GetTracer("test", "1.0");
 
   {
     std::unique_ptr<std::vector<int64_t>> numbers(new std::vector<int64_t>);
@@ -278,30 +285,13 @@ TEST(Tracer, StartSpanWithAttributesCopy)
   ASSERT_EQ("c", strings[2]);
 }
 
-TEST(Tracer, GetSampler)
-{
-  auto resource = Resource::Create({});
-  // Create a Tracer with a default AlwaysOnSampler
-  std::shared_ptr<SpanProcessor> processor_1(new SimpleSpanProcessor(nullptr));
-  std::shared_ptr<Tracer> tracer_on(new Tracer(std::move(processor_1), resource));
-
-  auto t1 = tracer_on->GetSampler();
-  ASSERT_EQ("AlwaysOnSampler", t1->GetDescription());
-
-  // Create a Tracer with a AlwaysOffSampler
-  std::shared_ptr<SpanProcessor> processor_2(new SimpleSpanProcessor(nullptr));
-  std::shared_ptr<Tracer> tracer_off(
-      new Tracer(std::move(processor_2), resource, std::make_shared<AlwaysOffSampler>()));
-
-  auto t2 = tracer_off->GetSampler();
-  ASSERT_EQ("AlwaysOffSampler", t2->GetDescription());
-}
 
 TEST(Tracer, SpanSetAttribute)
 {
   std::unique_ptr<InMemorySpanExporter> exporter(new InMemorySpanExporter());
   std::shared_ptr<InMemorySpanData> span_data = exporter->GetData();
-  auto tracer                                 = initTracer(std::move(exporter));
+  auto tracer_provider                        = initTracerProvider(std::move(exporter));
+  auto tracer                                 = tracer_provider->GetTracer("test", "1.0");
 
   auto span = tracer->StartSpan("span 1");
 
@@ -319,7 +309,8 @@ TEST(Tracer, SpanSetEvents)
 {
   std::unique_ptr<InMemorySpanExporter> exporter(new InMemorySpanExporter());
   std::shared_ptr<InMemorySpanData> span_data = exporter->GetData();
-  auto tracer                                 = initTracer(std::move(exporter));
+  auto tracer_provider                        = initTracerProvider(std::move(exporter));
+  auto tracer                                 = tracer_provider->GetTracer("test", "1.0");
 
   auto span = tracer->StartSpan("span 1");
   span->AddEvent("event 1");
@@ -344,7 +335,8 @@ TEST(Tracer, SpanSetLinks)
 {
   std::unique_ptr<InMemorySpanExporter> exporter(new InMemorySpanExporter());
   std::shared_ptr<InMemorySpanData> span_data = exporter->GetData();
-  auto tracer                                 = initTracer(std::move(exporter));
+  auto tracer_provider                        = initTracerProvider(std::move(exporter));
+  auto tracer                                 = tracer_provider->GetTracer("test", "1.0");
 
   {
 
@@ -421,7 +413,8 @@ TEST(Tracer, TestAlwaysOnSampler)
 {
   std::unique_ptr<InMemorySpanExporter> exporter(new InMemorySpanExporter());
   std::shared_ptr<InMemorySpanData> span_data = exporter->GetData();
-  auto tracer_on                              = initTracer(std::move(exporter));
+  auto tracer_provider                        = initTracerProvider(std::move(exporter));
+  auto tracer_on                              = tracer_provider->GetTracer("test", "1.0");
 
   // Testing AlwaysOn sampler.
   // Create two spans for each tracer. Check the exported result.
@@ -440,7 +433,8 @@ TEST(Tracer, TestAlwaysOffSampler)
 {
   std::unique_ptr<InMemorySpanExporter> exporter(new InMemorySpanExporter());
   std::shared_ptr<InMemorySpanData> span_data = exporter->GetData();
-  auto tracer_off = initTracer(std::move(exporter), std::make_shared<AlwaysOffSampler>());
+  auto tracer_provider                        = initTracerProvider(std::move(exporter), std::make_shared<AlwaysOffSampler>());
+  auto tracer_off                             = tracer_provider->GetTracer("test", "1.0");
   auto span_off_1 = tracer_off->StartSpan("span 1");
   auto span_off_2 = tracer_off->StartSpan("span 2");
 
@@ -459,9 +453,8 @@ TEST(Tracer, TestParentBasedSampler)
   // so this sampler will work as an AlwaysOnSampler.
   std::unique_ptr<InMemorySpanExporter> exporter(new InMemorySpanExporter());
   std::shared_ptr<InMemorySpanData> span_data_parent_on = exporter->GetData();
-  auto tracer_parent_on =
-      initTracer(std::move(exporter),
-                 std::make_shared<ParentBasedSampler>(std::make_shared<AlwaysOnSampler>()));
+  auto tracer_provider                        = initTracerProvider(std::move(exporter), std::make_shared<AlwaysOnSampler>());
+  auto tracer_parent_on                       = tracer_provider->GetTracer("test", "1.0");
 
   auto span_parent_on_1 = tracer_parent_on->StartSpan("span 1");
   auto span_parent_on_2 = tracer_parent_on->StartSpan("span 2");
@@ -480,9 +473,10 @@ TEST(Tracer, TestParentBasedSampler)
   // so this sampler will work as an AlwaysOnSampler.
   std::unique_ptr<InMemorySpanExporter> exporter2(new InMemorySpanExporter());
   std::shared_ptr<InMemorySpanData> span_data_parent_off = exporter2->GetData();
-  auto tracer_parent_off =
-      initTracer(std::move(exporter2),
+  auto tracer_provider_parent_off =
+      initTracerProvider(std::move(exporter2),
                  std::make_shared<ParentBasedSampler>(std::make_shared<AlwaysOffSampler>()));
+  auto tracer_parent_off = tracer_provider_parent_off->GetTracer("test", "1.0");
 
   auto span_parent_off_1 = tracer_parent_off->StartSpan("span 1");
   auto span_parent_off_2 = tracer_parent_off->StartSpan("span 2");
@@ -498,7 +492,8 @@ TEST(Tracer, WithActiveSpan)
 {
   std::unique_ptr<InMemorySpanExporter> exporter(new InMemorySpanExporter());
   std::shared_ptr<InMemorySpanData> span_data = exporter->GetData();
-  auto tracer                                 = initTracer(std::move(exporter));
+  auto tracer_provider                        = initTracerProvider(std::move(exporter));
+  auto tracer                                 = tracer_provider->GetTracer("test", "1.0");
   auto spans                                  = span_data.get()->GetSpans();
 
   ASSERT_EQ(0, spans.size());
@@ -533,7 +528,8 @@ TEST(Tracer, ExpectParent)
 {
   std::unique_ptr<InMemorySpanExporter> exporter(new InMemorySpanExporter());
   std::shared_ptr<InMemorySpanData> span_data = exporter->GetData();
-  auto tracer                                 = initTracer(std::move(exporter));
+  auto tracer_provider                        = initTracerProvider(std::move(exporter));
+  auto tracer                                 = tracer_provider->GetTracer("test", "1.0");
   auto spans                                  = span_data.get()->GetSpans();
 
   ASSERT_EQ(0, spans.size());

--- a/sdk/test/trace/tracer_test.cc
+++ b/sdk/test/trace/tracer_test.cc
@@ -73,7 +73,6 @@ TEST(Tracer, ToInMemorySpanExporter)
   std::shared_ptr<InMemorySpanData> span_data = exporter->GetData();
   auto tracer_provider                        = initTracerProvider(std::move(exporter));
   auto tracer                                 = tracer_provider->GetTracer("test", "1.0");
-
   auto span_first  = tracer->StartSpan("span 1");
   auto scope_first = tracer->WithActiveSpan(span_first);
   auto span_second = tracer->StartSpan("span 2");


### PR DESCRIPTION
This PR Is the result of discussion/design from #575.

- [x] Adds a `SetResourceRef` to the `Recordable` interface
- [x] Removes `Tracer` methods not in the specification.
- [x] Update `Tracer` to get `Processor`/`Exporter` solely from  `TracerProvider`
- [x] Update `Span` to keep a reference to generating `Tracer` and pull information from it rather than duplicating
- [x] Ensure `SetResourceRef` is called on `Recordable` when creating spans
- [x] Update OTLP exporter to also export `Resource`
- [x] Update OTLP exporter tests to check contents of exported protos
- [x] Fix windows exporters/builds (ETW)

For a separate PR?:
- [ ] Update `SpanProcessor` to be `unique_ptr` on `TracerProvider`.
- [ ] Update `Exporter` to be `unique_ptr` on `SpanProcessor`s.
- [ ] Add `InstrumentationLirbary` class
- [ ] Update `TracerProvider` to construct multiple `Tracer`s, each remembering their `InstrumentationLibrary`