### PR TITLE
Move from Gitter to Slack

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,7 +8,7 @@ See the [public meeting
 notes](https://docs.google.com/document/d/1i1E4-_y4uJ083lCutKGDhkpi3n4_e774SBLi9hPLocw/edit)
 for a summary description of past meetings. To request edit access, join the
 meeting or get in touch on
-[Gitter](https://gitter.im/open-telemetry/opentelemetry-cpp).
+[Slack](https://cloud-native.slack.com/archives/C01N3AT62SJ).
 
 See the [community membership
 document](https://github.com/open-telemetry/community/blob/main/community-membership.md)

--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 # OpenTelemetry C++
 
-[![Gitter
-chat](https://badges.gitter.im/open-telemetry/opentelemetry-cpp.svg)](https://gitter.im/open-telemetry/opentelemetry-cpp?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
+[![Slack](https://img.shields.io/badge/slack-@cncf/otel/cpp-brightgreen.svg?logo=slack)](https://cloud-native.slack.com/archives/C01N3AT62SJ)
 [![codecov.io](https://codecov.io/gh/open-telemetry/opentelemetry-cpp/branch/main/graphs/badge.svg?)](https://codecov.io/gh/open-telemetry/opentelemetry-cpp/)
 [![Build
 Status](https://action-badges.now.sh/open-telemetry/opentelemetry-cpp)](https://github.com/open-telemetry/opentelemetry-cpp/actions)
@@ -64,7 +63,7 @@ The passcode is _77777_.
 Meeting notes are available as a public [Google
 doc](https://docs.google.com/document/d/1i1E4-_y4uJ083lCutKGDhkpi3n4_e774SBLi9hPLocw/edit?usp=sharing).
 For edit access, get in touch on
-[Gitter](https://gitter.im/open-telemetry/opentelemetry-cpp).
+[Slack](https://cloud-native.slack.com/archives/C01N3AT62SJ).
 
 Approvers
 ([@open-telemetry/cpp-approvers](https://github.com/orgs/open-telemetry/teams/cpp-approvers)):


### PR DESCRIPTION
As agreed and announced [here](https://medium.com/opentelemetry/opentelemetry-specification-v1-0-0-tracing-edition-72dd08936978#), we're moving to to Slack for all the IMs.