### PR TITLE
move atomic_shared_ptr to sdk common namespace

### DIFF
--- a/sdk/include/opentelemetry/sdk/common/atomic_shared_ptr.h
+++ b/sdk/include/opentelemetry/sdk/common/atomic_shared_ptr.h
@@ -8,6 +8,8 @@
 OPENTELEMETRY_BEGIN_NAMESPACE
 namespace sdk
 {
+namespace common
+{
 /**
  * A wrapper to provide atomic shared pointers.
  *
@@ -52,5 +54,6 @@ private:
   std::shared_ptr<T> ptr_;
 };
 #endif
+}  // namespace common
 }  // namespace sdk
 OPENTELEMETRY_END_NAMESPACE

--- a/sdk/include/opentelemetry/sdk/logs/logger_provider.h
+++ b/sdk/include/opentelemetry/sdk/logs/logger_provider.h
@@ -88,7 +88,7 @@ public:
 
 private:
   // A pointer to the processor stored by this logger provider
-  opentelemetry::sdk::AtomicSharedPtr<LogProcessor> processor_;
+  opentelemetry::sdk::common::AtomicSharedPtr<LogProcessor> processor_;
 
   // A vector of pointers to all the loggers that have been created
   std::unordered_map<std::string, opentelemetry::nostd::shared_ptr<opentelemetry::logs::Logger>>

--- a/sdk/include/opentelemetry/sdk/trace/tracer.h
+++ b/sdk/include/opentelemetry/sdk/trace/tracer.h
@@ -57,7 +57,7 @@ public:
   void CloseWithMicroseconds(uint64_t timeout) noexcept override;
 
 private:
-  opentelemetry::sdk::AtomicSharedPtr<SpanProcessor> processor_;
+  opentelemetry::sdk::common::AtomicSharedPtr<SpanProcessor> processor_;
   const std::shared_ptr<Sampler> sampler_;
   const opentelemetry::sdk::resource::Resource &resource_;
 };

--- a/sdk/include/opentelemetry/sdk/trace/tracer_provider.h
+++ b/sdk/include/opentelemetry/sdk/trace/tracer_provider.h
@@ -72,7 +72,7 @@ public:
   bool ForceFlush(std::chrono::microseconds timeout = (std::chrono::microseconds::max)()) noexcept;
 
 private:
-  opentelemetry::sdk::AtomicSharedPtr<SpanProcessor> processor_;
+  opentelemetry::sdk::common::AtomicSharedPtr<SpanProcessor> processor_;
   std::shared_ptr<opentelemetry::trace::Tracer> tracer_;
   const std::shared_ptr<Sampler> sampler_;
   const opentelemetry::sdk::resource::Resource resource_;


### PR DESCRIPTION
Fixes #589 

## Changes

Slight cleanup, moved `atomic_shared_ptr` into `common` namespace.