### PR TITLE
Fix extracting TraceState from HttpTextMapCarrier

### DIFF
--- a/examples/http/tracer_common.h
+++ b/examples/http/tracer_common.h
@@ -47,7 +47,7 @@ public:
     }
     else if (key == opentelemetry::trace::propagation::kTraceState)
     {
-      key_to_compare == "Tracestate";
+      key_to_compare = "Tracestate";
     }
     auto it = headers_.find(key_to_compare);
     if (it != headers_.end())


### PR DESCRIPTION
## Changes

In the new http example, the extraction of `TraceState` from `HttpTextMapCarrier` doesn't use the right key. This is not currently expose because we default `TraceState` is used is coincidently displayed as empty string.

For significant contributions please make sure you have completed the following items:

* [ ] `CHANGELOG.md` updated for non-trivial changes
* [ ] Unit tests have been added
* [ ] Changes in public API reviewed