### PR TITLE
Jaeger exporter shutdown

### DIFF
--- a/exporters/jaeger/include/opentelemetry/exporters/jaeger/jaeger_exporter.h
+++ b/exporters/jaeger/include/opentelemetry/exporters/jaeger/jaeger_exporter.h
@@ -65,7 +65,10 @@ public:
    * @param timeout an option timeout, default to max.
    */
   bool Shutdown(
-      std::chrono::microseconds timeout = std::chrono::microseconds::max()) noexcept override;
+      std::chrono::microseconds timeout = std::chrono::microseconds::max()) noexcept override
+  {
+    return true;
+  }
 
 private:
   void InitializeEndpoint();

--- a/exporters/jaeger/include/opentelemetry/exporters/jaeger/jaeger_exporter.h
+++ b/exporters/jaeger/include/opentelemetry/exporters/jaeger/jaeger_exporter.h
@@ -65,10 +65,7 @@ public:
    * @param timeout an option timeout, default to max.
    */
   bool Shutdown(
-      std::chrono::microseconds timeout = std::chrono::microseconds::max()) noexcept override
-  {
-    return true;
-  }
+      std::chrono::microseconds timeout = std::chrono::microseconds::max()) noexcept override;
 
 private:
   void InitializeEndpoint();

--- a/exporters/jaeger/src/jaeger_exporter.cc
+++ b/exporters/jaeger/src/jaeger_exporter.cc
@@ -85,12 +85,6 @@ void JaegerExporter::InitializeEndpoint()
   assert(false);
 }
 
-bool JaegerExporter::Shutdown(std::chrono::microseconds timeout) noexcept
-{
-  is_shutdown_ = true;
-  return true;
-}
-
 }  // namespace jaeger
 }  // namespace exporter
 OPENTELEMETRY_END_NAMESPACE

--- a/exporters/jaeger/src/jaeger_exporter.cc
+++ b/exporters/jaeger/src/jaeger_exporter.cc
@@ -85,6 +85,12 @@ void JaegerExporter::InitializeEndpoint()
   assert(false);
 }
 
+bool JaegerExporter::Shutdown(std::chrono::microseconds timeout) noexcept
+{
+  is_shutdown_ = true;
+  return true;
+}
+
 }  // namespace jaeger
 }  // namespace exporter
 OPENTELEMETRY_END_NAMESPACE


### PR DESCRIPTION
Fixes Jaeger exporter shutdown

## Changes
Please provide a brief description of the changes here.
Jaeger exporter shutdown should set shutdown before return

For significant contributions please make sure you have completed the following items:

* [ ] `CHANGELOG.md` updated for non-trivial changes
* [ ] Unit tests have been added
* [ ] Changes in public API reviewed