### PR TITLE
Support environment variables for both `OtlpGrpcExporter` and `OtlpHttpExporter`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ Increment the:
 
 ## [Unreleased]
 
+* Support environment variables for both `OtlpGrpcExporter` and `OtlpHttpExporter` ([#983](https://github.com/open-telemetry/opentelemetry-cpp/pull/983))
+
 ## [1.0.0] 2021-09-16
 
 ### API

--- a/exporters/otlp/BUILD
+++ b/exporters/otlp/BUILD
@@ -40,6 +40,7 @@ cc_library(
         "src/otlp_grpc_exporter.cc",
     ],
     hdrs = [
+        "include/opentelemetry/exporters/otlp/otlp_environment.h",
         "include/opentelemetry/exporters/otlp/otlp_grpc_exporter.h",
         "include/opentelemetry/exporters/otlp/protobuf_include_prefix.h",
         "include/opentelemetry/exporters/otlp/protobuf_include_suffix.h",
@@ -61,6 +62,7 @@ cc_library(
         "src/otlp_http_exporter.cc",
     ],
     hdrs = [
+        "include/opentelemetry/exporters/otlp/otlp_environment.h",
         "include/opentelemetry/exporters/otlp/otlp_http_exporter.h",
         "include/opentelemetry/exporters/otlp/protobuf_include_prefix.h",
         "include/opentelemetry/exporters/otlp/protobuf_include_suffix.h",

--- a/exporters/otlp/README.md
+++ b/exporters/otlp/README.md
@@ -54,16 +54,24 @@ auto exporter = std::unique_ptr<sdktrace::SpanExporter>(new otlp::OtlpHttpExport
 |    | `OTEL_EXPORTER_OTLP_TRACES_CERTIFICATE` | | |
 | `ssl_credentials_cacert_as_string` | `OTEL_EXPORTER_OTLP_CERTIFICATE_STRING` | `""`  |   SSL Certifcate as in-memory string |
 |  | `OTEL_EXPORTER_OTLP_TRACES_CERTIFICATE_STRING` | | | |
+| `timeout`    | `OTEL_EXPORTER_OTLP_TIMEOUT` | `10s` | GRPC deadline |
+|              |   `OTEL_EXPORTER_OTLP_TRACES_TIMEOUT`  |  | |
+| `metadata`   | `OTEL_EXPORTER_OTLP_HEADERS` |  | Custom metadata for GRPC |
+|              |   `OTEL_EXPORTER_OTLP_TRACES_HEADERS`  |  | |
 
 ### Configuration options ( OTLP HTTP Exporter )
 
 | Option       | Env Variable |Default          | Description |
 | ------------ |-----|------------ |------|
-| `url`   | n/a    | `http://localhost:4317/v1/traces`  | The OTLP HTTP endpoint to connect to |
+| `url`   | `OTEL_EXPORTER_OTLP_ENDPOINT` | `http://localhost:4317/v1/traces`  | The OTLP HTTP endpoint to connect to |
+|              |   `OTEL_EXPORTER_OTLP_TRACES_ENDPOINT`  |  | |
 | `content_type` | n/a  | `application/json`  |   Data format used - JSON or Binary |
 | `json_bytes_mapping`  |  n/a | `JsonBytesMappingKind::kHexId` | Encoding used for trace_id and span_id |
 | `use_json_name` | n/a | `false`  | Whether to use json name of protobuf field to set the key of json |
-| `timeout`  | n/a  | `30000 ms` | http timeout |
+| `timeout`    | `OTEL_EXPORTER_OTLP_TIMEOUT` | `10s` | http timeout |
+|              |   `OTEL_EXPORTER_OTLP_TRACES_TIMEOUT`  |  |
+| `http_headers` | `OTEL_EXPORTER_OTLP_HEADERS` |  | http headers |
+|              |   `OTEL_EXPORTER_OTLP_TRACES_HEADERS`  |  | |
 
 ## Example
 

--- a/exporters/otlp/include/opentelemetry/exporters/otlp/otlp_environment.h
+++ b/exporters/otlp/include/opentelemetry/exporters/otlp/otlp_environment.h
@@ -1,0 +1,203 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <algorithm>
+#include <chrono>
+#include <map>
+#include <string>
+
+#include "opentelemetry/nostd/string_view.h"
+
+#include "opentelemetry/sdk/common/attribute_utils.h"
+#include "opentelemetry/sdk/common/env_variables.h"
+
+OPENTELEMETRY_BEGIN_NAMESPACE
+namespace exporter
+{
+namespace otlp
+{
+
+inline const std::string GetOtlpDefaultGrpcEndpoint()
+{
+  constexpr char kOtlpTracesEndpointEnv[] = "OTEL_EXPORTER_OTLP_TRACES_ENDPOINT";
+  constexpr char kOtlpEndpointEnv[]       = "OTEL_EXPORTER_OTLP_ENDPOINT";
+  constexpr char kOtlpEndpointDefault[]   = "http://localhost:4317";
+
+  auto endpoint = opentelemetry::sdk::common::GetEnvironmentVariable(kOtlpTracesEndpointEnv);
+  if (endpoint.empty())
+  {
+    endpoint = opentelemetry::sdk::common::GetEnvironmentVariable(kOtlpEndpointEnv);
+  }
+  return endpoint.size() ? endpoint : kOtlpEndpointDefault;
+}
+
+inline const std::string GetOtlpDefaultHttpEndpoint()
+{
+  constexpr char kOtlpTracesEndpointEnv[] = "OTEL_EXPORTER_OTLP_TRACES_ENDPOINT";
+  constexpr char kOtlpEndpointEnv[]       = "OTEL_EXPORTER_OTLP_ENDPOINT";
+  constexpr char kOtlpEndpointDefault[]   = "http://localhost:4317/v1/traces";
+
+  auto endpoint = opentelemetry::sdk::common::GetEnvironmentVariable(kOtlpTracesEndpointEnv);
+  if (endpoint.empty())
+  {
+    endpoint = opentelemetry::sdk::common::GetEnvironmentVariable(kOtlpEndpointEnv);
+  }
+  return endpoint.size() ? endpoint : kOtlpEndpointDefault;
+}
+
+inline const bool GetOtlpDefaultIsSslEnable()
+{
+  constexpr char kOtlpTracesIsSslEnableEnv[] = "OTEL_EXPORTER_OTLP_TRACES_SSL_ENABLE";
+  constexpr char kOtlpIsSslEnableEnv[]       = "OTEL_EXPORTER_OTLP_SSL_ENABLE";
+
+  auto ssl_enable = opentelemetry::sdk::common::GetEnvironmentVariable(kOtlpTracesIsSslEnableEnv);
+  if (ssl_enable.empty())
+  {
+    ssl_enable = opentelemetry::sdk::common::GetEnvironmentVariable(kOtlpIsSslEnableEnv);
+  }
+  if (ssl_enable == "True" || ssl_enable == "TRUE" || ssl_enable == "true" || ssl_enable == "1")
+  {
+    return true;
+  }
+  return false;
+}
+
+inline const std::string GetOtlpDefaultSslCertificatePath()
+{
+  constexpr char kOtlpTracesSslCertificate[] = "OTEL_EXPORTER_OTLP_TRACES_CERTIFICATE";
+  constexpr char kOtlpSslCertificate[]       = "OTEL_EXPORTER_OTLP_CERTIFICATE ";
+  auto ssl_cert_path =
+      opentelemetry::sdk::common::GetEnvironmentVariable(kOtlpTracesSslCertificate);
+  if (ssl_cert_path.empty())
+  {
+    ssl_cert_path = opentelemetry::sdk::common::GetEnvironmentVariable(kOtlpSslCertificate);
+  }
+  return ssl_cert_path.size() ? ssl_cert_path : "";
+}
+
+inline const std::string GetOtlpDefaultSslCertificateString()
+{
+  constexpr char kOtlpTracesSslCertificateString[] = "OTEL_EXPORTER_OTLP_CERTIFICATE_STRING";
+  constexpr char kOtlpSslCertificateString[] = "OTEL_EXPORTER_OTLP_TRACES_CERTIFICATE_STRING ";
+  auto ssl_cert =
+      opentelemetry::sdk::common::GetEnvironmentVariable(kOtlpTracesSslCertificateString);
+  if (ssl_cert.empty())
+  {
+    ssl_cert = opentelemetry::sdk::common::GetEnvironmentVariable(kOtlpSslCertificateString);
+  }
+  return ssl_cert.size() ? ssl_cert : "";
+}
+
+inline const std::chrono::system_clock::duration GetOtlpTimeoutFromString(const char *input)
+{
+  if (nullptr == input || 0 == *input)
+  {
+    return std::chrono::duration_cast<std::chrono::system_clock::duration>(
+        std::chrono::seconds{10});
+  }
+
+  std::chrono::system_clock::duration::rep result = 0;
+  // Skip spaces
+  for (; *input && (' ' == *input || '\t' == *input || '\r' == *input || '\n' == *input); ++input)
+    ;
+
+  for (; *input && (*input >= '0' && *input <= '9'); ++input)
+  {
+    result = result * 10 + (*input - '0');
+  }
+
+  opentelemetry::nostd::string_view unit{input};
+  if ("ns" == unit)
+  {
+    return std::chrono::duration_cast<std::chrono::system_clock::duration>(
+        std::chrono::nanoseconds{result});
+  }
+  else if ("us" == unit)
+  {
+    return std::chrono::duration_cast<std::chrono::system_clock::duration>(
+        std::chrono::microseconds{result});
+  }
+  else if ("ms" == unit)
+  {
+    return std::chrono::duration_cast<std::chrono::system_clock::duration>(
+        std::chrono::milliseconds{result});
+  }
+  else if ("m" == unit)
+  {
+    return std::chrono::duration_cast<std::chrono::system_clock::duration>(
+        std::chrono::minutes{result});
+  }
+  else if ("h" == unit)
+  {
+    return std::chrono::duration_cast<std::chrono::system_clock::duration>(
+        std::chrono::hours{result});
+  }
+  else
+  {
+    return std::chrono::duration_cast<std::chrono::system_clock::duration>(
+        std::chrono::seconds{result});
+  }
+}
+
+inline const std::chrono::system_clock::duration GetOtlpDefaultTimeout()
+{
+  constexpr char kOtlpTracesTimeoutEnv[] = "OTEL_EXPORTER_OTLP_TRACES_TIMEOUT";
+  constexpr char kOtlpTimeoutEnv[]       = "OTEL_EXPORTER_OTLP_TIMEOUT";
+
+  auto timeout = opentelemetry::sdk::common::GetEnvironmentVariable(kOtlpTracesTimeoutEnv);
+  if (timeout.empty())
+  {
+    timeout = opentelemetry::sdk::common::GetEnvironmentVariable(kOtlpTimeoutEnv);
+  }
+  return GetOtlpTimeoutFromString(timeout.c_str());
+}
+
+struct cmp_ic
+{
+  bool operator()(const std::string &s1, const std::string &s2) const
+  {
+    return std::lexicographical_compare(
+        s1.begin(), s1.end(), s2.begin(), s2.end(),
+        [](char c1, char c2) { return ::tolower(c1) < ::tolower(c2); });
+  }
+};
+using OtlpHeaders = std::multimap<std::string, std::string, cmp_ic>;
+
+inline void DumpOtlpHeaders(OtlpHeaders &output, const char *env_var_name)
+{
+  auto value = opentelemetry::sdk::common::GetEnvironmentVariable(env_var_name);
+  if (value.empty())
+  {
+    return;
+  }
+
+  opentelemetry::common::KeyValueStringTokenizer tokenizer{value};
+  opentelemetry::nostd::string_view header_key;
+  opentelemetry::nostd::string_view header_value;
+  bool header_valid = true;
+
+  while (tokenizer.next(header_valid, header_key, header_value))
+  {
+    if (header_valid)
+    {
+      output.emplace(std::make_pair((std::string)header_key, (std::string)header_value));
+    }
+  }
+}
+
+inline OtlpHeaders GetOtlpDefaultHeaders()
+{
+  constexpr char kOtlpTracesHeadersEnv[] = "OTEL_EXPORTER_OTLP_TRACES_HEADERS";
+  constexpr char kOtlpHeadersEnv[]       = "OTEL_EXPORTER_OTLP_HEADERS";
+
+  OtlpHeaders result;
+  DumpOtlpHeaders(result, kOtlpHeadersEnv);
+  DumpOtlpHeaders(result, kOtlpTracesHeadersEnv);
+  return result;
+}
+
+}  // namespace otlp
+}  // namespace exporter
+OPENTELEMETRY_END_NAMESPACE

--- a/exporters/otlp/include/opentelemetry/exporters/otlp/otlp_http_exporter.h
+++ b/exporters/otlp/include/opentelemetry/exporters/otlp/otlp_http_exporter.h
@@ -3,23 +3,23 @@
 
 #pragma once
 
+#include <chrono>
+#include <memory>
+#include <mutex>
+#include <string>
+
 // We need include exporter.h first, which will include Windows.h with NOMINMAX on Windows
 #include "opentelemetry/sdk/trace/exporter.h"
 
 #include "opentelemetry/ext/http/client/http_client.h"
 
-#include <chrono>
-#include <memory>
-#include <mutex>
-#include <string>
+#include "opentelemetry/exporters/otlp/otlp_environment.h"
 
 OPENTELEMETRY_BEGIN_NAMESPACE
 namespace exporter
 {
 namespace otlp
 {
-// The default URL path to post trace data.
-constexpr char kDefaultTracePath[] = "/v1/traces";
 // The default URL path to post metric data.
 constexpr char kDefaultMetricsPath[] = "/v1/metrics";
 // The default URL path to post metric data.
@@ -50,7 +50,7 @@ struct OtlpHttpExporterOptions
   // @see
   // https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/protocol/otlp.md
   // @see https://github.com/open-telemetry/opentelemetry-collector/tree/main/receiver/otlpreceiver
-  std::string url = std::string("http://localhost:4317") + kDefaultTracePath;
+  std::string url = GetOtlpDefaultHttpEndpoint();
 
   // By default, post json data
   HttpRequestContentType content_type = HttpRequestContentType::kJson;
@@ -67,7 +67,10 @@ struct OtlpHttpExporterOptions
   bool console_debug = false;
 
   // TODO: Enable/disable to verify SSL certificate
-  std::chrono::milliseconds timeout = std::chrono::milliseconds(30000);
+  std::chrono::system_clock::duration timeout = GetOtlpDefaultTimeout();
+
+  // Additional HTTP headers
+  OtlpHeaders http_headers = GetOtlpDefaultHeaders();
 };
 
 /**

--- a/exporters/otlp/src/otlp_grpc_exporter.cc
+++ b/exporters/otlp/src/otlp_grpc_exporter.cc
@@ -110,6 +110,16 @@ sdk::common::ExportResult OtlpGrpcExporter::Export(
   grpc::ClientContext context;
   proto::collector::trace::v1::ExportTraceServiceResponse response;
 
+  if (options_.timeout.count() > 0)
+  {
+    context.set_deadline(std::chrono::system_clock::now() + options_.timeout);
+  }
+
+  for (auto &header : options_.metadata)
+  {
+    context.AddMetadata(header.first, header.second);
+  }
+
   grpc::Status status = trace_service_stub_->Export(&context, request, &response);
 
   if (!status.ok())

--- a/exporters/otlp/test/otlp_grpc_exporter_test.cc
+++ b/exporters/otlp/test/otlp_grpc_exporter_test.cc
@@ -147,8 +147,8 @@ TEST_F(OtlpGrpcExporterTestPeer, ConfigFromEnv)
   const std::string endpoint_env = "OTEL_EXPORTER_OTLP_ENDPOINT=" + endpoint;
   putenv(const_cast<char *>(endpoint_env.data()));
   putenv("OTEL_EXPORTER_OTLP_TIMEOUT=20050ms");
-  putenv("OTEL_EXPORTER_OTLP_HEADERS=custom-header-a=a1,custom-header-b=b");
-  putenv("OTEL_EXPORTER_OTLP_TRACES_HEADERS=custom-header-a=a2");
+  putenv("OTEL_EXPORTER_OTLP_HEADERS=k1=v1,k2=v2");
+  putenv("OTEL_EXPORTER_OTLP_TRACES_HEADERS=k1=v3,k1=v4");
 
   std::unique_ptr<OtlpGrpcExporter> exporter(new OtlpGrpcExporter());
   EXPECT_EQ(GetOptions(exporter).ssl_credentials_cacert_as_string, cacert_str);
@@ -160,20 +160,20 @@ TEST_F(OtlpGrpcExporterTestPeer, ConfigFromEnv)
                 .count());
   EXPECT_EQ(GetOptions(exporter).metadata.size(), 3);
   {
-    // Test custom-header-b
-    auto range = GetOptions(exporter).metadata.equal_range("custom-header-b");
+    // Test k2
+    auto range = GetOptions(exporter).metadata.equal_range("k2");
     EXPECT_TRUE(range.first != range.second);
-    EXPECT_EQ(range.first->second, std::string("b"));
+    EXPECT_EQ(range.first->second, std::string("v2"));
     ++range.first;
     EXPECT_TRUE(range.first == range.second);
   }
   {
-    // Test custom-header-a
-    auto range = GetOptions(exporter).metadata.equal_range("custom-header-a");
+    // Test k1
+    auto range = GetOptions(exporter).metadata.equal_range("k1");
     EXPECT_TRUE(range.first != range.second);
-    EXPECT_EQ(range.first->second, std::string("a1"));
+    EXPECT_EQ(range.first->second, std::string("v3"));
     ++range.first;
-    EXPECT_EQ(range.first->second, std::string("a2"));
+    EXPECT_EQ(range.first->second, std::string("v4"));
     ++range.first;
     EXPECT_TRUE(range.first == range.second);
   }

--- a/exporters/otlp/test/otlp_http_exporter_test.cc
+++ b/exporters/otlp/test/otlp_http_exporter_test.cc
@@ -335,8 +335,8 @@ TEST_F(OtlpHttpExporterTestPeer, ConfigFromEnv)
   const std::string url_env = "OTEL_EXPORTER_OTLP_ENDPOINT=" + url;
   putenv(const_cast<char *>(url_env.data()));
   putenv("OTEL_EXPORTER_OTLP_TIMEOUT=20s");
-  putenv("OTEL_EXPORTER_OTLP_HEADERS=custom-header-a=a1,custom-header-b=b");
-  putenv("OTEL_EXPORTER_OTLP_TRACES_HEADERS=custom-header-a=a2");
+  putenv("OTEL_EXPORTER_OTLP_HEADERS=k1=v1,k2=v2");
+  putenv("OTEL_EXPORTER_OTLP_TRACES_HEADERS=k1=v3,k1=v4");
 
   std::unique_ptr<OtlpHttpExporter> exporter(new OtlpHttpExporter());
   EXPECT_EQ(GetOptions(exporter).url, url);
@@ -346,20 +346,20 @@ TEST_F(OtlpHttpExporterTestPeer, ConfigFromEnv)
           .count());
   EXPECT_EQ(GetOptions(exporter).http_headers.size(), 3);
   {
-    // Test custom-header-b
-    auto range = GetOptions(exporter).http_headers.equal_range("custom-header-b");
+    // Test k2
+    auto range = GetOptions(exporter).http_headers.equal_range("k2");
     EXPECT_TRUE(range.first != range.second);
-    EXPECT_EQ(range.first->second, std::string("b"));
+    EXPECT_EQ(range.first->second, std::string("v2"));
     ++range.first;
     EXPECT_TRUE(range.first == range.second);
   }
   {
-    // Test custom-header-a
-    auto range = GetOptions(exporter).http_headers.equal_range("custom-header-a");
+    // k1
+    auto range = GetOptions(exporter).http_headers.equal_range("k1");
     EXPECT_TRUE(range.first != range.second);
-    EXPECT_EQ(range.first->second, std::string("a1"));
+    EXPECT_EQ(range.first->second, std::string("v3"));
     ++range.first;
-    EXPECT_EQ(range.first->second, std::string("a2"));
+    EXPECT_EQ(range.first->second, std::string("v4"));
     ++range.first;
     EXPECT_TRUE(range.first == range.second);
   }

--- a/exporters/otlp/test/otlp_http_exporter_test.cc
+++ b/exporters/otlp/test/otlp_http_exporter_test.cc
@@ -59,10 +59,10 @@ public:
     int port = server_.addListeningPort(14371);
     std::ostringstream os;
     os << "localhost:" << port;
-    server_address_ = "http://" + os.str() + kDefaultTracePath;
+    server_address_ = "http://" + os.str() + "/v1/traces";
     server_.setServerName(os.str());
     server_.setKeepalive(false);
-    server_.addHandler(kDefaultTracePath, *this);
+    server_.addHandler("/v1/traces", *this);
     server_.start();
     is_running_ = true;
   }
@@ -89,7 +89,7 @@ public:
 
     int response_status = 0;
 
-    if (request.uri == kDefaultTracePath)
+    if (request.uri == "/v1/traces")
     {
       response.headers["Content-Type"] = "application/json";
       std::unique_lock<std::mutex> lk(mtx_requests);
@@ -326,6 +326,58 @@ TEST_F(OtlpHttpExporterTestPeer, ConfigJsonBytesMappingTest)
   std::unique_ptr<OtlpHttpExporter> exporter(new OtlpHttpExporter(opts));
   EXPECT_EQ(GetOptions(exporter).json_bytes_mapping, JsonBytesMappingKind::kHex);
 }
+
+#  ifndef NO_GETENV
+// Test exporter configuration options with use_ssl_credentials
+TEST_F(OtlpHttpExporterTestPeer, ConfigFromEnv)
+{
+  const std::string url     = "http://localhost:9999/v1/traces";
+  const std::string url_env = "OTEL_EXPORTER_OTLP_ENDPOINT=" + url;
+  putenv(const_cast<char *>(url_env.data()));
+  putenv("OTEL_EXPORTER_OTLP_TIMEOUT=20s");
+  putenv("OTEL_EXPORTER_OTLP_HEADERS=custom-header-a=a1,custom-header-b=b");
+  putenv("OTEL_EXPORTER_OTLP_TRACES_HEADERS=custom-header-a=a2");
+
+  std::unique_ptr<OtlpHttpExporter> exporter(new OtlpHttpExporter());
+  EXPECT_EQ(GetOptions(exporter).url, url);
+  EXPECT_EQ(
+      GetOptions(exporter).timeout.count(),
+      std::chrono::duration_cast<std::chrono::system_clock::duration>(std::chrono::seconds{20})
+          .count());
+  EXPECT_EQ(GetOptions(exporter).http_headers.size(), 3);
+  {
+    // Test custom-header-b
+    auto range = GetOptions(exporter).http_headers.equal_range("custom-header-b");
+    EXPECT_TRUE(range.first != range.second);
+    EXPECT_EQ(range.first->second, std::string("b"));
+    ++range.first;
+    EXPECT_TRUE(range.first == range.second);
+  }
+  {
+    // Test custom-header-a
+    auto range = GetOptions(exporter).http_headers.equal_range("custom-header-a");
+    EXPECT_TRUE(range.first != range.second);
+    EXPECT_EQ(range.first->second, std::string("a1"));
+    ++range.first;
+    EXPECT_EQ(range.first->second, std::string("a2"));
+    ++range.first;
+    EXPECT_TRUE(range.first == range.second);
+  }
+#    if defined(_MSC_VER)
+  putenv("OTEL_EXPORTER_OTLP_ENDPOINT=");
+  putenv("OTEL_EXPORTER_OTLP_TIMEOUT=");
+  putenv("OTEL_EXPORTER_OTLP_HEADERS=");
+  putenv("OTEL_EXPORTER_OTLP_TRACES_HEADERS=");
+
+#    else
+  unsetenv("OTEL_EXPORTER_OTLP_ENDPOINT");
+  unsetenv("OTEL_EXPORTER_OTLP_TIMEOUT");
+  unsetenv("OTEL_EXPORTER_OTLP_HEADERS");
+  unsetenv("OTEL_EXPORTER_OTLP_TRACES_HEADERS");
+
+#    endif
+}
+#  endif
 
 }  // namespace otlp
 }  // namespace exporter


### PR DESCRIPTION
Fixes #978 
Fixes #909 

## Changes

1. Add `otlp_environment.h` to maintain shared codes of `OtlpGrpcExporter` and `OtlpHttpExporter`
2. Add `timeout` and `metadata` options for `OtlpGrpcExporter`
3. Use environment variables `OTEL_EXPORTER_OTLP_TIMEOUT` , `OTEL_EXPORTER_OTLP_TRACES_TIMEOUT` , `OTEL_EXPORTER_OTLP_HEADERS` , `OTEL_EXPORTER_OTLP_TRACES_HEADERS` to initialize default options of `OtlpGrpcExporter` and `OtlpHttpExporter`
4. Use environment variables `OTEL_EXPORTER_OTLP_ENDPOINT` , `OTEL_EXPORTER_OTLP_TRACES_ENDPOINT` to initialize default options of `OtlpHttpExporter`

For significant contributions please make sure you have completed the following items:

* [x] `CHANGELOG.md` updated for non-trivial changes
* [x] Unit tests have been added
* [ ] Changes in public API reviewed