### PR TITLE
Add SpanContext accessor SpanDataLink

### DIFF
--- a/sdk/include/opentelemetry/sdk/trace/span_data.h
+++ b/sdk/include/opentelemetry/sdk/trace/span_data.h
@@ -61,7 +61,6 @@ private:
 
 /**
  * Class for storing links in SpanData.
- * TODO: Add getters for trace_id, span_id and trace_state when these are supported by SpanContext
  */
 class SpanDataLink
 {
@@ -79,6 +78,12 @@ public:
   {
     return attribute_map_.GetAttributes();
   }
+
+  /**
+   * Get the span context for this link
+   * @return the span context for this link
+   */
+  const opentelemetry::trace::SpanContext &GetSpanContext() const noexcept { return span_context_; }
 
 private:
   opentelemetry::trace::SpanContext span_context_;

--- a/sdk/test/trace/span_data_test.cc
+++ b/sdk/test/trace/span_data_test.cc
@@ -87,10 +87,24 @@ TEST(SpanData, Links)
   std::map<std::string, int64_t> attributes = {
       {keys[0], values[0]}, {keys[1], values[1]}, {keys[2], values[2]}};
 
+  // produce valid SpanContext with pseudo span and trace Id.
+  uint8_t span_id_buf[opentelemetry::trace::SpanId::kSize] = {
+      1,
+  };
+  opentelemetry::trace::SpanId span_id{span_id_buf};
+  uint8_t trace_id_buf[opentelemetry::trace::TraceId::kSize] = {
+      2,
+  };
+  opentelemetry::trace::TraceId trace_id{trace_id_buf};
+  const auto span_context = opentelemetry::trace::SpanContext(
+      trace_id, span_id,
+      opentelemetry::trace::TraceFlags{opentelemetry::trace::TraceFlags::kIsSampled}, true);
+
   data.AddLink(
-      opentelemetry::trace::SpanContext(false, false),
+      span_context,
       opentelemetry::common::KeyValueIterableView<std::map<std::string, int64_t>>(attributes));
 
+  EXPECT_EQ(data.GetLinks().at(0).GetSpanContext(), span_context);
   for (int i = 0; i < kNumAttributes; i++)
   {
     EXPECT_EQ(opentelemetry::nostd::get<int64_t>(data.GetLinks().at(0).GetAttributes().at(keys[i])),


### PR DESCRIPTION
Fixes #657

## Changes

Although the context was stored, it was not accessible. I've extended
tests to also validate that a valid context has been passed.

* [x] Unit tests have been added