### PR TITLE
Fix warning of deprecation of putenv for MSVC

### DIFF
--- a/exporters/otlp/test/otlp_grpc_exporter_test.cc
+++ b/exporters/otlp/test/otlp_grpc_exporter_test.cc
@@ -32,7 +32,7 @@
 #  include <gtest/gtest.h>
 
 #  if defined(_MSC_VER)
-#define putenv _putenv
+#    define putenv _putenv
 #  endif
 
 using namespace testing;

--- a/exporters/otlp/test/otlp_grpc_exporter_test.cc
+++ b/exporters/otlp/test/otlp_grpc_exporter_test.cc
@@ -31,6 +31,10 @@
 
 #  include <gtest/gtest.h>
 
+#  if defined(_MSC_VER)
+#define putenv _putenv
+#  endif
+
 using namespace testing;
 
 OPENTELEMETRY_BEGIN_NAMESPACE


### PR DESCRIPTION
Fixes compilation warning C4996.

> ..\exporters\otlp\test\otlp_grpc_exporter_test.cc(139): warning C4996: 'putenv': The POSIX name for this item is deprecated. Instead, use the ISO C and C++ conformant name: _putenv. See online help for details.

## Changes

Replace `putenv` by ISO conformant name `_putenv`.

For significant contributions please make sure you have completed the following items:

* [ ] `CHANGELOG.md` updated for non-trivial changes
* [ ] Unit tests have been added
* [ ] Changes in public API reviewed