### PR TITLE
Allow to use local GSL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ Increment the:
 
 ## [Unreleased]
 
+* [BUILD] Allow to use local GSL
+
 ## [1.0.0-rc3] 2021-07-12
 
 * [DOCS] Add doxygen reference docs for SDK ([#902](https://github.com/open-telemetry/opentelemetry-cpp/pull/902))

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -118,8 +118,13 @@ if(WITH_STL)
   # Guidelines Support Library path. Used if we are not on not get C++20.
   #
   # TODO: respect WITH_ABSEIL as alternate implementation of std::span
-  set(GSL_DIR third_party/ms-gsl)
-  include_directories(${GSL_DIR}/include)
+  find_package(Microsoft.GSL QUIET)
+  if(TARGET Microsoft.GSL::GSL)
+    list(APPEND CORE_RUNTIME_LIBS Microsoft.GSL::GSL)
+  else()
+    set(GSL_DIR third_party/ms-gsl)
+    include_directories(${GSL_DIR}/include)
+  endif()
 
   # Optimize for speed to reduce the hops
   if(CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")


### PR DESCRIPTION
Signed-off-by: owent <admin@owent.net>

Fixes # 914

## Changes

Allow to us elocal GSL.

Maybe need more discussion about using [gsl-lite](https://github.com/gsl-lite/gsl-lite) for old compilers?

For significant contributions please make sure you have completed the following items:

* [ ] `CHANGELOG.md` updated for non-trivial changes
* [ ] Unit tests have been added
* [ ] Changes in public API reviewed