### PR TITLE
Clone grpc and submodules with 1 level of git history

### DIFF
--- a/ci/setup_grpc.sh
+++ b/ci/setup_grpc.sh
@@ -10,8 +10,10 @@ fi
 export BUILD_DIR=/tmp/
 export INSTALL_DIR=/usr/local/
 pushd $BUILD_DIR
-git clone --recurse-submodules -b v1.34.0 https://github.com/grpc/grpc
+git clone --depth=1 -b v1.34.0 https://github.com/grpc/grpc
 cd grpc
+git submodule init
+git submodule update --depth 1
 mkdir -p cmake/build
 pushd cmake/build
 cmake -DgRPC_INSTALL=ON \


### PR DESCRIPTION
grpc repo with submodules has size close to 2GB. Eliminating clone the git history could save the size to ~300MB and also accelerate the clone process significantly.

For significant contributions please make sure you have completed the following items:

* [ ] `CHANGELOG.md` updated for non-trivial changes
* [ ] Unit tests have been added
* [ ] Changes in public API reviewed