### PR TITLE
Remove meeting link in contributing doc

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -142,7 +142,7 @@ on each other), the owner should try to get people aligned by:
 
 If none of the above worked and the PR has been stuck for more than 2 weeks, the
 owner should bring it to the OpenTelemetry C++ SIG meeting. See
-[README.md](README.md#Contributing) for the meeting link.
+[README.md](README.md#contributing) for the meeting link.
 
 ## Useful Resources
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -141,8 +141,8 @@ on each other), the owner should try to get people aligned by:
   split it up.
 
 If none of the above worked and the PR has been stuck for more than 2 weeks, the
-owner should bring it to the [OpenTelemetry C++ SIG
-meeting](https://zoom.us/j/8203130519). The meeting passcode is _77777_.
+owner should bring it to the OpenTelemetry C++ SIG meeting. See
+[README.md](README.md#Contributing) for the meeting link.
 
 ## Useful Resources
 


### PR DESCRIPTION
## Changes

We updated Zoom meeting in README in https://github.com/open-telemetry/opentelemetry-cpp/pull/887, but we also have the same link in contributing doc which needs to be fixed as well. Instead, this PR removes the duplicated link in the contributing doc.

For significant contributions please make sure you have completed the following items:

* [ ] `CHANGELOG.md` updated for non-trivial changes
* [ ] Unit tests have been added
* [ ] Changes in public API reviewed