### PR TITLE
ZipkinExporter shutdown

### DIFF
--- a/exporters/zipkin/include/opentelemetry/exporters/zipkin/zipkin_exporter.h
+++ b/exporters/zipkin/include/opentelemetry/exporters/zipkin/zipkin_exporter.h
@@ -82,10 +82,7 @@ public:
    * @param timeout an optional timeout, default to max.
    */
   bool Shutdown(
-      std::chrono::microseconds timeout = std::chrono::microseconds::max()) noexcept override
-  {
-    return true;
-  }
+      std::chrono::microseconds timeout = std::chrono::microseconds::max()) noexcept override;
 
 private:
   void InitializeLocalEndpoint();

--- a/exporters/zipkin/src/zipkin_exporter.cc
+++ b/exporters/zipkin/src/zipkin_exporter.cc
@@ -98,6 +98,12 @@ void ZipkinExporter::InitializeLocalEndpoint()
   local_end_point_["port"] = url_parser_.port_;
 }
 
+bool ZipkinExporter::Shutdown(std::chrono::microseconds timeout) noexcept
+{
+  isShutdown_ = true;
+  return true;
+}
+
 }  // namespace zipkin
 }  // namespace exporter
 OPENTELEMETRY_END_NAMESPACE


### PR DESCRIPTION
Fixes ZipkinExporter shutdown

## Changes

ZipkinExporter shutdown should set shutdown before return

For significant contributions please make sure you have completed the following items:

* [ ] `CHANGELOG.md` updated for non-trivial changes
* [ ] Unit tests have been added
* [ ] Changes in public API reviewed