### PR TITLE
Enforce the C++ standard in CMake when CXX_STANDARD is specified

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,6 +27,7 @@ else()
   )
 endif()
 
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
 if(NOT DEFINED CMAKE_CXX_STANDARD)
   set(CMAKE_CXX_STANDARD 11)
 endif()


### PR DESCRIPTION
Fixes

## Changes

Ensure the desired C++ standard is used when building the libraries. This is done enabling **[`CMAKE_CXX_STANDARD_REQUIRED`](https://cmake.org/cmake/help/v3.1/variable/CMAKE_CXX_STANDARD_REQUIRED.html).