### PR TITLE
Fix an issue with GMOCK_LIB NOTFOUND with Visual Studio 2019

### DIFF
--- a/exporters/otlp/CMakeLists.txt
+++ b/exporters/otlp/CMakeLists.txt
@@ -37,12 +37,13 @@ if(BUILD_TESTING)
     TEST_LIST recordable_test)
   if(MSVC)
     add_definitions(-DGTEST_LINKED_AS_SHARED_LIBRARY=1)
-  endif()
-  if(GMOCK_LIB)
-    # unset GMOCK_LIB to force find_library to redo the lookup, as the cached
-    # entry could cause linking to incorrect flavor of gmock and leading to
-    # runtime error.
-    unset(GMOCK_LIB CACHE)
+  else()
+    if(GMOCK_LIB)
+      # unset GMOCK_LIB to force find_library to redo the lookup, as the cached
+      # entry could cause linking to incorrect flavor of gmock and leading to
+      # runtime error.
+      unset(GMOCK_LIB CACHE)
+    endif()
   endif()
   if(MSVC AND CMAKE_BUILD_TYPE STREQUAL "Debug")
     find_library(GMOCK_LIB gmockd PATH_SUFFIXES lib)


### PR DESCRIPTION
## Changes

@ThomsonTan - I am hitting this issue with CMake+vcpkg in Visual Studio 2019 when I enable OTLP on Windows.

```console
CMake Error: The following variables are used in this project, but they are set to NOTFOUND.
Please set them or make sure they are set and tested correctly in the CMake files:
GMOCK_LIB
```

Full log:

```console
1> CMake generation started for configuration: 'nostd-x64-Debug'.
1> Command line: "cmd.exe" /c "%SYSTEMROOT%\System32\chcp.com 65001 >NUL && "C:\PROGRAM FILES (X86)\MICROSOFT VISUAL STUDIO\2019\ENTERPRISE\COMMON7\IDE\COMMONEXTENSIONS\MICROSOFT\CMAKE\CMake\bin\cmake.exe"  -G "Ninja"  -DCMAKE_BUILD_TYPE:STRING="Debug" -DCMAKE_INSTALL_PREFIX:PATH="C:\work\opentelemetry-cpp\out\vs2019\nostd-x64-Debug\install" -DWITH_OTLP:BOOL="True" -DWITH_EXAMPLES:BOOL="true" -DCMAKE_C_COMPILER:FILEPATH="C:/Program Files (x86)/Microsoft Visual Studio/2019/Enterprise/VC/Tools/MSVC/14.28.29910/bin/Hostx64/x64/cl.exe" -DCMAKE_CXX_COMPILER:FILEPATH="C:/Program Files (x86)/Microsoft Visual Studio/2019/Enterprise/VC/Tools/MSVC/14.28.29910/bin/Hostx64/x64/cl.exe"  -DCMAKE_MAKE_PROGRAM="C:\PROGRAM FILES (X86)\MICROSOFT VISUAL STUDIO\2019\ENTERPRISE\COMMON7\IDE\COMMONEXTENSIONS\MICROSOFT\CMAKE\Ninja\ninja.exe" "C:\work\opentelemetry-cpp" 2>&1"
1> Working directory: C:\work\opentelemetry-cpp\out\vs2019\nostd-x64-Debug
1> [CMake] -- Found RE2 via CMake.
1> [CMake] PROTOBUF_PROTOC_EXECUTABLE=C:/work/opentelemetry-cpp/tools/vcpkg/installed/x64-windows/tools/protobuf/protoc.exe
1> [CMake] GTEST_INCLUDE_DIRS   = C:/work/opentelemetry-cpp/tools/vcpkg/installed/x64-windows/include
1> [CMake] GTEST_BOTH_LIBRARIES = optimized;C:/work/opentelemetry-cpp/tools/vcpkg/installed/x64-windows/lib/gtest.lib;debug;C:/work/opentelemetry-cpp/tools/vcpkg/installed/x64-windows/debug/lib/gtestd.lib;optimized;C:/work/opentelemetry-cpp/tools/vcpkg/installed/x64-windows/lib/manual-link/gtest_main.lib;debug;C:/work/opentelemetry-cpp/tools/vcpkg/installed/x64-windows/debug/lib/manual-link/gtest_maind.lib
1> [CMake] Building with nostd types...
1> [CMake] -- Configuring done
1> [CMake] CMake Error: The following variables are used in this project, but they are set to NOTFOUND.
1> [CMake] Please set them or make sure they are set and tested correctly in the CMake files:
1> [CMake] GMOCK_LIB
1> [CMake]     linked by target "otlp_exporter_test" in directory C:/work/opentelemetry-cpp/exporters/otlp
1> [CMake] 
1> [CMake] -- Generating done
1> [CMake] CMake Generate step failed.  Build files cannot be regenerated correctly.
1> 'cmd.exe' '/c "%SYSTEMROOT%\System32\chcp.com 65001 >NUL && "C:\PROGRAM FILES (X86)\MICROSOFT VISUAL STUDIO\2019\ENTERPRISE\COMMON7\IDE\COMMONEXTENSIONS\MICROSOFT\CMAKE\CMake\bin\cmake.exe"  -G "Ninja"  -DCMAKE_BUILD_TYPE:STRING="Debug" -DCMAKE_INSTALL_PREFIX:PATH="C:\work\opentelemetry-cpp\out\vs2019\nostd-x64-Debug\install" -DWITH_OTLP:BOOL="True" -DWITH_EXAMPLES:BOOL="true" -DCMAKE_C_COMPILER:FILEPATH="C:/Program Files (x86)/Microsoft Visual Studio/2019/Enterprise/VC/Tools/MSVC/14.28.29910/bin/Hostx64/x64/cl.exe" -DCMAKE_CXX_COMPILER:FILEPATH="C:/Program Files (x86)/Microsoft Visual Studio/2019/Enterprise/VC/Tools/MSVC/14.28.29910/bin/Hostx64/x64/cl.exe"  -DCMAKE_MAKE_PROGRAM="C:\PROGRAM FILES (X86)\MICROSOFT VISUAL STUDIO\2019\ENTERPRISE\COMMON7\IDE\COMMONEXTENSIONS\MICROSOFT\CMAKE\Ninja\ninja.exe" "C:\work\opentelemetry-cpp" 2>&1"' execution failed with error: ''cmd.exe' '/c "%SYSTEMROOT%\System32\chcp.com 65001 >NUL && "C:\PROGRAM FILES (X86)\MICROSOFT VISUAL STUDIO\2019\ENTERPRISE\COMMON7\IDE\COMMONEXTENSIONS\MICROSOFT\CMAKE\CMake\bin\cmake.exe"  -G "Ninja"  -DCMAKE_BUILD_TYPE:STRING="Debug" -DCMAKE_INSTALL_PREFIX:PATH="C:\work\opentelemetry-cpp\out\vs2019\nostd-x64-Debug\install" -DWITH_OTLP:BOOL="True" -DWITH_EXAMPLES:BOOL="true" -DCMAKE_C_COMPILER:FILEPATH="C:/Program Files (x86)/Microsoft Visual Studio/2019/Enterprise/VC/Tools/MSVC/14.28.29910/bin/Hostx64/x64/cl.exe" -DCMAKE_CXX_COMPILER:FILEPATH="C:/Program Files (x86)/Microsoft Visual Studio/2019/Enterprise/VC/Tools/MSVC/14.28.29910/bin/Hostx64/x64/cl.exe"  -DCMAKE_MAKE_PROGRAM="C:\PROGRAM FILES (X86)\MICROSOFT VISUAL STUDIO\2019\ENTERPRISE\COMMON7\IDE\COMMONEXTENSIONS\MICROSOFT\CMAKE\Ninja\ninja.exe" "C:\work\opentelemetry-cpp" 2>&1"' returned with exit code: 1'.
```

I assume your recent change ( #726 ) - was somehow affecting Linux / gcc build. But not MSVC. Thus, I'm changing this a tiny bit - to apply your previous patch only to non-MSVC path. After I applied this change, I get it all building and working well witch CMake + Visual Studio 2019 (MSVC) + ninja. All tests are Okay. Please let me know if it makes sense. If you think this is not good, kindly elaborate on what exact issue you had originally with this variable defined.