### PR TITLE
Add #include <cctype> to baggage.h

### DIFF
--- a/api/include/opentelemetry/baggage/baggage.h
+++ b/api/include/opentelemetry/baggage/baggage.h
@@ -3,6 +3,8 @@
 
 #pragma once
 
+#include <cctype>
+
 #include "opentelemetry/common/kv_properties.h"
 #include "opentelemetry/nostd/shared_ptr.h"
 #include "opentelemetry/nostd/string_view.h"


### PR DESCRIPTION
Fixes #808

## Changes

Add `#include <cctype>` to make `isdigit`, `isalnum`, etc. available in `baggage.h`.

I also tested against the Abseil-variant branch and confirmed that 1) without this, we still get errors under MSVC2015 and 2) with this, there are no errors.

* (N/A) `CHANGELOG.md` updated for non-trivial changes
* (N/A) Unit tests have been added
* (N/A) Changes in public API reviewed