### PR TITLE
Update readthedocs api guide: nested spans and context propagator

### DIFF
--- a/docs/public/GettingStarted.rst
+++ b/docs/public/GettingStarted.rst
@@ -68,7 +68,7 @@ Create nested Spans
 
 
 Spans can be nested, and have a parent-child relationship with other spans.
-When a given span is active,the newly created span inherits the active span's
+When a given span is active, the newly created span inherits the active span's
 trace ID, and other context attributes.
 
 Context Propagation

--- a/docs/public/GettingStarted.rst
+++ b/docs/public/GettingStarted.rst
@@ -60,10 +60,10 @@ Create nested Spans
     {
         auto inner_span = tracer->StartSpan("Inner operation");
         auto inner_scope = tracer->WithActiveSpan(inner_span);
-        // inner operation
+        // ... perform inner operation
         inner_span->End();
     }
-    // outer operation
+    // ... perform outer operation
     outer_span->End();
 
 
@@ -76,6 +76,12 @@ Context Propagation
 
 .. code:: cpp
 
+    // set global propagator
+    opentelemetry::context::propagation::GlobalTextMapPropagator::SetGlobalPropagator(
+        nostd::shared_ptr<opentelemetry::context::propagation::TextMapPropagator>(
+            new opentelemetry::trace::propagation::HttpTraceContext()));
+
+    // get global propagator
     HttpTextMapCarrier<opentelemetry::ext::http::client::Headers> carrier;
     auto propagator =
         opentelemetry::context::propagation::GlobalTextMapPropagator::GetGlobalPropagator();

--- a/docs/public/GettingStarted.rst
+++ b/docs/public/GettingStarted.rst
@@ -53,17 +53,17 @@ active span. A span without a parent is called root span.
 Create nested Spans
 ^^^^^^^^^^^^^^^^^^^
 
-..code:: cpp
+.. code:: cpp
 
     auto outer_span = tracer->StartSpan("Outer operation");
     auto outer_scope = tracer->WithActiveSpan(outer_span);
     {
         auto inner_span = tracer->StartSpan("Inner operation");
         auto inner_scope = tracer->WithActiveSpan(inner_span);
-        ---
+        // inner operation
         inner_span->End();
     }
-    ---
+    // outer operation
     outer_span->End();
 
 
@@ -74,7 +74,7 @@ trace ID, and other context attributes.
 Context Propagation
 ^^^^^^^^^^^^^^^^^^
 
-..code:: cpp
+.. code:: cpp
 
     HttpTextMapCarrier<opentelemetry::ext::http::client::Headers> carrier;
     auto propagator =


### PR DESCRIPTION
Added Nested spans and Context Propagation in API Getting started guide.

Here is how it looks like:

https://labhas-opentelemetry-cpp.readthedocs.io/en/latest/GettingStarted.html

For significant contributions please make sure you have completed the following items:

* [ ] `CHANGELOG.md` updated for non-trivial changes
* [ ] Unit tests have been added
* [ ] Changes in public API reviewed