### PR TITLE
Rename Recordable under OTLP exporter to OtlpRecordable

### DIFF
--- a/exporters/otlp/BUILD
+++ b/exporters/otlp/BUILD
@@ -22,9 +22,9 @@ cc_library(
         "src/otlp_recordable.cc",
     ],
     hdrs = [
+        "include/opentelemetry/exporters/otlp/otlp_recordable.h",
         "include/opentelemetry/exporters/otlp/protobuf_include_prefix.h",
         "include/opentelemetry/exporters/otlp/protobuf_include_suffix.h",
-        "include/opentelemetry/exporters/otlp/otlp_recordable.h",
     ],
     strip_include_prefix = "include",
     deps = [

--- a/exporters/otlp/BUILD
+++ b/exporters/otlp/BUILD
@@ -17,14 +17,14 @@ package(default_visibility = ["//visibility:public"])
 load("//bazel:otel_cc_benchmark.bzl", "otel_cc_benchmark")
 
 cc_library(
-    name = "recordable",
+    name = "otlp_recordable",
     srcs = [
-        "src/recordable.cc",
+        "src/otlp_recordable.cc",
     ],
     hdrs = [
         "include/opentelemetry/exporters/otlp/protobuf_include_prefix.h",
         "include/opentelemetry/exporters/otlp/protobuf_include_suffix.h",
-        "include/opentelemetry/exporters/otlp/recordable.h",
+        "include/opentelemetry/exporters/otlp/otlp_recordable.h",
     ],
     strip_include_prefix = "include",
     deps = [
@@ -46,7 +46,7 @@ cc_library(
     ],
     strip_include_prefix = "include",
     deps = [
-        ":recordable",
+        ":otlp_recordable",
         "//sdk/src/trace",
 
         # For gRPC
@@ -56,10 +56,10 @@ cc_library(
 )
 
 cc_test(
-    name = "recordable_test",
-    srcs = ["test/recordable_test.cc"],
+    name = "otlp_recordable_test",
+    srcs = ["test/otlp_recordable_test.cc"],
     deps = [
-        ":recordable",
+        ":otlp_recordable",
         "@com_google_googletest//:gtest_main",
     ],
 )

--- a/exporters/otlp/CMakeLists.txt
+++ b/exporters/otlp/CMakeLists.txt
@@ -1,4 +1,4 @@
-add_library(opentelemetry_exporter_otprotocol src/recordable.cc
+add_library(opentelemetry_exporter_otprotocol src/otlp_recordable.cc
                                               src/otlp_exporter.cc)
 
 set_target_properties(opentelemetry_exporter_otprotocol
@@ -27,14 +27,14 @@ target_include_directories(
   PUBLIC "$<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}/include>")
 
 if(BUILD_TESTING)
-  add_executable(recordable_test test/recordable_test.cc)
+  add_executable(otlp_recordable_test test/otlp_recordable_test.cc)
   target_link_libraries(
-    recordable_test ${GTEST_BOTH_LIBRARIES} ${CMAKE_THREAD_LIBS_INIT}
+    otlp_recordable_test ${GTEST_BOTH_LIBRARIES} ${CMAKE_THREAD_LIBS_INIT}
     opentelemetry_exporter_otprotocol)
   gtest_add_tests(
-    TARGET recordable_test
+    TARGET otlp_recordable_test
     TEST_PREFIX exporter.otlp.
-    TEST_LIST recordable_test)
+    TEST_LIST otlp_recordable_test)
   if(MSVC)
     add_definitions(-DGTEST_LINKED_AS_SHARED_LIBRARY=1)
   endif()

--- a/exporters/otlp/include/opentelemetry/exporters/otlp/otlp_recordable.h
+++ b/exporters/otlp/include/opentelemetry/exporters/otlp/otlp_recordable.h
@@ -14,7 +14,7 @@ namespace exporter
 {
 namespace otlp
 {
-class Recordable final : public sdk::trace::Recordable
+class OtlpRecordable final : public sdk::trace::Recordable
 {
 public:
   const proto::trace::v1::Span &span() const noexcept { return span_; }

--- a/exporters/otlp/src/otlp_exporter.cc
+++ b/exporters/otlp/src/otlp_exporter.cc
@@ -1,5 +1,5 @@
 #include "opentelemetry/exporters/otlp/otlp_exporter.h"
-#include "opentelemetry/exporters/otlp/recordable.h"
+#include "opentelemetry/exporters/otlp/otlp_recordable.h"
 
 #include <grpcpp/grpcpp.h>
 #include <fstream>
@@ -27,7 +27,7 @@ void PopulateRequest(const nostd::span<std::unique_ptr<sdk::trace::Recordable>> 
 
   for (auto &recordable : spans)
   {
-    auto rec = std::unique_ptr<Recordable>(static_cast<Recordable *>(recordable.release()));
+    auto rec = std::unique_ptr<OtlpRecordable>(static_cast<OtlpRecordable *>(recordable.release()));
     *instrumentation_lib->add_spans() = std::move(rec->span());
 
     if (!has_resource)
@@ -91,7 +91,7 @@ OtlpExporter::OtlpExporter(
 
 std::unique_ptr<sdk::trace::Recordable> OtlpExporter::MakeRecordable() noexcept
 {
-  return std::unique_ptr<sdk::trace::Recordable>(new Recordable);
+  return std::unique_ptr<sdk::trace::Recordable>(new OtlpRecordable);
 }
 
 sdk::common::ExportResult OtlpExporter::Export(

--- a/exporters/otlp/src/otlp_recordable.cc
+++ b/exporters/otlp/src/otlp_recordable.cc
@@ -1,4 +1,4 @@
-#include "opentelemetry/exporters/otlp/recordable.h"
+#include "opentelemetry/exporters/otlp/otlp_recordable.h"
 
 OPENTELEMETRY_BEGIN_NAMESPACE
 namespace exporter
@@ -12,8 +12,8 @@ namespace otlp
 const int kAttributeValueSize      = 15;
 const int kOwnedAttributeValueSize = 15;
 
-void Recordable::SetIdentity(const opentelemetry::trace::SpanContext &span_context,
-                             opentelemetry::trace::SpanId parent_span_id) noexcept
+void OtlpRecordable::SetIdentity(const opentelemetry::trace::SpanContext &span_context,
+                                 opentelemetry::trace::SpanId parent_span_id) noexcept
 {
   span_.set_trace_id(reinterpret_cast<const char *>(span_context.trace_id().Id().data()),
                      trace::TraceId::kSize);
@@ -216,7 +216,7 @@ void PopulateAttribute(opentelemetry::proto::common::v1::KeyValue *attribute,
   }
 }
 
-proto::resource::v1::Resource Recordable::ProtoResource() const noexcept
+proto::resource::v1::Resource OtlpRecordable::ProtoResource() const noexcept
 {
   proto::resource::v1::Resource proto;
   if (resource_)
@@ -230,21 +230,21 @@ proto::resource::v1::Resource Recordable::ProtoResource() const noexcept
   return proto;
 }
 
-void Recordable::SetResource(const opentelemetry::sdk::resource::Resource &resource) noexcept
+void OtlpRecordable::SetResource(const opentelemetry::sdk::resource::Resource &resource) noexcept
 {
   resource_ = &resource;
 };
 
-void Recordable::SetAttribute(nostd::string_view key,
-                              const opentelemetry::common::AttributeValue &value) noexcept
+void OtlpRecordable::SetAttribute(nostd::string_view key,
+                                  const opentelemetry::common::AttributeValue &value) noexcept
 {
   auto *attribute = span_.add_attributes();
   PopulateAttribute(attribute, key, value);
 }
 
-void Recordable::AddEvent(nostd::string_view name,
-                          common::SystemTimestamp timestamp,
-                          const common::KeyValueIterable &attributes) noexcept
+void OtlpRecordable::AddEvent(nostd::string_view name,
+                              common::SystemTimestamp timestamp,
+                              const common::KeyValueIterable &attributes) noexcept
 {
   auto *event = span_.add_events();
   event->set_name(name.data(), name.size());
@@ -256,8 +256,8 @@ void Recordable::AddEvent(nostd::string_view name,
   });
 }
 
-void Recordable::AddLink(const opentelemetry::trace::SpanContext &span_context,
-                         const common::KeyValueIterable &attributes) noexcept
+void OtlpRecordable::AddLink(const opentelemetry::trace::SpanContext &span_context,
+                             const common::KeyValueIterable &attributes) noexcept
 {
   auto *link = span_.add_links();
   link->set_trace_id(reinterpret_cast<const char *>(span_context.trace_id().Id().data()),
@@ -272,18 +272,18 @@ void Recordable::AddLink(const opentelemetry::trace::SpanContext &span_context,
   // TODO: Populate trace_state when it is supported by SpanContext
 }
 
-void Recordable::SetStatus(trace::StatusCode code, nostd::string_view description) noexcept
+void OtlpRecordable::SetStatus(trace::StatusCode code, nostd::string_view description) noexcept
 {
   span_.mutable_status()->set_code(opentelemetry::proto::trace::v1::Status_StatusCode(code));
   span_.mutable_status()->set_message(description.data(), description.size());
 }
 
-void Recordable::SetName(nostd::string_view name) noexcept
+void OtlpRecordable::SetName(nostd::string_view name) noexcept
 {
   span_.set_name(name.data(), name.size());
 }
 
-void Recordable::SetSpanKind(opentelemetry::trace::SpanKind span_kind) noexcept
+void OtlpRecordable::SetSpanKind(opentelemetry::trace::SpanKind span_kind) noexcept
 {
   opentelemetry::proto::trace::v1::Span_SpanKind proto_span_kind =
       opentelemetry::proto::trace::v1::Span_SpanKind::Span_SpanKind_SPAN_KIND_UNSPECIFIED;
@@ -325,18 +325,18 @@ void Recordable::SetSpanKind(opentelemetry::trace::SpanKind span_kind) noexcept
   span_.set_kind(proto_span_kind);
 }
 
-void Recordable::SetStartTime(opentelemetry::common::SystemTimestamp start_time) noexcept
+void OtlpRecordable::SetStartTime(opentelemetry::common::SystemTimestamp start_time) noexcept
 {
   span_.set_start_time_unix_nano(start_time.time_since_epoch().count());
 }
 
-void Recordable::SetDuration(std::chrono::nanoseconds duration) noexcept
+void OtlpRecordable::SetDuration(std::chrono::nanoseconds duration) noexcept
 {
   const uint64_t unix_end_time = span_.start_time_unix_nano() + duration.count();
   span_.set_end_time_unix_nano(unix_end_time);
 }
 
-void Recordable::SetInstrumentationLibrary(
+void OtlpRecordable::SetInstrumentationLibrary(
     const opentelemetry::sdk::instrumentationlibrary::InstrumentationLibrary
         &instrumentation_library) noexcept
 {

--- a/exporters/otlp/test/otlp_exporter_benchmark.cc
+++ b/exporters/otlp/test/otlp_exporter_benchmark.cc
@@ -1,5 +1,5 @@
 #include "opentelemetry/exporters/otlp/otlp_exporter.h"
-#include "opentelemetry/exporters/otlp/recordable.h"
+#include "opentelemetry/exporters/otlp/otlp_recordable.h"
 
 #include <benchmark/benchmark.h>
 
@@ -73,7 +73,7 @@ void CreateEmptySpans(std::array<std::unique_ptr<sdk::trace::Recordable>, kBatch
 {
   for (int i = 0; i < kBatchSize; i++)
   {
-    auto recordable = std::unique_ptr<sdk::trace::Recordable>(new Recordable);
+    auto recordable = std::unique_ptr<sdk::trace::Recordable>(new OtlpRecordable);
     recordables[i]  = std::move(recordable);
   }
 }
@@ -83,7 +83,7 @@ void CreateSparseSpans(std::array<std::unique_ptr<sdk::trace::Recordable>, kBatc
 {
   for (int i = 0; i < kBatchSize; i++)
   {
-    auto recordable = std::unique_ptr<sdk::trace::Recordable>(new Recordable);
+    auto recordable = std::unique_ptr<sdk::trace::Recordable>(new OtlpRecordable);
 
     recordable->SetIdentity(kSpanContext, kParentSpanId);
     recordable->SetName("TestSpan");
@@ -99,7 +99,7 @@ void CreateDenseSpans(std::array<std::unique_ptr<sdk::trace::Recordable>, kBatch
 {
   for (int i = 0; i < kBatchSize; i++)
   {
-    auto recordable = std::unique_ptr<sdk::trace::Recordable>(new Recordable);
+    auto recordable = std::unique_ptr<sdk::trace::Recordable>(new OtlpRecordable);
 
     recordable->SetIdentity(kSpanContext, kParentSpanId);
     recordable->SetName("TestSpan");

--- a/exporters/otlp/test/otlp_recordable_test.cc
+++ b/exporters/otlp/test/otlp_recordable_test.cc
@@ -1,4 +1,4 @@
-#include "opentelemetry/exporters/otlp/recordable.h"
+#include "opentelemetry/exporters/otlp/otlp_recordable.h"
 #include <gtest/gtest.h>
 
 OPENTELEMETRY_BEGIN_NAMESPACE
@@ -6,7 +6,7 @@ namespace exporter
 {
 namespace otlp
 {
-TEST(Recordable, SetIdentity)
+TEST(OtlpRecordable, SetIdentity)
 {
   constexpr uint8_t trace_id_buf[]       = {1, 2, 3, 4, 5, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7, 8};
   constexpr uint8_t span_id_buf[]        = {1, 2, 3, 4, 5, 6, 7, 8};
@@ -20,7 +20,7 @@ TEST(Recordable, SetIdentity)
       opentelemetry::trace::TraceFlags{opentelemetry::trace::TraceFlags::kIsSampled}, true,
       trace_state};
 
-  Recordable rec;
+  OtlpRecordable rec;
 
   rec.SetIdentity(span_context, parent_span_id);
 
@@ -34,25 +34,25 @@ TEST(Recordable, SetIdentity)
                         trace::SpanId::kSize));
 }
 
-TEST(Recordable, SetName)
+TEST(OtlpRecordable, SetName)
 {
-  Recordable rec;
+  OtlpRecordable rec;
   nostd::string_view name = "Test Span";
   rec.SetName(name);
   EXPECT_EQ(rec.span().name(), name);
 }
-TEST(Recordable, SetSpanKind)
+TEST(OtlpRecordable, SetSpanKind)
 {
-  Recordable rec;
+  OtlpRecordable rec;
   opentelemetry::trace::SpanKind span_kind = opentelemetry::trace::SpanKind::kServer;
   rec.SetSpanKind(span_kind);
   EXPECT_EQ(rec.span().kind(),
             opentelemetry::proto::trace::v1::Span_SpanKind::Span_SpanKind_SPAN_KIND_SERVER);
 }
 
-TEST(Recordable, SetStartTime)
+TEST(OtlpRecordable, SetStartTime)
 {
-  Recordable rec;
+  OtlpRecordable rec;
   std::chrono::system_clock::time_point start_time = std::chrono::system_clock::now();
   common::SystemTimestamp start_timestamp(start_time);
 
@@ -63,9 +63,9 @@ TEST(Recordable, SetStartTime)
   EXPECT_EQ(rec.span().start_time_unix_nano(), unix_start);
 }
 
-TEST(Recordable, SetDuration)
+TEST(OtlpRecordable, SetDuration)
 {
-  Recordable rec;
+  OtlpRecordable rec;
   // Start time is 0
   common::SystemTimestamp start_timestamp;
 
@@ -78,9 +78,9 @@ TEST(Recordable, SetDuration)
   EXPECT_EQ(rec.span().end_time_unix_nano(), unix_end);
 }
 
-TEST(Recordable, SetStatus)
+TEST(OtlpRecordable, SetStatus)
 {
-  Recordable rec;
+  OtlpRecordable rec;
   trace::StatusCode code(trace::StatusCode::kOk);
   nostd::string_view description = "For test";
   rec.SetStatus(code, description);
@@ -89,9 +89,9 @@ TEST(Recordable, SetStatus)
   EXPECT_EQ(rec.span().status().message(), description);
 }
 
-TEST(Recordable, AddEventDefault)
+TEST(OtlpRecordable, AddEventDefault)
 {
-  Recordable rec;
+  OtlpRecordable rec;
   nostd::string_view name = "Test Event";
 
   std::chrono::system_clock::time_point event_time = std::chrono::system_clock::now();
@@ -107,9 +107,9 @@ TEST(Recordable, AddEventDefault)
   EXPECT_EQ(rec.span().events(0).attributes().size(), 0);
 }
 
-TEST(Recordable, AddEventWithAttributes)
+TEST(OtlpRecordable, AddEventWithAttributes)
 {
-  Recordable rec;
+  OtlpRecordable rec;
   const int kNumAttributes              = 3;
   std::string keys[kNumAttributes]      = {"attr1", "attr2", "attr3"};
   int values[kNumAttributes]            = {4, 7, 23};
@@ -126,9 +126,9 @@ TEST(Recordable, AddEventWithAttributes)
   }
 }
 
-TEST(Recordable, AddLink)
+TEST(OtlpRecordable, AddLink)
 {
-  Recordable rec;
+  OtlpRecordable rec;
   const int kNumAttributes              = 3;
   std::string keys[kNumAttributes]      = {"attr1", "attr2", "attr3"};
   int values[kNumAttributes]            = {5, 12, 40};
@@ -150,9 +150,9 @@ TEST(Recordable, AddLink)
   }
 }
 
-TEST(Recordable, SetResource)
+TEST(OtlpRecordable, SetResource)
 {
-  Recordable rec;
+  OtlpRecordable rec;
   const std::string service_name_key = "service.name";
   std::string service_name           = "test-otlp";
   auto resource =
@@ -173,9 +173,9 @@ TEST(Recordable, SetResource)
 }
 
 // Test non-int single types. Int single types are tested using templates (see IntAttributeTest)
-TEST(Recordable, SetSingleAtrribute)
+TEST(OtlpRecordable, SetSingleAtrribute)
 {
-  Recordable rec;
+  OtlpRecordable rec;
   nostd::string_view bool_key = "bool_attr";
   common::AttributeValue bool_val(true);
   rec.SetAttribute(bool_key, bool_val);
@@ -200,9 +200,9 @@ TEST(Recordable, SetSingleAtrribute)
 }
 
 // Test non-int array types. Int array types are tested using templates (see IntAttributeTest)
-TEST(Recordable, SetArrayAtrribute)
+TEST(OtlpRecordable, SetArrayAtrribute)
 {
-  Recordable rec;
+  OtlpRecordable rec;
   const int kArraySize = 3;
 
   bool bool_arr[kArraySize] = {true, false, true};
@@ -246,7 +246,7 @@ TYPED_TEST(IntAttributeTest, SetIntSingleAttribute)
   IntType i     = 2;
   common::AttributeValue int_val(i);
 
-  Recordable rec;
+  OtlpRecordable rec;
   rec.SetAttribute("int_attr", int_val);
   EXPECT_EQ(rec.span().attributes(0).value().int_value(), nostd::get<IntType>(int_val));
 }
@@ -259,7 +259,7 @@ TYPED_TEST(IntAttributeTest, SetIntArrayAttribute)
   IntType int_arr[kArraySize] = {4, 5, 6};
   nostd::span<const IntType> int_span(int_arr);
 
-  Recordable rec;
+  OtlpRecordable rec;
   rec.SetAttribute("int_arr_attr", int_span);
 
   for (int i = 0; i < kArraySize; i++)


### PR DESCRIPTION
## Changes

There is `class Recordable` from API, SDK and exporters. Share the same name could cause confuse and hinder extending it with multiple variants in one exporter.

* [ ] `CHANGELOG.md` updated for non-trivial changes
* [ ] Unit tests have been added
* [ ] Changes in public API reviewed