### PR TITLE
Fix MSVC build warning by replacing std::getenv by getenv_s

### DIFF
--- a/sdk/src/resource/resource_detector.cc
+++ b/sdk/src/resource/resource_detector.cc
@@ -12,10 +12,20 @@ const char *OTEL_RESOURCE_ATTRIBUTES = "OTEL_RESOURCE_ATTRIBUTES";
 
 Resource OTELResourceDetector::Detect() noexcept
 {
+#if defined(_MSC_VER)
+  size_t required_size = 0;
+  getenv_s(&required_size, nullptr, 0, OTEL_RESOURCE_ATTRIBUTES);
+  if (required_size == 0)
+    return Resource();
+  std::unique_ptr<char> attributes_buffer{new char[required_size]};
+  getenv_s(&required_size, attributes_buffer.get(), required_size, OTEL_RESOURCE_ATTRIBUTES);
+  char *attributes_str = attributes_buffer.get();
+#else
   char *attributes_str = std::getenv(OTEL_RESOURCE_ATTRIBUTES);
   if (attributes_str == nullptr)
     return Resource();
-  // return Resource::GetEmpty();
+#endif
+
   ResourceAttributes attributes;
   std::istringstream iss(attributes_str);
   std::string token;


### PR DESCRIPTION
Fixes # 655

## Changes

Replacing `std::getenv` by `getenv_s` for MSVC build to avoid the warning of calling unsafe CRT function.

For significant contributions please make sure you have completed the following items:

* [ ] `CHANGELOG.md` updated for non-trivial changes
* [ ] Unit tests have been added
* [ ] Changes in public API reviewed