### PR TITLE
Fix assertion to check the correct attribute value type

### DIFF
--- a/exporters/otlp/src/otlp_recordable.cc
+++ b/exporters/otlp/src/otlp_recordable.cc
@@ -138,9 +138,9 @@ void PopulateAttribute(opentelemetry::proto::common::v1::KeyValue *attribute,
 {
   // Assert size of variant to ensure that this method gets updated if the variant
   // definition changes
-  static_assert(nostd::variant_size<opentelemetry::common::AttributeValue>::value ==
-                    kOwnedAttributeValueSize + 1,
-                "AttributeValue contains unknown type");
+  static_assert(nostd::variant_size<sdk::common::OwnedAttributeValue>::value ==
+                    kOwnedAttributeValueSize,
+                "OwnedAttributeValue contains unknown type");
 
   attribute->set_key(key.data(), key.size());
 

--- a/exporters/otlp/src/otlp_recordable.cc
+++ b/exporters/otlp/src/otlp_recordable.cc
@@ -138,9 +138,9 @@ void PopulateAttribute(opentelemetry::proto::common::v1::KeyValue *attribute,
 {
   // Assert size of variant to ensure that this method gets updated if the variant
   // definition changes
-  static_assert(nostd::variant_size<sdk::common::OwnedAttributeValue>::value ==
-                    kOwnedAttributeValueSize,
-                "OwnedAttributeValue contains unknown type");
+  static_assert(
+      nostd::variant_size<sdk::common::OwnedAttributeValue>::value == kOwnedAttributeValueSize,
+      "OwnedAttributeValue contains unknown type");
 
   attribute->set_key(key.data(), key.size());
 


### PR DESCRIPTION
## Changes

We assert on `AttirbuteValue` while we are using `OwnedAttributeValue` in [PopulateAttribute](https://github.com/open-telemetry/opentelemetry-cpp/blob/main/exporters/otlp/src/otlp_recordable.cc#L141) from OTLP exporter.

For significant contributions please make sure you have completed the following items:

* [ ] `CHANGELOG.md` updated for non-trivial changes
* [ ] Unit tests have been added
* [ ] Changes in public API reviewed