### PR TITLE
Jaeger exporter: spans over 512 bytes

### DIFF
--- a/exporters/jaeger/src/udp_transport.cc
+++ b/exporters/jaeger/src/udp_transport.cc
@@ -19,9 +19,10 @@ UDPTransport::UDPTransport(const std::string &addr, uint16_t port)
 
   endpoint_transport_ = std::shared_ptr<TTransport>(new TUDPTransport(addr, port));
   endpoint_transport_->open();
-  transport_ = std::shared_ptr<TTransport>(new TBufferedTransport(endpoint_transport_));
-  protocol_  = std::shared_ptr<TProtocol>(new TCompactProtocol(transport_));
-  agent_     = std::unique_ptr<AgentClient>(new AgentClient(protocol_));
+  transport_ =
+      std::shared_ptr<TTransport>(new TBufferedTransport(endpoint_transport_, max_packet_size_));
+  protocol_ = std::shared_ptr<TProtocol>(new TCompactProtocol(transport_));
+  agent_    = std::unique_ptr<AgentClient>(new AgentClient(protocol_));
 }
 
 UDPTransport::~UDPTransport()


### PR DESCRIPTION
Fixes #1103 (issue)

## Changes

adds missing buffer size in allocations.
adds a log message when `ThriftSender::Append()` fails because of the size of the span

For significant contributions please make sure you have completed the following items:

* [ ] `CHANGELOG.md` updated for non-trivial changes
* [ ] Unit tests have been added
* [ ] Changes in public API reviewed