### PR TITLE
Minor api documentation cleanup

### DIFF
--- a/api/docs/Doxyfile
+++ b/api/docs/Doxyfile
@@ -839,6 +839,8 @@ RECURSIVE              = YES
 
 EXCLUDE                = ../include/opentelemetry/common/spin_lock_mutex.h \
                          ../include/opentelemetry/common/key_value_iterable_view.h \
+                         ../include/opentelemetry/common/kv_properties.h \
+                         ../include/opentelemetry/common/string_util.h \
                          ../include/opentelemetry/trace/span_context_kv_iterable_view.h \
                          ../include/opentelemetry/nostd/detail
 

--- a/api/docs/Doxyfile
+++ b/api/docs/Doxyfile
@@ -842,7 +842,7 @@ EXCLUDE                = ../include/opentelemetry/common/spin_lock_mutex.h \
                          ../include/opentelemetry/common/kv_properties.h \
                          ../include/opentelemetry/common/string_util.h \
                          ../include/opentelemetry/trace/span_context_kv_iterable_view.h \
-                         ../include/opentelemetry/nostd/detail
+                         ../include/opentelemetry/nostd
 
 # The EXCLUDE_SYMLINKS tag can be used to select whether or not files or
 # directories that are symbolic links (a Unix file system feature) are excluded

--- a/api/include/opentelemetry/common/key_value_iterable.h
+++ b/api/include/opentelemetry/common/key_value_iterable.h
@@ -29,23 +29,5 @@ public:
    */
   virtual size_t size() const noexcept = 0;
 };
-
-//
-// NULL object pattern empty iterable.
-//
-class NullKeyValueIterable : public KeyValueIterable
-{
-public:
-  NullKeyValueIterable(){};
-
-  virtual bool ForEachKeyValue(
-      nostd::function_ref<bool(nostd::string_view, common::AttributeValue)>) const noexcept
-  {
-    return true;
-  };
-
-  virtual size_t size() const noexcept { return 0; }
-};
-
 }  // namespace common
 OPENTELEMETRY_END_NAMESPACE


### PR DESCRIPTION
## Changes

* Remove documentation references for internal `common` classes that are not relevant to users.
* Remove documentation references for `nostd` classes. We shouldn't confuse the users with documentation for those classes, as we must strive for 100% compatibility with the standard library anyway.
* Remove `NullKeyValueIterable`. It isn't used anywhere in the code.

Cleanup of documentation in the `opentelemetry::trace` namespace will come in a separate PR.

* [ ] `CHANGELOG.md` updated for non-trivial changes
* [ ] Unit tests have been added
* [x] Changes in public API reviewed