### PR TITLE
Allow to build with alternate vcpkg.exe by respecting VCPKG_ROOT variable

### DIFF
--- a/tools/build.cmd
+++ b/tools/build.cmd
@@ -26,8 +26,8 @@ if ("%CMAKE_ARCH%"=="") (
 )
 
 REM Use preinstalled vcpkg if installed or use our local
-if "%VCPKG_INSTALLATION_ROOT%" neq "" (
-  set "VCPKG_CMAKE=%VCPKG_INSTALLATION_ROOT%\scripts\buildsystems\vcpkg.cmake"
+if "%VCPKG_ROOT%" neq "" (
+  set "VCPKG_CMAKE=%VCPKG_ROOT%\scripts\buildsystems\vcpkg.cmake"
 ) else (
   set "VCPKG_CMAKE=%CD%\vcpkg\scripts\buildsystems\vcpkg.cmake"
 )

--- a/tools/setup-buildtools.cmd
+++ b/tools/setup-buildtools.cmd
@@ -1,5 +1,6 @@
 @echo off
 set "PATH=%ProgramFiles%\CMake\bin;%~dp0;%~dp0vcpkg;%PATH%"
+if "%VCPKG_ROOT%" NEQ "" set "PATH=%VCPKG_ROOT%;%PATH%"
 pushd %~dp0
 
 net session >nul 2>&1


### PR DESCRIPTION
Fixes #701 

## Changes

This is quite small and simple change to start respecting [`VCPKG_ROOT` variable](https://github.com/microsoft/vcpkg/blob/master/docs/users/config-environment.md#vcpkg_root). This fix (partially) addresses the corner-case, when it turns out that the path to gRPC build tree is too long on Windows.

Developers may provide a short path to their own `vcpkg` installation. Such as `set VCPKG_ROOT=c:\vcpkg`, then the `setup-buildtools.cmd` is going to honor that short path. gRPC is then building successfully.

One side-effect is that developer-provided snapshot of `vcpkg` is going to be used in that case instead of opentelemetry submodule-provided version of `vcpkg`.

## Why this fix is needed

In my case I'm running an Azure pipeline build, where the project name and, subsequently, the path to project directory is relatively long. And OpenTelemetry itself lives in a `third_party` submodule of its parent project build tree. Plus, gRPC project has very long file names and directory names, that aggravates the [file length limit issue on Windows](https://docs.microsoft.com/en-us/windows/win32/fileio/maximum-file-path-limitation). 🤷  An adjustment to my pipeline then is to checkout the `vcpkg` separately in its own location to `C:\vcpkg` (shorter path). And use `VCPKG_ROOT` to direct the build script to use that instance of it instead.

I believe this fix would be beneficial to other OpenTelemetry devs as well.

## Alternate ideas considered

It is possible to use `mklink /J` command to create a directory junction from `C:\vcpkg` to OpenTelemetry snapshot of `vcpkg` submodule directory, as a shorter path-alias. But this is just too smart.. Has its own side-effects. Thus, I'm proposing a dumber and simpler quick fix instead. The entire quick fix is optional. If someone does not like it, then they just don't set `VCPKG_ROOT` variable at all.

On a positive note, this also means now you can reuse one instance of `vcpkg` installation across several checkouts of opentelemetry build tree instead of building it each and every time.

@meastp - please let me know if this quick fix seems reasonable to you.