### PR TITLE
Remove hardcoded Zoom link

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,10 +88,7 @@ We meet weekly, and the time of the meeting alternates between Monday at 15:00
 PT and Wednesday at 10:00 PT. The meeting is subject to change depending on
 contributors' availability. Check the [OpenTelemetry community
 calendar](https://calendar.google.com/calendar/embed?src=google.com_b79e3e90j7bbsa2n2p5an5lf60%40group.calendar.google.com)
-for specific dates.
-
-Meetings take place via [Zoom video conference](https://zoom.us/j/6729396170).
-The passcode is _77777_.
+for specific dates and Zoom meeting links.
 
 Meeting notes are available as a public [Google
 doc](https://docs.google.com/document/d/1i1E4-_y4uJ083lCutKGDhkpi3n4_e774SBLi9hPLocw/edit?usp=sharing).


### PR DESCRIPTION
Removes Zoom link and points viewers to the calendar