### PR TITLE
Adding prerequisite to the installation steps for Cmake build

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -26,6 +26,9 @@ You can link OpenTelemetry C++ SDK with libraries provided in [dependencies.md](
   the unittests. We use GoogleTest version 1.10.0 in our build system. To
   install GoogleTest, consult the [GoogleTest Build
   Instructions](https://github.com/google/googletest/blob/master/googletest/README.md#generic-build-instructions).
+- [Google Benchmark](https://github.com/google/benchmark) framework to build and run
+  benchmark and benchmark_main libraries and tests. We use Benchmark version 1.5.3 or above. To install Benchmark,
+  consult the [GoogleBenchmark Build Instructions](https://github.com/google/benchmark#installation)
 - Apart from above core requirements, the Exporters and Propagators have their
   build dependencies which are not covered here. E.g, Otlp Exporter needs
   grpc/protobuf library, Zipkin exporter needs nlohmann-json and libcurl, ETW

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -27,8 +27,8 @@ You can link OpenTelemetry C++ SDK with libraries provided in [dependencies.md](
   install GoogleTest, consult the [GoogleTest Build
   Instructions](https://github.com/google/googletest/blob/master/googletest/README.md#generic-build-instructions).
 - [Google Benchmark](https://github.com/google/benchmark) framework to build and run
-  benchmark and benchmark_main libraries and tests. We use Benchmark version 1.5.3 or above. To install Benchmark,
-  consult the [GoogleBenchmark Build Instructions](https://github.com/google/benchmark#installation)
+  benchmark tests. We use Benchmark version 1.5.3 or above. To install Benchmark,
+  consult the [GoogleBenchmark Build Instructions](https://github.com/google/benchmark#installation).
 - Apart from above core requirements, the Exporters and Propagators have their
   build dependencies which are not covered here. E.g, Otlp Exporter needs
   grpc/protobuf library, Zipkin exporter needs nlohmann-json and libcurl, ETW

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -23,11 +23,11 @@ You can link OpenTelemetry C++ SDK with libraries provided in [dependencies.md](
   unittests. We use CMake version 3.15.2 in our build system. To install CMake,
   consult the [Installing CMake](https://cmake.org/install/) guide.
 - [GoogleTest](https://github.com/google/googletest) framework to build and run
-  the unittests. Refer to [third_party_release](https://github.com/open-telemetry/opentelemetry-cpp/blob/main/third_party_release)
+  the unittests. Refer to [third_party_release](https://github.com/open-telemetry/opentelemetry-cpp/blob/main/third_party_release#L5)
   for version of GoogleTest used in CI. To install GoogleTest, consult the [GoogleTest Build
   Instructions](https://github.com/google/googletest/blob/master/googletest/README.md#generic-build-instructions).
 - [Google Benchmark](https://github.com/google/benchmark) framework to build and run
-  benchmark tests. Refer to [third_party_release](https://github.com/open-telemetry/opentelemetry-cpp/blob/main/third_party_release)
+  benchmark tests. Refer to [third_party_release](https://github.com/open-telemetry/opentelemetry-cpp/blob/main/third_party_release#L4)
   for version of Benchmark used in CI. To install Benchmark,
   consult the [GoogleBenchmark Build Instructions](https://github.com/google/benchmark#installation).
 - Apart from above core requirements, the Exporters and Propagators have their

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -23,11 +23,11 @@ You can link OpenTelemetry C++ SDK with libraries provided in [dependencies.md](
   unittests. We use CMake version 3.15.2 in our build system. To install CMake,
   consult the [Installing CMake](https://cmake.org/install/) guide.
 - [GoogleTest](https://github.com/google/googletest) framework to build and run
-  the unittests. Refer [third_party_release](https://github.com/open-telemetry/opentelemetry-cpp/blob/main/third_party_release)
+  the unittests. Refer to [third_party_release](https://github.com/open-telemetry/opentelemetry-cpp/blob/main/third_party_release)
   for version of GoogleTest used in CI. To install GoogleTest, consult the [GoogleTest Build
   Instructions](https://github.com/google/googletest/blob/master/googletest/README.md#generic-build-instructions).
 - [Google Benchmark](https://github.com/google/benchmark) framework to build and run
-  benchmark tests. Refer [third_party_release](https://github.com/open-telemetry/opentelemetry-cpp/blob/main/third_party_release)
+  benchmark tests. Refer to [third_party_release](https://github.com/open-telemetry/opentelemetry-cpp/blob/main/third_party_release)
   for version of Benchmark used in CI. To install Benchmark,
   consult the [GoogleBenchmark Build Instructions](https://github.com/google/benchmark#installation).
 - Apart from above core requirements, the Exporters and Propagators have their

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -23,11 +23,12 @@ You can link OpenTelemetry C++ SDK with libraries provided in [dependencies.md](
   unittests. We use CMake version 3.15.2 in our build system. To install CMake,
   consult the [Installing CMake](https://cmake.org/install/) guide.
 - [GoogleTest](https://github.com/google/googletest) framework to build and run
-  the unittests. We use GoogleTest version 1.10.0 in our build system. To
-  install GoogleTest, consult the [GoogleTest Build
+  the unittests. Refer [third_party_release](https://github.com/open-telemetry/opentelemetry-cpp/blob/main/third_party_release)
+  for version of GoogleTest used in CI. To install GoogleTest, consult the [GoogleTest Build
   Instructions](https://github.com/google/googletest/blob/master/googletest/README.md#generic-build-instructions).
 - [Google Benchmark](https://github.com/google/benchmark) framework to build and run
-  benchmark tests. We use Benchmark version 1.5.3 or above. To install Benchmark,
+  benchmark tests. Refer [third_party_release](https://github.com/open-telemetry/opentelemetry-cpp/blob/main/third_party_release)
+  for version of Benchmark used in CI. To install Benchmark,
   consult the [GoogleBenchmark Build Instructions](https://github.com/google/benchmark#installation).
 - Apart from above core requirements, the Exporters and Propagators have their
   build dependencies which are not covered here. E.g, Otlp Exporter needs

--- a/api/BUILD
+++ b/api/BUILD
@@ -18,4 +18,5 @@ cc_library(
     name = "api",
     hdrs = glob(["include/**/*.h"]),
     strip_include_prefix = "include",
+    tags = ["api"],
 )

--- a/api/include/opentelemetry/nostd/absl/meta/type_traits.h
+++ b/api/include/opentelemetry/nostd/absl/meta/type_traits.h
@@ -616,8 +616,21 @@ using common_type_t = typename std::common_type<T...>::type;
 template <typename T>
 using underlying_type_t = typename std::underlying_type<T>::type;
 
-template <typename T>
-using result_of_t = typename std::result_of<T>::type;
+namespace type_traits_internal {
+
+#if __cplusplus >= 201703L
+// std::result_of is deprecated (C++17) or removed (C++20)
+template<typename> struct result_of;
+template<typename F, typename... Args>
+struct result_of<F(Args...)> : std::invoke_result<F, Args...> {};
+#else
+template<typename F> using result_of = std::result_of<F>;
+#endif
+
+}  // namespace type_traits_internal
+
+template<typename F>
+using result_of_t = typename type_traits_internal::result_of<F>::type;
 
 namespace type_traits_internal {
 // In MSVC we can't probe std::hash or stdext::hash because it triggers a

--- a/api/test/_metrics/BUILD
+++ b/api/test/_metrics/BUILD
@@ -5,6 +5,11 @@ cc_test(
     srcs = [
         "meter_provider_test.cc",
     ],
+    tags = [
+        "api",
+        "metrics",
+        "test",
+    ],
     deps = [
         "//api",
         "@com_google_googletest//:gtest_main",
@@ -15,6 +20,11 @@ cc_test(
     name = "noop_metrics_test",
     srcs = [
         "noop_metrics_test.cc",
+    ],
+    tags = [
+        "api",
+        "metrics",
+        "test",
     ],
     deps = [
         "//api",
@@ -28,6 +38,11 @@ cc_test(
         "noop_instrument_test.cc",
     ],
     linkstatic = 1,
+    tags = [
+        "api",
+        "metrics",
+        "test",
+    ],
     deps = [
         "//api",
         "@com_google_googletest//:gtest_main",

--- a/api/test/baggage/BUILD
+++ b/api/test/baggage/BUILD
@@ -5,6 +5,10 @@ cc_test(
     srcs = [
         "baggage_test.cc",
     ],
+    tags = [
+        "api",
+        "test",
+    ],
     deps = [
         "//api",
         "@com_google_googletest//:gtest_main",
@@ -14,5 +18,9 @@ cc_test(
 otel_cc_benchmark(
     name = "baggage_benchmark",
     srcs = ["baggage_benchmark.cc"],
+    tags = [
+        "api",
+        "test",
+    ],
     deps = ["//api"],
 )

--- a/api/test/baggage/propagation/BUILD
+++ b/api/test/baggage/propagation/BUILD
@@ -5,6 +5,10 @@ cc_test(
     srcs = [
         "baggage_propagator_test.cc",
     ],
+    tags = [
+        "api",
+        "test",
+    ],
     deps = [
         "//api",
         "@com_google_googletest//:gtest_main",

--- a/api/test/common/BUILD
+++ b/api/test/common/BUILD
@@ -3,6 +3,10 @@ load("//bazel:otel_cc_benchmark.bzl", "otel_cc_benchmark")
 otel_cc_benchmark(
     name = "spinlock_benchmark",
     srcs = ["spinlock_benchmark.cc"],
+    tags = [
+        "api",
+        "test",
+    ],
     deps = ["//api"],
 )
 
@@ -10,6 +14,10 @@ cc_test(
     name = "kv_properties_test",
     srcs = [
         "kv_properties_test.cc",
+    ],
+    tags = [
+        "api",
+        "test",
     ],
     deps = [
         "//api",
@@ -21,6 +29,10 @@ cc_test(
     name = "string_util_test",
     srcs = [
         "string_util_test.cc",
+    ],
+    tags = [
+        "api",
+        "test",
     ],
     deps = [
         "//api",

--- a/api/test/context/BUILD
+++ b/api/test/context/BUILD
@@ -5,6 +5,10 @@ cc_test(
     srcs = [
         "context_test.cc",
     ],
+    tags = [
+        "api",
+        "test",
+    ],
     deps = [
         "//api",
         "@com_google_googletest//:gtest_main",
@@ -15,6 +19,10 @@ cc_test(
     name = "runtime_context_test",
     srcs = [
         "runtime_context_test.cc",
+    ],
+    tags = [
+        "api",
+        "test",
     ],
     deps = [
         "//api",

--- a/api/test/context/propagation/BUILD
+++ b/api/test/context/propagation/BUILD
@@ -5,6 +5,10 @@ cc_test(
     srcs = [
         "composite_propagator_test.cc",
     ],
+    tags = [
+        "api",
+        "test",
+    ],
     deps = [
         "//api",
         "@com_google_googletest//:gtest_main",

--- a/api/test/core/BUILD
+++ b/api/test/core/BUILD
@@ -3,6 +3,10 @@ cc_test(
     srcs = [
         "timestamp_test.cc",
     ],
+    tags = [
+        "api",
+        "test",
+    ],
     deps = [
         "//api",
         "@com_google_googletest//:gtest_main",

--- a/api/test/logs/BUILD
+++ b/api/test/logs/BUILD
@@ -5,6 +5,11 @@ cc_test(
     srcs = [
         "provider_test.cc",
     ],
+    tags = [
+        "api",
+        "logs",
+        "test",
+    ],
     deps = [
         "//api",
         "@com_google_googletest//:gtest_main",
@@ -15,6 +20,11 @@ cc_test(
     name = "logger_test",
     srcs = [
         "logger_test.cc",
+    ],
+    tags = [
+        "api",
+        "logs",
+        "test",
     ],
     deps = [
         "//api",

--- a/api/test/nostd/BUILD
+++ b/api/test/nostd/BUILD
@@ -3,6 +3,10 @@ cc_test(
     srcs = [
         "function_ref_test.cc",
     ],
+    tags = [
+        "api",
+        "test",
+    ],
     deps = [
         "//api",
         "@com_google_googletest//:gtest_main",
@@ -13,6 +17,10 @@ cc_test(
     name = "string_view_test",
     srcs = [
         "string_view_test.cc",
+    ],
+    tags = [
+        "api",
+        "test",
     ],
     deps = [
         "//api",
@@ -25,6 +33,10 @@ cc_test(
     srcs = [
         "variant_test.cc",
     ],
+    tags = [
+        "api",
+        "test",
+    ],
     deps = [
         "//api",
         "@com_google_googletest//:gtest_main",
@@ -35,6 +47,10 @@ cc_test(
     name = "unique_ptr_test",
     srcs = [
         "unique_ptr_test.cc",
+    ],
+    tags = [
+        "api",
+        "test",
     ],
     deps = [
         "//api",
@@ -47,6 +63,10 @@ cc_test(
     srcs = [
         "utility_test.cc",
     ],
+    tags = [
+        "api",
+        "test",
+    ],
     deps = [
         "//api",
         "@com_google_googletest//:gtest_main",
@@ -58,6 +78,10 @@ cc_test(
     srcs = [
         "span_test.cc",
     ],
+    tags = [
+        "api",
+        "test",
+    ],
     deps = [
         "//api",
         "@com_google_googletest//:gtest_main",
@@ -68,6 +92,10 @@ cc_test(
     name = "shared_ptr_test",
     srcs = [
         "shared_ptr_test.cc",
+    ],
+    tags = [
+        "api",
+        "test",
     ],
     deps = [
         "//api",

--- a/api/test/plugin/BUILD
+++ b/api/test/plugin/BUILD
@@ -6,6 +6,10 @@ cc_test(
     linkopts = [
         "-ldl",
     ],
+    tags = [
+        "api",
+        "test",
+    ],
     deps = [
         "//api",
         "@com_google_googletest//:gtest_main",

--- a/api/test/trace/BUILD
+++ b/api/test/trace/BUILD
@@ -5,6 +5,11 @@ cc_test(
     srcs = [
         "default_span_test.cc",
     ],
+    tags = [
+        "api",
+        "test",
+        "trace",
+    ],
     deps = [
         "//api",
         "@com_google_googletest//:gtest_main",
@@ -15,6 +20,11 @@ cc_test(
     name = "noop_test",
     srcs = [
         "noop_test.cc",
+    ],
+    tags = [
+        "api",
+        "test",
+        "trace",
     ],
     deps = [
         "//api",
@@ -27,6 +37,11 @@ cc_test(
     srcs = [
         "key_value_iterable_view_test.cc",
     ],
+    tags = [
+        "api",
+        "test",
+        "trace",
+    ],
     deps = [
         "//api",
         "@com_google_googletest//:gtest_main",
@@ -36,12 +51,22 @@ cc_test(
 otel_cc_benchmark(
     name = "span_id_benchmark",
     srcs = ["span_id_benchmark.cc"],
+    tags = [
+        "api",
+        "test",
+        "trace",
+    ],
     deps = ["//api"],
 )
 
 otel_cc_benchmark(
     name = "span_benchmark",
     srcs = ["span_benchmark.cc"],
+    tags = [
+        "api",
+        "test",
+        "trace",
+    ],
     deps = ["//api"],
 )
 
@@ -49,6 +74,11 @@ cc_test(
     name = "provider_test",
     srcs = [
         "provider_test.cc",
+    ],
+    tags = [
+        "api",
+        "test",
+        "trace",
     ],
     deps = [
         "//api",
@@ -61,6 +91,11 @@ cc_test(
     srcs = [
         "span_id_test.cc",
     ],
+    tags = [
+        "api",
+        "test",
+        "trace",
+    ],
     deps = [
         "//api",
         "@com_google_googletest//:gtest_main",
@@ -71,6 +106,11 @@ cc_test(
     name = "trace_flags_test",
     srcs = [
         "trace_flags_test.cc",
+    ],
+    tags = [
+        "api",
+        "test",
+        "trace",
     ],
     deps = [
         "//api",
@@ -83,6 +123,11 @@ cc_test(
     srcs = [
         "trace_id_test.cc",
     ],
+    tags = [
+        "api",
+        "test",
+        "trace",
+    ],
     deps = [
         "//api",
         "@com_google_googletest//:gtest_main",
@@ -93,6 +138,11 @@ cc_test(
     name = "span_context_test",
     srcs = [
         "span_context_test.cc",
+    ],
+    tags = [
+        "api",
+        "test",
+        "trace",
     ],
     deps = [
         "//api",
@@ -105,6 +155,11 @@ cc_test(
     srcs = [
         "trace_state_test.cc",
     ],
+    tags = [
+        "api",
+        "test",
+        "trace",
+    ],
     deps = [
         "//api",
         "@com_google_googletest//:gtest_main",
@@ -116,6 +171,11 @@ cc_test(
     srcs = [
         "scope_test.cc",
     ],
+    tags = [
+        "api",
+        "test",
+        "trace",
+    ],
     deps = [
         "//api",
         "@com_google_googletest//:gtest_main",
@@ -126,6 +186,11 @@ cc_test(
     name = "tracer_test",
     srcs = [
         "tracer_test.cc",
+    ],
+    tags = [
+        "api",
+        "test",
+        "trace",
     ],
     deps = [
         "//api",

--- a/api/test/trace/propagation/BUILD
+++ b/api/test/trace/propagation/BUILD
@@ -6,6 +6,11 @@ cc_test(
         "http_text_format_test.cc",
         "util.h",
     ],
+    tags = [
+        "api",
+        "test",
+        "trace",
+    ],
     deps = [
         "//api",
         "@com_google_googletest//:gtest_main",
@@ -18,6 +23,11 @@ cc_test(
         "b3_propagation_test.cc",
         "util.h",
     ],
+    tags = [
+        "api",
+        "test",
+        "trace",
+    ],
     deps = [
         "//api",
         "@com_google_googletest//:gtest_main",
@@ -29,6 +39,11 @@ cc_test(
     srcs = [
         "jaeger_propagation_test.cc",
         "util.h",
+    ],
+    tags = [
+        "api",
+        "test",
+        "trace",
     ],
     deps = [
         "//api",

--- a/docs/google-test.md
+++ b/docs/google-test.md
@@ -90,6 +90,7 @@ cc_test(
         "//sdk/src/trace",
         "@com_google_googletest//:gtest_main",
     ],
+    tags = ["test",],
 )
 ```
 

--- a/examples/otlp/BUILD
+++ b/examples/otlp/BUILD
@@ -3,7 +3,11 @@ cc_binary(
     srcs = [
         "grpc_main.cc",
     ],
-    tags = ["otlp"],
+    tags = [
+        "examples",
+        "otlp",
+        "otlp_grpc",
+    ],
     deps = [
         "//api",
         "//examples/common/foo_library:common_foo_library",
@@ -17,7 +21,11 @@ cc_binary(
     srcs = [
         "http_main.cc",
     ],
-    tags = ["otlp"],
+    tags = [
+        "examples",
+        "otlp",
+        "otlp_http",
+    ],
     deps = [
         "//api",
         "//examples/common/foo_library:common_foo_library",
@@ -31,7 +39,11 @@ cc_binary(
     srcs = [
         "http_log_main.cc",
     ],
-    tags = ["otlp"],
+    tags = [
+        "examples",
+        "otlp",
+        "otlp_http_log",
+    ],
     deps = [
         "//api",
         "//examples/common/logs_foo_library:common_logs_foo_library",
@@ -45,6 +57,11 @@ cc_binary(
     name = "example_otlp_grpc_log",
     srcs = [
         "grpc_log_main.cc",
+    ],
+    tags = [
+        "examples",
+        "otlp",
+        "otlp_grpc_log",
     ],
     deps = [
         "//api",

--- a/examples/simple/BUILD
+++ b/examples/simple/BUILD
@@ -3,7 +3,10 @@ cc_binary(
     srcs = [
         "main.cc",
     ],
-    tags = ["ostream"],
+    tags = [
+        "examples",
+        "ostream",
+    ],
     deps = [
         "//api",
         "//examples/common/foo_library:common_foo_library",

--- a/examples/zpages/BUILD
+++ b/examples/zpages/BUILD
@@ -23,6 +23,7 @@ cc_binary(
         "//bazel:windows": [],
         "//conditions:default": ["-pthread"],
     }),
+    tags = ["examples"],
     deps = [
         "//ext:headers",
         "//ext/src/zpages",

--- a/exporters/elasticsearch/BUILD
+++ b/exporters/elasticsearch/BUILD
@@ -31,7 +31,10 @@ cc_library(
 cc_test(
     name = "es_log_exporter_test",
     srcs = ["test/es_log_exporter_test.cc"],
-    tags = ["es"],
+    tags = [
+        "es",
+        "test",
+    ],
     deps = [
         ":es_log_exporter",
         "@com_google_googletest//:gtest_main",

--- a/exporters/etw/BUILD
+++ b/exporters/etw/BUILD
@@ -50,3 +50,20 @@ cc_test(
         "@github_nlohmann_json//:json",
     ],
 )
+
+cc_test(
+    name = "etw_logger_test",
+    srcs = ["test/etw_logger_test.cc"],
+    local_defines = [
+        "HAVE_MSGPACK",
+    ],
+    tags = [
+        "etw",
+        "test",
+    ],
+    deps = [
+        ":etw_exporter",
+        "@com_google_googletest//:gtest_main",
+        "@github_nlohmann_json//:json",
+    ],
+)

--- a/exporters/etw/BUILD
+++ b/exporters/etw/BUILD
@@ -23,7 +23,10 @@ cc_test(
     local_defines = [
         "HAVE_MSGPACK",
     ],
-    tags = ["etw"],
+    tags = [
+        "etw",
+        "test",
+    ],
     deps = [
         ":etw_exporter",
         "@com_google_googletest//:gtest_main",
@@ -37,7 +40,10 @@ cc_test(
     local_defines = [
         "HAVE_MSGPACK",
     ],
-    tags = ["etw"],
+    tags = [
+        "etw",
+        "test",
+    ],
     deps = [
         ":etw_exporter",
         "@com_google_googletest//:gtest_main",

--- a/exporters/memory/BUILD
+++ b/exporters/memory/BUILD
@@ -17,7 +17,10 @@ cc_library(
 cc_test(
     name = "in_memory_span_data_test",
     srcs = ["test/in_memory_span_data_test.cc"],
-    tags = ["memory"],
+    tags = [
+        "memory",
+        "test",
+    ],
     deps = [
         ":in_memory_span_data",
         "@com_google_googletest//:gtest_main",
@@ -30,7 +33,10 @@ cc_library(
         "include/opentelemetry/exporters/memory/in_memory_span_exporter.h",
     ],
     strip_include_prefix = "include",
-    tags = ["memory"],
+    tags = [
+        "memory",
+        "test",
+    ],
     deps = [
         ":in_memory_span_data",
         "//sdk/src/trace",
@@ -40,7 +46,10 @@ cc_library(
 cc_test(
     name = "in_memory_span_exporter_test",
     srcs = ["test/in_memory_span_exporter_test.cc"],
-    tags = ["memory"],
+    tags = [
+        "memory",
+        "test",
+    ],
     deps = [
         ":in_memory_span_exporter",
         "@com_google_googletest//:gtest_main",

--- a/exporters/ostream/BUILD
+++ b/exporters/ostream/BUILD
@@ -18,7 +18,10 @@ cc_library(
 cc_test(
     name = "ostream_log_test",
     srcs = ["test/ostream_log_test.cc"],
-    tags = ["ostream"],
+    tags = [
+        "ostream",
+        "test",
+    ],
     deps = [
         ":ostream_log_exporter",
         "@com_google_googletest//:gtest_main",
@@ -43,7 +46,10 @@ cc_library(
 cc_test(
     name = "ostream_metrics_test",
     srcs = ["test/ostream_metrics_test.cc"],
-    tags = ["ostream"],
+    tags = [
+        "ostream",
+        "test",
+    ],
     deps = [
         ":ostream_metrics_exporter_deprecated",
         "@com_google_googletest//:gtest_main",
@@ -79,7 +85,10 @@ cc_library(
 cc_test(
     name = "ostream_span_test",
     srcs = ["test/ostream_span_test.cc"],
-    tags = ["ostream"],
+    tags = [
+        "ostream",
+        "test",
+    ],
     deps = [
         ":ostream_capture",
         ":ostream_span_exporter",

--- a/exporters/otlp/BUILD
+++ b/exporters/otlp/BUILD
@@ -54,7 +54,10 @@ cc_library(
         "include/opentelemetry/exporters/otlp/protobuf_include_suffix.h",
     ],
     strip_include_prefix = "include",
-    tags = ["otlp"],
+    tags = [
+        "otlp",
+        "otlp_grpc",
+    ],
     deps = [
         ":otlp_recordable",
         "//ext:headers",
@@ -88,7 +91,11 @@ cc_library(
         "//conditions:default": [],
     }),
     strip_include_prefix = "include",
-    tags = ["otlp"],
+    tags = [
+        "otlp",
+        "otlp_http",
+        "otlp_http_log",
+    ],
     deps = [
         "//api",
         "//ext/src/http/client/curl:http_client_curl",
@@ -110,7 +117,10 @@ cc_library(
         "include/opentelemetry/exporters/otlp/protobuf_include_suffix.h",
     ],
     strip_include_prefix = "include",
-    tags = ["otlp"],
+    tags = [
+        "otlp",
+        "otlp_http",
+    ],
     deps = [
         ":otlp_http_client",
         ":otlp_recordable",
@@ -131,7 +141,10 @@ cc_library(
         "include/opentelemetry/exporters/otlp/protobuf_include_suffix.h",
     ],
     strip_include_prefix = "include",
-    tags = ["otlp"],
+    tags = [
+        "otlp",
+        "otlp_http_log",
+    ],
     deps = [
         ":otlp_http_client",
         ":otlp_recordable",
@@ -153,7 +166,10 @@ cc_library(
         "include/opentelemetry/exporters/otlp/protobuf_include_suffix.h",
     ],
     strip_include_prefix = "include",
-    tags = ["otlp"],
+    tags = [
+        "otlp",
+        "otlp_grpc_log",
+    ],
     deps = [
         ":otlp_recordable",
         "//ext:headers",
@@ -168,7 +184,10 @@ cc_library(
 cc_test(
     name = "otlp_recordable_test",
     srcs = ["test/otlp_recordable_test.cc"],
-    tags = ["otlp"],
+    tags = [
+        "otlp",
+        "test",
+    ],
     deps = [
         ":otlp_recordable",
         "@com_google_googletest//:gtest_main",
@@ -178,6 +197,10 @@ cc_test(
 cc_test(
     name = "otlp_log_recordable_test",
     srcs = ["test/otlp_log_recordable_test.cc"],
+    tags = [
+        "otlp",
+        "test",
+    ],
     deps = [
         ":otlp_recordable",
         "@com_github_opentelemetry_proto//:logs_service_proto_cc",
@@ -188,7 +211,11 @@ cc_test(
 cc_test(
     name = "otlp_grpc_exporter_test",
     srcs = ["test/otlp_grpc_exporter_test.cc"],
-    tags = ["otlp"],
+    tags = [
+        "otlp",
+        "otlp_grpc",
+        "test",
+    ],
     deps = [
         ":otlp_grpc_exporter",
         "//api",
@@ -199,7 +226,11 @@ cc_test(
 cc_test(
     name = "otlp_http_exporter_test",
     srcs = ["test/otlp_http_exporter_test.cc"],
-    tags = ["otlp"],
+    tags = [
+        "otlp",
+        "otlp_http",
+        "test",
+    ],
     deps = [
         ":otlp_http_exporter",
         "//api",
@@ -210,7 +241,11 @@ cc_test(
 cc_test(
     name = "otlp_http_log_exporter_test",
     srcs = ["test/otlp_http_log_exporter_test.cc"],
-    tags = ["otlp"],
+    tags = [
+        "otlp",
+        "otlp_http_log",
+        "test",
+    ],
     deps = [
         ":otlp_http_log_exporter",
         "//api",
@@ -221,7 +256,11 @@ cc_test(
 cc_test(
     name = "otlp_grpc_log_exporter_test",
     srcs = ["test/otlp_grpc_log_exporter_test.cc"],
-    tags = ["otlp"],
+    tags = [
+        "otlp",
+        "otlp_grpc_log",
+        "test",
+    ],
     deps = [
         ":otlp_grpc_log_exporter",
         "//api",
@@ -233,7 +272,11 @@ cc_test(
 otel_cc_benchmark(
     name = "otlp_grpc_exporter_benchmark",
     srcs = ["test/otlp_grpc_exporter_benchmark.cc"],
-    tags = ["otlp"],
+    tags = [
+        "otlp",
+        "otlp_grpc",
+        "test",
+    ],
     deps = [
         ":otlp_grpc_exporter",
     ],

--- a/exporters/prometheus/BUILD
+++ b/exporters/prometheus/BUILD
@@ -76,7 +76,10 @@ cc_test(
     srcs = [
         "test/prometheus_exporter_test.cc",
     ],
-    tags = ["prometheus"],
+    tags = [
+        "prometheus",
+        "test",
+    ],
     deps = [
         ":prometheus_exporter",
         "@com_google_googletest//:gtest_main",

--- a/exporters/zipkin/BUILD
+++ b/exporters/zipkin/BUILD
@@ -39,7 +39,10 @@ cc_library(
 cc_test(
     name = "zipkin_recordable_test",
     srcs = ["test/zipkin_recordable_test.cc"],
-    tags = ["zipkin"],
+    tags = [
+        "test",
+        "zipkin",
+    ],
     deps = [
         ":zipkin_recordable",
         "@com_google_googletest//:gtest_main",

--- a/ext/test/http/BUILD
+++ b/ext/test/http/BUILD
@@ -3,6 +3,7 @@ cc_test(
     srcs = [
         "curl_http_test.cc",
     ],
+    tags = ["test"],
     deps = [
         "//ext:headers",
         "//ext/src/http/client/curl:http_client_curl",

--- a/ext/test/zpages/BUILD
+++ b/ext/test/zpages/BUILD
@@ -3,6 +3,7 @@ cc_test(
     srcs = [
         "threadsafe_span_data_test.cc",
     ],
+    tags = ["test"],
     deps = [
         "//ext/src/zpages",
         "//sdk/src/trace",
@@ -15,6 +16,7 @@ cc_test(
     srcs = [
         "tracez_data_aggregator_test.cc",
     ],
+    tags = ["test"],
     deps = [
         "//ext/src/zpages",
         "//sdk/src/trace",
@@ -27,6 +29,7 @@ cc_test(
     srcs = [
         "tracez_processor_test.cc",
     ],
+    tags = ["test"],
     deps = [
         "//ext/src/zpages",
         "//sdk/src/trace",

--- a/sdk/test/_metrics/BUILD
+++ b/sdk/test/_metrics/BUILD
@@ -3,6 +3,10 @@ cc_test(
     srcs = [
         "controller_test.cc",
     ],
+    tags = [
+        "metrics",
+        "test",
+    ],
     deps = [
         "//exporters/ostream:ostream_metrics_exporter_deprecated",
         "//sdk/src/_metrics:metrics_deprecated",
@@ -15,6 +19,10 @@ cc_test(
     srcs = [
         "gauge_aggregator_test.cc",
     ],
+    tags = [
+        "metrics",
+        "test",
+    ],
     deps = [
         "//sdk/src/_metrics:metrics_deprecated",
         "@com_google_googletest//:gtest_main",
@@ -25,6 +33,10 @@ cc_test(
     name = "min_max_sum_count_aggregator_test",
     srcs = [
         "min_max_sum_count_aggregator_test.cc",
+    ],
+    tags = [
+        "metrics",
+        "test",
     ],
     deps = [
         "//sdk/src/_metrics:metrics_deprecated",
@@ -37,6 +49,10 @@ cc_test(
     srcs = [
         "meter_provider_sdk_test.cc",
     ],
+    tags = [
+        "metrics",
+        "test",
+    ],
     deps = [
         "//sdk/src/_metrics:metrics_deprecated",
         "@com_google_googletest//:gtest_main",
@@ -47,6 +63,10 @@ cc_test(
     name = "meter_test",
     srcs = [
         "meter_test.cc",
+    ],
+    tags = [
+        "metrics",
+        "test",
     ],
     deps = [
         "//sdk/src/_metrics:metrics_deprecated",
@@ -59,6 +79,10 @@ cc_test(
     srcs = [
         "counter_aggregator_test.cc",
     ],
+    tags = [
+        "metrics",
+        "test",
+    ],
     deps = [
         "//sdk/src/_metrics:metrics_deprecated",
         "@com_google_googletest//:gtest_main",
@@ -69,6 +93,10 @@ cc_test(
     name = "exact_aggregator_test",
     srcs = [
         "exact_aggregator_test.cc",
+    ],
+    tags = [
+        "metrics",
+        "test",
     ],
     deps = [
         "//sdk/src/_metrics:metrics_deprecated",
@@ -81,6 +109,10 @@ cc_test(
     srcs = [
         "histogram_aggregator_test.cc",
     ],
+    tags = [
+        "metrics",
+        "test",
+    ],
     deps = [
         "//sdk/src/_metrics:metrics_deprecated",
         "@com_google_googletest//:gtest_main",
@@ -91,6 +123,10 @@ cc_test(
     name = "metric_instrument_test",
     srcs = [
         "metric_instrument_test.cc",
+    ],
+    tags = [
+        "metrics",
+        "test",
     ],
     deps = [
         "//sdk/src/_metrics:metrics_deprecated",
@@ -103,6 +139,10 @@ cc_test(
     srcs = [
         "sketch_aggregator_test.cc",
     ],
+    tags = [
+        "metrics",
+        "test",
+    ],
     deps = [
         "//sdk/src/_metrics:metrics_deprecated",
         "@com_google_googletest//:gtest_main",
@@ -113,6 +153,10 @@ cc_test(
     name = "ungrouped_processor_test",
     srcs = [
         "ungrouped_processor_test.cc",
+    ],
+    tags = [
+        "metrics",
+        "test",
     ],
     deps = [
         "//sdk/src/_metrics:metrics_deprecated",

--- a/sdk/test/common/BUILD
+++ b/sdk/test/common/BUILD
@@ -5,6 +5,7 @@ cc_test(
     srcs = [
         "random_test.cc",
     ],
+    tags = ["test"],
     deps = [
         "//sdk/src/common:random",
         "@com_google_googletest//:gtest_main",
@@ -16,6 +17,7 @@ cc_test(
     srcs = [
         "fast_random_number_generator_test.cc",
     ],
+    tags = ["test"],
     deps = [
         "//sdk/src/common:random",
         "@com_google_googletest//:gtest_main",
@@ -25,6 +27,7 @@ cc_test(
 otel_cc_benchmark(
     name = "random_benchmark",
     srcs = ["random_benchmark.cc"],
+    tags = ["test"],
     deps = ["//sdk/src/common:random"],
 )
 
@@ -33,6 +36,7 @@ cc_test(
     srcs = [
         "atomic_unique_ptr_test.cc",
     ],
+    tags = ["test"],
     deps = [
         "//api",
         "//sdk:headers",
@@ -45,6 +49,7 @@ cc_test(
     srcs = [
         "circular_buffer_range_test.cc",
     ],
+    tags = ["test"],
     deps = [
         "//api",
         "//sdk:headers",
@@ -57,6 +62,7 @@ cc_test(
     srcs = [
         "random_fork_test.cc",
     ],
+    tags = ["test"],
     deps = [
         "//sdk/src/common:random",
     ],
@@ -76,6 +82,7 @@ cc_library(
 otel_cc_benchmark(
     name = "circular_buffer_benchmark",
     srcs = ["circular_buffer_benchmark.cc"],
+    tags = ["test"],
     deps = [
         ":baseline_circular_buffer",
         "//sdk:headers",
@@ -87,6 +94,7 @@ cc_test(
     srcs = [
         "empty_attributes_test.cc",
     ],
+    tags = ["test"],
     deps = [
         "//api",
         "//sdk:headers",
@@ -99,6 +107,7 @@ cc_test(
     srcs = [
         "attribute_utils_test.cc",
     ],
+    tags = ["test"],
     deps = [
         "//api",
         "//sdk:headers",

--- a/sdk/test/instrumentationlibrary/BUILD
+++ b/sdk/test/instrumentationlibrary/BUILD
@@ -5,6 +5,7 @@ cc_test(
     srcs = [
         "instrumentationlibrary_test.cc",
     ],
+    tags = ["test"],
     deps = [
         "//api",
         "//sdk:headers",

--- a/sdk/test/logs/BUILD
+++ b/sdk/test/logs/BUILD
@@ -3,6 +3,10 @@ cc_test(
     srcs = [
         "logger_provider_sdk_test.cc",
     ],
+    tags = [
+        "logs",
+        "test",
+    ],
     deps = [
         "//api",
         "//sdk/src/logs",
@@ -15,6 +19,10 @@ cc_test(
     srcs = [
         "logger_sdk_test.cc",
     ],
+    tags = [
+        "logs",
+        "test",
+    ],
     deps = [
         "//sdk/src/logs",
         "@com_google_googletest//:gtest_main",
@@ -25,6 +33,10 @@ cc_test(
     name = "simple_log_processor_test",
     srcs = [
         "simple_log_processor_test.cc",
+    ],
+    tags = [
+        "logs",
+        "test",
     ],
     deps = [
         "//sdk/src/logs",
@@ -37,6 +49,10 @@ cc_test(
     srcs = [
         "log_record_test.cc",
     ],
+    tags = [
+        "logs",
+        "test",
+    ],
     deps = [
         "//sdk/src/logs",
         "@com_google_googletest//:gtest_main",
@@ -47,6 +63,10 @@ cc_test(
     name = "batch_log_processor_test",
     srcs = [
         "batch_log_processor_test.cc",
+    ],
+    tags = [
+        "logs",
+        "test",
     ],
     deps = [
         "//sdk/src/logs",

--- a/sdk/test/resource/BUILD
+++ b/sdk/test/resource/BUILD
@@ -3,6 +3,7 @@ cc_test(
     srcs = [
         "resource_test.cc",
     ],
+    tags = ["test"],
     deps = [
         "//api",
         "//sdk/src/resource",

--- a/sdk/test/trace/BUILD
+++ b/sdk/test/trace/BUILD
@@ -5,6 +5,10 @@ cc_test(
     srcs = [
         "tracer_provider_test.cc",
     ],
+    tags = [
+        "test",
+        "trace",
+    ],
     deps = [
         "//sdk/src/resource",
         "//sdk/src/trace",
@@ -17,6 +21,10 @@ cc_test(
     srcs = [
         "span_data_test.cc",
     ],
+    tags = [
+        "test",
+        "trace",
+    ],
     deps = [
         "//sdk/src/trace",
         "@com_google_googletest//:gtest_main",
@@ -27,6 +35,10 @@ cc_test(
     name = "simple_processor_test",
     srcs = [
         "simple_processor_test.cc",
+    ],
+    tags = [
+        "test",
+        "trace",
     ],
     deps = [
         "//exporters/memory:in_memory_span_exporter",
@@ -40,6 +52,10 @@ cc_test(
     srcs = [
         "batch_span_processor_test.cc",
     ],
+    tags = [
+        "test",
+        "trace",
+    ],
     deps = [
         "//sdk/src/trace",
         "@com_google_googletest//:gtest_main",
@@ -50,6 +66,10 @@ cc_test(
     name = "tracer_test",
     srcs = [
         "tracer_test.cc",
+    ],
+    tags = [
+        "test",
+        "trace",
     ],
     deps = [
         "//exporters/memory:in_memory_span_exporter",
@@ -64,6 +84,10 @@ cc_test(
     srcs = [
         "always_on_sampler_test.cc",
     ],
+    tags = [
+        "test",
+        "trace",
+    ],
     deps = [
         "//sdk/src/trace",
         "@com_google_googletest//:gtest_main",
@@ -74,6 +98,10 @@ cc_test(
     name = "always_off_sampler_test",
     srcs = [
         "always_off_sampler_test.cc",
+    ],
+    tags = [
+        "test",
+        "trace",
     ],
     deps = [
         "//sdk/src/trace",
@@ -86,6 +114,10 @@ cc_test(
     srcs = [
         "parent_sampler_test.cc",
     ],
+    tags = [
+        "test",
+        "trace",
+    ],
     deps = [
         "//sdk/src/trace",
         "@com_google_googletest//:gtest_main",
@@ -97,6 +129,10 @@ cc_test(
     srcs = [
         "trace_id_ratio_sampler_test.cc",
     ],
+    tags = [
+        "test",
+        "trace",
+    ],
     deps = [
         "//sdk/src/common:random",
         "//sdk/src/trace",
@@ -107,6 +143,10 @@ cc_test(
 otel_cc_benchmark(
     name = "sampler_benchmark",
     srcs = ["sampler_benchmark.cc"],
+    tags = [
+        "test",
+        "trace",
+    ],
     deps = [
         "//exporters/memory:in_memory_span_exporter",
         "//sdk/src/resource",


### PR DESCRIPTION
This PR is to add prerequisite in the installation steps for Cmake build. It was missing in the documentation earlier which leads to the error as shown in attachment below

![image (2)](https://user-images.githubusercontent.com/41936996/145929933-caed21d5-f66e-4287-bc3a-c55ba99aca9d.png)
