### PR TITLE
Add explicit type conversion when assigning value_type to Jaeger tag

### DIFF
--- a/exporters/jaeger/test/jaeger_recordable_test.cc
+++ b/exporters/jaeger/test/jaeger_recordable_test.cc
@@ -168,15 +168,15 @@ void addTag(thrift::TagType::type tag_type,
   tag.__set_vType(tag_type);
   if (tag_type == thrift::TagType::LONG)
   {
-    tag.__set_vLong(value);
+    tag.__set_vLong(static_cast<int64_t>(value));
   }
   else if (tag_type == thrift::TagType::DOUBLE)
   {
-    tag.__set_vDouble(value);
+    tag.__set_vDouble(static_cast<double>(value));
   }
   else if (tag_type == thrift::TagType::BOOL)
   {
-    tag.__set_vBool(value);
+    tag.__set_vBool(static_cast<bool>(value));
   }
 
   tags.push_back(tag);


### PR DESCRIPTION
## Changes

The type conversion will tell the compiler that the operation is safe and prevent any warning from happening.

For significant contributions please make sure you have completed the following items:

* [ ] `CHANGELOG.md` updated for non-trivial changes
* [ ] Unit tests have been added
* [ ] Changes in public API reviewed