### PR TITLE
Improve the instructions for Bazel build.

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -137,13 +137,9 @@ target_link_libraries(foo PRIVATE ${OPENTELEMETRY_CPP_LIBRARIES})
 
 ## Build instructions using Bazel
 
-<<<<<<< HEAD
 NOTE: Experimental, and not supported for all the components. Make sure the
 [GoogleTest](https://github.com/google/googletest) installation may fail if there is a different version of googletest already installed in system-defined path.
-=======
-NOTE: Experimental, and not supported for all the components. Make sure the 
-[GoogleTest](https://github.com/google/googletest) is not installed prior to using the Bazel.
->>>>>>> 3c7c133ed9419d946b8148a0bc577407603c03ed
+
 
 ### Prerequisites for Bazel
 

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -140,7 +140,6 @@ target_link_libraries(foo PRIVATE ${OPENTELEMETRY_CPP_LIBRARIES})
 NOTE: Experimental, and not supported for all the components. Make sure the
 [GoogleTest](https://github.com/google/googletest) installation may fail if there is a different version of googletest already installed in system-defined path.
 
-
 ### Prerequisites for Bazel
 
 - A supported platform (e.g. Windows, macOS or Linux).

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -26,6 +26,9 @@ You can link OpenTelemetry C++ SDK with libraries provided in [dependencies.md](
   the unittests. We use GoogleTest version 1.10.0 in our build system. To
   install GoogleTest, consult the [GoogleTest Build
   Instructions](https://github.com/google/googletest/blob/master/googletest/README.md#generic-build-instructions).
+- [Google Benchmark](https://github.com/google/benchmark) framework to build and run
+  benchmark and benchmark_main libraries and tests. We use Benchmark version 1.5.3 or above. To install Benchmark,
+  consult the [GoogleBenchmark Build Instructions](https://github.com/google/benchmark#installation)
 - Apart from above core requirements, the Exporters and Propagators have their
   build dependencies which are not covered here. E.g, Otlp Exporter needs
   grpc/protobuf library, Zipkin exporter needs nlohmann-json and libcurl, ETW

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -26,9 +26,6 @@ You can link OpenTelemetry C++ SDK with libraries provided in [dependencies.md](
   the unittests. We use GoogleTest version 1.10.0 in our build system. To
   install GoogleTest, consult the [GoogleTest Build
   Instructions](https://github.com/google/googletest/blob/master/googletest/README.md#generic-build-instructions).
-- [Google Benchmark](https://github.com/google/benchmark) framework to build and run
-  benchmark and benchmark_main libraries and tests. We use Benchmark version 1.5.3 or above. To install Benchmark,
-  consult the [GoogleBenchmark Build Instructions](https://github.com/google/benchmark#installation)
 - Apart from above core requirements, the Exporters and Propagators have their
   build dependencies which are not covered here. E.g, Otlp Exporter needs
   grpc/protobuf library, Zipkin exporter needs nlohmann-json and libcurl, ETW
@@ -140,7 +137,8 @@ target_link_libraries(foo PRIVATE ${OPENTELEMETRY_CPP_LIBRARIES})
 
 ## Build instructions using Bazel
 
-NOTE: Experimental, and not supported for all the components.
+NOTE: Experimental, and not supported for all the components. Make sure the 
+[GoogleTest](https://github.com/google/googletest) is not installed prior to using Bazel to build.
 
 ### Prerequisites for Bazel
 
@@ -173,9 +171,10 @@ To install Bazel, consult the [Installing Bazel](https://docs.bazel.build/versio
    $
    ```
 
-2. Download the dependencies and build the source code:
+2. Navigate to the repository cloned above, download the dependencies and build the source code:
 
    ```console
+   $ cd opentelemtry-cpp
    $ bazel build //...
    bazel build -- //... -//exporters/otlp/... -//exporters/prometheus/...
    Extracting Bazel installation...

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -137,8 +137,8 @@ target_link_libraries(foo PRIVATE ${OPENTELEMETRY_CPP_LIBRARIES})
 
 ## Build instructions using Bazel
 
-NOTE: Experimental, and not supported for all the components. Make sure the 
-[GoogleTest](https://github.com/google/googletest) is not installed prior to using Bazel to build.
+NOTE: Experimental, and not supported for all the components. Make sure the
+[GoogleTest](https://github.com/google/googletest) installation may fail if there is a different version of googletest already installed in system-defined path.
 
 ### Prerequisites for Bazel
 

--- a/exporters/otlp/src/otlp_http_client.cc
+++ b/exporters/otlp/src/otlp_http_client.cc
@@ -28,7 +28,7 @@ namespace google
 {
 namespace protobuf
 {
-LIBPROTOBUF_EXPORT int Base64Escape(const unsigned char *src, int slen, char *dest, int szdest);
+LIBPROTOBUF_EXPORT void Base64Escape(StringPiece src, std::string *dest);
 }  // namespace protobuf
 }  // namespace google
 #endif


### PR DESCRIPTION
This PR is to propose the changes in instructions for building with bazel and adding the note to not to have GoogleTest installed.

Bazel will download, build and install gtest version from [here](https://github.com/open-telemetry/opentelemetry-cpp/blob/5e258b0c0c192620fe3410b9e56c7480fa278a82/bazel/repository.bzl#L27) and it will fail if it gets different gtest headers from system defined path.

Please feel free to add review comments.