### PR TITLE
🐛 fix zipkin exporter compile failure

### DIFF
--- a/exporters/zipkin/include/opentelemetry/exporters/zipkin/recordable.h
+++ b/exporters/zipkin/include/opentelemetry/exporters/zipkin/recordable.h
@@ -40,7 +40,7 @@ public:
   void AddLink(const opentelemetry::trace::SpanContext &span_context,
                const common::KeyValueIterable &attributes) noexcept override;
 
-  void SetStatus(trace::StatusCode code, nostd::string_view description) noexcept override;
+  void SetStatus(opentelemetry::trace::StatusCode code, nostd::string_view description) noexcept override;
 
   void SetName(nostd::string_view name) noexcept override;
 

--- a/exporters/zipkin/include/opentelemetry/exporters/zipkin/recordable.h
+++ b/exporters/zipkin/include/opentelemetry/exporters/zipkin/recordable.h
@@ -40,7 +40,8 @@ public:
   void AddLink(const opentelemetry::trace::SpanContext &span_context,
                const common::KeyValueIterable &attributes) noexcept override;
 
-  void SetStatus(opentelemetry::trace::StatusCode code, nostd::string_view description) noexcept override;
+  void SetStatus(opentelemetry::trace::StatusCode code,
+                 nostd::string_view description) noexcept override;
 
   void SetName(nostd::string_view name) noexcept override;
 


### PR DESCRIPTION
Fixes # (issue)

## Changes
The following method is marked override but it doesn't override:
`exporter::zipkin::Recordable::SetStatus(trace::StatusCode code, nostd::string_view description) noexcept override;`

compile error:
```
In file included from <path>/include/opentelemetry/exporters/zipkin/zipkin_exporter.h:6,
                 from /opt/otel/main.cc:11:
<path>/include/opentelemetry/exporters/zipkin/recordable.h:43:25: error: 'opentelemetry::v0::exporter::trace::StatusCode' has not been declared
   43 |   void SetStatus(trace::StatusCode code, nostd::string_view description) noexcept override;
      |                         ^~~~~~~~~~
<path>/include/opentelemetry/exporters/zipkin/recordable.h:43:8: error: 'void opentelemetry::v0::exporter::zipkin::Recordable::SetStatus(int, opentelemetry::v0::nostd::string_view)' marked 'override', but does not override
   43 |   void SetStatus(trace::StatusCode code, nostd::string_view description) noexcept override;
      |        ^~~~~~~~~
make[2]: *** [CMakeFiles/simpleOtel.dir/build.make:63: CMakeFiles/simpleOtel.dir/main.cc.o] Error 1
make[2]: Leaving directory '/opt/otel/build'
```

For significant contributions please make sure you have completed the following items:

* [ ] `CHANGELOG.md` updated for non-trivial changes
* [ ] Unit tests have been added
* [ ] Changes in public API reviewed