### PR TITLE
Fixing Visual Studio 2019 with `c++latest` (C++20) and `WITH_STL` build option

### DIFF
--- a/api/include/opentelemetry/trace/propagation/b3_propagator.h
+++ b/api/include/opentelemetry/trace/propagation/b3_propagator.h
@@ -135,10 +135,11 @@ public:
 
     char trace_identity[kTraceIdHexStrLength + kSpanIdHexStrLength + 3];
     static_assert(sizeof(trace_identity) == 51, "b3 trace identity buffer size mismatch");
-    span_context.trace_id().ToLowerBase16({&trace_identity[0], kTraceIdHexStrLength});
+    span_context.trace_id().ToLowerBase16(
+        nostd::span<char, 2 * TraceId::kSize>{&trace_identity[0], kTraceIdHexStrLength});
     trace_identity[kTraceIdHexStrLength] = '-';
-    span_context.span_id().ToLowerBase16(
-        {&trace_identity[kTraceIdHexStrLength + 1], kSpanIdHexStrLength});
+    span_context.span_id().ToLowerBase16(nostd::span<char, 2 * SpanId::kSize>{
+        &trace_identity[kTraceIdHexStrLength + 1], kSpanIdHexStrLength});
     trace_identity[kTraceIdHexStrLength + kSpanIdHexStrLength + 1] = '-';
     trace_identity[kTraceIdHexStrLength + kSpanIdHexStrLength + 2] =
         span_context.trace_flags().IsSampled() ? '1' : '0';

--- a/api/include/opentelemetry/trace/propagation/http_trace_context.h
+++ b/api/include/opentelemetry/trace/propagation/http_trace_context.h
@@ -12,9 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <array>
 #include "detail/context.h"
 #include "detail/hex.h"
 #include "detail/string.h"
+#include "opentelemetry/nostd/string_view.h"
 #include "opentelemetry/trace/default_span.h"
 #include "opentelemetry/trace/propagation/text_map_propagator.h"
 
@@ -95,11 +97,14 @@ private:
     trace_parent[0] = '0';
     trace_parent[1] = '0';
     trace_parent[2] = '-';
-    span_context.trace_id().ToLowerBase16({&trace_parent[3], kTraceIdSize});
+    span_context.trace_id().ToLowerBase16(
+        nostd::span<char, 2 * TraceId::kSize>{&trace_parent[3], kTraceIdSize});
     trace_parent[kTraceIdSize + 3] = '-';
-    span_context.span_id().ToLowerBase16({&trace_parent[kTraceIdSize + 4], kSpanIdSize});
+    span_context.span_id().ToLowerBase16(
+        nostd::span<char, 2 * SpanId::kSize>{&trace_parent[kTraceIdSize + 4], kSpanIdSize});
     trace_parent[kTraceIdSize + kSpanIdSize + 4] = '-';
-    span_context.trace_flags().ToLowerBase16({&trace_parent[kTraceIdSize + kSpanIdSize + 5], 2});
+    span_context.trace_flags().ToLowerBase16(
+        nostd::span<char, 2>{&trace_parent[kTraceIdSize + kSpanIdSize + 5], 2});
 
     carrier.Set(kTraceParent, nostd::string_view(trace_parent, sizeof(trace_parent)));
     carrier.Set(kTraceState, span_context.trace_state()->ToHeader());

--- a/api/include/opentelemetry/trace/propagation/jaeger.h
+++ b/api/include/opentelemetry/trace/propagation/jaeger.h
@@ -44,9 +44,11 @@ public:
 
     // trace-id(32):span-id(16):0:debug(2)
     char trace_identity[trace_id_length + span_id_length + 6];
-    span_context.trace_id().ToLowerBase16({&trace_identity[0], trace_id_length});
+    span_context.trace_id().ToLowerBase16(
+        nostd::span<char, 2 * TraceId::kSize>{&trace_identity[0], trace_id_length});
     trace_identity[trace_id_length] = ':';
-    span_context.span_id().ToLowerBase16({&trace_identity[trace_id_length + 1], span_id_length});
+    span_context.span_id().ToLowerBase16(
+        nostd::span<char, 2 * SpanId::kSize>{&trace_identity[trace_id_length + 1], span_id_length});
     trace_identity[trace_id_length + span_id_length + 1] = ':';
     trace_identity[trace_id_length + span_id_length + 2] = '0';
     trace_identity[trace_id_length + span_id_length + 3] = ':';

--- a/exporters/ostream/test/ostream_log_test.cc
+++ b/exporters/ostream/test/ostream_log_test.cc
@@ -1,5 +1,7 @@
+#include <array>
 #include "opentelemetry/exporters/ostream/log_exporter.h"
 #include "opentelemetry/logs/provider.h"
+#include "opentelemetry/nostd/span.h"
 #include "opentelemetry/sdk/logs/logger_provider.h"
 #include "opentelemetry/sdk/logs/simple_log_processor.h"
 

--- a/exporters/otlp/test/otlp_exporter_test.cc
+++ b/exporters/otlp/test/otlp_exporter_test.cc
@@ -1,16 +1,32 @@
-#include "opentelemetry/exporters/otlp/otlp_exporter.h"
+#ifndef HAVE_CPP_STDLIB
+// Unfortunately as of 04/27/2021 the fix is NOT in the vcpkg snapshot of Google Test.
+// Remove above `#ifdef` once the GMock fix for C++20 is in the mainline.
+//
+// Please refer to this GitHub issue for additional details:
+// https://github.com/google/googletest/issues/2914
+// https://github.com/google/googletest/commit/61f010d703b32de9bfb20ab90ece38ab2f25977f
+//
+// If we compile using Visual Studio 2019 with `c++latest` (C++20) without the GMock fix,
+// then the compilation here fails in `gmock-actions.h` from:
+//   .\tools\vcpkg\installed\x64-windows\include\gmock\gmock-actions.h(819):
+//   error C2653: 'result_of': is not a class or namespace name
+//
+// That is because `std::result_of` has been removed in C++20.
 
-#include "opentelemetry/exporters/otlp/protobuf_include_prefix.h"
+#  include "opentelemetry/exporters/otlp/otlp_exporter.h"
 
-#include "opentelemetry/proto/collector/trace/v1/trace_service_mock.grpc.pb.h"
+#  include "opentelemetry/exporters/otlp/protobuf_include_prefix.h"
 
-#include "opentelemetry/exporters/otlp/protobuf_include_suffix.h"
+// Problematic code that pulls in Gmock and breaks with vs2019/c++latest :
+#  include "opentelemetry/proto/collector/trace/v1/trace_service_mock.grpc.pb.h"
 
-#include "opentelemetry/sdk/trace/simple_processor.h"
-#include "opentelemetry/sdk/trace/tracer_provider.h"
-#include "opentelemetry/trace/provider.h"
+#  include "opentelemetry/exporters/otlp/protobuf_include_suffix.h"
 
-#include <gtest/gtest.h>
+#  include "opentelemetry/sdk/trace/simple_processor.h"
+#  include "opentelemetry/sdk/trace/tracer_provider.h"
+#  include "opentelemetry/trace/provider.h"
+
+#  include <gtest/gtest.h>
 
 using namespace testing;
 
@@ -112,3 +128,4 @@ TEST_F(OtlpExporterTestPeer, ConfigSslCredentialsTest)
 }  // namespace otlp
 }  // namespace exporter
 OPENTELEMETRY_END_NAMESPACE
+#endif

--- a/sdk/test/logs/logger_provider_sdk_test.cc
+++ b/sdk/test/logs/logger_provider_sdk_test.cc
@@ -14,8 +14,10 @@
  * limitations under the License.
  */
 
+#include <array>
 #include "opentelemetry/logs/provider.h"
 #include "opentelemetry/nostd/shared_ptr.h"
+#include "opentelemetry/nostd/string_view.h"
 #include "opentelemetry/sdk/logs/log_record.h"
 #include "opentelemetry/sdk/logs/logger.h"
 #include "opentelemetry/sdk/logs/logger_provider.h"


### PR DESCRIPTION
Fixes #703

## Changes

There are no API changes. Clean-up of the build failures with Visual Studio 2019, C++20 and `WITH_STL` ( `-DHAVE_CPP_STDLIB` ) option. Not a _significant_ contribution. However, we could mention that now the entire SDK can be compiled using vs2019 w/c++latest.