### PR TITLE
More vs2019 minor warnings cleanup

### DIFF
--- a/api/include/opentelemetry/context/context.h
+++ b/api/include/opentelemetry/context/context.h
@@ -140,7 +140,7 @@ private:
       next_  = nostd::shared_ptr<DataList>{nullptr};
     }
 
-    DataList &operator=(DataList &&other)
+    DataList &operator=(DataList &&other) noexcept
     {
       key_length_ = other.key_length_;
       value_      = std::move(other.value_);

--- a/api/include/opentelemetry/context/runtime_context.h
+++ b/api/include/opentelemetry/context/runtime_context.h
@@ -58,6 +58,8 @@ public:
    */
   virtual bool Detach(Token &token) noexcept = 0;
 
+  virtual ~RuntimeContextStorage(){};
+
 protected:
   nostd::unique_ptr<Token> CreateToken(const Context &context) noexcept
   {


### PR DESCRIPTION
## Changes

Two minor warnings clean-up:

- One functional clean-up - build warning: deleting object of polymorphic class which has non-virtual destructor might cause undefined behavior. Adding virtual destructor to resolve it.

- Another warning is purely aesthetic: Cpp Core Guidelines checker in latest Visual Studio 2019 complains that the method should be marked as `noexcept`.

