### PR TITLE
Fix missing notify of conditional variable in OTLP HTTP exporter test

### DIFF
--- a/exporters/otlp/include/opentelemetry/exporters/otlp/otlp_http_exporter.h
+++ b/exporters/otlp/include/opentelemetry/exporters/otlp/otlp_http_exporter.h
@@ -67,7 +67,6 @@ struct OtlpHttpExporterOptions
   bool console_debug = false;
 
   // TODO: Enable/disable to verify SSL certificate
-  // TODO: Reuqest timeout
   std::chrono::milliseconds timeout = std::chrono::milliseconds(30000);
 };
 

--- a/exporters/otlp/test/otlp_http_exporter_test.cc
+++ b/exporters/otlp/test/otlp_http_exporter_test.cc
@@ -226,7 +226,7 @@ TEST_F(OtlpHttpExporterTestPeer, ExportJsonIntegrationTest)
     report_trace_id.assign(trace_id_hex, sizeof(trace_id_hex));
   }
 
-  ASSERT_TRUE(waitForRequests(20, old_count + 1));
+  ASSERT_TRUE(waitForRequests(2, old_count + 1));
   auto check_json                   = received_requests_json_.back();
   auto resource_span                = *check_json["resource_spans"].begin();
   auto instrumentation_library_span = *resource_span["instrumentation_library_spans"].begin();

--- a/exporters/otlp/test/otlp_http_exporter_test.cc
+++ b/exporters/otlp/test/otlp_http_exporter_test.cc
@@ -104,7 +104,7 @@ public:
         }
         else
         {
-          response.body = "{\"code\": 400, \"message\": \"Parse binary failed\"}";
+          response.body   = "{\"code\": 400, \"message\": \"Parse binary failed\"}";
           response_status = 400;
         }
       }
@@ -114,7 +114,7 @@ public:
         response.headers["Content-Type"] = "application/json";
         if (json.is_discarded())
         {
-          response.body = "{\"code\": 400, \"message\": \"Parse json failed\"}";
+          response.body   = "{\"code\": 400, \"message\": \"Parse json failed\"}";
           response_status = 400;
         }
         else
@@ -125,7 +125,7 @@ public:
       }
       else
       {
-        response.body = "{\"code\": 400, \"message\": \"Unsupported content type\"}";
+        response.body   = "{\"code\": 400, \"message\": \"Unsupported content type\"}";
         response_status = 400;
       }
 
@@ -136,7 +136,7 @@ public:
       std::unique_lock<std::mutex> lk(mtx_requests);
       response.headers["Content-Type"] = "text/plain";
       response.body                    = "404 Not Found";
-      response_status = 200;
+      response_status                  = 200;
     }
 
     cv_got_events.notify_one();

--- a/ext/test/http/curl_http_test.cc
+++ b/ext/test/http/curl_http_test.cc
@@ -99,13 +99,14 @@ public:
   virtual int onHttpRequest(HTTP_SERVER_NS::HttpRequest const &request,
                             HTTP_SERVER_NS::HttpResponse &response) override
   {
+    int response_status = 404;
     if (request.uri == "/get/")
     {
 
       std::unique_lock<std::mutex> lk(mtx_requests);
       received_requests_.push_back(request);
       response.headers["Content-Type"] = "text/plain";
-      return 200;
+      response_status                  = 200;
     }
     if (request.uri == "/post/")
     {
@@ -113,9 +114,12 @@ public:
       received_requests_.push_back(request);
       response.headers["Content-Type"] = "application/json";
       response.body                    = "{'k1':'v1', 'k2':'v2', 'k3':'v3'}";
-      return 200;
+      response_status                  = 200;
     }
-    return 404;
+
+    cv_got_events.notify_one();
+
+    return response_status;
   }
 
   bool waitForRequests(unsigned timeOutSec, unsigned expected_count = 1)


### PR DESCRIPTION
Fixes #857 

## Changes

Added `notify_one` call to `cv_got_events` right after HTTP response processing.

For significant contributions please make sure you have completed the following items:

* [ ] `CHANGELOG.md` updated for non-trivial changes
* [ ] Unit tests have been added
* [ ] Changes in public API reviewed