### PR TITLE
Add ForceFlush to TracerProvider in SDK

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ Increment the:
 
 ## [Unreleased]
 
+* Added `ForceFlush` to `TracerProvider` in SDK. ([#588](https://github.com/open-telemetry/opentelemetry-cpp/pull/588)).
+
 ## [0.0.1] 2020-12-16
 
 ### Added

--- a/sdk/include/opentelemetry/sdk/trace/tracer_provider.h
+++ b/sdk/include/opentelemetry/sdk/trace/tracer_provider.h
@@ -66,6 +66,11 @@ public:
    */
   bool Shutdown() noexcept;
 
+  /**
+   * Force flush the span processor associated with this tracer provider.
+   */
+  bool ForceFlush(std::chrono::microseconds timeout = (std::chrono::microseconds::max)()) noexcept;
+
 private:
   opentelemetry::sdk::AtomicSharedPtr<SpanProcessor> processor_;
   std::shared_ptr<opentelemetry::trace::Tracer> tracer_;

--- a/sdk/src/logs/logger.cc
+++ b/sdk/src/logs/logger.cc
@@ -89,7 +89,7 @@ void Logger::Log(opentelemetry::logs::Severity severity,
   // Leave these fields in the recordable empty if neither the passed in values
   // nor the context values are valid (e.g. the application is not using traces)
 
-  // Traceid
+  // TraceId
   if (trace_id.IsValid())
   {
     recordable->SetTraceId(trace_id);
@@ -99,7 +99,7 @@ void Logger::Log(opentelemetry::logs::Severity severity,
     recordable->SetTraceId(span_context.trace_id());
   }
 
-  // Spanid
+  // SpanId
   if (span_id.IsValid())
   {
     recordable->SetSpanId(span_id);
@@ -109,7 +109,7 @@ void Logger::Log(opentelemetry::logs::Severity severity,
     recordable->SetSpanId(span_id);
   }
 
-  // Traceflags
+  // TraceFlags
   if (trace_flags.IsSampled())
   {
     recordable->SetTraceFlags(trace_flags);

--- a/sdk/src/trace/tracer_provider.cc
+++ b/sdk/src/trace/tracer_provider.cc
@@ -48,6 +48,11 @@ bool TracerProvider::Shutdown() noexcept
 {
   return GetProcessor()->Shutdown();
 }
+
+bool TracerProvider::ForceFlush(std::chrono::microseconds timeout) noexcept
+{
+  return GetProcessor()->Shutdown(timeout);
+}
 }  // namespace trace
 }  // namespace sdk
 OPENTELEMETRY_END_NAMESPACE

--- a/sdk/src/trace/tracer_provider.cc
+++ b/sdk/src/trace/tracer_provider.cc
@@ -51,7 +51,7 @@ bool TracerProvider::Shutdown() noexcept
 
 bool TracerProvider::ForceFlush(std::chrono::microseconds timeout) noexcept
 {
-  return GetProcessor()->Shutdown(timeout);
+  return GetProcessor()->ForceFlush(timeout);
 }
 }  // namespace trace
 }  // namespace sdk

--- a/sdk/test/trace/tracer_provider_test.cc
+++ b/sdk/test/trace/tracer_provider_test.cc
@@ -70,3 +70,12 @@ TEST(TracerProvider, Shutdown)
 
   EXPECT_TRUE(tp1.Shutdown());
 }
+
+TEST(TracerProvider, ForceFlush)
+{
+  std::shared_ptr<SpanProcessor> processor1(new SimpleSpanProcessor(nullptr));
+
+  TracerProvider tp1(processor1);
+
+  EXPECT_TRUE(tp1.ForceFlush());
+}


### PR DESCRIPTION
Fixes #587 

## Changes

Add `ForceFlush` to TracerProvider as per the spec PR https://github.com/open-telemetry/opentelemetry-specification/pull/1452

For significant contributions please make sure you have completed the following items:

* [x] `CHANGELOG.md` updated for non-trivial changes
* [x] Unit tests have been added
* [ ] Changes in public API reviewed