### PR TITLE
Output verbose error for failed unit-test in CI

### DIFF
--- a/ci/do_ci.sh
+++ b/ci/do_ci.sh
@@ -26,6 +26,7 @@ mkdir -p "${PLUGIN_DIR}"
 BAZEL_OPTIONS=""
 BAZEL_TEST_OPTIONS="$BAZEL_OPTIONS --test_output=errors"
 BAZEL_STARTUP_OPTIONS="--output_user_root=$HOME/.cache/bazel"
+CTEST_OUTPUT_ON_FAILURE=1
 
 if [[ "$1" == "cmake.test" ]]; then
   install_prometheus_cpp_client

--- a/ci/do_ci.sh
+++ b/ci/do_ci.sh
@@ -26,7 +26,8 @@ mkdir -p "${PLUGIN_DIR}"
 BAZEL_OPTIONS=""
 BAZEL_TEST_OPTIONS="$BAZEL_OPTIONS --test_output=errors"
 BAZEL_STARTUP_OPTIONS="--output_user_root=$HOME/.cache/bazel"
-CTEST_OUTPUT_ON_FAILURE=1
+
+export CTEST_OUTPUT_ON_FAILURE=1
 
 if [[ "$1" == "cmake.test" ]]; then
   install_prometheus_cpp_client


### PR DESCRIPTION
## Changes

Some CI failures could be hard to be reproduced locally, including race condition. Set `CTEST_OUTPUT_ON_FAILURE` to 1 will ask CTest to output more detail for the failure which will help offline investigation.

For significant contributions please make sure you have completed the following items:

* [ ] `CHANGELOG.md` updated for non-trivial changes
* [ ] Unit tests have been added
* [ ] Changes in public API reviewed