### PR TITLE
Fix dynamic_extent issue when compiling with vs2017 (C++14 or C++17)

### DIFF
--- a/api/include/opentelemetry/std/span.h
+++ b/api/include/opentelemetry/std/span.h
@@ -39,6 +39,7 @@
 OPENTELEMETRY_BEGIN_NAMESPACE
 namespace nostd
 {
+using gsl::dynamic_extent;
 template <class ElementType, std::size_t Extent = gsl::dynamic_extent>
 using span = gsl::span<ElementType, Extent>;
 }

--- a/api/include/opentelemetry/std/span.h
+++ b/api/include/opentelemetry/std/span.h
@@ -42,7 +42,7 @@ namespace nostd
 using gsl::dynamic_extent;
 template <class ElementType, std::size_t Extent = gsl::dynamic_extent>
 using span = gsl::span<ElementType, Extent>;
-}
+}  // namespace nostd
 OPENTELEMETRY_END_NAMESPACE
 #    define HAVE_SPAN
 #  else


### PR DESCRIPTION
## Changes

This issue is applicable to the following environment:
- build with `WITH_STL` ( `-DHAVE_CPP_STDLIB` )
- build with GSL span implementation available in the build tree ( `-DHAVE_GSL` )
- build with Visual Studio 2017 , `C++14` or `C++17` language standard, i.e. no `C++20` yet.

In that case, a portion of code in ETW exporter uses `nostd::dynamic_extent` here:
https://github.com/open-telemetry/opentelemetry-cpp/blob/3741a8f07256a2ff94ad944fb8cc1075289c9b40/exporters/etw/include/opentelemetry/exporters/etw/etw_properties.h#L83

The issue is that the feature `std::dynamic_extent` is only available in `C++20` - [link](https://en.cppreference.com/w/cpp/container/span/dynamic_extent) , so while the construct works well when we compile with Visual Studio 2019, it fails to compile with older compiler (older language standard) because we did not alias the `nostd::dynamic_extent` implementation to some implementation of it, e.g. to `gsl::dynamic_extent` when GSL is available.

**One-liner** fix to properly add `using gsl::dynamic_extent` if compiling with GSL, so that any code needing dynamic extent - may use it via `nostd::dynamic_extent`. Note that Visual Studio 2015 / `C++11` was unaffected : we are always building old Visual Studio 2015 without `WITH_STL`. Thus, the same code was compiling well with 2015 and 2019, but not 2017.