### PR TITLE
Rename bswap_64 to otel_bswap_64 to avoid clash with macro (#875)

### DIFF
--- a/exporters/jaeger/include/opentelemetry/exporters/jaeger/recordable.h
+++ b/exporters/jaeger/include/opentelemetry/exporters/jaeger/recordable.h
@@ -29,13 +29,13 @@ namespace jaeger
 
 #  if defined(__clang__) || \
       (defined(__GNUC__) && ((__GNUC__ == 4 && __GNUC_MINOR__ >= 8) || __GNUC__ >= 5))
-inline uint64_t bswap_64(uint64_t host_int)
+inline uint64_t otel_bswap_64(uint64_t host_int)
 {
   return __builtin_bswap64(host_int);
 }
 
 #  elif defined(_MSC_VER)
-inline uint64_t bswap_64(uint64_t host_int)
+inline uint64_t otel_bswap_64(uint64_t host_int)
 {
   return _byteswap_uint64(host_int);
 }

--- a/exporters/jaeger/src/recordable.cc
+++ b/exporters/jaeger/src/recordable.cc
@@ -46,13 +46,13 @@ void Recordable::SetIdentity(const trace::SpanContext &span_context,
   // https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/sdk_exporters/jaeger.md#ids
 #if JAEGER_IS_LITTLE_ENDIAN == 1
   span_->__set_traceIdHigh(
-      bswap_64(*(reinterpret_cast<const int64_t *>(span_context.trace_id().Id().data()))));
+      otel_bswap_64(*(reinterpret_cast<const int64_t *>(span_context.trace_id().Id().data()))));
   span_->__set_traceIdLow(
-      bswap_64(*(reinterpret_cast<const int64_t *>(span_context.trace_id().Id().data()) + 1)));
+      otel_bswap_64(*(reinterpret_cast<const int64_t *>(span_context.trace_id().Id().data()) + 1)));
   span_->__set_spanId(
-      bswap_64(*(reinterpret_cast<const int64_t *>(span_context.span_id().Id().data()))));
+      otel_bswap_64(*(reinterpret_cast<const int64_t *>(span_context.span_id().Id().data()))));
   span_->__set_parentSpanId(
-      bswap_64(*(reinterpret_cast<const int64_t *>(parent_span_id.Id().data()))));
+      otel_bswap_64(*(reinterpret_cast<const int64_t *>(parent_span_id.Id().data()))));
 #else
   span_->__set_traceIdLow(
       *(reinterpret_cast<const int64_t *>(span_context.trace_id().Id().data())));

--- a/exporters/jaeger/test/jaeger_recordable_test.cc
+++ b/exporters/jaeger/test/jaeger_recordable_test.cc
@@ -43,10 +43,10 @@ TEST(JaegerSpanRecordable, SetIdentity)
   std::unique_ptr<thrift::Span> span{rec.Span()};
 
 #if JAEGER_IS_LITTLE_ENDIAN == 1
-  EXPECT_EQ(span->traceIdLow, opentelemetry::exporter::jaeger::bswap_64(trace_id_val[1]));
-  EXPECT_EQ(span->traceIdHigh, opentelemetry::exporter::jaeger::bswap_64(trace_id_val[0]));
-  EXPECT_EQ(span->spanId, opentelemetry::exporter::jaeger::bswap_64(span_id_val));
-  EXPECT_EQ(span->parentSpanId, opentelemetry::exporter::jaeger::bswap_64(parent_span_id_val));
+  EXPECT_EQ(span->traceIdLow, opentelemetry::exporter::jaeger::otel_bswap_64(trace_id_val[1]));
+  EXPECT_EQ(span->traceIdHigh, opentelemetry::exporter::jaeger::otel_bswap_64(trace_id_val[0]));
+  EXPECT_EQ(span->spanId, opentelemetry::exporter::jaeger::otel_bswap_64(span_id_val));
+  EXPECT_EQ(span->parentSpanId, opentelemetry::exporter::jaeger::otel_bswap_64(parent_span_id_val));
 #else
   EXPECT_EQ(span->traceIdLow, trace_id_val[0]);
   EXPECT_EQ(span->traceIdHigh, trace_id_val[1]);


### PR DESCRIPTION
Fixes #875 

## Changes

On some platforms, bswap_64 is a macro. Rename the OpenTelemetry utility to otel_bswap_64 to avoid clashing with this.

For significant contributions please make sure you have completed the following items:

* N/A `CHANGELOG.md` updated for non-trivial changes
* N/A Unit tests have been added
* [ ] Changes in public API reviewed

  I believe this isn't part of the public API?