### PR TITLE
Update default OTLP http port

### DIFF
--- a/exporters/otlp/README.md
+++ b/exporters/otlp/README.md
@@ -44,9 +44,10 @@ auto exporter = std::unique_ptr<sdktrace::SpanExporter>(new otlp::OtlpHttpExport
 
 ### Configuration options
 
-| Option       | Default          |
-| ------------ |----------------- |
-| `endpoint`   | `localhost:4317` |
+| Option                               | Default          |
+| ------------------------------------ |----------------- |
+| `OtlpGrpcExporterOptions.endpoint`   | `localhost:4317` |
+| `OtlpHttpExporterOptions.endpoint`   | `localhost:4318` |
 
 ## Example
 

--- a/exporters/otlp/include/opentelemetry/exporters/otlp/otlp_http_exporter.h
+++ b/exporters/otlp/include/opentelemetry/exporters/otlp/otlp_http_exporter.h
@@ -50,7 +50,7 @@ struct OtlpHttpExporterOptions
   // @see
   // https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/protocol/otlp.md
   // @see https://github.com/open-telemetry/opentelemetry-collector/tree/main/receiver/otlpreceiver
-  std::string url = std::string("http://localhost:4317") + kDefaultTracePath;
+  std::string url = std::string("http://localhost:4318") + kDefaultTracePath;
 
   // By default, post json data
   HttpRequestContentType content_type = HttpRequestContentType::kJson;


### PR DESCRIPTION
## Changes

The default OTLP over HTTP port was changed from `4317` to `4318`. Update our exporter to comply with the spec.

https://github.com/open-telemetry/opentelemetry-specification/pull/1839

For significant contributions please make sure you have completed the following items:

* [ ] `CHANGELOG.md` updated for non-trivial changes
* [ ] Unit tests have been added
* [ ] Changes in public API reviewed