### PR TITLE
Fix deprecated usage of putenv for MSVC

### DIFF
--- a/exporters/otlp/test/otlp_http_exporter_test.cc
+++ b/exporters/otlp/test/otlp_http_exporter_test.cc
@@ -20,6 +20,10 @@
 
 #  include "nlohmann/json.hpp"
 
+#  if defined(_MSC_VER)
+#    define putenv _putenv
+#  endif
+
 using namespace testing;
 
 OPENTELEMETRY_BEGIN_NAMESPACE


### PR DESCRIPTION
## Changes

`putenv` is deprecated in MSVC, replace it by `_putenv`.

For significant contributions please make sure you have completed the following items:

* [ ] `CHANGELOG.md` updated for non-trivial changes
* [ ] Unit tests have been added
* [ ] Changes in public API reviewed