### PR TITLE
Small cleanup in http example to use GetSpan() function.

### DIFF
--- a/examples/http/server.cc
+++ b/examples/http/server.cc
@@ -25,7 +25,7 @@ public:
     auto prop = opentelemetry::context::propagation::GlobalTextMapPropagator::GetGlobalPropagator();
     auto current_ctx = opentelemetry::context::RuntimeContext::GetCurrent();
     auto new_context = prop->Extract(carrier, current_ctx);
-    options.parent   = GetSpanFromContext(new_context)->GetContext();
+    options.parent   = opentelemetry::trace::propagation::GetSpan(new_context)->GetContext();
 
     // start span with parent context extracted from http header
     auto span = get_tracer("http-server")

--- a/examples/http/tracer_common.h
+++ b/examples/http/tracer_common.h
@@ -16,19 +16,6 @@
 
 namespace
 {
-// TBD - This function be removed once #723 is merged
-inline nostd::shared_ptr<opentelemetry::trace::Span> GetSpanFromContext(
-    const opentelemetry::context::Context &context)
-{
-  opentelemetry::context::ContextValue span = context.GetValue(opentelemetry::trace::kSpanKey);
-  if (nostd::holds_alternative<nostd::shared_ptr<opentelemetry::trace::Span>>(span))
-  {
-    return nostd::get<nostd::shared_ptr<opentelemetry::trace::Span>>(span);
-  }
-  static nostd::shared_ptr<opentelemetry::trace::Span> invalid_span{
-      new opentelemetry::trace::DefaultSpan(opentelemetry::trace::SpanContext::GetInvalid())};
-  return invalid_span;
-}
 
 template <typename T>
 class HttpTextMapCarrier : public opentelemetry::context::propagation::TextMapCarrier


### PR DESCRIPTION
Now that #723 is merged, `GetSpan()` function introduced in that PR can be reused to get the span object from provided context.

* [ ] `CHANGELOG.md` updated for non-trivial changes
* [ ] Unit tests have been added
* [ ] Changes in public API reviewed