### PR TITLE
Set default service.name if missing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ Increment the:
 * [EXPORTER] Added Zipkin Exporter. ([#471](https://github.com/open-telemetry/opentelemetry-cpp/pull/471))
 * [API] Added Jaeger propagator. ([#599](https://github.com/open-telemetry/opentelemetry-cpp/pull/599))
 * [PROPAGATOR] Added Composite Propagator ([#597](https://github.com/open-telemetry/opentelemetry-cpp/pull/597))
+* [SDK] Add service.name if missing in Resource ([#616](https://github.com/open-telemetry/opentelemetry-cpp/pull/616))
 
 ## [0.2.0] 2021-03-02
 

--- a/sdk/test/resource/resource_test.cc
+++ b/sdk/test/resource/resource_test.cc
@@ -54,7 +54,6 @@ TEST(ResourceTest, create_without_servicename)
 
 TEST(ResourceTest, create_with_servicename)
 {
-
   opentelemetry::sdk::resource::ResourceAttributes expected_attributes = {
       {"version", (uint32_t)1},
       {"cost", 234.23},
@@ -63,7 +62,6 @@ TEST(ResourceTest, create_with_servicename)
       {"telemetry.sdk.version", OPENTELEMETRY_SDK_VERSION},
       {"service.name", "backend"},
   };
-
   opentelemetry::sdk::resource::ResourceAttributes attributes = {
       {"service.name", "backend"}, {"version", (uint32_t)1}, {"cost", 234.23}};
   auto resource            = opentelemetry::sdk::resource::Resource::Create(attributes);
@@ -85,6 +83,26 @@ TEST(ResourceTest, create_with_servicename)
   EXPECT_EQ(received_attributes.size(), expected_attributes.size());  // for missing service.name
 }
 
+TEST(ResourceTest, create_with_emptyatrributes)
+{
+  opentelemetry::sdk::resource::ResourceAttributes expected_attributes = {
+      {"telemetry.sdk.language", "cpp"},
+      {"telemetry.sdk.name", "opentelemetry"},
+      {"telemetry.sdk.version", OPENTELEMETRY_SDK_VERSION},
+      {"service.name", "unknown_service"},
+  };
+  opentelemetry::sdk::resource::ResourceAttributes attributes = {};
+  auto resource            = opentelemetry::sdk::resource::Resource::Create(attributes);
+  auto received_attributes = resource.GetAttributes();
+  for (auto &e : received_attributes)
+  {
+    EXPECT_TRUE(expected_attributes.find(e.first) != expected_attributes.end());
+    if (expected_attributes.find(e.first) != expected_attributes.end())
+      EXPECT_EQ(opentelemetry::nostd::get<std::string>(expected_attributes.find(e.first)->second),
+                opentelemetry::nostd::get<std::string>(e.second));
+  }
+  EXPECT_EQ(received_attributes.size(), expected_attributes.size());  // for missing service.name
+}
 TEST(ResourceTest, Merge)
 {
   TestResource resource1(
@@ -105,6 +123,7 @@ TEST(ResourceTest, Merge)
   }
   EXPECT_EQ(received_attributes.size(), expected_attributes.size());
 }
+
 TEST(ResourceTest, MergeEmptyString)
 {
   TestResource resource1({{"service", "backend"}, {"host", "service-host"}});


### PR DESCRIPTION
Fixes # (issue)

## Changes

The `service.name` attribute of Resource is mandatory and SDK should set the default value if not specified. This attribute is necessary for certain backends to identify the service that produced the spans.
as in [specs](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/resource/semantic_conventions/README.md#service):
* service.name
MUST be the same for all instances of horizontally scaled services. If the value was not specified, SDKs MUST fallback to unknown_service: concatenated with process.executable.name, e.g. `unknown_service:bash`. If process.executable.name is not available, the value MUST be set to `unknown_service`.

For significant contributions please make sure you have completed the following items:

* [X] `CHANGELOG.md` updated for non-trivial changes
* [X] Unit tests have been added
* [X] Changes in public API reviewed