### PR TITLE
Add main page for API documentation

### DIFF
--- a/api/docs/Doxyfile
+++ b/api/docs/Doxyfile
@@ -58,7 +58,7 @@ PROJECT_LOGO           = ./resources/opentelemetry_logo.jpg
 # entered, it will be relative to the location where doxygen was started. If
 # left blank the current directory will be used.
 
-OUTPUT_DIRECTORY       = 
+OUTPUT_DIRECTORY       =
 
 # If the CREATE_SUBDIRS tag is set to YES then doxygen will create 4096 sub-
 # directories (in 2 levels) under the output directory of each output format and

--- a/api/docs/Doxyfile
+++ b/api/docs/Doxyfile
@@ -58,7 +58,7 @@ PROJECT_LOGO           = ./resources/opentelemetry_logo.jpg
 # entered, it will be relative to the location where doxygen was started. If
 # left blank the current directory will be used.
 
-OUTPUT_DIRECTORY       = ./output
+OUTPUT_DIRECTORY       = 
 
 # If the CREATE_SUBDIRS tag is set to YES then doxygen will create 4096 sub-
 # directories (in 2 levels) under the output directory of each output format and
@@ -790,7 +790,7 @@ WARN_LOGFILE           =
 # spaces. See also FILE_PATTERNS and EXTENSION_MAPPING
 # Note: If this tag is empty the current directory is searched.
 
-INPUT                  = ../../README.md \
+INPUT                  = ./Overview.md \
                          ../include/opentelemetry/common \
                          ../include/opentelemetry/core \
                          ../include/opentelemetry/nostd/shared_ptr.h \
@@ -948,7 +948,7 @@ FILTER_SOURCE_PATTERNS =
 # (index.html). This can be useful if you have a project on for instance GitHub
 # and want to reuse the introduction page also for the doxygen output.
 
-USE_MDFILE_AS_MAINPAGE = ../../README.md
+USE_MDFILE_AS_MAINPAGE = ./Overview.md
 
 #---------------------------------------------------------------------------
 # Configuration options related to source browsing

--- a/api/docs/Overview.md
+++ b/api/docs/Overview.md
@@ -14,7 +14,7 @@ exported and processed.
 The OpenTelemetry C++ API is provided as a header-only library and supports all
 recent versions of the C++ standard, down to C++11.
 
-A single application might dynamically or statically link different libraries
+A single application might dynamically or statically link to different libraries
 that were compiled with different compilers, while several of the linked
 libraries are instrumented with OpenTelemetry. OpenTelemetry C++ supports those
 scenarios by providing a stable ABI. This is achieved by a careful API design,

--- a/api/docs/Overview.md
+++ b/api/docs/Overview.md
@@ -73,4 +73,6 @@ span.
   for further information and resources related to OpenTelemetry C++.
 * For questions related to OpenTelemetry C++ that are not covered by the
   existing documentation, please ask away in [GitHub discussions](https://github.com/open-telemetry/opentelemetry-cpp/discussions).
+* Feel free to join the [CNCF OpenTelemetry C++ Slack channel](https://cloud-native.slack.com/archives/C01N3AT62SJ).
+  If you are new, you can create a CNCF Slack account [here](http://slack.cncf.io/).
 * For bugs and feature requests, write a [GitHub issue](https://github.com/open-telemetry/opentelemetry-cpp/issues).

--- a/api/docs/Overview.md
+++ b/api/docs/Overview.md
@@ -19,7 +19,7 @@ that were compiled with different compilers, while several of the linked
 libraries are instrumented with OpenTelemetry. OpenTelemetry C++ supports those
 scenarios by providing a stable ABI. This is achieved by a careful API design,
 and most notably by providing ABI stable versions of classes from the standard
-library. All those classes are provided in the `opentelemetry:nostd` namespace.
+library. All those classes are provided in the `opentelemetry::nostd` namespace.
 
 ## Getting started
 

--- a/api/docs/Overview.md
+++ b/api/docs/Overview.md
@@ -34,6 +34,7 @@ requires three steps.
 auto provider = opentelemetry::trace::Provider::GetTracerProvider();
 auto tracer = provider->GetTracer("foo_library", "1.0.0");
 ```
+
 The `TracerProvider` acquired in the first step is a singleton object that
 is usually provided by the OpenTelemetry C++ SDK. It is used to provide
 specific implementations for API interfaces. In case no SDK is used, the API

--- a/api/docs/Overview.md
+++ b/api/docs/Overview.md
@@ -1,0 +1,76 @@
+# Overview
+
+The OpenTelemetry C++ API enables developers to instrument their applications
+and libraries in order to make them ready to create and emit telemetry data.
+The OpenTelemetry C++ API exclusively focuses on instrumentation and does not
+address concerns like exporting, sampling, and aggregating telemetry data.
+Those concerns are addressed by the OpenTelemetry C++ SDK. This architecture
+enables developers to instrument applications and libraries with the
+OpenTelemetry C++ API while being completely agnostic of how telemetry data is
+exported and processed.
+
+## Library design
+
+The OpenTelemetry C++ API is provided as a header-only library and supports all
+recent versions of the C++ standard, down to C++11.
+
+A single application might dynamically or statically link different libraries
+that were compiled with different compilers, while several of the linked
+libraries are instrumented with OpenTelemetry. OpenTelemetry C++ supports those
+scenarios by providing a stable ABI. This is achieved by a careful API design,
+and most notably by providing ABI stable versions of classes from the standard
+library. All those classes are provided in the `opentelemetry:nostd` namespace.
+
+## Getting started
+
+### Tracing
+
+When instrumenting libraries and applications, the most simple approach
+requires three steps.
+
+#### Obtain a tracer
+
+```cpp
+auto provider = opentelemetry::trace::Provider::GetTracerProvider();
+auto tracer = provider->GetTracer("foo_library", "1.0.0");
+```
+The `TracerProvider` acquired in the first step is a singleton object that
+is usually provided by the OpenTelemetry C++ SDK. It is used to provide
+specific implementations for API interfaces. In case no SDK is used, the API
+provides a default no-op implementation of a `TracerProvider`.
+
+The `Tracer` acquired in the second step is needed to create and start `Span`s.
+
+#### Start a span
+
+```cpp
+auto span = tracer->StartSpan("HandleRequest");
+```
+
+This creates a span, sets its name to `"HandleRequest"`, and sets its start
+time to the current time. Refer to the API documentation for other operations
+that are available to enrich spans with additional data.
+
+#### Mark a span as active
+
+```cpp
+auto scope = tracer->WithActiveSpan(span);
+```
+
+This marks a span as active and returns a `Scope` object bound to the
+lifetime of the span. When the `Scope` object is destroyed, the related span is
+ended.
+
+The concept of an active span is important, as any span that is created
+without explicitly specifying a parent is parented to the currently active
+span.
+
+## Getting help
+
+* Refer to [opentelemetry.io](https://opentelemetry.io/) for general
+  information about OpenTelemetry.
+* Refer to the [OpenTelemetry C++ GitHub repository](https://github.com/open-telemetry/opentelemetry-cpp)
+  for further information and resources related to OpenTelemetry C++.
+* For questions related to OpenTelemetry C++ that are not covered by the
+  existing documentation, please ask away in [GitHub discussions](https://github.com/open-telemetry/opentelemetry-cpp/discussions).
+* For bugs and feature requests, write a [GitHub issue](https://github.com/open-telemetry/opentelemetry-cpp/issues).

--- a/buildscripts/pre-commit
+++ b/buildscripts/pre-commit
@@ -44,9 +44,11 @@ branch="$(git rev-parse --abbrev-ref HEAD)"
 short_version="${major}.${minor}.${patch}"
 full_version="${short_version}-${pre_release}-${build_metadata}-${count_new_commits}-${branch}-${latest_commit_hash}"
 
-#update api version.h
+# Update api version.h
 sed -i "/^\#define OPENTELEMETRY_VERSION/c\#define OPENTELEMETRY_VERSION \"${short_version}\""  "$(pwd)/api/include/opentelemetry/version.h"
-#update sdk version.cc
+git add "$(pwd)/api/include/opentelemetry/version.h"
+
+# Update sdk version.cc
 cat > "$(pwd)/sdk/src/version/version.cc" <<END
 // Please DONOT touch this file.
 // Any changes done here would be overwritten by pre-commit git hook
@@ -74,3 +76,7 @@ namespace version
 OPENTELEMETRY_END_NAMESPACE
 END
 git add "$(pwd)/sdk/src/version/version.cc"
+
+# Update documentation version
+sed -i "/^PROJECT_BRIEF/cPROJECT_BRIEF = \"Version ${short_version}\""  "$(pwd)/api/docs/Doxyfile"
+git add "$(pwd)/api/docs/Doxyfile"


### PR DESCRIPTION
This PR adds a main page for the API reference documentation.

It also makes sure the version in the API documentation is updated by our release build scripts.