### PR TITLE
run_docker user

### DIFF
--- a/ci/run_docker.sh
+++ b/ci/run_docker.sh
@@ -13,5 +13,5 @@ docker image inspect "$BUILD_IMAGE" &> /dev/null || {
 if [[ $# -ge 1 ]]; then
   docker run --user "$(id -u):$(id -g)" -v "$PWD":/src -w /src -it "$BUILD_IMAGE" "$@"
 else
-  docker run --user "$(id -u):$(id -g)" -v "$PWD":/src -w /src --privileged -it "$BUILD_IMAGE" /bin/bash -l
+  docker run -v "$PWD":/src -w /src --privileged -it "$BUILD_IMAGE" /bin/bash -l
 fi

--- a/ci/run_docker.sh
+++ b/ci/run_docker.sh
@@ -11,7 +11,7 @@ docker image inspect "$BUILD_IMAGE" &> /dev/null || {
 }
 
 if [[ $# -ge 1 ]]; then
-  docker run -v "$PWD":/src -w /src -it "$BUILD_IMAGE" "$@"
+  docker run --user "$(id -u):$(id -g)" -v "$PWD":/src -w /src -it "$BUILD_IMAGE" "$@"
 else
-  docker run -v "$PWD":/src -w /src --privileged -it "$BUILD_IMAGE" /bin/bash -l
+  docker run --user "$(id -u):$(id -g)" -v "$PWD":/src -w /src --privileged -it "$BUILD_IMAGE" /bin/bash -l
 fi


### PR DESCRIPTION
Fixes file permission change after using `./ci/run_docker.sh tools/format.sh `

## Changes

by running the container with the current user id and group id we can avoid file permission change after running the script.

For significant contributions please make sure you have completed the following items:

* [ ] `CHANGELOG.md` updated for non-trivial changes
* [ ] Unit tests have been added
* [ ] Changes in public API reviewed