### PR TITLE
otlp gRPC log export should fail after shutdown

### DIFF
--- a/exporters/otlp/include/opentelemetry/exporters/otlp/otlp_grpc_log_exporter.h
+++ b/exporters/otlp/include/opentelemetry/exporters/otlp/otlp_grpc_log_exporter.h
@@ -58,10 +58,8 @@ public:
    * Shutdown this exporter.
    * @param timeout The maximum time to wait for the shutdown method to return.
    */
-  bool Shutdown(std::chrono::microseconds timeout = std::chrono::microseconds(0)) noexcept override
-  {
-    return true;
-  }
+  bool Shutdown(
+      std::chrono::microseconds timeout = std::chrono::microseconds::max()) noexcept override;
 
 private:
   // Configuration options for the exporter
@@ -79,6 +77,7 @@ private:
    * @param stub the service stub to be used for exporting
    */
   OtlpGrpcLogExporter(std::unique_ptr<proto::collector::logs::v1::LogsService::StubInterface> stub);
+  bool is_shutdown_ = false;
 };
 
 }  // namespace otlp

--- a/exporters/otlp/src/otlp_grpc_log_exporter.cc
+++ b/exporters/otlp/src/otlp_grpc_log_exporter.cc
@@ -125,6 +125,11 @@ std::unique_ptr<opentelemetry::sdk::logs::Recordable> OtlpGrpcLogExporter::MakeR
 opentelemetry::sdk::common::ExportResult OtlpGrpcLogExporter::Export(
     const nostd::span<std::unique_ptr<opentelemetry::sdk::logs::Recordable>> &logs) noexcept
 {
+  if (is_shutdown_)
+  {
+    OTEL_INTERNAL_LOG_ERROR("[OTLP gRPC log] Export failed, exporter is shutdown");
+    return sdk::common::ExportResult::kFailure;
+  }
   proto::collector::logs::v1::ExportLogsServiceRequest request;
   OtlpRecordableUtils::PopulateRequest(logs, &request);
 
@@ -148,6 +153,12 @@ opentelemetry::sdk::common::ExportResult OtlpGrpcLogExporter::Export(
     return sdk::common::ExportResult::kFailure;
   }
   return sdk::common::ExportResult::kSuccess;
+}
+
+bool OtlpGrpcLogExporter::Shutdown(std::chrono::microseconds timeout) noexcept
+{
+  is_shutdown_ = true;
+  return true;
 }
 
 }  // namespace otlp

--- a/exporters/otlp/test/otlp_grpc_log_exporter_test.cc
+++ b/exporters/otlp/test/otlp_grpc_log_exporter_test.cc
@@ -65,7 +65,7 @@ TEST_F(OtlpGrpcLogExporterTestPeer, ShutdownTest)
   // exporter shuold not be shutdown by default
   nostd::span<std::unique_ptr<sdk::logs::Recordable>> batch_1(&recordable_1, 1);
   EXPECT_CALL(*mock_stub, Export(_, _, _))
-      .Times(Exactly(2))
+      .Times(Exactly(1))
       .WillOnce(Return(grpc::Status::OK))
       .WillOnce(Return(grpc::Status::CANCELLED));
 
@@ -132,11 +132,9 @@ TEST_F(OtlpGrpcLogExporterTestPeer, ExportIntegrationTest)
 
   uint8_t trace_id_bin[opentelemetry::trace::TraceId::kSize] = {
       '0', '1', '2', '3', '4', '5', '6', '7', '8', '9', 'a', 'b', 'c', 'd', 'e', 'f'};
-  char trace_id_hex[2 * opentelemetry::trace::TraceId::kSize] = {0};
   opentelemetry::trace::TraceId trace_id{trace_id_bin};
-  uint8_t span_id_bin[opentelemetry::trace::SpanId::kSize]  = {'7', '6', '5', '4',
+  uint8_t span_id_bin[opentelemetry::trace::SpanId::kSize] = {'7', '6', '5', '4',
                                                               '3', '2', '1', '0'};
-  char span_id_hex[2 * opentelemetry::trace::SpanId::kSize] = {0};
   opentelemetry::trace::SpanId span_id{span_id_bin};
 
   auto logger = provider->GetLogger("test");


### PR DESCRIPTION
according to the exporter [specifications](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/sdk.md#shutdown-2), export after shutdown should fail
Also fixes compiler warning
## Changes

Please provide a brief description of the changes here.

For significant contributions please make sure you have completed the following items:

* [ ] `CHANGELOG.md` updated for non-trivial changes
* [ ] Unit tests have been added
* [ ] Changes in public API reviewed