### PR TITLE
Make our codecov settings more forgiving

### DIFF
--- a/.github/.codecov.yaml
+++ b/.github/.codecov.yaml
@@ -1,13 +1,22 @@
 codecov:
-  require_ci_to_pass: yes
+  require_ci_to_pass: false
   max_report_age: off
 
 coverage:
   precision: 2
-  round: down
+  round: up
   range: "80...100"
   status:
-    patch: off
+    project:
+      default:
+        informational: true
+        target: auto
+        threshold: 10%
+    patch:
+      default:
+        informational: true
+        target: auto
+        threshold: 10%
 
 parsers:
   gcov:
@@ -20,7 +29,7 @@ parsers:
 comment:
   layout: "reach,diff,flags,tree"
   behavior: default
-  require_changes: no
+  require_changes: false
 
 # Relative file path fixing.
 # CI file paths must match Git file paths.


### PR DESCRIPTION
This is a humble attempt to make our codecov settings more forgiving.

Main motivation for this PR is that our current codecov settings are flaky and trigger A LOT of false-positives.

Practical illustration. See those red marks - false-positives mostly associated with badly tuned codecov settings:

![image](https://user-images.githubusercontent.com/34072974/120043718-50325000-bfc1-11eb-8fc5-3a50afcff247.png)

Hopefully the new settings are going to:
- drop the codecov to informational.
- allow some float / slack in the settings.
- devs should still treat the generated report with respect and dignity, and use their best judgement to decide if they need to improve their newly added code code coverage.