### PR TITLE
Disable MSVC warning C4250 for metrics Instrument

### DIFF
--- a/sdk/include/opentelemetry/sdk/metrics/async_instruments.h
+++ b/sdk/include/opentelemetry/sdk/metrics/async_instruments.h
@@ -19,6 +19,11 @@ namespace sdk
 namespace metrics
 {
 
+#if defined(_MSC_VER)
+#  pragma warning(push)
+#  pragma warning(disable : 4250)  // inheriting methods via dominance
+#endif
+
 template <class T>
 class ValueObserver : public AsynchronousInstrument<T>, virtual public metrics_api::ValueObserver<T>
 {
@@ -266,6 +271,10 @@ public:
   // Public mapping from labels (stored as strings) to their respective aggregators
   std::unordered_map<std::string, std::shared_ptr<Aggregator<T>>> boundAggregators_;
 };
+
+#if defined(_MSC_VER)
+#  pragma warning(pop)
+#endif
 
 }  // namespace metrics
 }  // namespace sdk

--- a/sdk/include/opentelemetry/sdk/metrics/instrument.h
+++ b/sdk/include/opentelemetry/sdk/metrics/instrument.h
@@ -12,6 +12,10 @@
 #include "opentelemetry/sdk/metrics/record.h"
 #include "opentelemetry/version.h"
 
+#if defined(_MSC_VER)
+#pragma warning(disable:4250)
+#endif
+
 namespace metrics_api = opentelemetry::metrics;
 
 OPENTELEMETRY_BEGIN_NAMESPACE

--- a/sdk/include/opentelemetry/sdk/metrics/instrument.h
+++ b/sdk/include/opentelemetry/sdk/metrics/instrument.h
@@ -12,10 +12,6 @@
 #include "opentelemetry/sdk/metrics/record.h"
 #include "opentelemetry/version.h"
 
-#if defined(_MSC_VER)
-#pragma warning(disable:4250)
-#endif
-
 namespace metrics_api = opentelemetry::metrics;
 
 OPENTELEMETRY_BEGIN_NAMESPACE
@@ -23,6 +19,11 @@ namespace sdk
 {
 namespace metrics
 {
+
+#if defined(_MSC_VER)
+#  pragma warning(push)
+#  pragma warning(disable : 4250)  // inheriting methods via dominance
+#endif
 
 class Instrument : virtual public metrics_api::Instrument
 {
@@ -297,6 +298,10 @@ inline std::string KvToString(const opentelemetry::common::KeyValueIterable &kv)
   ss << "}";
   return ss.str();
 }
+
+#if defined(_MSC_VER)
+#  pragma warning(pop)
+#endif
 
 }  // namespace metrics
 }  // namespace sdk

--- a/sdk/include/opentelemetry/sdk/metrics/sync_instruments.h
+++ b/sdk/include/opentelemetry/sdk/metrics/sync_instruments.h
@@ -18,6 +18,11 @@ namespace sdk
 namespace metrics
 {
 
+#if defined(_MSC_VER)
+#  pragma warning(push)
+#  pragma warning(disable : 4250)  // inheriting methods via dominance
+#endif
+
 template <class T>
 class BoundCounter final : public BoundSynchronousInstrument<T>, public metrics_api::BoundCounter<T>
 {
@@ -430,6 +435,10 @@ public:
   std::unordered_map<std::string, nostd::shared_ptr<metrics_api::BoundValueRecorder<T>>>
       boundInstruments_;
 };
+
+#if defined(_MSC_VER)
+#  pragma warning(pop)
+#endif
 
 }  // namespace metrics
 }  // namespace sdk


### PR DESCRIPTION
Metrics SDK class `SynchronousInstrument` has multiple inheritance path from API `Instrument`, but only the SDK `instrument` class contains implementation of the virtual method, so it is safe to ignore C4250 (inherit via dominance) warning here.

For significant contributions please make sure you have completed the following items:

* [ ] `CHANGELOG.md` updated for non-trivial changes
* [ ] Unit tests have been added
* [ ] Changes in public API reviewed