### PR TITLE
Using system installed grpc,curl,protobuf to enable otlp exporters by default

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -325,7 +325,8 @@ endif()
 if(WITH_OTLP)
   set(protobuf_MODULE_COMPATIBLE ON)
   find_package(Protobuf)
-  if(WITH_OTLP_GRPC)
+  if(WITH_OTLP_GRPC OR (NOT DEFINED WITH_OTLP_GRPC AND NOT DEFINED
+                                                       CACHE{WITH_OTLP_GRPC}))
     find_package(gRPC)
   endif()
   if((NOT Protobuf_FOUND AND NOT PROTOBUF_FOUND) OR (NOT gRPC_FOUND))
@@ -343,7 +344,9 @@ if(WITH_OTLP)
     if(NOT Protobuf_FOUND AND NOT PROTOBUF_FOUND)
       find_package(Protobuf REQUIRED)
     endif()
-    if(WITH_OTLP_GRPC AND NOT gRPC_FOUND)
+    if((WITH_OTLP_GRPC OR (NOT DEFINED WITH_OTLP_GRPC AND NOT DEFINED
+                                                          CACHE{WITH_OTLP_GRPC})
+       ) AND NOT gRPC_FOUND)
       find_package(gRPC)
     endif()
     if(WIN32)
@@ -363,7 +366,10 @@ if(WITH_OTLP)
 
   include(cmake/opentelemetry-proto.cmake)
   include(CMakeDependentOption)
-  find_package(CURL)
+  if(WITH_OTLP_HTTP OR (NOT DEFINED WITH_OTLP_HTTP AND NOT DEFINED
+                                                       CACHE{WITH_OTLP_HTTP}))
+    find_package(CURL)
+  endif()
 
   cmake_dependent_option(
     WITH_OTLP_GRPC "Whether to include the OTLP gRPC exporter in the SDK" ON

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -344,9 +344,9 @@ if(WITH_OTLP)
     if(NOT Protobuf_FOUND AND NOT PROTOBUF_FOUND)
       find_package(Protobuf REQUIRED)
     endif()
-    if((WITH_OTLP_GRPC OR (NOT DEFINED WITH_OTLP_GRPC AND NOT DEFINED
-                                                          CACHE{WITH_OTLP_GRPC})
-       ) AND NOT gRPC_FOUND)
+    if(NOT gRPC_FOUND
+       AND (WITH_OTLP_GRPC OR (NOT DEFINED WITH_OTLP_GRPC
+                               AND NOT DEFINED CACHE{WITH_OTLP_GRPC})))
       find_package(gRPC)
     endif()
     if(WIN32)
@@ -362,9 +362,6 @@ if(WITH_OTLP)
       set(PROTOBUF_PROTOC_EXECUTABLE ${Protobuf_PROTOC_EXECUTABLE})
     endif()
   endif()
-  message("PROTOBUF_PROTOC_EXECUTABLE=${PROTOBUF_PROTOC_EXECUTABLE}")
-
-  include(cmake/opentelemetry-proto.cmake)
   include(CMakeDependentOption)
   if(WITH_OTLP_HTTP OR (NOT DEFINED WITH_OTLP_HTTP AND NOT DEFINED
                                                        CACHE{WITH_OTLP_HTTP}))
@@ -377,6 +374,9 @@ if(WITH_OTLP)
   cmake_dependent_option(
     WITH_OTLP_HTTP "Whether to include the OTLP http exporter in the SDK" ON
     "CURL_FOUND" OFF)
+
+  message(STATUS "PROTOBUF_PROTOC_EXECUTABLE=${PROTOBUF_PROTOC_EXECUTABLE}")
+  include(cmake/opentelemetry-proto.cmake)
 endif()
 
 list(APPEND CMAKE_PREFIX_PATH "${CMAKE_BINARY_DIR}")

--- a/cmake/opentelemetry-proto.cmake
+++ b/cmake/opentelemetry-proto.cmake
@@ -1,33 +1,27 @@
 if(EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/third_party/opentelemetry-proto/.git)
-    set(PROTO_PATH "${CMAKE_CURRENT_SOURCE_DIR}/third_party/opentelemetry-proto")
-    set(needs_proto_download FALSE)
+  set(PROTO_PATH "${CMAKE_CURRENT_SOURCE_DIR}/third_party/opentelemetry-proto")
+  set(needs_proto_download FALSE)
 else()
-    if("${opentelemetry-proto}" STREQUAL "")
-        set(opentelemetry-proto "main")
-    endif()
-    include(ExternalProject)
-    ExternalProject_Add(opentelemetry-proto
+  if("${opentelemetry-proto}" STREQUAL "")
+    set(opentelemetry-proto "main")
+  endif()
+  include(ExternalProject)
+  ExternalProject_Add(
+    opentelemetry-proto
     GIT_REPOSITORY https://github.com/open-telemetry/opentelemetry-proto.git
-    GIT_TAG
-        "${opentelemetry-proto}"
+    GIT_TAG "${opentelemetry-proto}"
     UPDATE_COMMAND ""
     BUILD_COMMAND ""
     INSTALL_COMMAND ""
     CONFIGURE_COMMAND ""
-    TEST_AFTER_INSTALL
-        0
-    DOWNLOAD_NO_PROGRESS
-        1
-    LOG_CONFIGURE
-        1
-    LOG_BUILD
-        1
-    LOG_INSTALL
-        1
-    )
-    ExternalProject_Get_Property(opentelemetry-proto INSTALL_DIR)
-    set(PROTO_PATH "${INSTALL_DIR}/src/opentelemetry-proto")
-    set(needs_proto_download TRUE)
+    TEST_AFTER_INSTALL 0
+    DOWNLOAD_NO_PROGRESS 1
+    LOG_CONFIGURE 1
+    LOG_BUILD 1
+    LOG_INSTALL 1)
+  ExternalProject_Get_Property(opentelemetry-proto INSTALL_DIR)
+  set(PROTO_PATH "${INSTALL_DIR}/src/opentelemetry-proto")
+  set(needs_proto_download TRUE)
 endif()
 
 include(${PROJECT_SOURCE_DIR}/cmake/proto-options-patch.cmake)
@@ -80,12 +74,12 @@ set(TRACE_SERVICE_PB_H_FILE
     "${GENERATED_PROTOBUF_PATH}/opentelemetry/proto/collector/trace/v1/trace_service.pb.h"
 )
 if(WITH_OTLP_GRPC)
-set(TRACE_SERVICE_GRPC_PB_CPP_FILE
-    "${GENERATED_PROTOBUF_PATH}/opentelemetry/proto/collector/trace/v1/trace_service.grpc.pb.cc"
-)
-set(TRACE_SERVICE_GRPC_PB_H_FILE
-    "${GENERATED_PROTOBUF_PATH}/opentelemetry/proto/collector/trace/v1/trace_service.grpc.pb.h"
-)
+  set(TRACE_SERVICE_GRPC_PB_CPP_FILE
+      "${GENERATED_PROTOBUF_PATH}/opentelemetry/proto/collector/trace/v1/trace_service.grpc.pb.cc"
+  )
+  set(TRACE_SERVICE_GRPC_PB_H_FILE
+      "${GENERATED_PROTOBUF_PATH}/opentelemetry/proto/collector/trace/v1/trace_service.grpc.pb.h"
+  )
 endif()
 set(LOGS_SERVICE_PB_CPP_FILE
     "${GENERATED_PROTOBUF_PATH}/opentelemetry/proto/collector/logs/v1/logs_service.pb.cc"
@@ -94,12 +88,12 @@ set(LOGS_SERVICE_PB_H_FILE
     "${GENERATED_PROTOBUF_PATH}/opentelemetry/proto/collector/logs/v1/logs_service.pb.h"
 )
 if(WITH_OTLP_GRPC)
-set(LOGS_SERVICE_GRPC_PB_CPP_FILE
-    "${GENERATED_PROTOBUF_PATH}/opentelemetry/proto/collector/logs/v1/logs_service.grpc.pb.cc"
-)
-set(LOGS_SERVICE_GRPC_PB_H_FILE
-    "${GENERATED_PROTOBUF_PATH}/opentelemetry/proto/collector/logs/v1/logs_service.grpc.pb.h"
-)
+  set(LOGS_SERVICE_GRPC_PB_CPP_FILE
+      "${GENERATED_PROTOBUF_PATH}/opentelemetry/proto/collector/logs/v1/logs_service.grpc.pb.cc"
+  )
+  set(LOGS_SERVICE_GRPC_PB_H_FILE
+      "${GENERATED_PROTOBUF_PATH}/opentelemetry/proto/collector/logs/v1/logs_service.grpc.pb.h"
+  )
 endif()
 set(METRICS_SERVICE_PB_CPP_FILE
     "${GENERATED_PROTOBUF_PATH}/opentelemetry/proto/collector/metrics/v1/metrics_service.pb.cc"
@@ -108,12 +102,12 @@ set(METRICS_SERVICE_PB_H_FILE
     "${GENERATED_PROTOBUF_PATH}/opentelemetry/proto/collector/metrics/v1/metrics_service.pb.h"
 )
 if(WITH_OTLP_GRPC)
-set(METRICS_SERVICE_GRPC_PB_CPP_FILE
-    "${GENERATED_PROTOBUF_PATH}/opentelemetry/proto/collector/metrics/v1/metrics_service.grpc.pb.cc"
-)
-set(METRICS_SERVICE_GRPC_PB_H_FILE
-    "${GENERATED_PROTOBUF_PATH}/opentelemetry/proto/collector/metrics/v1/metrics_service.grpc.pb.h"
-)
+  set(METRICS_SERVICE_GRPC_PB_CPP_FILE
+      "${GENERATED_PROTOBUF_PATH}/opentelemetry/proto/collector/metrics/v1/metrics_service.grpc.pb.cc"
+  )
+  set(METRICS_SERVICE_GRPC_PB_H_FILE
+      "${GENERATED_PROTOBUF_PATH}/opentelemetry/proto/collector/metrics/v1/metrics_service.grpc.pb.h"
+  )
 endif()
 
 foreach(IMPORT_DIR ${PROTOBUF_IMPORT_DIRS})
@@ -121,100 +115,107 @@ foreach(IMPORT_DIR ${PROTOBUF_IMPORT_DIRS})
 endforeach()
 
 if(WITH_OTLP_GRPC)
-if(CMAKE_CROSSCOMPILING)
+  if(CMAKE_CROSSCOMPILING)
     find_program(gRPC_CPP_PLUGIN_EXECUTABLE grpc_cpp_plugin)
-else()
-    set(gRPC_CPP_PLUGIN_EXECUTABLE $<TARGET_FILE:gRPC::grpc_cpp_plugin>)
-endif()
+  else()
+    if(TARGET gRPC::grpc_cpp_plugin)
+      project_build_tools_get_imported_location(gRPC_CPP_PLUGIN_EXECUTABLE
+                                                gRPC::grpc_cpp_plugin)
+    else()
+      find_program(gRPC_CPP_PLUGIN_EXECUTABLE grpc_cpp_plugin)
+    endif()
+  endif()
+  message(STATUS "gRPC_CPP_PLUGIN_EXECUTABLE=${gRPC_CPP_PLUGIN_EXECUTABLE}")
 endif()
 
 if(WITH_OTLP_GRPC)
-add_custom_command(
-  OUTPUT ${COMMON_PB_H_FILE}
-         ${COMMON_PB_CPP_FILE}
-         ${RESOURCE_PB_H_FILE}
-         ${RESOURCE_PB_CPP_FILE}
-         ${TRACE_PB_H_FILE}
-         ${TRACE_PB_CPP_FILE}
-         ${LOGS_PB_H_FILE}
-         ${LOGS_PB_CPP_FILE}
-         ${METRICS_PB_H_FILE}
-         ${METRICS_PB_CPP_FILE}
-         ${TRACE_SERVICE_PB_H_FILE}
-         ${TRACE_SERVICE_PB_CPP_FILE}
-         ${TRACE_SERVICE_GRPC_PB_H_FILE}
-         ${TRACE_SERVICE_GRPC_PB_CPP_FILE}
-         ${LOGS_SERVICE_PB_H_FILE}
-         ${LOGS_SERVICE_PB_CPP_FILE}
-         ${LOGS_SERVICE_GRPC_PB_H_FILE}
-         ${LOGS_SERVICE_GRPC_PB_CPP_FILE}
-         ${METRICS_SERVICE_PB_H_FILE}
-         ${METRICS_SERVICE_PB_CPP_FILE}
-         ${METRICS_SERVICE_GRPC_PB_H_FILE}
-         ${METRICS_SERVICE_GRPC_PB_CPP_FILE}
-  COMMAND
-    ${PROTOBUF_PROTOC_EXECUTABLE} ARGS "--proto_path=${PROTO_PATH}"
-    ${PROTOBUF_INCLUDE_FLAGS} "--cpp_out=${GENERATED_PROTOBUF_PATH}"
-    "--grpc_out=generate_mock_code=true:${GENERATED_PROTOBUF_PATH}"
-    --plugin=protoc-gen-grpc="${gRPC_CPP_PLUGIN_EXECUTABLE}" ${COMMON_PROTO}
-    ${RESOURCE_PROTO} ${TRACE_PROTO} ${LOGS_PROTO} ${METRICS_PROTO}
-    ${TRACE_SERVICE_PROTO} ${LOGS_SERVICE_PROTO} ${METRICS_SERVICE_PROTO})
+  add_custom_command(
+    OUTPUT ${COMMON_PB_H_FILE}
+           ${COMMON_PB_CPP_FILE}
+           ${RESOURCE_PB_H_FILE}
+           ${RESOURCE_PB_CPP_FILE}
+           ${TRACE_PB_H_FILE}
+           ${TRACE_PB_CPP_FILE}
+           ${LOGS_PB_H_FILE}
+           ${LOGS_PB_CPP_FILE}
+           ${METRICS_PB_H_FILE}
+           ${METRICS_PB_CPP_FILE}
+           ${TRACE_SERVICE_PB_H_FILE}
+           ${TRACE_SERVICE_PB_CPP_FILE}
+           ${TRACE_SERVICE_GRPC_PB_H_FILE}
+           ${TRACE_SERVICE_GRPC_PB_CPP_FILE}
+           ${LOGS_SERVICE_PB_H_FILE}
+           ${LOGS_SERVICE_PB_CPP_FILE}
+           ${LOGS_SERVICE_GRPC_PB_H_FILE}
+           ${LOGS_SERVICE_GRPC_PB_CPP_FILE}
+           ${METRICS_SERVICE_PB_H_FILE}
+           ${METRICS_SERVICE_PB_CPP_FILE}
+           ${METRICS_SERVICE_GRPC_PB_H_FILE}
+           ${METRICS_SERVICE_GRPC_PB_CPP_FILE}
+    COMMAND
+      ${PROTOBUF_PROTOC_EXECUTABLE} ARGS "--proto_path=${PROTO_PATH}"
+      ${PROTOBUF_INCLUDE_FLAGS} "--cpp_out=${GENERATED_PROTOBUF_PATH}"
+      "--grpc_out=generate_mock_code=true:${GENERATED_PROTOBUF_PATH}"
+      --plugin=protoc-gen-grpc="${gRPC_CPP_PLUGIN_EXECUTABLE}" ${COMMON_PROTO}
+      ${RESOURCE_PROTO} ${TRACE_PROTO} ${LOGS_PROTO} ${METRICS_PROTO}
+      ${TRACE_SERVICE_PROTO} ${LOGS_SERVICE_PROTO} ${METRICS_SERVICE_PROTO})
 else()
-add_custom_command(
-  OUTPUT ${COMMON_PB_H_FILE}
-         ${COMMON_PB_CPP_FILE}
-         ${RESOURCE_PB_H_FILE}
-         ${RESOURCE_PB_CPP_FILE}
-         ${TRACE_PB_H_FILE}
-         ${TRACE_PB_CPP_FILE}
-         ${LOGS_PB_H_FILE}
-         ${LOGS_PB_CPP_FILE}
-         ${METRICS_PB_H_FILE}
-         ${METRICS_PB_CPP_FILE}
-         ${TRACE_SERVICE_PB_H_FILE}
-         ${TRACE_SERVICE_PB_CPP_FILE}
-         ${LOGS_SERVICE_PB_H_FILE}
-         ${LOGS_SERVICE_PB_CPP_FILE}
-         ${METRICS_SERVICE_PB_H_FILE}
-         ${METRICS_SERVICE_PB_CPP_FILE}
-  COMMAND
-    ${PROTOBUF_PROTOC_EXECUTABLE} ARGS "--proto_path=${PROTO_PATH}"
-    ${PROTOBUF_INCLUDE_FLAGS} "--cpp_out=${GENERATED_PROTOBUF_PATH}"
-    ${COMMON_PROTO} ${RESOURCE_PROTO} ${TRACE_PROTO} ${LOGS_PROTO} ${METRICS_PROTO}
-    ${TRACE_SERVICE_PROTO} ${LOGS_SERVICE_PROTO} ${METRICS_SERVICE_PROTO})
+  add_custom_command(
+    OUTPUT ${COMMON_PB_H_FILE}
+           ${COMMON_PB_CPP_FILE}
+           ${RESOURCE_PB_H_FILE}
+           ${RESOURCE_PB_CPP_FILE}
+           ${TRACE_PB_H_FILE}
+           ${TRACE_PB_CPP_FILE}
+           ${LOGS_PB_H_FILE}
+           ${LOGS_PB_CPP_FILE}
+           ${METRICS_PB_H_FILE}
+           ${METRICS_PB_CPP_FILE}
+           ${TRACE_SERVICE_PB_H_FILE}
+           ${TRACE_SERVICE_PB_CPP_FILE}
+           ${LOGS_SERVICE_PB_H_FILE}
+           ${LOGS_SERVICE_PB_CPP_FILE}
+           ${METRICS_SERVICE_PB_H_FILE}
+           ${METRICS_SERVICE_PB_CPP_FILE}
+    COMMAND
+      ${PROTOBUF_PROTOC_EXECUTABLE} ARGS "--proto_path=${PROTO_PATH}"
+      ${PROTOBUF_INCLUDE_FLAGS} "--cpp_out=${GENERATED_PROTOBUF_PATH}"
+      ${COMMON_PROTO} ${RESOURCE_PROTO} ${TRACE_PROTO} ${LOGS_PROTO}
+      ${METRICS_PROTO} ${TRACE_SERVICE_PROTO} ${LOGS_SERVICE_PROTO}
+      ${METRICS_SERVICE_PROTO})
 endif()
 
 include_directories("${GENERATED_PROTOBUF_PATH}")
 
 if(WITH_OTLP_GRPC)
-add_library(
-  opentelemetry_proto STATIC
-  ${COMMON_PB_CPP_FILE}
-  ${RESOURCE_PB_CPP_FILE}
-  ${TRACE_PB_CPP_FILE}
-  ${LOGS_PB_CPP_FILE}
-  ${METRICS_PB_CPP_FILE}
-  ${TRACE_SERVICE_PB_CPP_FILE}
-  ${TRACE_SERVICE_GRPC_PB_CPP_FILE}
-  ${LOGS_SERVICE_PB_CPP_FILE}
-  ${LOGS_SERVICE_GRPC_PB_CPP_FILE}
-  ${METRICS_SERVICE_PB_CPP_FILE}
-  ${METRICS_SERVICE_GRPC_PB_CPP_FILE})
+  add_library(
+    opentelemetry_proto STATIC
+    ${COMMON_PB_CPP_FILE}
+    ${RESOURCE_PB_CPP_FILE}
+    ${TRACE_PB_CPP_FILE}
+    ${LOGS_PB_CPP_FILE}
+    ${METRICS_PB_CPP_FILE}
+    ${TRACE_SERVICE_PB_CPP_FILE}
+    ${TRACE_SERVICE_GRPC_PB_CPP_FILE}
+    ${LOGS_SERVICE_PB_CPP_FILE}
+    ${LOGS_SERVICE_GRPC_PB_CPP_FILE}
+    ${METRICS_SERVICE_PB_CPP_FILE}
+    ${METRICS_SERVICE_GRPC_PB_CPP_FILE})
 else()
-add_library(
-  opentelemetry_proto STATIC
-  ${COMMON_PB_CPP_FILE}
-  ${RESOURCE_PB_CPP_FILE}
-  ${TRACE_PB_CPP_FILE}
-  ${LOGS_PB_CPP_FILE}
-  ${METRICS_PB_CPP_FILE}
-  ${TRACE_SERVICE_PB_CPP_FILE}
-  ${LOGS_SERVICE_PB_CPP_FILE}
-  ${METRICS_SERVICE_PB_CPP_FILE})
+  add_library(
+    opentelemetry_proto STATIC
+    ${COMMON_PB_CPP_FILE}
+    ${RESOURCE_PB_CPP_FILE}
+    ${TRACE_PB_CPP_FILE}
+    ${LOGS_PB_CPP_FILE}
+    ${METRICS_PB_CPP_FILE}
+    ${TRACE_SERVICE_PB_CPP_FILE}
+    ${LOGS_SERVICE_PB_CPP_FILE}
+    ${METRICS_SERVICE_PB_CPP_FILE})
 endif()
 
 if(needs_proto_download)
-    add_dependencies(opentelemetry_proto opentelemetry-proto)
+  add_dependencies(opentelemetry_proto opentelemetry-proto)
 endif()
 set_target_properties(opentelemetry_proto PROPERTIES EXPORT_NAME proto)
 patch_protobuf_targets(opentelemetry_proto)

--- a/cmake/proto-options-patch.cmake
+++ b/cmake/proto-options-patch.cmake
@@ -80,3 +80,37 @@ function(patch_protobuf_targets)
     unset(PROTO_TARGET_OPTIONS)
   endif()
 endfunction()
+
+function(project_build_tools_get_imported_location OUTPUT_VAR_NAME TARGET_NAME)
+  if(CMAKE_BUILD_TYPE)
+    string(TOUPPER "IMPORTED_LOCATION_${CMAKE_BUILD_TYPE}"
+                   TRY_SPECIFY_IMPORTED_LOCATION)
+    get_target_property(${OUTPUT_VAR_NAME} ${TARGET_NAME}
+                        ${TRY_SPECIFY_IMPORTED_LOCATION})
+  endif()
+  if(NOT ${OUTPUT_VAR_NAME})
+    get_target_property(${OUTPUT_VAR_NAME} ${TARGET_NAME} IMPORTED_LOCATION)
+  endif()
+  if(NOT ${OUTPUT_VAR_NAME})
+    get_target_property(
+      project_build_tools_get_imported_location_IMPORTED_CONFIGURATIONS
+      ${TARGET_NAME} IMPORTED_CONFIGURATIONS)
+    foreach(
+      project_build_tools_get_imported_location_IMPORTED_CONFIGURATION IN
+      LISTS project_build_tools_get_imported_location_IMPORTED_CONFIGURATIONS)
+      get_target_property(
+        ${OUTPUT_VAR_NAME}
+        ${TARGET_NAME}
+        "IMPORTED_LOCATION_${project_build_tools_get_imported_location_IMPORTED_CONFIGURATION}"
+      )
+      if(${OUTPUT_VAR_NAME})
+        break()
+      endif()
+    endforeach()
+  endif()
+  if(${OUTPUT_VAR_NAME})
+    set(${OUTPUT_VAR_NAME}
+        ${${OUTPUT_VAR_NAME}}
+        PARENT_SCOPE)
+  endif()
+endfunction()

--- a/examples/grpc/CMakeLists.txt
+++ b/examples/grpc/CMakeLists.txt
@@ -15,7 +15,7 @@ add_custom_command(
   COMMAND
     ${PROTOBUF_PROTOC_EXECUTABLE} ARGS "--grpc_out=${CMAKE_CURRENT_BINARY_DIR}"
     "--cpp_out=${CMAKE_CURRENT_BINARY_DIR}" "--proto_path=${proto_file_path}"
-    --plugin=protoc-gen-grpc="${gRPC_CPP_PLUGIN_EXECUTABLE}" "${proto_file}")
+    "--plugin=protoc-gen-grpc=${gRPC_CPP_PLUGIN_EXECUTABLE}" "${proto_file}")
 
 add_library(example_grpc_proto ${example_grpc_srcs} ${example_grpc_hdrs}
                                ${example_proto_srcs} ${example_proto_hdrs})


### PR DESCRIPTION
Signed-off-by: owentou <owentou@tencent.com>

Fixes #1130

## Changes

Using system installed grpc,curl,protobuf to enable otlp exporters by default

For significant contributions please make sure you have completed the following items:

* [x] `CHANGELOG.md` updated for non-trivial changes
* [x] Unit tests have been added
* [x] Changes in public API reviewed