### PR TITLE
Fix timeout of `OtlpHttpExporterTestPeer` and `OtlpHttpLogExporterTestPeer` when run under valgrind.

### DIFF
--- a/exporters/otlp/test/otlp_http_exporter_test.cc
+++ b/exporters/otlp/test/otlp_http_exporter_test.cc
@@ -240,7 +240,7 @@ TEST_F(OtlpHttpExporterTestPeer, ExportJsonIntegrationTest)
     report_trace_id.assign(trace_id_hex, sizeof(trace_id_hex));
   }
 
-  ASSERT_TRUE(waitForRequests(2, old_count + 1));
+  ASSERT_TRUE(waitForRequests(8, old_count + 1));
   auto check_json                   = received_requests_json_.back();
   auto resource_span                = *check_json["resource_spans"].begin();
   auto instrumentation_library_span = *resource_span["instrumentation_library_spans"].begin();
@@ -310,7 +310,7 @@ TEST_F(OtlpHttpExporterTestPeer, ExportBinaryIntegrationTest)
     report_trace_id.assign(reinterpret_cast<char *>(trace_id_binary), sizeof(trace_id_binary));
   }
 
-  ASSERT_TRUE(waitForRequests(2, old_count + 1));
+  ASSERT_TRUE(waitForRequests(8, old_count + 1));
 
   auto received_trace_id = received_requests_binary_.back()
                                .resource_spans(0)

--- a/exporters/otlp/test/otlp_http_log_exporter_test.cc
+++ b/exporters/otlp/test/otlp_http_log_exporter_test.cc
@@ -251,7 +251,7 @@ TEST_F(OtlpHttpLogExporterTestPeer, ExportJsonIntegrationTest)
     report_span_id.assign(span_id_hex, sizeof(span_id_hex));
   }
 
-  ASSERT_TRUE(waitForRequests(2, old_count + 1));
+  ASSERT_TRUE(waitForRequests(8, old_count + 1));
   auto check_json                   = received_requests_json_.back();
   auto resource_logs                = *check_json["resource_logs"].begin();
   auto instrumentation_library_span = *resource_logs["instrumentation_library_logs"].begin();
@@ -339,7 +339,7 @@ TEST_F(OtlpHttpLogExporterTestPeer, ExportBinaryIntegrationTest)
     report_span_id.assign(reinterpret_cast<const char *>(span_id_bin), sizeof(span_id_bin));
   }
 
-  ASSERT_TRUE(waitForRequests(2, old_count + 1));
+  ASSERT_TRUE(waitForRequests(8, old_count + 1));
   auto received_log =
       received_requests_binary_.back().resource_logs(0).instrumentation_library_logs(0).logs(0);
   EXPECT_EQ(received_log.trace_id(), report_trace_id);


### PR DESCRIPTION
Signed-off-by: owent <admin@owent.net>

Fixes #1049

## Changes

Increase timeout for `OtlpHttpExporterTestPeer` and `OtlpHttpLogExporterTestPeer` .

Please provide a brief description of the changes here.

For significant contributions please make sure you have completed the following items:

* [x] `CHANGELOG.md` updated for non-trivial changes
* [x] Unit tests have been added
* [x] Changes in public API reviewed