### PR TITLE
Add resource and instrumentation library support for OStreamSpanExporter

### DIFF
--- a/exporters/ostream/include/opentelemetry/exporters/ostream/span_exporter.h
+++ b/exporters/ostream/include/opentelemetry/exporters/ostream/span_exporter.h
@@ -119,6 +119,12 @@ private:
   void printEvents(const std::vector<sdktrace::SpanDataEvent> &events);
 
   void printLinks(const std::vector<sdktrace::SpanDataLink> &links);
+
+  void printResources(const opentelemetry::sdk::resource::Resource &resources);
+
+  void printInstrumentationLibrary(
+      const opentelemetry::sdk::instrumentationlibrary::InstrumentationLibrary
+          &instrumentation_library);
 };
 }  // namespace trace
 }  // namespace exporter

--- a/exporters/ostream/src/span_exporter.cc
+++ b/exporters/ostream/src/span_exporter.cc
@@ -80,6 +80,10 @@ sdk::common::ExportResult OStreamSpanExporter::Export(
       printEvents(span->GetEvents());
       sout_ << "\n  links         : ";
       printLinks(span->GetLinks());
+      sout_ << "\n  resources     : ";
+      printResources(span->GetResource());
+      sout_ << "\n  instr-lib     : ";
+      printInstrumentationLibrary(span->GetInstrumentationLibrary());
       sout_ << "\n}\n";
     }
   }
@@ -132,6 +136,27 @@ void OStreamSpanExporter::printLinks(const std::vector<sdktrace::SpanDataLink> &
           << "\n\t  attributes    : ";
     printAttributes(link.GetAttributes(), "\n\t\t");
     sout_ << "\n\t}";
+  }
+}
+
+void OStreamSpanExporter::printResources(const opentelemetry::sdk::resource::Resource &resources)
+{
+  auto attributes = resources.GetAttributes();
+  if (attributes.size())
+  {
+    printAttributes(attributes, "\n\t");
+  }
+}
+
+void OStreamSpanExporter::printInstrumentationLibrary(
+    const opentelemetry::sdk::instrumentationlibrary::InstrumentationLibrary
+        &instrumentation_library)
+{
+  sout_ << instrumentation_library.GetName();
+  auto version = instrumentation_library.GetVersion();
+  if (version.size())
+  {
+    sout_ << "-" << version;
   }
 }
 

--- a/sdk/include/opentelemetry/sdk/trace/span_data.h
+++ b/sdk/include/opentelemetry/sdk/trace/span_data.h
@@ -177,9 +177,10 @@ public:
     {
       // this shouldn't happen as Tracer ensures there is valid default instrumentation library.
       static std::unique_ptr<opentelemetry::sdk::instrumentationlibrary::InstrumentationLibrary>
-          ilib = opentelemetry::sdk::instrumentationlibrary::InstrumentationLibrary::Create(
-              "unknown_service");
-      return *ilib;
+          instrumentation_library =
+              opentelemetry::sdk::instrumentationlibrary::InstrumentationLibrary::Create(
+                  "unknown_service");
+      return *instrumentation_library;
     }
     return *instrumentation_library_;
   }

--- a/sdk/include/opentelemetry/sdk/trace/span_data.h
+++ b/sdk/include/opentelemetry/sdk/trace/span_data.h
@@ -99,6 +99,7 @@ private:
 class SpanData final : public Recordable
 {
 public:
+  SpanData() : resource_{nullptr}, instrumentation_library_{nullptr} {}
   /**
    * Get the trace id for this span
    * @return the trace id for this span
@@ -152,7 +153,36 @@ public:
    * @returns the attributes associated with the resource configured for TracerProvider
    */
 
-  const opentelemetry::sdk::resource::Resource &GetResource() const noexcept { return *resource_; }
+  const opentelemetry::sdk::resource::Resource &GetResource() const noexcept
+  {
+    if (resource_ == nullptr)
+    {
+      // this shouldn't happen as TraceProvider provides default resources
+      static opentelemetry::sdk::resource::Resource resource =
+          opentelemetry::sdk::resource::Resource::GetEmpty();
+      return resource;
+    }
+    return *resource_;
+  }
+
+  /**
+   * Get the attributes associated with the resource
+   * @returns the attributes associated with the resource configured for TracerProvider
+   */
+
+  const opentelemetry::sdk::trace::InstrumentationLibrary &GetInstrumentationLibrary()
+      const noexcept
+  {
+    if (instrumentation_library_ == nullptr)
+    {
+      // this shouldn't happen as Tracer ensures there is valid default instrumentation library.
+      static std::unique_ptr<opentelemetry::sdk::instrumentationlibrary::InstrumentationLibrary>
+          ilib = opentelemetry::sdk::instrumentationlibrary::InstrumentationLibrary::Create(
+              "unknown_service");
+      return *ilib;
+    }
+    return *instrumentation_library_;
+  }
 
   /**
    * Get the start time for this span


### PR DESCRIPTION
## Changes
OStreamSpanExporter span exporter doesn't export resources and instrumentation library. This makes it difficult to debug issues related to resources/instrumentation library. This PR adds support for it. 

For significant contributions please make sure you have completed the following items:

* [ ] `CHANGELOG.md` updated for non-trivial changes
* [x] Unit tests have been added
* [x] Changes in public API reviewed