### PR TITLE
Resolve "Level 4" warnings about unused parameter in interface definitions in span API headers

### DIFF
--- a/api/include/opentelemetry/trace/default_span.h
+++ b/api/include/opentelemetry/trace/default_span.h
@@ -17,15 +17,17 @@ public:
 
   bool IsRecording() const noexcept { return false; }
 
-  void SetAttribute(nostd::string_view key, const common::AttributeValue &value) noexcept {}
+  void SetAttribute(nostd::string_view /* key */,
+                    const common::AttributeValue & /* value */) noexcept
+  {}
 
-  void AddEvent(nostd::string_view name) noexcept {}
+  void AddEvent(nostd::string_view /* name */) noexcept {}
 
-  void AddEvent(nostd::string_view name, core::SystemTimestamp timestamp) noexcept {}
+  void AddEvent(nostd::string_view /* name */, core::SystemTimestamp /* timestamp */) noexcept {}
 
-  void AddEvent(nostd::string_view name,
-                core::SystemTimestamp timestamp,
-                const common::KeyValueIterable &attributes) noexcept
+  void AddEvent(nostd::string_view /* name */,
+                core::SystemTimestamp /* timestamp */,
+                const common::KeyValueIterable & /* attributes */) noexcept
   {}
 
   void AddEvent(nostd::string_view name, const common::KeyValueIterable &attributes) noexcept
@@ -33,11 +35,11 @@ public:
     this->AddEvent(name, std::chrono::system_clock::now(), attributes);
   }
 
-  void SetStatus(StatusCode status, nostd::string_view description) noexcept {}
+  void SetStatus(StatusCode /* status */, nostd::string_view /* description */) noexcept {}
 
-  void UpdateName(nostd::string_view name) noexcept {}
+  void UpdateName(nostd::string_view /* name */) noexcept {}
 
-  void End(const EndSpanOptions &options = {}) noexcept {}
+  void End(const EndSpanOptions & /* options */ = {}) noexcept {}
 
   nostd::string_view ToString() { return "DefaultSpan"; }
 

--- a/api/include/opentelemetry/trace/span_context_kv_iterable.h
+++ b/api/include/opentelemetry/trace/span_context_kv_iterable.h
@@ -39,7 +39,7 @@ class NullSpanContext : public SpanContextKeyValueIterable
 public:
   bool ForEachKeyValue(
       nostd::function_ref<bool(SpanContext, const opentelemetry::common::KeyValueIterable &)>
-          callback) const noexcept override
+      /* callback */) const noexcept override
   {
     return true;
   }


### PR DESCRIPTION
## Changes

Main motivation for this PR is to resolve ALL compilation warnings in Visual Studio, including (somewhat silly) Level 4 warnings.

API headers contain "interface definition" / Default implementation of `Span`. Plus `NullSpanContext` - empty context. In both cases the methods declare parameters that are not used. This is tripping a (fairly useless) [Level 4 warning](https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-4-c4100?view=msvc-160) in Visual Studio.

There are two implementation options here:

- comment out parameter names : this may be causing a potential problem for tools like Doxygen. But it's a universal approach that resolves the issue in a compiler-agnostic way. Approach works well even if the same paranoid warning is enabled with gcc or clang compiler, i.e. universally works for all compilers.

OR

- add compiler-specific warning suppression pragma, i.e. suppress c4100 for Visual Studio and add `#pragma GCC diagnostic ignored ...` for GCC.

I'm implementing the first option above. But open to opinions / suggestions. The second option also looks reasonable to me, as long as we can ultimately resolve this silly warning. 😄 

