### PR TITLE
Visual Studio 2019 fixes for API headers

### DIFF
--- a/api/include/opentelemetry/nostd/function_ref.h
+++ b/api/include/opentelemetry/nostd/function_ref.h
@@ -77,7 +77,7 @@ public:
       typename std::enable_if<!std::is_same<function_ref, typename std::decay<F>::type>::value,
                               int>::type = 0,
       typename std::enable_if<
-#if (__cplusplus >= 201703L)
+#if (__cplusplus >= 201703L) || (defined(_MSVC_LANG) && (_MSVC_LANG > 201402))
           // std::result_of deprecated in C++17, removed in C++20
           std::is_convertible<typename std::invoke_result<F, Args...>::type, R>::value,
 #else

--- a/api/include/opentelemetry/nostd/span.h
+++ b/api/include/opentelemetry/nostd/span.h
@@ -14,9 +14,13 @@
 
 #pragma once
 
+// Try to use either `std::span` or `gsl::span`
 #ifdef HAVE_CPP_STDLIB
 #  include "opentelemetry/std/span.h"
-#else
+#endif
+
+// Fallback to `nostd::span` if necessary
+#if !defined(HAVE_SPAN)
 #  include <array>
 #  include <cassert>
 #  include <cstddef>

--- a/api/include/opentelemetry/std/span.h
+++ b/api/include/opentelemetry/std/span.h
@@ -33,7 +33,7 @@
 #    endif
 #    // Check for other compiler span implementation
 #    if !defined(_MSVC_VALUE) && __has_include(<span>)
-       // This works as long as compiler standard is set to C++20
+// This works as long as compiler standard is set to C++20
 #      define HAVE_SPAN
 #    endif
 #  endif
@@ -51,7 +51,7 @@ template <class ElementType, std::size_t Extent = gsl::dynamic_extent>
 using span = gsl::span<ElementType, Extent>;
 }
 OPENTELEMETRY_END_NAMESPACE
-#  define HAVE_SPAN
+#    define HAVE_SPAN
 #  else
 // No `gsl::span`, no `std::span`, fallback to `nostd::span`
 #  endif

--- a/api/include/opentelemetry/std/span.h
+++ b/api/include/opentelemetry/std/span.h
@@ -26,13 +26,16 @@
 #      define HAVE_SPAN
 #    endif
 #  endif
-#  if __has_include(<span>) && !defined(HAVE_SPAN)  // Check for span
-#    define HAVE_SPAN
-#  endif
-#  if !__has_include(<string_view>)  // Check for string_view
-#    error \
-        "STL library does not support std::span. Possible solution:"                   \
-         " - #undef HAVE_CPP_STDLIB // to use OpenTelemetry nostd::string_view"
+#  if !defined(HAVE_SPAN)
+#    // Check for Visual Studio span
+#    if defined(_MSVC_VALUE) && _HAS_CXX20
+#      define HAVE_SPAN
+#    endif
+#    // Check for other compiler span implementation
+#    if !defined(_MSVC_VALUE) && __has_include(<span>)
+       // This works as long as compiler standard is set to C++20
+#      define HAVE_SPAN
+#    endif
 #  endif
 #endif
 
@@ -48,12 +51,9 @@ template <class ElementType, std::size_t Extent = gsl::dynamic_extent>
 using span = gsl::span<ElementType, Extent>;
 }
 OPENTELEMETRY_END_NAMESPACE
+#  define HAVE_SPAN
 #  else
-// No span implementation provided.
-#    error \
-        "STL library does not support std::span. Possible solutions:"                  \
-         " - #undef HAVE_CPP_STDLIB // to use OpenTelemetry nostd::span .. or      "    \
-         " - #define HAVE_GSL       // to use gsl::span                            "
+// No `gsl::span`, no `std::span`, fallback to `nostd::span`
 #  endif
 
 #else  // HAVE_SPAN

--- a/api/include/opentelemetry/std/span.h
+++ b/api/include/opentelemetry/std/span.h
@@ -28,11 +28,11 @@
 #  endif
 #  if !defined(HAVE_SPAN)
 #    // Check for Visual Studio span
-#    if defined(_MSVC_VALUE) && _HAS_CXX20
+#    if defined(_MSVC_LANG) && _HAS_CXX20
 #      define HAVE_SPAN
 #    endif
 #    // Check for other compiler span implementation
-#    if !defined(_MSVC_VALUE) && __has_include(<span>)
+#    if !defined(_MSVC_LANG) && __has_include(<span>)
 // This works as long as compiler standard is set to C++20
 #      define HAVE_SPAN
 #    endif


### PR DESCRIPTION
## Changes

There are three fundamental changes here:

- Better detection of compiler features in Visual Studio 2019. For example, you can't just assume that if `<span>` exists, then the feature is available. It is shielded beyond `c++latest` flag, so have to check for that flag too. That way if you build with Visual Studio 2019 IDE and latest headers, but using `c++17` flag - the code would still compile successfully.

- compiler error fix in case if `__cplusplus` has incorrect value. This is long-standing issue, that even [has its own Reddit thread here](https://www.reddit.com/r/cpp/comments/bqsyss/zc_cplusplus_by_default/) ... We solve this in CMake and Bazel builds by defining corresponding build flag (`/Zc:__cplusplus`). But other build systems and libraries may not have that flag set. This presents a challenge when they include our API headers. Thus, it'd be best to use smarter compiler feature logic for MSVC, based off MSVC-specific compiler language detection.

- improve handling of `HAVE_CPP_STDLIB` build option: if we are building with `c++17` and use `std::variant`, we can still fallback to use `nostd::span` implementation that comes with OpenTelemetry. This happens if you are building with Visual Studio 2019 with `c++17` standard and not with the latest. That is when you would prefer to use `std::variant` (neither Abseil nor nostd), but you do not want to use `gsl::span` due to whatever reason.

This is a short summary. I will cover user-focused summary: build flavors, options, when one can use `HAVE_CPP_STDLIB`, and when one gets the `std::span` versus `gsl::span` versus `nostd::span` (e.g. Abseil Span) in a separate documentation-only PR.
