### PR TITLE
Remove warnings of protobuf

### DIFF
--- a/cmake/opentelemetry-proto.cmake
+++ b/cmake/opentelemetry-proto.cmake
@@ -1,3 +1,86 @@
+macro(check_append_cxx_compiler_flag OUTPUT_VAR)
+  foreach(CHECK_FLAG ${ARGN})
+    check_cxx_compiler_flag(${CHECK_FLAG}
+                            "check_cxx_compiler_flag_${CHECK_FLAG}")
+    if(check_cxx_compiler_flag_${CHECK_FLAG})
+      list(APPEND ${OUTPUT_VAR} ${CHECK_FLAG})
+    endif()
+  endforeach()
+endmacro()
+
+if(NOT PATCH_PROTOBUF_SOURCES_OPTIONS_SET)
+  if(MSVC)
+    unset(PATCH_PROTOBUF_SOURCES_OPTIONS CACHE)
+    set(PATCH_PROTOBUF_SOURCES_OPTIONS /wd4244 /wd4251 /wd4267 /wd4309)
+
+    if(MSVC_VERSION GREATER_EQUAL 1922)
+      # see
+      # https://docs.microsoft.com/en-us/cpp/overview/cpp-conformance-improvements?view=vs-2019#improvements_162
+      # for detail
+      list(APPEND PATCH_PROTOBUF_SOURCES_OPTIONS /wd5054)
+    endif()
+
+    if(MSVC_VERSION GREATER_EQUAL 1925)
+      list(APPEND PATCH_PROTOBUF_SOURCES_OPTIONS /wd4996)
+    endif()
+
+    if(MSVC_VERSION LESS 1910)
+      list(APPEND PATCH_PROTOBUF_SOURCES_OPTIONS /wd4800)
+    endif()
+  else()
+    unset(PATCH_PROTOBUF_SOURCES_OPTIONS CACHE)
+    include(CheckCXXCompilerFlag)
+    check_append_cxx_compiler_flag(
+      PATCH_PROTOBUF_SOURCES_OPTIONS -Wno-type-limits
+      -Wno-deprecated-declarations -Wno-unused-parameter)
+  endif()
+  set(PATCH_PROTOBUF_SOURCES_OPTIONS_SET TRUE)
+  if(PATCH_PROTOBUF_SOURCES_OPTIONS)
+    set(PATCH_PROTOBUF_SOURCES_OPTIONS
+        ${PATCH_PROTOBUF_SOURCES_OPTIONS}
+        CACHE INTERNAL
+              "Options to disable warning of generated protobuf sources" FORCE)
+  endif()
+endif()
+
+function(patch_protobuf_sources)
+  if(PATCH_PROTOBUF_SOURCES_OPTIONS)
+    foreach(PROTO_SRC ${ARGN})
+      unset(PROTO_SRC_OPTIONS)
+      get_source_file_property(PROTO_SRC_OPTIONS ${PROTO_SRC} COMPILE_OPTIONS)
+      if(PROTO_SRC_OPTIONS)
+        list(APPEND PROTO_SRC_OPTIONS ${PATCH_PROTOBUF_SOURCES_OPTIONS})
+      else()
+        set(PROTO_SRC_OPTIONS ${PATCH_PROTOBUF_SOURCES_OPTIONS})
+      endif()
+
+      set_source_files_properties(
+        ${PROTO_SRC} PROPERTIES COMPILE_OPTIONS "${PROTO_SRC_OPTIONS}")
+    endforeach()
+    unset(PROTO_SRC)
+    unset(PROTO_SRC_OPTIONS)
+  endif()
+endfunction()
+
+function(patch_protobuf_targets)
+  if(PATCH_PROTOBUF_SOURCES_OPTIONS)
+    foreach(PROTO_TARGET ${ARGN})
+      unset(PROTO_TARGET_OPTIONS)
+      get_target_property(PROTO_TARGET_OPTIONS ${PROTO_TARGET} COMPILE_OPTIONS)
+      if(PROTO_TARGET_OPTIONS)
+        list(APPEND PROTO_TARGET_OPTIONS ${PATCH_PROTOBUF_SOURCES_OPTIONS})
+      else()
+        set(PROTO_TARGET_OPTIONS ${PATCH_PROTOBUF_SOURCES_OPTIONS})
+      endif()
+
+      set_target_properties(
+        ${PROTO_TARGET} PROPERTIES COMPILE_OPTIONS "${PROTO_TARGET_OPTIONS}")
+    endforeach()
+    unset(PROTO_TARGET)
+    unset(PROTO_TARGET_OPTIONS)
+  endif()
+endfunction()
+
 set(PROTO_PATH "${CMAKE_CURRENT_SOURCE_DIR}/third_party/opentelemetry-proto")
 
 set(COMMON_PROTO "${PROTO_PATH}/opentelemetry/proto/common/v1/common.proto")
@@ -132,6 +215,7 @@ add_library(
   ${METRICS_SERVICE_GRPC_PB_CPP_FILE})
 
 set_target_properties(opentelemetry_proto PROPERTIES EXPORT_NAME proto)
+patch_protobuf_targets(opentelemetry_proto)
 
 install(
   TARGETS opentelemetry_proto
@@ -151,8 +235,7 @@ if(TARGET protobuf::libprotobuf)
 else() # cmake 3.8 or lower
   target_include_directories(opentelemetry_proto
                              PUBLIC ${Protobuf_INCLUDE_DIRS})
-  target_link_libraries(opentelemetry_proto
-                        INTERFACE ${Protobuf_LIBRARIES})
+  target_link_libraries(opentelemetry_proto INTERFACE ${Protobuf_LIBRARIES})
 endif()
 
 if(BUILD_SHARED_LIBS)

--- a/exporters/otlp/BUILD
+++ b/exporters/otlp/BUILD
@@ -22,6 +22,8 @@ cc_library(
         "src/recordable.cc",
     ],
     hdrs = [
+        "include/opentelemetry/exporters/otlp/protobuf_include_prefix.h",
+        "include/opentelemetry/exporters/otlp/protobuf_include_suffix.h",
         "include/opentelemetry/exporters/otlp/recordable.h",
     ],
     strip_include_prefix = "include",
@@ -37,6 +39,8 @@ cc_library(
         "src/otlp_exporter.cc",
     ],
     hdrs = [
+        "include/opentelemetry/exporters/otlp/protobuf_include_prefix.h",
+        "include/opentelemetry/exporters/otlp/protobuf_include_suffix.h",
         "include/opentelemetry/exporters/otlp/otlp_exporter.h",
     ],
     strip_include_prefix = "include",

--- a/exporters/otlp/BUILD
+++ b/exporters/otlp/BUILD
@@ -39,9 +39,9 @@ cc_library(
         "src/otlp_exporter.cc",
     ],
     hdrs = [
+        "include/opentelemetry/exporters/otlp/otlp_exporter.h",
         "include/opentelemetry/exporters/otlp/protobuf_include_prefix.h",
         "include/opentelemetry/exporters/otlp/protobuf_include_suffix.h",
-        "include/opentelemetry/exporters/otlp/otlp_exporter.h",
     ],
     strip_include_prefix = "include",
     deps = [

--- a/exporters/otlp/include/opentelemetry/exporters/otlp/otlp_exporter.h
+++ b/exporters/otlp/include/opentelemetry/exporters/otlp/otlp_exporter.h
@@ -1,6 +1,11 @@
 #pragma once
 
+#include "opentelemetry/exporters/otlp/protobuf_include_prefix.h"
+
 #include "opentelemetry/proto/collector/trace/v1/trace_service.grpc.pb.h"
+
+#include "opentelemetry/exporters/otlp/protobuf_include_suffix.h"
+
 #include "opentelemetry/sdk/trace/exporter.h"
 
 OPENTELEMETRY_BEGIN_NAMESPACE

--- a/exporters/otlp/include/opentelemetry/exporters/otlp/protobuf_include_prefix.h
+++ b/exporters/otlp/include/opentelemetry/exporters/otlp/protobuf_include_prefix.h
@@ -1,0 +1,32 @@
+// This file may be include multiple times, do not add #pragma once here
+
+#if defined(_MSC_VER)
+#  pragma warning(push)
+#  if ((defined(__cplusplus) && __cplusplus >= 201704L) || \
+       (defined(_MSVC_LANG) && _MSVC_LANG >= 201704L))
+#    pragma warning(disable : 4996)
+#    pragma warning(disable : 4309)
+#    if _MSC_VER >= 1922
+#      pragma warning(disable : 5054)
+#    endif
+#  endif
+
+#  if _MSC_VER < 1910
+#    pragma warning(disable : 4800)
+#  endif
+#  pragma warning(disable : 4244)
+#  pragma warning(disable : 4251)
+#  pragma warning(disable : 4267)
+#endif
+
+#if defined(__GNUC__) && !defined(__clang__) && !defined(__apple_build_version__)
+#  if (__GNUC__ * 100 + __GNUC_MINOR__ * 10) >= 460
+#    pragma GCC diagnostic push
+#  endif
+#  pragma GCC diagnostic ignored "-Wunused-parameter"
+#  pragma GCC diagnostic ignored "-Wtype-limits"
+#elif defined(__clang__) || defined(__apple_build_version__)
+#  pragma clang diagnostic push
+#  pragma clang diagnostic ignored "-Wunused-parameter"
+#  pragma clang diagnostic ignored "-Wtype-limits"
+#endif

--- a/exporters/otlp/include/opentelemetry/exporters/otlp/protobuf_include_suffix.h
+++ b/exporters/otlp/include/opentelemetry/exporters/otlp/protobuf_include_suffix.h
@@ -1,0 +1,13 @@
+// This file may be include multiple times, do not add #pragma once here
+
+#if defined(__GNUC__) && !defined(__clang__) && !defined(__apple_build_version__)
+#  if (__GNUC__ * 100 + __GNUC_MINOR__ * 10) >= 460
+#    pragma GCC diagnostic pop
+#  endif
+#elif defined(__clang__) || defined(__apple_build_version__)
+#  pragma clang diagnostic pop
+#endif
+
+#if defined(_MSC_VER)
+#  pragma warning(pop)
+#endif

--- a/exporters/otlp/include/opentelemetry/exporters/otlp/recordable.h
+++ b/exporters/otlp/include/opentelemetry/exporters/otlp/recordable.h
@@ -1,6 +1,11 @@
 #pragma once
 
+#include "opentelemetry/exporters/otlp/protobuf_include_prefix.h"
+
 #include "opentelemetry/proto/trace/v1/trace.pb.h"
+
+#include "opentelemetry/exporters/otlp/protobuf_include_suffix.h"
+
 #include "opentelemetry/sdk/trace/recordable.h"
 #include "opentelemetry/version.h"
 

--- a/exporters/otlp/test/otlp_exporter_test.cc
+++ b/exporters/otlp/test/otlp_exporter_test.cc
@@ -1,5 +1,11 @@
 #include "opentelemetry/exporters/otlp/otlp_exporter.h"
+
+#include "opentelemetry/exporters/otlp/protobuf_include_prefix.h"
+
 #include "opentelemetry/proto/collector/trace/v1/trace_service_mock.grpc.pb.h"
+
+#include "opentelemetry/exporters/otlp/protobuf_include_suffix.h"
+
 #include "opentelemetry/sdk/trace/simple_processor.h"
 #include "opentelemetry/sdk/trace/tracer_provider.h"
 #include "opentelemetry/trace/provider.h"

--- a/exporters/otlp/test/recordable_test.cc
+++ b/exporters/otlp/test/recordable_test.cc
@@ -212,7 +212,7 @@ struct IntAttributeTest : public testing::Test
 };
 
 using IntTypes = testing::Types<int, int64_t, unsigned int, uint64_t>;
-TYPED_TEST_CASE(IntAttributeTest, IntTypes);
+TYPED_TEST_SUITE(IntAttributeTest, IntTypes);
 
 TYPED_TEST(IntAttributeTest, SetIntSingleAttribute)
 {


### PR DESCRIPTION
Related to #249 

## Changes

Remove warnings of protobuf. There is no functional change.

For significant contributions please make sure you have completed the following items:

* [x] `CHANGELOG.md` updated for non-trivial changes
* [x] Unit tests have been added
* [x] Changes in public API reviewed