### PR TITLE
Fix the reference to tracer provider in ETW logger exporter

### DIFF
--- a/exporters/etw/include/opentelemetry/exporters/etw/etw_logger.h
+++ b/exporters/etw/include/opentelemetry/exporters/etw/etw_logger.h
@@ -148,7 +148,7 @@ public:
       evt[ETW_FIELD_TIME] = utils::formatUtcTimestampMsAsISO8601(millis);
     }
 #  endif
-    const auto &cfg = GetConfiguration(tracerProvider_);
+    const auto &cfg = GetConfiguration(loggerProvider_);
     if (cfg.enableSpanId)
     {
       evt[ETW_FIELD_SPAN_ID] = ToLowerBase16(span_id);


### PR DESCRIPTION
## Changes

`loggerProvider_` should be used instead of `tracerProvider_` in ETW log exporter.

For significant contributions please make sure you have completed the following items:

* [ ] `CHANGELOG.md` updated for non-trivial changes
* [ ] Unit tests have been added
* [ ] Changes in public API reviewed