### PR TITLE
Fix casting to microseconds

### DIFF
--- a/api/include/opentelemetry/trace/tracer.h
+++ b/api/include/opentelemetry/trace/tracer.h
@@ -170,8 +170,8 @@ public:
   template <class Rep, class Period>
   void ForceFlush(std::chrono::duration<Rep, Period> timeout) noexcept
   {
-    this->ForceFlushWithMicroseconds(
-        static_cast<uint64_t>(std::chrono::duration_cast<std::chrono::microseconds>(timeout).count()));
+    this->ForceFlushWithMicroseconds(static_cast<uint64_t>(
+        std::chrono::duration_cast<std::chrono::microseconds>(timeout).count()));
   }
 
   virtual void ForceFlushWithMicroseconds(uint64_t timeout) noexcept = 0;
@@ -183,8 +183,8 @@ public:
   template <class Rep, class Period>
   void Close(std::chrono::duration<Rep, Period> timeout) noexcept
   {
-    this->CloseWithMicroseconds(
-        static_cast<uint64_t>(std::chrono::duration_cast<std::chrono::microseconds>(timeout).count()));
+    this->CloseWithMicroseconds(static_cast<uint64_t>(
+        std::chrono::duration_cast<std::chrono::microseconds>(timeout).count()));
   }
 
   virtual void CloseWithMicroseconds(uint64_t timeout) noexcept = 0;

--- a/api/include/opentelemetry/trace/tracer.h
+++ b/api/include/opentelemetry/trace/tracer.h
@@ -171,7 +171,7 @@ public:
   void ForceFlush(std::chrono::duration<Rep, Period> timeout) noexcept
   {
     this->ForceFlushWithMicroseconds(
-        static_cast<uint64_t>(std::chrono::duration_cast<std::chrono::microseconds>(timeout)));
+        static_cast<uint64_t>(std::chrono::duration_cast<std::chrono::microseconds>(timeout).count()));
   }
 
   virtual void ForceFlushWithMicroseconds(uint64_t timeout) noexcept = 0;
@@ -184,7 +184,7 @@ public:
   void Close(std::chrono::duration<Rep, Period> timeout) noexcept
   {
     this->CloseWithMicroseconds(
-        static_cast<uint64_t>(std::chrono::duration_cast<std::chrono::microseconds>(timeout)));
+        static_cast<uint64_t>(std::chrono::duration_cast<std::chrono::microseconds>(timeout).count()));
   }
 
   virtual void CloseWithMicroseconds(uint64_t timeout) noexcept = 0;


### PR DESCRIPTION
## Changes
std::chrono::duration can be converted to integral value via count() function