### PR TITLE
Perf benchmark tests for span creation ( along with context management )

### DIFF
--- a/api/test/trace/BUILD
+++ b/api/test/trace/BUILD
@@ -39,6 +39,12 @@ otel_cc_benchmark(
     deps = ["//api"],
 )
 
+otel_cc_benchmark(
+    name = "span_benchmark",
+    srcs = ["span_benchmark.cc"],
+    deps = ["//api"],
+)
+
 cc_test(
     name = "provider_test",
     srcs = [

--- a/api/test/trace/CMakeLists.txt
+++ b/api/test/trace/CMakeLists.txt
@@ -24,3 +24,6 @@ endforeach()
 add_executable(span_id_benchmark span_id_benchmark.cc)
 target_link_libraries(span_id_benchmark benchmark::benchmark
                       ${CMAKE_THREAD_LIBS_INIT} opentelemetry_api)
+add_executable(span_benchmark span_benchmark.cc)
+target_link_libraries(span_benchmark benchmark::benchmark
+                      ${CMAKE_THREAD_LIBS_INIT} opentelemetry_api)

--- a/api/test/trace/span_benchmark.cc
+++ b/api/test/trace/span_benchmark.cc
@@ -41,11 +41,9 @@ void BM_SpanCreationWithScope(benchmark::State &state)
   auto tracer = initTracer();
   while (state.KeepRunning())
   {
-    auto span = tracer->StartSpan("span");
-    {
-      auto scope = tracer->WithActiveSpan(span);
-      span->End();
-    }
+    auto span  = tracer->StartSpan("span");
+    auto scope = tracer->WithActiveSpan(span);
+    span->End();
   }
 }
 BENCHMARK(BM_SpanCreationWithScope);

--- a/api/test/trace/span_benchmark.cc
+++ b/api/test/trace/span_benchmark.cc
@@ -1,0 +1,129 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+#include "opentelemetry/nostd/shared_ptr.h"
+#include "opentelemetry/trace/noop.h"
+#include "opentelemetry/trace/propagation/detail/context.h"
+#include "opentelemetry/trace/span_id.h"
+#include "opentelemetry/trace/trace_id.h"
+
+#include <cstdint>
+
+#include <benchmark/benchmark.h>
+
+using opentelemetry::trace::SpanContext;
+namespace trace_api = opentelemetry::trace;
+namespace nostd     = opentelemetry::nostd;
+
+namespace
+{
+
+std::shared_ptr<opentelemetry::trace::Tracer> initTracer()
+{
+  return std::shared_ptr<opentelemetry::trace::Tracer>(new trace_api::NoopTracer());
+}
+
+// Test to measure performance for span creation
+void BM_SpanCreation(benchmark::State &state)
+{
+  auto tracer = initTracer();
+  while (state.KeepRunning())
+  {
+    auto span = tracer->StartSpan("span");
+    span->End();
+  }
+}
+BENCHMARK(BM_SpanCreation);
+
+// Test to measure performance for single span creation with scope
+void BM_SpanCreationWithScope(benchmark::State &state)
+{
+  auto tracer = initTracer();
+  while (state.KeepRunning())
+  {
+    auto span = tracer->StartSpan("span");
+    {
+      auto scope = tracer->WithActiveSpan(span);
+      span->End();
+    }
+  }
+}
+BENCHMARK(BM_SpanCreationWithScope);
+
+// Test to measure performance for nested span creation with scope
+void BM_NestedSpanCreationWithScope(benchmark::State &state)
+{
+  auto tracer = initTracer();
+  while (state.KeepRunning())
+  {
+    auto span  = tracer->StartSpan("outer");
+    auto scope = tracer->WithActiveSpan(span);
+    {
+      auto span  = tracer->StartSpan("inner");
+      auto scope = tracer->WithActiveSpan(span);
+      {
+        auto span  = tracer->StartSpan("innermost");
+        auto scope = tracer->WithActiveSpan(span);
+        span->End();
+      }
+      span->End();
+    }
+    span->End();
+  }
+}
+
+BENCHMARK(BM_NestedSpanCreationWithScope);
+
+// Test to measure performance for nested span creation with manual span context management
+void BM_SpanCreationWithManualSpanContextPropagation(benchmark::State &state)
+{
+  auto tracer              = initTracer();
+  constexpr uint8_t buf1[] = {1, 2, 3, 4, 5, 6, 7, 8};
+  trace_api::SpanId span_id(buf1);
+  constexpr uint8_t buf2[] = {1, 2, 3, 4, 5, 6, 7, 8, 8, 7, 6, 5, 4, 3, 2, 1};
+  trace_api::TraceId trace_id(buf2);
+
+  while (state.KeepRunning())
+  {
+    auto outer_span_context = SpanContext(trace_id, span_id, trace_api::TraceFlags(), false);
+    trace_api::StartSpanOptions options;
+    options.parent          = outer_span_context;
+    auto inner_span         = tracer->StartSpan("inner", options);
+    auto inner_span_context = inner_span->GetContext();
+    options.parent          = inner_span_context;
+    auto innermost_span     = tracer->StartSpan("innermost", options);
+    innermost_span->End();
+    inner_span->End();
+  }
+}
+BENCHMARK(BM_SpanCreationWithManualSpanContextPropagation);
+
+// Test to measure performance for nested span creation with context propagation
+void BM_SpanCreationWitContextPropagation(benchmark::State &state)
+{
+  auto tracer              = initTracer();
+  constexpr uint8_t buf1[] = {1, 2, 3, 4, 5, 6, 7, 8};
+  trace_api::SpanId span_id(buf1);
+  constexpr uint8_t buf2[] = {1, 2, 3, 4, 5, 6, 7, 8, 8, 7, 6, 5, 4, 3, 2, 1};
+  trace_api::TraceId trace_id(buf2);
+
+  while (state.KeepRunning())
+  {
+    auto current_ctx        = opentelemetry::context::RuntimeContext::GetCurrent();
+    auto outer_span_context = SpanContext(trace_id, span_id, trace_api::TraceFlags(), false);
+    auto outer_span =
+        nostd::shared_ptr<trace_api::Span>(new trace_api::DefaultSpan(outer_span_context));
+    trace_api::propagation::SetSpan(current_ctx, outer_span);
+    auto inner_child = tracer->StartSpan("inner");
+    auto scope       = tracer->WithActiveSpan(inner_child);
+    {
+      auto innermost_child = tracer->StartSpan("innermost");
+      auto scope           = tracer->WithActiveSpan(innermost_child);
+      innermost_child->End();
+    }
+    inner_child->End();
+  }
+}
+BENCHMARK(BM_SpanCreationWitContextPropagation);
+}  // namespace
+BENCHMARK_MAIN();

--- a/api/test/trace/span_benchmark.cc
+++ b/api/test/trace/span_benchmark.cc
@@ -83,9 +83,10 @@ void BM_SpanCreationWithManualSpanContextPropagation(benchmark::State &state)
 
   while (state.KeepRunning())
   {
-    auto outer_span_context = SpanContext(trace_id, span_id, trace_api::TraceFlags(), false);
+    auto outer_span = nostd::shared_ptr<trace_api::Span>(
+        new trace_api::DefaultSpan(SpanContext(trace_id, span_id, trace_api::TraceFlags(), false)));
     trace_api::StartSpanOptions options;
-    options.parent          = outer_span_context;
+    options.parent          = outer_span->GetContext();
     auto inner_span         = tracer->StartSpan("inner", options);
     auto inner_span_context = inner_span->GetContext();
     options.parent          = inner_span_context;


### PR DESCRIPTION
## Changes

As we are discussing performance changes for the api, it's important to get some numbers for span creation and context management involved in the process. The tests are:

- Test to measure performance for single-span creation
- Test to measure performance for single-span creation with scope ( involves stack )
- Test to measure performance for nested span creation with scope 
- Test to measure performance for nested span creation with manual span context management (no stack involved)
- Test to measure performance for nested span creation with context propagation

These are the numbers as tested locally:
```
------------------------------------------------------------------------------------------
Benchmark                                                Time             CPU   Iterations
------------------------------------------------------------------------------------------
BM_SpanCreation                                        263 ns          263 ns      2538457
BM_SpanCreationWithScope                              2222 ns         2221 ns       314466
BM_NestedSpanCreationWithScope                        7892 ns         7891 ns        87182
BM_SpanCreationWithManualSpanContextPropagation       1164 ns         1164 ns       629233
BM_SpanCreationWitContextPropagation                  6642 ns         6641 ns        97745
```

For significant contributions please make sure you have completed the following items:

* [ ] `CHANGELOG.md` updated for non-trivial changes
* [ ] Unit tests have been added
* [ ] Changes in public API reviewed