### PR TITLE
Idar oss/build error memcpy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ Increment the:
 ## [Unreleased]
 
 * Support environment variables for both `OtlpGrpcExporter` and `OtlpHttpExporter` ([#983](https://github.com/open-telemetry/opentelemetry-cpp/pull/983))
+* Fix build issue where _memcpy_ was not declared in scope ([#985](https://github.com/open-telemetry/opentelemetry-cpp/issues/985))
 
 ## [1.0.0] 2021-09-16
 

--- a/api/include/opentelemetry/common/kv_properties.h
+++ b/api/include/opentelemetry/common/kv_properties.h
@@ -11,6 +11,7 @@
 #include "opentelemetry/nostd/unique_ptr.h"
 #include "opentelemetry/version.h"
 
+#include <cstring>
 #include <string>
 #include <type_traits>
 


### PR DESCRIPTION
Fixes #985 

## Changes

Add include statement of _cstring_ to opentelemetry-cpp/api/include/opentelemetry/common/kv_properties.h which caused build error for missing _memcpy_ in scope.

For significant contributions please make sure you have completed the following items:

* [x] `CHANGELOG.md` updated for non-trivial changes
* [ ] Unit tests have been added
* [ ] Changes in public API reviewed