### PR TITLE
Set proto file path based on CMAKE_CURRENT_SOURCE_DIR

### DIFF
--- a/cmake/opentelemetry-proto.cmake
+++ b/cmake/opentelemetry-proto.cmake
@@ -1,4 +1,4 @@
-set(PROTO_PATH "${CMAKE_SOURCE_DIR}/third_party/opentelemetry-proto")
+set(PROTO_PATH "${CMAKE_CURRENT_SOURCE_DIR}/third_party/opentelemetry-proto")
 
 set(COMMON_PROTO "${PROTO_PATH}/opentelemetry/proto/common/v1/common.proto")
 set(RESOURCE_PROTO


### PR DESCRIPTION
We found the issue in our internal integration of opentelemetry-cpp.

If opentelemetry-cpp is included by other projects directly via CMake, `CMAKE_SOURCE_DIR` would be the root of the referencing project instead of opentelemetry-cpp, then the relative path which assumes `CMAKE_SOURCE_DIR` is the root dir of opentelemetry-cpp will be incorrect. This PR fixes the issue by replacing `CMAKE_SOURCE_DIR` by `CMAKE_CURRENT_SOURCE_DIR`.

For significant contributions please make sure you have completed the following items:

* [ ] `CHANGELOG.md` updated for non-trivial changes
* [ ] Unit tests have been added
* [ ] Changes in public API reviewed