### PR TITLE
Attribute value cleanup

### DIFF
--- a/api/docs/Doxyfile
+++ b/api/docs/Doxyfile
@@ -867,7 +867,7 @@ EXCLUDE_PATTERNS       =
 # Note that the wildcards are matched against the file with absolute path, so to
 # exclude all test directories use the pattern */test/*
 
-EXCLUDE_SYMBOLS        =
+EXCLUDE_SYMBOLS        = "AttributeType"
 
 # The EXAMPLE_PATH tag can be used to specify one or more files or directories
 # that contain example code fragments that are included (see the \include

--- a/api/include/opentelemetry/common/attribute_value.h
+++ b/api/include/opentelemetry/common/attribute_value.h
@@ -10,26 +10,47 @@
 OPENTELEMETRY_BEGIN_NAMESPACE
 namespace common
 {
+/// OpenTelemetry signals can be enriched by adding attributes. The
+/// \c AttributeValue type is defined as a variant of all attribute value
+/// types the OpenTelemetry C++ API supports.
+///
+/// The following attribute value types are supported by the OpenTelemetry
+/// specification:
+///  - Primitive types: string, boolean, double precision floating point
+///    (IEEE 754-1985) or signed 64 bit integer.
+///  - Homogenous arrays of primitive type values.
+///
+/// \warning 
+/// \parblock The OpenTelemetry C++ API currently supports several attribute
+/// value types that are not covered by the OpenTelemetry specification:
+///  - \c uint64_t
+///  - \c nostd::span<const uint64_t>
+///  - \c nostd::span<uint8_t>
+///
+/// Those types are reserved for future use and currently should not be
+/// used. There are no guarantees around how those values are handled by
+/// exporters.
+/// \endparblock
 using AttributeValue =
     nostd::variant<bool,
                    int32_t,
                    int64_t,
                    uint32_t,
-                   uint64_t,
                    double,
                    nostd::string_view,
-#ifdef HAVE_SPAN_BYTE
-                   // TODO: 8-bit byte arrays / binary blobs are not part of OT spec yet!
-                   // Ref: https://github.com/open-telemetry/opentelemetry-specification/issues/780
-                   nostd::span<const uint8_t>,
-#endif
                    nostd::span<const bool>,
                    nostd::span<const int32_t>,
                    nostd::span<const int64_t>,
                    nostd::span<const uint32_t>,
-                   nostd::span<const uint64_t>,
                    nostd::span<const double>,
-                   nostd::span<const nostd::string_view>>;
+                   nostd::span<const nostd::string_view>,
+		   // Not currently supported by the specification, but reserved for future use.
+                   // See https://github.com/open-telemetry/opentelemetry-specification/issues/780
+                   uint64_t,
+		   // Not currently supported by the specification, but reserved for future use.
+                   nostd::span<const uint64_t>,
+		   // Not currently supported by the specification, but reserved for future use.
+                   nostd::span<const uint8_t>>;
 
 enum AttributeType
 {
@@ -37,19 +58,17 @@ enum AttributeType
   kTypeInt,
   kTypeInt64,
   kTypeUInt,
-  kTypeUInt64,
   kTypeDouble,
   kTypeString,
-#ifdef HAVE_SPAN_BYTE
-  kTypeSpanByte,
-#endif
   kTypeSpanBool,
   kTypeSpanInt,
   kTypeSpanInt64,
   kTypeSpanUInt,
-  kTypeSpanUInt64,
   kTypeSpanDouble,
-  kTypeSpanString
+  kTypeSpanString,
+  kTypeUInt64,
+  kTypeSpanUInt64,
+  kTypeSpanByte
 };
 
 }  // namespace common

--- a/api/include/opentelemetry/common/attribute_value.h
+++ b/api/include/opentelemetry/common/attribute_value.h
@@ -44,12 +44,14 @@ using AttributeValue =
                    nostd::span<const uint32_t>,
                    nostd::span<const double>,
                    nostd::span<const nostd::string_view>,
-		   // Not currently supported by the specification, but reserved for future use.
-                   // See https://github.com/open-telemetry/opentelemetry-specification/issues/780
+                   // Not currently supported by the specification, but reserved for future use.
+		   // Added to provide support for all primitive C++ types.
                    uint64_t,
-		   // Not currently supported by the specification, but reserved for future use.
+                   // Not currently supported by the specification, but reserved for future use.
+		   // Added to provide support for all primitive C++ types.
                    nostd::span<const uint64_t>,
-		   // Not currently supported by the specification, but reserved for future use.
+                   // Not currently supported by the specification, but reserved for future use.
+                   // See https://github.com/open-telemetry/opentelemetry-specification/issues/780
                    nostd::span<const uint8_t>>;
 
 enum AttributeType

--- a/api/include/opentelemetry/common/attribute_value.h
+++ b/api/include/opentelemetry/common/attribute_value.h
@@ -20,7 +20,7 @@ namespace common
 ///    (IEEE 754-1985) or signed 64 bit integer.
 ///  - Homogenous arrays of primitive type values.
 ///
-/// \warning 
+/// \warning
 /// \parblock The OpenTelemetry C++ API currently supports several attribute
 /// value types that are not covered by the OpenTelemetry specification:
 ///  - \c uint64_t
@@ -45,10 +45,10 @@ using AttributeValue =
                    nostd::span<const double>,
                    nostd::span<const nostd::string_view>,
                    // Not currently supported by the specification, but reserved for future use.
-		   // Added to provide support for all primitive C++ types.
+                   // Added to provide support for all primitive C++ types.
                    uint64_t,
                    // Not currently supported by the specification, but reserved for future use.
-		   // Added to provide support for all primitive C++ types.
+                   // Added to provide support for all primitive C++ types.
                    nostd::span<const uint64_t>,
                    // Not currently supported by the specification, but reserved for future use.
                    // See https://github.com/open-telemetry/opentelemetry-specification/issues/780

--- a/exporters/etw/include/opentelemetry/exporters/etw/etw_properties.h
+++ b/exporters/etw/include/opentelemetry/exporters/etw/etw_properties.h
@@ -302,8 +302,8 @@ public:
         return nostd::string_view(data, (data) ? strlen(data) : 0);
         break;
       }
-      case common::AttributeType::kTypeSpanByte: {
-        value = to_span(nostd::get<std::vector<uint8_t>>(self));
+      case PropertyType::kTypeSpanByte: {
+        value = to_span(nostd::get<std::vector<uint8_t>>(*this));
         break;
       }
       case PropertyType::kTypeSpanBool: {

--- a/exporters/etw/include/opentelemetry/exporters/etw/etw_properties.h
+++ b/exporters/etw/include/opentelemetry/exporters/etw/etw_properties.h
@@ -42,11 +42,9 @@ using PropertyVariant =
                    double,
                    std::string,
                    const char *,
-#ifdef HAVE_SPAN_BYTE
-                   // TODO: 8-bit byte arrays / binary blobs are not part of OT spec yet!
+                   // 8-bit byte arrays / binary blobs are not part of OT spec yet!
                    // Ref: https://github.com/open-telemetry/opentelemetry-specification/issues/780
                    std::vector<uint8_t>,
-#endif
                    std::vector<bool>,
                    std::vector<int32_t>,
                    std::vector<int64_t>,
@@ -65,9 +63,7 @@ enum PropertyType
   kTypeDouble,
   kTypeString,
   kTypeCString,
-#ifdef HAVE_SPAN_BYTE
   kTypeSpanByte,
-#endif
   kTypeSpanBool,
   kTypeSpanInt,
   kTypeSpanInt64,
@@ -229,11 +225,11 @@ public:
         PropertyVariant::operator=(nostd::string_view(nostd::get<nostd::string_view>(v)).data());
         break;
       };
-#ifdef HAVE_SPAN_BYTE
+
       case common::AttributeType::kTypeSpanByte:
         PropertyVariant::operator=(to_vector(nostd::get<nostd::span<const uint8_t>>(v)));
         break;
-#endif
+
       case common::AttributeType::kTypeSpanBool:
         PropertyVariant::operator=(to_vector(nostd::get<nostd::span<const bool>>(v)));
         break;
@@ -306,13 +302,10 @@ public:
         return nostd::string_view(data, (data) ? strlen(data) : 0);
         break;
       }
-
-#ifdef HAVE_SPAN_BYTE
-      case common::AttributeType::kTypeSpanByte:
+      case common::AttributeType::kTypeSpanByte: {
         value = to_span(nostd::get<std::vector<uint8_t>>(self));
         break;
-#endif
-
+      }
       case PropertyType::kTypeSpanBool: {
         const auto &vec = nostd::get<std::vector<bool>>(*this);
         // FIXME: sort out how to remap from vector<bool> to span<bool>

--- a/exporters/etw/include/opentelemetry/exporters/etw/etw_provider.h
+++ b/exporters/etw/include/opentelemetry/exporters/etw/etw_provider.h
@@ -274,6 +274,9 @@ public:
       case PropertyType::kTypeString:
         eventName = (char *)(nostd::get<std::string>(nameField).data());  // must be 0-terminated!
         break;
+      case PropertyType::kTypeCString:
+        eventName = (char *)(nostd::get<const char *>(nameField));
+        break;
       default:
         // If invalid event name is supplied, then we replace it with 'NoName'
         break;
@@ -333,6 +336,11 @@ public:
           jObj[name] = nostd::get<std::string>(value);
           break;
         }
+        case PropertyType::kTypeCString: {
+          auto temp  = nostd::get<const char *>(value);
+          jObj[name] = temp;
+          break;
+        }
 #  if HAVE_TYPE_GUID
           // TODO: consider adding UUID/GUID to spec
         case common::AttributeType::TYPE_GUID: {
@@ -344,7 +352,7 @@ public:
 #  endif
 
         // TODO: arrays are not supported yet
-#  endif
+        case PropertyType::kTypeSpanByte:
         case PropertyType::kTypeSpanBool:
         case PropertyType::kTypeSpanInt:
         case PropertyType::kTypeSpanInt64:
@@ -352,7 +360,6 @@ public:
         case PropertyType::kTypeSpanUInt64:
         case PropertyType::kTypeSpanDouble:
         case PropertyType::kTypeSpanString:
-        case common::AttributeType::kTypeSpanByte:
         default:
           // TODO: unsupported type
           break;
@@ -444,6 +451,9 @@ public:
       case PropertyType::kTypeString:
         eventName = (char *)(nostd::get<std::string>(nameField).data());
         break;
+      case PropertyType::kTypeCString:
+        eventName = (char *)(nostd::get<const char *>(nameField));
+        break;
       default:
         // This is user error. Invalid event name!
         // We supply default 'NoName' event name in this case.
@@ -502,6 +512,12 @@ public:
           dbuilder.AddString(nostd::get<std::string>(value).data());
           break;
         }
+        case PropertyType::kTypeCString: {
+          builder.AddField(name, tld::TypeUtf8String);
+          auto temp = nostd::get<const char *>(value);
+          dbuilder.AddString(temp);
+          break;
+        }
 #  if HAVE_TYPE_GUID
           // TODO: consider adding UUID/GUID to spec
         case PropertyType::kGUID: {
@@ -513,6 +529,7 @@ public:
 #  endif
 
         // TODO: arrays are not supported
+        case PropertyType::kTypeSpanByte:
         case PropertyType::kTypeSpanBool:
         case PropertyType::kTypeSpanInt:
         case PropertyType::kTypeSpanInt64:
@@ -520,7 +537,6 @@ public:
         case PropertyType::kTypeSpanUInt64:
         case PropertyType::kTypeSpanDouble:
         case PropertyType::kTypeSpanString:
-        case PropertyType::kTypeSpanByte:
         default:
           // TODO: unsupported type
           break;

--- a/exporters/etw/include/opentelemetry/exporters/etw/etw_provider.h
+++ b/exporters/etw/include/opentelemetry/exporters/etw/etw_provider.h
@@ -274,9 +274,6 @@ public:
       case PropertyType::kTypeString:
         eventName = (char *)(nostd::get<std::string>(nameField).data());  // must be 0-terminated!
         break;
-      case PropertyType::kTypeCString:
-        eventName = (char *)(nostd::get<const char *>(nameField));
-        break;
       default:
         // If invalid event name is supplied, then we replace it with 'NoName'
         break;
@@ -336,11 +333,6 @@ public:
           jObj[name] = nostd::get<std::string>(value);
           break;
         }
-        case PropertyType::kTypeCString: {
-          auto temp  = nostd::get<const char *>(value);
-          jObj[name] = temp;
-          break;
-        }
 #  if HAVE_TYPE_GUID
           // TODO: consider adding UUID/GUID to spec
         case common::AttributeType::TYPE_GUID: {
@@ -352,8 +344,6 @@ public:
 #  endif
 
         // TODO: arrays are not supported yet
-#  ifdef HAVE_SPAN_BYTE
-        case common::AttributeType::TYPE_SPAN_BYTE:
 #  endif
         case PropertyType::kTypeSpanBool:
         case PropertyType::kTypeSpanInt:
@@ -362,6 +352,7 @@ public:
         case PropertyType::kTypeSpanUInt64:
         case PropertyType::kTypeSpanDouble:
         case PropertyType::kTypeSpanString:
+        case common::AttributeType::kTypeSpanByte:
         default:
           // TODO: unsupported type
           break;
@@ -453,9 +444,6 @@ public:
       case PropertyType::kTypeString:
         eventName = (char *)(nostd::get<std::string>(nameField).data());
         break;
-      case PropertyType::kTypeCString:
-        eventName = (char *)(nostd::get<const char *>(nameField));
-        break;
       default:
         // This is user error. Invalid event name!
         // We supply default 'NoName' event name in this case.
@@ -514,12 +502,6 @@ public:
           dbuilder.AddString(nostd::get<std::string>(value).data());
           break;
         }
-        case PropertyType::kTypeCString: {
-          builder.AddField(name, tld::TypeUtf8String);
-          auto temp = nostd::get<const char *>(value);
-          dbuilder.AddString(temp);
-          break;
-        }
 #  if HAVE_TYPE_GUID
           // TODO: consider adding UUID/GUID to spec
         case PropertyType::kGUID: {
@@ -531,9 +513,6 @@ public:
 #  endif
 
         // TODO: arrays are not supported
-#  ifdef HAVE_SPAN_BYTE
-        case PropertyType::kTypeSpanByte:
-#  endif
         case PropertyType::kTypeSpanBool:
         case PropertyType::kTypeSpanInt:
         case PropertyType::kTypeSpanInt64:
@@ -541,6 +520,7 @@ public:
         case PropertyType::kTypeSpanUInt64:
         case PropertyType::kTypeSpanDouble:
         case PropertyType::kTypeSpanString:
+        case PropertyType::kTypeSpanByte:
         default:
           // TODO: unsupported type
           break;

--- a/exporters/otlp/src/recordable.cc
+++ b/exporters/otlp/src/recordable.cc
@@ -70,7 +70,6 @@ void PopulateAttribute(opentelemetry::proto::common::v1::KeyValue *attribute,
     attribute->mutable_value()->set_string_value(nostd::get<nostd::string_view>(value).data(),
                                                  nostd::get<nostd::string_view>(value).size());
   }
-#ifdef HAVE_SPAN_BYTE
   else if (nostd::holds_alternative<nostd::span<const uint8_t>>(value))
   {
     for (const auto &val : nostd::get<nostd::span<const uint8_t>>(value))
@@ -78,7 +77,6 @@ void PopulateAttribute(opentelemetry::proto::common::v1::KeyValue *attribute,
       attribute->mutable_value()->mutable_array_value()->add_values()->set_int_value(val);
     }
   }
-#endif
   else if (nostd::holds_alternative<nostd::span<const bool>>(value))
   {
     for (const auto &val : nostd::get<nostd::span<const bool>>(value))

--- a/exporters/otlp/src/recordable.cc
+++ b/exporters/otlp/src/recordable.cc
@@ -8,14 +8,8 @@ namespace otlp
 
 //
 // See `attribute_value.h` for details.
-// Expecting to remove the two feature gates for:
-// - HAVE_SPAN_BYTE     - proposal for binary type or byte array (uint8_t[]).
 //
-#if defined(HAVE_SPAN_BYTE)
 const int kAttributeValueSize = 15;
-#else
-const int kAttributeValueSize = 14;
-#endif
 
 void Recordable::SetIdentity(const opentelemetry::trace::SpanContext &span_context,
                              opentelemetry::trace::SpanId parent_span_id) noexcept

--- a/exporters/zipkin/src/recordable.cc
+++ b/exporters/zipkin/src/recordable.cc
@@ -26,14 +26,8 @@ namespace zipkin
 
 //
 // See `attribute_value.h` for details.
-// Expecting to remove the two feature gates for:
-// - HAVE_SPAN_BYTE     - proposal for binary type or byte array (uint8_t[]).
 //
-#if defined(HAVE_SPAN_BYTE)
 const int kAttributeValueSize = 15;
-#else
-const int kAttributeValueSize = 14;
-#endif
 
 void Recordable::SetIdentity(const opentelemetry::trace::SpanContext &span_context,
                              opentelemetry::trace::SpanId parent_span_id) noexcept
@@ -88,7 +82,6 @@ void PopulateAttribute(nlohmann::json &attribute,
     attribute[key.data()] = nostd::string_view(nostd::get<nostd::string_view>(value).data(),
                                                nostd::get<nostd::string_view>(value).size());
   }
-#ifdef HAVE_SPAN_BYTE
   else if (nostd::holds_alternative<nostd::span<const uint8_t>>(value))
   {
     attribute[key.data()] = {};
@@ -97,7 +90,6 @@ void PopulateAttribute(nlohmann::json &attribute,
       attribute[key.data()].push_back(val);
     }
   }
-#endif
   else if (nostd::holds_alternative<nostd::span<const bool>>(value))
   {
     attribute[key.data()] = {};

--- a/sdk/include/opentelemetry/sdk/common/attribute_utils.h
+++ b/sdk/include/opentelemetry/sdk/common/attribute_utils.h
@@ -31,23 +31,26 @@ namespace common
  * A counterpart to AttributeValue that makes sure a value is owned. This
  * replaces all non-owning references with owned copies.
  */
-using OwnedAttributeValue = nostd::variant<bool,
-                                           int32_t,
-                                           int64_t,
-                                           uint32_t,
-                                           uint64_t,
-                                           double,
-                                           std::string,
-#ifdef HAVE_SPAN_BYTE
-                                           std::vector<uint8_t>,
-#endif
-                                           std::vector<bool>,
-                                           std::vector<int32_t>,
-                                           std::vector<int64_t>,
-                                           std::vector<uint32_t>,
-                                           std::vector<uint64_t>,
-                                           std::vector<double>,
-                                           std::vector<std::string>>;
+using OwnedAttributeValue =
+	nostd::variant<bool,
+                       int32_t,
+                       uint32_t,
+                       int64_t,
+                       double,
+                       std::string,
+                       std::vector<bool>,
+                       std::vector<int32_t>,
+                       std::vector<uint32_t>,
+                       std::vector<int64_t>,
+                       std::vector<double>,
+                       std::vector<std::string>>,
+		       // Not currently supported by the specification, but reserved for future use.
+                       // See https://github.com/open-telemetry/opentelemetry-specification/issues/780
+                       uint64_t,
+		       // Not currently supported by the specification, but reserved for future use.
+                       std::vector<uint64_t>,
+		       // Not currently supported by the specification, but reserved for future use.
+                       std::vector<uint8_t>;
 
 enum OwnedAttributeType
 {
@@ -55,19 +58,17 @@ enum OwnedAttributeType
   kTypeInt,
   kTypeInt64,
   kTypeUInt,
-  kTypeUInt64,
   kTypeDouble,
   kTypeString,
-#ifdef HAVE_SPAN_BYTE
-  kTypeSpanByte,
-#endif
   kTypeSpanBool,
   kTypeSpanInt,
   kTypeSpanInt64,
   kTypeSpanUInt,
-  kTypeSpanUInt64,
   kTypeSpanDouble,
-  kTypeSpanString
+  kTypeSpanString,
+  kTypeUInt64,
+  kTypeSpanUInt64,
+  kTypeSpanByte
 };
 
 /**
@@ -86,9 +87,7 @@ struct AttributeConverter
     return OwnedAttributeValue(std::string(v));
   }
   OwnedAttributeValue operator()(const char *v) { return OwnedAttributeValue(std::string(v)); }
-#ifdef HAVE_SPAN_BYTE
   OwnedAttributeValue operator()(nostd::span<const uint8_t> v) { return convertSpan<uint8_t>(v); }
-#endif
   OwnedAttributeValue operator()(nostd::span<const bool> v) { return convertSpan<bool>(v); }
   OwnedAttributeValue operator()(nostd::span<const int32_t> v) { return convertSpan<int32_t>(v); }
   OwnedAttributeValue operator()(nostd::span<const uint32_t> v) { return convertSpan<uint32_t>(v); }

--- a/sdk/include/opentelemetry/sdk/common/attribute_utils.h
+++ b/sdk/include/opentelemetry/sdk/common/attribute_utils.h
@@ -30,27 +30,28 @@ namespace common
 /**
  * A counterpart to AttributeValue that makes sure a value is owned. This
  * replaces all non-owning references with owned copies.
+ *
+ * The following types are not currently supported by the OpenTelemetry
+ * specification, but reserved for future use:
+ *  - uint64_t
+ *  - std::vector<uint64_t>
+ *  - std::vector<uint8_t>
  */
-using OwnedAttributeValue =
-	nostd::variant<bool,
-                       int32_t,
-                       uint32_t,
-                       int64_t,
-                       double,
-                       std::string,
-                       std::vector<bool>,
-                       std::vector<int32_t>,
-                       std::vector<uint32_t>,
-                       std::vector<int64_t>,
-                       std::vector<double>,
-                       std::vector<std::string>>,
-                       // Not currently supported by the specification, but reserved for future use.
-                       uint64_t,
-                       // Not currently supported by the specification, but reserved for future use.
-                       std::vector<uint64_t>,
-                       // Not currently supported by the specification, but reserved for future use.
-                       // See https://github.com/open-telemetry/opentelemetry-specification/issues/780
-                       std::vector<uint8_t>;
+using OwnedAttributeValue = nostd::variant<bool,
+                                           int32_t,
+                                           uint32_t,
+                                           int64_t,
+                                           double,
+                                           std::string,
+                                           std::vector<bool>,
+                                           std::vector<int32_t>,
+                                           std::vector<uint32_t>,
+                                           std::vector<int64_t>,
+                                           std::vector<double>,
+                                           std::vector<std::string>,
+                                           uint64_t,
+                                           std::vector<uint64_t>,
+                                           std::vector<uint8_t>>;
 
 enum OwnedAttributeType
 {

--- a/sdk/include/opentelemetry/sdk/common/attribute_utils.h
+++ b/sdk/include/opentelemetry/sdk/common/attribute_utils.h
@@ -44,12 +44,12 @@ using OwnedAttributeValue =
                        std::vector<int64_t>,
                        std::vector<double>,
                        std::vector<std::string>>,
-		       // Not currently supported by the specification, but reserved for future use.
-                       // See https://github.com/open-telemetry/opentelemetry-specification/issues/780
+                       // Not currently supported by the specification, but reserved for future use.
                        uint64_t,
-		       // Not currently supported by the specification, but reserved for future use.
+                       // Not currently supported by the specification, but reserved for future use.
                        std::vector<uint64_t>,
-		       // Not currently supported by the specification, but reserved for future use.
+                       // Not currently supported by the specification, but reserved for future use.
+                       // See https://github.com/open-telemetry/opentelemetry-specification/issues/780
                        std::vector<uint8_t>;
 
 enum OwnedAttributeType


### PR DESCRIPTION
Fixes #634.

## Changes

This change is based on discussion we recently had (in #634 and in SIG meetings).

This PR purposely tries to keep the scope of `AttributeValue` very wide, as any change to this `variant` will require us to release a new major version, as any change to the `variant` is a breaking API change.

* `std::span<uint8_t>` is included as there's an [open issue](https://github.com/open-telemetry/opentelemetry-specification/issues/780) for adding this, and there's interest from user side to have this.
* `uint64_t` and `std::span<uint64_t>` are added to provide complete support for primitive C++ types.

The documentation adds a warning that those types are not part of the specification and that supports from exporter side is not guaranteed.

* [ ] `CHANGELOG.md` updated for non-trivial changes
* [ ] Unit tests have been added
* [x] Changes in public API reviewed