### PR TITLE
Fix cmake find thrift when vcpkg is used

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,7 +16,7 @@ project(opentelemetry-cpp)
 mark_as_advanced(CMAKE_TOOLCHAIN_FILE)
 
 # Don't use customized cmake modules if vcpkg is used to resolve dependence.
-if (NOT DEFINED CMAKE_TOOLCHAIN_FILE)
+if(NOT DEFINED CMAKE_TOOLCHAIN_FILE)
   list(APPEND CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/cmake/modules/")
 endif()
 


### PR DESCRIPTION
## Changes

When vcpkg is used, we don't need provide customized cmake find script to resolve dependence. Relying on it could cause find_package to fail even it is installed via vcpkg.

For significant contributions please make sure you have completed the following items:

* [ ] `CHANGELOG.md` updated for non-trivial changes
* [ ] Unit tests have been added
* [ ] Changes in public API reviewed