### PR TITLE
Adding new Logger:log() method

### DIFF
--- a/api/include/opentelemetry/logs/logger.h
+++ b/api/include/opentelemetry/logs/logger.h
@@ -143,7 +143,7 @@ public:
    */
   template <class T,
             nostd::enable_if_t<common::detail::is_key_value_iterable<T>::value> * = nullptr>
-  inline void Log(Severity severity, const T &attributes) noexcept
+  void Log(Severity severity, const T &attributes) noexcept
   {
     this->Log(severity, "", "", std::map<std::string, std::string>{}, attributes, {}, {}, {},
               std::chrono::system_clock::now());
@@ -157,7 +157,7 @@ public:
    */
   template <class T,
             nostd::enable_if_t<common::detail::is_key_value_iterable<T>::value> * = nullptr>
-  inline void Log(Severity severity, nostd::string_view name, const T &attributes) noexcept
+  void Log(Severity severity, nostd::string_view name, const T &attributes) noexcept
   {
     this->Log(severity, name, "", std::map<std::string, std::string>{}, attributes, {}, {}, {},
               std::chrono::system_clock::now());

--- a/api/include/opentelemetry/logs/logger.h
+++ b/api/include/opentelemetry/logs/logger.h
@@ -189,6 +189,23 @@ public:
     this->Log(severity, name, "", {}, attributes, {}, {}, {}, std::chrono::system_clock::now());
   }
 
+  /**
+   * Writes a log.
+   * @param severity The severity of the log
+   * @param name The name of the log
+   * @param attributes the attributes, stored as a 2D list of key/value pairs, that are associated
+   * with the log event
+   */
+  void Log(Severity severity,
+           nostd::string_view name,
+           common::KeyValueIterable &attributes) noexcept
+  {
+    this->Log(severity, name, {},
+              common::KeyValueIterableView<
+                  std::initializer_list<std::pair<nostd::string_view, common::AttributeValue>>>({}),
+              attributes, {}, {}, {}, std::chrono::system_clock::now());
+  }
+
   /** Trace severity overloads **/
 
   /**

--- a/sdk/include/opentelemetry/sdk/logs/logger.h
+++ b/sdk/include/opentelemetry/sdk/logs/logger.h
@@ -52,8 +52,8 @@ public:
            nostd::string_view body,
            const opentelemetry::common::KeyValueIterable &resource,
            const opentelemetry::common::KeyValueIterable &attributes,
-           trace::TraceId trace_id,
-           trace::SpanId span_id,
+           opentelemetry::trace::TraceId trace_id,
+           opentelemetry::trace::SpanId span_id,
            trace::TraceFlags trace_flags,
            opentelemetry::common::SystemTimestamp timestamp) noexcept override;
 


### PR DESCRIPTION
## Changes

This is to add the `Logger: Log()` method for the below use-case:

```cpp
  Properties attribs = {{"attrib1", 1}, {"attrib2", 2}};
  logger.log(severity, name, attribs);
```
where `Properties` class implements `common::KeyValueIterable`.

Similar method is supported by `Traccer::StartSpan()`:
https://github.com/open-telemetry/opentelemetry-cpp/blob/21a441e2be80ca335a7d6abd033af2f1cdf477ab/api/include/opentelemetry/trace/tracer.h#L60-L65

Also, a minor change to use full `tracer` namespace in logger sdk, in order to avoid including unnecessary tracer headers for logger instrumentation.

For significant contributions please make sure you have completed the following items:

* [ ] `CHANGELOG.md` updated for non-trivial changes
* [ ] Unit tests have been added
* [ ] Changes in public API reviewed