### PR TITLE
fix in memory exporter test bazel

### DIFF
--- a/exporters/memory/BUILD
+++ b/exporters/memory/BUILD
@@ -16,6 +16,7 @@ cc_library(
 
 cc_test(
     name = "in_memory_span_data_test",
+    srcs = ["test/in_memory_span_data_test.cc"],
     tags = ["memory"],
     deps = [
         ":in_memory_span_data",
@@ -38,6 +39,7 @@ cc_library(
 
 cc_test(
     name = "in_memory_span_exporter_test",
+    srcs = ["test/in_memory_span_exporter_test.cc"],
     tags = ["memory"],
     deps = [
         ":in_memory_span_exporter",


### PR DESCRIPTION
Fixes in memory exporter test bazel

## Changes
Adds the missing `src` files in the `cc_test` rules of in memory exporter.
For significant contributions please make sure you have completed the following items:

* [ ] `CHANGELOG.md` updated for non-trivial changes
* [ ] Unit tests have been added
* [ ] Changes in public API reviewed