### PR TITLE
Fix definitions for `bad_variant_access` and dependencies of some examples.

### DIFF
--- a/api/CMakeLists.txt
+++ b/api/CMakeLists.txt
@@ -52,3 +52,7 @@ if(WITH_STL)
 else()
   message("Building with nostd types...")
 endif()
+
+if(CORE_RUNTIME_LIBS)
+  target_link_libraries(opentelemetry_api INTERFACE ${CORE_RUNTIME_LIBS})
+endif()

--- a/api/include/opentelemetry/nostd/variant.h
+++ b/api/include/opentelemetry/nostd/variant.h
@@ -59,6 +59,9 @@ OPENTELEMETRY_END_NAMESPACE
 OPENTELEMETRY_BEGIN_NAMESPACE
 namespace nostd
 {
+#  ifdef HAVE_ABSEIL
+using absl::bad_variant_access;
+#  endif
 using absl::get;
 using absl::get_if;
 using absl::holds_alternative;

--- a/api/test/baggage/CMakeLists.txt
+++ b/api/test/baggage/CMakeLists.txt
@@ -2,9 +2,8 @@ include(GoogleTest)
 
 foreach(testname baggage_test)
   add_executable(${testname} "${testname}.cc")
-  target_link_libraries(
-    ${testname} ${GTEST_BOTH_LIBRARIES} ${CORE_RUNTIME_LIBS}
-    ${CMAKE_THREAD_LIBS_INIT} opentelemetry_api)
+  target_link_libraries(${testname} ${GTEST_BOTH_LIBRARIES}
+                        ${CMAKE_THREAD_LIBS_INIT} opentelemetry_api)
   gtest_add_tests(
     TARGET ${testname}
     TEST_PREFIX baggage.

--- a/api/test/baggage/propagation/CMakeLists.txt
+++ b/api/test/baggage/propagation/CMakeLists.txt
@@ -1,8 +1,7 @@
 foreach(testname baggage_propagator_test)
   add_executable(${testname} "${testname}.cc")
-  target_link_libraries(
-    ${testname} ${GTEST_BOTH_LIBRARIES} ${CORE_RUNTIME_LIBS}
-    ${CMAKE_THREAD_LIBS_INIT} opentelemetry_api)
+  target_link_libraries(${testname} ${GTEST_BOTH_LIBRARIES}
+                        ${CMAKE_THREAD_LIBS_INIT} opentelemetry_api)
   gtest_add_tests(
     TARGET ${testname}
     TEST_PREFIX baggage.

--- a/api/test/common/CMakeLists.txt
+++ b/api/test/common/CMakeLists.txt
@@ -2,9 +2,8 @@ include(GoogleTest)
 
 foreach(testname kv_properties_test string_util_test)
   add_executable(${testname} "${testname}.cc")
-  target_link_libraries(
-    ${testname} ${GTEST_BOTH_LIBRARIES} ${CORE_RUNTIME_LIBS}
-    ${CMAKE_THREAD_LIBS_INIT} opentelemetry_api)
+  target_link_libraries(${testname} ${GTEST_BOTH_LIBRARIES}
+                        ${CMAKE_THREAD_LIBS_INIT} opentelemetry_api)
   gtest_add_tests(
     TARGET ${testname}
     TEST_PREFIX common.

--- a/api/test/context/CMakeLists.txt
+++ b/api/test/context/CMakeLists.txt
@@ -4,9 +4,8 @@ include(GoogleTest)
 
 foreach(testname context_test runtime_context_test)
   add_executable(${testname} "${testname}.cc")
-  target_link_libraries(
-    ${testname} ${GTEST_BOTH_LIBRARIES} ${CORE_RUNTIME_LIBS}
-    ${CMAKE_THREAD_LIBS_INIT} opentelemetry_api)
+  target_link_libraries(${testname} ${GTEST_BOTH_LIBRARIES}
+                        ${CMAKE_THREAD_LIBS_INIT} opentelemetry_api)
   gtest_add_tests(
     TARGET ${testname}
     TEST_PREFIX context.

--- a/api/test/context/propagation/CMakeLists.txt
+++ b/api/test/context/propagation/CMakeLists.txt
@@ -1,8 +1,7 @@
 foreach(testname composite_propagator_test)
   add_executable(${testname} "${testname}.cc")
-  target_link_libraries(
-    ${testname} ${GTEST_BOTH_LIBRARIES} ${CORE_RUNTIME_LIBS}
-    ${CMAKE_THREAD_LIBS_INIT} opentelemetry_api)
+  target_link_libraries(${testname} ${GTEST_BOTH_LIBRARIES}
+                        ${CMAKE_THREAD_LIBS_INIT} opentelemetry_api)
   gtest_add_tests(
     TARGET ${testname}
     TEST_PREFIX trace.

--- a/api/test/core/CMakeLists.txt
+++ b/api/test/core/CMakeLists.txt
@@ -1,9 +1,8 @@
 include(GoogleTest)
 
 add_executable(timestamp_test timestamp_test.cc)
-target_link_libraries(
-  timestamp_test ${GTEST_BOTH_LIBRARIES} ${CORE_RUNTIME_LIBS}
-  ${CMAKE_THREAD_LIBS_INIT} opentelemetry_api)
+target_link_libraries(timestamp_test ${GTEST_BOTH_LIBRARIES}
+                      ${CMAKE_THREAD_LIBS_INIT} opentelemetry_api)
 gtest_add_tests(
   TARGET timestamp_test
   TEST_PREFIX trace.

--- a/api/test/metrics/CMakeLists.txt
+++ b/api/test/metrics/CMakeLists.txt
@@ -1,8 +1,7 @@
 foreach(testname noop_instrument_test meter_provider_test noop_metrics_test)
   add_executable(${testname} "${testname}.cc")
-  target_link_libraries(
-    ${testname} ${GTEST_BOTH_LIBRARIES} ${CORE_RUNTIME_LIBS}
-    ${CMAKE_THREAD_LIBS_INIT} opentelemetry_api)
+  target_link_libraries(${testname} ${GTEST_BOTH_LIBRARIES}
+                        ${CMAKE_THREAD_LIBS_INIT} opentelemetry_api)
   gtest_add_tests(
     TARGET ${testname}
     TEST_PREFIX metrics.

--- a/api/test/nostd/CMakeLists.txt
+++ b/api/test/nostd/CMakeLists.txt
@@ -10,9 +10,8 @@ foreach(
   shared_ptr_test
   variant_test)
   add_executable(${testname} "${testname}.cc")
-  target_link_libraries(
-    ${testname} ${GTEST_BOTH_LIBRARIES} ${CORE_RUNTIME_LIBS}
-    ${CMAKE_THREAD_LIBS_INIT} opentelemetry_api)
+  target_link_libraries(${testname} ${GTEST_BOTH_LIBRARIES}
+                        ${CMAKE_THREAD_LIBS_INIT} opentelemetry_api)
   gtest_add_tests(
     TARGET ${testname}
     TEST_PREFIX nostd.

--- a/api/test/plugin/CMakeLists.txt
+++ b/api/test/plugin/CMakeLists.txt
@@ -1,9 +1,8 @@
 include(GoogleTest)
 
 add_executable(dynamic_load_test dynamic_load_test.cc)
-target_link_libraries(
-  dynamic_load_test ${GTEST_BOTH_LIBRARIES} ${CORE_RUNTIME_LIBS}
-  ${CMAKE_THREAD_LIBS_INIT} opentelemetry_api)
+target_link_libraries(dynamic_load_test ${GTEST_BOTH_LIBRARIES}
+                      ${CMAKE_THREAD_LIBS_INIT} opentelemetry_api)
 target_link_libraries(dynamic_load_test ${CMAKE_DL_LIBS})
 gtest_add_tests(
   TARGET dynamic_load_test

--- a/api/test/trace/CMakeLists.txt
+++ b/api/test/trace/CMakeLists.txt
@@ -13,9 +13,8 @@ foreach(
   trace_state_test
   tracer_test)
   add_executable(api_${testname} "${testname}.cc")
-  target_link_libraries(
-    api_${testname} ${GTEST_BOTH_LIBRARIES} ${CORE_RUNTIME_LIBS}
-    ${CMAKE_THREAD_LIBS_INIT} opentelemetry_api)
+  target_link_libraries(api_${testname} ${GTEST_BOTH_LIBRARIES}
+                        ${CMAKE_THREAD_LIBS_INIT} opentelemetry_api)
   gtest_add_tests(
     TARGET api_${testname}
     TEST_PREFIX trace.

--- a/api/test/trace/propagation/CMakeLists.txt
+++ b/api/test/trace/propagation/CMakeLists.txt
@@ -1,9 +1,8 @@
 foreach(testname http_text_format_test b3_propagation_test
                  jaeger_propagation_test)
   add_executable(${testname} "${testname}.cc")
-  target_link_libraries(
-    ${testname} ${GTEST_BOTH_LIBRARIES} ${CORE_RUNTIME_LIBS}
-    ${CMAKE_THREAD_LIBS_INIT} opentelemetry_api)
+  target_link_libraries(${testname} ${GTEST_BOTH_LIBRARIES}
+                        ${CMAKE_THREAD_LIBS_INIT} opentelemetry_api)
   gtest_add_tests(
     TARGET ${testname}
     TEST_PREFIX trace.

--- a/examples/batch/CMakeLists.txt
+++ b/examples/batch/CMakeLists.txt
@@ -2,6 +2,5 @@ include_directories(${CMAKE_SOURCE_DIR}/exporters/ostream/include)
 
 add_executable(batch_span_processor_example main.cc)
 
-target_link_libraries(
-  batch_span_processor_example ${CMAKE_THREAD_LIBS_INIT} ${CORE_RUNTIME_LIBS}
-  opentelemetry_exporter_ostream_span opentelemetry_trace)
+target_link_libraries(batch_span_processor_example ${CMAKE_THREAD_LIBS_INIT}
+                      opentelemetry_exporter_ostream_span opentelemetry_trace)

--- a/examples/http/CMakeLists.txt
+++ b/examples/http/CMakeLists.txt
@@ -10,15 +10,10 @@ else()
   add_executable(http_server server.cc)
 
   target_link_libraries(
-    http_client
-    ${CMAKE_THREAD_LIBS_INIT}
-    ${CORE_RUNTIME_LIBS}
-    opentelemetry_trace
-    http_client_curl
-    opentelemetry_exporter_ostream_span
-    ${CURL_LIBRARIES})
+    http_client ${CMAKE_THREAD_LIBS_INIT} opentelemetry_trace http_client_curl
+    opentelemetry_exporter_ostream_span ${CURL_LIBRARIES})
 
   target_link_libraries(
-    http_server ${CMAKE_THREAD_LIBS_INIT} ${CORE_RUNTIME_LIBS}
-    opentelemetry_trace http_client_curl opentelemetry_exporter_ostream_span)
+    http_server ${CMAKE_THREAD_LIBS_INIT} opentelemetry_trace http_client_curl
+    opentelemetry_exporter_ostream_span)
 endif()

--- a/examples/jaeger/CMakeLists.txt
+++ b/examples/jaeger/CMakeLists.txt
@@ -2,9 +2,9 @@ include_directories(${CMAKE_SOURCE_DIR}/exporters/jaeger/include)
 
 add_library(jaeger_foo_library foo_library/foo_library.cc)
 target_link_libraries(jaeger_foo_library ${CMAKE_THREAD_LIBS_INIT}
-                      ${CORE_RUNTIME_LIBS} opentelemetry_api)
+                      opentelemetry_api)
 
 add_executable(example_jaeger main.cc)
 target_link_libraries(
   example_jaeger ${CMAKE_THREAD_LIBS_INIT} jaeger_foo_library
-  opentelemetry_trace ${CORE_RUNTIME_LIBS} jaeger_trace_exporter)
+  opentelemetry_trace jaeger_trace_exporter)

--- a/examples/metrics_simple/CMakeLists.txt
+++ b/examples/metrics_simple/CMakeLists.txt
@@ -3,4 +3,4 @@ include_directories(${CMAKE_SOURCE_DIR}/exporters/ostream/include)
 add_executable(simple_metrics main.cc)
 target_link_libraries(
   simple_metrics ${CMAKE_THREAD_LIBS_INIT} opentelemetry_metrics
-  ${CORE_RUNTIME_LIBS} opentelemetry_exporter_ostream_metrics)
+  opentelemetry_exporter_ostream_metrics)

--- a/examples/otlp/CMakeLists.txt
+++ b/examples/otlp/CMakeLists.txt
@@ -4,23 +4,18 @@ include_directories(${CMAKE_SOURCE_DIR}/exporters/otlp/include)
 
 add_library(otlp_foo_library foo_library/foo_library.cc)
 target_link_libraries(otlp_foo_library ${CMAKE_THREAD_LIBS_INIT}
-                      ${CORE_RUNTIME_LIBS} opentelemetry_api)
+                      opentelemetry_api)
 
 if(WITH_OTLP_GRPC)
   add_executable(example_otlp_grpc grpc_main.cc)
   target_link_libraries(
-    example_otlp_grpc
-    ${CMAKE_THREAD_LIBS_INIT}
-    otlp_foo_library
-    opentelemetry_trace
-    ${CORE_RUNTIME_LIBS}
-    opentelemetry_exporter_otlp_grpc
-    gRPC::grpc++)
+    example_otlp_grpc ${CMAKE_THREAD_LIBS_INIT} otlp_foo_library
+    opentelemetry_trace opentelemetry_exporter_otlp_grpc gRPC::grpc++)
 endif()
 
 if(WITH_OTLP_HTTP)
   add_executable(example_otlp_http http_main.cc)
   target_link_libraries(
     example_otlp_http ${CMAKE_THREAD_LIBS_INIT} otlp_foo_library
-    opentelemetry_trace ${CORE_RUNTIME_LIBS} opentelemetry_exporter_otlp_http)
+    opentelemetry_trace opentelemetry_exporter_otlp_http)
 endif()

--- a/examples/plugin/load/CMakeLists.txt
+++ b/examples/plugin/load/CMakeLists.txt
@@ -1,2 +1,2 @@
 add_executable(load_plugin_example main.cc)
-target_link_libraries(load_plugin_example ${CMAKE_DL_LIBS})
+target_link_libraries(load_plugin_example opentelemetry_api ${CMAKE_DL_LIBS})

--- a/examples/plugin/plugin/CMakeLists.txt
+++ b/examples/plugin/plugin/CMakeLists.txt
@@ -1,1 +1,2 @@
 add_library(example_plugin SHARED tracer.cc factory_impl.cc)
+target_link_libraries(example_plugin opentelemetry_api)

--- a/sdk/src/common/CMakeLists.txt
+++ b/sdk/src/common/CMakeLists.txt
@@ -11,7 +11,7 @@ set_target_properties(opentelemetry_common PROPERTIES EXPORT_NAME common)
 
 target_link_libraries(
   opentelemetry_common PUBLIC opentelemetry_api opentelemetry_sdk
-                              Threads::Threads ${CORE_RUNTIME_LIBS})
+                              Threads::Threads)
 
 install(
   TARGETS opentelemetry_common

--- a/sdk/test/common/CMakeLists.txt
+++ b/sdk/test/common/CMakeLists.txt
@@ -5,7 +5,7 @@ foreach(testname
   add_executable(${testname} "${testname}.cc")
   target_link_libraries(
     ${testname} ${GTEST_BOTH_LIBRARIES} ${CMAKE_THREAD_LIBS_INIT}
-    ${CORE_RUNTIME_LIBS} opentelemetry_common opentelemetry_trace)
+    opentelemetry_common opentelemetry_trace)
 
   gtest_add_tests(
     TARGET ${testname}
@@ -18,11 +18,9 @@ target_link_libraries(random_fork_test opentelemetry_common)
 add_test(random_fork_test random_fork_test)
 
 add_executable(random_benchmark random_benchmark.cc)
-target_link_libraries(
-  random_benchmark benchmark::benchmark ${CORE_RUNTIME_LIBS}
-  ${CMAKE_THREAD_LIBS_INIT} opentelemetry_common)
+target_link_libraries(random_benchmark benchmark::benchmark
+                      ${CMAKE_THREAD_LIBS_INIT} opentelemetry_common)
 
 add_executable(circular_buffer_benchmark circular_buffer_benchmark.cc)
-target_link_libraries(
-  circular_buffer_benchmark benchmark::benchmark ${CORE_RUNTIME_LIBS}
-  ${CMAKE_THREAD_LIBS_INIT} opentelemetry_api)
+target_link_libraries(circular_buffer_benchmark benchmark::benchmark
+                      ${CMAKE_THREAD_LIBS_INIT} opentelemetry_api)

--- a/sdk/test/instrumentationlibrary/CMakeLists.txt
+++ b/sdk/test/instrumentationlibrary/CMakeLists.txt
@@ -2,9 +2,8 @@ include(GoogleTest)
 
 foreach(testname instrumentationlibrary_test)
   add_executable(${testname} "${testname}.cc")
-  target_link_libraries(
-    ${testname} ${GTEST_BOTH_LIBRARIES} ${CORE_RUNTIME_LIBS}
-    ${CMAKE_THREAD_LIBS_INIT} opentelemetry_api)
+  target_link_libraries(${testname} ${GTEST_BOTH_LIBRARIES}
+                        ${CMAKE_THREAD_LIBS_INIT} opentelemetry_api)
   gtest_add_tests(
     TARGET ${testname}
     TEST_PREFIX instrumentationlibrary.

--- a/sdk/test/trace/CMakeLists.txt
+++ b/sdk/test/trace/CMakeLists.txt
@@ -12,7 +12,6 @@ foreach(
   add_executable(${testname} "${testname}.cc")
   target_link_libraries(
     ${testname}
-    ${CORE_RUNTIME_LIBS}
     ${GTEST_BOTH_LIBRARIES}
     ${CMAKE_THREAD_LIBS_INIT}
     opentelemetry_common
@@ -27,10 +26,5 @@ endforeach()
 
 add_executable(sampler_benchmark sampler_benchmark.cc)
 target_link_libraries(
-  sampler_benchmark
-  benchmark::benchmark
-  ${CMAKE_THREAD_LIBS_INIT}
-  ${CORE_RUNTIME_LIBS}
-  opentelemetry_trace
-  opentelemetry_resources
-  opentelemetry_exporter_in_memory)
+  sampler_benchmark benchmark::benchmark ${CMAKE_THREAD_LIBS_INIT}
+  opentelemetry_trace opentelemetry_resources opentelemetry_exporter_in_memory)


### PR DESCRIPTION


Signed-off-by: owent <admin@owent.net>

Fixes #849

## Changes

+ Move `CORE_RUNTIME_LIBS` into dependency of `opentelemetry_api`
  > I found all targets link `CORE_RUNTIME_LIBS` alse depend `opentelemetry_api`. So I move `CORE_RUNTIME_LIBS` into dependency of `opentelemetry_api` for easier usage.
+ Add alias of `nostd::bad_variant_access` to `absl::bad_variant_access` when have abseil

For significant contributions please make sure you have completed the following items:

* [x] `CHANGELOG.md` updated for non-trivial changes
* [x] Unit tests have been added
* [x] Changes in public API reviewed