### PR TITLE
Fix 32bit build error

### DIFF
--- a/api/test/context/runtime_context_test.cc
+++ b/api/test/context/runtime_context_test.cc
@@ -108,7 +108,7 @@ TEST(RuntimeContextTest, DetachOutOfOrder)
   std::vector<context::Context> contexts;
   for (auto i : indices)
   {
-    contexts.push_back(context::Context("index", i));
+    contexts.push_back(context::Context("index", (int64_t)i));
   }
 
   do


### PR DESCRIPTION
Fixes build issue on 32bit linux builds (no github issue, due to trivial fix)

## Changes

One-liner, see code, the rest of this template seems irrelevant given how trivial this is, so I've removed it

## Context

I was unable to build a 32bit linux build due to the following error:

```
2021/03/31 04:40:14 ERROR bldroot_builddeb(100211): //opt/bb/libexec/build-base/g++ -D_GLIBCXX_USE_CXX11_ABI=0 -march=westmere -m64 -g -O2 -fno-strict-aliasing -fasynchronous-unwind-tables -Wl,--enable-new-dtags -Wl,--gc-sections -Wl,-uplink_timestamp___ -rdynamic CMakeFiles/dynami
c_load_test.dir/dynamic_load_test.cc.o -o dynamic_load_test  -Wl,-rpath,/opt/SUNWspro12/lib/amd64:/opt/SUNWspro12/rtlibs/amd64:/usr/lib64:/lib64:.:/bb/bin/so/64/NS02:/bb/bin/so/64:/bb/bin //opt/bb/lib64/libgtest.a //opt/bb/lib64/libgtest_main.a -lpthread -ldl 
2021/03/31 04:40:14 ERROR bldroot_builddeb(100211): /tmp/opentelemetry-0.3.0/api/test/context/runtime_context_test.cc: In member function 'virtual void RuntimeContextTest_DetachOutOfOrder_Test::TestBody()':
2021/03/31 04:40:14 ERROR bldroot_builddeb(100211): /tmp/opentelemetry-0.3.0/api/test/context/runtime_context_test.cc:111:51: error: no matching function for call to 'opentelemetry::v0::context::Context::Context(const char [6], unsigned int&)'
2021/03/31 04:40:14 ERROR bldroot_builddeb(100211):      contexts.push_back(context::Context("index", i));
2021/03/31 04:40:14 ERROR bldroot_builddeb(100211):                                                    ^
2021/03/31 04:40:14 ERROR bldroot_builddeb(100211): In file included from /tmp/opentelemetry-0.3.0/api/include/opentelemetry/context/runtime_context.h:3:0,
2021/03/31 04:40:14 ERROR bldroot_builddeb(100211):                  from /tmp/opentelemetry-0.3.0/api/test/context/runtime_context_test.cc:1:
2021/03/31 04:40:14 ERROR bldroot_builddeb(100211): /tmp/opentelemetry-0.3.0/api/include/opentelemetry/context/context.h:31:3: note: candidate: opentelemetry::v0::context::Context::Context(opentelemetry::v0::nostd::string_view, opentelemetry::v0::context::ContextValue)
2021/03/31 04:40:14 ERROR bldroot_builddeb(100211):    Context(nostd::string_view key, ContextValue value)
2021/03/31 04:40:14 ERROR bldroot_builddeb(100211):    ^~~~~~~
2021/03/31 04:40:14 ERROR bldroot_builddeb(100211): /tmp/opentelemetry-0.3.0/api/include/opentelemetry/context/context.h:31:3: note:   no known conversion for argument 2 from 'unsigned int' to 'opentelemetry::v0::context::ContextValue {aka opentelemetry::v0::nostd::variant<bool, lo
ng long int, long long unsigned int, double, opentelemetry::v0::nostd::shared_ptr<opentelemetry::v0::trace::Span>, opentelemetry::v0::nostd::shared_ptr<opentelemetry::v0::trace::SpanContext> >}'
2021/03/31 04:40:14 ERROR bldroot_builddeb(100211): /tmp/opentelemetry-0.3.0/api/include/opentelemetry/context/context.h:24:3: note: candidate: template<class T> opentelemetry::v0::context::Context::Context(const T&)
2021/03/31 04:40:14 ERROR bldroot_builddeb(100211):    Context(const T &keys_and_values)
2021/03/31 04:40:14 ERROR bldroot_builddeb(100211):    ^~~~~~~
2021/03/31 04:40:14 ERROR bldroot_builddeb(100211): /tmp/opentelemetry-0.3.0/api/include/opentelemetry/context/context.h:24:3: note:   template argument deduction/substitution failed:
2021/03/31 04:40:14 ERROR bldroot_builddeb(100211): /tmp/opentelemetry-0.3.0/api/test/context/runtime_context_test.cc:111:51: note:   candidate expects 1 argument, 2 provided
2021/03/31 04:40:14 ERROR bldroot_builddeb(100211):      contexts.push_back(context::Context("index", i));
2021/03/31 04:40:14 ERROR bldroot_builddeb(100211):                                                    ^
2021/03/31 04:40:14 ERROR bldroot_builddeb(100211): In file included from /tmp/opentelemetry-0.3.0/api/include/opentelemetry/context/runtime_context.h:3:0,
2021/03/31 04:40:14 ERROR bldroot_builddeb(100211):                  from /tmp/opentelemetry-0.3.0/api/test/context/runtime_context_test.cc:1:
2021/03/31 04:40:14 ERROR bldroot_builddeb(100211): /tmp/opentelemetry-0.3.0/api/include/opentelemetry/context/context.h:20:3: note: candidate: opentelemetry::v0::context::Context::Context()
2021/03/31 04:40:14 ERROR bldroot_builddeb(100211):    Context() = default;
2021/03/31 04:40:14 ERROR bldroot_builddeb(100211):    ^~~~~~~
2021/03/31 04:40:14 ERROR bldroot_builddeb(100211): /tmp/opentelemetry-0.3.0/api/include/opentelemetry/context/context.h:20:3: note:   candidate expects 0 arguments, 2 provided
2021/03/31 04:40:14 ERROR bldroot_builddeb(100211): /tmp/opentelemetry-0.3.0/api/include/opentelemetry/context/context.h:16:7: note: candidate: opentelemetry::v0::context::Context::Context(const opentelemetry::v0::context::Context&)
2021/03/31 04:40:14 ERROR bldroot_builddeb(100211):  class Context
2021/03/31 04:40:14 ERROR bldroot_builddeb(100211):        ^~~~~~~
2021/03/31 04:40:14 ERROR bldroot_builddeb(100211): /tmp/opentelemetry-0.3.0/api/include/opentelemetry/context/context.h:16:7: note:   candidate expects 1 argument, 2 provided
2021/03/31 04:40:14 ERROR bldroot_builddeb(100211): /tmp/opentelemetry-0.3.0/api/include/opentelemetry/context/context.h:16:7: note: candidate: opentelemetry::v0::context::Context::Context(opentelemetry::v0::context::Context&&)
2021/03/31 04:40:14 ERROR bldroot_builddeb(100211): /tmp/opentelemetry-0.3.0/api/include/opentelemetry/context/context.h:16:7: note:   candidate expects 1 argument, 2 provided
```

I didn't investigate in detail, but gut feel suggests that the instantiation of a variant type with int64 types was failed to be instantiated from a int type which on 32bit is different but normally the same for 64bit builds. This was already done in different parts of this file, e.g. https://github.com/open-telemetry/opentelemetry-cpp/compare/main...eyakimov-bbg:main#diff-3941b3fea9097fe328dde2217095b66e726faf59fad861f02f23390d0cb47bb5L95