### PR TITLE
nlohmann_json::nlohmann_json added

### DIFF
--- a/exporters/otlp/CMakeLists.txt
+++ b/exporters/otlp/CMakeLists.txt
@@ -33,9 +33,10 @@ if(WITH_OTLP_HTTP)
   set_target_properties(opentelemetry_exporter_otlp_http
                         PROPERTIES EXPORT_NAME otlp_http_exporter)
 
-  target_link_libraries(opentelemetry_exporter_otlp_http
-                        PUBLIC opentelemetry_otlp_recordable http_client_curl 
-                               nlohmann_json::nlohmann_json)
+  target_link_libraries(
+    opentelemetry_exporter_otlp_http
+    PUBLIC opentelemetry_otlp_recordable http_client_curl
+           nlohmann_json::nlohmann_json)
 
   list(APPEND OPENTELEMETRY_OTLP_TARGETS opentelemetry_exporter_otlp_http)
 endif()

--- a/exporters/otlp/CMakeLists.txt
+++ b/exporters/otlp/CMakeLists.txt
@@ -34,7 +34,7 @@ if(WITH_OTLP_HTTP)
                         PROPERTIES EXPORT_NAME otlp_http_exporter)
 
   target_link_libraries(opentelemetry_exporter_otlp_http
-                        PUBLIC opentelemetry_otlp_recordable http_client_curl)
+                        PUBLIC opentelemetry_otlp_recordable http_client_curl nlohmann_json::nlohmann_json)
 
   list(APPEND OPENTELEMETRY_OTLP_TARGETS opentelemetry_exporter_otlp_http)
 endif()

--- a/exporters/otlp/CMakeLists.txt
+++ b/exporters/otlp/CMakeLists.txt
@@ -34,7 +34,8 @@ if(WITH_OTLP_HTTP)
                         PROPERTIES EXPORT_NAME otlp_http_exporter)
 
   target_link_libraries(opentelemetry_exporter_otlp_http
-                        PUBLIC opentelemetry_otlp_recordable http_client_curl nlohmann_json::nlohmann_json)
+                        PUBLIC opentelemetry_otlp_recordable http_client_curl 
+                               nlohmann_json::nlohmann_json)
 
   list(APPEND OPENTELEMETRY_OTLP_TARGETS opentelemetry_exporter_otlp_http)
 endif()


### PR DESCRIPTION
nlohmann_json::nlohmann_json added as target_lik_library for the opentelemetry_exporter_otlp_http

Fixes build error for the case WITH_OTLP=ON as exporters/otlp/src/otlp_http_exporter.cc directly includes nlohmann/json.hpp

This does not work if library is not added to the target.
