### PR TITLE
Update opentelemetry-proto for bazel build to 0.9.0

### DIFF
--- a/bazel/repository.bzl
+++ b/bazel/repository.bzl
@@ -55,9 +55,9 @@ def opentelemetry_cpp_deps():
         name = "com_github_opentelemetry_proto",
         build_file = "@io_opentelemetry_cpp//bazel:opentelemetry_proto.BUILD",
         sha256 = "08f090570e0a112bfae276ba37e9c45bf724b64d902a7a001db33123b840ebd6",
-        strip_prefix = "opentelemetry-proto-0.6.0",
+        strip_prefix = "opentelemetry-proto-0.9.0",
         urls = [
-            "https://github.com/open-telemetry/opentelemetry-proto/archive/v0.6.0.tar.gz",
+            "https://github.com/open-telemetry/opentelemetry-proto/archive/v0.9.0.tar.gz",
         ],
     )
 

--- a/bazel/repository.bzl
+++ b/bazel/repository.bzl
@@ -54,7 +54,7 @@ def opentelemetry_cpp_deps():
         http_archive,
         name = "com_github_opentelemetry_proto",
         build_file = "@io_opentelemetry_cpp//bazel:opentelemetry_proto.BUILD",
-        sha256 = "08f090570e0a112bfae276ba37e9c45bf724b64d902a7a001db33123b840ebd6",
+        sha256 = "9ec38ab51eedbd7601979b0eda962cf37bc8a4dc35fcef604801e463f01dcc00",
         strip_prefix = "opentelemetry-proto-0.9.0",
         urls = [
             "https://github.com/open-telemetry/opentelemetry-proto/archive/v0.9.0.tar.gz",


### PR DESCRIPTION
## Changes

Our OpenTelemetry-proto submodule was updated to 0.9.0 in https://github.com/open-telemetry/opentelemetry-cpp/pull/825, update bazel build script to consume the same version of OpenTelemetry-proto for consistency.

For significant contributions please make sure you have completed the following items:

* [ ] `CHANGELOG.md` updated for non-trivial changes
* [ ] Unit tests have been added
* [ ] Changes in public API reviewed