### PR TITLE
Populate resource attributes into process tags in Jaeger

### DIFF
--- a/exporters/jaeger/include/opentelemetry/exporters/jaeger/recordable.h
+++ b/exporters/jaeger/include/opentelemetry/exporters/jaeger/recordable.h
@@ -56,6 +56,7 @@ public:
 
   thrift::Span *Span() noexcept { return span_.release(); }
   std::vector<thrift::Tag> Tags() noexcept { return std::move(tags_); }
+  std::vector<thrift::Tag> ResourceTags() noexcept { return std::move(resource_tags_); }
   std::vector<thrift::Log> Logs() noexcept { return std::move(logs_); }
   const std::string &ServiceName() const noexcept { return service_name_; }
 
@@ -99,9 +100,14 @@ private:
                          const opentelemetry::common::AttributeValue &value,
                          std::vector<thrift::Tag> &tags);
 
+  void PopulateAttribute(nostd::string_view key,
+                         const sdk::common::OwnedAttributeValue &value,
+                         std::vector<thrift::Tag> &tags);
+
 private:
   std::unique_ptr<thrift::Span> span_;
   std::vector<thrift::Tag> tags_;
+  std::vector<thrift::Tag> resource_tags_;
   std::vector<thrift::Log> logs_;
   std::string service_name_;
 };

--- a/exporters/jaeger/src/thrift_sender.cc
+++ b/exporters/jaeger/src/thrift_sender.cc
@@ -29,6 +29,7 @@ int ThriftSender::Append(std::unique_ptr<Recordable> &&span) noexcept
   if (process_.serviceName.empty())
   {
     process_.serviceName = span->ServiceName();
+    process_.__set_tags(span->ResourceTags());
 
     process_bytes_size_ = CalcSizeOfSerializedThrift(process_);
     max_span_bytes -= process_bytes_size_;

--- a/exporters/jaeger/test/jaeger_recordable_test.cc
+++ b/exporters/jaeger/test/jaeger_recordable_test.cc
@@ -186,7 +186,7 @@ TEST(JaegerSpanRecordable, SetResource)
   const std::string service_name_key = "service.name";
   std::string service_name_value     = "test-jaeger-service-name";
   auto resource                      = opentelemetry::sdk::resource::Resource::Create(
-                           {{service_name_key, service_name_value}, {"key1", "value1"}, {"key2", "value2"}});
+      {{service_name_key, service_name_value}, {"key1", "value1"}, {"key2", "value2"}});
   rec.SetResource(resource);
 
   auto service_name  = rec.ServiceName();

--- a/exporters/jaeger/test/jaeger_recordable_test.cc
+++ b/exporters/jaeger/test/jaeger_recordable_test.cc
@@ -178,3 +178,38 @@ TEST(JaegerSpanRecordable, SetInstrumentationLibrary)
   EXPECT_EQ(tags[1].vType, thrift::TagType::STRING);
   EXPECT_EQ(tags[1].vStr, library_version);
 }
+
+TEST(JaegerSpanRecordable, SetResource)
+{
+  opentelemetry::exporter::jaeger::Recordable rec;
+
+  const std::string service_name_key = "service.name";
+  std::string service_name_value     = "test-jaeger-service-name";
+  auto resource                      = opentelemetry::sdk::resource::Resource::Create(
+                           {{service_name_key, service_name_value}, {"key1", "value1"}, {"key2", "value2"}});
+  rec.SetResource(resource);
+
+  auto service_name  = rec.ServiceName();
+  auto resource_tags = rec.ResourceTags();
+
+  EXPECT_GE(resource_tags.size(), 2);
+  EXPECT_EQ(service_name, service_name_value);
+
+  bool found_key1 = false;
+  bool found_key2 = false;
+  for (const auto &tag : resource_tags)
+  {
+    if (tag.key == "key1")
+    {
+      found_key1 = true;
+      EXPECT_EQ(tag.vType, thrift::TagType::STRING);
+      EXPECT_EQ(tag.vStr, "value1");
+    }
+    else if (tag.key == "key2")
+    {
+      found_key2 = true;
+      EXPECT_EQ(tag.vType, thrift::TagType::STRING);
+      EXPECT_EQ(tag.vStr, "value2");
+    }
+  }
+}


### PR DESCRIPTION
Fixes #767

## Changes

Current only `service.name` is set to Jaeger span, this PR populates all other resources attributes into tags in Jaeger process object.

For significant contributions please make sure you have completed the following items:

* [ ] `CHANGELOG.md` updated for non-trivial changes
* [x] Unit tests have been added
* [ ] Changes in public API reviewed