### PR TITLE
Enable CMake to search the new package variable <PackageName>_ROOT

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,6 +4,12 @@ cmake_minimum_required(VERSION 3.1)
 # versions of gtest
 cmake_policy(SET CMP0057 NEW)
 
+# See https://cmake.org/cmake/help/v3.12/policy/CMP0074.html required by certain
+# version of zlib which is dependeded by cURL.
+if(${CMAKE_VERSION} VERSION_GREATER_EQUAL "3.12")
+    cmake_policy(SET CMP0074 NEW)
+endif()
+
 project(opentelemetry-cpp)
 
 # Mark variables as used so cmake doesn't complain about them

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,7 +7,7 @@ cmake_policy(SET CMP0057 NEW)
 # See https://cmake.org/cmake/help/v3.12/policy/CMP0074.html required by certain
 # version of zlib which is dependeded by cURL.
 if(${CMAKE_VERSION} VERSION_GREATER_EQUAL "3.12")
-    cmake_policy(SET CMP0074 NEW)
+  cmake_policy(SET CMP0074 NEW)
 endif()
 
 project(opentelemetry-cpp)


### PR DESCRIPTION
We have dependency on cURL which dpendes on zlib. The latest vcpkg port of zlib introduced `ZLIB_ROOT` in [this PR](https://github.com/microsoft/vcpkg/pull/18914). The default policy of CMake 3.12 and above is warning on the user of this variable and ignore it. This PR asks CMake to follow the new behavior and honor `ZLIB_ROOT` accordingly.

For significant contributions please make sure you have completed the following items:

* [ ] `CHANGELOG.md` updated for non-trivial changes
* [ ] Unit tests have been added
* [ ] Changes in public API reviewed