### PR TITLE
Fixes missing namespace in Jaeger exporter config doc

### DIFF
--- a/examples/jaeger/BUILD
+++ b/examples/jaeger/BUILD
@@ -8,6 +8,7 @@ cc_library(
     ],
     deps = [
         "//api",
+        "//sdk:headers",
     ],
 )
 

--- a/examples/jaeger/foo_library/foo_library.cc
+++ b/examples/jaeger/foo_library/foo_library.cc
@@ -1,6 +1,7 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
+#include "opentelemetry/sdk/version/version.h"
 #include "opentelemetry/trace/provider.h"
 
 namespace trace = opentelemetry::trace;
@@ -11,7 +12,7 @@ namespace
 nostd::shared_ptr<trace::Tracer> get_tracer()
 {
   auto provider = trace::Provider::GetTracerProvider();
-  return provider->GetTracer("foo_library");
+  return provider->GetTracer("foo_library", OPENTELEMETRY_SDK_VERSION);
 }
 
 void f1()

--- a/exporters/jaeger/README.md
+++ b/exporters/jaeger/README.md
@@ -7,7 +7,7 @@
 
 ## Installation
 
-## CMake Installation Instructions
+### CMake Installation Instructions
 
 Refer to install instructions
 [INSTALL.md](../../INSTALL.md#building-as-standalone-cmake-project). Modify step
@@ -31,13 +31,13 @@ TODO
 
 ## Usage
 
-Install the exporter on your application and pass the options.
+Install the exporter in your application, initialize and pass the `options` to it.
 
 ```cpp
 opentelemetry::exporter::jaeger::JaegerExporterOptions options;
 options.server_addr      = "localhost";
 options.server_port      = 6831;
-options.transport_format = TransportFormat::kThriftUdpCompact;
+options.transport_format = opentelemetry::exporter::jaeger::TransportFormat::kThriftUdpCompact;
 
 auto exporter = std::unique_ptr<opentelemetry::sdk::trace::SpanExporter>(
     new opentelemetry::exporter::jaeger::JaegerExporter(options));


### PR DESCRIPTION
## Changes

Fix the Jaeger example code to make it buildable after copy/paste.

The current example has issue to build as mentioned in https://github.com/open-telemetry/opentelemetry-cpp/issues/901.

For significant contributions please make sure you have completed the following items:

* [ ] `CHANGELOG.md` updated for non-trivial changes
* [ ] Unit tests have been added
* [ ] Changes in public API reviewed