### PR TITLE
Add Jaeger propagator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ Increment the:
 ## [Unreleased]
 
 * [EXPORTER] Added Zipkin Exporter. ([#471](https://github.com/open-telemetry/opentelemetry-cpp/pull/471))
+* [API] Added Jaeger propagator. ([#599](https://github.com/open-telemetry/opentelemetry-cpp/pull/599))
 
 ## [0.2.0] 2021-03-02
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -119,7 +119,7 @@ A PR is considered to be **ready to merge** when:
   /
   [Maintainer](https://github.com/open-telemetry/community/blob/main/community-membership.md#maintainer)
   (at different company).
-* A pull reqeust opened by an Approver / Maintainer can be merged with only one
+* A pull request opened by an Approver / Maintainer can be merged with only one
   approval from  Approver / Maintainer (at different company).
 * Major feedback items/points are resolved.
 * It has been open for review for at least one working day. This gives people

--- a/api/include/opentelemetry/context/context.h
+++ b/api/include/opentelemetry/context/context.h
@@ -60,7 +60,7 @@ public:
   }
 
   // Returns the value associated with the passed in key.
-  context::ContextValue GetValue(const nostd::string_view key) noexcept
+  context::ContextValue GetValue(const nostd::string_view key) const noexcept
   {
     for (DataList *data = head_.get(); data != nullptr; data = data->next_.get())
     {
@@ -92,6 +92,17 @@ public:
   }
 
   bool operator==(const Context &other) const noexcept { return (head_ == other.head_); }
+
+  trace::SpanContext GetCurrentSpan() const
+  {
+    ContextValue span = GetValue(trace::kSpanKey);
+    if (nostd::holds_alternative<nostd::shared_ptr<trace::Span>>(span))
+    {
+      return nostd::get<nostd::shared_ptr<trace::Span>>(span).get()->GetContext();
+    }
+
+    return trace::SpanContext::GetInvalid();
+  }
 
 private:
   // A linked list to contain the keys and values of this context node

--- a/api/include/opentelemetry/context/context.h
+++ b/api/include/opentelemetry/context/context.h
@@ -93,17 +93,6 @@ public:
 
   bool operator==(const Context &other) const noexcept { return (head_ == other.head_); }
 
-  trace::SpanContext GetCurrentSpan() const
-  {
-    ContextValue span = GetValue(trace::kSpanKey);
-    if (nostd::holds_alternative<nostd::shared_ptr<trace::Span>>(span))
-    {
-      return nostd::get<nostd::shared_ptr<trace::Span>>(span).get()->GetContext();
-    }
-
-    return trace::SpanContext::GetInvalid();
-  }
-
 private:
   // A linked list to contain the keys and values of this context node
   class DataList

--- a/api/include/opentelemetry/trace/propagation/b3_propagator.h
+++ b/api/include/opentelemetry/trace/propagation/b3_propagator.h
@@ -4,6 +4,7 @@
 #include <iostream>
 #include <map>
 #include <string>
+#include "detail/context.h"
 #include "opentelemetry/common/key_value_iterable.h"
 #include "opentelemetry/context/context.h"
 #include "opentelemetry/nostd/shared_ptr.h"
@@ -202,7 +203,7 @@ public:
   // Sets the context for a HTTP header carrier with self defined rules.
   void Inject(Setter setter, T &carrier, const context::Context &context) noexcept override
   {
-    SpanContext span_context = context.GetCurrentSpan();
+    SpanContext span_context = detail::GetCurrentSpan(context);
     if (!span_context.IsValid())
     {
       return;
@@ -240,7 +241,7 @@ public:
                           nostd::string_view trace_description);
   void Inject(Setter setter, T &carrier, const context::Context &context) noexcept override
   {
-    SpanContext span_context = context.GetCurrentSpan();
+    SpanContext span_context = detail::GetCurrentSpan(context);
     if (!span_context.IsValid())
     {
       return;

--- a/api/include/opentelemetry/trace/propagation/b3_propagator.h
+++ b/api/include/opentelemetry/trace/propagation/b3_propagator.h
@@ -62,17 +62,6 @@ public:
     return context.SetValue(kSpanKey, sp);
   }
 
-  static SpanContext GetCurrentSpan(const context::Context &context)
-  {
-    context::Context ctx(context);
-    context::ContextValue span = ctx.GetValue(kSpanKey);
-    if (nostd::holds_alternative<nostd::shared_ptr<Span>>(span))
-    {
-      return nostd::get<nostd::shared_ptr<Span>>(span).get()->GetContext();
-    }
-    return SpanContext::GetInvalid();
-  }
-
   static TraceId GenerateTraceIdFromString(nostd::string_view trace_id)
   {
     uint8_t buf[kTraceIdHexStrLength / 2];
@@ -213,7 +202,7 @@ public:
   // Sets the context for a HTTP header carrier with self defined rules.
   void Inject(Setter setter, T &carrier, const context::Context &context) noexcept override
   {
-    SpanContext span_context = B3PropagatorExtractor<T>::GetCurrentSpan(context);
+    SpanContext span_context = context.GetCurrentSpan();
     if (!span_context.IsValid())
     {
       return;
@@ -251,7 +240,7 @@ public:
                           nostd::string_view trace_description);
   void Inject(Setter setter, T &carrier, const context::Context &context) noexcept override
   {
-    SpanContext span_context = B3PropagatorExtractor<T>::GetCurrentSpan(context);
+    SpanContext span_context = context.GetCurrentSpan();
     if (!span_context.IsValid())
     {
       return;

--- a/api/include/opentelemetry/trace/propagation/detail/context.h
+++ b/api/include/opentelemetry/trace/propagation/detail/context.h
@@ -1,0 +1,26 @@
+#pragma once
+#include "opentelemetry/context/context.h"
+
+OPENTELEMETRY_BEGIN_NAMESPACE
+namespace trace
+{
+namespace propagation
+{
+namespace detail
+{
+
+trace::SpanContext GetCurrentSpan(const context::Context& context)
+{
+  context::ContextValue span = context.GetValue(trace::kSpanKey);
+  if (nostd::holds_alternative<nostd::shared_ptr<trace::Span>>(span))
+  {
+    return nostd::get<nostd::shared_ptr<trace::Span>>(span).get()->GetContext();
+  }
+
+  return trace::SpanContext::GetInvalid();
+}
+
+}  // namespace detail
+}  // namespace propagation
+}  // namespace trace
+OPENTELEMETRY_END_NAMESPACE

--- a/api/include/opentelemetry/trace/propagation/detail/context.h
+++ b/api/include/opentelemetry/trace/propagation/detail/context.h
@@ -9,7 +9,7 @@ namespace propagation
 namespace detail
 {
 
-trace::SpanContext GetCurrentSpan(const context::Context& context)
+trace::SpanContext GetCurrentSpan(const context::Context &context)
 {
   context::ContextValue span = context.GetValue(trace::kSpanKey);
   if (nostd::holds_alternative<nostd::shared_ptr<trace::Span>>(span))

--- a/api/include/opentelemetry/trace/propagation/detail/hex.h
+++ b/api/include/opentelemetry/trace/propagation/detail/hex.h
@@ -1,0 +1,74 @@
+#pragma once
+
+#include "opentelemetry/nostd/string_view.h"
+
+#include <algorithm>
+#include <cstring>
+
+OPENTELEMETRY_BEGIN_NAMESPACE
+namespace trace
+{
+namespace propagation
+{
+namespace detail
+{
+
+constexpr int8_t kHexDigits[256] = {
+    -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
+    -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
+    0,  1,  2,  3,  4,  5,  6,  7,  8,  9,  -1, -1, -1, -1, -1, -1, -1, 10, 11, 12, 13, 14, 15, -1,
+    -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
+    -1, 10, 11, 12, 13, 14, 15, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
+    -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
+    -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
+    -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
+    -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
+    -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
+    -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
+};
+
+inline int8_t HexToInt(char c)
+{
+  return kHexDigits[uint8_t(c)];
+}
+
+bool IsValidHex(nostd::string_view s)
+{
+  return std::all_of(s.begin(), s.end(), [](char c) { return HexToInt(c) != -1; });
+}
+
+/**
+ * Converts a hexadecimal to binary format if the hex string will fit the buffer.
+ * Smaller hex strings are left padded with zeroes.
+ */
+bool HexToBinary(nostd::string_view hex, uint8_t *buffer, size_t buffer_size)
+{
+  if (hex.size() > buffer_size * 2)
+  {
+    return false;
+  }
+
+  std::memset(buffer, 0, buffer_size);
+
+  int64_t hex_size     = int64_t(hex.size());
+  int64_t buffer_pos   = int64_t(buffer_size) - (hex_size + 1) / 2;
+  int64_t last_hex_pos = hex_size - 1;
+
+  int64_t i = 0;
+  for (; i < last_hex_pos; i += 2)
+  {
+    buffer[buffer_pos++] = (HexToInt(hex[i]) << 4) | HexToInt(hex[i + 1]);
+  }
+
+  if (i == last_hex_pos)
+  {
+    buffer[buffer_pos] = HexToInt(hex[i]);
+  }
+
+  return true;
+}
+
+}  // namespace detail
+}  // namespace propagation
+}  // namespace trace
+OPENTELEMETRY_END_NAMESPACE

--- a/api/include/opentelemetry/trace/propagation/detail/string.h
+++ b/api/include/opentelemetry/trace/propagation/detail/string.h
@@ -1,0 +1,54 @@
+#pragma once
+
+#include "opentelemetry/nostd/string_view.h"
+
+OPENTELEMETRY_BEGIN_NAMESPACE
+namespace trace
+{
+namespace propagation
+{
+namespace detail
+{
+
+/**
+ * Splits a string by separator, up to given buffer count words.
+ * Returns the amount of words the input was split into.
+ */
+size_t SplitString(nostd::string_view s, char separator, nostd::string_view *results, size_t count)
+{
+  if (count == 0)
+  {
+    return count;
+  }
+
+  size_t filled      = 0;
+  size_t token_start = 0;
+  for (size_t i = 0; i < s.size(); i++)
+  {
+    if (s[i] != separator)
+    {
+      continue;
+    }
+
+    results[filled++] = s.substr(token_start, i - token_start);
+
+    if (filled == count)
+    {
+      return count;
+    }
+
+    token_start = i + 1;
+  }
+
+  if (filled < count)
+  {
+    results[filled++] = s.substr(token_start);
+  }
+
+  return filled;
+}
+
+}  // namespace detail
+}  // namespace propagation
+}  // namespace trace
+OPENTELEMETRY_END_NAMESPACE

--- a/api/include/opentelemetry/trace/propagation/http_trace_context.h
+++ b/api/include/opentelemetry/trace/propagation/http_trace_context.h
@@ -16,6 +16,7 @@
 #include <iostream>
 #include <map>
 #include <string>
+#include "detail/context.h"
 #include "opentelemetry/common/key_value_iterable.h"
 #include "opentelemetry/context/context.h"
 #include "opentelemetry/nostd/shared_ptr.h"
@@ -65,7 +66,7 @@ public:
 
   void Inject(Setter setter, T &carrier, const context::Context &context) noexcept override
   {
-    SpanContext span_context = context.GetCurrentSpan();
+    SpanContext span_context = detail::GetCurrentSpan(context);
     if (!span_context.IsValid())
     {
       return;

--- a/api/include/opentelemetry/trace/propagation/http_trace_context.h
+++ b/api/include/opentelemetry/trace/propagation/http_trace_context.h
@@ -65,7 +65,7 @@ public:
 
   void Inject(Setter setter, T &carrier, const context::Context &context) noexcept override
   {
-    SpanContext span_context = GetCurrentSpan(context);
+    SpanContext span_context = context.GetCurrentSpan();
     if (!span_context.IsValid())
     {
       return;
@@ -80,17 +80,6 @@ public:
     SpanContext span_context = ExtractImpl(getter, carrier);
     nostd::shared_ptr<Span> sp{new DefaultSpan(span_context)};
     return context.SetValue(kSpanKey, sp);
-  }
-
-  static SpanContext GetCurrentSpan(const context::Context &context)
-  {
-    context::Context ctx(context);
-    context::ContextValue span = ctx.GetValue(kSpanKey);
-    if (nostd::holds_alternative<nostd::shared_ptr<Span>>(span))
-    {
-      return nostd::get<nostd::shared_ptr<Span>>(span).get()->GetContext();
-    }
-    return SpanContext::GetInvalid();
   }
 
   static TraceId GenerateTraceIdFromString(nostd::string_view trace_id)

--- a/api/include/opentelemetry/trace/propagation/jaeger.h
+++ b/api/include/opentelemetry/trace/propagation/jaeger.h
@@ -16,6 +16,7 @@
 
 #include "detail/hex.h"
 #include "detail/string.h"
+#include "detail/context.h"
 #include "opentelemetry/trace/default_span.h"
 #include "opentelemetry/trace/propagation/text_map_propagator.h"
 
@@ -39,7 +40,7 @@ public:
 
   void Inject(Setter setter, T &carrier, const context::Context &context) noexcept override
   {
-    SpanContext span_context = context.GetCurrentSpan();
+    SpanContext span_context = detail::GetCurrentSpan(context);
     if (!span_context.IsValid())
     {
       return;

--- a/api/include/opentelemetry/trace/propagation/jaeger.h
+++ b/api/include/opentelemetry/trace/propagation/jaeger.h
@@ -14,9 +14,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include "detail/context.h"
 #include "detail/hex.h"
 #include "detail/string.h"
-#include "detail/context.h"
 #include "opentelemetry/trace/default_span.h"
 #include "opentelemetry/trace/propagation/text_map_propagator.h"
 
@@ -86,7 +86,8 @@ private:
     const size_t trace_field_count = 4;
     nostd::string_view trace_fields[trace_field_count];
 
-    if (detail::SplitString(trace_identity, ':', trace_fields, trace_field_count) != trace_field_count)
+    if (detail::SplitString(trace_identity, ':', trace_fields, trace_field_count) !=
+        trace_field_count)
     {
       return SpanContext::GetInvalid();
     }

--- a/api/include/opentelemetry/trace/propagation/jaeger.h
+++ b/api/include/opentelemetry/trace/propagation/jaeger.h
@@ -73,9 +73,11 @@ public:
   }
 
 private:
+  static constexpr uint8_t kIsSampled = 0x01;
+
   static TraceFlags GetTraceFlags(uint8_t jaeger_flags)
   {
-    uint8_t sampled = jaeger_flags & 0x01;
+    uint8_t sampled = jaeger_flags & kIsSampled;
     return TraceFlags(sampled);
   }
 

--- a/api/include/opentelemetry/trace/propagation/jaeger.h
+++ b/api/include/opentelemetry/trace/propagation/jaeger.h
@@ -49,17 +49,17 @@ public:
     const size_t span_id_length  = 16;
 
     // trace-id(32):span-id(16):0:debug(2)
-    char trace_state[trace_id_length + span_id_length + 6];
-    span_context.trace_id().ToLowerBase16({&trace_state[0], trace_id_length});
-    trace_state[trace_id_length] = ':';
-    span_context.span_id().ToLowerBase16({&trace_state[trace_id_length + 1], span_id_length});
-    trace_state[trace_id_length + span_id_length + 1] = ':';
-    trace_state[trace_id_length + span_id_length + 2] = '0';
-    trace_state[trace_id_length + span_id_length + 3] = ':';
-    trace_state[trace_id_length + span_id_length + 4] = '0';
-    trace_state[trace_id_length + span_id_length + 5] = span_context.IsSampled() ? '1' : '0';
+    char trace_identity[trace_id_length + span_id_length + 6];
+    span_context.trace_id().ToLowerBase16({&trace_identity[0], trace_id_length});
+    trace_identity[trace_id_length] = ':';
+    span_context.span_id().ToLowerBase16({&trace_identity[trace_id_length + 1], span_id_length});
+    trace_identity[trace_id_length + span_id_length + 1] = ':';
+    trace_identity[trace_id_length + span_id_length + 2] = '0';
+    trace_identity[trace_id_length + span_id_length + 3] = ':';
+    trace_identity[trace_id_length + span_id_length + 4] = '0';
+    trace_identity[trace_id_length + span_id_length + 5] = span_context.IsSampled() ? '1' : '0';
 
-    setter(carrier, kTraceHeader, nostd::string_view(trace_state, sizeof(trace_state)));
+    setter(carrier, kTraceHeader, nostd::string_view(trace_identity, sizeof(trace_identity)));
   }
 
   context::Context Extract(Getter getter,
@@ -80,12 +80,12 @@ private:
 
   static SpanContext ExtractImpl(Getter getter, const T &carrier)
   {
-    nostd::string_view trace_state = getter(carrier, kTraceHeader);
+    nostd::string_view trace_identity = getter(carrier, kTraceHeader);
 
     const size_t trace_field_count = 4;
     nostd::string_view trace_fields[trace_field_count];
 
-    if (detail::SplitString(trace_state, ':', trace_fields, trace_field_count) != trace_field_count)
+    if (detail::SplitString(trace_identity, ':', trace_fields, trace_field_count) != trace_field_count)
     {
       return SpanContext::GetInvalid();
     }

--- a/api/include/opentelemetry/trace/propagation/jaeger.h
+++ b/api/include/opentelemetry/trace/propagation/jaeger.h
@@ -1,0 +1,129 @@
+#pragma once
+
+// Copyright 2021, OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "detail/hex.h"
+#include "detail/string.h"
+#include "opentelemetry/trace/default_span.h"
+#include "opentelemetry/trace/propagation/text_map_propagator.h"
+
+OPENTELEMETRY_BEGIN_NAMESPACE
+namespace trace
+{
+namespace propagation
+{
+
+static const nostd::string_view kTraceHeader = "uber-trace-id";
+
+template <typename T>
+class JaegerPropagator : public TextMapPropagator<T>
+{
+public:
+  using Getter = nostd::string_view (*)(const T &carrier, nostd::string_view trace_type);
+
+  using Setter = void (*)(T &carrier,
+                          nostd::string_view trace_type,
+                          nostd::string_view trace_description);
+
+  void Inject(Setter setter, T &carrier, const context::Context &context) noexcept override
+  {
+    SpanContext span_context = context.GetCurrentSpan();
+    if (!span_context.IsValid())
+    {
+      return;
+    }
+
+    const size_t trace_id_length = 32;
+    const size_t span_id_length  = 16;
+
+    // trace-id(32):span-id(16):0:debug(2)
+    char trace_state[trace_id_length + span_id_length + 6];
+    span_context.trace_id().ToLowerBase16(
+        nostd::span<char, trace_id_length>(&trace_state[0], trace_id_length));
+    trace_state[trace_id_length] = ':';
+    span_context.span_id().ToLowerBase16(
+        nostd::span<char, span_id_length>(&trace_state[trace_id_length + 1], span_id_length));
+    trace_state[trace_id_length + span_id_length + 1] = ':';
+    trace_state[trace_id_length + span_id_length + 2] = '0';
+    trace_state[trace_id_length + span_id_length + 3] = ':';
+    trace_state[trace_id_length + span_id_length + 4] = '0';
+    trace_state[trace_id_length + span_id_length + 5] = span_context.IsSampled() ? '1' : '0';
+
+    setter(carrier, kTraceHeader, trace_state);
+  }
+
+  context::Context Extract(Getter getter,
+                           const T &carrier,
+                           context::Context &context) noexcept override
+  {
+    SpanContext span_context = ExtractImpl(getter, carrier);
+    nostd::shared_ptr<Span> sp{new DefaultSpan(span_context)};
+    return context.SetValue(kSpanKey, sp);
+  }
+
+private:
+  static TraceFlags GetTraceFlags(uint8_t jaeger_flags)
+  {
+    uint8_t sampled = jaeger_flags & 0x01;
+    return TraceFlags(sampled);
+  }
+
+  static SpanContext ExtractImpl(Getter getter, const T &carrier)
+  {
+    nostd::string_view trace_state = getter(carrier, kTraceHeader);
+
+    const size_t trace_field_count = 4;
+    nostd::string_view trace_fields[trace_field_count];
+
+    if (detail::SplitString(trace_state, ':', trace_fields, trace_field_count) != trace_field_count)
+    {
+      return SpanContext::GetInvalid();
+    }
+
+    nostd::string_view trace_id_hex = trace_fields[0];
+    nostd::string_view span_id_hex  = trace_fields[1];
+    nostd::string_view flags_hex    = trace_fields[3];
+
+    if (!detail::IsValidHex(trace_id_hex) || !detail::IsValidHex(span_id_hex) ||
+        !detail::IsValidHex(flags_hex))
+    {
+      return SpanContext::GetInvalid();
+    }
+
+    uint8_t trace_id[16];
+    if (!detail::HexToBinary(trace_id_hex, trace_id, sizeof(trace_id)))
+    {
+      return SpanContext::GetInvalid();
+    }
+
+    uint8_t span_id[8];
+    if (!detail::HexToBinary(span_id_hex, span_id, sizeof(span_id)))
+    {
+      return SpanContext::GetInvalid();
+    }
+
+    uint8_t flags;
+    if (!detail::HexToBinary(flags_hex, &flags, sizeof(flags)))
+    {
+      return SpanContext::GetInvalid();
+    }
+
+    return SpanContext(TraceId(trace_id), SpanId(span_id), GetTraceFlags(flags), true);
+  }
+};
+
+}  // namespace propagation
+}  // namespace trace
+OPENTELEMETRY_END_NAMESPACE

--- a/api/include/opentelemetry/trace/propagation/jaeger.h
+++ b/api/include/opentelemetry/trace/propagation/jaeger.h
@@ -50,18 +50,16 @@ public:
 
     // trace-id(32):span-id(16):0:debug(2)
     char trace_state[trace_id_length + span_id_length + 6];
-    span_context.trace_id().ToLowerBase16(
-        nostd::span<char, trace_id_length>(&trace_state[0], trace_id_length));
+    span_context.trace_id().ToLowerBase16({&trace_state[0], trace_id_length});
     trace_state[trace_id_length] = ':';
-    span_context.span_id().ToLowerBase16(
-        nostd::span<char, span_id_length>(&trace_state[trace_id_length + 1], span_id_length));
+    span_context.span_id().ToLowerBase16({&trace_state[trace_id_length + 1], span_id_length});
     trace_state[trace_id_length + span_id_length + 1] = ':';
     trace_state[trace_id_length + span_id_length + 2] = '0';
     trace_state[trace_id_length + span_id_length + 3] = ':';
     trace_state[trace_id_length + span_id_length + 4] = '0';
     trace_state[trace_id_length + span_id_length + 5] = span_context.IsSampled() ? '1' : '0';
 
-    setter(carrier, kTraceHeader, trace_state);
+    setter(carrier, kTraceHeader, nostd::string_view(trace_state, sizeof(trace_state)));
   }
 
   context::Context Extract(Getter getter,

--- a/api/test/trace/propagation/BUILD
+++ b/api/test/trace/propagation/BUILD
@@ -16,6 +16,7 @@ cc_test(
     srcs = [
         "jaeger_propagation_test.cc",
     ],
+    hdrs = ["util.h"],
     deps = [
         "//api",
         "@com_google_googletest//:gtest_main",

--- a/api/test/trace/propagation/BUILD
+++ b/api/test/trace/propagation/BUILD
@@ -15,8 +15,8 @@ cc_test(
     name = "jaeger_propagation_test",
     srcs = [
         "jaeger_propagation_test.cc",
+        "util.h"
     ],
-    hdrs = ["util.h"],
     deps = [
         "//api",
         "@com_google_googletest//:gtest_main",

--- a/api/test/trace/propagation/BUILD
+++ b/api/test/trace/propagation/BUILD
@@ -10,3 +10,14 @@ cc_test(
         "@com_google_googletest//:gtest_main",
     ],
 )
+
+cc_test(
+    name = "jaeger_propagation_test",
+    srcs = [
+        "jaeger_propagation_test.cc",
+    ],
+    deps = [
+        "//api",
+        "@com_google_googletest//:gtest_main",
+    ],
+)

--- a/api/test/trace/propagation/BUILD
+++ b/api/test/trace/propagation/BUILD
@@ -15,7 +15,7 @@ cc_test(
     name = "jaeger_propagation_test",
     srcs = [
         "jaeger_propagation_test.cc",
-        "util.h"
+        "util.h",
     ],
     deps = [
         "//api",

--- a/api/test/trace/propagation/CMakeLists.txt
+++ b/api/test/trace/propagation/CMakeLists.txt
@@ -1,4 +1,7 @@
-foreach(testname http_text_format_test b3_propagation_test)
+foreach(testname
+  http_text_format_test
+  b3_propagation_test
+  jaeger_propagation_test)
   add_executable(${testname} "${testname}.cc")
   target_link_libraries(
     ${testname} ${GTEST_BOTH_LIBRARIES} ${CORE_RUNTIME_LIBS}

--- a/api/test/trace/propagation/CMakeLists.txt
+++ b/api/test/trace/propagation/CMakeLists.txt
@@ -1,7 +1,5 @@
-foreach(testname
-  http_text_format_test
-  b3_propagation_test
-  jaeger_propagation_test)
+foreach(testname http_text_format_test b3_propagation_test
+                 jaeger_propagation_test)
   add_executable(${testname} "${testname}.cc")
   target_link_libraries(
     ${testname} ${GTEST_BOTH_LIBRARIES} ${CORE_RUNTIME_LIBS}

--- a/api/test/trace/propagation/CMakeLists.txt
+++ b/api/test/trace/propagation/CMakeLists.txt
@@ -1,6 +1,5 @@
 foreach(testname http_text_format_test b3_propagation_test
-                 jaeger_propagation_test
-                 composite_propagator_test)
+                 jaeger_propagation_test composite_propagator_test)
   add_executable(${testname} "${testname}.cc")
   target_link_libraries(
     ${testname} ${GTEST_BOTH_LIBRARIES} ${CORE_RUNTIME_LIBS}

--- a/api/test/trace/propagation/jaeger_propagation_test.cc
+++ b/api/test/trace/propagation/jaeger_propagation_test.cc
@@ -92,7 +92,7 @@ TEST(JaegerPropagatorTest, ExtractValidSpans)
     context::Context ctx1                            = context::Context{};
     context::Context ctx2                            = format.Extract(Getter, carrier, ctx1);
 
-    auto span = ctx2.GetCurrentSpan();
+    auto span = trace::propagation::detail::GetCurrentSpan(ctx2);
     EXPECT_TRUE(span.IsValid());
 
     EXPECT_EQ(Hex(span.trace_id()), test_trace.expected_trace_id);
@@ -120,7 +120,7 @@ TEST(JaegerPropagatorTest, ExctractInvalidSpans)
     context::Context ctx1                            = context::Context{};
     context::Context ctx2                            = format.Extract(Getter, carrier, ctx1);
 
-    auto span = ctx2.GetCurrentSpan();
+    auto span = trace::propagation::detail::GetCurrentSpan(ctx2);
     EXPECT_FALSE(span.IsValid());
   }
 }

--- a/api/test/trace/propagation/jaeger_propagation_test.cc
+++ b/api/test/trace/propagation/jaeger_propagation_test.cc
@@ -1,0 +1,150 @@
+#include "opentelemetry/trace/propagation/jaeger.h"
+#include "opentelemetry/trace/scope.h"
+#include "util.h"
+
+#include <map>
+
+#include <gtest/gtest.h>
+
+using namespace opentelemetry;
+
+static nostd::string_view Getter(const std::map<std::string, std::string> &carrier,
+                                 nostd::string_view trace_type = "uber-trace-id")
+{
+  auto it = carrier.find(std::string(trace_type));
+  if (it != carrier.end())
+  {
+    return nostd::string_view(it->second);
+  }
+  return "";
+}
+
+static void Setter(std::map<std::string, std::string> &carrier,
+                   nostd::string_view trace_type        = "uber-trace-id",
+                   nostd::string_view trace_description = "")
+{
+  carrier[std::string(trace_type)] = std::string(trace_description);
+}
+
+using Propagator = trace::propagation::JaegerPropagator<std::map<std::string, std::string>>;
+
+static Propagator format = Propagator();
+
+TEST(JaegerPropagatorTest, ExtractValidSpans)
+{
+  struct TestTrace
+  {
+    std::string trace_state;
+    std::string expected_trace_id;
+    std::string expected_span_id;
+    bool sampled;
+  };
+
+  std::vector<TestTrace> traces = {
+      {
+          "4bf92f3577b34da6a3ce929d0e0e4736:0102030405060708:0:00",
+          "4bf92f3577b34da6a3ce929d0e0e4736",
+          "0102030405060708",
+          false,
+      },
+      {
+          "4bf92f3577b34da6a3ce929d0e0e4736:0102030405060708:0:ff",
+          "4bf92f3577b34da6a3ce929d0e0e4736",
+          "0102030405060708",
+          true,
+      },
+      {
+          "4bf92f3577b34da6a3ce929d0e0e4736:0102030405060708:0:f",
+          "4bf92f3577b34da6a3ce929d0e0e4736",
+          "0102030405060708",
+          true,
+      },
+      {
+          "a3ce929d0e0e4736:0102030405060708:0:00",
+          "0000000000000000a3ce929d0e0e4736",
+          "0102030405060708",
+          false,
+      },
+      {
+          "A3CE929D0E0E4736:ABCDEFABCDEF1234:0:01",
+          "0000000000000000a3ce929d0e0e4736",
+          "abcdefabcdef1234",
+          true,
+      },
+      {
+          "ff:ABCDEFABCDEF1234:0:0",
+          "000000000000000000000000000000ff",
+          "abcdefabcdef1234",
+          false,
+      },
+      {
+          "4bf92f3577b34da6a3ce929d0e0e4736:0102030405060708:0102030405060708:00",
+          "4bf92f3577b34da6a3ce929d0e0e4736",
+          "0102030405060708",
+          false,
+      },
+
+  };
+
+  for (TestTrace &test_trace : traces)
+  {
+    const std::map<std::string, std::string> carrier = {{"uber-trace-id", test_trace.trace_state}};
+    context::Context ctx1                            = context::Context{};
+    context::Context ctx2                            = format.Extract(Getter, carrier, ctx1);
+
+    auto span = ctx2.GetCurrentSpan();
+    EXPECT_TRUE(span.IsValid());
+
+    EXPECT_EQ(Hex(span.trace_id()), test_trace.expected_trace_id);
+    EXPECT_EQ(Hex(span.span_id()), test_trace.expected_span_id);
+    EXPECT_EQ(span.IsSampled(), test_trace.sampled);
+    EXPECT_EQ(span.IsRemote(), true);
+  }
+}
+
+TEST(JaegerPropagatorTest, ExctractInvalidSpans)
+{
+  std::vector<std::string> traces = {
+      "4bf92f3577b34da6a3ce929d0e0e47344:0102030405060708:0:00",  // too long trace id
+      "4bf92f3577b34da6a3ce929d0e0e4734:01020304050607089:0:00",  // too long span id
+      "4bf92f3577b34da6a3ce929d0e0e4734::0:00",
+      "",
+      "::::",
+      "0:0:0:0",
+      ":abcdef12:0:0",
+  };
+
+  for (auto &trace : traces)
+  {
+    const std::map<std::string, std::string> carrier = {{"uber-trace-id", trace}};
+    context::Context ctx1                            = context::Context{};
+    context::Context ctx2                            = format.Extract(Getter, carrier, ctx1);
+
+    auto span = ctx2.GetCurrentSpan();
+    EXPECT_FALSE(span.IsValid());
+  }
+}
+
+TEST(JaegerPropagatorTest, InjectsContext)
+{
+  constexpr uint8_t buf_span[]  = {1, 2, 3, 4, 5, 6, 7, 8};
+  constexpr uint8_t buf_trace[] = {1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16};
+  trace::SpanContext span_context{trace::TraceId{buf_trace}, trace::SpanId{buf_span},
+                                  trace::TraceFlags{true}, false};
+  nostd::shared_ptr<trace::Span> sp{new trace::DefaultSpan{span_context}};
+  trace::Scope scoped_span{sp};
+
+  std::map<std::string, std::string> headers = {};
+  format.Inject(Setter, headers, context::RuntimeContext::GetCurrent());
+  EXPECT_EQ(headers["uber-trace-id"], "0102030405060708090a0b0c0d0e0f10:0102030405060708:0:01");
+}
+
+TEST(JaegerPropagatorTest, DoNotInjectInvalidContext)
+{
+  std::map<std::string, std::string> carrier = {};
+  context::Context ctx{
+      "current-span",
+      nostd::shared_ptr<trace::Span>(new trace::DefaultSpan(trace::SpanContext::GetInvalid()))};
+  format.Inject(Setter, carrier, ctx);
+  EXPECT_TRUE(carrier.count("uber-trace-id") == 0);
+}

--- a/api/test/trace/propagation/jaeger_propagation_test.cc
+++ b/api/test/trace/propagation/jaeger_propagation_test.cc
@@ -107,6 +107,8 @@ TEST(JaegerPropagatorTest, ExctractInvalidSpans)
   std::vector<std::string> traces = {
       "4bf92f3577b34da6a3ce929d0e0e47344:0102030405060708:0:00",  // too long trace id
       "4bf92f3577b34da6a3ce929d0e0e4734:01020304050607089:0:00",  // too long span id
+      "4bf92f3577b34da6x3ce929d0y0e4734:01020304050607089:0:00",  // invalid trace id character
+      "4bf92f3577b34da6a3ce929d0e0e4734:01020304g50607089:0:00",  // invalid span id character
       "4bf92f3577b34da6a3ce929d0e0e4734::0:00",
       "",
       "::::",

--- a/api/test/trace/propagation/util.h
+++ b/api/test/trace/propagation/util.h
@@ -1,0 +1,11 @@
+#pragma once
+
+#include <string>
+
+template <typename T>
+static std::string Hex(const T &id_item)
+{
+  char buf[T::kSize * 2];
+  id_item.ToLowerBase16(buf);
+  return std::string(buf, sizeof(buf));
+}


### PR DESCRIPTION
Fixes #542 

## Changes

Adds Jaeger trace extraction and injection as specified [here](https://www.jaegertracing.io/docs/1.22/client-libraries/#propagation-format).

Baggage is not part of the PR as it's not supported by the otel-cpp API yet.

Miscellaneous:
* Removed `GetCurrentSpan` duplication from each propagator. Moved it to context's member function.
* Added hex (zero left-padded parse) and string helper (split) functions. These can be used in the b3 and http propagators to simplify code and remove duplication. Not part of this PR though, I will do a follow up if this one gets merged.

For significant contributions please make sure you have completed the following items:

* [x] `CHANGELOG.md` updated for non-trivial changes
* [x] Unit tests have been added
* [x] Changes in public API reviewed