### PR TITLE
Unset GMOCK_LIB from cache only for MSVC

### DIFF
--- a/exporters/otlp/CMakeLists.txt
+++ b/exporters/otlp/CMakeLists.txt
@@ -69,7 +69,6 @@ if(BUILD_TESTING)
     # library. These flavors have different prefix on Windows, gmock and gmockd
     # respectively.
     add_definitions(-DGTEST_LINKED_AS_SHARED_LIBRARY=1)
-  else()
     if(GMOCK_LIB)
       # unset GMOCK_LIB to force find_library to redo the lookup, as the cached
       # entry could cause linking to incorrect flavor of gmock and leading to


### PR DESCRIPTION
## Changes

Unset CMake cached variable `GMOCK_LIB` should only apply to MSVC, because gmockd.lib is MSVC specific. Max reported some build issue from VS2019, but I cannot repro. Need to address that with new repro. Besides that, the current PR is necessary to get working build while switching CMake build type between Debug and Release.

For significant contributions please make sure you have completed the following items:

* [ ] `CHANGELOG.md` updated for non-trivial changes
* [ ] Unit tests have been added
* [ ] Changes in public API reviewed