### PR TITLE
Fix GMock linkage error on Windows

### DIFF
--- a/exporters/otlp/CMakeLists.txt
+++ b/exporters/otlp/CMakeLists.txt
@@ -33,7 +33,14 @@ if(BUILD_TESTING)
     TARGET recordable_test
     TEST_PREFIX exporter.otlp.
     TEST_LIST recordable_test)
-  find_library(GMOCK_LIB gmock PATH_SUFFIXES lib)
+  if(MSVC)
+    add_definitions(-DGTEST_LINKED_AS_SHARED_LIBRARY=1)
+  endif()
+  if(MSVC AND CMAKE_BUILD_TYPE STREQUAL "Debug")
+    find_library(GMOCK_LIB gmockd PATH_SUFFIXES lib)
+  else()
+    find_library(GMOCK_LIB gmock PATH_SUFFIXES lib)
+  endif()
   if(GMOCK_LIB)
     add_executable(otlp_exporter_test test/otlp_exporter_test.cc)
     target_link_libraries(


### PR DESCRIPTION
@ThomsonTan  - There's a minor regression (build break on Windows) introduced by #630 for Windows-CMake builds:

![image](https://user-images.githubusercontent.com/34072974/112696079-6fd2be00-8e42-11eb-94a1-66bc62a07e65.png)

I found this while rebasing my other PR to latest. We should probably add Windows CMake builds with OTLP testing enabled to the loop (maybe in another PR, this one is just to fix the build break).

## Changes

- vcpkg-installed GMock on Windows for **Debug** build lives in `gmockd.dll` , so searching for `gmock` is morally wrong... 😄 This is idiosyncrasy of Google Test library itself, that it names the two flavors differently and does not provide an easy-to-use CMake config for that.
 
- vcpkg-installed GMock on Windows requires `#define GTEST_LINKED_AS_SHARED_LIBRARY 1`