### PR TITLE
Disable noisy `nostd::variant` compiler warnings with Visual Studio 2015/2017

### DIFF
--- a/api/include/opentelemetry/nostd/variant.h
+++ b/api/include/opentelemetry/nostd/variant.h
@@ -22,7 +22,17 @@
 // toolchains, it may drop support for Visual Studio 2015 in future versions. Perhaps a good
 // option would be to determine if Abseil is available, then use the outside implementation,
 // but it is not guaranteed to be still compatible with 2015. Thus, the local snapshot here.
+#  ifdef _MSC_VER
+// Abseil variant implementation contains some benign non-impacting warnings
+// that should be suppressed if compiling with Visual Studio 2017 and above.
+#    pragma warning(push)
+#    pragma warning(disable : 4245)  // conversion from int to const unsigned _int64
+#    pragma warning(disable : 4127)  // conditional expression is constant
+#  endif
 #  include "./absl/types/variant.h"
+#  ifdef _MSC_VER
+#    pragma warning(pop)
+#  endif
 
 OPENTELEMETRY_BEGIN_NAMESPACE
 namespace nostd
@@ -63,10 +73,17 @@ namespace absl
 {
 namespace variant_internal
 {
+#  ifdef _MSC_VER
+#    pragma warning(push)
+#    pragma warning(disable : 4211)  // nonstandard extension used: redefined extern to static
+#  endif
 static void ThrowBadVariantAccess()
 {
   THROW_BAD_VARIANT_ACCESS;
 };
+#  ifdef _MSC_VER
+#    pragma warning(pop)
+#  endif
 };  // namespace variant_internal
 };  // namespace absl
 


### PR DESCRIPTION
## Changes

If SDK is compiled with `HAVE_ABSEIL_VARIANT` option, i.e. using Google `absl::variant` implementation instead of MPark Variant, then the code emits a few warnings at "Level 4" if compiled with Visual Studio 2017. These warnings are all benign and do not impact the actual functionality. The fix is to disable / suppress specific warnings for the compilation unit, then restore back to original setting.

Warnings are:
- in Google Abseil - 4245: conversion from int to const unsigned _int64
- in Google Abseil - 4127: conditional expression is constant
- in nostd/variant  - [4211: nonstandard extension used: redefined extern to static](https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-4-c4211?view=msvc-160)

Last one is emitted because we do not link the actual entire Abseil library. And instead we stub out the variant exception handler with our own inline, emitting `nostd::bad_variant_access` exception that is implemented straight in the same header. We can't fix it per se, since replacing `extern` with `static` requires a patch in the actual Abseil variant header. And we don't want to alter it. Since this replacement of `extern` with `static` - works fine across all of msvc, clang, gcc. And only msvc triggers a bogus "Level 4" warning, despite the fact that everything is working well.. Thus, the fix is to suppress the warning.

Note that later on, as we get to `HAVE_CPP_STDLIB` (C++20 and above, e.g. when enabling this option with Visual Studio 2019), this entire variant code becomes `optional` and `irrelevant`, as we could fully enjoy the native `std::variant` support coming with Visual Studio 2019+ when compiled with `c++-latest`... Thus, the warnings suppression is largely unique to vs2015 and vs2017 at this point.