### PR TITLE
Propagate trace_flags from parent span to child span

### DIFF
--- a/sdk/src/trace/span.cc
+++ b/sdk/src/trace/span.cc
@@ -78,8 +78,9 @@ Span::Span(std::shared_ptr<Tracer> &&tracer,
   recordable_->SetName(name);
 
   trace_api::TraceId trace_id;
-  trace_api::SpanId span_id = GenerateRandomSpanId();
-  bool is_parent_span_valid = false;
+  trace_api::SpanId span_id         = GenerateRandomSpanId();
+  trace_api::TraceFlags trace_flags = parent_span_context.trace_flags();
+  bool is_parent_span_valid         = false;
 
   if (parent_span_context.IsValid())
   {
@@ -94,7 +95,7 @@ Span::Span(std::shared_ptr<Tracer> &&tracer,
   }
 
   span_context_ = std::unique_ptr<trace_api::SpanContext>(
-      new trace_api::SpanContext(trace_id, span_id, trace_api::TraceFlags(), false,
+      new trace_api::SpanContext(trace_id, span_id, trace_flags, false,
                                  is_parent_span_valid ? parent_span_context.trace_state()
                                                       : trace_api::TraceState::GetDefault()));
 

--- a/sdk/src/trace/span.h
+++ b/sdk/src/trace/span.h
@@ -15,14 +15,15 @@ namespace trace_api = opentelemetry::trace;
 class Span final : public trace_api::Span
 {
 public:
-  explicit Span(std::shared_ptr<Tracer> &&tracer,
-                std::shared_ptr<SpanProcessor> processor,
-                nostd::string_view name,
-                const opentelemetry::common::KeyValueIterable &attributes,
-                const trace_api::SpanContextKeyValueIterable &links,
-                const trace_api::StartSpanOptions &options,
-                const trace_api::SpanContext &parent_span_context,
-                const opentelemetry::sdk::resource::Resource &resource) noexcept;
+  Span(std::shared_ptr<Tracer> &&tracer,
+       std::shared_ptr<SpanProcessor> processor,
+       nostd::string_view name,
+       const opentelemetry::common::KeyValueIterable &attributes,
+       const trace_api::SpanContextKeyValueIterable &links,
+       const trace_api::StartSpanOptions &options,
+       const trace_api::SpanContext &parent_span_context,
+       const opentelemetry::sdk::resource::Resource &resource,
+       const bool sampled = false) noexcept;
 
   ~Span() override;
 

--- a/sdk/src/trace/tracer.cc
+++ b/sdk/src/trace/tracer.cc
@@ -75,7 +75,7 @@ nostd::shared_ptr<trace_api::Span> Tracer::StartSpan(
   {
     auto span = nostd::shared_ptr<trace_api::Span>{
         new (std::nothrow) Span{this->shared_from_this(), processor_.load(), name, attributes,
-                                links, options, parent, resource_}};
+                                links, options, parent, resource_, true}};
 
     // if the attributes is not nullptr, add attributes to the span.
     if (sampling_result.attributes)

--- a/sdk/test/trace/tracer_test.cc
+++ b/sdk/test/trace/tracer_test.cc
@@ -19,6 +19,7 @@ using opentelemetry::common::KeyValueIterableView;
 using opentelemetry::exporter::memory::InMemorySpanData;
 using opentelemetry::exporter::memory::InMemorySpanExporter;
 using opentelemetry::trace::SpanContext;
+using opentelemetry::trace::TraceFlags;
 
 /**
  * A mock sampler that returns non-empty sampling results attributes.
@@ -559,6 +560,54 @@ TEST(Tracer, ExpectParent)
   EXPECT_EQ("span 1", spandata_first->GetName());
   EXPECT_EQ("span 2", spandata_second->GetName());
   EXPECT_EQ("span 3", spandata_third->GetName());
+
+  EXPECT_EQ(spandata_first->GetSpanId(), spandata_second->GetParentSpanId());
+  EXPECT_EQ(spandata_second->GetSpanId(), spandata_third->GetParentSpanId());
+}
+
+TEST(Tracer, ExpectParentWithValidSpanContext)
+{
+  std::unique_ptr<InMemorySpanExporter> exporter(new InMemorySpanExporter());
+  std::shared_ptr<InMemorySpanData> span_data = exporter->GetData();
+  auto tracer                                 = initTracer(std::move(exporter));
+  auto spans                                  = span_data.get()->GetSpans();
+
+  ASSERT_EQ(0, spans.size());
+
+  // produce valid SpanContext with pseudo span and trace Id.
+  uint8_t span_id_buf[trace_api::SpanId::kSize] = {
+      1,
+  };
+  trace_api::SpanId span_id{span_id_buf};
+  uint8_t trace_id_buf[trace_api::TraceId::kSize] = {
+      2,
+  };
+  trace_api::TraceId trace_id{trace_id_buf};
+
+  trace_api::StartSpanOptions options;
+  options.parent = SpanContext(trace_id, span_id, TraceFlags{TraceFlags::kIsSampled}, true);
+
+  auto span_first = tracer->StartSpan("span 1", options);
+
+  EXPECT_EQ(span_first->GetContext().trace_flags().IsSampled(), true);
+
+  options.parent   = span_first->GetContext();
+  auto span_second = tracer->StartSpan("span 2", options);
+  EXPECT_EQ(span_second->GetContext().trace_flags().IsSampled(), true);
+
+  options.parent  = span_second->GetContext();
+  auto span_third = tracer->StartSpan("span 3", options);
+  EXPECT_EQ(span_third->GetContext().trace_flags().IsSampled(), true);
+
+  span_third->End();
+  span_second->End();
+  span_first->End();
+
+  spans = span_data->GetSpans();
+  ASSERT_EQ(3, spans.size());
+  auto spandata_first  = std::move(spans.at(2));
+  auto spandata_second = std::move(spans.at(1));
+  auto spandata_third  = std::move(spans.at(0));
 
   EXPECT_EQ(spandata_first->GetSpanId(), spandata_second->GetParentSpanId());
   EXPECT_EQ(spandata_second->GetSpanId(), spandata_third->GetParentSpanId());


### PR DESCRIPTION
Fixes #602 

## Changes

`trace_flags` is propagated from parent span to child span at span creation time.

For significant contributions please make sure you have completed the following items:

* [ ] `CHANGELOG.md` updated for non-trivial changes
* [x] Unit tests have been added
* [ ] Changes in public API reviewed