### PR TITLE
Add opentelemetry.io docs

### DIFF
--- a/website_docs/_index.md
+++ b/website_docs/_index.md
@@ -1,0 +1,28 @@
+---
+title: "C++"
+weight: 11
+description: >
+  A language-specific implementation of OpenTelemetry in C++.
+---
+
+This is the OpenTelemetry for C++ documentation. OpenTelemetry is an
+observability framework -- an API, SDK, and tools that are designed to aid in
+the generation and collection of application telemetry data such as metrics,
+logs, and traces. This documentation is designed to help you understand how to
+get started using OpenTelemetry for C++.
+
+## Status and Releases
+
+The current status of the major functional components for OpenTelemetry C++ is
+as follows:
+
+| Tracing   | Metrics   | Logging             |
+| -------   | -------   | -------             |
+| Pre-Alpha | Pre-Alpha | Not Yet Implemented |
+
+The current release can be found [here](https://github.com/open-telemetry/opentelemetry-cpp/releases)
+
+## Further Reading
+
+- [OpenTelemetry for C++ on GitHub](https://github.com/open-telemetry/opentelemetry-cpp)
+- [Examples](https://github.com/open-telemetry/opentelemetry-cpp/tree/main/examples)


### PR DESCRIPTION
Per open-telemetry/opentelemetry.io#472, we're mirroring the docs content on the website to each SIG. When a release occurs and these docs are updated, please make an issue or PR mirroring them to their appropriate location in the website repo (https://github.com/open-telemetry/opentelemetry.io/tree/main/content/en/docs/cpp).