### PR TITLE
Mark cURL as required dependence for building Zipkin exporter

### DIFF
--- a/exporters/zipkin/CMakeLists.txt
+++ b/exporters/zipkin/CMakeLists.txt
@@ -13,12 +13,7 @@
 # limitations under the License.
 
 include_directories(include)
-find_package(CURL)
-if(NOT CURL_FOUND)
-  message(
-    FATAL_ERROR "CURL not found: CURL is required to build zipkin exporter.")
-endif()
-
+find_package(CURL REQUIRED)
 add_definitions(-DWITH_CURL)
 add_library(opentelemetry_exporter_zipkin_trace src/zipkin_exporter.cc
                                                 src/recordable.cc)

--- a/exporters/zipkin/CMakeLists.txt
+++ b/exporters/zipkin/CMakeLists.txt
@@ -14,9 +14,11 @@
 
 include_directories(include)
 find_package(CURL)
-if(CURL_FOUND)
-  add_definitions(-DWITH_CURL)
+if(NOT CURL_FOUND)
+  message(FATAL_ERROR "CURL not found: CURL is required to build zipkin exporter.")
 endif()
+
+add_definitions(-DWITH_CURL)
 add_library(opentelemetry_exporter_zipkin_trace src/zipkin_exporter.cc
                                                 src/recordable.cc)
 

--- a/exporters/zipkin/CMakeLists.txt
+++ b/exporters/zipkin/CMakeLists.txt
@@ -15,7 +15,8 @@
 include_directories(include)
 find_package(CURL)
 if(NOT CURL_FOUND)
-  message(FATAL_ERROR "CURL not found: CURL is required to build zipkin exporter.")
+  message(
+    FATAL_ERROR "CURL not found: CURL is required to build zipkin exporter.")
 endif()
 
 add_definitions(-DWITH_CURL)


### PR DESCRIPTION
## Changes

`http_client_curl` is required to build Zipkin exporter. It is better to report error when running CMake files if cURL is not found for Zipkin, or it will be surfaced as link error during later linking stage.

For significant contributions please make sure you have completed the following items:

* [ ] `CHANGELOG.md` updated for non-trivial changes
* [ ] Unit tests have been added
* [ ] Changes in public API reviewed