### PR TITLE
Breathe needs to be initialized in parent sphinx project

### DIFF
--- a/docs/public/conf.py
+++ b/docs/public/conf.py
@@ -44,7 +44,14 @@ shutil.copytree(os.path.join(apidir, 'otel_api'), targetdir)
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
 extensions = [
+    "breathe",
 ]
+
+breathe_projects = {
+        "OpenTelemetry C++ API": "../../api/docs/doxyoutput/xml"
+}
+
+breathe_default_project = "OpenTelemetry C++ API"
 
 primary_domain = "cpp"
 


### PR DESCRIPTION
## Changes

This initialized the sphinx `breathe` extension also in the parent sphinx project. This makes sure that documentation for all classes and member methods is included in the generated documentation (https://github.com/open-telemetry/opentelemetry-cpp/pull/595#issuecomment-790124174).