### PR TITLE
Remove stale bot to operate on PRs

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,4 +1,4 @@
-name: 'Mark and close stale issues and PRs'
+name: 'Mark and close stale issues'
 on:
   schedule:
     - cron: '30 1 * * *'
@@ -9,8 +9,8 @@ jobs:
     steps:
       - uses: actions/stale@v4
         with:
-          stale-issue-message: 'This issue was marked as stale due to lack of activity. It will be closed in 7 days.'
+          stale-issue-message: 'This issue was marked as stale due to lack of activity. It will be closed in 7 days if no furthur activity occurs.'
           close-issue-message: 'Closed as inactive. Feel free to reopen if this is still an issue.'
-          days-before-stale: 60
-          days-before-close: 7
+          days-before-issue-stale: 60
+          days-before-issue-close: 7
           exempt-pr-labels: 'do-not-stale'


### PR DESCRIPTION
It seems `days-before-stale` and `days-before-close` apply to both issues and PRs, even without the message specified. This PR use the more concrete property `days-before-issue-stale` and `days-before-issue-close` to get the expected behavior we agreed.

For significant contributions please make sure you have completed the following items:

* [ ] `CHANGELOG.md` updated for non-trivial changes
* [ ] Unit tests have been added
* [ ] Changes in public API reviewed