### PR TITLE
Mention doc update in the release process

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -88,4 +88,6 @@ should include all the release notes from the Changelog for this release.
 
 ## Post Release
 
-Update the OpenTelemetry.io document [here](https://github.com/open-telemetry/opentelemetry.io/tree/main/content/en/docs/cpp) by sending a Pull Request.
+Update the OpenTelemetry.io document
+[here](https://github.com/open-telemetry/opentelemetry.io/tree/main/content/en/docs/cpp)
+by sending a Pull Request.

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -85,3 +85,7 @@ git push --tags --force
 
 Finally create a Release for the new `<new-tag>` on GitHub. The release body
 should include all the release notes from the Changelog for this release.
+
+## Post Release
+
+Update the OpenTelemetry.io document [here](https://github.com/open-telemetry/opentelemetry.io/tree/main/content/en/docs/cpp) by sending a Pull Request.


### PR DESCRIPTION
Related to #636.

## Changes

Added a small section to remind the maintainers to update the opentelemetry.io docs.

For significant contributions please make sure you have completed the following items:

* [ ] `CHANGELOG.md` updated for non-trivial changes
* [ ] Unit tests have been added
* [ ] Changes in public API reviewed