### PR TITLE
Remove unused variable in http server example

### DIFF
--- a/examples/http/server.cc
+++ b/examples/http/server.cc
@@ -50,7 +50,6 @@ public:
 int main(int argc, char *argv[])
 {
   initTracer();
-  uint16_t port;
 
   // The port the validation service listens to can be specified via the command line.
   if (argc > 1)


### PR DESCRIPTION
Remove the unused `port` variable.

For significant contributions please make sure you have completed the following items:

* [ ] `CHANGELOG.md` updated for non-trivial changes
* [ ] Unit tests have been added
* [ ] Changes in public API reviewed