### PR TITLE
Rename Recordable to JaegerRecordable in Jaeger exporter

### DIFF
--- a/exporters/jaeger/include/opentelemetry/exporters/jaeger/recordable.h
+++ b/exporters/jaeger/include/opentelemetry/exporters/jaeger/recordable.h
@@ -49,10 +49,10 @@ inline uint64_t otel_bswap_64(uint64_t host_int)
 
 using namespace jaegertracing;
 
-class Recordable final : public sdk::trace::Recordable
+class JaegerRecordable final : public sdk::trace::Recordable
 {
 public:
-  Recordable();
+  JaegerRecordable();
 
   thrift::Span *Span() noexcept { return span_.release(); }
   std::vector<thrift::Tag> Tags() noexcept { return std::move(tags_); }

--- a/exporters/jaeger/src/jaeger_exporter.cc
+++ b/exporters/jaeger/src/jaeger_exporter.cc
@@ -40,7 +40,8 @@ sdk_common::ExportResult JaegerExporter::Export(
 
   for (auto &recordable : spans)
   {
-    auto rec = std::unique_ptr<JaegerRecordable>(static_cast<JaegerRecordable *>(recordable.release()));
+    auto rec =
+        std::unique_ptr<JaegerRecordable>(static_cast<JaegerRecordable *>(recordable.release()));
     if (rec != nullptr)
     {
       exported_size += sender_->Append(std::move(rec));

--- a/exporters/jaeger/src/jaeger_exporter.cc
+++ b/exporters/jaeger/src/jaeger_exporter.cc
@@ -25,7 +25,7 @@ JaegerExporter::JaegerExporter() : JaegerExporter(JaegerExporterOptions()) {}
 
 std::unique_ptr<trace_sdk::Recordable> JaegerExporter::MakeRecordable() noexcept
 {
-  return std::unique_ptr<sdk::trace::Recordable>(new Recordable);
+  return std::unique_ptr<sdk::trace::Recordable>(new JaegerRecordable);
 }
 
 sdk_common::ExportResult JaegerExporter::Export(
@@ -40,7 +40,7 @@ sdk_common::ExportResult JaegerExporter::Export(
 
   for (auto &recordable : spans)
   {
-    auto rec = std::unique_ptr<Recordable>(static_cast<Recordable *>(recordable.release()));
+    auto rec = std::unique_ptr<JaegerRecordable>(static_cast<JaegerRecordable *>(recordable.release()));
     if (rec != nullptr)
     {
       exported_size += sender_->Append(std::move(rec));

--- a/exporters/jaeger/src/recordable.cc
+++ b/exporters/jaeger/src/recordable.cc
@@ -12,9 +12,9 @@ namespace jaeger
 
 using namespace opentelemetry::sdk::resource;
 
-Recordable::Recordable() : span_{new thrift::Span} {}
+JaegerRecordable::JaegerRecordable() : span_{new thrift::Span} {}
 
-void Recordable::PopulateAttribute(nostd::string_view key,
+void JaegerRecordable::PopulateAttribute(nostd::string_view key,
                                    const common::AttributeValue &value,
                                    std::vector<thrift::Tag> &tags)
 {
@@ -41,7 +41,7 @@ void Recordable::PopulateAttribute(nostd::string_view key,
   // TODO: extend other AttributeType to the types supported by Jaeger.
 }
 
-void Recordable::PopulateAttribute(nostd::string_view key,
+void JaegerRecordable::PopulateAttribute(nostd::string_view key,
                                    const sdk::common::OwnedAttributeValue &value,
                                    std::vector<thrift::Tag> &tags)
 {
@@ -64,7 +64,7 @@ void Recordable::PopulateAttribute(nostd::string_view key,
   // TODO: extend other OwnedAttributeType to the types supported by Jaeger.
 }
 
-void Recordable::SetIdentity(const trace::SpanContext &span_context,
+void JaegerRecordable::SetIdentity(const trace::SpanContext &span_context,
                              trace::SpanId parent_span_id) noexcept
 {
   // IDs should be converted to big endian before transmission.
@@ -90,12 +90,12 @@ void Recordable::SetIdentity(const trace::SpanContext &span_context,
   // TODO: set trace_state.
 }
 
-void Recordable::SetAttribute(nostd::string_view key, const common::AttributeValue &value) noexcept
+void JaegerRecordable::SetAttribute(nostd::string_view key, const common::AttributeValue &value) noexcept
 {
   PopulateAttribute(key, value, tags_);
 }
 
-void Recordable::AddEvent(nostd::string_view name,
+void JaegerRecordable::AddEvent(nostd::string_view name,
                           common::SystemTimestamp timestamp,
                           const common::KeyValueIterable &attributes) noexcept
 {
@@ -113,7 +113,7 @@ void Recordable::AddEvent(nostd::string_view name,
   logs_.push_back(log);
 }
 
-void Recordable::SetInstrumentationLibrary(
+void JaegerRecordable::SetInstrumentationLibrary(
     const opentelemetry::sdk::instrumentationlibrary::InstrumentationLibrary
         &instrumentation_library) noexcept
 {
@@ -121,13 +121,13 @@ void Recordable::SetInstrumentationLibrary(
   AddTag("otel.library.version", instrumentation_library.GetVersion(), tags_);
 }
 
-void Recordable::AddLink(const trace::SpanContext &span_context,
+void JaegerRecordable::AddLink(const trace::SpanContext &span_context,
                          const common::KeyValueIterable &attributes) noexcept
 {
   // TODO: convert link to SpanRefernece
 }
 
-void Recordable::SetStatus(trace::StatusCode code, nostd::string_view description) noexcept
+void JaegerRecordable::SetStatus(trace::StatusCode code, nostd::string_view description) noexcept
 {
   if (code == trace::StatusCode::kUnset)
   {
@@ -147,12 +147,12 @@ void Recordable::SetStatus(trace::StatusCode code, nostd::string_view descriptio
   AddTag("otel.status_description", std::string{description}, tags_);
 }
 
-void Recordable::SetName(nostd::string_view name) noexcept
+void JaegerRecordable::SetName(nostd::string_view name) noexcept
 {
   span_->__set_operationName(static_cast<std::string>(name));
 }
 
-void Recordable::SetResource(const opentelemetry::sdk::resource::Resource &resource) noexcept
+void JaegerRecordable::SetResource(const opentelemetry::sdk::resource::Resource &resource) noexcept
 {
   for (const auto &attribute_iter : resource.GetAttributes())
   {
@@ -168,18 +168,18 @@ void Recordable::SetResource(const opentelemetry::sdk::resource::Resource &resou
   }
 }
 
-void Recordable::SetStartTime(common::SystemTimestamp start_time) noexcept
+void JaegerRecordable::SetStartTime(common::SystemTimestamp start_time) noexcept
 {
   span_->__set_startTime(
       std::chrono::duration_cast<std::chrono::microseconds>(start_time.time_since_epoch()).count());
 }
 
-void Recordable::SetDuration(std::chrono::nanoseconds duration) noexcept
+void JaegerRecordable::SetDuration(std::chrono::nanoseconds duration) noexcept
 {
   span_->__set_duration(std::chrono::duration_cast<std::chrono::microseconds>(duration).count());
 }
 
-void Recordable::SetSpanKind(trace::SpanKind span_kind) noexcept
+void JaegerRecordable::SetSpanKind(trace::SpanKind span_kind) noexcept
 {
   const char *span_kind_str = nullptr;
 
@@ -212,7 +212,7 @@ void Recordable::SetSpanKind(trace::SpanKind span_kind) noexcept
   }
 }
 
-void Recordable::AddTag(const std::string &key,
+void JaegerRecordable::AddTag(const std::string &key,
                         const std::string &value,
                         std::vector<thrift::Tag> &tags)
 {
@@ -225,12 +225,12 @@ void Recordable::AddTag(const std::string &key,
   tags.push_back(tag);
 }
 
-void Recordable::AddTag(const std::string &key, const char *value, std::vector<thrift::Tag> &tags)
+void JaegerRecordable::AddTag(const std::string &key, const char *value, std::vector<thrift::Tag> &tags)
 {
   AddTag(key, std::string{value}, tags);
 }
 
-void Recordable::AddTag(const std::string &key, bool value, std::vector<thrift::Tag> &tags)
+void JaegerRecordable::AddTag(const std::string &key, bool value, std::vector<thrift::Tag> &tags)
 {
   thrift::Tag tag;
 
@@ -241,7 +241,7 @@ void Recordable::AddTag(const std::string &key, bool value, std::vector<thrift::
   tags.push_back(tag);
 }
 
-void Recordable::AddTag(const std::string &key, int64_t value, std::vector<thrift::Tag> &tags)
+void JaegerRecordable::AddTag(const std::string &key, int64_t value, std::vector<thrift::Tag> &tags)
 {
   thrift::Tag tag;
 
@@ -252,7 +252,7 @@ void Recordable::AddTag(const std::string &key, int64_t value, std::vector<thrif
   tags.push_back(tag);
 }
 
-void Recordable::AddTag(const std::string &key, double value, std::vector<thrift::Tag> &tags)
+void JaegerRecordable::AddTag(const std::string &key, double value, std::vector<thrift::Tag> &tags)
 {
   thrift::Tag tag;
 

--- a/exporters/jaeger/src/recordable.cc
+++ b/exporters/jaeger/src/recordable.cc
@@ -15,8 +15,8 @@ using namespace opentelemetry::sdk::resource;
 JaegerRecordable::JaegerRecordable() : span_{new thrift::Span} {}
 
 void JaegerRecordable::PopulateAttribute(nostd::string_view key,
-                                   const common::AttributeValue &value,
-                                   std::vector<thrift::Tag> &tags)
+                                         const common::AttributeValue &value,
+                                         std::vector<thrift::Tag> &tags)
 {
   if (nostd::holds_alternative<int64_t>(value))
   {
@@ -42,8 +42,8 @@ void JaegerRecordable::PopulateAttribute(nostd::string_view key,
 }
 
 void JaegerRecordable::PopulateAttribute(nostd::string_view key,
-                                   const sdk::common::OwnedAttributeValue &value,
-                                   std::vector<thrift::Tag> &tags)
+                                         const sdk::common::OwnedAttributeValue &value,
+                                         std::vector<thrift::Tag> &tags)
 {
   if (nostd::holds_alternative<int64_t>(value))
   {
@@ -65,7 +65,7 @@ void JaegerRecordable::PopulateAttribute(nostd::string_view key,
 }
 
 void JaegerRecordable::SetIdentity(const trace::SpanContext &span_context,
-                             trace::SpanId parent_span_id) noexcept
+                                   trace::SpanId parent_span_id) noexcept
 {
   // IDs should be converted to big endian before transmission.
   // https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/sdk_exporters/jaeger.md#ids
@@ -90,14 +90,15 @@ void JaegerRecordable::SetIdentity(const trace::SpanContext &span_context,
   // TODO: set trace_state.
 }
 
-void JaegerRecordable::SetAttribute(nostd::string_view key, const common::AttributeValue &value) noexcept
+void JaegerRecordable::SetAttribute(nostd::string_view key,
+                                    const common::AttributeValue &value) noexcept
 {
   PopulateAttribute(key, value, tags_);
 }
 
 void JaegerRecordable::AddEvent(nostd::string_view name,
-                          common::SystemTimestamp timestamp,
-                          const common::KeyValueIterable &attributes) noexcept
+                                common::SystemTimestamp timestamp,
+                                const common::KeyValueIterable &attributes) noexcept
 {
   std::vector<thrift::Tag> tags;
   PopulateAttribute("event", static_cast<common::AttributeValue>(name.data()), tags);
@@ -122,7 +123,7 @@ void JaegerRecordable::SetInstrumentationLibrary(
 }
 
 void JaegerRecordable::AddLink(const trace::SpanContext &span_context,
-                         const common::KeyValueIterable &attributes) noexcept
+                               const common::KeyValueIterable &attributes) noexcept
 {
   // TODO: convert link to SpanRefernece
 }
@@ -213,8 +214,8 @@ void JaegerRecordable::SetSpanKind(trace::SpanKind span_kind) noexcept
 }
 
 void JaegerRecordable::AddTag(const std::string &key,
-                        const std::string &value,
-                        std::vector<thrift::Tag> &tags)
+                              const std::string &value,
+                              std::vector<thrift::Tag> &tags)
 {
   thrift::Tag tag;
 
@@ -225,7 +226,9 @@ void JaegerRecordable::AddTag(const std::string &key,
   tags.push_back(tag);
 }
 
-void JaegerRecordable::AddTag(const std::string &key, const char *value, std::vector<thrift::Tag> &tags)
+void JaegerRecordable::AddTag(const std::string &key,
+                              const char *value,
+                              std::vector<thrift::Tag> &tags)
 {
   AddTag(key, std::string{value}, tags);
 }

--- a/exporters/jaeger/src/sender.h
+++ b/exporters/jaeger/src/sender.h
@@ -19,7 +19,7 @@ public:
   Sender()          = default;
   virtual ~Sender() = default;
 
-  virtual int Append(std::unique_ptr<Recordable> &&span) = 0;
+  virtual int Append(std::unique_ptr<JaegerRecordable> &&span) = 0;
 
   virtual int Flush() = 0;
 

--- a/exporters/jaeger/src/thrift_sender.cc
+++ b/exporters/jaeger/src/thrift_sender.cc
@@ -18,7 +18,7 @@ ThriftSender::ThriftSender(std::unique_ptr<Transport> &&transport)
       thrift_buffer_(new apache::thrift::transport::TMemoryBuffer())
 {}
 
-int ThriftSender::Append(std::unique_ptr<Recordable> &&span) noexcept
+int ThriftSender::Append(std::unique_ptr<JaegerRecordable> &&span) noexcept
 {
   if (span == nullptr)
   {

--- a/exporters/jaeger/src/thrift_sender.h
+++ b/exporters/jaeger/src/thrift_sender.h
@@ -32,7 +32,7 @@ public:
   ThriftSender(std::unique_ptr<Transport> &&transport);
   ~ThriftSender() override { Close(); }
 
-  int Append(std::unique_ptr<Recordable> &&span) noexcept override;
+  int Append(std::unique_ptr<JaegerRecordable> &&span) noexcept override;
   int Flush() override;
   void Close() override;
 
@@ -57,7 +57,7 @@ private:
   }
 
 private:
-  std::vector<std::unique_ptr<Recordable>> spans_;
+  std::vector<std::unique_ptr<JaegerRecordable>> spans_;
   std::vector<thrift::Span> span_buffer_;
   std::unique_ptr<Transport> transport_;
   std::unique_ptr<apache::thrift::protocol::TProtocolFactory> protocol_factory_;

--- a/exporters/jaeger/test/jaeger_recordable_test.cc
+++ b/exporters/jaeger/test/jaeger_recordable_test.cc
@@ -20,7 +20,7 @@ using namespace opentelemetry::sdk::instrumentationlibrary;
 
 TEST(JaegerSpanRecordable, SetIdentity)
 {
-  opentelemetry::exporter::jaeger::Recordable rec;
+  opentelemetry::exporter::jaeger::JaegerRecordable rec;
 
   int64_t trace_id_val[2]    = {0x0000000000000000, 0x1000000000000000};
   int64_t span_id_val        = 0x2000000000000000;
@@ -57,7 +57,7 @@ TEST(JaegerSpanRecordable, SetIdentity)
 
 TEST(JaegerSpanRecordable, SetName)
 {
-  opentelemetry::exporter::jaeger::Recordable rec;
+  opentelemetry::exporter::jaeger::JaegerRecordable rec;
 
   nostd::string_view name = "Test Span";
   rec.SetName(name);
@@ -69,7 +69,7 @@ TEST(JaegerSpanRecordable, SetName)
 
 TEST(JaegerSpanRecordable, SetStartTime)
 {
-  opentelemetry::exporter::jaeger::Recordable rec;
+  opentelemetry::exporter::jaeger::JaegerRecordable rec;
 
   std::chrono::system_clock::time_point start_time = std::chrono::system_clock::now();
   opentelemetry::common::SystemTimestamp start_timestamp(start_time);
@@ -84,7 +84,7 @@ TEST(JaegerSpanRecordable, SetStartTime)
 
 TEST(JaegerSpanRecordable, SetDuration)
 {
-  opentelemetry::exporter::jaeger::Recordable rec;
+  opentelemetry::exporter::jaeger::JaegerRecordable rec;
 
   opentelemetry::common::SystemTimestamp start_timestamp;
 
@@ -102,7 +102,7 @@ TEST(JaegerSpanRecordable, SetDuration)
 
 TEST(JaegerSpanRecordable, SetStatus)
 {
-  opentelemetry::exporter::jaeger::Recordable rec;
+  opentelemetry::exporter::jaeger::JaegerRecordable rec;
 
   const char *error_description = "Error test";
   rec.SetStatus(trace::StatusCode::kError, error_description);
@@ -125,7 +125,7 @@ TEST(JaegerSpanRecordable, SetStatus)
 
 TEST(JaegerSpanRecordable, AddEvent)
 {
-  opentelemetry::exporter::jaeger::Recordable rec;
+  opentelemetry::exporter::jaeger::JaegerRecordable rec;
 
   nostd::string_view name = "Test Event";
 
@@ -159,7 +159,7 @@ TEST(JaegerSpanRecordable, AddEvent)
 
 TEST(JaegerSpanRecordable, SetInstrumentationLibrary)
 {
-  opentelemetry::exporter::jaeger::Recordable rec;
+  opentelemetry::exporter::jaeger::JaegerRecordable rec;
 
   std::string library_name     = "opentelemetry-cpp";
   std::string library_version  = "0.1.0";
@@ -181,7 +181,7 @@ TEST(JaegerSpanRecordable, SetInstrumentationLibrary)
 
 TEST(JaegerSpanRecordable, SetResource)
 {
-  opentelemetry::exporter::jaeger::Recordable rec;
+  opentelemetry::exporter::jaeger::JaegerRecordable rec;
 
   const std::string service_name_key = "service.name";
   std::string service_name_value     = "test-jaeger-service-name";


### PR DESCRIPTION
Fixes #735

## Changes

The Recordable applies to Jaeger exporter. The concrete protocols are abstracted to the `ThriftSender`, so no need to include the protocol name here.

For significant contributions please make sure you have completed the following items:

* [ ] `CHANGELOG.md` updated for non-trivial changes
* [ ] Unit tests have been added
* [ ] Changes in public API reviewed