### PR TITLE
🐛 Fix for Stack::Resize that new_capacity is not assigned to capacity_

### DIFF
--- a/api/include/opentelemetry/context/runtime_context.h
+++ b/api/include/opentelemetry/context/runtime_context.h
@@ -294,7 +294,8 @@ private:
         }
         delete[] base_;
       }
-      base_ = temp;
+      base_     = temp;
+      capacity_ = new_capacity;
     }
 
     ~Stack() noexcept { delete[] base_; }


### PR DESCRIPTION
## Changes

Fix for Stack::Resize that new_capacity is not assigned to capacity_ , caused stack to constantly allocate memory when size_>0.


For significant contributions please make sure you have completed the following items:

* [ ] `CHANGELOG.md` updated for non-trivial changes
* [ ] Unit tests have been added
* [ ] Changes in public API reviewed