### PR TITLE
Add action to mark and close stale issues after timeout

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,15 @@
+name: 'Mark and close stale issues and PRs'
+on:
+  schedule:
+    - cron: '30 1 * * *'
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v4
+        with:
+          stale-issue-message: 'This issue was marked as stale due to lack of activity. It will be closed in 7 days.'
+          stale-pr-message: 'This PR was marked as stale due to lack of activity. It will be closed in 7 days.'
+          days-before-stale: 60
+          days-before-close: 7

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -10,6 +10,7 @@ jobs:
       - uses: actions/stale@v4
         with:
           stale-issue-message: 'This issue was marked as stale due to lack of activity. It will be closed in 7 days.'
-          stale-pr-message: 'This PR was marked as stale due to lack of activity. It will be closed in 7 days.'
+          close-issue-message: 'Closed as inactive. Feel free to reopen if this is still an issue.'
           days-before-stale: 60
           days-before-close: 7
+          exempt-pr-labels: 'do-not-stale'


### PR DESCRIPTION
## Changes

Based on the discussion in our community meeting, adding bot to detect stale issues and PRs will help us track progress.

For significant contributions please make sure you have completed the following items:

* [ ] `CHANGELOG.md` updated for non-trivial changes
* [ ] Unit tests have been added
* [ ] Changes in public API reviewed