### PR TITLE
Set Spankind for Zipkin exporter

### DIFF
--- a/exporters/zipkin/src/recordable.cc
+++ b/exporters/zipkin/src/recordable.cc
@@ -231,10 +231,6 @@ void Recordable::SetSpanKind(opentelemetry::trace::SpanKind span_kind) noexcept
   {
     span_["kind"] = span_iter->second;
   }
-  else
-  {
-    span_["kind"] = nullptr;
-  }
 }
 }  // namespace zipkin
 }  // namespace exporter

--- a/exporters/zipkin/src/recordable.cc
+++ b/exporters/zipkin/src/recordable.cc
@@ -16,13 +16,21 @@
 
 #include "opentelemetry/exporters/zipkin/recordable.h"
 
-#include <iostream>
+#include <map>
+#include <string>
 
 OPENTELEMETRY_BEGIN_NAMESPACE
 namespace exporter
 {
 namespace zipkin
 {
+
+std::map<opentelemetry::trace::SpanKind, std::string> kSpanKindMap = {
+    {opentelemetry::trace::SpanKind::kClient, "CLIENT"},
+    {opentelemetry::trace::SpanKind::kServer, "SERVER"},
+    {opentelemetry::trace::SpanKind::kConsumer, "CONSUMER"},
+    {opentelemetry::trace::SpanKind::kProducer, "PRODUCER"},
+};
 
 //
 // See `attribute_value.h` for details.
@@ -215,7 +223,17 @@ void Recordable::SetDuration(std::chrono::nanoseconds duration) noexcept
   span_["duration"] = duration.count();
 }
 
-void Recordable::SetSpanKind(opentelemetry::trace::SpanKind span_kind) noexcept {}
+void Recordable::SetSpanKind(opentelemetry::trace::SpanKind span_kind) noexcept
+{
+  if (kSpanKindMap.find(span_kind) != kSpanKindMap.end())
+  {
+    span_["kind"] = kSpanKindMap[span_kind];
+  }
+  else
+  {
+    span_["kind"] = nullptr;
+  }
+}
 }  // namespace zipkin
 }  // namespace exporter
 OPENTELEMETRY_END_NAMESPACE

--- a/exporters/zipkin/src/recordable.cc
+++ b/exporters/zipkin/src/recordable.cc
@@ -240,7 +240,7 @@ void Recordable::SetInstrumentationLibrary(
   span_["tags"]["otel.library.name"]    = instrumentation_library.GetName();
   span_["tags"]["otel.library.version"] = instrumentation_library.GetVersion();
 }
-  
+
 }  // namespace zipkin
 }  // namespace exporter
 OPENTELEMETRY_END_NAMESPACE

--- a/exporters/zipkin/src/recordable.cc
+++ b/exporters/zipkin/src/recordable.cc
@@ -25,7 +25,8 @@ namespace exporter
 namespace zipkin
 {
 
-std::map<opentelemetry::trace::SpanKind, std::string> kSpanKindMap = {
+// constexpr needs keys to be constexpr, const is next best to use.
+const std::map<opentelemetry::trace::SpanKind, std::string> kSpanKindMap = {
     {opentelemetry::trace::SpanKind::kClient, "CLIENT"},
     {opentelemetry::trace::SpanKind::kServer, "SERVER"},
     {opentelemetry::trace::SpanKind::kConsumer, "CONSUMER"},

--- a/exporters/zipkin/src/recordable.cc
+++ b/exporters/zipkin/src/recordable.cc
@@ -26,7 +26,7 @@ namespace zipkin
 {
 
 // constexpr needs keys to be constexpr, const is next best to use.
-const std::map<opentelemetry::trace::SpanKind, std::string> kSpanKindMap = {
+static const std::map<opentelemetry::trace::SpanKind, std::string> kSpanKindMap = {
     {opentelemetry::trace::SpanKind::kClient, "CLIENT"},
     {opentelemetry::trace::SpanKind::kServer, "SERVER"},
     {opentelemetry::trace::SpanKind::kConsumer, "CONSUMER"},
@@ -228,7 +228,7 @@ void Recordable::SetSpanKind(opentelemetry::trace::SpanKind span_kind) noexcept
 {
   if (kSpanKindMap.find(span_kind) != kSpanKindMap.end())
   {
-    span_["kind"] = kSpanKindMap[span_kind];
+    span_["kind"] = kSpanKindMap.at(span_kind);
   }
   else
   {

--- a/exporters/zipkin/src/recordable.cc
+++ b/exporters/zipkin/src/recordable.cc
@@ -226,9 +226,10 @@ void Recordable::SetDuration(std::chrono::nanoseconds duration) noexcept
 
 void Recordable::SetSpanKind(opentelemetry::trace::SpanKind span_kind) noexcept
 {
-  if (kSpanKindMap.find(span_kind) != kSpanKindMap.end())
+  auto span_iter = kSpanKindMap.find(span_kind);
+  if (span_iter != kSpanKindMap.end())
   {
-    span_["kind"] = kSpanKindMap.at(span_kind);
+    span_["kind"] = *span_iter;
   }
   else
   {

--- a/exporters/zipkin/src/recordable.cc
+++ b/exporters/zipkin/src/recordable.cc
@@ -229,7 +229,7 @@ void Recordable::SetSpanKind(opentelemetry::trace::SpanKind span_kind) noexcept
   auto span_iter = kSpanKindMap.find(span_kind);
   if (span_iter != kSpanKindMap.end())
   {
-    span_["kind"] = *span_iter;
+    span_["kind"] = span_iter->second;
   }
   else
   {

--- a/exporters/zipkin/test/zipkin_recordable_test.cc
+++ b/exporters/zipkin/test/zipkin_recordable_test.cc
@@ -117,12 +117,9 @@ TEST(ZipkinSpanRecordable, SetStatus)
 TEST(ZipkinSpanRecordable, SetSpanKind)
 {
   json j_json_client = {{"kind", "CLIENT"}};
-  json j_json_null   = {{"kind", nullptr}};
   opentelemetry::exporter::zipkin::Recordable rec;
   rec.SetSpanKind(opentelemetry::trace::SpanKind::kClient);
   EXPECT_EQ(rec.span(), j_json_client);
-  rec.SetSpanKind(opentelemetry::trace::SpanKind::kInternal);
-  EXPECT_EQ(rec.span(), j_json_null);
 }
 
 TEST(ZipkinSpanRecordable, AddEventDefault)

--- a/exporters/zipkin/test/zipkin_recordable_test.cc
+++ b/exporters/zipkin/test/zipkin_recordable_test.cc
@@ -114,6 +114,17 @@ TEST(ZipkinSpanRecordable, SetStatus)
   }
 }
 
+TEST(ZipkinSpanRecordable, SetSpanKind)
+{
+  json j_json_client = {{"kind", "CLIENT"}};
+  json j_json_null   = {{"kind", nullptr}};
+  opentelemetry::exporter::zipkin::Recordable rec;
+  rec.SetSpanKind(opentelemetry::trace::SpanKind::kClient);
+  EXPECT_EQ(rec.span(), j_json_client);
+  rec.SetSpanKind(opentelemetry::trace::SpanKind::kInternal);
+  EXPECT_EQ(rec.span(), j_json_null);
+}
+
 TEST(ZipkinSpanRecordable, AddEventDefault)
 {
   opentelemetry::exporter::zipkin::Recordable rec;

--- a/exporters/zipkin/test/zipkin_recordable_test.cc
+++ b/exporters/zipkin/test/zipkin_recordable_test.cc
@@ -217,7 +217,7 @@ struct ZipkinIntAttributeTest : public testing::Test
 };
 
 using IntTypes = testing::Types<int, int64_t, unsigned int, uint64_t>;
-TYPED_TEST_CASE(ZipkinIntAttributeTest, IntTypes);
+TYPED_TEST_SUITE(ZipkinIntAttributeTest, IntTypes);
 
 TYPED_TEST(ZipkinIntAttributeTest, SetIntSingleAttribute)
 {


### PR DESCRIPTION
## Changes

Small fix to populate spankind attribute for Zipkin exporter.
specs : https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/sdk_exporters/zipkin.md#spankind

For significant contributions please make sure you have completed the following items:

* [ ] `CHANGELOG.md` updated for non-trivial changes
* [x] Unit tests have been added
* [x] Changes in public API reviewed