### PR TITLE
Make `Context::HasKey` const

### DIFF
--- a/api/include/opentelemetry/context/context.h
+++ b/api/include/opentelemetry/context/context.h
@@ -76,7 +76,7 @@ public:
   }
 
   // Checks for key and returns true if found
-  bool HasKey(const nostd::string_view key) noexcept
+  bool HasKey(const nostd::string_view key) const noexcept
   {
     for (DataList *data = head_.get(); data != nullptr; data = data->next_.get())
     {

--- a/api/test/context/context_test.cc
+++ b/api/test/context/context_test.cc
@@ -18,7 +18,7 @@ TEST(ContextTest, ContextGetValueReturnsExpectedValue)
 {
   std::map<std::string, context::ContextValue> map_test = {{"test_key", (int64_t)123},
                                                            {"foo_key", (int64_t)456}};
-  context::Context test_context                         = context::Context(map_test);
+  const context::Context test_context                   = context::Context(map_test);
   EXPECT_EQ(nostd::get<int64_t>(test_context.GetValue("test_key")), 123);
   EXPECT_EQ(nostd::get<int64_t>(test_context.GetValue("foo_key")), 456);
 }
@@ -119,7 +119,7 @@ TEST(ContextTest, ContextEmptyMap)
 TEST(ContextTest, ContextHasKey)
 {
   std::map<std::string, context::ContextValue> map_test = {{"test_key", (int64_t)123}};
-  context::Context context_test                         = context::Context(map_test);
+  const context::Context context_test                   = context::Context(map_test);
   EXPECT_TRUE(context_test.HasKey("test_key"));
   EXPECT_FALSE(context_test.HasKey("foo_key"));
 }


### PR DESCRIPTION
Fixes #670 

## Changes

- Update `Context::HasKey` to be const
- Add const qualifier in tests for HasKey, GetValue to validate constness

* [x] Unit tests have been updated