### PR TITLE
Add reference to getting started doc and api doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Please refer to [INSTALL.md](./INSTALL.md).
 
 ## Getting Started
 
-You can find a getting started guide on [opentelemetry-cpp.readthedocs.io](https://opentelemetry-cpp.readthedocs.io/en/latest/)
+As an application owner, or the library author, you can find a getting started guide on [opentelemetry-cpp.readthedocs.io](https://opentelemetry-cpp.readthedocs.io/en/latest/)
 
 The `examples/simple` directory contains a minimal program demonstrating how to
 instrument a small library using a simple `processor` and console `exporter`,

--- a/README.md
+++ b/README.md
@@ -41,7 +41,9 @@ having C++ compiler with [supported C++ standards](#supported-c-versions).
 
 Please refer to [INSTALL.md](./INSTALL.md).
 
-## Quick Start
+## Getting Started
+
+You can find a getting started guide on [opentelemetry-cpp.readthedocs.io](https://opentelemetry-cpp.readthedocs.io/en/latest/)
 
 The `examples/simple` directory contains a minimal program demonstrating how to
 instrument a small library using a simple `processor` and console `exporter`,

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Please refer to [INSTALL.md](./INSTALL.md).
 
 ## Getting Started
 
-As an application owner, or the library author, you can find a getting started guide on [opentelemetry-cpp.readthedocs.io](https://opentelemetry-cpp.readthedocs.io/en/latest/)
+As an application owner or the library author, you can find the getting started guide and reference documentation on [opentelemetry-cpp.readthedocs.io](https://opentelemetry-cpp.readthedocs.io/en/latest/)
 
 The `examples/simple` directory contains a minimal program demonstrating how to
 instrument a small library using a simple `processor` and console `exporter`,


### PR DESCRIPTION
Fixes # (issue)
Trivial change

## Changes

Added a reference to API and Getting Started doc from opentelemetry-cpp.readthedocs.io