### PR TITLE
Fixes #804

### DIFF
--- a/exporters/elasticsearch/CMakeLists.txt
+++ b/exporters/elasticsearch/CMakeLists.txt
@@ -1,10 +1,28 @@
-include_directories(include)
-include_directories(${CMAKE_SOURCE_DIR}/ext/include)
-
 add_library(opentelemetry_exporter_elasticsearch_logs src/es_log_exporter.cc)
+
+set_target_properties(opentelemetry_exporter_elasticsearch_logs
+                      PROPERTIES EXPORT_NAME elasticsearch_log_exporter)
+
+target_include_directories(
+  opentelemetry_exporter_elasticsearch_logs
+  PUBLIC "$<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}/include>"
+         "$<INSTALL_INTERFACE:include>")
 
 target_link_libraries(opentelemetry_exporter_elasticsearch_logs
                       PUBLIC opentelemetry_trace http_client_curl)
+
+install(
+  TARGETS opentelemetry_exporter_elasticsearch_logs
+  EXPORT "${PROJECT_NAME}-target"
+  RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+  LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+  ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR})
+
+install(
+  DIRECTORY include/opentelemetry/exporters/elasticsearch
+  DESTINATION include/opentelemetry/exporters/
+  FILES_MATCHING
+  PATTERN "*.h")
 
 if(BUILD_TESTING)
   add_executable(es_log_exporter_test test/es_log_exporter_test.cc)
@@ -12,19 +30,6 @@ if(BUILD_TESTING)
   target_link_libraries(
     es_log_exporter_test ${GTEST_BOTH_LIBRARIES} ${CMAKE_THREAD_LIBS_INIT}
     opentelemetry_exporter_elasticsearch_logs)
-
-  install(
-    TARGETS opentelemetry_exporter_elasticsearch_logs
-    EXPORT "${PROJECT_NAME}-target"
-    RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
-    LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
-    ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR})
-
-  install(
-    DIRECTORY include/opentelemetry/exporters/elasticsearch
-    DESTINATION include/opentelemetry/exporters/
-    FILES_MATCHING
-    PATTERN "*.h")
 
   gtest_add_tests(
     TARGET es_log_exporter_test

--- a/exporters/etw/CMakeLists.txt
+++ b/exporters/etw/CMakeLists.txt
@@ -1,5 +1,30 @@
-include_directories(include
-                    ${CMAKE_SOURCE_DIR}/third_party/nlohmann-json/include)
+find_package(nlohmann_json REQUIRED)
+
+add_library(opentelemetry_exporter_etw INTERFACE)
+
+target_include_directories(
+  opentelemetry_exporter_etw
+  INTERFACE "$<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}/include>"
+            "$<INSTALL_INTERFACE:include>")
+
+set_target_properties(opentelemetry_exporter_etw PROPERTIES EXPORT_NAME
+                                                            etw_exporter)
+
+target_link_libraries(opentelemetry_exporter_etw
+                      INTERFACE nlohmann_json::nlohmann_json)
+
+install(
+  TARGETS opentelemetry_exporter_etw
+  EXPORT "${PROJECT_NAME}-target"
+  RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+  LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+  ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR})
+
+install(
+  DIRECTORY include/opentelemetry/exporters/etw
+  DESTINATION include/opentelemetry/exporters/
+  FILES_MATCHING
+  PATTERN "*.h")
 
 if(BUILD_TESTING)
   add_executable(etw_provider_test test/etw_provider_test.cc)
@@ -7,13 +32,14 @@ if(BUILD_TESTING)
   add_executable(etw_perf_test test/etw_perf_test.cc)
 
   target_link_libraries(etw_provider_test ${GTEST_BOTH_LIBRARIES}
-                        ${CMAKE_THREAD_LIBS_INIT})
+                        opentelemetry_exporter_etw ${CMAKE_THREAD_LIBS_INIT})
 
   target_link_libraries(etw_tracer_test ${GTEST_BOTH_LIBRARIES}
-                        ${CMAKE_THREAD_LIBS_INIT})
+                        opentelemetry_exporter_etw ${CMAKE_THREAD_LIBS_INIT})
 
-  target_link_libraries(etw_perf_test benchmark::benchmark
-                        ${GTEST_BOTH_LIBRARIES} ${CMAKE_THREAD_LIBS_INIT})
+  target_link_libraries(
+    etw_perf_test benchmark::benchmark ${GTEST_BOTH_LIBRARIES}
+    opentelemetry_exporter_etw ${CMAKE_THREAD_LIBS_INIT})
 
   gtest_add_tests(
     TARGET etw_provider_test

--- a/exporters/jaeger/CMakeLists.txt
+++ b/exporters/jaeger/CMakeLists.txt
@@ -1,4 +1,3 @@
-include_directories(include)
 include_directories(thrift-gen)
 
 find_package(Thrift REQUIRED)
@@ -13,6 +12,15 @@ set(JAEGER_EXPORTER_SOURCES
 
 add_library(jaeger_trace_exporter ${JAEGER_EXPORTER_SOURCES}
                                   ${JAEGER_THRIFT_GENCPP_SOURCES})
+
+set_target_properties(jaeger_trace_exporter PROPERTIES EXPORT_NAME
+                                                       jaeger_trace_exporter)
+
+target_include_directories(
+  jaeger_trace_exporter
+  PUBLIC "$<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}/include>"
+         "$<INSTALL_INTERFACE:include>")
+
 target_link_libraries(
   jaeger_trace_exporter
   PUBLIC opentelemetry_resources
@@ -25,6 +33,19 @@ if(MSVC)
                                PUBLIC THRIFT_STATIC_DEFINE)
   endif()
 endif()
+
+install(
+  TARGETS jaeger_trace_exporter
+  EXPORT "${PROJECT_NAME}-target"
+  RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+  LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+  ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR})
+
+install(
+  DIRECTORY include/opentelemetry/exporters/jaeger
+  DESTINATION include/opentelemetry/exporters/
+  FILES_MATCHING
+  PATTERN "*.h")
 
 if(BUILD_TESTING)
   add_executable(jaeger_recordable_test test/jaeger_recordable_test.cc)

--- a/exporters/memory/CMakeLists.txt
+++ b/exporters/memory/CMakeLists.txt
@@ -1,5 +1,3 @@
-include_directories(include)
-
 add_library(opentelemetry_exporter_in_memory INTERFACE)
 
 target_include_directories(

--- a/exporters/ostream/CMakeLists.txt
+++ b/exporters/ostream/CMakeLists.txt
@@ -33,7 +33,8 @@ install(
   DIRECTORY include/opentelemetry/exporters/ostream
   DESTINATION include/opentelemetry/exporters/
   FILES_MATCHING
-  PATTERN "metrics_exporter.h" EXCLUDE)
+  PATTERN "metrics_exporter.h" EXCLUDE
+  PATTERN "*.h")
 
 if(BUILD_TESTING)
   add_executable(ostream_span_test test/ostream_span_test.cc)

--- a/ext/CMakeLists.txt
+++ b/ext/CMakeLists.txt
@@ -1,4 +1,3 @@
-include_directories(sdk)
 add_library(opentelemetry_ext INTERFACE)
 target_include_directories(
   opentelemetry_ext
@@ -20,7 +19,6 @@ install(
   FILES_MATCHING
   PATTERN "*.h")
 
-include_directories(include)
 add_subdirectory(src)
 
 if(BUILD_TESTING)

--- a/ext/src/http/client/curl/CMakeLists.txt
+++ b/ext/src/http/client/curl/CMakeLists.txt
@@ -6,10 +6,13 @@ if(CURL_FOUND)
                                                     http_client_curl)
 
   if(TARGET CURL::libcurl)
-    target_link_libraries(http_client_curl PUBLIC CURL::libcurl)
+    target_link_libraries(http_client_curl PUBLIC opentelemetry_ext
+                                                  CURL::libcurl)
   else()
-    include_directories(${CURL_INCLUDE_DIRS})
-    target_link_libraries(http_client_curl PUBLIC ${CURL_LIBRARIES})
+    target_include_directories(http_client_curl
+                               INTERFACE "${CURL_INCLUDE_DIRS}")
+    target_link_libraries(http_client_curl PUBLIC opentelemetry_ext
+                                                  ${CURL_LIBRARIES})
   endif()
 
   install(

--- a/opentelemetry-cpp-config.cmake.in
+++ b/opentelemetry-cpp-config.cmake.in
@@ -34,6 +34,9 @@
 #   opentelemetry-cpp::ostream_metrics_exporter   - Imported target of opentelemetry-cpp::ostream_metrics_exporter
 #   opentelemetry-cpp::ostream_span_exporter      - Imported target of opentelemetry-cpp::ostream_span_exporter
 #   opentelemetry-cpp::prometheus_exporter        - Imported target of opentelemetry-cpp::prometheus_exporter
+#   opentelemetry-cpp::elasticsearch_log_exporter - Imported target of opentelemetry-cpp::elasticsearch_log_exporter
+#   opentelemetry-cpp::etw_exporter               - Imported target of opentelemetry-cpp::etw_exporter
+#   opentelemetry-cpp::jaeger_trace_exporter      - Imported target of opentelemetry-cpp::jaeger_trace_exporter
 #   opentelemetry-cpp::zpages                     - Imported target of opentelemetry-cpp::zpages
 #   opentelemetry-cpp::http_client_curl           - Imported target of opentelemetry-cpp::http_client_curl
 #
@@ -77,7 +80,8 @@ set(_OPENTELEMETRY_CPP_LIBRARIES_TEST_TARGETS
     ostream_log_exporter
     ostream_metrics_exporter
     ostream_span_exporter
-    zpages)
+    zpages
+    http_client_curl)
 foreach(_TEST_TARGET IN LISTS _OPENTELEMETRY_CPP_LIBRARIES_TEST_TARGETS)
   if(TARGET opentelemetry-cpp::${_TEST_TARGET})
     list(APPEND OPENTELEMETRY_CPP_LIBRARIES opentelemetry-cpp::${_TEST_TARGET})

--- a/opentelemetry-cpp-config.cmake.in
+++ b/opentelemetry-cpp-config.cmake.in
@@ -76,10 +76,15 @@ set(_OPENTELEMETRY_CPP_LIBRARIES_TEST_TARGETS
     trace
     metrics
     logs
+    in_memory_span_exporter
     otlp_exporter
     ostream_log_exporter
     ostream_metrics_exporter
     ostream_span_exporter
+    prometheus_exporter
+    elasticsearch_log_exporter
+    etw_exporter
+    jaeger_trace_exporter
     zpages
     http_client_curl)
 foreach(_TEST_TARGET IN LISTS _OPENTELEMETRY_CPP_LIBRARIES_TEST_TARGETS)


### PR DESCRIPTION
Signed-off-by: owent <admin@owent.net>

Fixes #804

## Changes

1. Fix install rule for header files of ostream exporter
2. Add more export targets for cmake

For significant contributions please make sure you have completed the following items:

* [x] `CHANGELOG.md` updated for non-trivial changes
* [x] Unit tests have been added
* [x] Changes in public API reviewed