### PR TITLE
Unset GMOCK_LIB before find_library to force lookup

### DIFF
--- a/exporters/otlp/CMakeLists.txt
+++ b/exporters/otlp/CMakeLists.txt
@@ -37,6 +37,12 @@ if(BUILD_TESTING)
   if(MSVC)
     add_definitions(-DGTEST_LINKED_AS_SHARED_LIBRARY=1)
   endif()
+  if(GMOCK_LIB)
+    # unset GMOCK_LIB to force find_library to redo the lookup, as the cached
+    # entry could cause linking to incorrect flavor of gmock and leading to
+    # runtime error.
+    unset(GMOCK_LIB CACHE)
+  endif()
   if(MSVC AND CMAKE_BUILD_TYPE STREQUAL "Debug")
     find_library(GMOCK_LIB gmockd PATH_SUFFIXES lib)
   else()


### PR DESCRIPTION
## Changes

`find_library` is used to get the path of gmock, and build type (`CMAKE_BUILD_TYPE`) is checked to link to either gmockd.lib for debug build or gmock.lib for others.

The problem is that `find_library` stores the found library in cache variable which will **NOT** be re-checked for the CMake re-run, so if the re-run changes build type, it will link to the previous gmock, which causes runtime exception, as the OTLP test and gmock then run with 2 different flavors of CRT library, and trigger exception when passing C++ types around, such as `std::string`.

For significant contributions please make sure you have completed the following items:

* [ ] `CHANGELOG.md` updated for non-trivial changes
* [ ] Unit tests have been added
* [ ] Changes in public API reviewed