### PR TITLE
Allow to build `WITH_JAEGER` in Visual Studio 2019 + CMake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,6 +6,20 @@ cmake_policy(SET CMP0057 NEW)
 
 project(opentelemetry-cpp)
 
+# Mark variables as used so cmake doesn't complain about them
+mark_as_advanced(CMAKE_TOOLCHAIN_FILE)
+
+# Autodetect vcpkg toolchain
+if(DEFINED ENV{VCPKG_ROOT} AND NOT DEFINED CMAKE_TOOLCHAIN_FILE)
+  set(CMAKE_TOOLCHAIN_FILE
+      "$ENV{VCPKG_ROOT}/scripts/buildsystems/vcpkg.cmake"
+      CACHE STRING "")
+endif()
+
+if(VCPKG_CHAINLOAD_TOOLCHAIN_FILE)
+  include("${VCPKG_CHAINLOAD_TOOLCHAIN_FILE}")
+endif()
+
 file(READ "${CMAKE_CURRENT_LIST_DIR}/api/include/opentelemetry/version.h"
      OPENTELEMETRY_CPP_HEADER_VERSION_H)
 if(OPENTELEMETRY_CPP_HEADER_VERSION_H MATCHES
@@ -92,6 +106,7 @@ option(WITH_JAEGER "Whether to include the Jaeger exporter" OFF)
 
 option(BUILD_TESTING "Whether to enable tests" ON)
 if(WIN32)
+  add_definitions(-DNOMINMAX)
   if(BUILD_TESTING)
     if(MSVC)
       # GTest bug: https://github.com/google/googletest/issues/860
@@ -134,6 +149,16 @@ function(install_windows_deps)
       ${CMAKE_CURRENT_SOURCE_DIR}/tools/vcpkg/scripts/buildsystems/vcpkg.cmake
       PARENT_SCOPE)
 endfunction()
+
+if(WITH_JAEGER)
+  find_package(Thrift QUIET CONFIG)
+  if(NOT Thrift_FOUND)
+    # Install Thrift and propagate via vcpkg toolchain file
+    if(WIN32 AND (NOT DEFINED CMAKE_TOOLCHAIN_FILE))
+      install_windows_deps()
+    endif()
+  endif()
+endif()
 
 if(MSVC)
   # Options for Visual C++ compiler: /Zc:__cplusplus - report an updated value

--- a/exporters/jaeger/CMakeLists.txt
+++ b/exporters/jaeger/CMakeLists.txt
@@ -1,7 +1,7 @@
 include_directories(thrift-gen)
 
 find_package(Thrift REQUIRED)
-# vcpkg config recipe points to THRIFT_INCLUDE_DIR=...\thrift Ensure that the
+# vcpkg config recipe points to THRIFT_INCLUDE_DIR=...\thrift . Ensure that the
 # include dir for thrift-gen code is 1 level-up from that:
 include_directories(SYSTEM ${THRIFT_INCLUDE_DIR}/..)
 

--- a/exporters/jaeger/CMakeLists.txt
+++ b/exporters/jaeger/CMakeLists.txt
@@ -1,6 +1,9 @@
 include_directories(thrift-gen)
 
 find_package(Thrift REQUIRED)
+# vcpkg config recipe points to THRIFT_INCLUDE_DIR=...\thrift Ensure that the
+# include dir for thrift-gen code is 1 level-up from that:
+include_directories(SYSTEM ${THRIFT_INCLUDE_DIR}/..)
 
 set(JAEGER_THRIFT_GENCPP_SOURCES
     thrift-gen/Agent.cpp thrift-gen/jaeger_types.cpp thrift-gen/Collector.cpp

--- a/tools/setup-buildtools.cmd
+++ b/tools/setup-buildtools.cmd
@@ -64,5 +64,6 @@ vcpkg install protobuf:%ARCH%-windows
 vcpkg install gRPC:%ARCH%-windows
 vcpkg install prometheus-cpp:%ARCH%-windows
 vcpkg install curl:%ARCH%-windows
+vcpkg install thrift:%ARCH%-windows
 popd
 exit /b 0


### PR DESCRIPTION
## Changes

Can't build `WITH_JAEGER` on Windows via Visual Studio 2019, and/or via `tools/build.cmd`

Changes:
- install Thrift via vcpkg in `setup-buildtools.cmd`
- add Thrift detection logic in the main `CMakeLists.txt`
- respect the path that is auto-detected by vcpkg-installed Thrift : it's 1-level up from what thrift-gen is expecting, i.e. the include dir name contains `thrift/` but the code also includes `thrift/*.h`, so we need to append a dir that's 1-level up to make thrift-gen happy.

These changes allow to build `WITH_JAGER` on Windows.

UNRELATED ISSUE: Thrift is extremely bulky and requires Boost.. takes quite a bit of time to build.