### PR TITLE
Rename HTTPTextFormat to TextMapPropagator

### DIFF
--- a/api/include/opentelemetry/trace/propagation/b3_propagator.h
+++ b/api/include/opentelemetry/trace/propagation/b3_propagator.h
@@ -11,7 +11,7 @@
 #include "opentelemetry/nostd/string_view.h"
 #include "opentelemetry/nostd/variant.h"
 #include "opentelemetry/trace/default_span.h"
-#include "opentelemetry/trace/propagation/http_text_format.h"
+#include "opentelemetry/trace/propagation/text_map_propagator.h"
 #include "opentelemetry/trace/span.h"
 #include "opentelemetry/trace/span_context.h"
 
@@ -46,7 +46,7 @@ static const int kTraceFlagHexStrLength = 1;
 // providing the object containing the headers, and a getter function for the extraction. Based on:
 // https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/context/api-propagators.md#b3-extract
 template <typename T>
-class B3PropagatorExtractor : public HTTPTextFormat<T>
+class B3PropagatorExtractor : public TextMapPropagator<T>
 {
 public:
   // Rules that manages how context will be extracted from carrier.

--- a/api/include/opentelemetry/trace/propagation/http_trace_context.h
+++ b/api/include/opentelemetry/trace/propagation/http_trace_context.h
@@ -23,7 +23,7 @@
 #include "opentelemetry/nostd/string_view.h"
 #include "opentelemetry/nostd/variant.h"
 #include "opentelemetry/trace/default_span.h"
-#include "opentelemetry/trace/propagation/http_text_format.h"
+#include "opentelemetry/trace/propagation/text_map_propagator.h"
 #include "opentelemetry/trace/span.h"
 #include "opentelemetry/trace/span_context.h"
 
@@ -52,7 +52,7 @@ static const int kTraceFlagBytes       = 2;
 //    HttpTraceContext.inject(setter,&carrier,&context);
 //    HttpTraceContext.extract(getter,&carrier,&context);
 template <typename T>
-class HttpTraceContext : public HTTPTextFormat<T>
+class HttpTraceContext : public TextMapPropagator<T>
 {
 public:
   // Rules that manages how context will be extracted from carrier.

--- a/api/include/opentelemetry/trace/propagation/text_map_propagator.h
+++ b/api/include/opentelemetry/trace/propagation/text_map_propagator.h
@@ -12,7 +12,7 @@ namespace propagation
 {
 
 // The TextMapPropagator class provides an interface that enables extracting and injecting
-// context into headers of HTTP requests. HTTP frameworks and clients
+// context into carriers that travel in-band across process boundaries. HTTP frameworks and clients
 // can integrate with TextMapPropagator by providing the object containing the
 // headers, and a getter and setter function for the extraction and
 // injection of values, respectively.
@@ -28,12 +28,12 @@ public:
                           nostd::string_view trace_type,
                           nostd::string_view trace_description);
 
-  // Returns the context that is stored in the HTTP header carrier with the getter as extractor.
+  // Returns the context that is stored in the carrier with the getter as extractor.
   virtual context::Context Extract(Getter get_from_carrier,
                                    const T &carrier,
                                    context::Context &context) noexcept = 0;
 
-  // Sets the context for a HTTP header carrier with self defined rules.
+  // Sets the context for carrier with self defined rules.
   virtual void Inject(Setter set_from_carrier,
                       T &carrier,
                       const context::Context &context) noexcept = 0;

--- a/api/include/opentelemetry/trace/propagation/text_map_propagator.h
+++ b/api/include/opentelemetry/trace/propagation/text_map_propagator.h
@@ -11,13 +11,13 @@ namespace trace
 namespace propagation
 {
 
-// The HTTPTextFormat class provides an interface that enables extracting and injecting
+// The TextMapPropagator class provides an interface that enables extracting and injecting
 // context into headers of HTTP requests. HTTP frameworks and clients
-// can integrate with HTTPTextFormat by providing the object containing the
+// can integrate with TextMapPropagator by providing the object containing the
 // headers, and a getter and setter function for the extraction and
 // injection of values, respectively.
 template <typename T>
-class HTTPTextFormat
+class TextMapPropagator
 {
 public:
   // Rules that manages how context will be extracted from carrier.

--- a/api/test/trace/propagation/b3_propagation_test.cc
+++ b/api/test/trace/propagation/b3_propagation_test.cc
@@ -17,7 +17,7 @@
 
 #include "opentelemetry/trace/default_span.h"
 #include "opentelemetry/trace/propagation/b3_propagator.h"
-#include "opentelemetry/trace/propagation/http_text_format.h"
+#include "opentelemetry/trace/propagation/text_map_propagator.h"
 
 using namespace opentelemetry;
 

--- a/api/test/trace/propagation/http_text_format_test.cc
+++ b/api/test/trace/propagation/http_text_format_test.cc
@@ -16,8 +16,8 @@
 #include <gtest/gtest.h>
 
 #include "opentelemetry/trace/default_span.h"
-#include "opentelemetry/trace/propagation/text_map_propagator.h"
 #include "opentelemetry/trace/propagation/http_trace_context.h"
+#include "opentelemetry/trace/propagation/text_map_propagator.h"
 
 using namespace opentelemetry;
 

--- a/api/test/trace/propagation/http_text_format_test.cc
+++ b/api/test/trace/propagation/http_text_format_test.cc
@@ -16,7 +16,7 @@
 #include <gtest/gtest.h>
 
 #include "opentelemetry/trace/default_span.h"
-#include "opentelemetry/trace/propagation/http_text_format.h"
+#include "opentelemetry/trace/propagation/text_map_propagator.h"
 #include "opentelemetry/trace/propagation/http_trace_context.h"
 
 using namespace opentelemetry;
@@ -52,25 +52,25 @@ using MapHttpTraceContext =
 
 static MapHttpTraceContext format = MapHttpTraceContext();
 
-TEST(HTTPTextFormatTest, TraceIdBufferGeneration)
+TEST(TextMapPropagatorTest, TraceIdBufferGeneration)
 {
   constexpr uint8_t buf[] = {1, 2, 3, 4, 5, 6, 7, 8, 8, 7, 0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0xff};
   EXPECT_EQ(MapHttpTraceContext::GenerateTraceIdFromString("01020304050607080807aabbccddeeff"),
             trace::TraceId(buf));
 }
 
-TEST(HTTPTextFormatTest, SpanIdBufferGeneration)
+TEST(TextMapPropagatorTest, SpanIdBufferGeneration)
 {
   constexpr uint8_t buf[] = {1, 2, 0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0xff};
   EXPECT_EQ(MapHttpTraceContext::GenerateSpanIdFromString("0102aabbccddeeff"), trace::SpanId(buf));
 }
 
-TEST(HTTPTextFormatTest, TraceFlagsBufferGeneration)
+TEST(TextMapPropagatorTest, TraceFlagsBufferGeneration)
 {
   EXPECT_EQ(MapHttpTraceContext::GenerateTraceFlagsFromString("00"), trace::TraceFlags());
 }
 
-TEST(HTTPTextFormatTest, NoSendEmptyTraceState)
+TEST(TextMapPropagatorTest, NoSendEmptyTraceState)
 {
   // If the trace state is empty, do not set the header.
   const std::map<std::string, std::string> carrier = {
@@ -85,7 +85,7 @@ TEST(HTTPTextFormatTest, NoSendEmptyTraceState)
   EXPECT_FALSE(carrier.count("tracestate") > 0);
 }
 
-TEST(HTTPTextFormatTest, PropagateInvalidContext)
+TEST(TextMapPropagatorTest, PropagateInvalidContext)
 {
   // Do not propagate invalid trace context.
   std::map<std::string, std::string> carrier = {};
@@ -96,7 +96,7 @@ TEST(HTTPTextFormatTest, PropagateInvalidContext)
   EXPECT_TRUE(carrier.count("traceparent") == 0);
 }
 
-TEST(HTTPTextFormatTest, SetRemoteSpan)
+TEST(TextMapPropagatorTest, SetRemoteSpan)
 {
   const std::map<std::string, std::string> carrier = {
       {"traceparent", "00-4bf92f3577b34da6a3ce929d0e0e4736-0102030405060708-01"}};
@@ -114,7 +114,7 @@ TEST(HTTPTextFormatTest, SetRemoteSpan)
   EXPECT_EQ(span->GetContext().IsRemote(), true);
 }
 
-TEST(HTTPTextFormatTest, GetCurrentSpan)
+TEST(TextMapPropagatorTest, GetCurrentSpan)
 {
   constexpr uint8_t buf_span[]  = {1, 2, 3, 4, 5, 6, 7, 8};
   constexpr uint8_t buf_trace[] = {1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16};


### PR DESCRIPTION
Fixes #536

## Changes

As per spec open-telemetry/opentelemetry-specification#793

Trivial change.