### PR TITLE
extend zipkin exporter with ability to provide headers

### DIFF
--- a/exporters/zipkin/include/opentelemetry/exporters/zipkin/zipkin_exporter.h
+++ b/exporters/zipkin/include/opentelemetry/exporters/zipkin/zipkin_exporter.h
@@ -44,6 +44,7 @@ struct ZipkinExporterOptions
   std::string service_name = "default-service";
   std::string ipv4;
   std::string ipv6;
+  ext::http::client::Headers headers = {{"content-type", "application/json"}};
 };
 
 namespace trace_sdk   = opentelemetry::sdk::trace;

--- a/exporters/zipkin/src/zipkin_exporter.cc
+++ b/exporters/zipkin/src/zipkin_exporter.cc
@@ -62,7 +62,7 @@ sdk::common::ExportResult ZipkinExporter::Export(
   }
   auto body_s = json_spans.dump();
   http_client::Body body_v(body_s.begin(), body_s.end());
-  auto result = http_client_->Post(url_parser_.url_, body_v);
+  auto result = http_client_->Post(url_parser_.url_, body_v, options_.headers);
   if (result &&
       (result.GetResponse().GetStatusCode() == 200 || result.GetResponse().GetStatusCode() == 202))
   {


### PR DESCRIPTION
## Changes
add possibility to provide custom http headers via Zipkin options. 
http headers are useful for custom authentication mechanism into collector

