### PR TITLE
Adding Baggage api benchmark tests

### DIFF
--- a/api/test/baggage/BUILD
+++ b/api/test/baggage/BUILD
@@ -10,3 +10,9 @@ cc_test(
         "@com_google_googletest//:gtest_main",
     ],
 )
+
+otel_cc_benchmark(
+    name = "baggage_benchmark",
+    srcs = ["baggage_benchmark.cc"],
+    deps = ["//api"],
+)

--- a/api/test/baggage/CMakeLists.txt
+++ b/api/test/baggage/CMakeLists.txt
@@ -9,4 +9,7 @@ foreach(testname baggage_test)
     TEST_PREFIX baggage.
     TEST_LIST ${testname})
 endforeach()
+add_executable(baggage_benchmark baggage_benchmark.cc)
+target_link_libraries(baggage_benchmark benchmark::benchmark
+                      ${CMAKE_THREAD_LIBS_INIT} opentelemetry_api)
 add_subdirectory(propagation)

--- a/api/test/baggage/baggage_benchmark.cc
+++ b/api/test/baggage/baggage_benchmark.cc
@@ -1,0 +1,117 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+#include "opentelemetry/baggage/baggage.h"
+#include "opentelemetry/nostd/string_view.h"
+
+#include <benchmark/benchmark.h>
+#include <cstdint>
+
+using namespace opentelemetry::baggage;
+namespace nostd = opentelemetry::nostd;
+
+namespace
+{
+
+const size_t kNumEntries = 10;
+
+std::string header_with_custom_entries(size_t num_entries)
+{
+  std::string header;
+  for (size_t i = 0; i < num_entries; i++)
+  {
+    std::string key   = "ADecentlyLargekey" + std::to_string(i);
+    std::string value = "ADecentlyLargeValue" + std::to_string(i);
+    header += key + "=" + value;
+    if (i != num_entries - 1)
+    {
+      header += ",";
+    }
+  }
+  return header;
+}
+
+void BM_CreateBaggageFromTenEntries(benchmark::State &state)
+{
+  std::string header = header_with_custom_entries(kNumEntries);
+  while (state.KeepRunning())
+  {
+    auto baggage = Baggage::FromHeader(header);
+  }
+}
+BENCHMARK(BM_CreateBaggageFromTenEntries);
+
+void BM_ExtractBaggageHavingTenEntries(benchmark::State &state)
+{
+  auto baggage = Baggage::FromHeader(header_with_custom_entries(kNumEntries));
+  while (state.KeepRunning())
+  {
+    baggage->GetAllEntries([](nostd::string_view key, nostd::string_view value) { return true; });
+  }
+}
+BENCHMARK(BM_ExtractBaggageHavingTenEntries);
+
+void BM_CreateBaggageFrom180Entries(benchmark::State &state)
+{
+  std::string header = header_with_custom_entries(Baggage::kMaxKeyValuePairs);
+  while (state.KeepRunning())
+  {
+    auto baggage = Baggage::FromHeader(header);
+  }
+}
+BENCHMARK(BM_CreateBaggageFrom180Entries);
+
+void BM_ExtractBaggageWith180Entries(benchmark::State &state)
+{
+  auto baggage = Baggage::FromHeader(header_with_custom_entries(Baggage::kMaxKeyValuePairs));
+  while (state.KeepRunning())
+  {
+    baggage->GetAllEntries([](nostd::string_view key, nostd::string_view value) { return true; });
+  }
+}
+BENCHMARK(BM_ExtractBaggageWith180Entries);
+
+void BM_SetValueBaggageWithTenEntries(benchmark::State &state)
+{
+  auto baggage = Baggage::FromHeader(
+      header_with_custom_entries(kNumEntries - 1));  // 9 entries, and add one new
+  while (state.KeepRunning())
+  {
+    auto new_baggage = baggage->Set("new_key", "new_value");
+  }
+}
+BENCHMARK(BM_SetValueBaggageWithTenEntries);
+
+void BM_SetValueBaggageWith180Entries(benchmark::State &state)
+{
+  auto baggage = Baggage::FromHeader(header_with_custom_entries(
+      Baggage::kMaxKeyValuePairs - 1));  // keep 179 entries, and add one new
+  while (state.KeepRunning())
+  {
+    auto new_baggage = baggage->Set("new_key", "new_value");
+  }
+}
+BENCHMARK(BM_SetValueBaggageWith180Entries);
+
+void BM_BaggageToHeaderTenEntries(benchmark::State &state)
+{
+  auto baggage = Baggage::FromHeader(header_with_custom_entries(kNumEntries));
+  while (state.KeepRunning())
+  {
+    auto new_baggage = baggage->ToHeader();
+  }
+}
+BENCHMARK(BM_BaggageToHeaderTenEntries);
+
+void BM_BaggageToHeader180Entries(benchmark::State &state)
+{
+  auto baggage = Baggage::FromHeader(header_with_custom_entries(Baggage::kMaxKeyValuePairs));
+  while (state.KeepRunning())
+  {
+    auto new_baggage = baggage->ToHeader();
+  }
+}
+BENCHMARK(BM_BaggageToHeader180Entries);
+}  // namespace
+
+BENCHMARK_MAIN();


### PR DESCRIPTION
Fixes #837 

## Changes

Add performance benchmark tests for Baggage. This would be important to evaluate the performance of the internal key-value data structure used for `Baggage` and `TraceState`.
Tests are using
  - 10 key-value pair entries in baggage ( Optimal scenario used most of the time).
  - 180 key-value pair entries in baggage ( Max possible entries).
with decently sized keys and values.

The result from running locally:
```
CPU Caches:
  L1 Data 32K (x4)
  L1 Instruction 32K (x4)
  L2 Unified 256K (x4)
  L3 Unified 8192K (x1)
Load Average: 0.38, 0.44, 0.35
----------------------------------------------------------------------------
Benchmark                                  Time             CPU   Iterations
----------------------------------------------------------------------------
BM_CreateBaggageFromTenEntries         14671 ns        14671 ns        44127
BM_ExtractBaggageHavingTenEntries        361 ns          361 ns      1853059
BM_CreateBaggageFrom180Entries        271756 ns       271757 ns         2541
BM_ExtractBaggageWith180Entries         5815 ns         5815 ns       115602
BM_SetValueBaggageWithTenEntries        2344 ns         2344 ns       301103
BM_SetValueBaggageWith180Entries       42179 ns        42179 ns        16987
BM_BaggageToHeaderTenEntries            3992 ns         3992 ns       178561
BM_BaggageToHeader180Entries           69452 ns        69451 ns         9263
```

For significant contributions please make sure you have completed the following items:

* [ ] `CHANGELOG.md` updated for non-trivial changes
* [x] Unit tests have been added
* [x] Changes in public API reviewed