### PR TITLE
update api doxygen conf file

### DIFF
--- a/api/docs/Doxyfile
+++ b/api/docs/Doxyfile
@@ -790,8 +790,9 @@ WARN_LOGFILE           =
 # spaces. See also FILE_PATTERNS and EXTENSION_MAPPING
 # Note: If this tag is empty the current directory is searched.
 
-INPUT                  = ../include/opentelemetry/common \
-                         ../include/opentelemetry/core \
+INPUT                  = ../include/opentelemetry/baggage \
+                         ../include/opentelemetry/context \
+                         ../include/opentelemetry/common \
                          ../include/opentelemetry/nostd/shared_ptr.h \
                          ../include/opentelemetry/nostd/span.h \
                          ../include/opentelemetry/nostd/string_view.h \
@@ -844,6 +845,7 @@ EXCLUDE                = ../include/opentelemetry/common/spin_lock_mutex.h \
                          ../include/opentelemetry/trace/span_context_kv_iterable_view.h \
                          ../include/opentelemetry/nostd
 
+
 # The EXCLUDE_SYMLINKS tag can be used to select whether or not files or
 # directories that are symbolic links (a Unix file system feature) are excluded
 # from the input.
@@ -869,7 +871,10 @@ EXCLUDE_PATTERNS       =
 # Note that the wildcards are matched against the file with absolute path, so to
 # exclude all test directories use the pattern */test/*
 
-EXCLUDE_SYMBOLS        = "AttributeType"
+EXCLUDE_SYMBOLS        = AttributeType \
+                         Context::DataList \
+                         ThreadLocalContextStorage::Stack
+
 
 # The EXAMPLE_PATH tag can be used to specify one or more files or directories
 # that contain example code fragments that are included (see the \include

--- a/api/docs/Doxyfile
+++ b/api/docs/Doxyfile
@@ -845,7 +845,6 @@ EXCLUDE                = ../include/opentelemetry/common/spin_lock_mutex.h \
                          ../include/opentelemetry/trace/span_context_kv_iterable_view.h \
                          ../include/opentelemetry/nostd
 
-
 # The EXCLUDE_SYMLINKS tag can be used to select whether or not files or
 # directories that are symbolic links (a Unix file system feature) are excluded
 # from the input.


### PR DESCRIPTION
## Changes

Change includes
  - Include  header files from `/include/opentelemetry/baggage` and `/include/opentelemetry/context` subdirectories 
  - Remove `/include/opentelemetry/core` subdirectory as it no longer exists.
  - Excluding internal classes from context api.

This is how it will look after merge:

https://labhas-opentelemetry-cpp.readthedocs.io/en/latest/index.html

Need to update `Getting Started` doc for extracting and injecting context from/to w3c header as separate PR

For significant contributions please make sure you have completed the following items:

* [ ] `CHANGELOG.md` updated for non-trivial changes
* [ ] Unit tests have been added
* [ ] Changes in public API reviewed