### PR TITLE
fix: update curl lib build_file

### DIFF
--- a/bazel/repository.bzl
+++ b/bazel/repository.bzl
@@ -87,7 +87,7 @@ def opentelemetry_cpp_deps():
     maybe(
         http_archive,
         name = "curl",
-        build_file = "@//bazel:curl.BUILD",
+        build_file = "@io_opentelemetry_cpp//bazel:curl.BUILD",
         sha256 = "ba98332752257b47b9dea6d8c0ad25ec1745c20424f1dd3ff2c99ab59e97cf91",
         strip_prefix = "curl-7.73.0",
         urls = ["https://curl.haxx.se/download/curl-7.73.0.tar.gz"],


### PR DESCRIPTION
When trying to import otlp as a dependency through Bazel, build_file can't be found in current repository. This commit standardize it to @io_opentelemetry_cpp as it is in other deps.

Fixes # (issue)

## Changes

Updates path to curl build file

For significant contributions please make sure you have completed the following items:

* [ ] `CHANGELOG.md` updated for non-trivial changes
* [ ] Unit tests have been added
* [ ] Changes in public API reviewed