### PR TITLE
Fix exporting of Jaeger exporter target name

### DIFF
--- a/exporters/jaeger/CMakeLists.txt
+++ b/exporters/jaeger/CMakeLists.txt
@@ -11,14 +11,14 @@ set(JAEGER_THRIFT_GENCPP_SOURCES
 
 set(JAEGER_EXPORTER_SOURCES
     src/jaeger_exporter.cc src/thrift_sender.cc src/udp_transport.cc
-    src/recordable.cc src/TUDPTransport.cc)
+    src/recordable.cc src/TUDPTransport.cc src/http_transport.cc src/THttpTransport.cc)
 
 add_library(opentelemetry_exporter_jaeger_trace ${JAEGER_EXPORTER_SOURCES}
                                                 ${JAEGER_THRIFT_GENCPP_SOURCES})
 
 set_target_properties(
   opentelemetry_exporter_jaeger_trace
-  PROPERTIES EXPORT_NAME opentelemetry_exporter_jaeger_trace)
+  PROPERTIES EXPORT_NAME jaeger_trace_exporter)
 
 target_include_directories(
   opentelemetry_exporter_jaeger_trace

--- a/exporters/jaeger/CMakeLists.txt
+++ b/exporters/jaeger/CMakeLists.txt
@@ -16,9 +16,8 @@ set(JAEGER_EXPORTER_SOURCES
 add_library(opentelemetry_exporter_jaeger_trace ${JAEGER_EXPORTER_SOURCES}
                                                 ${JAEGER_THRIFT_GENCPP_SOURCES})
 
-set_target_properties(
-  opentelemetry_exporter_jaeger_trace
-  PROPERTIES EXPORT_NAME jaeger_trace_exporter)
+set_target_properties(opentelemetry_exporter_jaeger_trace
+                      PROPERTIES EXPORT_NAME jaeger_trace_exporter)
 
 target_include_directories(
   opentelemetry_exporter_jaeger_trace

--- a/exporters/jaeger/CMakeLists.txt
+++ b/exporters/jaeger/CMakeLists.txt
@@ -11,7 +11,7 @@ set(JAEGER_THRIFT_GENCPP_SOURCES
 
 set(JAEGER_EXPORTER_SOURCES
     src/jaeger_exporter.cc src/thrift_sender.cc src/udp_transport.cc
-    src/recordable.cc src/TUDPTransport.cc src/http_transport.cc src/THttpTransport.cc)
+    src/recordable.cc src/TUDPTransport.cc)
 
 add_library(opentelemetry_exporter_jaeger_trace ${JAEGER_EXPORTER_SOURCES}
                                                 ${JAEGER_THRIFT_GENCPP_SOURCES})

--- a/opentelemetry-cpp-config.cmake.in
+++ b/opentelemetry-cpp-config.cmake.in
@@ -86,7 +86,7 @@ set(_OPENTELEMETRY_CPP_LIBRARIES_TEST_TARGETS
     prometheus_exporter
     elasticsearch_log_exporter
     etw_exporter
-    opentelemetry_exporter_jaeger_trace
+    jaeger_trace_exporter
     zpages
     http_client_curl)
 foreach(_TEST_TARGET IN LISTS _OPENTELEMETRY_CPP_LIBRARIES_TEST_TARGETS)

--- a/opentelemetry-cpp-config.cmake.in
+++ b/opentelemetry-cpp-config.cmake.in
@@ -86,7 +86,7 @@ set(_OPENTELEMETRY_CPP_LIBRARIES_TEST_TARGETS
     prometheus_exporter
     elasticsearch_log_exporter
     etw_exporter
-    jaeger_trace_exporter
+    opentelemetry_exporter_jaeger_trace
     zpages
     http_client_curl)
 foreach(_TEST_TARGET IN LISTS _OPENTELEMETRY_CPP_LIBRARIES_TEST_TARGETS)


### PR DESCRIPTION
I believe it was introduced in https://github.com/open-telemetry/opentelemetry-cpp/pull/918

When doing `make install` the generated `opentelemetry-cpp-config.cmake` was trying to find a non-existent target, thus the `OPENTELEMETRY_CPP_LIBRARIES` variable did not have Jaeger exporter set.