### PR TITLE
Fix CMake 3.20 warning in curl http client

### DIFF
--- a/ext/src/http/client/curl/CMakeLists.txt
+++ b/ext/src/http/client/curl/CMakeLists.txt
@@ -1,6 +1,6 @@
 find_package(CURL)
 if(CURL_FOUND)
-  add_library(http_client_curl http_client_factory_curl http_client_curl)
+  add_library(http_client_curl http_client_factory_curl.cc http_client_curl.cc)
 
   set_target_properties(http_client_curl PROPERTIES EXPORT_NAME
                                                     http_client_curl)


### PR DESCRIPTION
Cleaning up build warning. No code changes.

Fix CMake 3.20+ warning. If you are building with fresh CMake that comes in latest Visual Studio 2019 update, then it complains about filenames in `CMakeLists.txt` not having extensions. This is happening due to [new policy CMP0115 described here](https://cmake.org/cmake/help/git-stage/policy/CMP0115.html) - `Source file extensions must be explicit.`. This logically makes sense when target library name matches that one of a source file name, to clearly disambiguate between the two: what is target name, and what is source file name.

![image](https://user-images.githubusercontent.com/34072974/118311949-762a0180-b4a5-11eb-81e5-1c35c3b723c1.png)
