### PR TITLE
compiler error with gcc 5.4.0 fixed 

### DIFF
--- a/exporters/ostream/include/opentelemetry/exporters/ostream/span_exporter.h
+++ b/exporters/ostream/include/opentelemetry/exporters/ostream/span_exporter.h
@@ -100,7 +100,7 @@ private:
 #if __cplusplus < 201402L
     nostd::visit(OwnedAttributeValueVisitor(*this), value);
 #else
-    nostd::visit([this](auto &&arg) { print_value(arg); }, value);
+    nostd::visit([this](auto &&arg) { this->print_value(arg); }, value);
 #endif
   }
 

--- a/exporters/ostream/include/opentelemetry/exporters/ostream/span_exporter.h
+++ b/exporters/ostream/include/opentelemetry/exporters/ostream/span_exporter.h
@@ -100,7 +100,12 @@ private:
 #if __cplusplus < 201402L
     nostd::visit(OwnedAttributeValueVisitor(*this), value);
 #else
-    nostd::visit([this](auto &&arg) { /* explicit this is needed by some gcc versions (observed with v5.4.0)*/ this->print_value(arg); }, value);
+    nostd::visit(
+        [this](auto &&arg) {
+          /* explicit this is needed by some gcc versions (observed with v5.4.0)*/
+          this->print_value(arg);
+        },
+        value);
 #endif
   }
 

--- a/exporters/ostream/include/opentelemetry/exporters/ostream/span_exporter.h
+++ b/exporters/ostream/include/opentelemetry/exporters/ostream/span_exporter.h
@@ -100,7 +100,7 @@ private:
 #if __cplusplus < 201402L
     nostd::visit(OwnedAttributeValueVisitor(*this), value);
 #else
-    nostd::visit([this](auto &&arg) { this->print_value(arg); }, value);
+    nostd::visit([this](auto &&arg) { /* explicit this is needed by some gcc versions (observed with v5.4.0)*/ this->print_value(arg); }, value);
 #endif
   }
 


### PR DESCRIPTION
(passing this to lambda does not resolve method names correctly)

this is just a small fix in order to get a build with gcc v5.4.0 with -std=c++14 to work. 
With current implementation I get the following compile error:
```cpp
...include/opentelemetry/exporters/ostream/span_exporter.h:103:39: error: cannot call member function ‘void opentelemetry::v0::exporter::trace::OStreamSpanExporter::print_value(const std::vector<T>&) [with T = std::__cxx11::basic_string<char>]’ without object
```

This solves this issue for me:
```cpp
nostd::visit([this](auto &&arg) { **this->**print_value(arg); }, value);
```

It seems to be an inconsistent behaviour of gcc in this specific version.

Please takeover if you agree with the fix.
