### PR TITLE
Remove deprecated use of TYPED_TEST_CASE

### DIFF
--- a/exporters/zipkin/test/zipkin_recordable_test.cc
+++ b/exporters/zipkin/test/zipkin_recordable_test.cc
@@ -217,7 +217,7 @@ struct ZipkinIntAttributeTest : public testing::Test
 };
 
 using IntTypes = testing::Types<int, int64_t, unsigned int, uint64_t>;
-TYPED_TEST_CASE(ZipkinIntAttributeTest, IntTypes);
+TYPED_TEST_SUITE(ZipkinIntAttributeTest, IntTypes);
 
 TYPED_TEST(ZipkinIntAttributeTest, SetIntSingleAttribute)
 {


### PR DESCRIPTION
## Changes

As the mentioned in [gtest](https://github.com/google/googletest/blob/master/googletest/include/gtest/internal/gtest-internal.h#L1305), `TYPED_TEST_CASE` is deprecated and `TYPED_TEST_SUITE` should be used.

For significant contributions please make sure you have completed the following items:

* [ ] `CHANGELOG.md` updated for non-trivial changes
* [ ] Unit tests have been added
* [ ] Changes in public API reviewed