### PR TITLE
otlp_grpc_exporter export after shutdown should fail

### DIFF
--- a/exporters/otlp/include/opentelemetry/exporters/otlp/otlp_grpc_exporter.h
+++ b/exporters/otlp/include/opentelemetry/exporters/otlp/otlp_grpc_exporter.h
@@ -78,10 +78,7 @@ public:
    * @return return the status of this operation
    */
   bool Shutdown(
-      std::chrono::microseconds timeout = std::chrono::microseconds::max()) noexcept override
-  {
-    return true;
-  }
+      std::chrono::microseconds timeout = std::chrono::microseconds::max()) noexcept override;
 
 private:
   // The configuration options associated with this exporter.
@@ -99,6 +96,7 @@ private:
    * @param stub the service stub to be used for exporting
    */
   OtlpGrpcExporter(std::unique_ptr<proto::collector::trace::v1::TraceService::StubInterface> stub);
+  bool is_shutdown_ = false;
 };
 }  // namespace otlp
 }  // namespace exporter

--- a/exporters/otlp/src/otlp_grpc_exporter.cc
+++ b/exporters/otlp/src/otlp_grpc_exporter.cc
@@ -94,6 +94,11 @@ std::unique_ptr<sdk::trace::Recordable> OtlpGrpcExporter::MakeRecordable() noexc
 sdk::common::ExportResult OtlpGrpcExporter::Export(
     const nostd::span<std::unique_ptr<sdk::trace::Recordable>> &spans) noexcept
 {
+  if (is_shutdown_)
+  {
+    OTEL_INTERNAL_LOG_ERROR("[OTLP gRPC] Export failed, exporter is shutdown");
+    return sdk::common::ExportResult::kFailure;
+  }
   proto::collector::trace::v1::ExportTraceServiceRequest request;
   OtlpRecordableUtils::PopulateRequest(spans, &request);
 
@@ -120,6 +125,13 @@ sdk::common::ExportResult OtlpGrpcExporter::Export(
   }
   return sdk::common::ExportResult::kSuccess;
 }
+
+bool OtlpGrpcExporter::Shutdown(std::chrono::microseconds timeout) noexcept
+{
+  is_shutdown_ = true;
+  return true;
+}
+
 }  // namespace otlp
 }  // namespace exporter
 OPENTELEMETRY_END_NAMESPACE

--- a/exporters/otlp/test/otlp_grpc_exporter_test.cc
+++ b/exporters/otlp/test/otlp_grpc_exporter_test.cc
@@ -60,6 +60,31 @@ public:
   }
 };
 
+TEST_F(OtlpGrpcExporterTestPeer, ShutdownTest)
+{
+  auto mock_stub = new proto::collector::trace::v1::MockTraceServiceStub();
+  std::unique_ptr<proto::collector::trace::v1::TraceService::StubInterface> stub_interface(
+      mock_stub);
+  auto exporter = GetExporter(stub_interface);
+
+  auto recordable_1 = exporter->MakeRecordable();
+  recordable_1->SetName("Test span 1");
+  auto recordable_2 = exporter->MakeRecordable();
+  recordable_2->SetName("Test span 2");
+
+  // exporter shuold not be shutdown by default
+  nostd::span<std::unique_ptr<sdk::trace::Recordable>> batch_1(&recordable_1, 1);
+  EXPECT_CALL(*mock_stub, Export(_, _, _)).Times(Exactly(1)).WillOnce(Return(grpc::Status::OK));
+  auto result = exporter->Export(batch_1);
+  EXPECT_EQ(sdk::common::ExportResult::kSuccess, result);
+
+  exporter->Shutdown();
+
+  nostd::span<std::unique_ptr<sdk::trace::Recordable>> batch_2(&recordable_2, 1);
+  result = exporter->Export(batch_2);
+  EXPECT_EQ(sdk::common::ExportResult::kFailure, result);
+}
+
 // Call Export() directly
 TEST_F(OtlpGrpcExporterTestPeer, ExportUnitTest)
 {


### PR DESCRIPTION
according to the exporter [specifications](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/sdk.md#shutdown-2), export after shutdown should fail

## Changes

Please provide a brief description of the changes here.

For significant contributions please make sure you have completed the following items:

* [ ] `CHANGELOG.md` updated for non-trivial changes
* [x] Unit tests have been added
* [ ] Changes in public API reviewed