### PR TITLE
Fix build status icon

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![Slack](https://img.shields.io/badge/slack-@cncf/otel/cpp-brightgreen.svg?logo=slack)](https://cloud-native.slack.com/archives/C01N3AT62SJ)
 [![codecov.io](https://codecov.io/gh/open-telemetry/opentelemetry-cpp/branch/main/graphs/badge.svg?)](https://codecov.io/gh/open-telemetry/opentelemetry-cpp/)
 [![Build
-Status](https://action-badges.now.sh/open-telemetry/opentelemetry-cpp)](https://github.com/open-telemetry/opentelemetry-cpp/actions)
+Status](https://github.com/open-telemetry/opentelemetry-cpp/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/open-telemetry/opentelemetry-cpp/actions)
 [![Release](https://img.shields.io/github/v/release/open-telemetry/opentelemetry-cpp?include_prereleases&style=)](https://github.com/open-telemetry/opentelemetry-cpp/releases/)
 
 The C++ [OpenTelemetry](https://opentelemetry.io/) client.


### PR DESCRIPTION
## Changes

action-badges.now.sh seems deprecated (see [here](https://github.com/JasonEtco/action-badges)) and doesn't show the build status of this repo (currently `build: unknown` is displayed on the badge https://action-badges.vercel.app/open-telemetry/opentelemetry-cpp). Replace it with the github action badge.

For significant contributions please make sure you have completed the following items:

* [ ] `CHANGELOG.md` updated for non-trivial changes
* [ ] Unit tests have been added
* [ ] Changes in public API reviewed