### PR TITLE
Add curl via vcpkg to Windows builds

### DIFF
--- a/tools/setup-buildtools.cmd
+++ b/tools/setup-buildtools.cmd
@@ -54,5 +54,6 @@ vcpkg install abseil:x64-windows
 vcpkg install protobuf:x64-windows
 vcpkg install gRPC:x64-windows
 vcpkg install prometheus-cpp:x64-windows
+vcpkg install curl:x64-windows
 popd
 exit /b 0


### PR DESCRIPTION
**Minor Developer Experience Improvement**

Minor build infra change would enable to build all exporters with the following workflow.

Run as - Administrator, in `cmd.exe`

```console
cd tools
setup-buildtools.cmd
build.cmd
```

Subsequently the directory may be opened `as directory` in [Visual Studio 2019+CMake](https://docs.microsoft.com/en-us/cpp/build/customize-cmake-settings?view=msvc-160), to enjoy the benefits of hassle-free build system, built-in test integration, as well as `ninja` (much faster builds).

This time with ALL exporters available to be built in this flow, including Elastic and Zipkin that presently rely on `libcurl` on Windows.