### PR TITLE
Add SpanContext (and TraceState) to Recordable

### DIFF
--- a/api/include/opentelemetry/common/kv_properties.h
+++ b/api/include/opentelemetry/common/kv_properties.h
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#pragma once
+
 #include "opentelemetry/common/key_value_iterable_view.h"
 #include "opentelemetry/common/string_util.h"
 #include "opentelemetry/nostd/function_ref.h"

--- a/exporters/ostream/src/span_exporter.cc
+++ b/exporters/ostream/src/span_exporter.cc
@@ -64,6 +64,7 @@ sdk::common::ExportResult OStreamSpanExporter::Export(
             << "\n  name          : " << span->GetName()
             << "\n  trace_id      : " << std::string(trace_id, 32)
             << "\n  span_id       : " << std::string(span_id, 16)
+            << "\n  tracestate    : " << span->GetSpanContext().trace_state()->ToHeader()
             << "\n  parent_span_id: " << std::string(parent_span_id, 16)
             << "\n  start         : " << span->GetStartTime().time_since_epoch().count()
             << "\n  duration      : " << span->GetDuration().count()

--- a/exporters/ostream/test/ostream_span_test.cc
+++ b/exporters/ostream/test/ostream_span_test.cc
@@ -48,6 +48,7 @@ constexpr const char *kDefaultSpanPrinted =
     "  name          : \n"
     "  trace_id      : 00000000000000000000000000000000\n"
     "  span_id       : 0000000000000000\n"
+    "  tracestate    : \n"
     "  parent_span_id: 0000000000000000\n"
     "  start         : 0\n"
     "  duration      : 0\n"
@@ -85,16 +86,21 @@ TEST(OStreamSpanExporter, PrintSpanWithBasicFields)
 
   auto recordable = processor->MakeRecordable();
 
+  constexpr uint8_t trace_id_buf[]       = {1, 2, 3, 4, 5, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7, 8};
+  constexpr uint8_t span_id_buf[]        = {1, 2, 3, 4, 5, 6, 7, 8};
+  constexpr uint8_t parent_span_id_buf[] = {8, 7, 6, 5, 4, 3, 2, 1};
+  opentelemetry::trace::TraceId trace_id{trace_id_buf};
+  opentelemetry::trace::SpanId span_id{span_id_buf};
+  opentelemetry::trace::SpanId parent_span_id{parent_span_id_buf};
+  const auto trace_state = opentelemetry::trace::TraceState::GetDefault()->Set("state1", "value");
+  const opentelemetry::trace::SpanContext span_context{
+      trace_id, span_id,
+      opentelemetry::trace::TraceFlags{opentelemetry::trace::TraceFlags::kIsSampled}, true,
+      trace_state};
+
+  recordable->SetIdentity(span_context, parent_span_id);
   recordable->SetName("Test Span");
   opentelemetry::core::SystemTimestamp now(std::chrono::system_clock::now());
-
-  constexpr uint8_t trace_id_buf[] = {1, 2, 3, 4, 5, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7, 8};
-  opentelemetry::trace::TraceId t_id(trace_id_buf);
-  constexpr uint8_t span_id_buf[] = {1, 2, 3, 4, 5, 6, 7, 8};
-  opentelemetry::trace::SpanId s_id(span_id_buf);
-
-  recordable->SetIds(t_id, s_id, s_id);
-
   recordable->SetStartTime(now);
   recordable->SetDuration(std::chrono::nanoseconds(100));
   recordable->SetStatus(opentelemetry::trace::StatusCode::kOk, "Test Description");
@@ -109,7 +115,8 @@ TEST(OStreamSpanExporter, PrintSpanWithBasicFields)
       "  name          : Test Span\n"
       "  trace_id      : 01020304050607080102030405060708\n"
       "  span_id       : 0102030405060708\n"
-      "  parent_span_id: 0102030405060708\n"
+      "  tracestate    : state1=value\n"
+      "  parent_span_id: 0807060504030201\n"
       "  start         : " +
       start +
       "\n"
@@ -143,6 +150,7 @@ TEST(OStreamSpanExporter, PrintSpanWithAttribute)
       "  name          : \n"
       "  trace_id      : 00000000000000000000000000000000\n"
       "  span_id       : 0000000000000000\n"
+      "  tracestate    : \n"
       "  parent_span_id: 0000000000000000\n"
       "  start         : 0\n"
       "  duration      : 0\n"
@@ -178,6 +186,7 @@ TEST(OStreamSpanExporter, PrintSpanWithArrayAttribute)
       "  name          : \n"
       "  trace_id      : 00000000000000000000000000000000\n"
       "  span_id       : 0000000000000000\n"
+      "  tracestate    : \n"
       "  parent_span_id: 0000000000000000\n"
       "  start         : 0\n"
       "  duration      : 0\n"
@@ -219,6 +228,7 @@ TEST(OStreamSpanExporter, PrintSpanWithEvents)
       "  name          : \n"
       "  trace_id      : 00000000000000000000000000000000\n"
       "  span_id       : 0000000000000000\n"
+      "  tracestate    : \n"
       "  parent_span_id: 0000000000000000\n"
       "  start         : 0\n"
       "  duration      : 0\n"
@@ -291,6 +301,7 @@ TEST(OStreamSpanExporter, PrintSpanWithLinks)
       "  name          : \n"
       "  trace_id      : 00000000000000000000000000000000\n"
       "  span_id       : 0000000000000000\n"
+      "  tracestate    : \n"
       "  parent_span_id: 0000000000000000\n"
       "  start         : 0\n"
       "  duration      : 0\n"

--- a/exporters/otlp/include/opentelemetry/exporters/otlp/recordable.h
+++ b/exporters/otlp/include/opentelemetry/exporters/otlp/recordable.h
@@ -19,9 +19,8 @@ class Recordable final : public sdk::trace::Recordable
 public:
   const proto::trace::v1::Span &span() const noexcept { return span_; }
 
-  void SetIds(trace::TraceId trace_id,
-              trace::SpanId span_id,
-              trace::SpanId parent_span_id) noexcept override;
+  void SetIdentity(const opentelemetry::trace::SpanContext &span_context,
+                   opentelemetry::trace::SpanId parent_span_id) noexcept override;
 
   void SetAttribute(nostd::string_view key,
                     const opentelemetry::common::AttributeValue &value) noexcept override;

--- a/exporters/otlp/src/recordable.cc
+++ b/exporters/otlp/src/recordable.cc
@@ -17,14 +17,16 @@ const int kAttributeValueSize = 15;
 const int kAttributeValueSize = 14;
 #endif
 
-void Recordable::SetIds(trace::TraceId trace_id,
-                        trace::SpanId span_id,
-                        trace::SpanId parent_span_id) noexcept
+void Recordable::SetIdentity(const opentelemetry::trace::SpanContext &span_context,
+                             opentelemetry::trace::SpanId parent_span_id) noexcept
 {
-  span_.set_trace_id(reinterpret_cast<const char *>(trace_id.Id().data()), trace::TraceId::kSize);
-  span_.set_span_id(reinterpret_cast<const char *>(span_id.Id().data()), trace::SpanId::kSize);
+  span_.set_trace_id(reinterpret_cast<const char *>(span_context.trace_id().Id().data()),
+                     trace::TraceId::kSize);
+  span_.set_span_id(reinterpret_cast<const char *>(span_context.span_id().Id().data()),
+                    trace::SpanId::kSize);
   span_.set_parent_span_id(reinterpret_cast<const char *>(parent_span_id.Id().data()),
                            trace::SpanId::kSize);
+  span_.set_trace_state(span_context.trace_state()->ToHeader());
 }
 
 void PopulateAttribute(opentelemetry::proto::common::v1::KeyValue *attribute,

--- a/exporters/otlp/test/otlp_exporter_benchmark.cc
+++ b/exporters/otlp/test/otlp_exporter_benchmark.cc
@@ -19,6 +19,11 @@ const trace::SpanId kSpanId(std::array<const uint8_t, trace::SpanId::kSize>({0, 
                                                                              2}));
 const trace::SpanId kParentSpanId(std::array<const uint8_t, trace::SpanId::kSize>({0, 0, 0, 0, 0, 0,
                                                                                    0, 3}));
+const auto kTraceState = opentelemetry::trace::TraceState::GetDefault() -> Set("key1", "value");
+const opentelemetry::trace::SpanContext kSpanContext{
+    kTraceId, kSpanId,
+    opentelemetry::trace::TraceFlags{opentelemetry::trace::TraceFlags::kIsSampled}, true,
+    kTraceState};
 
 // ----------------------- Helper classes and functions ------------------------
 
@@ -80,7 +85,7 @@ void CreateSparseSpans(std::array<std::unique_ptr<sdk::trace::Recordable>, kBatc
   {
     auto recordable = std::unique_ptr<sdk::trace::Recordable>(new Recordable);
 
-    recordable->SetIds(kTraceId, kSpanId, kParentSpanId);
+    recordable->SetIdentity(kSpanContext, kParentSpanId);
     recordable->SetName("TestSpan");
     recordable->SetStartTime(core::SystemTimestamp(std::chrono::system_clock::now()));
     recordable->SetDuration(std::chrono::nanoseconds(10));
@@ -96,7 +101,7 @@ void CreateDenseSpans(std::array<std::unique_ptr<sdk::trace::Recordable>, kBatch
   {
     auto recordable = std::unique_ptr<sdk::trace::Recordable>(new Recordable);
 
-    recordable->SetIds(kTraceId, kSpanId, kParentSpanId);
+    recordable->SetIdentity(kSpanContext, kParentSpanId);
     recordable->SetName("TestSpan");
     recordable->SetStartTime(core::SystemTimestamp(std::chrono::system_clock::now()));
     recordable->SetDuration(std::chrono::nanoseconds(10));

--- a/exporters/zipkin/include/opentelemetry/exporters/zipkin/recordable.h
+++ b/exporters/zipkin/include/opentelemetry/exporters/zipkin/recordable.h
@@ -38,9 +38,8 @@ class Recordable final : public sdk::trace::Recordable
 public:
   const ZipkinSpan &span() const noexcept { return span_; }
 
-  void SetIds(trace::TraceId trace_id,
-              trace::SpanId span_id,
-              trace::SpanId parent_span_id) noexcept override;
+  void SetIdentity(const opentelemetry::trace::SpanContext &span_context,
+                   opentelemetry::trace::SpanId parent_span_id) noexcept override;
 
   void SetAttribute(nostd::string_view key,
                     const opentelemetry::common::AttributeValue &value) noexcept override;

--- a/exporters/zipkin/src/recordable.cc
+++ b/exporters/zipkin/src/recordable.cc
@@ -35,14 +35,13 @@ const int kAttributeValueSize = 15;
 const int kAttributeValueSize = 14;
 #endif
 
-void Recordable::SetIds(trace::TraceId trace_id,
-                        trace::SpanId span_id,
-                        trace::SpanId parent_span_id) noexcept
+void Recordable::SetIdentity(const opentelemetry::trace::SpanContext &span_context,
+                             opentelemetry::trace::SpanId parent_span_id) noexcept
 {
   char trace_id_lower_base16[trace::TraceId::kSize * 2] = {0};
-  trace_id.ToLowerBase16(trace_id_lower_base16);
+  span_context.trace_id().ToLowerBase16(trace_id_lower_base16);
   char span_id_lower_base16[trace::SpanId::kSize * 2] = {0};
-  span_id.ToLowerBase16(span_id_lower_base16);
+  span_context.span_id().ToLowerBase16(span_id_lower_base16);
   char parent_span_id_lower_base16[trace::SpanId::kSize * 2] = {0};
   parent_span_id.ToLowerBase16(parent_span_id_lower_base16);
   span_["id"]       = std::string(span_id_lower_base16, 16);

--- a/exporters/zipkin/test/zipkin_recordable_test.cc
+++ b/exporters/zipkin/test/zipkin_recordable_test.cc
@@ -35,7 +35,7 @@ namespace sdktrace = opentelemetry::sdk::trace;
 using json         = nlohmann::json;
 
 // Testing Shutdown functionality of OStreamSpanExporter, should expect no data to be sent to Stream
-TEST(ZipkinSpanRecordable, SetIds)
+TEST(ZipkinSpanRecordable, SetIdentity)
 {
   json j_span = {{"id", "0000000000000002"},
                  {"parentId", "0000000000000003"},
@@ -50,7 +50,11 @@ TEST(ZipkinSpanRecordable, SetIds)
   const trace::SpanId parent_span_id(
       std::array<const uint8_t, trace::SpanId::kSize>({0, 0, 0, 0, 0, 0, 0, 3}));
 
-  rec.SetIds(trace_id, span_id, parent_span_id);
+  const opentelemetry::trace::SpanContext span_context{
+      trace_id, span_id,
+      opentelemetry::trace::TraceFlags{opentelemetry::trace::TraceFlags::kIsSampled}, true};
+
+  rec.SetIdentity(span_context, parent_span_id);
   EXPECT_EQ(rec.span(), j_span);
 }
 

--- a/ext/test/zpages/threadsafe_span_data_test.cc
+++ b/ext/test/zpages/threadsafe_span_data_test.cc
@@ -12,12 +12,13 @@ using opentelemetry::sdk::common::OwnedAttributeValue;
 
 TEST(ThreadsafeSpanData, DefaultValues)
 {
-  opentelemetry::trace::TraceId zero_trace_id;
+  opentelemetry::trace::SpanContext empty_span_context{false, false};
   opentelemetry::trace::SpanId zero_span_id;
   ThreadsafeSpanData data;
 
-  ASSERT_EQ(data.GetTraceId(), zero_trace_id);
-  ASSERT_EQ(data.GetSpanId(), zero_span_id);
+  ASSERT_EQ(data.GetTraceId(), empty_span_context.trace_id());
+  ASSERT_EQ(data.GetSpanId(), empty_span_context.span_id());
+  ASSERT_EQ(data.GetSpanContext(), empty_span_context);
   ASSERT_EQ(data.GetParentSpanId(), zero_span_id);
   ASSERT_EQ(data.GetName(), "");
   ASSERT_EQ(data.GetStatus(), opentelemetry::trace::StatusCode::kUnset);
@@ -29,27 +30,40 @@ TEST(ThreadsafeSpanData, DefaultValues)
 
 TEST(ThreadsafeSpanData, Set)
 {
-  opentelemetry::trace::TraceId trace_id;
-  opentelemetry::trace::SpanId span_id;
-  opentelemetry::trace::SpanId parent_span_id;
+  constexpr uint8_t trace_id_buf[]       = {1, 2, 3, 4, 5, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7, 8};
+  constexpr uint8_t span_id_buf[]        = {1, 2, 3, 4, 5, 6, 7, 8};
+  constexpr uint8_t parent_span_id_buf[] = {8, 7, 6, 5, 4, 3, 2, 1};
+  opentelemetry::trace::TraceId trace_id{trace_id_buf};
+  opentelemetry::trace::SpanId span_id{span_id_buf};
+  opentelemetry::trace::SpanId parent_span_id{parent_span_id_buf};
+  const auto trace_state = opentelemetry::trace::TraceState::GetDefault()->Set("key1", "value");
+  const opentelemetry::trace::SpanContext span_context{
+      trace_id, span_id,
+      opentelemetry::trace::TraceFlags{opentelemetry::trace::TraceFlags::kIsSampled}, true,
+      trace_state};
   opentelemetry::core::SystemTimestamp now(std::chrono::system_clock::now());
 
   ThreadsafeSpanData data;
-  data.SetIds(trace_id, span_id, parent_span_id);
+  data.SetIdentity(span_context, parent_span_id);
   data.SetName("span name");
+  data.SetSpanKind(opentelemetry::trace::SpanKind::kServer);
   data.SetStatus(opentelemetry::trace::StatusCode::kOk, "description");
   data.SetStartTime(now);
   data.SetDuration(std::chrono::nanoseconds(1000000));
-  data.SetAttribute("attr1", 314159);
+  data.SetAttribute("attr1", (int64_t)314159);
   data.AddEvent("event1", now);
 
   ASSERT_EQ(data.GetTraceId(), trace_id);
   ASSERT_EQ(data.GetSpanId(), span_id);
+  ASSERT_EQ(data.GetSpanContext(), span_context);
+  std::string trace_state_key1_value;
+  ASSERT_EQ(data.GetSpanContext().trace_state()->Get("key1", trace_state_key1_value), true);
+  ASSERT_EQ(trace_state_key1_value, "value");
   ASSERT_EQ(data.GetParentSpanId(), parent_span_id);
   ASSERT_EQ(data.GetName(), "span name");
   ASSERT_EQ(data.GetStatus(), opentelemetry::trace::StatusCode::kOk);
   ASSERT_EQ(data.GetDescription(), "description");
   ASSERT_EQ(data.GetStartTime().time_since_epoch(), now.time_since_epoch());
   ASSERT_EQ(data.GetDuration(), std::chrono::nanoseconds(1000000));
-  ASSERT_EQ(opentelemetry::nostd::get<int>(data.GetAttributes().at("attr1")), 314159);
+  ASSERT_EQ(opentelemetry::nostd::get<int64_t>(data.GetAttributes().at("attr1")), 314159);
 }

--- a/sdk/include/opentelemetry/sdk/trace/recordable.h
+++ b/sdk/include/opentelemetry/sdk/trace/recordable.h
@@ -32,14 +32,12 @@ public:
   virtual ~Recordable() = default;
 
   /**
-   * Set a trace id, span id and parent span id for this span.
-   * @param trace_id the trace id to set
-   * @param span_id the span id to set
+   * Set the span context and parent span id
+   * @param span_context the span context to set
    * @param parent_span_id the parent span id to set
    */
-  virtual void SetIds(opentelemetry::trace::TraceId trace_id,
-                      opentelemetry::trace::SpanId span_id,
-                      opentelemetry::trace::SpanId parent_span_id) noexcept = 0;
+  virtual void SetIdentity(const opentelemetry::trace::SpanContext &span_context,
+                           opentelemetry::trace::SpanId parent_span_id) noexcept = 0;
 
   /**
    * Set an attribute of a span.
@@ -115,6 +113,7 @@ public:
    * @param span_kind the spankind to set
    */
   virtual void SetSpanKind(opentelemetry::trace::SpanKind span_kind) noexcept = 0;
+
   /**
    * Set the start time of the span.
    * @param start_time the start time to set

--- a/sdk/src/trace/span.cc
+++ b/sdk/src/trace/span.cc
@@ -99,9 +99,9 @@ Span::Span(std::shared_ptr<Tracer> &&tracer,
       trace_id, span_id,
       sampled ? trace_api::TraceFlags{trace_api::TraceFlags::kIsSampled} : trace_api::TraceFlags{},
       false,
-      trace_state            ? trace_state
-      : is_parent_span_valid ? parent_span_context.trace_state()
-                             : trace_api::TraceState::GetDefault()));
+      trace_state ? trace_state
+                  : is_parent_span_valid ? parent_span_context.trace_state()
+                                         : trace_api::TraceState::GetDefault()));
 
   recordable_->SetIdentity(*span_context_, parent_span_id);
 

--- a/sdk/src/trace/span.cc
+++ b/sdk/src/trace/span.cc
@@ -81,27 +81,29 @@ Span::Span(std::shared_ptr<Tracer> &&tracer,
 
   trace_api::TraceId trace_id;
   trace_api::SpanId span_id = GenerateRandomSpanId();
+  trace_api::SpanId parent_span_id;
   bool is_parent_span_valid = false;
 
   if (parent_span_context.IsValid())
   {
-    trace_id = parent_span_context.trace_id();
-    recordable_->SetIds(trace_id, span_id, parent_span_context.span_id());
+    trace_id             = parent_span_context.trace_id();
+    parent_span_id       = parent_span_context.span_id();
     is_parent_span_valid = true;
   }
   else
   {
     trace_id = GenerateRandomTraceId();
-    recordable_->SetIds(trace_id, span_id, trace_api::SpanId());
   }
 
   span_context_ = std::unique_ptr<trace_api::SpanContext>(new trace_api::SpanContext(
       trace_id, span_id,
       sampled ? trace_api::TraceFlags{trace_api::TraceFlags::kIsSampled} : trace_api::TraceFlags{},
       false,
-      trace_state ? trace_state
-                  : is_parent_span_valid ? parent_span_context.trace_state()
-                                         : trace_api::TraceState::GetDefault()));
+      trace_state            ? trace_state
+      : is_parent_span_valid ? parent_span_context.trace_state()
+                             : trace_api::TraceState::GetDefault()));
+
+  recordable_->SetIdentity(*span_context_, parent_span_id);
 
   attributes.ForEachKeyValue(
       [&](nostd::string_view key, opentelemetry::common::AttributeValue value) noexcept {


### PR DESCRIPTION
Fixes #661

## Changes

- Updated Recordable interface to take a span context and parent span id
rather than just the trace/span ids.
- Updated SpanData to new interface and added new getters for accessing
SpanContext
- Updated ThreadsafeSpanData with the same
- Updated tests for both (and made consistent)
- Updated OStreamSpanExporter to print tracestate and tests

For significant contributions please make sure you have completed the following items:

* [ ] `CHANGELOG.md` updated for non-trivial changes
* [x] Unit tests have been **updated**
* [ ] Changes in public API reviewed