### PR TITLE
checkout opentelemetry-proto v0.11.0

### DIFF
--- a/ci/README.md
+++ b/ci/README.md
@@ -18,6 +18,7 @@ CI tests can be run on docker by invoking the script `./ci/run_docker.sh
   checker.
 * `benchmark`: run all benchmarks.
 * `format`: use `tools/format.sh` to enforce text formatting.
+* `third_party.tags`: store third_party release tags.
 * `code.coverage`: build cmake targets with CXX option `--coverage` and run
   tests.
 

--- a/ci/do_ci.sh
+++ b/ci/do_ci.sh
@@ -226,7 +226,10 @@ elif [[ "$1" == "code.coverage" ]]; then
   cp tmp_coverage.info coverage.info
   exit 0
 elif [[ "$1" == "third_party.tags" ]]; then
-  git submodule status | sed 's:.*/::' | sed 's/ (/=/g' | sed 's/)//g' > third_party_release
+  echo "gRPC=v1.39.1" > third_party_release
+  echo "thrift=0.14.1" >> third_party_release
+  echo "abseil=20210324.0" >> third_party_release
+  git submodule status | sed 's:.*/::' | sed 's/ (/=/g' | sed 's/)//g' >> third_party_release
   exit 0
 fi
 

--- a/ci/do_ci.sh
+++ b/ci/do_ci.sh
@@ -225,6 +225,9 @@ elif [[ "$1" == "code.coverage" ]]; then
   lcov --remove coverage.info '*/ext/http/server/*'> tmp_coverage.info 2>/dev/null
   cp tmp_coverage.info coverage.info
   exit 0
+elif [[ "$1" == "third_party.tags" ]]; then
+  git submodule status | sed 's:.*/::' | sed 's/ (/=/g' | sed 's/)//g' > third_party_release
+  exit 0
 fi
 
 echo "Invalid do_ci.sh target, see ci/README.md for valid targets."

--- a/third_party_release
+++ b/third_party_release
@@ -1,0 +1,7 @@
+benchmark=v1.5.3
+googletest=release-1.8.0-2523-ga6dfd3ac
+ms-gsl=v1.0.0-393-g6f45293
+nlohmann-json=v3.9.1
+opentelemetry-proto=v0.11.0
+prometheus-cpp=v0.11.0
+vcpkg=2020.04-2702-g5568f110b

--- a/third_party_release
+++ b/third_party_release
@@ -1,3 +1,6 @@
+gRPC=v1.39.1
+thrift=0.14.1
+abseil=20210324.0
 benchmark=v1.5.3
 googletest=release-1.8.0-2523-ga6dfd3ac
 ms-gsl=v1.0.0-393-g6f45293


### PR DESCRIPTION
Related to #1051 (issue)

## Changes

checkout opentelemetry-proto v0.11.0 and store the third_party release tags in a file
For significant contributions please make sure you have completed the following items:

* [ ] `CHANGELOG.md` updated for non-trivial changes
* [ ] Unit tests have been added
* [ ] Changes in public API reviewed