### PR TITLE
fix: issue 368- consistent namespace scope resolution

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,8 +56,10 @@ of the current project.
 | macOS 10.15 (Xcode 12.2)                                            | Bazel         |
 | Windows Server 2019 (Visual Studio Enterprise 2019)                 | CMake, Bazel  |
 
-[1]: Bazel build is disabled for GCC 4.8, as gRPC library (required by OTLP expoter)
-  doesn't build with this compiler. CMake build won't build OTLP exporter with GCC 4.8.
+[1]: Bazel build is disabled for GCC 4.8, as gRPC library 1.38 and above
+  (required by OTLP expoter) don't build with this compiler. See gRPC [official
+  support](https://grpc.io/docs/#official-support) document. CMake build doesn't
+  build OTLP exporter with GCC 4.8.
 
 In general, the code shipped from this repository should build on all platforms
 having C++ compiler with [supported C++ standards](#supported-c-versions).

--- a/api/test/baggage/propagation/baggage_propagator_test.cc
+++ b/api/test/baggage/propagation/baggage_propagator_test.cc
@@ -48,7 +48,7 @@ TEST(BaggagePropagatorTest, ExtractAndInjectBaggage)
 {
   // create header string for baggage larger than allowed size (kMaxKeyValueSize)
   std::string very_large_baggage_header =
-      std::string(baggage::Baggage::kMaxKeyValueSize / 2 + 1, 'k') + "="
+      std::string(baggage::Baggage::kMaxKeyValueSize / 2 + 1, 'k') + "=" +
       std::string(baggage::Baggage::kMaxKeyValueSize / 2 + 1, 'v');
 
   std::map<std::string, std::string> baggages = {

--- a/api/test/baggage/propagation/baggage_propagator_test.cc
+++ b/api/test/baggage/propagation/baggage_propagator_test.cc
@@ -48,7 +48,7 @@ TEST(BaggagePropagatorTest, ExtractAndInjectBaggage)
 {
   // create header string for baggage larger than allowed size (kMaxKeyValueSize)
   std::string very_large_baggage_header =
-      std::string(baggage::Baggage::kMaxKeyValueSize / 2 + 1, 'k') + "=" +
+      std::string(baggage::Baggage::kMaxKeyValueSize / 2 + 1, 'k') + "="
       std::string(baggage::Baggage::kMaxKeyValueSize / 2 + 1, 'v');
 
   std::map<std::string, std::string> baggages = {

--- a/api/test/common/kv_properties_test.cc
+++ b/api/test/common/kv_properties_test.cc
@@ -13,11 +13,12 @@
 
 using namespace opentelemetry;
 using opentelemetry::common::KeyValueProperties;
+namespace nostd = opentelemetry::nostd;
 // Test constructor that takes a key-value pair
 TEST(EntryTest, KeyValueConstruction)
 {
-  opentelemetry::nostd::string_view key = "test_key";
-  opentelemetry::nostd::string_view val = "test_value";
+  nostd::string_view key = "test_key";
+  nostd::string_view val = "test_value";
   KeyValueProperties::Entry e(key, val);
 
   EXPECT_EQ(key.size(), e.GetKey().size());
@@ -49,7 +50,7 @@ TEST(EntryTest, Assignment)
 TEST(EntryTest, SetValue)
 {
   KeyValueProperties::Entry e("test_key", "test_value");
-  opentelemetry::nostd::string_view new_val = "new_value";
+  nostd::string_view new_val = "new_value";
   e.SetValue(new_val);
 
   EXPECT_EQ(new_val.size(), e.GetValue().size());
@@ -65,7 +66,7 @@ TEST(KVStringTokenizer, SinglePair)
 {
   bool valid_kv;
   nostd::string_view key, value;
-  opentelemetry::nostd::string_view str = "k1=v1";
+  nostd::string_view str = "k1=v1";
   KeyValueStringTokenizerOptions opts;
   KeyValueStringTokenizer tk(str, opts);
   EXPECT_TRUE(tk.next(valid_kv, key, value));
@@ -79,7 +80,7 @@ TEST(KVStringTokenizer, AcceptEmptyEntries)
 {
   bool valid_kv;
   nostd::string_view key, value;
-  opentelemetry::nostd::string_view str = ":k1=v1::k2=v2: ";
+  nostd::string_view str = ":k1=v1::k2=v2: ";
   KeyValueStringTokenizerOptions opts;
   opts.member_separator     = ':';
   opts.ignore_empty_members = false;
@@ -100,7 +101,7 @@ TEST(KVStringTokenizer, AcceptEmptyEntries)
 
 TEST(KVStringTokenizer, ValidPairsWithEmptyEntries)
 {
-  opentelemetry::nostd::string_view str = "k1:v1===k2:v2==";
+  nostd::string_view str = "k1:v1===k2:v2==";
   bool valid_kv;
   nostd::string_view key, value;
   KeyValueStringTokenizerOptions opts;
@@ -123,7 +124,7 @@ TEST(KVStringTokenizer, ValidPairsWithEmptyEntries)
 
 TEST(KVStringTokenizer, InvalidPairs)
 {
-  opentelemetry::nostd::string_view str = "k1=v1,invalid  ,,  k2=v2   ,invalid";
+  nostd::string_view str = "k1=v1,invalid  ,,  k2=v2   ,invalid";
   KeyValueStringTokenizer tk(str);
   bool valid_kv;
   nostd::string_view key, value;
@@ -218,8 +219,8 @@ TEST(KeyValueProperties, GetAllEntries)
   std::vector<std::pair<std::string, std::string>> kv_pairs = {
       {"k1", "v1"}, {"k2", "v2"}, {"k3", "v3"}};
   const size_t kNumPairs                              = 3;
-  opentelemetry::nostd::string_view keys[kNumPairs]   = {"k1", "k2", "k3"};
-  opentelemetry::nostd::string_view values[kNumPairs] = {"v1", "v2", "v3"};
+  nostd::string_view keys[kNumPairs]   = {"k1", "k2", "k3"};
+  nostd::string_view values[kNumPairs] = {"v1", "v2", "v3"};
   auto kv_properties                                  = KeyValueProperties(kv_pairs);
 
   size_t index = 0;

--- a/api/test/context/propagation/composite_propagator_test.cc
+++ b/api/test/context/propagation/composite_propagator_test.cc
@@ -118,7 +118,7 @@ TEST_F(CompositePropagatorTest, Inject)
     return true;
   });
   EXPECT_EQ(fields.size(), 3);
-  EXPECT_EQ(fields[0], opentelemetry::trace::propagation::kTraceParent);
-  EXPECT_EQ(fields[1], opentelemetry::trace::propagation::kTraceState);
-  EXPECT_EQ(fields[2], opentelemetry::trace::propagation::kB3CombinedHeader);
+  EXPECT_EQ(fields[0], trace::propagation::kTraceParent);
+  EXPECT_EQ(fields[1], trace::propagation::kTraceState);
+  EXPECT_EQ(fields[2], trace::propagation::kB3CombinedHeader);
 }

--- a/api/test/logs/logger_test.cc
+++ b/api/test/logs/logger_test.cc
@@ -18,6 +18,10 @@ using opentelemetry::logs::Severity;
 using opentelemetry::nostd::shared_ptr;
 using opentelemetry::nostd::span;
 using opentelemetry::nostd::string_view;
+namespace common = opentelemetry::common;
+namespace nostd = opentelemetry::nostd;
+namespace trace = opentelemetry::trace;
+
 
 // Check that the default logger is a noop logger instance
 TEST(Logger, GetLoggerDefault)
@@ -72,17 +76,17 @@ TEST(Logger, LogMethodOverloads)
 // Define a basic Logger class
 class TestLogger : public Logger
 {
-  const opentelemetry::nostd::string_view GetName() noexcept override { return "test logger"; }
+  const nostd::string_view GetName() noexcept override { return "test logger"; }
 
   void Log(Severity severity,
            string_view name,
            string_view body,
-           const opentelemetry::common::KeyValueIterable &resource,
-           const opentelemetry::common::KeyValueIterable &attributes,
-           opentelemetry::trace::TraceId trace_id,
-           opentelemetry::trace::SpanId span_id,
-           opentelemetry::trace::TraceFlags trace_flags,
-           opentelemetry::common::SystemTimestamp timestamp) noexcept override
+           const common::KeyValueIterable &resource,
+           const common::KeyValueIterable &attributes,
+           trace::TraceId trace_id,
+           trace::SpanId span_id,
+           trace::TraceFlags trace_flags,
+           common::SystemTimestamp timestamp) noexcept override
   {}
 };
 

--- a/api/test/metrics/meter_provider_test.cc
+++ b/api/test/metrics/meter_provider_test.cc
@@ -9,14 +9,15 @@
 using opentelemetry::metrics::Meter;
 using opentelemetry::metrics::MeterProvider;
 using opentelemetry::metrics::Provider;
+namespace nostd = opentelemetry::nostd;
 
 class TestProvider : public MeterProvider
 {
-  opentelemetry::nostd::shared_ptr<Meter> GetMeter(
-      opentelemetry::nostd::string_view library_name,
-      opentelemetry::nostd::string_view library_version) override
+  nostd::shared_ptr<Meter> GetMeter(
+      nostd::string_view library_name,
+      nostd::string_view library_version) override
   {
-    return opentelemetry::nostd::shared_ptr<Meter>(nullptr);
+    return nostd::shared_ptr<Meter>(nullptr);
   }
 };
 
@@ -28,16 +29,16 @@ TEST(Provider, GetMeterProviderDefault)
 
 TEST(Provider, SetMeterProvider)
 {
-  auto tf = opentelemetry::nostd::shared_ptr<MeterProvider>(new TestProvider());
+  auto tf = nostd::shared_ptr<MeterProvider>(new TestProvider());
   Provider::SetMeterProvider(tf);
   ASSERT_EQ(tf, Provider::GetMeterProvider());
 }
 
 TEST(Provider, MultipleMeterProviders)
 {
-  auto tf = opentelemetry::nostd::shared_ptr<MeterProvider>(new TestProvider());
+  auto tf = nostd::shared_ptr<MeterProvider>(new TestProvider());
   Provider::SetMeterProvider(tf);
-  auto tf2 = opentelemetry::nostd::shared_ptr<MeterProvider>(new TestProvider());
+  auto tf2 = nostd::shared_ptr<MeterProvider>(new TestProvider());
   Provider::SetMeterProvider(tf2);
 
   ASSERT_NE(Provider::GetMeterProvider(), tf);

--- a/api/test/nostd/utility_test.cc
+++ b/api/test/nostd/utility_test.cc
@@ -9,13 +9,15 @@
 
 #include <gtest/gtest.h>
 
+namespace nostd = opentelemetry::nostd;
+
 template <class T>
-auto IsDataCallable(const T &t) -> decltype(opentelemetry::nostd::data(t), std::true_type{});
+auto IsDataCallable(const T &t) -> decltype(nostd::data(t), std::true_type{});
 
 std::false_type IsDataCallable(...);
 
 template <class T>
-auto IsSizeCallable(const T &t) -> decltype(opentelemetry::nostd::size(t), std::true_type{});
+auto IsSizeCallable(const T &t) -> decltype(nostd::size(t), std::true_type{});
 
 std::false_type IsSizeCallable(...);
 
@@ -27,9 +29,9 @@ TEST(UtilityTest, Data)
   int x       = 0;
   std::ignore = x;
 
-  EXPECT_EQ(opentelemetry::nostd::data(v), v.data());
-  EXPECT_EQ(opentelemetry::nostd::data(array), array);
-  EXPECT_EQ(opentelemetry::nostd::data(list), list.begin());
+  EXPECT_EQ(nostd::data(v), v.data());
+  EXPECT_EQ(nostd::data(array), array);
+  EXPECT_EQ(nostd::data(list), list.begin());
   EXPECT_FALSE(decltype(IsDataCallable(x)){});
 }
 
@@ -40,18 +42,18 @@ TEST(UtilityTest, Size)
   int x              = 0;
   std::ignore        = x;
 
-  EXPECT_EQ(opentelemetry::nostd::size(v), v.size());
-  EXPECT_EQ(opentelemetry::nostd::size(array), 3);
+  EXPECT_EQ(nostd::size(v), v.size());
+  EXPECT_EQ(nostd::size(array), 3);
 
   EXPECT_FALSE(decltype(IsSizeCallable(x)){});
 }
 
 TEST(UtilityTest, MakeIndexSequence)
 {
-  EXPECT_TRUE((std::is_same<opentelemetry::nostd::make_index_sequence<0>,
-                            opentelemetry::nostd::index_sequence<>>::value));
-  EXPECT_TRUE((std::is_same<opentelemetry::nostd::make_index_sequence<1>,
-                            opentelemetry::nostd::index_sequence<0>>::value));
-  EXPECT_TRUE((std::is_same<opentelemetry::nostd::make_index_sequence<2>,
-                            opentelemetry::nostd::index_sequence<0, 1>>::value));
+  EXPECT_TRUE((std::is_same<nostd::make_index_sequence<0>,
+                            nostd::index_sequence<>>::value));
+  EXPECT_TRUE((std::is_same<nostd::make_index_sequence<1>,
+                            nostd::index_sequence<0>>::value));
+  EXPECT_TRUE((std::is_same<nostd::make_index_sequence<2>,
+                            nostd::index_sequence<0, 1>>::value));
 }

--- a/api/test/trace/noop_test.cc
+++ b/api/test/trace/noop_test.cc
@@ -36,7 +36,7 @@ TEST(NoopTest, UseNoopTracers)
 
   EXPECT_EQ(s1->IsRecording(), false);
 
-  s1->SetStatus(opentelemetry::trace::StatusCode::kUnset, "span unset");
+  s1->SetStatus(trace_api::StatusCode::kUnset, "span unset");
 
   s1->UpdateName("test_name");
 

--- a/api/test/trace/propagation/http_text_format_test.cc
+++ b/api/test/trace/propagation/http_text_format_test.cc
@@ -206,6 +206,6 @@ TEST(GlobalPropagator, SetAndGet)
     return true;
   });
   EXPECT_EQ(fields.size(), 2);
-  EXPECT_EQ(fields[0], opentelemetry::trace::propagation::kTraceParent);
-  EXPECT_EQ(fields[1], opentelemetry::trace::propagation::kTraceState);
+  EXPECT_EQ(fields[0], trace::propagation::kTraceParent);
+  EXPECT_EQ(fields[1], trace::propagation::kTraceState);
 }

--- a/api/test/trace/provider_test.cc
+++ b/api/test/trace/provider_test.cc
@@ -10,14 +10,16 @@ using opentelemetry::trace::Provider;
 using opentelemetry::trace::Tracer;
 using opentelemetry::trace::TracerProvider;
 
+namespace nostd     = opentelemetry::nostd;
+
 class TestProvider : public TracerProvider
 {
-  opentelemetry::nostd::shared_ptr<Tracer> GetTracer(
-      opentelemetry::nostd::string_view library_name,
-      opentelemetry::nostd::string_view library_version,
-      opentelemetry::nostd::string_view schema_url) override
+  nostd::shared_ptr<Tracer> GetTracer(
+      nostd::string_view library_name,
+      nostd::string_view library_version,
+      nostd::string_view schema_url) override
   {
-    return opentelemetry::nostd::shared_ptr<Tracer>(nullptr);
+    return nostd::shared_ptr<Tracer>(nullptr);
   }
 };
 
@@ -29,7 +31,7 @@ TEST(Provider, GetTracerProviderDefault)
 
 TEST(Provider, SetTracerProvider)
 {
-  auto tf = opentelemetry::nostd::shared_ptr<TracerProvider>(new TestProvider());
+  auto tf = nostd::shared_ptr<TracerProvider>(new TestProvider());
   Provider::SetTracerProvider(tf);
   ASSERT_EQ(tf, Provider::GetTracerProvider());
 }

--- a/api/test/trace/span_benchmark.cc
+++ b/api/test/trace/span_benchmark.cc
@@ -14,13 +14,14 @@
 using opentelemetry::trace::SpanContext;
 namespace trace_api = opentelemetry::trace;
 namespace nostd     = opentelemetry::nostd;
+namespace context   = opentelemetry::context;
 
 namespace
 {
 
-std::shared_ptr<opentelemetry::trace::Tracer> initTracer()
+std::shared_ptr<trace_api::Tracer> initTracer()
 {
-  return std::shared_ptr<opentelemetry::trace::Tracer>(new trace_api::NoopTracer());
+  return std::shared_ptr<trace_api::Tracer>(new trace_api::NoopTracer());
 }
 
 // Test to measure performance for span creation
@@ -108,7 +109,7 @@ void BM_SpanCreationWitContextPropagation(benchmark::State &state)
 
   while (state.KeepRunning())
   {
-    auto current_ctx        = opentelemetry::context::RuntimeContext::GetCurrent();
+    auto current_ctx        = context::RuntimeContext::GetCurrent();
     auto outer_span_context = SpanContext(trace_id, span_id, trace_api::TraceFlags(), false);
     auto outer_span =
         nostd::shared_ptr<trace_api::Span>(new trace_api::DefaultSpan(outer_span_context));

--- a/api/test/trace/span_context_test.cc
+++ b/api/test/trace/span_context_test.cc
@@ -8,6 +8,7 @@
 #include <gtest/gtest.h>
 
 using opentelemetry::trace::SpanContext;
+namespace trace_api = opentelemetry::trace;
 
 TEST(SpanContextTest, IsSampled)
 {
@@ -49,6 +50,6 @@ TEST(SpanContextTest, Invalid)
   EXPECT_FALSE(s1.IsValid());
 
   // Test that trace id and span id are invalid
-  EXPECT_EQ(s1.trace_id(), opentelemetry::trace::TraceId());
-  EXPECT_EQ(s1.span_id(), opentelemetry::trace::SpanId());
+  EXPECT_EQ(s1.trace_id(), trace_api::TraceId());
+  EXPECT_EQ(s1.span_id(), trace_api::SpanId());
 }

--- a/docs/building-with-stdlib.md
+++ b/docs/building-with-stdlib.md
@@ -5,7 +5,7 @@ process (environment where ABI compat is not a requirement), or for
 "header-only" implementation of SDK.
 
 Proposed approach cannot be employed for shared libs in environments where ABI
-compatibility is required. OpenTelemetry SDK binary compiled with `compiler A
+compatibility is required. OpenTelemetry SDK binary compiled with `compiler A +
 STL B` will not be ABI -compatible with the main executable compiled with
 `compiler C + STL D`.
 

--- a/docs/building-with-stdlib.md
+++ b/docs/building-with-stdlib.md
@@ -5,7 +5,7 @@ process (environment where ABI compat is not a requirement), or for
 "header-only" implementation of SDK.
 
 Proposed approach cannot be employed for shared libs in environments where ABI
-compatibility is required. OpenTelemetry SDK binary compiled with `compiler A +
+compatibility is required. OpenTelemetry SDK binary compiled with `compiler A
 STL B` will not be ABI -compatible with the main executable compiled with
 `compiler C + STL D`.
 

--- a/examples/batch/main.cc
+++ b/examples/batch/main.cc
@@ -11,6 +11,9 @@
 #include <thread>
 
 constexpr int kNumSpans = 10;
+namespace trace_api = opentelemetry::trace;
+namespace resource = opentelemetry::sdk::resource;
+namespace exporter_trace = opentelemetry::exporter::trace;
 
 namespace
 {
@@ -18,7 +21,7 @@ namespace
 void initTracer()
 {
   auto exporter = std::unique_ptr<sdktrace::SpanExporter>(
-      new opentelemetry::exporter::trace::OStreamSpanExporter);
+      new exporter_trace::OStreamSpanExporter);
 
   // CONFIGURE BATCH SPAN PROCESSOR PARAMETERS
 
@@ -31,22 +34,22 @@ void initTracer()
   // We export `kNumSpans` after every `schedule_delay_millis` milliseconds.
   options.max_export_batch_size = kNumSpans;
 
-  opentelemetry::sdk::resource::ResourceAttributes attributes = {{"service", "test_service"},
+  resource::ResourceAttributes attributes = {{"service", "test_service"},
                                                                  {"version", (uint32_t)1}};
-  auto resource = opentelemetry::sdk::resource::Resource::Create(attributes);
+  auto resource = resource::Resource::Create(attributes);
 
   auto processor = std::unique_ptr<sdktrace::SpanProcessor>(
       new sdktrace::BatchSpanProcessor(std::move(exporter), options));
 
-  auto provider = nostd::shared_ptr<opentelemetry::trace::TracerProvider>(
+  auto provider = nostd::shared_ptr<trace_api::TracerProvider>(
       new sdktrace::TracerProvider(std::move(processor), resource));
   // Set the global trace provider.
-  opentelemetry::trace::Provider::SetTracerProvider(provider);
+  trace_api::Provider::SetTracerProvider(provider);
 }
 
-nostd::shared_ptr<opentelemetry::trace::Tracer> get_tracer()
+nostd::shared_ptr<trace_api::Tracer> get_tracer()
 {
-  auto provider = opentelemetry::trace::Provider::GetTracerProvider();
+  auto provider = trace_api::Provider::GetTracerProvider();
   return provider->GetTracer("foo_library");
 }
 

--- a/examples/grpc/client.cc
+++ b/examples/grpc/client.cc
@@ -25,7 +25,7 @@ using grpc_example::GreetResponse;
 
 namespace
 {
-
+namespace context = opentelemetry::context;
 using namespace opentelemetry::trace;
 class GreeterClient
 {
@@ -40,8 +40,8 @@ public:
     ClientContext context;
     request.set_request("Nice to meet you!");
 
-    opentelemetry::trace::StartSpanOptions options;
-    options.kind = opentelemetry::trace::SpanKind::kClient;
+    StartSpanOptions options;
+    options.kind = SpanKind::kClient;
 
     std::string span_name = "GreeterClient/Greet";
     auto span             = get_tracer("grpc")->StartSpan(
@@ -56,16 +56,16 @@ public:
     auto scope = get_tracer("grpc-client")->WithActiveSpan(span);
 
     // inject current context to grpc metadata
-    auto current_ctx = opentelemetry::context::RuntimeContext::GetCurrent();
+    auto current_ctx = context::RuntimeContext::GetCurrent();
     GrpcClientCarrier carrier(&context);
-    auto prop = opentelemetry::context::propagation::GlobalTextMapPropagator::GetGlobalPropagator();
+    auto prop = context::propagation::GlobalTextMapPropagator::GetGlobalPropagator();
     prop->Inject(carrier, current_ctx);
 
     // Send request to server
     Status status = stub_->Greet(&context, request, &response);
     if (status.ok())
     {
-      span->SetStatus(opentelemetry::trace::StatusCode::kOk);
+      span->SetStatus(StatusCode::kOk);
       span->SetAttribute(OTEL_CPP_GET_ATTR(AttrRpcGrpcStatusCode), status.error_code());
       // Make sure to end your spans!
       span->End();
@@ -74,7 +74,7 @@ public:
     else
     {
       std::cout << status.error_code() << ": " << status.error_message() << std::endl;
-      span->SetStatus(opentelemetry::trace::StatusCode::kError);
+      span->SetStatus(StatusCode::kError);
       span->SetAttribute(OTEL_CPP_GET_ATTR(AttrRpcGrpcStatusCode), status.error_code());
       // Make sure to end your spans!
       span->End();
@@ -99,9 +99,9 @@ int main(int argc, char **argv)
 {
   initTracer();
   // set global propagator
-  opentelemetry::context::propagation::GlobalTextMapPropagator::SetGlobalPropagator(
-      nostd::shared_ptr<opentelemetry::context::propagation::TextMapPropagator>(
-          new opentelemetry::trace::propagation::HttpTraceContext()));
+  context::propagation::GlobalTextMapPropagator::SetGlobalPropagator(
+      nostd::shared_ptr<context::propagation::TextMapPropagator>(
+          new propagation::HttpTraceContext()));
   constexpr uint16_t default_port = 8800;
   uint16_t port;
   if (argc > 1)

--- a/examples/grpc/server.cc
+++ b/examples/grpc/server.cc
@@ -35,6 +35,8 @@ using Span        = opentelemetry::trace::Span;
 using SpanContext = opentelemetry::trace::SpanContext;
 using namespace opentelemetry::trace;
 
+namespace context = opentelemetry::context;
+
 namespace
 {
 class GreeterServer final : public Greeter::Service
@@ -50,16 +52,16 @@ public:
     }
 
     // Create a SpanOptions object and set the kind to Server to inform OpenTel.
-    opentelemetry::trace::StartSpanOptions options;
-    options.kind = opentelemetry::trace::SpanKind::kServer;
+    StartSpanOptions options;
+    options.kind = SpanKind::kServer;
 
     // extract context from grpc metadata
     GrpcServerCarrier carrier(context);
 
-    auto prop = opentelemetry::context::propagation::GlobalTextMapPropagator::GetGlobalPropagator();
-    auto current_ctx = opentelemetry::context::RuntimeContext::GetCurrent();
+    auto prop = context::propagation::GlobalTextMapPropagator::GetGlobalPropagator();
+    auto current_ctx = context::RuntimeContext::GetCurrent();
     auto new_context = prop->Extract(carrier, current_ctx);
-    options.parent   = opentelemetry::trace::GetSpan(new_context)->GetContext();
+    options.parent   = GetSpan(new_context)->GetContext();
 
     std::string span_name = "GreeterService/Greet";
     auto span =
@@ -81,7 +83,7 @@ public:
     response->set_response(message);
     span->AddEvent("Response sent to client");
 
-    span->SetStatus(opentelemetry::trace::StatusCode::kOk);
+    span->SetStatus(StatusCode::kOk);
     // Make sure to end your spans!
     span->End();
     return Status::OK;

--- a/examples/http/client.cc
+++ b/examples/http/client.cc
@@ -59,7 +59,7 @@ void sendRequest(const std::string &url)
   else
   {
     span->SetStatus(StatusCode::kError,
-                    "Response Status :"
+                    "Response Status :" +
                         std::to_string(static_cast<typename std::underlying_type<
                                            http_client::SessionState>::type>(
                             result.GetSessionState())));
@@ -88,7 +88,7 @@ int main(int argc, char *argv[])
     port = default_port;
   }
 
-  std::string url = "http://" + std::string(default_host) + ":" + std::to_string(port)
+  std::string url = "http://" + std::string(default_host) + ":" + std::to_string(port) +
                     std::string(default_path);
   sendRequest(url);
 }

--- a/examples/http/client.cc
+++ b/examples/http/client.cc
@@ -10,14 +10,17 @@ namespace
 {
 
 using namespace opentelemetry::trace;
+namespace http_client = opentelemetry::ext::http::client;
+namespace context = opentelemetry::context;
+namespace nostd = opentelemetry::nostd;
 
 void sendRequest(const std::string &url)
 {
-  auto http_client = opentelemetry::ext::http::client::HttpClientFactory::CreateSync();
+  auto http_client = http_client::HttpClientFactory::CreateSync();
 
   // start active span
-  opentelemetry::trace::StartSpanOptions options;
-  options.kind = opentelemetry::trace::SpanKind::kClient;  // client
+  StartSpanOptions options;
+  options.kind = SpanKind::kClient;  // client
   opentelemetry::ext::http::common::UrlParser url_parser(url);
 
   std::string span_name = url_parser.path_;
@@ -30,35 +33,35 @@ void sendRequest(const std::string &url)
   auto scope = get_tracer("http-client")->WithActiveSpan(span);
 
   // inject current context into http header
-  auto current_ctx = opentelemetry::context::RuntimeContext::GetCurrent();
-  HttpTextMapCarrier<opentelemetry::ext::http::client::Headers> carrier;
-  auto prop = opentelemetry::context::propagation::GlobalTextMapPropagator::GetGlobalPropagator();
+  auto current_ctx = context::RuntimeContext::GetCurrent();
+  HttpTextMapCarrier<http_client::Headers> carrier;
+  auto prop = context::propagation::GlobalTextMapPropagator::GetGlobalPropagator();
   prop->Inject(carrier, current_ctx);
 
   // send http request
-  opentelemetry::ext::http::client::Result result = http_client->Get(url, carrier.headers_);
+  http_client::Result result = http_client->Get(url, carrier.headers_);
   if (result)
   {
     // set span attributes
     auto status_code = result.GetResponse().GetStatusCode();
     span->SetAttribute(OTEL_CPP_GET_ATTR(AttrHttpStatusCode), status_code);
-    result.GetResponse().ForEachHeader([&span](opentelemetry::nostd::string_view header_name,
-                                               opentelemetry::nostd::string_view header_value) {
+    result.GetResponse().ForEachHeader([&span](nostd::string_view header_name,
+                                               nostd::string_view header_value) {
       span->SetAttribute("http.header." + std::string(header_name.data()), header_value);
       return true;
     });
 
     if (status_code >= 400)
     {
-      span->SetStatus(opentelemetry::trace::StatusCode::kError);
+      span->SetStatus(StatusCode::kError);
     }
   }
   else
   {
-    span->SetStatus(opentelemetry::trace::StatusCode::kError,
-                    "Response Status :" +
+    span->SetStatus(StatusCode::kError,
+                    "Response Status :"
                         std::to_string(static_cast<typename std::underlying_type<
-                                           opentelemetry::ext::http::client::SessionState>::type>(
+                                           http_client::SessionState>::type>(
                             result.GetSessionState())));
   }
   // end span and export data
@@ -85,7 +88,7 @@ int main(int argc, char *argv[])
     port = default_port;
   }
 
-  std::string url = "http://" + std::string(default_host) + ":" + std::to_string(port) +
+  std::string url = "http://" + std::string(default_host) + ":" + std::to_string(port)
                     std::string(default_path);
   sendRequest(url);
 }

--- a/examples/metrics_simple/main.cc
+++ b/examples/metrics_simple/main.cc
@@ -11,12 +11,15 @@
 
 namespace sdkmetrics = opentelemetry::sdk::metrics;
 namespace nostd      = opentelemetry::nostd;
+namespace exportermetrics = opentelemetry::exporter::metrics;
+namespace metrics_api = opentelemetry::metrics;
+
 
 int main()
 {
   // Initialize and set the global MeterProvider
   auto provider = nostd::shared_ptr<metrics_api::MeterProvider>(new sdkmetrics::MeterProvider);
-  opentelemetry::metrics::Provider::SetMeterProvider(provider);
+  metrics_api::Provider::SetMeterProvider(provider);
 
   // Get the Meter from the MeterProvider
   nostd::shared_ptr<metrics_api::Meter> meter = provider->GetMeter("Test", "0.1.0");
@@ -25,9 +28,9 @@ int main()
   sdkmetrics::PushController ControllerStateless(
       meter,
       std::unique_ptr<sdkmetrics::MetricsExporter>(
-          new opentelemetry::exporter::metrics::OStreamMetricsExporter),
+          new exportermetrics::OStreamMetricsExporter),
       std::shared_ptr<sdkmetrics::MetricsProcessor>(
-          new opentelemetry::sdk::metrics::UngroupedMetricsProcessor(false)),
+          new sdkmetrics::UngroupedMetricsProcessor(false)),
       .05);
 
   // Create and instrument
@@ -36,7 +39,7 @@ int main()
 
   // Create a labelset
   std::map<std::string, std::string> labels = {{"key", "value"}};
-  auto labelkv = opentelemetry::common::KeyValueIterableView<decltype(labels)>{labels};
+  auto labelkv = common::KeyValueIterableView<decltype(labels)>{labels};
 
   // Create arrays of instrument and values to add to them
   metrics_api::SynchronousInstrument<int> *iinstr_arr[] = {intupdowncounter.get(),
@@ -92,9 +95,9 @@ int main()
   sdkmetrics::PushController ControllerStateful(
       meter,
       std::unique_ptr<sdkmetrics::MetricsExporter>(
-          new opentelemetry::exporter::metrics::OStreamMetricsExporter),
+          new exportermetrics::OStreamMetricsExporter),
       std::shared_ptr<sdkmetrics::MetricsProcessor>(
-          new opentelemetry::sdk::metrics::UngroupedMetricsProcessor(true)),
+          new sdkmetrics::UngroupedMetricsProcessor(true)),
       .05);
 
   // Start exporting from the Controller with Stateful Processor

--- a/examples/multi_processor/main.cc
+++ b/examples/multi_processor/main.cc
@@ -12,6 +12,8 @@
 #include "opentelemetry/exporters/ostream/span_exporter.h"
 
 using opentelemetry::exporter::memory::InMemorySpanExporter;
+namespace trace_api = opentelemetry::trace;
+namespace trace_sdk = opentelemetry::sdk::trace;
 
 InMemorySpanExporter *memory_span_exporter;
 
@@ -32,18 +34,18 @@ void initTracer()
   auto processor2 = std::unique_ptr<sdktrace::SpanProcessor>(
       new sdktrace::SimpleSpanProcessor(std::move(exporter2)));
 
-  auto provider = nostd::shared_ptr<opentelemetry::sdk::trace::TracerProvider>(
+  auto provider = nostd::shared_ptr<trace_sdk::TracerProvider>(
       new sdktrace::TracerProvider(std::move(processor1)));
   provider->AddProcessor(std::move(processor2));
   // Set the global trace provider
-  opentelemetry::trace::Provider::SetTracerProvider(std::move(provider));
+  trace_api::Provider::SetTracerProvider(std::move(provider));
 }
 
-void dumpSpans(std::vector<std::unique_ptr<opentelemetry::sdk::trace::SpanData>> &spans)
+void dumpSpans(std::vector<std::unique_ptr<trace_sdk::SpanData>> &spans)
 {
-  char span_buf[opentelemetry::trace::SpanId::kSize * 2];
-  char trace_buf[opentelemetry::trace::TraceId::kSize * 2];
-  char parent_span_buf[opentelemetry::trace::SpanId::kSize * 2];
+  char span_buf[trace_api::SpanId::kSize * 2];
+  char trace_buf[trace_api::TraceId::kSize * 2];
+  char parent_span_buf[trace_api::SpanId::kSize * 2];
   std::cout << "\nSpans from memory :" << std::endl;
 
   for (auto &span : spans)
@@ -60,11 +62,11 @@ void dumpSpans(std::vector<std::unique_ptr<opentelemetry::sdk::trace::SpanData>>
 
     std::cout << "\t\tDescription: " << span->GetDescription() << std::endl;
     std::cout << "\t\tSpan kind:"
-              << static_cast<typename std::underlying_type<opentelemetry::trace::SpanKind>::type>(
+              << static_cast<typename std::underlying_type<trace_api::SpanKind>::type>(
                      span->GetSpanKind())
               << std::endl;
     std::cout << "\t\tSpan Status: "
-              << static_cast<typename std::underlying_type<opentelemetry::trace::StatusCode>::type>(
+              << static_cast<typename std::underlying_type<trace_api::StatusCode>::type>(
                      span->GetStatus())
               << std::endl;
   }

--- a/examples/otlp/http_main.cc
+++ b/examples/otlp/http_main.cc
@@ -47,7 +47,7 @@ int main(int argc, char *argv[])
       std::string binary_mode = argv[3];
       if (binary_mode.size() >= 3 && binary_mode.substr(0, 3) == "bin")
       {
-        opts.content_type = opentelemetry::exporter::otlp::HttpRequestContentType::kBinary;
+        opts.content_type = otlp::HttpRequestContentType::kBinary;
       }
     }
   }

--- a/examples/plugin/plugin/factory_impl.cc
+++ b/examples/plugin/plugin/factory_impl.cc
@@ -5,7 +5,10 @@
 #include "opentelemetry/plugin/hook.h"
 #include "tracer.h"
 
-class TracerHandle final : public opentelemetry::plugin::TracerHandle
+namespace nostd    = opentelemetry::nostd;
+namespace plugin    = opentelemetry::plugin;
+
+class TracerHandle final : public plugin::TracerHandle
 {
 public:
   explicit TracerHandle(std::shared_ptr<Tracer> &&tracer) noexcept : tracer_{std::move(tracer)} {}
@@ -17,31 +20,31 @@ private:
   std::shared_ptr<Tracer> tracer_;
 };
 
-class FactoryImpl final : public opentelemetry::plugin::Factory::FactoryImpl
+class FactoryImpl final : public plugin::Factory::FactoryImpl
 {
 public:
   // opentelemetry::plugin::Factory::FactoryImpl
-  opentelemetry::nostd::unique_ptr<opentelemetry::plugin::TracerHandle> MakeTracerHandle(
-      opentelemetry::nostd::string_view tracer_config,
-      opentelemetry::nostd::unique_ptr<char[]> &error_message) const noexcept override
+  nostd::unique_ptr<plugin::TracerHandle> MakeTracerHandle(
+      nostd::string_view tracer_config,
+      nostd::unique_ptr<char[]> &error_message) const noexcept override
   {
     std::shared_ptr<Tracer> tracer{new (std::nothrow) Tracer{""}};
     if (tracer == nullptr)
     {
       return nullptr;
     }
-    return opentelemetry::nostd::unique_ptr<TracerHandle>{new (std::nothrow)
+    return nostd::unique_ptr<TracerHandle>{new (std::nothrow)
                                                               TracerHandle{std::move(tracer)}};
   }
 };
 
-static opentelemetry::nostd::unique_ptr<opentelemetry::plugin::Factory::FactoryImpl>
-MakeFactoryImpl(const opentelemetry::plugin::LoaderInfo &loader_info,
-                opentelemetry::nostd::unique_ptr<char[]> &error_message) noexcept
+static nostd::unique_ptr<plugin::Factory::FactoryImpl>
+MakeFactoryImpl(const plugin::LoaderInfo &loader_info,
+                nostd::unique_ptr<char[]> &error_message) noexcept
 {
   (void)loader_info;
   (void)error_message;
-  return opentelemetry::nostd::unique_ptr<opentelemetry::plugin::Factory::FactoryImpl>{
+  return nostd::unique_ptr<plugin::Factory::FactoryImpl>{
       new (std::nothrow) FactoryImpl{}};
 }
 

--- a/examples/plugin/plugin/tracer.cc
+++ b/examples/plugin/plugin/tracer.cc
@@ -19,8 +19,8 @@ class Span final : public trace::Span
 public:
   Span(std::shared_ptr<Tracer> &&tracer,
        nostd::string_view name,
-       const opentelemetry::common::KeyValueIterable & /*attributes*/,
-       const opentelemetry::trace::SpanContextKeyValueIterable & /*links*/,
+       const common::KeyValueIterable & /*attributes*/,
+       const trace::SpanContextKeyValueIterable & /*links*/,
        const trace::StartSpanOptions & /*options*/) noexcept
       : tracer_{std::move(tracer)}, name_{name}, span_context_{trace::SpanContext::GetInvalid()}
   {
@@ -67,10 +67,10 @@ Tracer::Tracer(nostd::string_view /*output*/) {}
 
 nostd::shared_ptr<trace::Span> Tracer::StartSpan(
     nostd::string_view name,
-    const opentelemetry::common::KeyValueIterable &attributes,
-    const opentelemetry::trace::SpanContextKeyValueIterable &links,
+    const common::KeyValueIterable &attributes,
+    const trace::SpanContextKeyValueIterable &links,
     const trace::StartSpanOptions &options) noexcept
 {
-  return nostd::shared_ptr<opentelemetry::trace::Span>{
+  return nostd::shared_ptr<trace::Span>{
       new (std::nothrow) Span{this->shared_from_this(), name, attributes, links, options}};
 }

--- a/examples/simple/main.cc
+++ b/examples/simple/main.cc
@@ -9,6 +9,8 @@
 #include "foo_library/foo_library.h"
 #include "opentelemetry/exporters/ostream/span_exporter.h"
 
+namespace trace_api = opentelemetry::trace;
+
 namespace
 {
 void initTracer()
@@ -17,11 +19,11 @@ void initTracer()
       new opentelemetry::exporter::trace::OStreamSpanExporter);
   auto processor = std::unique_ptr<sdktrace::SpanProcessor>(
       new sdktrace::SimpleSpanProcessor(std::move(exporter)));
-  auto provider = nostd::shared_ptr<opentelemetry::trace::TracerProvider>(
+  auto provider = nostd::shared_ptr<trace_api::TracerProvider>(
       new sdktrace::TracerProvider(std::move(processor)));
 
   // Set the global trace provider
-  opentelemetry::trace::Provider::SetTracerProvider(provider);
+  trace_api::Provider::SetTracerProvider(provider);
 }
 }  // namespace
 

--- a/examples/zipkin/main.cc
+++ b/examples/zipkin/main.cc
@@ -12,16 +12,17 @@ namespace trace    = opentelemetry::trace;
 namespace nostd    = opentelemetry::nostd;
 namespace sdktrace = opentelemetry::sdk::trace;
 namespace zipkin   = opentelemetry::exporter::zipkin;
+namespace resource   = opentelemetry::sdk::resource;
 
 namespace
 {
-opentelemetry::exporter::zipkin::ZipkinExporterOptions opts;
+zipkin::ZipkinExporterOptions opts;
 void InitTracer()
 {
   // Create zipkin exporter instance
-  opentelemetry::sdk::resource::ResourceAttributes attributes = {
+  resource::ResourceAttributes attributes = {
       {"service.name", "zipkin_demo_service"}};
-  auto resource  = opentelemetry::sdk::resource::Resource::Create(attributes);
+  auto resource  = resource::Resource::Create(attributes);
   auto exporter  = std::unique_ptr<sdktrace::SpanExporter>(new zipkin::ZipkinExporter(opts));
   auto processor = std::unique_ptr<sdktrace::SpanProcessor>(
       new sdktrace::SimpleSpanProcessor(std::move(exporter)));

--- a/examples/zpages/zpages_example.cc
+++ b/examples/zpages/zpages_example.cc
@@ -12,6 +12,7 @@
 #include "opentelemetry/ext/zpages/zpages.h"  // Required file include for zpages
 
 using opentelemetry::common::SteadyTimestamp;
+namespace trace_api = opentelemetry::trace;
 
 int main(int argc, char *argv[])
 {
@@ -23,7 +24,7 @@ int main(int argc, char *argv[])
    * Note that the webserver is destroyed after the application ends execution.
    */
   ZPages::Initialize();
-  auto tracer = opentelemetry::trace::Provider::GetTracerProvider()->GetTracer("");
+  auto tracer = trace_api::Provider::GetTracerProvider()->GetTracer("");
 
   std::cout << "This example for zPages creates a few types of spans and then "
             << "creates a span every second for the duration of the application"
@@ -33,14 +34,14 @@ int main(int argc, char *argv[])
   std::map<std::string, opentelemetry::common::AttributeValue> attribute_map;
   attribute_map["completed_search_for"] = "Unknown user";
   tracer->StartSpan("find user", attribute_map)
-      ->SetStatus(opentelemetry::trace::StatusCode::kError, "User not found");
+      ->SetStatus(trace_api::StatusCode::kError, "User not found");
 
   // Long time duration span
   std::map<std::string, opentelemetry::common::AttributeValue> attribute_map2;
   attribute_map2["completed_search_for"] = "John Doe";
-  opentelemetry::trace::StartSpanOptions start;
+  trace_api::StartSpanOptions start;
   start.start_steady_time = SteadyTimestamp(nanoseconds(1));
-  opentelemetry::trace::EndSpanOptions end;
+  trace_api::EndSpanOptions end;
   end.end_steady_time = SteadyTimestamp(nanoseconds(1000000000000));
   tracer->StartSpan("find user", attribute_map2, start)->End(end);
 

--- a/exporters/elasticsearch/src/es_log_exporter.cc
+++ b/exporters/elasticsearch/src/es_log_exporter.cc
@@ -71,7 +71,7 @@ public:
 
   // Callback method when an http event occurs
   void OnEvent(http_client::SessionState state,
-               opentelemetry::nostd::string_view reason) noexcept override
+               nostd::string_view reason) noexcept override
   {
     // If any failure event occurs, release the condition variable to unblock main thread
     switch (state)

--- a/exporters/jaeger/src/recordable.cc
+++ b/exporters/jaeger/src/recordable.cc
@@ -11,6 +11,7 @@ namespace jaeger
 {
 
 using namespace opentelemetry::sdk::resource;
+namespace trace_api = opentelemetry::trace;
 
 JaegerRecordable::JaegerRecordable() : span_{new thrift::Span} {}
 
@@ -187,19 +188,19 @@ void JaegerRecordable::SetSpanKind(trace::SpanKind span_kind) noexcept
   // map SpanKind to Jaeger tag span.kind.
   switch (span_kind)
   {
-    case opentelemetry::trace::SpanKind::kClient: {
+    case trace_api::SpanKind::kClient: {
       span_kind_str = "client";
       break;
     }
-    case opentelemetry::trace::SpanKind::kServer: {
+    case trace_api::SpanKind::kServer: {
       span_kind_str = "server";
       break;
     }
-    case opentelemetry::trace::SpanKind::kConsumer: {
+    case trace_api::SpanKind::kConsumer: {
       span_kind_str = "consumer";
       break;
     }
-    case opentelemetry::trace::SpanKind::kProducer: {
+    case trace_api::SpanKind::kProducer: {
       span_kind_str = "producer";
       break;
     }

--- a/exporters/jaeger/test/jaeger_recordable_test.cc
+++ b/exporters/jaeger/test/jaeger_recordable_test.cc
@@ -13,6 +13,7 @@
 namespace trace    = opentelemetry::trace;
 namespace nostd    = opentelemetry::nostd;
 namespace sdktrace = opentelemetry::sdk::trace;
+namespace common   = opentelemetry::common;
 
 using namespace jaegertracing;
 using namespace opentelemetry::exporter::jaeger;
@@ -20,7 +21,7 @@ using namespace opentelemetry::sdk::instrumentationlibrary;
 
 TEST(JaegerSpanRecordable, SetIdentity)
 {
-  opentelemetry::exporter::jaeger::JaegerRecordable rec;
+  JaegerRecordable rec;
 
   int64_t trace_id_val[2]    = {0x0000000000000000, 0x1000000000000000};
   int64_t span_id_val        = 0x2000000000000000;
@@ -35,18 +36,18 @@ TEST(JaegerSpanRecordable, SetIdentity)
   const trace::SpanId parent_span_id(
       nostd::span<uint8_t, 8>(reinterpret_cast<uint8_t *>(&parent_span_id_val), 8));
 
-  const opentelemetry::trace::SpanContext span_context{
+  const trace::SpanContext span_context{
       trace_id, span_id,
-      opentelemetry::trace::TraceFlags{opentelemetry::trace::TraceFlags::kIsSampled}, true};
+      trace::TraceFlags{trace::TraceFlags::kIsSampled}, true};
   rec.SetIdentity(span_context, parent_span_id);
 
   std::unique_ptr<thrift::Span> span{rec.Span()};
 
 #if JAEGER_IS_LITTLE_ENDIAN == 1
-  EXPECT_EQ(span->traceIdLow, opentelemetry::exporter::jaeger::otel_bswap_64(trace_id_val[1]));
-  EXPECT_EQ(span->traceIdHigh, opentelemetry::exporter::jaeger::otel_bswap_64(trace_id_val[0]));
-  EXPECT_EQ(span->spanId, opentelemetry::exporter::jaeger::otel_bswap_64(span_id_val));
-  EXPECT_EQ(span->parentSpanId, opentelemetry::exporter::jaeger::otel_bswap_64(parent_span_id_val));
+  EXPECT_EQ(span->traceIdLow, otel_bswap_64(trace_id_val[1]));
+  EXPECT_EQ(span->traceIdHigh, otel_bswap_64(trace_id_val[0]));
+  EXPECT_EQ(span->spanId, otel_bswap_64(span_id_val));
+  EXPECT_EQ(span->parentSpanId, otel_bswap_64(parent_span_id_val));
 #else
   EXPECT_EQ(span->traceIdLow, trace_id_val[0]);
   EXPECT_EQ(span->traceIdHigh, trace_id_val[1]);
@@ -57,7 +58,7 @@ TEST(JaegerSpanRecordable, SetIdentity)
 
 TEST(JaegerSpanRecordable, SetName)
 {
-  opentelemetry::exporter::jaeger::JaegerRecordable rec;
+  JaegerRecordable rec;
 
   nostd::string_view name = "Test Span";
   rec.SetName(name);
@@ -69,10 +70,10 @@ TEST(JaegerSpanRecordable, SetName)
 
 TEST(JaegerSpanRecordable, SetStartTime)
 {
-  opentelemetry::exporter::jaeger::JaegerRecordable rec;
+  JaegerRecordable rec;
 
   std::chrono::system_clock::time_point start_time = std::chrono::system_clock::now();
-  opentelemetry::common::SystemTimestamp start_timestamp(start_time);
+  common::SystemTimestamp start_timestamp(start_time);
   uint64_t unix_start =
       std::chrono::duration_cast<std::chrono::microseconds>(start_time.time_since_epoch()).count();
   rec.SetStartTime(start_timestamp);
@@ -84,9 +85,9 @@ TEST(JaegerSpanRecordable, SetStartTime)
 
 TEST(JaegerSpanRecordable, SetDuration)
 {
-  opentelemetry::exporter::jaeger::JaegerRecordable rec;
+  JaegerRecordable rec;
 
-  opentelemetry::common::SystemTimestamp start_timestamp;
+  common::SystemTimestamp start_timestamp;
 
   std::chrono::microseconds duration(10);
   uint64_t unix_end = duration.count();
@@ -102,7 +103,7 @@ TEST(JaegerSpanRecordable, SetDuration)
 
 TEST(JaegerSpanRecordable, SetStatus)
 {
-  opentelemetry::exporter::jaeger::JaegerRecordable rec;
+  JaegerRecordable rec;
 
   const char *error_description = "Error test";
   rec.SetStatus(trace::StatusCode::kError, error_description);
@@ -125,12 +126,12 @@ TEST(JaegerSpanRecordable, SetStatus)
 
 TEST(JaegerSpanRecordable, AddEvent)
 {
-  opentelemetry::exporter::jaeger::JaegerRecordable rec;
+  JaegerRecordable rec;
 
   nostd::string_view name = "Test Event";
 
   std::chrono::system_clock::time_point event_time = std::chrono::system_clock::now();
-  opentelemetry::common::SystemTimestamp event_timestamp(event_time);
+  common::SystemTimestamp event_timestamp(event_time);
   uint64_t epoch_us =
       std::chrono::duration_cast<std::chrono::microseconds>(event_time.time_since_epoch()).count();
 
@@ -142,7 +143,7 @@ TEST(JaegerSpanRecordable, AddEvent)
 
   rec.AddEvent(
       "Test Event", event_timestamp,
-      opentelemetry::common::KeyValueIterableView<std::map<std::string, int64_t>>(attributes));
+      common::KeyValueIterableView<std::map<std::string, int64_t>>(attributes));
   thrift::Log log = rec.Logs().at(0);
   EXPECT_EQ(log.timestamp, epoch_us);
   auto tags    = log.fields;
@@ -159,7 +160,7 @@ TEST(JaegerSpanRecordable, AddEvent)
 
 TEST(JaegerSpanRecordable, SetInstrumentationLibrary)
 {
-  opentelemetry::exporter::jaeger::JaegerRecordable rec;
+  JaegerRecordable rec;
 
   std::string library_name     = "opentelemetry-cpp";
   std::string library_version  = "0.1.0";
@@ -181,7 +182,7 @@ TEST(JaegerSpanRecordable, SetInstrumentationLibrary)
 
 TEST(JaegerSpanRecordable, SetResource)
 {
-  opentelemetry::exporter::jaeger::JaegerRecordable rec;
+  JaegerRecordable rec;
 
   const std::string service_name_key = "service.name";
   std::string service_name_value     = "test-jaeger-service-name";

--- a/exporters/ostream/src/span_exporter.cc
+++ b/exporters/ostream/src/span_exporter.cc
@@ -7,6 +7,7 @@
 
 namespace nostd    = opentelemetry::nostd;
 namespace sdktrace = opentelemetry::sdk::trace;
+namespace trace_api = opentelemetry::trace;
 
 OPENTELEMETRY_BEGIN_NAMESPACE
 namespace exporter
@@ -14,19 +15,19 @@ namespace exporter
 namespace trace
 {
 
-std::ostream &operator<<(std::ostream &os, opentelemetry::trace::SpanKind span_kind)
+std::ostream &operator<<(std::ostream &os, trace_api::SpanKind span_kind)
 {
   switch (span_kind)
   {
-    case opentelemetry::trace::SpanKind::kClient:
+    case trace_api::SpanKind::kClient:
       return os << "Client";
-    case opentelemetry::trace::SpanKind::kInternal:
+    case trace_api::SpanKind::kInternal:
       return os << "Internal";
-    case opentelemetry::trace::SpanKind::kServer:
+    case trace_api::SpanKind::kServer:
       return os << "Server";
-    case opentelemetry::trace::SpanKind::kProducer:
+    case trace_api::SpanKind::kProducer:
       return os << "Producer";
-    case opentelemetry::trace::SpanKind::kConsumer:
+    case trace_api::SpanKind::kConsumer:
       return os << "Consumer";
   };
   return os << "";

--- a/exporters/ostream/test/ostream_log_test.cc
+++ b/exporters/ostream/test/ostream_log_test.cc
@@ -123,8 +123,8 @@ TEST(OStreamLogExporter, SimpleLogToCout)
 
   std::string expectedOutput =
       "{\n"
-      "  timestamp     : "
-      std::to_string(now.time_since_epoch().count())
+      "  timestamp     : " +
+      std::to_string(now.time_since_epoch().count()) +
       "\n"
       "  severity_num  : 1\n"
       "  severity_text : TRACE\n"
@@ -271,8 +271,8 @@ TEST(OStreamLogExporter, IntegrationTest)
   // Compare actual vs expected outputs
   std::string expectedOutput =
       "{\n"
-      "  timestamp     : "
-      std::to_string(now.time_since_epoch().count())
+      "  timestamp     : " +
+      std::to_string(now.time_since_epoch().count()) +
       "\n"
       "  severity_num  : 5\n"
       "  severity_text : DEBUG\n"

--- a/exporters/ostream/test/ostream_log_test.cc
+++ b/exporters/ostream/test/ostream_log_test.cc
@@ -16,6 +16,9 @@
 namespace sdklogs  = opentelemetry::sdk::logs;
 namespace logs_api = opentelemetry::logs;
 namespace nostd    = opentelemetry::nostd;
+namespace exporterlogs  = opentelemetry::exporter::logs;
+namespace common    = opentelemetry::common;
+
 
 OPENTELEMETRY_BEGIN_NAMESPACE
 namespace exporter
@@ -27,7 +30,7 @@ namespace logs
 TEST(OStreamLogExporter, Shutdown)
 {
   auto exporter =
-      std::unique_ptr<sdklogs::LogExporter>(new opentelemetry::exporter::logs::OStreamLogExporter);
+      std::unique_ptr<sdklogs::LogExporter>(new exporterlogs::OStreamLogExporter);
 
   // Save cout's original buffer here
   std::streambuf *original = std::cout.rdbuf();
@@ -56,7 +59,7 @@ TEST(OStreamLogExporter, Shutdown)
 TEST(OstreamLogExporter, DefaultLogRecordToCout)
 {
   auto exporter = std::unique_ptr<sdklogs::LogExporter>(
-      new opentelemetry::exporter::logs::OStreamLogExporter(std::cout));
+      new exporterlogs::OStreamLogExporter(std::cout));
 
   // Save cout's original buffer here
   std::streambuf *original = std::cout.rdbuf();
@@ -95,7 +98,7 @@ TEST(OStreamLogExporter, SimpleLogToCout)
 {
   // Initialize an Ostream exporter to std::cout
   auto exporter = std::unique_ptr<sdklogs::LogExporter>(
-      new opentelemetry::exporter::logs::OStreamLogExporter(std::cout));
+      new exporterlogs::OStreamLogExporter(std::cout));
 
   // Save original stream buffer, then redirect cout to our new stream buffer
   std::streambuf *original = std::cout.rdbuf();
@@ -104,7 +107,7 @@ TEST(OStreamLogExporter, SimpleLogToCout)
 
   // Pass a default recordable created by the exporter to be exported
   // Create a log record and manually timestamp, severity, name, message
-  opentelemetry::common::SystemTimestamp now(std::chrono::system_clock::now());
+  common::SystemTimestamp now(std::chrono::system_clock::now());
 
   auto record = std::unique_ptr<sdklogs::Recordable>(new sdklogs::LogRecord());
   record->SetTimestamp(now);
@@ -120,8 +123,8 @@ TEST(OStreamLogExporter, SimpleLogToCout)
 
   std::string expectedOutput =
       "{\n"
-      "  timestamp     : " +
-      std::to_string(now.time_since_epoch().count()) +
+      "  timestamp     : "
+      std::to_string(now.time_since_epoch().count())
       "\n"
       "  severity_num  : 1\n"
       "  severity_text : TRACE\n"
@@ -144,7 +147,7 @@ TEST(OStreamLogExporter, LogWithStringAttributesToCerr)
 {
   // Initialize an Ostream exporter to cerr
   auto exporter = std::unique_ptr<sdklogs::LogExporter>(
-      new opentelemetry::exporter::logs::OStreamLogExporter(std::cerr));
+      new exporterlogs::OStreamLogExporter(std::cerr));
 
   // Save original stream buffer, then redirect cout to our new stream buffer
   std::streambuf *original = std::cerr.rdbuf();
@@ -191,7 +194,7 @@ TEST(OStreamLogExporter, LogWithVariantTypesToClog)
 
   // Initialize an Ostream exporter to cerr
   auto exporter = std::unique_ptr<sdklogs::LogExporter>(
-      new opentelemetry::exporter::logs::OStreamLogExporter(std::clog));
+      new exporterlogs::OStreamLogExporter(std::clog));
 
   // Save original stream buffer, then redirect cout to our new stream buffer
   std::streambuf *original = std::clog.rdbuf();
@@ -203,13 +206,13 @@ TEST(OStreamLogExporter, LogWithVariantTypesToClog)
 
   // Set resources for this log record of only integer types as the value
   std::array<int, 3> array1 = {1, 2, 3};
-  opentelemetry::nostd::span<int> data1{array1.data(), array1.size()};
+  nostd::span<int> data1{array1.data(), array1.size()};
   record->SetResource("res1", data1);
 
   // Set resources for this log record of bool types as the value
   // e.g. key/value is a par of type <string, array of bools>
   std::array<bool, 3> array = {false, true, false};
-  record->SetAttribute("attr1", opentelemetry::nostd::span<bool>{array.data(), array.size()});
+  record->SetAttribute("attr1", nostd::span<bool>{array.data(), array.size()});
 
   // Log a record to clog
   exporter->Export(nostd::span<std::unique_ptr<sdklogs::Recordable>>(&record, 1));
@@ -241,7 +244,7 @@ TEST(OStreamLogExporter, IntegrationTest)
 {
   // Initialize a logger
   auto exporter =
-      std::unique_ptr<sdklogs::LogExporter>(new opentelemetry::exporter::logs::OStreamLogExporter);
+      std::unique_ptr<sdklogs::LogExporter>(new exporterlogs::OStreamLogExporter);
   auto processor =
       std::shared_ptr<sdklogs::LogProcessor>(new sdklogs::SimpleLogProcessor(std::move(exporter)));
   auto sdkProvider = std::shared_ptr<sdklogs::LoggerProvider>(new sdklogs::LoggerProvider());
@@ -259,8 +262,8 @@ TEST(OStreamLogExporter, IntegrationTest)
   std::cout.rdbuf(stdcoutOutput.rdbuf());
 
   // Write a log to ostream exporter
-  opentelemetry::common::SystemTimestamp now(std::chrono::system_clock::now());
-  logger->Log(opentelemetry::logs::Severity::kDebug, "", "Hello", {}, {}, {}, {}, {}, now);
+  common::SystemTimestamp now(std::chrono::system_clock::now());
+  logger->Log(logs_api::Severity::kDebug, "", "Hello", {}, {}, {}, {}, {}, now);
 
   // Restore cout's original streambuf
   std::cout.rdbuf(original);
@@ -268,8 +271,8 @@ TEST(OStreamLogExporter, IntegrationTest)
   // Compare actual vs expected outputs
   std::string expectedOutput =
       "{\n"
-      "  timestamp     : " +
-      std::to_string(now.time_since_epoch().count()) +
+      "  timestamp     : "
+      std::to_string(now.time_since_epoch().count())
       "\n"
       "  severity_num  : 5\n"
       "  severity_text : DEBUG\n"

--- a/exporters/ostream/test/ostream_metrics_test.cc
+++ b/exporters/ostream/test/ostream_metrics_test.cc
@@ -18,14 +18,15 @@
 namespace sdkmetrics  = opentelemetry::sdk::metrics;
 namespace metrics_api = opentelemetry::metrics;
 namespace nostd       = opentelemetry::nostd;
+namespace exportermetrics  = opentelemetry::exporter::metrics;
 
 TEST(OStreamMetricsExporter, PrintCounter)
 {
   auto exporter = std::unique_ptr<sdkmetrics::MetricsExporter>(
-      new opentelemetry::exporter::metrics::OStreamMetricsExporter);
+      new exportermetrics::OStreamMetricsExporter);
 
-  auto aggregator = std::shared_ptr<opentelemetry::sdk::metrics::Aggregator<double>>(
-      new opentelemetry::sdk::metrics::CounterAggregator<double>(
+  auto aggregator = std::shared_ptr<sdkmetrics::Aggregator<double>>(
+      new sdkmetrics::CounterAggregator<double>(
           metrics_api::InstrumentKind::Counter));
 
   aggregator->update(5.5);
@@ -62,10 +63,10 @@ TEST(OStreamMetricsExporter, PrintCounter)
 TEST(OStreamMetricsExporter, PrintMinMaxSumCount)
 {
   auto exporter = std::unique_ptr<sdkmetrics::MetricsExporter>(
-      new opentelemetry::exporter::metrics::OStreamMetricsExporter);
+      new exportermetrics::OStreamMetricsExporter);
 
-  auto aggregator = std::shared_ptr<opentelemetry::sdk::metrics::Aggregator<int>>(
-      new opentelemetry::sdk::metrics::MinMaxSumCountAggregator<int>(
+  auto aggregator = std::shared_ptr<sdkmetrics::Aggregator<int>>(
+      new sdkmetrics::MinMaxSumCountAggregator<int>(
           metrics_api::InstrumentKind::Counter));
 
   aggregator->update(1);
@@ -106,10 +107,10 @@ TEST(OStreamMetricsExporter, PrintMinMaxSumCount)
 TEST(OStreamMetricsExporter, PrintGauge)
 {
   auto exporter = std::unique_ptr<sdkmetrics::MetricsExporter>(
-      new opentelemetry::exporter::metrics::OStreamMetricsExporter);
+      new exportermetrics::OStreamMetricsExporter);
 
-  auto aggregator = std::shared_ptr<opentelemetry::sdk::metrics::Aggregator<short>>(
-      new opentelemetry::sdk::metrics::GaugeAggregator<short>(
+  auto aggregator = std::shared_ptr<sdkmetrics::Aggregator<short>>(
+      new sdkmetrics::GaugeAggregator<short>(
           metrics_api::InstrumentKind::Counter));
 
   aggregator->update(1);
@@ -139,8 +140,8 @@ TEST(OStreamMetricsExporter, PrintGauge)
       "  description : description\n"
       "  labels      : labels\n"
       "  last value  : 9\n"
-      "  timestamp   : " +
-      std::to_string(aggregator->get_checkpoint_timestamp().time_since_epoch().count()) +
+      "  timestamp   : "
+      std::to_string(aggregator->get_checkpoint_timestamp().time_since_epoch().count())
       "\n"
       "}\n";
 
@@ -150,14 +151,14 @@ TEST(OStreamMetricsExporter, PrintGauge)
 TEST(OStreamMetricsExporter, PrintExact)
 {
   auto exporter = std::unique_ptr<sdkmetrics::MetricsExporter>(
-      new opentelemetry::exporter::metrics::OStreamMetricsExporter);
+      new exportermetrics::OStreamMetricsExporter);
 
-  auto aggregator = std::shared_ptr<opentelemetry::sdk::metrics::Aggregator<short>>(
-      new opentelemetry::sdk::metrics::ExactAggregator<short>(metrics_api::InstrumentKind::Counter,
+  auto aggregator = std::shared_ptr<sdkmetrics::Aggregator<short>>(
+      new sdkmetrics::ExactAggregator<short>(metrics_api::InstrumentKind::Counter,
                                                               true));
 
-  auto aggregator2 = std::shared_ptr<opentelemetry::sdk::metrics::Aggregator<short>>(
-      new opentelemetry::sdk::metrics::ExactAggregator<short>(metrics_api::InstrumentKind::Counter,
+  auto aggregator2 = std::shared_ptr<sdkmetrics::Aggregator<short>>(
+      new sdkmetrics::ExactAggregator<short>(metrics_api::InstrumentKind::Counter,
                                                               false));
 
   for (int i = 0; i < 10; i++)
@@ -207,11 +208,11 @@ TEST(OStreamMetricsExporter, PrintExact)
 TEST(OStreamMetricsExporter, PrintHistogram)
 {
   auto exporter = std::unique_ptr<sdkmetrics::MetricsExporter>(
-      new opentelemetry::exporter::metrics::OStreamMetricsExporter);
+      new exportermetrics::OStreamMetricsExporter);
 
   std::vector<double> boundaries{10, 20, 30, 40, 50};
-  auto aggregator = std::shared_ptr<opentelemetry::sdk::metrics::Aggregator<float>>(
-      new opentelemetry::sdk::metrics::HistogramAggregator<float>(
+  auto aggregator = std::shared_ptr<sdkmetrics::Aggregator<float>>(
+      new sdkmetrics::HistogramAggregator<float>(
           metrics_api::InstrumentKind::Counter, boundaries));
 
   for (float i = 0; i < 60; i++)
@@ -252,11 +253,11 @@ TEST(OStreamMetricsExporter, PrintHistogram)
 TEST(OStreamMetricsExporter, PrintSketch)
 {
   auto exporter = std::unique_ptr<sdkmetrics::MetricsExporter>(
-      new opentelemetry::exporter::metrics::OStreamMetricsExporter);
+      new exportermetrics::OStreamMetricsExporter);
 
   std::vector<double> boundaries{1, 3, 5, 7, 9};
-  auto aggregator = std::shared_ptr<opentelemetry::sdk::metrics::Aggregator<int>>(
-      new opentelemetry::sdk::metrics::SketchAggregator<int>(metrics_api::InstrumentKind::Counter,
+  auto aggregator = std::shared_ptr<sdkmetrics::Aggregator<int>>(
+      new sdkmetrics::SketchAggregator<int>(metrics_api::InstrumentKind::Counter,
                                                              .000005));
 
   for (int i = 0; i < 10; i++)

--- a/exporters/ostream/test/ostream_metrics_test.cc
+++ b/exporters/ostream/test/ostream_metrics_test.cc
@@ -140,8 +140,8 @@ TEST(OStreamMetricsExporter, PrintGauge)
       "  description : description\n"
       "  labels      : labels\n"
       "  last value  : 9\n"
-      "  timestamp   : "
-      std::to_string(aggregator->get_checkpoint_timestamp().time_since_epoch().count())
+      "  timestamp   : " +
+      std::to_string(aggregator->get_checkpoint_timestamp().time_since_epoch().count()) +
       "\n"
       "}\n";
 

--- a/exporters/ostream/test/ostream_span_test.cc
+++ b/exporters/ostream/test/ostream_span_test.cc
@@ -135,8 +135,8 @@ TEST(OStreamSpanExporter, PrintSpanWithBasicFields)
       "  span_id       : 0102030405060708\n"
       "  tracestate    : state1=value\n"
       "  parent_span_id: 0807060504030201\n"
-      "  start         : "
-      start
+      "  start         : " +
+      start +
       "\n"
       "  duration      : 100\n"
       "  description   : Test Description\n"
@@ -236,7 +236,7 @@ TEST(OStreamSpanExporter, PrintSpanWithEvents)
 
   auto recordable = processor->MakeRecordable();
   common::SystemTimestamp now(std::chrono::system_clock::now());
-  common::SystemTimestamp next(std::chrono::system_clock::now()
+  common::SystemTimestamp next(std::chrono::system_clock::now() +
                                               std::chrono::seconds(1));
 
   std::string now_str  = std::to_string(now.time_since_epoch().count());
@@ -264,15 +264,15 @@ TEST(OStreamSpanExporter, PrintSpanWithEvents)
       "  events        : \n"
       "\t{\n"
       "\t  name          : hello\n"
-      "\t  timestamp     : "
-      now_str
+      "\t  timestamp     : " +
+      now_str +
       "\n"
       "\t  attributes    : \n"
       "\t}\n"
       "\t{\n"
       "\t  name          : world\n"
-      "\t  timestamp     : "
-      next_str
+      "\t  timestamp     : " +
+      next_str +
       "\n"
       "\t  attributes    : \n"
       "\t\tattr1: string\n"

--- a/exporters/otlp/src/otlp_http_exporter.cc
+++ b/exporters/otlp/src/otlp_http_exporter.cc
@@ -71,8 +71,8 @@ public:
       {
         std::stringstream ss;
         ss << "[OTLP HTTP Exporter] Status:" << response.GetStatusCode() << "Header:";
-        response.ForEachHeader([&ss](opentelemetry::nostd::string_view header_name,
-                                     opentelemetry::nostd::string_view header_value) {
+        response.ForEachHeader([&ss](nostd::string_view header_name,
+                                     nostd::string_view header_value) {
           ss << "\t" << header_name.data() << " : " << header_value.data() << ",";
           return true;
         });
@@ -109,7 +109,7 @@ public:
 
   // Callback method when an http event occurs
   void OnEvent(http_client::SessionState state,
-               opentelemetry::nostd::string_view reason) noexcept override
+               nostd::string_view reason) noexcept override
   {
     // If any failure event occurs, release the condition variable to unblock main thread
     switch (state)

--- a/exporters/otlp/test/otlp_grpc_exporter_benchmark.cc
+++ b/exporters/otlp/test/otlp_grpc_exporter_benchmark.cc
@@ -12,6 +12,8 @@ namespace exporter
 namespace otlp
 {
 
+namespace trace_api = opentelemetry::trace;
+
 const int kBatchSize     = 200;
 const int kNumAttributes = 5;
 const int kNumIterations = 1000;
@@ -22,10 +24,10 @@ const trace::SpanId kSpanId(std::array<const uint8_t, trace::SpanId::kSize>({0, 
                                                                              2}));
 const trace::SpanId kParentSpanId(std::array<const uint8_t, trace::SpanId::kSize>({0, 0, 0, 0, 0, 0,
                                                                                    0, 3}));
-const auto kTraceState = opentelemetry::trace::TraceState::GetDefault() -> Set("key1", "value");
-const opentelemetry::trace::SpanContext kSpanContext{
+const auto kTraceState = trace_api::TraceState::GetDefault() -> Set("key1", "value");
+const trace_api::SpanContext kSpanContext{
     kTraceId, kSpanId,
-    opentelemetry::trace::TraceFlags{opentelemetry::trace::TraceFlags::kIsSampled}, true,
+    trace_api::TraceFlags{trace_api::TraceFlags::kIsSampled}, true,
     kTraceState};
 
 // ----------------------- Helper classes and functions ------------------------

--- a/exporters/prometheus/test/prometheus_collector_test.cc
+++ b/exporters/prometheus/test/prometheus_collector_test.cc
@@ -20,6 +20,8 @@
 #  include "opentelemetry/version.h"
 
 using opentelemetry::exporter::prometheus::PrometheusCollector;
+namespace metric_api = opentelemetry::metrics;
+
 
 OPENTELEMETRY_BEGIN_NAMESPACE
 
@@ -36,35 +38,35 @@ std::shared_ptr<metric_sdk::Aggregator<T>> CreateAgg(metric_sdk::AggregatorKind 
   {
     case metric_sdk::AggregatorKind::Counter: {
       aggregator = std::shared_ptr<metric_sdk::Aggregator<T>>(
-          new metric_sdk::CounterAggregator<T>(opentelemetry::metrics::InstrumentKind::Counter));
+          new metric_sdk::CounterAggregator<T>(metric_api::InstrumentKind::Counter));
       break;
     }
     case metric_sdk::AggregatorKind::MinMaxSumCount: {
       aggregator =
           std::shared_ptr<metric_sdk::Aggregator<T>>(new metric_sdk::MinMaxSumCountAggregator<T>(
-              opentelemetry::metrics::InstrumentKind::Counter));
+              metric_api::InstrumentKind::Counter));
       break;
     }
     case metric_sdk::AggregatorKind::Gauge: {
       aggregator = std::shared_ptr<metric_sdk::Aggregator<T>>(
-          new metric_sdk::GaugeAggregator<T>(opentelemetry::metrics::InstrumentKind::Counter));
+          new metric_sdk::GaugeAggregator<T>(metric_api::InstrumentKind::Counter));
       break;
     }
     case metric_sdk::AggregatorKind::Sketch: {
       aggregator = std::shared_ptr<metric_sdk::Aggregator<T>>(new metric_sdk::SketchAggregator<T>(
-          opentelemetry::metrics::InstrumentKind::Counter, 0.000005));
+          metric_api::InstrumentKind::Counter, 0.000005));
       break;
     }
     case metric_sdk::AggregatorKind::Histogram: {
       std::vector<double> boundaries{10, 20};
       aggregator =
           std::shared_ptr<metric_sdk::Aggregator<T>>(new metric_sdk::HistogramAggregator<T>(
-              opentelemetry::metrics::InstrumentKind::Counter, boundaries));
+              metric_api::InstrumentKind::Counter, boundaries));
       break;
     }
     case metric_sdk::AggregatorKind::Exact: {
       aggregator = std::shared_ptr<metric_sdk::Aggregator<T>>(new metric_sdk::ExactAggregator<T>(
-          opentelemetry::metrics::InstrumentKind::Counter, exactMode));
+          metric_api::InstrumentKind::Counter, exactMode));
       break;
     }
     default:

--- a/exporters/zipkin/src/recordable.cc
+++ b/exporters/zipkin/src/recordable.cc
@@ -14,13 +14,16 @@ namespace zipkin
 {
 
 using namespace opentelemetry::sdk::resource;
+namespace trace_api = opentelemetry::trace;
+namespace common = opentelemetry::common;
+namespace sdk = opentelemetry::sdk;
 
 // constexpr needs keys to be constexpr, const is next best to use.
-static const std::map<opentelemetry::trace::SpanKind, std::string> kSpanKindMap = {
-    {opentelemetry::trace::SpanKind::kClient, "CLIENT"},
-    {opentelemetry::trace::SpanKind::kServer, "SERVER"},
-    {opentelemetry::trace::SpanKind::kConsumer, "CONSUMER"},
-    {opentelemetry::trace::SpanKind::kProducer, "PRODUCER"},
+static const std::map<trace_api::SpanKind, std::string> kSpanKindMap = {
+    {trace_api::SpanKind::kClient, "CLIENT"},
+    {trace_api::SpanKind::kServer, "SERVER"},
+    {trace_api::SpanKind::kConsumer, "CONSUMER"},
+    {trace_api::SpanKind::kProducer, "PRODUCER"},
 };
 
 //
@@ -28,8 +31,8 @@ static const std::map<opentelemetry::trace::SpanKind, std::string> kSpanKindMap 
 //
 const int kAttributeValueSize = 16;
 
-void Recordable::SetIdentity(const opentelemetry::trace::SpanContext &span_context,
-                             opentelemetry::trace::SpanId parent_span_id) noexcept
+void Recordable::SetIdentity(const trace_api::SpanContext &span_context,
+                             trace_api::SpanId parent_span_id) noexcept
 {
   char trace_id_lower_base16[trace::TraceId::kSize * 2] = {0};
   span_context.trace_id().ToLowerBase16(trace_id_lower_base16);
@@ -48,12 +51,12 @@ void Recordable::SetIdentity(const opentelemetry::trace::SpanContext &span_conte
 
 void PopulateAttribute(nlohmann::json &attribute,
                        nostd::string_view key,
-                       const opentelemetry::common::AttributeValue &value)
+                       const common::AttributeValue &value)
 {
   // Assert size of variant to ensure that this method gets updated if the variant
   // definition changes
   static_assert(
-      nostd::variant_size<opentelemetry::common::AttributeValue>::value == kAttributeValueSize,
+      nostd::variant_size<common::AttributeValue>::value == kAttributeValueSize,
       "AttributeValue contains unknown type");
 
   if (nostd::holds_alternative<bool>(value))
@@ -156,7 +159,7 @@ void PopulateAttribute(nlohmann::json &attribute,
 }
 
 void Recordable::SetAttribute(nostd::string_view key,
-                              const opentelemetry::common::AttributeValue &value) noexcept
+                              const common::AttributeValue &value) noexcept
 {
   if (!span_.contains("tags"))
   {
@@ -187,7 +190,7 @@ void Recordable::AddEvent(nostd::string_view name,
   span_["annotations"].push_back(annotation);
 }
 
-void Recordable::AddLink(const opentelemetry::trace::SpanContext &span_context,
+void Recordable::AddLink(const trace_api::SpanContext &span_context,
                          const common::KeyValueIterable &attributes) noexcept
 {
   // TODO: Currently not supported by specs:
@@ -211,7 +214,7 @@ void Recordable::SetName(nostd::string_view name) noexcept
   span_["name"] = name.data();
 }
 
-void Recordable::SetResource(const opentelemetry::sdk::resource::Resource &resource) noexcept
+void Recordable::SetResource(const sdk::resource::Resource &resource) noexcept
 {
   // only service.name attribute is supported by specs as of now.
   auto attributes = resource.GetAttributes();
@@ -221,7 +224,7 @@ void Recordable::SetResource(const opentelemetry::sdk::resource::Resource &resou
   }
 }
 
-void Recordable::SetStartTime(opentelemetry::common::SystemTimestamp start_time) noexcept
+void Recordable::SetStartTime(common::SystemTimestamp start_time) noexcept
 {
   span_["timestamp"] =
       std::chrono::duration_cast<std::chrono::microseconds>(start_time.time_since_epoch()).count();
@@ -232,7 +235,7 @@ void Recordable::SetDuration(std::chrono::nanoseconds duration) noexcept
   span_["duration"] = std::chrono::duration_cast<std::chrono::microseconds>(duration).count();
 }
 
-void Recordable::SetSpanKind(opentelemetry::trace::SpanKind span_kind) noexcept
+void Recordable::SetSpanKind(trace_api::SpanKind span_kind) noexcept
 {
   auto span_iter = kSpanKindMap.find(span_kind);
   if (span_iter != kSpanKindMap.end())
@@ -242,7 +245,7 @@ void Recordable::SetSpanKind(opentelemetry::trace::SpanKind span_kind) noexcept
 }
 
 void Recordable::SetInstrumentationLibrary(
-    const opentelemetry::sdk::instrumentationlibrary::InstrumentationLibrary
+    const sdk::instrumentationlibrary::InstrumentationLibrary
         &instrumentation_library) noexcept
 {
   span_["tags"]["otel.library.name"]    = instrumentation_library.GetName();

--- a/ext/src/http/client/curl/http_client_factory_curl.cc
+++ b/ext/src/http/client/curl/http_client_factory_curl.cc
@@ -5,14 +5,16 @@
 #include "opentelemetry/ext/http/client/http_client.h"
 #include "opentelemetry/ext/http/client/http_client_factory.h"
 
-std::shared_ptr<opentelemetry::ext::http::client::HttpClient>
-opentelemetry::ext::http::client::HttpClientFactory::Create()
+namespace http_client = opentelemetry::ext::http::client;
+
+std::shared_ptr<http_client::HttpClient>
+http_client::HttpClientFactory::Create()
 {
-  return std::make_shared<opentelemetry::ext::http::client::curl::HttpClient>();
+  return std::make_shared<http_client::curl::HttpClient>();
 }
 
-std::shared_ptr<opentelemetry::ext::http::client::HttpClientSync>
-opentelemetry::ext::http::client::HttpClientFactory::CreateSync()
+std::shared_ptr<http_client::HttpClientSync>
+http_client::HttpClientFactory::CreateSync()
 {
-  return std::make_shared<opentelemetry::ext::http::client::curl::HttpClientSync>();
+  return std::make_shared<http_client::curl::HttpClientSync>();
 }

--- a/ext/src/zpages/tracez_http_server.cc
+++ b/ext/src/zpages/tracez_http_server.cc
@@ -8,6 +8,7 @@ namespace ext
 {
 namespace zpages
 {
+namespace nostd = opentelemetry::nostd;
 
 json TracezHttpServer::GetAggregations()
 {
@@ -123,34 +124,34 @@ json TracezHttpServer::GetAttributesJSON(
     switch (val.index())
     {
       case 0:
-        attributes_json[key] = opentelemetry::nostd::get<0>(val);
+        attributes_json[key] = nostd::get<0>(val);
         break;
       case 1:
-        attributes_json[key] = opentelemetry::nostd::get<1>(val);
+        attributes_json[key] = nostd::get<1>(val);
         break;
       case 2:
-        attributes_json[key] = opentelemetry::nostd::get<2>(val);
+        attributes_json[key] = nostd::get<2>(val);
         break;
       case 3:
-        attributes_json[key] = opentelemetry::nostd::get<3>(val);
+        attributes_json[key] = nostd::get<3>(val);
         break;
       case 4:
-        attributes_json[key] = opentelemetry::nostd::get<4>(val);
+        attributes_json[key] = nostd::get<4>(val);
         break;
       case 5:
-        attributes_json[key] = opentelemetry::nostd::get<5>(val);
+        attributes_json[key] = nostd::get<5>(val);
         break;
       case 6:
-        attributes_json[key] = opentelemetry::nostd::get<6>(val);
+        attributes_json[key] = nostd::get<6>(val);
         break;
       case 7:
-        attributes_json[key] = opentelemetry::nostd::get<7>(val);
+        attributes_json[key] = nostd::get<7>(val);
         break;
       case 8:
-        attributes_json[key] = opentelemetry::nostd::get<8>(val);
+        attributes_json[key] = nostd::get<8>(val);
         break;
       case 9:
-        attributes_json[key] = opentelemetry::nostd::get<9>(val);
+        attributes_json[key] = nostd::get<9>(val);
         break;
     }
   }

--- a/ext/src/zpages/tracez_processor.cc
+++ b/ext/src/zpages/tracez_processor.cc
@@ -8,15 +8,16 @@ namespace ext
 {
 namespace zpages
 {
+namespace trace_sdk = opentelemetry::sdk::trace;
 
-void TracezSpanProcessor::OnStart(opentelemetry::sdk::trace::Recordable &span,
+void TracezSpanProcessor::OnStart(trace_sdk::Recordable &span,
                                   const opentelemetry::trace::SpanContext &parent_context) noexcept
 {
   shared_data_->OnStart(static_cast<ThreadsafeSpanData *>(&span));
 }
 
 void TracezSpanProcessor::OnEnd(
-    std::unique_ptr<opentelemetry::sdk::trace::Recordable> &&span) noexcept
+    std::unique_ptr<trace_sdk::Recordable> &&span) noexcept
 {
   shared_data_->OnEnd(
       std::unique_ptr<ThreadsafeSpanData>(static_cast<ThreadsafeSpanData *>(span.release())));

--- a/ext/test/http/curl_http_test.cc
+++ b/ext/test/http/curl_http_test.cc
@@ -20,13 +20,14 @@
 
 namespace curl        = opentelemetry::ext::http::client::curl;
 namespace http_client = opentelemetry::ext::http::client;
+namespace nostd = opentelemetry::nostd;
 
 class CustomEventHandler : public http_client::EventHandler
 {
 public:
   virtual void OnResponse(http_client::Response &response) noexcept override{};
   virtual void OnEvent(http_client::SessionState state,
-                       opentelemetry::nostd::string_view reason) noexcept override
+                       nostd::string_view reason) noexcept override
   {}
   virtual void OnConnecting(const http_client::SSLCertificate &) noexcept {}
   virtual ~CustomEventHandler() = default;
@@ -166,8 +167,8 @@ TEST_F(BasicCurlHttpTests, HttpResponse)
   const char *b          = "test-data";
   http_client::Body body = {b, b + strlen(b)};
   int count              = 0;
-  res.ForEachHeader("name1", [&count](opentelemetry::nostd::string_view name,
-                                      opentelemetry::nostd::string_view value) {
+  res.ForEachHeader("name1", [&count](nostd::string_view name,
+                                      nostd::string_view value) {
     if (name != "name1")
       return false;
     if (value != "value1_1" && value != "value1_2")
@@ -178,7 +179,7 @@ TEST_F(BasicCurlHttpTests, HttpResponse)
   ASSERT_EQ(count, 2);
   count = 0;
   res.ForEachHeader(
-      [&count](opentelemetry::nostd::string_view name, opentelemetry::nostd::string_view value) {
+      [&count](nostd::string_view name, nostd::string_view value) {
         if (name != "name1" && name != "name2" && name != "name3")
           return false;
         if (value != "value1_1" && value != "value1_2" && value != "value2" && value != "value3")

--- a/ext/test/zpages/threadsafe_span_data_test.cc
+++ b/ext/test/zpages/threadsafe_span_data_test.cc
@@ -13,10 +13,12 @@ using opentelemetry::ext::zpages::ThreadsafeSpanData;
 using opentelemetry::sdk::common::AttributeConverter;
 using opentelemetry::sdk::common::OwnedAttributeValue;
 
+namespace trace_api    = opentelemetry::trace;
+
 TEST(ThreadsafeSpanData, DefaultValues)
 {
-  opentelemetry::trace::SpanContext empty_span_context{false, false};
-  opentelemetry::trace::SpanId zero_span_id;
+  trace_api::SpanContext empty_span_context{false, false};
+  trace_api::SpanId zero_span_id;
   ThreadsafeSpanData data;
 
   ASSERT_EQ(data.GetTraceId(), empty_span_context.trace_id());
@@ -24,7 +26,7 @@ TEST(ThreadsafeSpanData, DefaultValues)
   ASSERT_EQ(data.GetSpanContext(), empty_span_context);
   ASSERT_EQ(data.GetParentSpanId(), zero_span_id);
   ASSERT_EQ(data.GetName(), "");
-  ASSERT_EQ(data.GetStatus(), opentelemetry::trace::StatusCode::kUnset);
+  ASSERT_EQ(data.GetStatus(), trace_api::StatusCode::kUnset);
   ASSERT_EQ(data.GetDescription(), "");
   ASSERT_EQ(data.GetStartTime().time_since_epoch(), std::chrono::nanoseconds(0));
   ASSERT_EQ(data.GetDuration(), std::chrono::nanoseconds(0));
@@ -36,21 +38,21 @@ TEST(ThreadsafeSpanData, Set)
   constexpr uint8_t trace_id_buf[]       = {1, 2, 3, 4, 5, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7, 8};
   constexpr uint8_t span_id_buf[]        = {1, 2, 3, 4, 5, 6, 7, 8};
   constexpr uint8_t parent_span_id_buf[] = {8, 7, 6, 5, 4, 3, 2, 1};
-  opentelemetry::trace::TraceId trace_id{trace_id_buf};
-  opentelemetry::trace::SpanId span_id{span_id_buf};
-  opentelemetry::trace::SpanId parent_span_id{parent_span_id_buf};
-  const auto trace_state = opentelemetry::trace::TraceState::GetDefault()->Set("key1", "value");
-  const opentelemetry::trace::SpanContext span_context{
+  trace_api::TraceId trace_id{trace_id_buf};
+  trace_api::SpanId span_id{span_id_buf};
+  trace_api::SpanId parent_span_id{parent_span_id_buf};
+  const auto trace_state = trace_api::TraceState::GetDefault()->Set("key1", "value");
+  const trace_api::SpanContext span_context{
       trace_id, span_id,
-      opentelemetry::trace::TraceFlags{opentelemetry::trace::TraceFlags::kIsSampled}, true,
+      trace_api::TraceFlags{trace_api::TraceFlags::kIsSampled}, true,
       trace_state};
   opentelemetry::common::SystemTimestamp now(std::chrono::system_clock::now());
 
   ThreadsafeSpanData data;
   data.SetIdentity(span_context, parent_span_id);
   data.SetName("span name");
-  data.SetSpanKind(opentelemetry::trace::SpanKind::kServer);
-  data.SetStatus(opentelemetry::trace::StatusCode::kOk, "description");
+  data.SetSpanKind(trace_api::SpanKind::kServer);
+  data.SetStatus(trace_api::StatusCode::kOk, "description");
   data.SetStartTime(now);
   data.SetDuration(std::chrono::nanoseconds(1000000));
   data.SetAttribute("attr1", (int64_t)314159);
@@ -64,7 +66,7 @@ TEST(ThreadsafeSpanData, Set)
   ASSERT_EQ(trace_state_key1_value, "value");
   ASSERT_EQ(data.GetParentSpanId(), parent_span_id);
   ASSERT_EQ(data.GetName(), "span name");
-  ASSERT_EQ(data.GetStatus(), opentelemetry::trace::StatusCode::kOk);
+  ASSERT_EQ(data.GetStatus(), trace_api::StatusCode::kOk);
   ASSERT_EQ(data.GetDescription(), "description");
   ASSERT_EQ(data.GetStartTime().time_since_epoch(), now.time_since_epoch());
   ASSERT_EQ(data.GetDuration(), std::chrono::nanoseconds(1000000));

--- a/sdk/src/logs/logger_provider.cc
+++ b/sdk/src/logs/logger_provider.cc
@@ -5,6 +5,9 @@
 
 #  include "opentelemetry/sdk/logs/logger_provider.h"
 
+namespace nostd = opentelemetry::nostd;
+namespace logs = opentelemetry::logs;
+
 OPENTELEMETRY_BEGIN_NAMESPACE
 namespace sdk
 {
@@ -13,9 +16,9 @@ namespace logs
 
 LoggerProvider::LoggerProvider() noexcept : processor_{nullptr} {}
 
-opentelemetry::nostd::shared_ptr<opentelemetry::logs::Logger> LoggerProvider::GetLogger(
-    opentelemetry::nostd::string_view name,
-    opentelemetry::nostd::string_view options) noexcept
+nostd::shared_ptr<logs::Logger> LoggerProvider::GetLogger(
+    nostd::string_view name,
+    nostd::string_view options) noexcept
 {
   // Ensure only one thread can read/write from the map of loggers
   std::lock_guard<std::mutex> lock_guard{mu_};
@@ -24,7 +27,7 @@ opentelemetry::nostd::shared_ptr<opentelemetry::logs::Logger> LoggerProvider::Ge
   auto loggerkv = loggers_.find(name.data());
   if (loggerkv != loggers_.end())
   {
-    return opentelemetry::nostd::shared_ptr<opentelemetry::logs::Logger>(loggerkv->second);
+    return nostd::shared_ptr<logs::Logger>(loggerkv->second);
   }
 
   // Check if creating a new logger would exceed the max number of loggers
@@ -42,14 +45,14 @@ opentelemetry::nostd::shared_ptr<opentelemetry::logs::Logger> LoggerProvider::Ge
 
   // If no logger with that name exists yet, create it and add it to the map of loggers
 
-  opentelemetry::nostd::shared_ptr<opentelemetry::logs::Logger> logger(
+  nostd::shared_ptr<logs::Logger> logger(
       new Logger(name, this->shared_from_this()));
   loggers_[name.data()] = logger;
   return logger;
 }
 
-opentelemetry::nostd::shared_ptr<opentelemetry::logs::Logger> LoggerProvider::GetLogger(
-    opentelemetry::nostd::string_view name,
+nostd::shared_ptr<logs::Logger> LoggerProvider::GetLogger(
+    nostd::string_view name,
     nostd::span<nostd::string_view> args) noexcept
 {
   // Currently, no args support

--- a/sdk/src/metrics/meter_provider.cc
+++ b/sdk/src/metrics/meter_provider.cc
@@ -9,15 +9,18 @@ namespace sdk
 {
 namespace metrics
 {
+namespace nostd        = opentelemetry::nostd;
+namespace metrics_api  = opentelemetry::metrics;
+
 MeterProvider::MeterProvider(std::string library_name, std::string library_version) noexcept
     : meter_(new Meter(library_name, library_version))
 {}
 
-opentelemetry::nostd::shared_ptr<opentelemetry::metrics::Meter> MeterProvider::GetMeter(
+nostd::shared_ptr<metrics_api::Meter> MeterProvider::GetMeter(
     nostd::string_view library_name,
     nostd::string_view library_version) noexcept
 {
-  return opentelemetry::nostd::shared_ptr<opentelemetry::metrics::Meter>(meter_);
+  return nostd::shared_ptr<metrics_api::Meter>(meter_);
 }
 
 }  // namespace metrics

--- a/sdk/src/trace/random_id_generator.cc
+++ b/sdk/src/trace/random_id_generator.cc
@@ -10,19 +10,21 @@ namespace sdk
 {
 namespace trace
 {
+namespace trace_api = opentelemetry::trace;
 
-opentelemetry::trace::SpanId RandomIdGenerator::GenerateSpanId() noexcept
+
+trace_api::SpanId RandomIdGenerator::GenerateSpanId() noexcept
 {
-  uint8_t span_id_buf[opentelemetry::trace::SpanId::kSize];
+  uint8_t span_id_buf[trace_api::SpanId::kSize];
   sdk::common::Random::GenerateRandomBuffer(span_id_buf);
-  return opentelemetry::trace::SpanId(span_id_buf);
+  return trace_api::SpanId(span_id_buf);
 }
 
-opentelemetry::trace::TraceId RandomIdGenerator::GenerateTraceId() noexcept
+trace_api::TraceId RandomIdGenerator::GenerateTraceId() noexcept
 {
-  uint8_t trace_id_buf[opentelemetry::trace::TraceId::kSize];
+  uint8_t trace_id_buf[trace_api::TraceId::kSize];
   sdk::common::Random::GenerateRandomBuffer(trace_id_buf);
-  return opentelemetry::trace::TraceId(trace_id_buf);
+  return trace_api::TraceId(trace_id_buf);
 }
 }  // namespace trace
 }  // namespace sdk

--- a/sdk/src/trace/span.cc
+++ b/sdk/src/trace/span.cc
@@ -16,6 +16,7 @@ namespace trace
 
 using opentelemetry::common::SteadyTimestamp;
 using opentelemetry::common::SystemTimestamp;
+namespace common = opentelemetry::common;
 
 namespace
 {
@@ -46,7 +47,7 @@ SteadyTimestamp NowOr(const SteadyTimestamp &steady)
 
 Span::Span(std::shared_ptr<Tracer> &&tracer,
            nostd::string_view name,
-           const opentelemetry::common::KeyValueIterable &attributes,
+           const common::KeyValueIterable &attributes,
            const trace_api::SpanContextKeyValueIterable &links,
            const trace_api::StartSpanOptions &options,
            const trace_api::SpanContext &parent_span_context,
@@ -68,13 +69,13 @@ Span::Span(std::shared_ptr<Tracer> &&tracer,
                                                : trace_api::SpanId());
 
   attributes.ForEachKeyValue(
-      [&](nostd::string_view key, opentelemetry::common::AttributeValue value) noexcept {
+      [&](nostd::string_view key, common::AttributeValue value) noexcept {
         recordable_->SetAttribute(key, value);
         return true;
       });
 
   links.ForEachKeyValue([&](opentelemetry::trace::SpanContext span_context,
-                            const opentelemetry::common::KeyValueIterable &attributes) {
+                            const common::KeyValueIterable &attributes) {
     recordable_->AddLink(span_context, attributes);
     return true;
   });
@@ -92,7 +93,7 @@ Span::~Span()
 }
 
 void Span::SetAttribute(nostd::string_view key,
-                        const opentelemetry::common::AttributeValue &value) noexcept
+                        const common::AttributeValue &value) noexcept
 {
   std::lock_guard<std::mutex> lock_guard{mu_};
 
@@ -121,7 +122,7 @@ void Span::AddEvent(nostd::string_view name, SystemTimestamp timestamp) noexcept
 
 void Span::AddEvent(nostd::string_view name,
                     SystemTimestamp timestamp,
-                    const opentelemetry::common::KeyValueIterable &attributes) noexcept
+                    const common::KeyValueIterable &attributes) noexcept
 {
   std::lock_guard<std::mutex> lock_guard{mu_};
   if (recordable_ == nullptr)

--- a/sdk/src/trace/tracer_context.cc
+++ b/sdk/src/trace/tracer_context.cc
@@ -9,9 +9,10 @@ namespace sdk
 {
 namespace trace
 {
+namespace resource = opentelemetry::sdk::resource;
 
 TracerContext::TracerContext(std::vector<std::unique_ptr<SpanProcessor>> &&processors,
-                             opentelemetry::sdk::resource::Resource resource,
+                             resource::Resource resource,
                              std::unique_ptr<Sampler> sampler,
                              std::unique_ptr<IdGenerator> id_generator) noexcept
     : resource_(resource),
@@ -25,7 +26,7 @@ Sampler &TracerContext::GetSampler() const noexcept
   return *sampler_;
 }
 
-const opentelemetry::sdk::resource::Resource &TracerContext::GetResource() const noexcept
+const resource::Resource &TracerContext::GetResource() const noexcept
 {
   return resource_;
 }

--- a/sdk/src/trace/tracer_provider.cc
+++ b/sdk/src/trace/tracer_provider.cc
@@ -9,12 +9,15 @@ namespace sdk
 {
 namespace trace
 {
+namespace resource = opentelemetry::sdk::resource;
+namespace trace_api = opentelemetry::trace;
+
 TracerProvider::TracerProvider(std::shared_ptr<sdk::trace::TracerContext> context) noexcept
     : context_{context}
 {}
 
 TracerProvider::TracerProvider(std::unique_ptr<SpanProcessor> processor,
-                               opentelemetry::sdk::resource::Resource resource,
+                               resource::Resource resource,
                                std::unique_ptr<Sampler> sampler,
                                std::unique_ptr<IdGenerator> id_generator) noexcept
 {
@@ -25,7 +28,7 @@ TracerProvider::TracerProvider(std::unique_ptr<SpanProcessor> processor,
 }
 
 TracerProvider::TracerProvider(std::vector<std::unique_ptr<SpanProcessor>> &&processors,
-                               opentelemetry::sdk::resource::Resource resource,
+                               resource::Resource resource,
                                std::unique_ptr<Sampler> sampler,
                                std::unique_ptr<IdGenerator> id_generator) noexcept
 {
@@ -33,7 +36,7 @@ TracerProvider::TracerProvider(std::vector<std::unique_ptr<SpanProcessor>> &&pro
                                              std::move(id_generator));
 }
 
-nostd::shared_ptr<opentelemetry::trace::Tracer> TracerProvider::GetTracer(
+nostd::shared_ptr<trace_api::Tracer> TracerProvider::GetTracer(
     nostd::string_view library_name,
     nostd::string_view library_version,
     nostd::string_view schema_url) noexcept
@@ -55,14 +58,14 @@ nostd::shared_ptr<opentelemetry::trace::Tracer> TracerProvider::GetTracer(
     auto &tracer_lib = tracer->GetInstrumentationLibrary();
     if (tracer_lib.equal(library_name, library_version, schema_url))
     {
-      return nostd::shared_ptr<opentelemetry::trace::Tracer>{tracer};
+      return nostd::shared_ptr<trace_api::Tracer>{tracer};
     }
   }
 
   auto lib = InstrumentationLibrary::Create(library_name, library_version, schema_url);
   tracers_.push_back(std::shared_ptr<opentelemetry::sdk::trace::Tracer>(
       new sdk::trace::Tracer(context_, std::move(lib))));
-  return nostd::shared_ptr<opentelemetry::trace::Tracer>{tracers_.back()};
+  return nostd::shared_ptr<trace_api::Tracer>{tracers_.back()};
 }
 
 void TracerProvider::AddProcessor(std::unique_ptr<SpanProcessor> processor) noexcept
@@ -70,7 +73,7 @@ void TracerProvider::AddProcessor(std::unique_ptr<SpanProcessor> processor) noex
   context_->AddProcessor(std::move(processor));
 }
 
-const opentelemetry::sdk::resource::Resource &TracerProvider::GetResource() const noexcept
+const resource::Resource &TracerProvider::GetResource() const noexcept
 {
   return context_->GetResource();
 }

--- a/sdk/test/logs/log_record_test.cc
+++ b/sdk/test/logs/log_record_test.cc
@@ -11,16 +11,20 @@
 #  include <gtest/gtest.h>
 
 using opentelemetry::sdk::logs::LogRecord;
+namespace trace_api = opentelemetry::trace;
+namespace logs_api = opentelemetry::logs;
+namespace nostd = opentelemetry::nostd;
+
 
 // Test what a default LogRecord with no fields set holds
 TEST(LogRecord, GetDefaultValues)
 {
-  opentelemetry::trace::TraceId zero_trace_id;
-  opentelemetry::trace::SpanId zero_span_id;
-  opentelemetry::trace::TraceFlags zero_trace_flags;
+  trace_api::TraceId zero_trace_id;
+  trace_api::SpanId zero_span_id;
+  trace_api::TraceFlags zero_trace_flags;
   LogRecord record;
 
-  ASSERT_EQ(record.GetSeverity(), opentelemetry::logs::Severity::kInvalid);
+  ASSERT_EQ(record.GetSeverity(), logs_api::Severity::kInvalid);
   ASSERT_EQ(record.GetName(), "");
   ASSERT_EQ(record.GetBody(), "");
   ASSERT_EQ(record.GetResource().size(), 0);
@@ -34,14 +38,14 @@ TEST(LogRecord, GetDefaultValues)
 // Test LogRecord fields are properly set and get
 TEST(LogRecord, SetAndGet)
 {
-  opentelemetry::trace::TraceId trace_id;
-  opentelemetry::trace::SpanId span_id;
-  opentelemetry::trace::TraceFlags trace_flags;
+  trace_api::TraceId trace_id;
+  trace_api::SpanId span_id;
+  trace_api::TraceFlags trace_flags;
   opentelemetry::common::SystemTimestamp now(std::chrono::system_clock::now());
 
   // Set all fields of the LogRecord
   LogRecord record;
-  record.SetSeverity(opentelemetry::logs::Severity::kInvalid);
+  record.SetSeverity(logs_api::Severity::kInvalid);
   record.SetName("Log name");
   record.SetBody("Message");
   record.SetResource("res1", (bool)true);
@@ -52,11 +56,11 @@ TEST(LogRecord, SetAndGet)
   record.SetTimestamp(now);
 
   // Test that all fields match what was set
-  ASSERT_EQ(record.GetSeverity(), opentelemetry::logs::Severity::kInvalid);
+  ASSERT_EQ(record.GetSeverity(), logs_api::Severity::kInvalid);
   ASSERT_EQ(record.GetName(), "Log name");
   ASSERT_EQ(record.GetBody(), "Message");
-  ASSERT_EQ(opentelemetry::nostd::get<bool>(record.GetResource().at("res1")), 1);
-  ASSERT_EQ(opentelemetry::nostd::get<int64_t>(record.GetAttributes().at("attr1")), 314159);
+  ASSERT_EQ(nostd::get<bool>(record.GetResource().at("res1")), 1);
+  ASSERT_EQ(nostd::get<int64_t>(record.GetAttributes().at("attr1")), 314159);
   ASSERT_EQ(record.GetTraceId(), trace_id);
   ASSERT_EQ(record.GetSpanId(), span_id);
   ASSERT_EQ(record.GetTraceFlags(), trace_flags);

--- a/sdk/test/logs/logger_provider_sdk_test.cc
+++ b/sdk/test/logs/logger_provider_sdk_test.cc
@@ -14,20 +14,22 @@
 #  include <gtest/gtest.h>
 
 using namespace opentelemetry::sdk::logs;
+namespace logs_api = opentelemetry::logs;
+namespace nostd = opentelemetry::nostd;
 
 TEST(LoggerProviderSDK, PushToAPI)
 {
-  auto lp = opentelemetry::nostd::shared_ptr<opentelemetry::logs::LoggerProvider>(
-      new opentelemetry::sdk::logs::LoggerProvider());
-  opentelemetry::logs::Provider::SetLoggerProvider(lp);
+  auto lp = nostd::shared_ptr<logs_api::LoggerProvider>(
+      new opentelemetry::sdk::logs_api::LoggerProvider());
+  logs_api::Provider::SetLoggerProvider(lp);
 
   // Check that the loggerprovider was correctly pushed into the API
-  ASSERT_EQ(lp, opentelemetry::logs::Provider::GetLoggerProvider());
+  ASSERT_EQ(lp, logs_api::Provider::GetLoggerProvider());
 }
 
 TEST(LoggerProviderSDK, LoggerProviderGetLoggerSimple)
 {
-  auto lp = std::shared_ptr<opentelemetry::logs::LoggerProvider>(new LoggerProvider());
+  auto lp = std::shared_ptr<logs_api::LoggerProvider>(new LoggerProvider());
 
   auto logger1 = lp->GetLogger("logger1");
   auto logger2 = lp->GetLogger("logger2");
@@ -49,13 +51,13 @@ TEST(LoggerProviderSDK, LoggerProviderLoggerArguments)
   // Currently, arguments are not supported by the loggers.
   // TODO: Once the logging spec defines what arguments are allowed, add more
   // detail to this test
-  auto lp = std::shared_ptr<opentelemetry::logs::LoggerProvider>(new LoggerProvider());
+  auto lp = std::shared_ptr<logs_api::LoggerProvider>(new LoggerProvider());
 
   auto logger1 = lp->GetLogger("logger1", "");
 
   // Check GetLogger(logger_name, args)
-  std::array<opentelemetry::nostd::string_view, 1> sv{"string"};
-  opentelemetry::nostd::span<opentelemetry::nostd::string_view> args{sv};
+  std::array<nostd::string_view, 1> sv{"string"};
+  nostd::span<nostd::string_view> args{sv};
   auto logger2 = lp->GetLogger("logger2", args);
 }
 

--- a/sdk/test/logs/logger_sdk_test.cc
+++ b/sdk/test/logs/logger_sdk_test.cc
@@ -9,6 +9,7 @@
 #  include <gtest/gtest.h>
 
 using namespace opentelemetry::sdk::logs;
+namespace logs_api = opentelemetry::logs;
 
 TEST(LoggerSDK, LogToNullProcessor)
 {
@@ -16,7 +17,7 @@ TEST(LoggerSDK, LogToNullProcessor)
   // even when there is no processor set
   // since it calls Processor::OnReceive()
 
-  auto lp     = std::shared_ptr<opentelemetry::logs::LoggerProvider>(new LoggerProvider());
+  auto lp     = std::shared_ptr<logs_api::LoggerProvider>(new LoggerProvider());
   auto logger = lp->GetLogger("logger");
 
   // Log a sample log record to a nullptr processor
@@ -64,7 +65,7 @@ public:
 TEST(LoggerSDK, LogToAProcessor)
 {
   // Create an API LoggerProvider and logger
-  auto api_lp = std::shared_ptr<opentelemetry::logs::LoggerProvider>(new LoggerProvider());
+  auto api_lp = std::shared_ptr<logs_api::LoggerProvider>(new LoggerProvider());
   auto logger = api_lp->GetLogger("logger");
 
   // Cast the API LoggerProvider to an SDK Logger Provider and assert that it is still the same
@@ -81,9 +82,9 @@ TEST(LoggerSDK, LogToAProcessor)
   ASSERT_EQ(processor, lp->GetProcessor());
 
   // Check that the recordable created by the Log() statement is set properly
-  logger->Log(opentelemetry::logs::Severity::kWarn, "Log Name", "Log Message");
+  logger->Log(logs_api::Severity::kWarn, "Log Name", "Log Message");
 
-  ASSERT_EQ(shared_recordable->GetSeverity(), opentelemetry::logs::Severity::kWarn);
+  ASSERT_EQ(shared_recordable->GetSeverity(), logs_api::Severity::kWarn);
   ASSERT_EQ(shared_recordable->GetName(), "Log Name");
   ASSERT_EQ(shared_recordable->GetBody(), "Log Message");
 }

--- a/sdk/test/logs/simple_log_processor_test.cc
+++ b/sdk/test/logs/simple_log_processor_test.cc
@@ -15,6 +15,7 @@
 
 using namespace opentelemetry::sdk::logs;
 using namespace opentelemetry::sdk::common;
+namespace nostd = opentelemetry::nostd;
 
 /*
  * A test exporter that can return a vector of all the records it has received,
@@ -38,7 +39,7 @@ public:
 
   // Stores the names of the log records this exporter receives to an internal list
   ExportResult Export(
-      const opentelemetry::nostd::span<std::unique_ptr<Recordable>> &records) noexcept override
+      const nostd::span<std::unique_ptr<Recordable>> &records) noexcept override
   {
     *batch_size_received = records.size();
     for (auto &record : records)
@@ -134,7 +135,7 @@ public:
   }
 
   ExportResult Export(
-      const opentelemetry::nostd::span<std::unique_ptr<Recordable>> &records) noexcept override
+      const nostd::span<std::unique_ptr<Recordable>> &records) noexcept override
   {
     return ExportResult::kSuccess;
   }

--- a/sdk/test/metrics/exact_aggregator_test.cc
+++ b/sdk/test/metrics/exact_aggregator_test.cc
@@ -9,10 +9,11 @@
 #  include "opentelemetry/sdk/metrics/aggregator/exact_aggregator.h"
 
 using namespace opentelemetry::sdk::metrics;
+namespace metrics_api = opentelemetry::metrics;
 
 TEST(ExactAggregatorOrdered, Update)
 {
-  ExactAggregator<int> agg(opentelemetry::metrics::InstrumentKind::Counter);
+  ExactAggregator<int> agg(metrics_api::InstrumentKind::Counter);
 
   std::vector<int> correct;
 
@@ -33,7 +34,7 @@ TEST(ExactAggregatorOrdered, Update)
 
 TEST(ExactAggregatorOrdered, Checkpoint)
 {
-  ExactAggregator<int> agg(opentelemetry::metrics::InstrumentKind::Counter);
+  ExactAggregator<int> agg(metrics_api::InstrumentKind::Counter);
 
   std::vector<int> correct;
 
@@ -48,8 +49,8 @@ TEST(ExactAggregatorOrdered, Checkpoint)
 
 TEST(ExactAggregatorOrdered, Merge)
 {
-  ExactAggregator<int> agg1(opentelemetry::metrics::InstrumentKind::Counter);
-  ExactAggregator<int> agg2(opentelemetry::metrics::InstrumentKind::Counter);
+  ExactAggregator<int> agg1(metrics_api::InstrumentKind::Counter);
+  ExactAggregator<int> agg2(metrics_api::InstrumentKind::Counter);
 
   agg1.update(1);
   agg2.update(2);
@@ -64,8 +65,8 @@ TEST(ExactAggregatorOrdered, BadMerge)
 {
   // This verifies that we encounter and error when we try to merge
   // two aggregators of different numeric types together.
-  ExactAggregator<int> agg1(opentelemetry::metrics::InstrumentKind::Counter);
-  ExactAggregator<int> agg2(opentelemetry::metrics::InstrumentKind::ValueRecorder);
+  ExactAggregator<int> agg1(metrics_api::InstrumentKind::Counter);
+  ExactAggregator<int> agg2(metrics_api::InstrumentKind::ValueRecorder);
 
   agg1.update(1);
   agg2.update(2);
@@ -81,10 +82,10 @@ TEST(ExactAggregatorOrdered, Types)
 {
   // This test verifies that we do not encounter any errors when
   // using various numeric types.
-  ExactAggregator<int> agg_int(opentelemetry::metrics::InstrumentKind::Counter);
-  ExactAggregator<long> agg_long(opentelemetry::metrics::InstrumentKind::Counter);
-  ExactAggregator<float> agg_float(opentelemetry::metrics::InstrumentKind::Counter);
-  ExactAggregator<double> agg_double(opentelemetry::metrics::InstrumentKind::Counter);
+  ExactAggregator<int> agg_int(metrics_api::InstrumentKind::Counter);
+  ExactAggregator<long> agg_long(metrics_api::InstrumentKind::Counter);
+  ExactAggregator<float> agg_float(metrics_api::InstrumentKind::Counter);
+  ExactAggregator<double> agg_double(metrics_api::InstrumentKind::Counter);
 
   for (int i = 1; i <= 5; ++i)
   {
@@ -111,7 +112,7 @@ TEST(ExactAggregatorOrdered, Types)
 
 TEST(ExactAggregatorQuant, Update)
 {
-  ExactAggregator<int> agg(opentelemetry::metrics::InstrumentKind::Counter, true);
+  ExactAggregator<int> agg(metrics_api::InstrumentKind::Counter, true);
 
   std::vector<int> correct;
 
@@ -135,7 +136,7 @@ TEST(ExactAggregatorQuant, Checkpoint)
   // This test verifies that the aggregator updates correctly when
   // quantile estimation is turned on.
 
-  ExactAggregator<int> agg(opentelemetry::metrics::InstrumentKind::Counter, true);
+  ExactAggregator<int> agg(metrics_api::InstrumentKind::Counter, true);
 
   std::vector<int> correct;
 
@@ -159,7 +160,7 @@ TEST(ExactAggregatorQuant, Quantile)
   // This test verifies that the quantile estimation function returns
   // the correct values.
 
-  ExactAggregator<int> agg(opentelemetry::metrics::InstrumentKind::Counter, true);
+  ExactAggregator<int> agg(metrics_api::InstrumentKind::Counter, true);
 
   std::vector<int> tmp{3, 9, 42, 57, 163, 210, 272, 300};
   for (int i : tmp)
@@ -176,7 +177,7 @@ TEST(ExactAggregatorInOrder, Quantile)
 {
   // This test verifies that if the user has an exact aggregator in "in-order" mode
   // an exception will be thrown if they call the quantile() function.
-  ExactAggregator<int> agg(opentelemetry::metrics::InstrumentKind::Counter);
+  ExactAggregator<int> agg(metrics_api::InstrumentKind::Counter);
 
   std::vector<int> tmp{3, 9, 42, 57, 163, 210, 272, 300};
   for (int i : tmp)
@@ -202,7 +203,7 @@ TEST(ExactAggregatorQuant, Concurrency)
 {
   // This test checks that the aggregator updates appropriately
   // when called in a multi-threaded context.
-  ExactAggregator<int> agg(opentelemetry::metrics::InstrumentKind::Counter, true);
+  ExactAggregator<int> agg(metrics_api::InstrumentKind::Counter, true);
 
   std::thread first(&callback, std::ref(agg));
   std::thread second(&callback, std::ref(agg));

--- a/sdk/test/metrics/gauge_aggregator_test.cc
+++ b/sdk/test/metrics/gauge_aggregator_test.cc
@@ -8,12 +8,13 @@
 #  include "opentelemetry/sdk/metrics/aggregator/gauge_aggregator.h"
 
 using namespace opentelemetry::sdk::metrics;
+namespace metrics_api = opentelemetry::metrics;
 
 TEST(GaugeAggregator, Update)
 {
   // This tests that the aggregator updates the maintained value correctly
   // after a call to the update() function.
-  auto agg = new GaugeAggregator<int>(opentelemetry::metrics::InstrumentKind::Counter);
+  auto agg = new GaugeAggregator<int>(metrics_api::InstrumentKind::Counter);
 
   // Verify default value
   ASSERT_EQ(agg->get_values()[0], 0);
@@ -36,7 +37,7 @@ TEST(GaugeAggregator, Checkpoint)
   // This tests that the aggregator correctly updates the
   // checkpoint_ value after a call to update() followed
   // by a call to checkpoint().
-  GaugeAggregator<int> agg(opentelemetry::metrics::InstrumentKind::Counter);
+  GaugeAggregator<int> agg(metrics_api::InstrumentKind::Counter);
 
   // Verify default checkpoint, before updates
   ASSERT_EQ(agg.get_checkpoint()[0], 0);
@@ -52,8 +53,8 @@ TEST(GaugeAggregator, Merge)
 {
   // This tests that the values_ vector is updated correctly after
   // two aggregators are merged together.
-  GaugeAggregator<int> agg1(opentelemetry::metrics::InstrumentKind::Counter);
-  GaugeAggregator<int> agg2(opentelemetry::metrics::InstrumentKind::Counter);
+  GaugeAggregator<int> agg1(metrics_api::InstrumentKind::Counter);
+  GaugeAggregator<int> agg2(metrics_api::InstrumentKind::Counter);
 
   agg1.update(1);
   agg2.update(2);
@@ -68,8 +69,8 @@ TEST(GaugeAggregator, BadMerge)
 {
   // This verifies that we encounter and error when we try to merge
   // two aggregators of different numeric types together.
-  GaugeAggregator<int> agg1(opentelemetry::metrics::InstrumentKind::Counter);
-  GaugeAggregator<int> agg2(opentelemetry::metrics::InstrumentKind::ValueRecorder);
+  GaugeAggregator<int> agg1(metrics_api::InstrumentKind::Counter);
+  GaugeAggregator<int> agg2(metrics_api::InstrumentKind::ValueRecorder);
 
   agg1.update(1);
   agg2.update(2);
@@ -84,10 +85,10 @@ TEST(GaugeAggregator, Types)
 {
   // This test verifies that we do not encounter any errors when
   // using various numeric types.
-  GaugeAggregator<int> agg_int(opentelemetry::metrics::InstrumentKind::Counter);
-  GaugeAggregator<long> agg_long(opentelemetry::metrics::InstrumentKind::Counter);
-  GaugeAggregator<float> agg_float(opentelemetry::metrics::InstrumentKind::Counter);
-  GaugeAggregator<double> agg_double(opentelemetry::metrics::InstrumentKind::Counter);
+  GaugeAggregator<int> agg_int(metrics_api::InstrumentKind::Counter);
+  GaugeAggregator<long> agg_long(metrics_api::InstrumentKind::Counter);
+  GaugeAggregator<float> agg_float(metrics_api::InstrumentKind::Counter);
+  GaugeAggregator<double> agg_double(metrics_api::InstrumentKind::Counter);
 
   for (int i = 1; i <= 10; ++i)
   {
@@ -119,7 +120,7 @@ TEST(GaugeAggregator, Concurrency)
 {
   // This test checks that the aggregator updates appropriately
   // when called in a multi-threaded context.
-  GaugeAggregator<int> agg(opentelemetry::metrics::InstrumentKind::Counter);
+  GaugeAggregator<int> agg(metrics_api::InstrumentKind::Counter);
 
   std::thread first(&callback, std::ref(agg));
   std::thread second(&callback, std::ref(agg));

--- a/sdk/test/metrics/histogram_aggregator_test.cc
+++ b/sdk/test/metrics/histogram_aggregator_test.cc
@@ -87,7 +87,7 @@ TEST(Histogram, Merge)
   alpha.merge(beta);
   alpha.checkpoint();
 
-  EXPECT_EQ(alpha.get_checkpoint()[0], std::accumulate(vals.begin(), vals.end(), 0)
+  EXPECT_EQ(alpha.get_checkpoint()[0], std::accumulate(vals.begin(), vals.end(), 0) +
                                            std::accumulate(otherVals.begin(), otherVals.end(), 0));
   EXPECT_EQ(alpha.get_checkpoint()[1], vals.size() + otherVals.size());
 

--- a/sdk/test/metrics/histogram_aggregator_test.cc
+++ b/sdk/test/metrics/histogram_aggregator_test.cc
@@ -87,7 +87,7 @@ TEST(Histogram, Merge)
   alpha.merge(beta);
   alpha.checkpoint();
 
-  EXPECT_EQ(alpha.get_checkpoint()[0], std::accumulate(vals.begin(), vals.end(), 0) +
+  EXPECT_EQ(alpha.get_checkpoint()[0], std::accumulate(vals.begin(), vals.end(), 0)
                                            std::accumulate(otherVals.begin(), otherVals.end(), 0));
   EXPECT_EQ(alpha.get_checkpoint()[1], vals.size() + otherVals.size());
 

--- a/sdk/test/metrics/meter_test.cc
+++ b/sdk/test/metrics/meter_test.cc
@@ -9,6 +9,8 @@
 
 using namespace opentelemetry::sdk::metrics;
 namespace metrics_api = opentelemetry::metrics;
+namespace common = opentelemetry::common;
+namespace nostd = opentelemetry::nostd;
 
 OPENTELEMETRY_BEGIN_NAMESPACE
 
@@ -74,13 +76,13 @@ TEST(Meter, CollectSyncInstruments)
   auto counter = m.NewShortCounter("Test-counter", "For testing", "Unitless", true);
 
   std::map<std::string, std::string> labels = {{"Key", "Value"}};
-  auto labelkv = opentelemetry::common::KeyValueIterableView<decltype(labels)>{labels};
+  auto labelkv = common::KeyValueIterableView<decltype(labels)>{labels};
 
   counter->add(1, labelkv);
 
   std::vector<Record> res = m.Collect();
   auto agg_var            = res[0].GetAggregator();
-  auto agg                = opentelemetry::nostd::get<0>(agg_var);
+  auto agg                = nostd::get<0>(agg_var);
 
   ASSERT_EQ(agg->get_checkpoint()[0], 1);
 
@@ -91,7 +93,7 @@ TEST(Meter, CollectSyncInstruments)
 
   res     = m.Collect();
   agg_var = res[0].GetAggregator();
-  agg     = opentelemetry::nostd::get<0>(agg_var);
+  agg     = nostd::get<0>(agg_var);
 
   ASSERT_EQ(agg->get_checkpoint()[0], 10);
 }
@@ -106,7 +108,7 @@ TEST(Meter, CollectDeletedSync)
   ASSERT_EQ(m.Collect().size(), 0);
 
   std::map<std::string, std::string> labels = {{"Key", "Value"}};
-  auto labelkv = opentelemetry::common::KeyValueIterableView<decltype(labels)>{labels};
+  auto labelkv = common::KeyValueIterableView<decltype(labels)>{labels};
   {
     auto counter = m.NewShortCounter("Test-counter", "For testing", "Unitless", true);
     counter->add(1, labelkv);
@@ -114,13 +116,13 @@ TEST(Meter, CollectDeletedSync)
 
   std::vector<Record> res = m.Collect();
   auto agg_var            = res[0].GetAggregator();
-  auto agg                = opentelemetry::nostd::get<0>(agg_var);
+  auto agg                = nostd::get<0>(agg_var);
 
   ASSERT_EQ(agg->get_checkpoint()[0], 1);
 }
 
 // Dummy function for asynchronous instrument constructors.
-void Callback(opentelemetry::metrics::ObserverResult<short> result)
+void Callback(metrics_api::ObserverResult<short> result)
 {
   std::map<std::string, std::string> labels = {{"key", "value"}};
   auto labelkv = common::KeyValueIterableView<decltype(labels)>{labels};
@@ -139,13 +141,13 @@ TEST(Meter, CollectAsyncInstruments)
       m.NewShortSumObserver("Test-counter", "For testing", "Unitless", true, &ShortCallback);
 
   std::map<std::string, std::string> labels = {{"Key", "Value"}};
-  auto labelkv = opentelemetry::common::KeyValueIterableView<decltype(labels)>{labels};
+  auto labelkv = common::KeyValueIterableView<decltype(labels)>{labels};
 
   sumobs->observe(1, labelkv);
 
   std::vector<Record> res = m.Collect();
   auto agg_var            = res[0].GetAggregator();
-  auto agg                = opentelemetry::nostd::get<0>(agg_var);
+  auto agg                = nostd::get<0>(agg_var);
 
   ASSERT_EQ(agg->get_checkpoint()[0], 1);
 
@@ -156,7 +158,7 @@ TEST(Meter, CollectAsyncInstruments)
 
   res     = m.Collect();
   agg_var = res[0].GetAggregator();
-  agg     = opentelemetry::nostd::get<0>(agg_var);
+  agg     = nostd::get<0>(agg_var);
 
   ASSERT_EQ(agg->get_checkpoint()[0], 10);
 }
@@ -171,7 +173,7 @@ TEST(Meter, CollectDeletedAsync)
   ASSERT_EQ(m.Collect().size(), 0);
 
   std::map<std::string, std::string> labels = {{"Key", "Value"}};
-  auto labelkv = opentelemetry::common::KeyValueIterableView<decltype(labels)>{labels};
+  auto labelkv = common::KeyValueIterableView<decltype(labels)>{labels};
   {
     auto sumobs = m.NewShortSumObserver("Test-counter", "For testing", "Unitless", true, &Callback);
     sumobs->observe(1, labelkv);
@@ -179,7 +181,7 @@ TEST(Meter, CollectDeletedAsync)
 
   std::vector<Record> res = m.Collect();
   auto agg_var            = res[0].GetAggregator();
-  auto agg                = opentelemetry::nostd::get<0>(agg_var);
+  auto agg                = nostd::get<0>(agg_var);
 
   ASSERT_EQ(agg->get_checkpoint()[0], 1);
 }
@@ -196,7 +198,7 @@ TEST(Meter, RecordBatch)
   auto dcounter = m.NewDoubleCounter("Test-dcounter", "For testing", "Unitless", true);
 
   std::map<std::string, std::string> labels = {{"Key", "Value"}};
-  auto labelkv = opentelemetry::common::KeyValueIterableView<decltype(labels)>{labels};
+  auto labelkv = common::KeyValueIterableView<decltype(labels)>{labels};
 
   metrics_api::SynchronousInstrument<short> *sinstr_arr[] = {scounter.get()};
   short svalues_arr[]                                     = {1};
@@ -207,7 +209,7 @@ TEST(Meter, RecordBatch)
   m.RecordShortBatch(labelkv, sinstrs, svalues);
   std::vector<Record> res = m.Collect();
   auto short_agg_var      = res[0].GetAggregator();
-  auto short_agg          = opentelemetry::nostd::get<0>(short_agg_var);
+  auto short_agg          = nostd::get<0>(short_agg_var);
   ASSERT_EQ(short_agg->get_checkpoint()[0], 1);
 
   metrics_api::SynchronousInstrument<int> *iinstr_arr[] = {icounter.get()};
@@ -219,7 +221,7 @@ TEST(Meter, RecordBatch)
   m.RecordIntBatch(labelkv, iinstrs, ivalues);
   res              = m.Collect();
   auto int_agg_var = res[0].GetAggregator();
-  auto int_agg     = opentelemetry::nostd::get<1>(int_agg_var);
+  auto int_agg     = nostd::get<1>(int_agg_var);
   ASSERT_EQ(int_agg->get_checkpoint()[0], 1);
 
   metrics_api::SynchronousInstrument<float> *finstr_arr[] = {fcounter.get()};
@@ -231,7 +233,7 @@ TEST(Meter, RecordBatch)
   m.RecordFloatBatch(labelkv, finstrs, fvalues);
   res                = m.Collect();
   auto float_agg_var = res[0].GetAggregator();
-  auto float_agg     = opentelemetry::nostd::get<2>(float_agg_var);
+  auto float_agg     = nostd::get<2>(float_agg_var);
   ASSERT_EQ(float_agg->get_checkpoint()[0], 1.0);
 
   metrics_api::SynchronousInstrument<double> *dinstr_arr[] = {dcounter.get()};
@@ -243,7 +245,7 @@ TEST(Meter, RecordBatch)
   m.RecordDoubleBatch(labelkv, dinstrs, dvalues);
   res                 = m.Collect();
   auto double_agg_var = res[0].GetAggregator();
-  auto double_agg     = opentelemetry::nostd::get<3>(double_agg_var);
+  auto double_agg     = nostd::get<3>(double_agg_var);
   ASSERT_EQ(double_agg->get_checkpoint()[0], 1.0);
 }
 
@@ -251,7 +253,7 @@ TEST(Meter, DisableCollectSync)
 {
   Meter m("Test");
   std::map<std::string, std::string> labels = {{"Key", "Value"}};
-  auto labelkv = opentelemetry::common::KeyValueIterableView<decltype(labels)>{labels};
+  auto labelkv = common::KeyValueIterableView<decltype(labels)>{labels};
   auto c       = m.NewShortCounter("c", "", "", false);
   c->add(1, labelkv);
   ASSERT_EQ(m.Collect().size(), 0);
@@ -261,7 +263,7 @@ TEST(Meter, DisableCollectAsync)
 {
   Meter m("Test");
   std::map<std::string, std::string> labels = {{"Key", "Value"}};
-  auto labelkv = opentelemetry::common::KeyValueIterableView<decltype(labels)>{labels};
+  auto labelkv = common::KeyValueIterableView<decltype(labels)>{labels};
   auto c       = m.NewShortValueObserver("c", "", "", false, &ShortCallback);
   c->observe(1, labelkv);
   ASSERT_EQ(m.Collect().size(), 0);

--- a/sdk/test/metrics/min_max_sum_count_aggregator_test.cc
+++ b/sdk/test/metrics/min_max_sum_count_aggregator_test.cc
@@ -8,12 +8,13 @@
 #  include "opentelemetry/sdk/metrics/aggregator/min_max_sum_count_aggregator.h"
 
 using namespace opentelemetry::sdk::metrics;
+namespace metrics_api = opentelemetry::metrics;
 
 TEST(MinMaxSumCountAggregator, Update)
 {
   // This tests that the aggregator updates the maintained value correctly
   // after a call to the update() function.
-  MinMaxSumCountAggregator<int> agg(opentelemetry::metrics::InstrumentKind::Counter);
+  MinMaxSumCountAggregator<int> agg(metrics_api::InstrumentKind::Counter);
   auto value_set = agg.get_values();
   ASSERT_EQ(value_set[0], 0);
   ASSERT_EQ(value_set[1], 0);
@@ -37,7 +38,7 @@ TEST(MinMaxSumCountAggregator, FirstUpdate)
 {
   // This tests that the aggregator appropriately maintains the min and
   // max values after a single update call.
-  MinMaxSumCountAggregator<int> agg(opentelemetry::metrics::InstrumentKind::Counter);
+  MinMaxSumCountAggregator<int> agg(metrics_api::InstrumentKind::Counter);
   agg.update(1);
   auto value_set = agg.get_values();
   ASSERT_EQ(value_set[0], 1);  // min
@@ -51,7 +52,7 @@ TEST(MinMaxSumCountAggregator, Checkpoint)
   // This test verifies that the default checkpoint is set correctly
   // and that the checkpoint values update correctly after a call
   // to the checkpoint() function.
-  MinMaxSumCountAggregator<int> agg(opentelemetry::metrics::InstrumentKind::Counter);
+  MinMaxSumCountAggregator<int> agg(metrics_api::InstrumentKind::Counter);
 
   // Verify that the default checkpoint is set correctly.
   auto checkpoint_set = agg.get_checkpoint();
@@ -87,8 +88,8 @@ TEST(MinMaxSumCountAggregator, Merge)
 {
   // This tests that the values_ vector is updated correctly after
   // two aggregators are merged together.
-  MinMaxSumCountAggregator<int> agg1(opentelemetry::metrics::InstrumentKind::Counter);
-  MinMaxSumCountAggregator<int> agg2(opentelemetry::metrics::InstrumentKind::Counter);
+  MinMaxSumCountAggregator<int> agg1(metrics_api::InstrumentKind::Counter);
+  MinMaxSumCountAggregator<int> agg2(metrics_api::InstrumentKind::Counter);
 
   // 1 + 2 + 3 + ... + 10 = 55
   for (int i = 1; i <= 10; ++i)
@@ -116,8 +117,8 @@ TEST(MinMaxSumCountAggregator, BadMerge)
 {
   // This verifies that we encounter and error when we try to merge
   // two aggregators of different numeric types together.
-  MinMaxSumCountAggregator<int> agg1(opentelemetry::metrics::InstrumentKind::Counter);
-  MinMaxSumCountAggregator<int> agg2(opentelemetry::metrics::InstrumentKind::ValueRecorder);
+  MinMaxSumCountAggregator<int> agg1(metrics_api::InstrumentKind::Counter);
+  MinMaxSumCountAggregator<int> agg2(metrics_api::InstrumentKind::ValueRecorder);
 
   agg1.update(1);
   agg2.update(2);
@@ -136,10 +137,10 @@ TEST(MinMaxSumCountAggregator, Types)
 {
   // This test verifies that we do not encounter any errors when
   // using various numeric types.
-  MinMaxSumCountAggregator<int> agg_int(opentelemetry::metrics::InstrumentKind::Counter);
-  MinMaxSumCountAggregator<long> agg_long(opentelemetry::metrics::InstrumentKind::Counter);
-  MinMaxSumCountAggregator<float> agg_float(opentelemetry::metrics::InstrumentKind::Counter);
-  MinMaxSumCountAggregator<double> agg_double(opentelemetry::metrics::InstrumentKind::Counter);
+  MinMaxSumCountAggregator<int> agg_int(metrics_api::InstrumentKind::Counter);
+  MinMaxSumCountAggregator<long> agg_long(metrics_api::InstrumentKind::Counter);
+  MinMaxSumCountAggregator<float> agg_float(metrics_api::InstrumentKind::Counter);
+  MinMaxSumCountAggregator<double> agg_double(metrics_api::InstrumentKind::Counter);
 
   for (int i = 1; i <= 10; ++i)
   {
@@ -191,7 +192,7 @@ TEST(MinMaxSumCountAggregator, Concurrency)
 {
   // This test checks that the aggregator updates appropriately
   // when called in a multi-threaded context.
-  MinMaxSumCountAggregator<int> agg(opentelemetry::metrics::InstrumentKind::Counter);
+  MinMaxSumCountAggregator<int> agg(metrics_api::InstrumentKind::Counter);
 
   std::thread first(&callback, std::ref(agg));
   std::thread second(&callback, std::ref(agg));

--- a/sdk/test/metrics/sketch_aggregator_test.cc
+++ b/sdk/test/metrics/sketch_aggregator_test.cc
@@ -150,7 +150,7 @@ TEST(Sketch, MergeSmall)
   alpha.merge(beta);
   alpha.checkpoint();
 
-  EXPECT_EQ(alpha.get_checkpoint()[0], std::accumulate(vals.begin(), vals.end(), 0)
+  EXPECT_EQ(alpha.get_checkpoint()[0], std::accumulate(vals.begin(), vals.end(), 0) +
                                            std::accumulate(otherVals.begin(), otherVals.end(), 0));
   EXPECT_EQ(alpha.get_checkpoint()[1], vals.size() + otherVals.size());
 
@@ -178,7 +178,7 @@ TEST(Sketch, MergeLarge)
   alpha.merge(beta);
   alpha.checkpoint();
 
-  EXPECT_EQ(alpha.get_checkpoint()[0], std::accumulate(vals.begin(), vals.end(), 0)
+  EXPECT_EQ(alpha.get_checkpoint()[0], std::accumulate(vals.begin(), vals.end(), 0) +
                                            std::accumulate(otherVals.begin(), otherVals.end(), 0));
   EXPECT_EQ(alpha.get_checkpoint()[1], vals.size() + otherVals.size());
 

--- a/sdk/test/metrics/sketch_aggregator_test.cc
+++ b/sdk/test/metrics/sketch_aggregator_test.cc
@@ -150,7 +150,7 @@ TEST(Sketch, MergeSmall)
   alpha.merge(beta);
   alpha.checkpoint();
 
-  EXPECT_EQ(alpha.get_checkpoint()[0], std::accumulate(vals.begin(), vals.end(), 0) +
+  EXPECT_EQ(alpha.get_checkpoint()[0], std::accumulate(vals.begin(), vals.end(), 0)
                                            std::accumulate(otherVals.begin(), otherVals.end(), 0));
   EXPECT_EQ(alpha.get_checkpoint()[1], vals.size() + otherVals.size());
 
@@ -178,7 +178,7 @@ TEST(Sketch, MergeLarge)
   alpha.merge(beta);
   alpha.checkpoint();
 
-  EXPECT_EQ(alpha.get_checkpoint()[0], std::accumulate(vals.begin(), vals.end(), 0) +
+  EXPECT_EQ(alpha.get_checkpoint()[0], std::accumulate(vals.begin(), vals.end(), 0)
                                            std::accumulate(otherVals.begin(), otherVals.end(), 0));
   EXPECT_EQ(alpha.get_checkpoint()[1], vals.size() + otherVals.size());
 

--- a/sdk/test/metrics/ungrouped_processor_test.cc
+++ b/sdk/test/metrics/ungrouped_processor_test.cc
@@ -16,14 +16,14 @@ namespace nostd       = opentelemetry::nostd;
 TEST(UngroupedMetricsProcessor, UngroupedProcessorFinishedCollectionStateless)
 {
   auto processor = std::unique_ptr<sdkmetrics::MetricsProcessor>(
-      new opentelemetry::sdk::metrics::UngroupedMetricsProcessor(false));
+      new sdkmetrics::UngroupedMetricsProcessor(false));
 
-  auto aggregator = std::shared_ptr<opentelemetry::sdk::metrics::Aggregator<double>>(
-      new opentelemetry::sdk::metrics::CounterAggregator<double>(
+  auto aggregator = std::shared_ptr<sdkmetrics::Aggregator<double>>(
+      new sdkmetrics::CounterAggregator<double>(
           metrics_api::InstrumentKind::Counter));
 
-  auto aggregator2 = std::shared_ptr<opentelemetry::sdk::metrics::Aggregator<double>>(
-      new opentelemetry::sdk::metrics::CounterAggregator<double>(
+  auto aggregator2 = std::shared_ptr<sdkmetrics::Aggregator<double>>(
+      new sdkmetrics::CounterAggregator<double>(
           metrics_api::InstrumentKind::Counter));
 
   aggregator->update(5.5);
@@ -53,14 +53,14 @@ TEST(UngroupedMetricsProcessor, UngroupedProcessorFinishedCollectionStateless)
 TEST(UngroupedMetricsProcessor, UngroupedProcessorFinishedCollectionStateful)
 {
   auto processor = std::unique_ptr<sdkmetrics::MetricsProcessor>(
-      new opentelemetry::sdk::metrics::UngroupedMetricsProcessor(true));
+      new sdkmetrics::UngroupedMetricsProcessor(true));
 
-  auto aggregator = std::shared_ptr<opentelemetry::sdk::metrics::Aggregator<double>>(
-      new opentelemetry::sdk::metrics::CounterAggregator<double>(
+  auto aggregator = std::shared_ptr<sdkmetrics::Aggregator<double>>(
+      new sdkmetrics::CounterAggregator<double>(
           metrics_api::InstrumentKind::Counter));
 
-  auto aggregator2 = std::shared_ptr<opentelemetry::sdk::metrics::Aggregator<double>>(
-      new opentelemetry::sdk::metrics::CounterAggregator<double>(
+  auto aggregator2 = std::shared_ptr<sdkmetrics::Aggregator<double>>(
+      new sdkmetrics::CounterAggregator<double>(
           metrics_api::InstrumentKind::Counter));
 
   aggregator->update(5.5);
@@ -88,10 +88,10 @@ TEST(UngroupedMetricsProcessor, UngroupedProcessorFinishedCollectionStateful)
 TEST(UngroupedMetricsProcessor, UngroupedProcessorKeepsRecordInformationStatelessShort)
 {
   auto processor = std::unique_ptr<sdkmetrics::MetricsProcessor>(
-      new opentelemetry::sdk::metrics::UngroupedMetricsProcessor(false));
+      new sdkmetrics::UngroupedMetricsProcessor(false));
 
-  auto aggregator = std::shared_ptr<opentelemetry::sdk::metrics::Aggregator<short>>(
-      new opentelemetry::sdk::metrics::CounterAggregator<short>(
+  auto aggregator = std::shared_ptr<sdkmetrics::Aggregator<short>>(
+      new sdkmetrics::CounterAggregator<short>(
           metrics_api::InstrumentKind::Counter));
 
   aggregator->update(4);
@@ -113,10 +113,10 @@ TEST(UngroupedMetricsProcessor, UngroupedProcessorKeepsRecordInformationStateles
 TEST(UngroupedMetricsProcessor, UngroupedProcessorKeepsRecordInformationStatelessInt)
 {
   auto processor = std::unique_ptr<sdkmetrics::MetricsProcessor>(
-      new opentelemetry::sdk::metrics::UngroupedMetricsProcessor(false));
+      new sdkmetrics::UngroupedMetricsProcessor(false));
 
-  auto aggregator = std::shared_ptr<opentelemetry::sdk::metrics::Aggregator<int>>(
-      new opentelemetry::sdk::metrics::CounterAggregator<int>(
+  auto aggregator = std::shared_ptr<sdkmetrics::Aggregator<int>>(
+      new sdkmetrics::CounterAggregator<int>(
           metrics_api::InstrumentKind::Counter));
 
   aggregator->update(5);
@@ -137,10 +137,10 @@ TEST(UngroupedMetricsProcessor, UngroupedProcessorKeepsRecordInformationStateles
 TEST(UngroupedMetricsProcessor, UngroupedProcessorKeepsRecordInformationStatelessFloat)
 {
   auto processor = std::unique_ptr<sdkmetrics::MetricsProcessor>(
-      new opentelemetry::sdk::metrics::UngroupedMetricsProcessor(false));
+      new sdkmetrics::UngroupedMetricsProcessor(false));
 
-  auto aggregator = std::shared_ptr<opentelemetry::sdk::metrics::Aggregator<float>>(
-      new opentelemetry::sdk::metrics::CounterAggregator<float>(
+  auto aggregator = std::shared_ptr<sdkmetrics::Aggregator<float>>(
+      new sdkmetrics::CounterAggregator<float>(
           metrics_api::InstrumentKind::Counter));
 
   aggregator->update(8.5);
@@ -162,10 +162,10 @@ TEST(UngroupedMetricsProcessor, UngroupedProcessorKeepsRecordInformationStateles
 TEST(UngroupedMetricsProcessor, UngroupedProcessorKeepsRecordInformationStatelessDouble)
 {
   auto processor = std::unique_ptr<sdkmetrics::MetricsProcessor>(
-      new opentelemetry::sdk::metrics::UngroupedMetricsProcessor(false));
+      new sdkmetrics::UngroupedMetricsProcessor(false));
 
-  auto aggregator = std::shared_ptr<opentelemetry::sdk::metrics::Aggregator<double>>(
-      new opentelemetry::sdk::metrics::CounterAggregator<double>(
+  auto aggregator = std::shared_ptr<sdkmetrics::Aggregator<double>>(
+      new sdkmetrics::CounterAggregator<double>(
           metrics_api::InstrumentKind::Counter));
 
   aggregator->update(5.5);
@@ -192,14 +192,14 @@ TEST(UngroupedMetricsProcessor, UngroupedProcessorKeepsRecordInformationStateles
 TEST(UngroupedMetricsProcessor, UngroupedProcessorKeepsRecordInformationStatefulShort)
 {
   auto processor = std::unique_ptr<sdkmetrics::MetricsProcessor>(
-      new opentelemetry::sdk::metrics::UngroupedMetricsProcessor(true));
+      new sdkmetrics::UngroupedMetricsProcessor(true));
 
-  auto aggregator = std::shared_ptr<opentelemetry::sdk::metrics::Aggregator<short>>(
-      new opentelemetry::sdk::metrics::CounterAggregator<short>(
+  auto aggregator = std::shared_ptr<sdkmetrics::Aggregator<short>>(
+      new sdkmetrics::CounterAggregator<short>(
           metrics_api::InstrumentKind::Counter));
 
-  auto aggregator_test = std::shared_ptr<opentelemetry::sdk::metrics::Aggregator<short>>(
-      new opentelemetry::sdk::metrics::CounterAggregator<short>(
+  auto aggregator_test = std::shared_ptr<sdkmetrics::Aggregator<short>>(
+      new sdkmetrics::CounterAggregator<short>(
           metrics_api::InstrumentKind::Counter));
 
   aggregator->update(5);
@@ -237,14 +237,14 @@ TEST(UngroupedMetricsProcessor, UngroupedProcessorKeepsRecordInformationStateful
 TEST(UngroupedMetricsProcessor, UngroupedProcessorKeepsRecordInformationStatefulInt)
 {
   auto processor = std::unique_ptr<sdkmetrics::MetricsProcessor>(
-      new opentelemetry::sdk::metrics::UngroupedMetricsProcessor(true));
+      new sdkmetrics::UngroupedMetricsProcessor(true));
 
-  auto aggregator = std::shared_ptr<opentelemetry::sdk::metrics::Aggregator<int>>(
-      new opentelemetry::sdk::metrics::CounterAggregator<int>(
+  auto aggregator = std::shared_ptr<sdkmetrics::Aggregator<int>>(
+      new sdkmetrics::CounterAggregator<int>(
           metrics_api::InstrumentKind::Counter));
 
-  auto aggregator_test = std::shared_ptr<opentelemetry::sdk::metrics::Aggregator<int>>(
-      new opentelemetry::sdk::metrics::CounterAggregator<int>(
+  auto aggregator_test = std::shared_ptr<sdkmetrics::Aggregator<int>>(
+      new sdkmetrics::CounterAggregator<int>(
           metrics_api::InstrumentKind::Counter));
 
   aggregator->update(5);
@@ -280,14 +280,14 @@ TEST(UngroupedMetricsProcessor, UngroupedProcessorKeepsRecordInformationStateful
 TEST(UngroupedMetricsProcessor, UngroupedProcessorKeepsRecordInformationStatefulFloat)
 {
   auto processor = std::unique_ptr<sdkmetrics::MetricsProcessor>(
-      new opentelemetry::sdk::metrics::UngroupedMetricsProcessor(true));
+      new sdkmetrics::UngroupedMetricsProcessor(true));
 
-  auto aggregator = std::shared_ptr<opentelemetry::sdk::metrics::Aggregator<float>>(
-      new opentelemetry::sdk::metrics::CounterAggregator<float>(
+  auto aggregator = std::shared_ptr<sdkmetrics::Aggregator<float>>(
+      new sdkmetrics::CounterAggregator<float>(
           metrics_api::InstrumentKind::Counter));
 
-  auto aggregator_test = std::shared_ptr<opentelemetry::sdk::metrics::Aggregator<float>>(
-      new opentelemetry::sdk::metrics::CounterAggregator<float>(
+  auto aggregator_test = std::shared_ptr<sdkmetrics::Aggregator<float>>(
+      new sdkmetrics::CounterAggregator<float>(
           metrics_api::InstrumentKind::Counter));
 
   aggregator->update(5);
@@ -325,14 +325,14 @@ TEST(UngroupedMetricsProcessor, UngroupedProcessorKeepsRecordInformationStateful
 TEST(UngroupedMetricsProcessor, UngroupedProcessorKeepsRecordInformationStatefulDouble)
 {
   auto processor = std::unique_ptr<sdkmetrics::MetricsProcessor>(
-      new opentelemetry::sdk::metrics::UngroupedMetricsProcessor(true));
+      new sdkmetrics::UngroupedMetricsProcessor(true));
 
-  auto aggregator = std::shared_ptr<opentelemetry::sdk::metrics::Aggregator<double>>(
-      new opentelemetry::sdk::metrics::CounterAggregator<double>(
+  auto aggregator = std::shared_ptr<sdkmetrics::Aggregator<double>>(
+      new sdkmetrics::CounterAggregator<double>(
           metrics_api::InstrumentKind::Counter));
 
-  auto aggregator_test = std::shared_ptr<opentelemetry::sdk::metrics::Aggregator<double>>(
-      new opentelemetry::sdk::metrics::CounterAggregator<double>(
+  auto aggregator_test = std::shared_ptr<sdkmetrics::Aggregator<double>>(
+      new sdkmetrics::CounterAggregator<double>(
           metrics_api::InstrumentKind::Counter));
 
   aggregator->update(5.5);
@@ -370,14 +370,14 @@ TEST(UngroupedMetricsProcessor, UngroupedProcessorKeepsRecordInformationStateful
 TEST(UngroupedMetricsProcessor, UngroupedProcessorKeepsRecordInformationStatefulMinMaxSumCount)
 {
   auto processor = std::unique_ptr<sdkmetrics::MetricsProcessor>(
-      new opentelemetry::sdk::metrics::UngroupedMetricsProcessor(true));
+      new sdkmetrics::UngroupedMetricsProcessor(true));
 
-  auto aggregator = std::shared_ptr<opentelemetry::sdk::metrics::Aggregator<double>>(
-      new opentelemetry::sdk::metrics::MinMaxSumCountAggregator<double>(
+  auto aggregator = std::shared_ptr<sdkmetrics::Aggregator<double>>(
+      new sdkmetrics::MinMaxSumCountAggregator<double>(
           metrics_api::InstrumentKind::Counter));
 
-  auto aggregator2 = std::shared_ptr<opentelemetry::sdk::metrics::Aggregator<double>>(
-      new opentelemetry::sdk::metrics::MinMaxSumCountAggregator<double>(
+  auto aggregator2 = std::shared_ptr<sdkmetrics::Aggregator<double>>(
+      new sdkmetrics::MinMaxSumCountAggregator<double>(
           metrics_api::InstrumentKind::Counter));
 
   aggregator->update(1.1);
@@ -417,10 +417,10 @@ TEST(UngroupedMetricsProcessor, UngroupedProcessorKeepsRecordInformationStateful
 TEST(UngroupedMetricsProcessor, UngroupedProcessorKeepsRecordInformationStatefulGauge)
 {
   auto processor = std::unique_ptr<sdkmetrics::MetricsProcessor>(
-      new opentelemetry::sdk::metrics::UngroupedMetricsProcessor(true));
+      new sdkmetrics::UngroupedMetricsProcessor(true));
 
-  auto aggregator = std::shared_ptr<opentelemetry::sdk::metrics::Aggregator<double>>(
-      new opentelemetry::sdk::metrics::GaugeAggregator<double>(
+  auto aggregator = std::shared_ptr<sdkmetrics::Aggregator<double>>(
+      new sdkmetrics::GaugeAggregator<double>(
           metrics_api::InstrumentKind::Counter));
 
   aggregator->update(1.1);
@@ -456,14 +456,14 @@ TEST(UngroupedMetricsProcessor, UngroupedProcessorKeepsRecordInformationStateful
 TEST(UngroupedMetricsProcessor, UngroupedProcessorKeepsRecordInformationStatefulExact)
 {
   auto processor = std::unique_ptr<sdkmetrics::MetricsProcessor>(
-      new opentelemetry::sdk::metrics::UngroupedMetricsProcessor(true));
+      new sdkmetrics::UngroupedMetricsProcessor(true));
 
-  auto aggregator = std::shared_ptr<opentelemetry::sdk::metrics::Aggregator<double>>(
-      new opentelemetry::sdk::metrics::ExactAggregator<double>(metrics_api::InstrumentKind::Counter,
+  auto aggregator = std::shared_ptr<sdkmetrics::Aggregator<double>>(
+      new sdkmetrics::ExactAggregator<double>(metrics_api::InstrumentKind::Counter,
                                                                false));
 
-  auto aggregator2 = std::shared_ptr<opentelemetry::sdk::metrics::Aggregator<double>>(
-      new opentelemetry::sdk::metrics::ExactAggregator<double>(metrics_api::InstrumentKind::Counter,
+  auto aggregator2 = std::shared_ptr<sdkmetrics::Aggregator<double>>(
+      new sdkmetrics::ExactAggregator<double>(metrics_api::InstrumentKind::Counter,
                                                                false));
 
   aggregator->update(1.1);
@@ -504,15 +504,15 @@ TEST(UngroupedMetricsProcessor, UngroupedProcessorKeepsRecordInformationStateful
 TEST(UngroupedMetricsProcessor, UngroupedProcessorKeepsRecordInformationStatefulHistogram)
 {
   auto processor = std::unique_ptr<sdkmetrics::MetricsProcessor>(
-      new opentelemetry::sdk::metrics::UngroupedMetricsProcessor(true));
+      new sdkmetrics::UngroupedMetricsProcessor(true));
 
   std::vector<double> boundaries{10, 20, 30, 40, 50};
-  auto aggregator = std::shared_ptr<opentelemetry::sdk::metrics::Aggregator<int>>(
-      new opentelemetry::sdk::metrics::HistogramAggregator<int>(
+  auto aggregator = std::shared_ptr<sdkmetrics::Aggregator<int>>(
+      new sdkmetrics::HistogramAggregator<int>(
           metrics_api::InstrumentKind::Counter, boundaries));
 
-  auto aggregator2 = std::shared_ptr<opentelemetry::sdk::metrics::Aggregator<int>>(
-      new opentelemetry::sdk::metrics::HistogramAggregator<int>(
+  auto aggregator2 = std::shared_ptr<sdkmetrics::Aggregator<int>>(
+      new sdkmetrics::HistogramAggregator<int>(
           metrics_api::InstrumentKind::Counter, boundaries));
 
   for (int i = 0; i < 60; i++)
@@ -567,14 +567,14 @@ TEST(UngroupedMetricsProcessor, UngroupedProcessorKeepsRecordInformationStateful
 TEST(UngroupedMetricsProcessor, UngroupedProcessorKeepsRecordInformationStatefulSketch)
 {
   auto processor = std::unique_ptr<sdkmetrics::MetricsProcessor>(
-      new opentelemetry::sdk::metrics::UngroupedMetricsProcessor(true));
+      new sdkmetrics::UngroupedMetricsProcessor(true));
 
-  auto aggregator = std::shared_ptr<opentelemetry::sdk::metrics::Aggregator<int>>(
-      new opentelemetry::sdk::metrics::SketchAggregator<int>(metrics_api::InstrumentKind::Counter,
+  auto aggregator = std::shared_ptr<sdkmetrics::Aggregator<int>>(
+      new sdkmetrics::SketchAggregator<int>(metrics_api::InstrumentKind::Counter,
                                                              .00005));
 
-  auto test_aggregator = std::shared_ptr<opentelemetry::sdk::metrics::Aggregator<int>>(
-      new opentelemetry::sdk::metrics::SketchAggregator<int>(metrics_api::InstrumentKind::Counter,
+  auto test_aggregator = std::shared_ptr<sdkmetrics::Aggregator<int>>(
+      new sdkmetrics::SketchAggregator<int>(metrics_api::InstrumentKind::Counter,
                                                              .00005));
 
   for (int i = 0; i < 60; i++)

--- a/sdk/test/resource/resource_test.cc
+++ b/sdk/test/resource/resource_test.cc
@@ -19,6 +19,7 @@
 #endif
 
 using namespace opentelemetry::sdk::resource;
+namespace nostd = opentelemetry::nostd;
 
 class TestResource : public Resource
 {
@@ -46,14 +47,14 @@ TEST(ResourceTest, create_without_servicename)
     EXPECT_TRUE(expected_attributes.find(e.first) != expected_attributes.end());
     if (expected_attributes.find(e.first) != expected_attributes.end())
       if (e.first == "version")
-        EXPECT_EQ(opentelemetry::nostd::get<uint32_t>(expected_attributes.find(e.first)->second),
-                  opentelemetry::nostd::get<uint32_t>(e.second));
+        EXPECT_EQ(nostd::get<uint32_t>(expected_attributes.find(e.first)->second),
+                  nostd::get<uint32_t>(e.second));
       else if (e.first == "cost")
-        EXPECT_EQ(opentelemetry::nostd::get<double>(expected_attributes.find(e.first)->second),
-                  opentelemetry::nostd::get<double>(e.second));
+        EXPECT_EQ(nostd::get<double>(expected_attributes.find(e.first)->second),
+                  nostd::get<double>(e.second));
       else
-        EXPECT_EQ(opentelemetry::nostd::get<std::string>(expected_attributes.find(e.first)->second),
-                  opentelemetry::nostd::get<std::string>(e.second));
+        EXPECT_EQ(nostd::get<std::string>(expected_attributes.find(e.first)->second),
+                  nostd::get<std::string>(e.second));
   }
   EXPECT_EQ(received_attributes.size(), expected_attributes.size());  // for missing service.name
 }
@@ -78,14 +79,14 @@ TEST(ResourceTest, create_with_servicename)
     if (expected_attributes.find(e.first) != expected_attributes.end())
     {
       if (e.first == "version")
-        EXPECT_EQ(opentelemetry::nostd::get<uint32_t>(expected_attributes.find(e.first)->second),
-                  opentelemetry::nostd::get<uint32_t>(e.second));
+        EXPECT_EQ(nostd::get<uint32_t>(expected_attributes.find(e.first)->second),
+                  nostd::get<uint32_t>(e.second));
       else if (e.first == "cost")
-        EXPECT_EQ(opentelemetry::nostd::get<double>(expected_attributes.find(e.first)->second),
-                  opentelemetry::nostd::get<double>(e.second));
+        EXPECT_EQ(nostd::get<double>(expected_attributes.find(e.first)->second),
+                  nostd::get<double>(e.second));
       else
-        EXPECT_EQ(opentelemetry::nostd::get<std::string>(expected_attributes.find(e.first)->second),
-                  opentelemetry::nostd::get<std::string>(e.second));
+        EXPECT_EQ(nostd::get<std::string>(expected_attributes.find(e.first)->second),
+                  nostd::get<std::string>(e.second));
     }
   }
   EXPECT_EQ(received_attributes.size(), expected_attributes.size());  // for missing service.name
@@ -106,8 +107,8 @@ TEST(ResourceTest, create_with_emptyatrributes)
   {
     EXPECT_TRUE(expected_attributes.find(e.first) != expected_attributes.end());
     if (expected_attributes.find(e.first) != expected_attributes.end())
-      EXPECT_EQ(opentelemetry::nostd::get<std::string>(expected_attributes.find(e.first)->second),
-                opentelemetry::nostd::get<std::string>(e.second));
+      EXPECT_EQ(nostd::get<std::string>(expected_attributes.find(e.first)->second),
+                nostd::get<std::string>(e.second));
   }
   EXPECT_EQ(received_attributes.size(), expected_attributes.size());  // for missing service.name
 }
@@ -137,7 +138,7 @@ TEST(ResourceTest, Merge)
     if (expected_attributes.find(e.first) != expected_attributes.end())
     {
       EXPECT_EQ(expected_attributes.find(e.first)->second,
-                opentelemetry::nostd::get<std::string>(e.second));
+                nostd::get<std::string>(e.second));
     }
   }
   EXPECT_EQ(received_attributes.size(), expected_attributes.size());
@@ -159,7 +160,7 @@ TEST(ResourceTest, MergeEmptyString)
     if (expected_attributes.find(e.first) != expected_attributes.end())
     {
       EXPECT_EQ(expected_attributes.find(e.first)->second,
-                opentelemetry::nostd::get<std::string>(e.second));
+                nostd::get<std::string>(e.second));
     }
   }
   EXPECT_EQ(received_attributes.size(), expected_attributes.size());
@@ -182,7 +183,7 @@ TEST(ResourceTest, OtelResourceDetector)
     if (expected_attributes.find(e.first) != expected_attributes.end())
     {
       EXPECT_EQ(expected_attributes.find(e.first)->second,
-                opentelemetry::nostd::get<std::string>(e.second));
+                nostd::get<std::string>(e.second));
     }
   }
   EXPECT_EQ(received_attributes.size(), expected_attributes.size());
@@ -210,7 +211,7 @@ TEST(ResourceTest, OtelResourceDetectorEmptyEnv)
     if (expected_attributes.find(e.first) != expected_attributes.end())
     {
       EXPECT_EQ(expected_attributes.find(e.first)->second,
-                opentelemetry::nostd::get<std::string>(e.second));
+                nostd::get<std::string>(e.second));
     }
   }
   EXPECT_EQ(received_attributes.size(), expected_attributes.size());

--- a/sdk/test/trace/always_off_sampler_test.cc
+++ b/sdk/test/trace/always_off_sampler_test.cc
@@ -8,13 +8,15 @@
 using opentelemetry::sdk::trace::AlwaysOffSampler;
 using opentelemetry::sdk::trace::Decision;
 using opentelemetry::trace::SpanContext;
+namespace trace_api = opentelemetry::trace;
+
 
 TEST(AlwaysOffSampler, ShouldSample)
 {
   AlwaysOffSampler sampler;
 
-  opentelemetry::trace::TraceId trace_id;
-  opentelemetry::trace::SpanKind span_kind = opentelemetry::trace::SpanKind::kInternal;
+  trace_api::TraceId trace_id;
+  trace_api::SpanKind span_kind = trace_api::SpanKind::kInternal;
 
   using M = std::map<std::string, int>;
   M m1    = {{}};
@@ -23,7 +25,7 @@ TEST(AlwaysOffSampler, ShouldSample)
   L l1    = {{SpanContext(false, false), {}}, {SpanContext(false, false), {}}};
 
   opentelemetry::common::KeyValueIterableView<M> view{m1};
-  opentelemetry::trace::SpanContextKeyValueIterableView<L> links{l1};
+  trace_api::SpanContextKeyValueIterableView<L> links{l1};
 
   auto sampling_result =
       sampler.ShouldSample(SpanContext::GetInvalid(), trace_id, "", span_kind, view, links);

--- a/sdk/test/trace/parent_sampler_test.cc
+++ b/sdk/test/trace/parent_sampler_test.cc
@@ -25,7 +25,7 @@ TEST(ParentBasedSampler, ShouldSample)
   uint8_t span_id_buffer[trace_api::SpanId::kSize] = {1};
   trace_api::SpanId span_id{span_id_buffer};
 
-  opentelemetry::trace::SpanKind span_kind = opentelemetry::trace::SpanKind::kInternal;
+  trace_api::SpanKind span_kind = trace_api::SpanKind::kInternal;
   using M                                  = std::map<std::string, int>;
   M m1                                     = {{}};
 
@@ -34,7 +34,7 @@ TEST(ParentBasedSampler, ShouldSample)
 
   opentelemetry::common::KeyValueIterableView<M> view{m1};
   trace_api::SpanContextKeyValueIterableView<L> links{l1};
-  auto trace_state = opentelemetry::trace::TraceState::FromHeader("congo=t61rcWkgMzE");
+  auto trace_state = trace_api::TraceState::FromHeader("congo=t61rcWkgMzE");
   trace_api::SpanContext parent_context_sampled(trace_id, span_id, trace_api::TraceFlags{1}, false,
                                                 trace_state);
   trace_api::SpanContext parent_context_nonsampled(trace_id, span_id, trace_api::TraceFlags{0},

--- a/sdk/test/trace/sampler_benchmark.cc
+++ b/sdk/test/trace/sampler_benchmark.cc
@@ -19,6 +19,7 @@
 using namespace opentelemetry::sdk::trace;
 using opentelemetry::exporter::memory::InMemorySpanExporter;
 using opentelemetry::trace::SpanContext;
+namespace trace_api = opentelemetry::trace;
 
 namespace
 {
@@ -63,8 +64,8 @@ BENCHMARK(BM_TraceIdRatioBasedSamplerConstruction);
 // Sampler Helper Function
 void BenchmarkShouldSampler(Sampler &sampler, benchmark::State &state)
 {
-  opentelemetry::trace::TraceId trace_id;
-  opentelemetry::trace::SpanKind span_kind = opentelemetry::trace::SpanKind::kInternal;
+  trace_api::TraceId trace_id;
+  trace_api::SpanKind span_kind = trace_api::SpanKind::kInternal;
 
   using M = std::map<std::string, int>;
   M m1    = {{}};
@@ -126,7 +127,7 @@ void BenchmarkSpanCreation(std::shared_ptr<Sampler> sampler, benchmark::State &s
   processors.push_back(std::move(processor));
   auto context  = std::make_shared<TracerContext>(std::move(processors));
   auto resource = opentelemetry::sdk::resource::Resource::Create({});
-  auto tracer   = std::shared_ptr<opentelemetry::trace::Tracer>(new Tracer(context));
+  auto tracer   = std::shared_ptr<trace_api::Tracer>(new Tracer(context));
 
   while (state.KeepRunning())
   {

--- a/sdk/test/trace/span_data_test.cc
+++ b/sdk/test/trace/span_data_test.cc
@@ -10,11 +10,14 @@
 #include <gtest/gtest.h>
 
 using opentelemetry::sdk::trace::SpanData;
+namespace trace_api = opentelemetry::trace;
+namespace common = opentelemetry::common;
+namespace nostd = opentelemetry::nostd;
 
 TEST(SpanData, DefaultValues)
 {
-  opentelemetry::trace::SpanContext empty_span_context{false, false};
-  opentelemetry::trace::SpanId zero_span_id;
+  trace_api::SpanContext empty_span_context{false, false};
+  trace_api::SpanId zero_span_id;
   SpanData data;
 
   ASSERT_EQ(data.GetTraceId(), empty_span_context.trace_id());
@@ -22,7 +25,7 @@ TEST(SpanData, DefaultValues)
   ASSERT_EQ(data.GetSpanContext(), empty_span_context);
   ASSERT_EQ(data.GetParentSpanId(), zero_span_id);
   ASSERT_EQ(data.GetName(), "");
-  ASSERT_EQ(data.GetStatus(), opentelemetry::trace::StatusCode::kUnset);
+  ASSERT_EQ(data.GetStatus(), trace_api::StatusCode::kUnset);
   ASSERT_EQ(data.GetDescription(), "");
   ASSERT_EQ(data.GetStartTime().time_since_epoch(), std::chrono::nanoseconds(0));
   ASSERT_EQ(data.GetDuration(), std::chrono::nanoseconds(0));
@@ -35,21 +38,21 @@ TEST(SpanData, Set)
   constexpr uint8_t trace_id_buf[]       = {1, 2, 3, 4, 5, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7, 8};
   constexpr uint8_t span_id_buf[]        = {1, 2, 3, 4, 5, 6, 7, 8};
   constexpr uint8_t parent_span_id_buf[] = {8, 7, 6, 5, 4, 3, 2, 1};
-  opentelemetry::trace::TraceId trace_id{trace_id_buf};
-  opentelemetry::trace::SpanId span_id{span_id_buf};
-  opentelemetry::trace::SpanId parent_span_id{parent_span_id_buf};
-  const auto trace_state = opentelemetry::trace::TraceState::GetDefault()->Set("key1", "value");
-  const opentelemetry::trace::SpanContext span_context{
+  trace_api::TraceId trace_id{trace_id_buf};
+  trace_api::SpanId span_id{span_id_buf};
+  trace_api::SpanId parent_span_id{parent_span_id_buf};
+  const auto trace_state = trace_api::TraceState::GetDefault()->Set("key1", "value");
+  const trace_api::SpanContext span_context{
       trace_id, span_id,
-      opentelemetry::trace::TraceFlags{opentelemetry::trace::TraceFlags::kIsSampled}, true,
+      trace_api::TraceFlags{trace_api::TraceFlags::kIsSampled}, true,
       trace_state};
-  opentelemetry::common::SystemTimestamp now(std::chrono::system_clock::now());
+  common::SystemTimestamp now(std::chrono::system_clock::now());
 
   SpanData data;
   data.SetIdentity(span_context, parent_span_id);
   data.SetName("span name");
-  data.SetSpanKind(opentelemetry::trace::SpanKind::kServer);
-  data.SetStatus(opentelemetry::trace::StatusCode::kOk, "description");
+  data.SetSpanKind(trace_api::SpanKind::kServer);
+  data.SetStatus(trace_api::StatusCode::kOk, "description");
   data.SetStartTime(now);
   data.SetDuration(std::chrono::nanoseconds(1000000));
   data.SetAttribute("attr1", (int64_t)314159);
@@ -63,12 +66,12 @@ TEST(SpanData, Set)
   ASSERT_EQ(trace_state_key1_value, "value");
   ASSERT_EQ(data.GetParentSpanId(), parent_span_id);
   ASSERT_EQ(data.GetName(), "span name");
-  ASSERT_EQ(data.GetSpanKind(), opentelemetry::trace::SpanKind::kServer);
-  ASSERT_EQ(data.GetStatus(), opentelemetry::trace::StatusCode::kOk);
+  ASSERT_EQ(data.GetSpanKind(), trace_api::SpanKind::kServer);
+  ASSERT_EQ(data.GetStatus(), trace_api::StatusCode::kOk);
   ASSERT_EQ(data.GetDescription(), "description");
   ASSERT_EQ(data.GetStartTime().time_since_epoch(), now.time_since_epoch());
   ASSERT_EQ(data.GetDuration(), std::chrono::nanoseconds(1000000));
-  ASSERT_EQ(opentelemetry::nostd::get<int64_t>(data.GetAttributes().at("attr1")), 314159);
+  ASSERT_EQ(nostd::get<int64_t>(data.GetAttributes().at("attr1")), 314159);
   ASSERT_EQ(data.GetEvents().at(0).GetName(), "event1");
   ASSERT_EQ(data.GetEvents().at(0).GetTimestamp(), now);
 }
@@ -84,12 +87,12 @@ TEST(SpanData, EventAttributes)
 
   data.AddEvent(
       "Test Event", std::chrono::system_clock::now(),
-      opentelemetry::common::KeyValueIterableView<std::map<std::string, int64_t>>(attributes));
+      common::KeyValueIterableView<std::map<std::string, int64_t>>(attributes));
 
   for (int i = 0; i < kNumAttributes; i++)
   {
     EXPECT_EQ(
-        opentelemetry::nostd::get<int64_t>(data.GetEvents().at(0).GetAttributes().at(keys[i])),
+        nostd::get<int64_t>(data.GetEvents().at(0).GetAttributes().at(keys[i])),
         values[i]);
   }
 }
@@ -114,26 +117,26 @@ TEST(SpanData, Links)
       {keys[0], values[0]}, {keys[1], values[1]}, {keys[2], values[2]}};
 
   // produce valid SpanContext with pseudo span and trace Id.
-  uint8_t span_id_buf[opentelemetry::trace::SpanId::kSize] = {
+  uint8_t span_id_buf[trace_api::SpanId::kSize] = {
       1,
   };
-  opentelemetry::trace::SpanId span_id{span_id_buf};
-  uint8_t trace_id_buf[opentelemetry::trace::TraceId::kSize] = {
+  trace_api::SpanId span_id{span_id_buf};
+  uint8_t trace_id_buf[trace_api::TraceId::kSize] = {
       2,
   };
-  opentelemetry::trace::TraceId trace_id{trace_id_buf};
-  const auto span_context = opentelemetry::trace::SpanContext(
+  trace_api::TraceId trace_id{trace_id_buf};
+  const auto span_context = trace_api::SpanContext(
       trace_id, span_id,
-      opentelemetry::trace::TraceFlags{opentelemetry::trace::TraceFlags::kIsSampled}, true);
+      trace_api::TraceFlags{trace_api::TraceFlags::kIsSampled}, true);
 
   data.AddLink(
       span_context,
-      opentelemetry::common::KeyValueIterableView<std::map<std::string, int64_t>>(attributes));
+      common::KeyValueIterableView<std::map<std::string, int64_t>>(attributes));
 
   EXPECT_EQ(data.GetLinks().at(0).GetSpanContext(), span_context);
   for (int i = 0; i < kNumAttributes; i++)
   {
-    EXPECT_EQ(opentelemetry::nostd::get<int64_t>(data.GetLinks().at(0).GetAttributes().at(keys[i])),
+    EXPECT_EQ(nostd::get<int64_t>(data.GetLinks().at(0).GetAttributes().at(keys[i])),
               values[i]);
   }
 }

--- a/sdk/test/trace/trace_id_ratio_sampler_test.cc
+++ b/sdk/test/trace/trace_id_ratio_sampler_test.cc
@@ -13,6 +13,7 @@ using opentelemetry::sdk::common::Random;
 using opentelemetry::sdk::trace::Decision;
 using opentelemetry::sdk::trace::TraceIdRatioBasedSampler;
 namespace trace_api = opentelemetry::trace;
+namespace common = opentelemetry::common;
 
 namespace
 {
@@ -34,7 +35,7 @@ int RunShouldSampleCountDecision(trace_api::SpanContext &context,
 {
   int actual_count = 0;
 
-  opentelemetry::trace::SpanKind span_kind = opentelemetry::trace::SpanKind::kInternal;
+  trace_api::SpanKind span_kind = trace_api::SpanKind::kInternal;
 
   using M = std::map<std::string, int>;
   M m1    = {{}};
@@ -42,7 +43,7 @@ int RunShouldSampleCountDecision(trace_api::SpanContext &context,
   using L = std::vector<std::pair<trace_api::SpanContext, std::map<std::string, std::string>>>;
   L l1 = {{trace_api::SpanContext(false, false), {}}, {trace_api::SpanContext(false, false), {}}};
 
-  opentelemetry::common::KeyValueIterableView<M> view{m1};
+  common::KeyValueIterableView<M> view{m1};
   trace_api::SpanContextKeyValueIterableView<L> links{l1};
 
   for (int i = 0; i < iterations; ++i)
@@ -50,7 +51,7 @@ int RunShouldSampleCountDecision(trace_api::SpanContext &context,
     uint8_t buf[16] = {0};
     Random::GenerateRandomBuffer(buf);
 
-    opentelemetry::trace::TraceId trace_id(buf);
+    trace_api::TraceId trace_id(buf);
 
     auto result = sampler.ShouldSample(context, trace_id, "", span_kind, view, links);
     if (result.decision == Decision::RECORD_AND_SAMPLE)
@@ -65,9 +66,9 @@ int RunShouldSampleCountDecision(trace_api::SpanContext &context,
 
 TEST(TraceIdRatioBasedSampler, ShouldSampleWithoutContext)
 {
-  opentelemetry::trace::TraceId invalid_trace_id;
+  trace_api::TraceId invalid_trace_id;
 
-  opentelemetry::trace::SpanKind span_kind = opentelemetry::trace::SpanKind::kInternal;
+  trace_api::SpanKind span_kind = trace_api::SpanKind::kInternal;
 
   using M = std::map<std::string, int>;
   M m1    = {{}};
@@ -75,7 +76,7 @@ TEST(TraceIdRatioBasedSampler, ShouldSampleWithoutContext)
   using L = std::vector<std::pair<trace_api::SpanContext, std::map<std::string, std::string>>>;
   L l1 = {{trace_api::SpanContext(false, false), {}}, {trace_api::SpanContext(false, false), {}}};
 
-  opentelemetry::common::KeyValueIterableView<M> view{m1};
+  common::KeyValueIterableView<M> view{m1};
   trace_api::SpanContextKeyValueIterableView<L> links{l1};
 
   TraceIdRatioBasedSampler s1(0.01);
@@ -87,7 +88,7 @@ TEST(TraceIdRatioBasedSampler, ShouldSampleWithoutContext)
   ASSERT_EQ(nullptr, sampling_result.attributes);
 
   constexpr uint8_t buf[] = {0, 0, 0, 0, 0, 0, 0, 0x80, 0, 0, 0, 0, 0, 0, 0, 0};
-  opentelemetry::trace::TraceId valid_trace_id(buf);
+  trace_api::TraceId valid_trace_id(buf);
 
   sampling_result = s1.ShouldSample(trace_api::SpanContext::GetInvalid(), valid_trace_id, "",
                                     span_kind, view, links);
@@ -128,7 +129,7 @@ TEST(TraceIdRatioBasedSampler, ShouldSampleWithContext)
   uint8_t span_id_buffer[trace_api::SpanId::kSize] = {1};
   trace_api::SpanId span_id{span_id_buffer};
 
-  opentelemetry::trace::SpanKind span_kind = opentelemetry::trace::SpanKind::kInternal;
+  trace_api::SpanKind span_kind = trace_api::SpanKind::kInternal;
   trace_api::SpanContext c1(trace_id, span_id, trace_api::TraceFlags{0}, false);
   trace_api::SpanContext c2(trace_id, span_id, trace_api::TraceFlags{1}, false);
   trace_api::SpanContext c3(trace_id, span_id, trace_api::TraceFlags{0}, true);
@@ -140,7 +141,7 @@ TEST(TraceIdRatioBasedSampler, ShouldSampleWithContext)
   using L = std::vector<std::pair<trace_api::SpanContext, std::map<std::string, std::string>>>;
   L l1 = {{trace_api::SpanContext(false, false), {}}, {trace_api::SpanContext(false, false), {}}};
 
-  opentelemetry::common::KeyValueIterableView<M> view{m1};
+  common::KeyValueIterableView<M> view{m1};
   trace_api::SpanContextKeyValueIterableView<L> links{l1};
 
   TraceIdRatioBasedSampler s1(0.01);


### PR DESCRIPTION
Fixes # (368)
In .cc files across whole project, opentelemetry::* is simplified to * , to follow the namespace guidelines. To do this, following
namespace aliases were used, to establish convention:
- namespace common = opentelemetry::common;
- namespace nostd = opentelemetry::nostd;
- namespace trace = opentelemetry::trace;
- namespace trace_api = opentelemetry::trace;
- namespace resource = opentelemetry::sdk::resource;
- namespace exporter_trace = opentelemetry::exporter::trace;
- namespace context = opentelemetry::context;
- namespace metrics_api = opentelemetry::metrics;
- namespace sdkmetrics  = opentelemetry::sdk::metrics;
- namespace exportermetrics = opentelemetry::exporter::metrics;
- namespace trace_sdk = opentelemetry::sdk::trace;
- namespace sdktrace = opentelemetry::sdk::trace;
- namespace exporterlogs  = opentelemetry::exporter::logs;
- namespace exportertrace = opentelemetry::exporter::trace;
- namespace proto = opentelemetry::proto;
- namespace runtimecontext     = opentelemetry::context::RuntimeContext;
- namespace otlp     = opentelemetry::exporter::otlp;
- namespace plugin    = opentelemetry::plugin;
- namespace curl = opentelemetry::ext::http::client::curl;
- namespace http_client = opentelemetry::ext::http::client;
- namespace logs_api    = opentelemetry::logs;
- namespace sdklogs  = opentelemetry::sdk::logs;

**Note:** _trace and trace_api both are used for opentelemetry::trace;
 trace_sdk and sdktrace both are used for opentelemetry::sdk::trace; These were already existing in the code._


Please provide a brief description of the changes here.
Usage of scope resolution was made consistent across all files using namespace convention and guidelines.