### PR TITLE
Reinstate the TracerContext constructor for single processor

### DIFF
--- a/sdk/include/opentelemetry/sdk/trace/tracer_context.h
+++ b/sdk/include/opentelemetry/sdk/trace/tracer_context.h
@@ -33,6 +33,18 @@ class TracerContext
 {
 public:
   explicit TracerContext(
+      std::unique_ptr<SpanProcessor> processor,
+      opentelemetry::sdk::resource::Resource resource =
+          opentelemetry::sdk::resource::Resource::Create({}),
+      std::unique_ptr<Sampler> sampler = std::unique_ptr<AlwaysOnSampler>(new AlwaysOnSampler),
+      std::unique_ptr<IdGenerator> id_generator =
+          std::unique_ptr<IdGenerator>(new RandomIdGenerator())) noexcept
+      : processor_(std::move(processor)),
+        resource_(resource),
+        sampler_(std::move(sampler)),
+        id_generator_(std::move(id_generator)){};
+
+  explicit TracerContext(
       std::vector<std::unique_ptr<SpanProcessor>> &&processor,
       opentelemetry::sdk::resource::Resource resource =
           opentelemetry::sdk::resource::Resource::Create({}),


### PR DESCRIPTION
## Changes

Recent refactor removed the constructor for single processor, assuming that there is always a vector of processors #692 . However, the most common trivial scenario is when a customer provides a single processor rather than a vector of them. The intent of this change is to reinstate the previous constructor that got (inadvertently?) removed, keeping the simpler constructor in place where it was before.

No significant changes. Just reinstating what was accidentally removed.

Since the constructor is rather trivial (empty), implementation is included inline in the header, not added to separate .cc file. I do not have objection if there is an ask to move the empty body into separate compilation unit. But it seems okay to me as-is.