### PR TITLE
Zipkin timestamp should be in microseconds according to the api

### DIFF
--- a/exporters/zipkin/src/recordable.cc
+++ b/exporters/zipkin/src/recordable.cc
@@ -191,7 +191,7 @@ void Recordable::SetName(nostd::string_view name) noexcept
 
 void Recordable::SetStartTime(opentelemetry::core::SystemTimestamp start_time) noexcept
 {
-    span_["timestamp"] = std::chrono::duration_cast<std::chrono::microseconds>(start_time.time_since_epoch()).count();
+  span_["timestamp"] = std::chrono::duration_cast<std::chrono::microseconds>(start_time.time_since_epoch()).count();
 }
 
 void Recordable::SetDuration(std::chrono::nanoseconds duration) noexcept

--- a/exporters/zipkin/src/recordable.cc
+++ b/exporters/zipkin/src/recordable.cc
@@ -191,7 +191,8 @@ void Recordable::SetName(nostd::string_view name) noexcept
 
 void Recordable::SetStartTime(opentelemetry::core::SystemTimestamp start_time) noexcept
 {
-  span_["timestamp"] = std::chrono::duration_cast<std::chrono::microseconds>(start_time.time_since_epoch()).count();
+  span_["timestamp"] =
+      std::chrono::duration_cast<std::chrono::microseconds>(start_time.time_since_epoch()).count();
 }
 
 void Recordable::SetDuration(std::chrono::nanoseconds duration) noexcept

--- a/exporters/zipkin/src/recordable.cc
+++ b/exporters/zipkin/src/recordable.cc
@@ -191,7 +191,7 @@ void Recordable::SetName(nostd::string_view name) noexcept
 
 void Recordable::SetStartTime(opentelemetry::core::SystemTimestamp start_time) noexcept
 {
-  span_["timestamp"] = start_time.time_since_epoch().count();
+    span_["timestamp"] = std::chrono::duration_cast<std::chrono::microseconds>(start_time.time_since_epoch()).count();
 }
 
 void Recordable::SetDuration(std::chrono::nanoseconds duration) noexcept


### PR DESCRIPTION
Fixes # (issue)

## Changes

Cast timestamp to microseconds to match the api

For significant contributions please make sure you have completed the following items:

* [ ] `CHANGELOG.md` updated for non-trivial changes
* [ ] Unit tests have been added
* [ ] Changes in public API reviewed