### PR TITLE
Remove sleep_for in ETW TracerCheck test

### DIFF
--- a/exporters/etw/test/etw_tracer_test.cc
+++ b/exporters/etw/test/etw_tracer_test.cc
@@ -60,7 +60,6 @@ TEST(ETWTracer, TracerCheck)
   {
     auto topSpan = tracer->StartSpan("MySpanTop");
     auto topScope = tracer->WithActiveSpan(topSpan);
-    std::this_thread::sleep_for (std::chrono::seconds(1));
     {
       auto outerSpan = tracer->StartSpan("MySpanL2", attribs);
       auto outerScope = tracer->WithActiveSpan(outerSpan);
@@ -80,7 +79,6 @@ TEST(ETWTracer, TracerCheck)
           {"strKey", "someValue"}
         };
         EXPECT_NO_THROW(outerSpan->AddEvent(eventName1, event1));
-        std::this_thread::sleep_for (std::chrono::seconds(1));
 
         // Add second event
         std::string eventName2 = "MyEvent2";
@@ -91,7 +89,6 @@ TEST(ETWTracer, TracerCheck)
           {"strKey", "anotherValue"}
         };
         EXPECT_NO_THROW(outerSpan->AddEvent(eventName2, event2));
-        std::this_thread::sleep_for (std::chrono::seconds(2));
 
         std::string eventName3= "MyEvent3";
         Properties event3 =
@@ -104,7 +101,6 @@ TEST(ETWTracer, TracerCheck)
           {"tempString", getTemporaryValue() }
         };
         EXPECT_NO_THROW(innerSpan->AddEvent(eventName3, event3));
-        std::this_thread::sleep_for (std::chrono::seconds(1));
         EXPECT_NO_THROW(innerSpan->End());
 
       }


### PR DESCRIPTION
Fixes #783 

## Changes

Discussed with @maxgolov and confirmed these `sleep_for` calls are not necessary. Remove them could save us 5 seconds when running ETW `TracerCheck` test.

For significant contributions please make sure you have completed the following items:

* [ ] `CHANGELOG.md` updated for non-trivial changes
* [ ] Unit tests have been added
* [ ] Changes in public API reviewed