### PR TITLE
Add --recursive git option to install doc

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -64,8 +64,8 @@ build systems for opentelemetry-cpp.
 
    - `-DCMAKE_POSITION_INDEPENDENT_CODE=ON` : Please note that with default
      configuration, the code is compiled without `-fpic` option, so it is not
-     suitable for inclusion in shared library. To enable the code for inclusion
-     in shared libraries, this variable is used.
+     suitable for inclusion in shared libraries. To enable the code for
+     inclusion in shared libraries, this variable is used.
 
    - `-DWITH_OTLP=ON` : To enable building Otlp exporter.
    - `-DWITH_PROMETHEUS=ON` : To enable building prometheus exporter.

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -1,33 +1,32 @@
 # Building opentelemetry-cpp
 
-[Bazel](https://bazel.build) and [CMake](https://cmake.org/) are the official
+[CMake](https://cmake.org/) and [Bazel](https://bazel.build) are the official
 build systems for opentelemetry-cpp.
 
 ## Build instructions using CMake
 
 ### Prerequisites
 
-- A supported platform (e.g. Windows, macOS or Linux).
-Refer to [Platforms Supported](./README.md#supported-development-platforms)
-for more information.
-- A compatible C++ compiler supporting at least C++11.
-Major compilers are supported.
-Refer to [Supported Compilers](./README.md#supported-c-versions) for more information.
-- [Git](https://git-scm.com/) for fetching opentelemetry-cpp source code from repository.
-To install Git, consult the [Set up Git](https://help.github.com/articles/set-up-git/)
-guide on GitHub.
-- [CMake](https://cmake.org/) for building opentelemetry-cpp API,
-SDK with their unittests. We use CMake version 3.15.2 in our build system.
-To install CMake, consult the [Installing CMake](https://cmake.org/install/) guide.
-- [GoogleTest](https://github.com/google/googletest) framework to build and
-run the unittests.
-We use GoogleTest version 1.10.0 in our build system. To install GoogleTest,
-consult the [GoogleTest Build Instructions](https://github.com/google/googletest/blob/master/googletest/README.md#generic-build-instructions).
+- A supported platform (e.g. Windows, macOS or Linux). Refer to [Platforms
+  Supported](./README.md#supported-development-platforms) for more information.
+- A compatible C++ compiler supporting at least C++11. Major compilers are
+  supported. Refer to [Supported Compilers](./README.md#supported-c-versions)
+  for more information.
+- [Git](https://git-scm.com/) for fetching opentelemetry-cpp source code from
+  repository. To install Git, consult the [Set up
+  Git](https://help.github.com/articles/set-up-git/) guide on GitHub.
+- [CMake](https://cmake.org/) for building opentelemetry-cpp API, SDK with their
+  unittests. We use CMake version 3.15.2 in our build system. To install CMake,
+  consult the [Installing CMake](https://cmake.org/install/) guide.
+- [GoogleTest](https://github.com/google/googletest) framework to build and run
+  the unittests. We use GoogleTest version 1.10.0 in our build system. To
+  install GoogleTest, consult the [GoogleTest Build
+  Instructions](https://github.com/google/googletest/blob/master/googletest/README.md#generic-build-instructions).
 - Apart from above core requirements, the Exporters and Propagators have their
-build dependencies which are not covered here. E.g, Otlp Exporter needs
-grpc/protobuf library, Zipkin exporter needs nlohmann-json and libcurl,
-ETW exporter need nlohmann-json to build. This is covered in the build
-instructions for these components.
+  build dependencies which are not covered here. E.g, Otlp Exporter needs
+  grpc/protobuf library, Zipkin exporter needs nlohmann-json and libcurl, ETW
+  exporter need nlohmann-json to build. This is covered in the build
+  instructions for each of these components.
 
 ### Building as Standalone CMake Project
 
@@ -37,15 +36,15 @@ instructions for these components.
    # Change to the directory where you want to create the code repository
    $ cd ~
    $ mkdir source && cd source
-   $ git clone https://github.com/open-telemetry/opentelemetry-cpp
+   $ git clone --recursive https://github.com/open-telemetry/opentelemetry-cpp
    Cloning into 'opentelemetry-cpp'...
    ...
    Resolving deltas: 100% (3225/3225), done.
    $
    ```
 
-2. Navigate to the repository cloned above, and create the `CMake`
-build configuration.
+2. Navigate to the repository cloned above, and create the `CMake` build
+   configuration.
 
    ```console
    $ cd opentelemetry-cpp
@@ -60,20 +59,20 @@ build configuration.
    $
    ```
 
-   Some of the available cmake build variables we can use during
-   cmake configuration:
+   Some of the available cmake build variables we can use during cmake
+   configuration:
 
    - `-DCMAKE_POSITION_INDEPENDENT_CODE=ON` : Please note that with default
-   configuration, the code is compiled without `-fpic` option, so it is not
-   suitable for inclusion in shared library. To enable the code for inclusion
-   in shared libraries, this variable is used.
+     configuration, the code is compiled without `-fpic` option, so it is not
+     suitable for inclusion in shared library. To enable the code for inclusion
+     in shared libraries, this variable is used.
 
    - `-DWITH_OTLP=ON` : To enable building Otlp exporter.
    - `-DWITH_PROMETHEUS=ON` : To enable building prometheus exporter.
 
-3. Once build configuration is created, build the CMake targets -
- this includes building SDKs, and building unittests for API and SDK.
- Note that since API is header only library, no separate build is triggered for it.
+3. Once build configuration is created, build the CMake targets - this includes
+   building SDKs, and building unittests for API and SDK. Note that since API is
+   header only library, no separate build is triggered for it.
 
    ```console
    $ cmake --build . --target all
@@ -101,8 +100,8 @@ build configuration.
    $
    ```
 
-5. Optionally install the header files for API, and generated
-targets and header files for SDK at custom/default install location.
+5. Optionally install the header files for API, and generated targets and header
+   files for SDK at custom/default install location.
 
    ```console
    $ cmake --install . --config Debug --prefix /<install_root>/
@@ -120,13 +119,13 @@ targets and header files for SDK at custom/default install location.
 
 To use the library from a CMake project, you can locate it directly with
  `find_package` and use the imported targets from generated package
- configurations. As of now, this will import targets for both API and SDK.
-In future, there may be separate packages for API and SDK which can be
-installed and imported separtely according to need.
+ configurations. As of now, this will import targets for both API and SDK. In
+ future, there may be separate packages for API and SDK which can be installed
+ and imported separtely according to need.
 
 ```cmake
 # CMakeLists.txt
-find_package(opentelemetry-cpp REQUIRED)
+find_package(opentelemetry-cpp CONFIG REQUIRED)
 ...
 target_include_directories(foo PRIVATE ${OPENTELEMETRY_CPP_INCLUDE_DIRS})
 target_link_libraries(foo PRIVATE ${OPENTELEMETRY_CPP_LIBRARIES})


### PR DESCRIPTION
Add option `--recursive` to `git clone` command to out install document, in case the user build any components which require submodule like OTLP proto files, etc.

Some minor cleanup.

## Changes

Please provide a brief description of the changes here.

For significant contributions please make sure you have completed the following items:

* [ ] `CHANGELOG.md` updated for non-trivial changes
* [ ] Unit tests have been added
* [ ] Changes in public API reviewed