### PR TITLE
Adding prerequisite to the installation steps for Cmake build [new PR]

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -23,9 +23,14 @@ You can link OpenTelemetry C++ SDK with libraries provided in [dependencies.md](
   unittests. We use CMake version 3.15.2 in our build system. To install CMake,
   consult the [Installing CMake](https://cmake.org/install/) guide.
 - [GoogleTest](https://github.com/google/googletest) framework to build and run
-  the unittests. We use GoogleTest version 1.10.0 in our build system. To
+  the unittests. Refer to [third_party_release](https://github.com/open-telemetry/opentelemetry-cpp/blob/main/third_party_release#L5)
+  for version of GoogleTest used in CI. To
   install GoogleTest, consult the [GoogleTest Build
   Instructions](https://github.com/google/googletest/blob/master/googletest/README.md#generic-build-instructions).
+- [Google Benchmark](https://github.com/google/benchmark) framework to build and run
+  benchmark tests. Refer to [third_party_release](https://github.com/open-telemetry/opentelemetry-cpp/blob/main/third_party_release#L4)
+  for version of Benchmark used in CI. To install Benchmark,
+  consult the [GoogleBenchmark Build Instructions](https://github.com/google/benchmark#installation).
 - Apart from above core requirements, the Exporters and Propagators have their
   build dependencies which are not covered here. E.g, Otlp Exporter needs
   grpc/protobuf library, Zipkin exporter needs nlohmann-json and libcurl, ETW


### PR DESCRIPTION
This PR is to add prerequisite in the installation steps for Cmake build. It was missing in the documentation earlier which leads to the error as shown in attachment below

![](https://user-images.githubusercontent.com/41936996/145929933-caed21d5-f66e-4287-bc3a-c55ba99aca9d.png)
