### PR TITLE
Mark tags to bazel targets

### DIFF
--- a/bazel/otel_cc_benchmark.bzl
+++ b/bazel/otel_cc_benchmark.bzl
@@ -1,4 +1,4 @@
-def otel_cc_benchmark(name, srcs, deps):
+def otel_cc_benchmark(name, srcs, deps, tags = [""]):
     """
     Creates targets for the benchmark and related targets.
 
@@ -23,7 +23,7 @@ def otel_cc_benchmark(name, srcs, deps):
         name = name,
         srcs = srcs,
         deps = deps + ["@com_github_google_benchmark//:benchmark"],
-        tags = ["manual"],
+        tags = tags + ["manual"],
     )
 
     # The result of running the benchmark, captured into a text file.
@@ -31,7 +31,7 @@ def otel_cc_benchmark(name, srcs, deps):
         name = name + "_result",
         outs = [name + "_result.txt"],
         tools = [":" + name],
-        tags = ["benchmark_result", "manual"],
+        tags = tags + ["benchmark_result", "manual"],
         testonly = True,
         cmd = "$(location :" + name + (") --benchmark_color=false --benchmark_min_time=.1 &> $@"),
     )
@@ -43,5 +43,5 @@ def otel_cc_benchmark(name, srcs, deps):
         srcs = srcs,
         deps = deps + ["@com_github_google_benchmark//:benchmark"],
         args = ["--benchmark_min_time=0"],
-        tags = ["benchmark"],
+        tags = tags + ["benchmark"],
     )

--- a/examples/batch/BUILD
+++ b/examples/batch/BUILD
@@ -4,6 +4,7 @@ cc_binary(
         "main.cc",
     ],
     linkopts = ["-lpthread"],
+    tags = ["ostream"],
     deps = [
         "//api",
         "//exporters/ostream:ostream_span_exporter",

--- a/examples/grpc/BUILD
+++ b/examples/grpc/BUILD
@@ -24,6 +24,7 @@ cc_library(
     name = "tracer_common",
     srcs = ["tracer_common.h"],
     defines = ["BAZEL_BUILD"],
+    tags = ["ostream"],
     deps = [
         "//exporters/ostream:ostream_span_exporter",
     ],
@@ -35,6 +36,7 @@ cc_binary(
         "client.cc",
     ],
     defines = ["BAZEL_BUILD"],
+    tags = ["ostream"],
     deps = [
         "messages_cc_grpc",
         ":tracer_common",
@@ -50,6 +52,7 @@ cc_binary(
         "server.cc",
     ],
     defines = ["BAZEL_BUILD"],
+    tags = ["ostream"],
     deps = [
         "messages_cc_grpc",
         ":tracer_common",

--- a/examples/http/BUILD
+++ b/examples/http/BUILD
@@ -15,6 +15,7 @@ cc_binary(
         ],
         "//conditions:default": [],
     }),
+    tags = ["ostream"],
     deps = [
         "//api",
         "//exporters/ostream:ostream_span_exporter",
@@ -31,6 +32,7 @@ cc_binary(
         "server.h",
         "tracer_common.h",
     ],
+    tags = ["ostream"],
     deps = [
         "//api",
         "//exporters/ostream:ostream_span_exporter",

--- a/examples/metrics_simple/BUILD
+++ b/examples/metrics_simple/BUILD
@@ -4,6 +4,7 @@ cc_binary(
         "main.cc",
     ],
     linkopts = ["-pthread"],
+    tags = ["ostream"],
     deps = [
         "//api",
         "//exporters/ostream:ostream_metrics_exporter_deprecated",

--- a/examples/multi_processor/BUILD
+++ b/examples/multi_processor/BUILD
@@ -3,6 +3,10 @@ cc_binary(
     srcs = [
         "main.cc",
     ],
+    tags = [
+        "memory",
+        "ostream",
+    ],
     deps = [
         "//api",
         "//examples/common/foo_library:common_foo_library",

--- a/examples/multithreaded/BUILD
+++ b/examples/multithreaded/BUILD
@@ -3,6 +3,7 @@ cc_binary(
     srcs = [
         "main.cc",
     ],
+    tags = ["ostream"],
     deps = [
         "//api",
         "//exporters/ostream:ostream_span_exporter",

--- a/examples/otlp/BUILD
+++ b/examples/otlp/BUILD
@@ -3,6 +3,7 @@ cc_binary(
     srcs = [
         "grpc_main.cc",
     ],
+    tags = ["otlp"],
     deps = [
         "//api",
         "//examples/common/foo_library:common_foo_library",
@@ -16,6 +17,7 @@ cc_binary(
     srcs = [
         "http_main.cc",
     ],
+    tags = ["otlp"],
     deps = [
         "//api",
         "//examples/common/foo_library:common_foo_library",
@@ -29,6 +31,7 @@ cc_binary(
     srcs = [
         "http_log_main.cc",
     ],
+    tags = ["otlp"],
     deps = [
         "//api",
         "//examples/common/logs_foo_library:common_logs_foo_library",

--- a/examples/simple/BUILD
+++ b/examples/simple/BUILD
@@ -3,6 +3,7 @@ cc_binary(
     srcs = [
         "main.cc",
     ],
+    tags = ["ostream"],
     deps = [
         "//api",
         "//examples/common/foo_library:common_foo_library",

--- a/exporters/elasticsearch/BUILD
+++ b/exporters/elasticsearch/BUILD
@@ -18,6 +18,7 @@ cc_library(
         "//conditions:default": [],
     }),
     strip_include_prefix = "include",
+    tags = ["es"],
     deps = [
         "//ext:headers",
         "//ext/src/http/client/curl:http_client_curl",
@@ -30,6 +31,7 @@ cc_library(
 cc_test(
     name = "es_log_exporter_test",
     srcs = ["test/es_log_exporter_test.cc"],
+    tags = ["es"],
     deps = [
         ":es_log_exporter",
         "@com_google_googletest//:gtest_main",

--- a/exporters/etw/BUILD
+++ b/exporters/etw/BUILD
@@ -9,6 +9,7 @@ cc_library(
     local_defines = [
         "HAVE_MSGPACK",
     ],
+    tags = ["etw"],
     deps = [
         "//api",
         "//sdk/src/trace",
@@ -22,6 +23,7 @@ cc_test(
     local_defines = [
         "HAVE_MSGPACK",
     ],
+    tags = ["etw"],
     deps = [
         ":etw_exporter",
         "@com_google_googletest//:gtest_main",
@@ -35,6 +37,7 @@ cc_test(
     local_defines = [
         "HAVE_MSGPACK",
     ],
+    tags = ["etw"],
     deps = [
         ":etw_exporter",
         "@com_google_googletest//:gtest_main",

--- a/exporters/memory/BUILD
+++ b/exporters/memory/BUILD
@@ -6,6 +6,7 @@ cc_library(
         "include/opentelemetry/exporters/memory/in_memory_span_data.h",
     ],
     strip_include_prefix = "include",
+    tags = ["memory"],
     deps = [
         "//api",
         "//sdk/src/resource",
@@ -15,6 +16,7 @@ cc_library(
 
 cc_test(
     name = "in_memory_span_data_test",
+    tags = ["memory"],
     deps = [
         ":in_memory_span_data",
         "@com_google_googletest//:gtest_main",
@@ -27,6 +29,7 @@ cc_library(
         "include/opentelemetry/exporters/memory/in_memory_span_exporter.h",
     ],
     strip_include_prefix = "include",
+    tags = ["memory"],
     deps = [
         ":in_memory_span_data",
         "//sdk/src/trace",
@@ -35,6 +38,7 @@ cc_library(
 
 cc_test(
     name = "in_memory_span_exporter_test",
+    tags = ["memory"],
     deps = [
         ":in_memory_span_exporter",
         "@com_google_googletest//:gtest_main",

--- a/exporters/ostream/BUILD
+++ b/exporters/ostream/BUILD
@@ -9,6 +9,7 @@ cc_library(
         "include/opentelemetry/exporters/ostream/log_exporter.h",
     ],
     strip_include_prefix = "include",
+    tags = ["ostream"],
     deps = [
         "//sdk/src/logs",
     ],
@@ -17,6 +18,7 @@ cc_library(
 cc_test(
     name = "ostream_log_test",
     srcs = ["test/ostream_log_test.cc"],
+    tags = ["ostream"],
     deps = [
         ":ostream_log_exporter",
         "@com_google_googletest//:gtest_main",
@@ -32,6 +34,7 @@ cc_library(
         "include/opentelemetry/exporters/ostream/metrics_exporter.h",
     ],
     strip_include_prefix = "include",
+    tags = ["ostream"],
     deps = [
         "//sdk/src/_metrics:metrics_deprecated",
     ],
@@ -40,6 +43,7 @@ cc_library(
 cc_test(
     name = "ostream_metrics_test",
     srcs = ["test/ostream_metrics_test.cc"],
+    tags = ["ostream"],
     deps = [
         ":ostream_metrics_exporter_deprecated",
         "@com_google_googletest//:gtest_main",
@@ -55,6 +59,7 @@ cc_library(
         "include/opentelemetry/exporters/ostream/span_exporter.h",
     ],
     strip_include_prefix = "include",
+    tags = ["ostream"],
     deps = [
         "//sdk/src/trace",
     ],
@@ -65,6 +70,7 @@ cc_library(
     hdrs = [
         "test/ostream_capture.h",
     ],
+    tags = ["ostream"],
     deps = [
         "//api",
     ],
@@ -73,6 +79,7 @@ cc_library(
 cc_test(
     name = "ostream_span_test",
     srcs = ["test/ostream_span_test.cc"],
+    tags = ["ostream"],
     deps = [
         ":ostream_capture",
         ":ostream_span_exporter",

--- a/exporters/otlp/BUILD
+++ b/exporters/otlp/BUILD
@@ -31,6 +31,7 @@ cc_library(
         "include/opentelemetry/exporters/otlp/protobuf_include_suffix.h",
     ],
     strip_include_prefix = "include",
+    tags = ["otlp"],
     deps = [
         "//sdk/src/logs",
         "//sdk/src/resource",
@@ -53,6 +54,7 @@ cc_library(
         "include/opentelemetry/exporters/otlp/protobuf_include_suffix.h",
     ],
     strip_include_prefix = "include",
+    tags = ["otlp"],
     deps = [
         ":otlp_recordable",
         "//ext:headers",
@@ -86,6 +88,7 @@ cc_library(
         "//conditions:default": [],
     }),
     strip_include_prefix = "include",
+    tags = ["otlp"],
     deps = [
         "//api",
         "//ext/src/http/client/curl:http_client_curl",
@@ -107,6 +110,7 @@ cc_library(
         "include/opentelemetry/exporters/otlp/protobuf_include_suffix.h",
     ],
     strip_include_prefix = "include",
+    tags = ["otlp"],
     deps = [
         ":otlp_http_client",
         ":otlp_recordable",
@@ -127,6 +131,7 @@ cc_library(
         "include/opentelemetry/exporters/otlp/protobuf_include_suffix.h",
     ],
     strip_include_prefix = "include",
+    tags = ["otlp"],
     deps = [
         ":otlp_http_client",
         ":otlp_recordable",
@@ -148,6 +153,7 @@ cc_library(
         "include/opentelemetry/exporters/otlp/protobuf_include_suffix.h",
     ],
     strip_include_prefix = "include",
+    tags = ["otlp"],
     deps = [
         ":otlp_recordable",
         "//ext:headers",
@@ -162,6 +168,7 @@ cc_library(
 cc_test(
     name = "otlp_recordable_test",
     srcs = ["test/otlp_recordable_test.cc"],
+    tags = ["otlp"],
     deps = [
         ":otlp_recordable",
         "@com_google_googletest//:gtest_main",
@@ -171,6 +178,7 @@ cc_test(
 cc_test(
     name = "otlp_grpc_exporter_test",
     srcs = ["test/otlp_grpc_exporter_test.cc"],
+    tags = ["otlp"],
     deps = [
         ":otlp_grpc_exporter",
         "//api",
@@ -181,6 +189,7 @@ cc_test(
 cc_test(
     name = "otlp_http_exporter_test",
     srcs = ["test/otlp_http_exporter_test.cc"],
+    tags = ["otlp"],
     deps = [
         ":otlp_http_exporter",
         "//api",
@@ -191,6 +200,7 @@ cc_test(
 cc_test(
     name = "otlp_http_log_exporter_test",
     srcs = ["test/otlp_http_log_exporter_test.cc"],
+    tags = ["otlp"],
     deps = [
         ":otlp_http_log_exporter",
         "//api",
@@ -201,6 +211,7 @@ cc_test(
 cc_test(
     name = "otlp_grpc_log_exporter_test",
     srcs = ["test/otlp_grpc_log_exporter_test.cc"],
+    tags = ["otlp"],
     deps = [
         ":otlp_grpc_log_exporter",
         "//api",
@@ -212,6 +223,7 @@ cc_test(
 otel_cc_benchmark(
     name = "otlp_grpc_exporter_benchmark",
     srcs = ["test/otlp_grpc_exporter_benchmark.cc"],
+    tags = ["otlp"],
     deps = [
         ":otlp_grpc_exporter",
     ],

--- a/exporters/prometheus/BUILD
+++ b/exporters/prometheus/BUILD
@@ -23,6 +23,7 @@ cc_library(
         "include/opentelemetry/exporters/prometheus/prometheus_exporter.h",
     ],
     strip_include_prefix = "include",
+    tags = ["prometheus"],
     deps = [
         ":prometheus_collector",
         ":prometheus_exporter_utils",
@@ -42,6 +43,7 @@ cc_library(
         "include/opentelemetry/exporters/prometheus/prometheus_exporter_utils.h",
     ],
     strip_include_prefix = "include",
+    tags = ["prometheus"],
     deps = [
         "//api",
         "//sdk:headers",
@@ -59,6 +61,7 @@ cc_library(
         "include/opentelemetry/exporters/prometheus/prometheus_collector.h",
     ],
     strip_include_prefix = "include",
+    tags = ["prometheus"],
     deps = [
         ":prometheus_exporter_utils",
         "//api",
@@ -73,6 +76,7 @@ cc_test(
     srcs = [
         "test/prometheus_exporter_test.cc",
     ],
+    tags = ["prometheus"],
     deps = [
         ":prometheus_exporter",
         "@com_google_googletest//:gtest_main",

--- a/exporters/zipkin/BUILD
+++ b/exporters/zipkin/BUILD
@@ -9,6 +9,7 @@ cc_library(
         "include/opentelemetry/exporters/zipkin/recordable.h",
     ],
     strip_include_prefix = "include",
+    tags = ["zipkin"],
     deps = [
         "//sdk/src/resource",
         "//sdk/src/trace",
@@ -28,6 +29,7 @@ cc_library(
         "-DCURL_STATICLIB",
     ],
     strip_include_prefix = "include",
+    tags = ["zipkin"],
     deps = [
         ":zipkin_recordable",
         "//ext/src/http/client/curl:http_client_curl",
@@ -37,6 +39,7 @@ cc_library(
 cc_test(
     name = "zipkin_recordable_test",
     srcs = ["test/zipkin_recordable_test.cc"],
+    tags = ["zipkin"],
     deps = [
         ":zipkin_recordable",
         "@com_google_googletest//:gtest_main",


### PR DESCRIPTION
Fixes #1072 (issue)

## Changes
mark tags to bazel targets.

Please provide a brief description of the changes here.
can exclude targets e.g.
`bazel build //... --build_tag_filters=-otlp,-es,-etw,-prometheus,-zipkin`
For significant contributions please make sure you have completed the following items:

* [ ] `CHANGELOG.md` updated for non-trivial changes
* [ ] Unit tests have been added
* [ ] Changes in public API reviewed