### PR TITLE
Use gmock full path for linking in CMake script

### DIFF
--- a/exporters/otlp/CMakeLists.txt
+++ b/exporters/otlp/CMakeLists.txt
@@ -33,15 +33,15 @@ if(BUILD_TESTING)
     TARGET recordable_test
     TEST_PREFIX exporter.otlp.
     TEST_LIST recordable_test)
-  find_library(IS_GMOCK gmock PATH_SUFFIXES lib)
-  if(IS_GMOCK)
+  find_library(GMOCK_LIB gmockx PATH_SUFFIXES lib)
+  if(GMOCK_LIB)
     add_executable(otlp_exporter_test test/otlp_exporter_test.cc)
     target_link_libraries(
       otlp_exporter_test
       ${GTEST_BOTH_LIBRARIES}
       ${CMAKE_THREAD_LIBS_INIT}
       opentelemetry_exporter_otprotocol
-      gmock
+      ${GMOCK_LIB}
       protobuf::libprotobuf
       gRPC::grpc++)
     gtest_add_tests(

--- a/exporters/otlp/CMakeLists.txt
+++ b/exporters/otlp/CMakeLists.txt
@@ -33,7 +33,7 @@ if(BUILD_TESTING)
     TARGET recordable_test
     TEST_PREFIX exporter.otlp.
     TEST_LIST recordable_test)
-  find_library(GMOCK_LIB gmockx PATH_SUFFIXES lib)
+  find_library(GMOCK_LIB gmock PATH_SUFFIXES lib)
   if(GMOCK_LIB)
     add_executable(otlp_exporter_test test/otlp_exporter_test.cc)
     target_link_libraries(


### PR DESCRIPTION
gmock.lib is specified to otlp exporter for linking which cannot be found by linker if it is not in system path. Actually the full path returned by `find_library()` should be used.