### PR TITLE
Release for  0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,12 +17,13 @@ Increment the:
 
 ## [0.2.0] 2021-03-02
 
-* [SDK] Added `ForceFlush` to `TracerProvider` in SDK. ([#588](https://github.com/open-telemetry/opentelemetry-cpp/pull/588)).
-* [SDK] Added Resource API
-* [API] Added TraceState support for w3c trace context.
-* [API] Added B3 Propagator
-* [Exporter] Added ETW Exporter
-* [CI] Enable cache for Bazel for faster builds.
+* [SDK] Added `ForceFlush` to `TracerProvider`. ([#588](https://github.com/open-telemetry/opentelemetry-cpp/pull/588)).
+* [SDK] Added Resource API.  ([#502](https://github.com/open-telemetry/opentelemetry-cpp/pull/502))
+* [API] Modified TraceState support for w3c trace context as per specs.
+([#551](https://github.com/open-telemetry/opentelemetry-cpp/pull/551))
+* [API] Added B3 Propagator. ([#523](https://github.com/open-telemetry/opentelemetry-cpp/pull/523))
+* [Exporter] Added ETW Exporter. ([#376](https://github.com/open-telemetry/opentelemetry-cpp/pull/376))
+* [CI] Enable cache for Bazel for faster builds. ([#505](https://github.com/open-telemetry/opentelemetry-cpp/pull/505))
 
 ## [0.0.1] 2020-12-16
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ Increment the:
 * PATCH version when you make backwards compatible bug fixes.
 
 ## [Unreleased]
- 
+
 ## [0.2.0] 2021-03-02
 
 * [SDK] Added `ForceFlush` to `TracerProvider` in SDK. ([#588](https://github.com/open-telemetry/opentelemetry-cpp/pull/588)).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ Increment the:
 * PATCH version when you make backwards compatible bug fixes.
 
 ## [Unreleased]
+ 
+## [0.2.0] 2021-03-02
 
 * Added `ForceFlush` to `TracerProvider` in SDK. ([#588](https://github.com/open-telemetry/opentelemetry-cpp/pull/588)).
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,12 @@ Increment the:
  
 ## [0.2.0] 2021-03-02
 
-* Added `ForceFlush` to `TracerProvider` in SDK. ([#588](https://github.com/open-telemetry/opentelemetry-cpp/pull/588)).
+* [SDK] Added `ForceFlush` to `TracerProvider` in SDK. ([#588](https://github.com/open-telemetry/opentelemetry-cpp/pull/588)).
+* [SDK] Added Resource API
+* [API] Added TraceState support for w3c trace context.
+* [API] Added B3 Propagator
+* [Exporter] Added ETW Exporter
+* [CI] Enable cache for Bazel for faster builds.
 
 ## [0.0.1] 2020-12-16
 

--- a/api/docs/Doxyfile
+++ b/api/docs/Doxyfile
@@ -44,7 +44,7 @@ PROJECT_NUMBER         =
 # for a project that appears at the top of each page and should give viewer a
 # quick idea about the purpose of the project. Keep the description short.
 
-PROJECT_BRIEF          = "Version 0.1.0"
+PROJECT_BRIEF          = "Version 0.2.0"
 
 # With the PROJECT_LOGO tag one can specify a logo or an icon that is included
 # in the documentation. The maximum height of the logo should not exceed 55

--- a/api/include/opentelemetry/version.h
+++ b/api/include/opentelemetry/version.h
@@ -3,7 +3,7 @@
 #include "opentelemetry/detail/preprocessor.h"
 
 #define OPENTELEMETRY_ABI_VERSION_NO 0
-#define OPENTELEMETRY_VERSION "0.1.0"
+#define OPENTELEMETRY_VERSION "0.2.0"
 #define OPENTELEMETRY_ABI_VERSION OPENTELEMETRY_STRINGIFY(OPENTELEMETRY_ABI_VERSION_NO)
 
 // clang-format off

--- a/sdk/src/version/version.cc
+++ b/sdk/src/version/version.cc
@@ -9,7 +9,7 @@ namespace sdk
 namespace version
 {
 const int MAJOR_VERSION     = 0;
-const int MINOR_VERSION     = 0;
+const int MINOR_VERSION     = 2;
 const int PATCH_VERSION     = 0;
 const char *PRE_RELEASE     = "";
 const char *BUILD_METADATA  = "";


### PR DESCRIPTION
Release 0.2.0
## Changes

New alpha release 0.2.0

As of now, it's ok to have same semver for both api and sdk, and hence single source package release. Once we start deviating in release number, we can plan to have separate source packages for api, and sdk  ( including exporters, propagators, instrumentations )

For significant contributions please make sure you have completed the following items:

* [X] `CHANGELOG.md` updated for non-trivial changes
* [ ] Unit tests have been added
* [X] Changes in public API reviewed