### PR TITLE
remove recordable header from CMake install rules for exporters

### DIFF
--- a/exporters/elasticsearch/CMakeLists.txt
+++ b/exporters/elasticsearch/CMakeLists.txt
@@ -22,7 +22,8 @@ install(
   DIRECTORY include/opentelemetry/exporters/elasticsearch
   DESTINATION include/opentelemetry/exporters/
   FILES_MATCHING
-  PATTERN "*.h")
+  PATTERN "*.h"
+  PATTERN "es_log_recordable.h" EXCLUDE)
 
 if(BUILD_TESTING)
   add_executable(es_log_exporter_test test/es_log_exporter_test.cc)

--- a/exporters/jaeger/CMakeLists.txt
+++ b/exporters/jaeger/CMakeLists.txt
@@ -50,7 +50,8 @@ install(
   DIRECTORY include/opentelemetry/exporters/jaeger
   DESTINATION include/opentelemetry/exporters/
   FILES_MATCHING
-  PATTERN "*.h")
+  PATTERN "*.h"
+  PATTERN "recordable.h" EXCLUDE)
 
 if(BUILD_TESTING)
   add_executable(jaeger_recordable_test test/jaeger_recordable_test.cc)

--- a/exporters/otlp/CMakeLists.txt
+++ b/exporters/otlp/CMakeLists.txt
@@ -52,7 +52,8 @@ install(
   DIRECTORY include/opentelemetry/exporters/otlp
   DESTINATION include/opentelemetry/exporters/
   FILES_MATCHING
-  PATTERN "*.h")
+  PATTERN "*.h"
+  PATTERN "otlp_recordable.h" EXCLUDE)
 
 if(BUILD_TESTING)
   add_executable(otlp_recordable_test test/otlp_recordable_test.cc)

--- a/exporters/zipkin/CMakeLists.txt
+++ b/exporters/zipkin/CMakeLists.txt
@@ -34,7 +34,8 @@ install(
   DIRECTORY include/opentelemetry/exporters/zipkin
   DESTINATION include/opentelemetry/exporters/
   FILES_MATCHING
-  PATTERN "*.h")
+  PATTERN "*.h"
+  PATTERN "recordable.h" EXCLUDE)
 
 if(BUILD_TESTING)
   add_executable(zipkin_recordable_test test/zipkin_recordable_test.cc)

--- a/exporters/zipkin/include/opentelemetry/exporters/zipkin/recordable.h
+++ b/exporters/zipkin/include/opentelemetry/exporters/zipkin/recordable.h
@@ -14,12 +14,6 @@ namespace zipkin
 {
 using ZipkinSpan = nlohmann::json;
 
-enum class TransportFormat
-{
-  kJson,
-  kProtobuf
-};
-
 class Recordable final : public sdk::trace::Recordable
 {
 public:

--- a/exporters/zipkin/include/opentelemetry/exporters/zipkin/zipkin_exporter.h
+++ b/exporters/zipkin/include/opentelemetry/exporters/zipkin/zipkin_exporter.h
@@ -3,7 +3,6 @@
 
 #pragma once
 
-#include "opentelemetry/exporters/zipkin/recordable.h"
 #include "opentelemetry/ext/http/client/http_client_factory.h"
 #include "opentelemetry/ext/http/common/url_parser.h"
 #include "opentelemetry/sdk/trace/exporter.h"
@@ -40,6 +39,12 @@ inline const std::string GetDefaultZipkinEndpoint()
 #endif
   return std::string{endpoint_from_env ? endpoint_from_env : kZipkinEndpointDefault};
 }
+
+enum class TransportFormat
+{
+  kJson,
+  kProtobuf
+};
 
 /**
  * Struct to hold Zipkin  exporter options.


### PR DESCRIPTION
## Changes

As discussed here ( https://github.com/open-telemetry/opentelemetry-cpp/discussions/922#discussioncomment-1045351 ), exporter specific recordable.h shouldn't be included in the exporter's install targets. This header shouldn't be used by application developers. So this PR excludes this header from the exporter's install rule.

For significant contributions please make sure you have completed the following items:

* [ ] `CHANGELOG.md` updated for non-trivial changes
* [ ] Unit tests have been added
* [ ] Changes in public API reviewed