### PR TITLE
fix: redefinition

### DIFF
--- a/api/include/opentelemetry/trace/propagation/http_trace_context.h
+++ b/api/include/opentelemetry/trace/propagation/http_trace_context.h
@@ -1,6 +1,8 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
+#pragma once
+
 #include <array>
 #include "detail/hex.h"
 #include "detail/string.h"


### PR DESCRIPTION
add include guard