### PR TITLE
Logger: Propagating resources through LoggerProvider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,8 +16,9 @@ Increment the:
 ## [Unreleased]
 
 * [SDK] Add LogLevel to internal_log ([#1147](https://github.com/open-telemetry/opentelemetry-cpp/pull/1147))
+* [API/SDK] Logger: Propagating resources through LoggerProvider ([#1154](https://github.com/open-telemetry/opentelemetry-cpp/pull/1154))
 
-## [1.1.1] 2021-12-
+## [1.1.1] 2021-12-20
 
 * [SDK] Rename OTEL_CPP_GET_ATTR macro, and define it using fully qualified attr function ([#1140](https://github.com/open-telemetry/opentelemetry-cpp/pull/1140))
 * [SDK] Default resource attributes and attributes in OTEL_RESOURCE_ATTRIBUTES are missing when using Otlp*LogExporter ([#1082](https://github.com/open-telemetry/opentelemetry-cpp/pull/1082))

--- a/api/include/opentelemetry/common/macros.h
+++ b/api/include/opentelemetry/common/macros.h
@@ -9,45 +9,45 @@
 
 /// \brief Declare class, variable or functions as deprecated
 /// usage:
-///   OPENTELEMETRY_DEPRECATED_ATTR int a;
-///   class OPENTELEMETRY_DEPRECATED_ATTR a;
-///   OPENTELEMETRY_DEPRECATED_ATTR int a();
+///   OPENTELEMETRY_DEPRECATED int a;
+///   class OPENTELEMETRY_DEPRECATED a;
+///   OPENTELEMETRY_DEPRECATED int a();
 /// usage:
-///   OPENTELEMETRY_DEPRECATED_MSG("there is better choose") int a;
+///   OPENTELEMETRY_DEPRECATED_MESSAGE("there is better choose") int a;
 ///   class DEPRECATED_MSG("there is better choose") a;
-///   OPENTELEMETRY_DEPRECATED_MSG("there is better choose") int a();
+///   OPENTELEMETRY_DEPRECATED_MESSAGE("there is better choose") int a();
 ///
 
 #if defined(__cplusplus) && __cplusplus >= 201402L
-#  define OPENTELEMETRY_DEPRECATED_ATTR [[deprecated]]
+#  define OPENTELEMETRY_DEPRECATED [[deprecated]]
 #elif defined(__clang__)
-#  define OPENTELEMETRY_DEPRECATED_ATTR __attribute__((deprecated))
+#  define OPENTELEMETRY_DEPRECATED __attribute__((deprecated))
 #elif defined(__GNUC__) && ((__GNUC__ >= 4) || ((__GNUC__ == 3) && (__GNUC_MINOR__ >= 1)))
-#  define OPENTELEMETRY_DEPRECATED_ATTR __attribute__((deprecated))
+#  define OPENTELEMETRY_DEPRECATED __attribute__((deprecated))
 #elif defined(_MSC_VER) && _MSC_VER >= 1400  // vs 2005 or higher
 #  if _MSC_VER >= 1910 && defined(_MSVC_LANG) && _MSVC_LANG >= 201703L
-#    define OPENTELEMETRY_DEPRECATED_ATTR [[deprecated]]
+#    define OPENTELEMETRY_DEPRECATED [[deprecated]]
 #  else
-#    define OPENTELEMETRY_DEPRECATED_ATTR __declspec(deprecated)
+#    define OPENTELEMETRY_DEPRECATED __declspec(deprecated)
 #  endif
 #else
-#  define OPENTELEMETRY_DEPRECATED_ATTR
+#  define OPENTELEMETRY_DEPRECATED
 #endif
 
 #if defined(__cplusplus) && __cplusplus >= 201402L
-#  define OPENTELEMETRY_DEPRECATED_MSG(msg) [[deprecated(msg)]]
+#  define OPENTELEMETRY_DEPRECATED_MESSAGE(msg) [[deprecated(msg)]]
 #elif defined(__clang__)
-#  define OPENTELEMETRY_DEPRECATED_MSG(msg) __attribute__((deprecated(msg)))
+#  define OPENTELEMETRY_DEPRECATED_MESSAGE(msg) __attribute__((deprecated(msg)))
 #elif defined(__GNUC__) && ((__GNUC__ >= 4) || ((__GNUC__ == 3) && (__GNUC_MINOR__ >= 1)))
-#  define OPENTELEMETRY_DEPRECATED_MSG(msg) __attribute__((deprecated(msg)))
+#  define OPENTELEMETRY_DEPRECATED_MESSAGE(msg) __attribute__((deprecated(msg)))
 #elif defined(_MSC_VER) && _MSC_VER >= 1400  // vs 2005 or higher
 #  if _MSC_VER >= 1910 && defined(_MSVC_LANG) && _MSVC_LANG >= 201703L
-#    define OPENTELEMETRY_DEPRECATED_MSG(msg) [[deprecated(msg)]]
+#    define OPENTELEMETRY_DEPRECATED_MESSAGE(msg) [[deprecated(msg)]]
 #  else
-#    define OPENTELEMETRY_DEPRECATED_MSG(msg) __declspec(deprecated(msg))
+#    define OPENTELEMETRY_DEPRECATED_MESSAGE(msg) __declspec(deprecated(msg))
 #  endif
 #else
-#  define OPENTELEMETRY_DEPRECATED_MSG(msg)
+#  define OPENTELEMETRY_DEPRECATED_MESSAGE(msg)
 #endif
 
 /// \brief Declare variable as maybe unused

--- a/api/include/opentelemetry/common/macros.h
+++ b/api/include/opentelemetry/common/macros.h
@@ -7,49 +7,6 @@
 
 #include "opentelemetry/version.h"
 
-/// \brief Declare class, variable or functions as deprecated
-/// usage:
-///   OPENTELEMETRY_DEPRECATED int a;
-///   class OPENTELEMETRY_DEPRECATED a;
-///   OPENTELEMETRY_DEPRECATED int a();
-/// usage:
-///   OPENTELEMETRY_DEPRECATED_MESSAGE("there is better choose") int a;
-///   class DEPRECATED_MSG("there is better choose") a;
-///   OPENTELEMETRY_DEPRECATED_MESSAGE("there is better choose") int a();
-///
-
-#if defined(__cplusplus) && __cplusplus >= 201402L
-#  define OPENTELEMETRY_DEPRECATED [[deprecated]]
-#elif defined(__clang__)
-#  define OPENTELEMETRY_DEPRECATED __attribute__((deprecated))
-#elif defined(__GNUC__) && ((__GNUC__ >= 4) || ((__GNUC__ == 3) && (__GNUC_MINOR__ >= 1)))
-#  define OPENTELEMETRY_DEPRECATED __attribute__((deprecated))
-#elif defined(_MSC_VER) && _MSC_VER >= 1400  // vs 2005 or higher
-#  if _MSC_VER >= 1910 && defined(_MSVC_LANG) && _MSVC_LANG >= 201703L
-#    define OPENTELEMETRY_DEPRECATED [[deprecated]]
-#  else
-#    define OPENTELEMETRY_DEPRECATED __declspec(deprecated)
-#  endif
-#else
-#  define OPENTELEMETRY_DEPRECATED
-#endif
-
-#if defined(__cplusplus) && __cplusplus >= 201402L
-#  define OPENTELEMETRY_DEPRECATED_MESSAGE(msg) [[deprecated(msg)]]
-#elif defined(__clang__)
-#  define OPENTELEMETRY_DEPRECATED_MESSAGE(msg) __attribute__((deprecated(msg)))
-#elif defined(__GNUC__) && ((__GNUC__ >= 4) || ((__GNUC__ == 3) && (__GNUC_MINOR__ >= 1)))
-#  define OPENTELEMETRY_DEPRECATED_MESSAGE(msg) __attribute__((deprecated(msg)))
-#elif defined(_MSC_VER) && _MSC_VER >= 1400  // vs 2005 or higher
-#  if _MSC_VER >= 1910 && defined(_MSVC_LANG) && _MSVC_LANG >= 201703L
-#    define OPENTELEMETRY_DEPRECATED_MESSAGE(msg) [[deprecated(msg)]]
-#  else
-#    define OPENTELEMETRY_DEPRECATED_MESSAGE(msg) __declspec(deprecated(msg))
-#  endif
-#else
-#  define OPENTELEMETRY_DEPRECATED_MESSAGE(msg)
-#endif
-
 /// \brief Declare variable as maybe unused
 /// usage:
 ///   OPENTELEMETRY_MAYBE_UNUSED int a;
@@ -70,34 +27,4 @@
 #  endif
 #else
 #  define OPENTELEMETRY_MAYBE_UNUSED
-#endif
-
-/// \brief Allow fallthrough of case in switch
-/// usage:
-///   OPENTELEMETRY_FALLTHROUGH int a;
-///   switch (xxx) {
-///      case XXX:
-///      OPENTELEMETRY_FALLTHROUGH
-///
-#if defined(__cplusplus) && __cplusplus >= 201703L
-#  define OPENTELEMETRY_FALLTHROUGH [[fallthrough]];
-#elif defined(__clang__) && ((__clang_major__ * 100) + __clang_minor__) >= 309
-#  if defined(__apple_build_version__)
-#    define OPENTELEMETRY_FALLTHROUGH
-#  elif defined(__has_warning) && __has_feature(cxx_attributes) && \
-      __has_warning("-Wimplicit-fallthrough")
-#    define OPENTELEMETRY_FALLTHROUGH [[clang::fallthrough]];
-#  else
-#    define OPENTELEMETRY_FALLTHROUGH
-#  endif
-#elif defined(__GNUC__) && (__GNUC__ >= 7)
-#  define OPENTELEMETRY_FALLTHROUGH [[gnu::fallthrough]];
-#elif defined(_MSC_VER) && _MSC_VER >= 1700  // vs 2012 or higher
-#  if _MSC_VER >= 1910 && defined(_MSVC_LANG) && _MSVC_LANG >= 201703L
-#    define OPENTELEMETRY_FALLTHROUGH [[fallthrough]];
-#  else
-#    define OPENTELEMETRY_FALLTHROUGH
-#  endif
-#else
-#  define OPENTELEMETRY_FALLTHROUGH
 #endif

--- a/api/include/opentelemetry/common/macros.h
+++ b/api/include/opentelemetry/common/macros.h
@@ -19,12 +19,8 @@
 #  define OPENTELEMETRY_MAYBE_UNUSED __attribute__((unused))
 #elif defined(__GNUC__) && ((__GNUC__ >= 4) || ((__GNUC__ == 3) && (__GNUC_MINOR__ >= 1)))
 #  define OPENTELEMETRY_MAYBE_UNUSED __attribute__((unused))
-#elif defined(_MSC_VER) && _MSC_VER >= 1700  // vs 2012 or higher
-#  if _MSC_VER >= 1910 && defined(_MSVC_LANG) && _MSVC_LANG >= 201703L
-#    define OPENTELEMETRY_MAYBE_UNUSED [[maybe_unused]]
-#  else
-#    define OPENTELEMETRY_MAYBE_UNUSED
-#  endif
+#elif (defined(_MSC_VER) && _MSC_VER >= 1910) && (defined(_MSVC_LANG) && _MSVC_LANG >= 201703L)
+#  define OPENTELEMETRY_MAYBE_UNUSED [[maybe_unused]]
 #else
 #  define OPENTELEMETRY_MAYBE_UNUSED
 #endif

--- a/api/include/opentelemetry/common/macros.h
+++ b/api/include/opentelemetry/common/macros.h
@@ -1,0 +1,103 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <cstdint>
+
+#include "opentelemetry/version.h"
+
+/// \brief Declare class, variable or functions as deprecated
+/// usage:
+///   OPENTELEMETRY_DEPRECATED_ATTR int a;
+///   class OPENTELEMETRY_DEPRECATED_ATTR a;
+///   OPENTELEMETRY_DEPRECATED_ATTR int a();
+/// usage:
+///   OPENTELEMETRY_DEPRECATED_MSG("there is better choose") int a;
+///   class DEPRECATED_MSG("there is better choose") a;
+///   OPENTELEMETRY_DEPRECATED_MSG("there is better choose") int a();
+///
+
+#if defined(__cplusplus) && __cplusplus >= 201402L
+#  define OPENTELEMETRY_DEPRECATED_ATTR [[deprecated]]
+#elif defined(__clang__)
+#  define OPENTELEMETRY_DEPRECATED_ATTR __attribute__((deprecated))
+#elif defined(__GNUC__) && ((__GNUC__ >= 4) || ((__GNUC__ == 3) && (__GNUC_MINOR__ >= 1)))
+#  define OPENTELEMETRY_DEPRECATED_ATTR __attribute__((deprecated))
+#elif defined(_MSC_VER) && _MSC_VER >= 1400  // vs 2005 or higher
+#  if _MSC_VER >= 1910 && defined(_MSVC_LANG) && _MSVC_LANG >= 201703L
+#    define OPENTELEMETRY_DEPRECATED_ATTR [[deprecated]]
+#  else
+#    define OPENTELEMETRY_DEPRECATED_ATTR __declspec(deprecated)
+#  endif
+#else
+#  define OPENTELEMETRY_DEPRECATED_ATTR
+#endif
+
+#if defined(__cplusplus) && __cplusplus >= 201402L
+#  define OPENTELEMETRY_DEPRECATED_MSG(msg) [[deprecated(msg)]]
+#elif defined(__clang__)
+#  define OPENTELEMETRY_DEPRECATED_MSG(msg) __attribute__((deprecated(msg)))
+#elif defined(__GNUC__) && ((__GNUC__ >= 4) || ((__GNUC__ == 3) && (__GNUC_MINOR__ >= 1)))
+#  define OPENTELEMETRY_DEPRECATED_MSG(msg) __attribute__((deprecated(msg)))
+#elif defined(_MSC_VER) && _MSC_VER >= 1400  // vs 2005 or higher
+#  if _MSC_VER >= 1910 && defined(_MSVC_LANG) && _MSVC_LANG >= 201703L
+#    define OPENTELEMETRY_DEPRECATED_MSG(msg) [[deprecated(msg)]]
+#  else
+#    define OPENTELEMETRY_DEPRECATED_MSG(msg) __declspec(deprecated(msg))
+#  endif
+#else
+#  define OPENTELEMETRY_DEPRECATED_MSG(msg)
+#endif
+
+/// \brief Declare variable as maybe unused
+/// usage:
+///   OPENTELEMETRY_MAYBE_UNUSED int a;
+///   class OPENTELEMETRY_MAYBE_UNUSED a;
+///   OPENTELEMETRY_MAYBE_UNUSED int a();
+///
+#if defined(__cplusplus) && __cplusplus >= 201703L
+#  define OPENTELEMETRY_MAYBE_UNUSED [[maybe_unused]]
+#elif defined(__clang__)
+#  define OPENTELEMETRY_MAYBE_UNUSED __attribute__((unused))
+#elif defined(__GNUC__) && ((__GNUC__ >= 4) || ((__GNUC__ == 3) && (__GNUC_MINOR__ >= 1)))
+#  define OPENTELEMETRY_MAYBE_UNUSED __attribute__((unused))
+#elif defined(_MSC_VER) && _MSC_VER >= 1700  // vs 2012 or higher
+#  if _MSC_VER >= 1910 && defined(_MSVC_LANG) && _MSVC_LANG >= 201703L
+#    define OPENTELEMETRY_MAYBE_UNUSED [[maybe_unused]]
+#  else
+#    define OPENTELEMETRY_MAYBE_UNUSED
+#  endif
+#else
+#  define OPENTELEMETRY_MAYBE_UNUSED
+#endif
+
+/// \brief Allow fallthrough of case in switch
+/// usage:
+///   OPENTELEMETRY_FALLTHROUGH int a;
+///   switch (xxx) {
+///      case XXX:
+///      OPENTELEMETRY_FALLTHROUGH
+///
+#if defined(__cplusplus) && __cplusplus >= 201703L
+#  define OPENTELEMETRY_FALLTHROUGH [[fallthrough]];
+#elif defined(__clang__) && ((__clang_major__ * 100) + __clang_minor__) >= 309
+#  if defined(__apple_build_version__)
+#    define OPENTELEMETRY_FALLTHROUGH
+#  elif defined(__has_warning) && __has_feature(cxx_attributes) && \
+      __has_warning("-Wimplicit-fallthrough")
+#    define OPENTELEMETRY_FALLTHROUGH [[clang::fallthrough]];
+#  else
+#    define OPENTELEMETRY_FALLTHROUGH
+#  endif
+#elif defined(__GNUC__) && (__GNUC__ >= 7)
+#  define OPENTELEMETRY_FALLTHROUGH [[gnu::fallthrough]];
+#elif defined(_MSC_VER) && _MSC_VER >= 1700  // vs 2012 or higher
+#  if _MSC_VER >= 1910 && defined(_MSVC_LANG) && _MSVC_LANG >= 201703L
+#    define OPENTELEMETRY_FALLTHROUGH [[fallthrough]];
+#  else
+#    define OPENTELEMETRY_FALLTHROUGH
+#  endif
+#else
+#  define OPENTELEMETRY_FALLTHROUGH
+#endif

--- a/api/include/opentelemetry/logs/logger.h
+++ b/api/include/opentelemetry/logs/logger.h
@@ -11,7 +11,6 @@
 #  include "opentelemetry/common/attribute_value.h"
 #  include "opentelemetry/common/key_value_iterable.h"
 #  include "opentelemetry/common/key_value_iterable_view.h"
-#  include "opentelemetry/common/macros.h"
 #  include "opentelemetry/common/timestamp.h"
 #  include "opentelemetry/logs/severity.h"
 #  include "opentelemetry/nostd/shared_ptr.h"
@@ -66,20 +65,6 @@ public:
                    trace::TraceFlags trace_flags,
                    common::SystemTimestamp timestamp) noexcept = 0;
 
-  OPENTELEMETRY_DEPRECATED_MESSAGE("resource is removed and ignored")
-  void Log(Severity severity,
-           nostd::string_view name,
-           nostd::string_view body,
-           OPENTELEMETRY_MAYBE_UNUSED const common::KeyValueIterable &resource,
-           const common::KeyValueIterable &attributes,
-           trace::TraceId trace_id,
-           trace::SpanId span_id,
-           trace::TraceFlags trace_flags,
-           common::SystemTimestamp timestamp) noexcept
-  {
-    this->Log(severity, name, body, attributes, trace_id, span_id, trace_flags, timestamp);
-  }
-
   /*** Overloaded methods for KeyValueIterables ***/
   /**
    * The secondary base Log(...) method that all other Log(...) overloaded methods except the one
@@ -100,46 +85,9 @@ public:
         trace_flags, timestamp);
   }
 
-  template <class T,
-            class U,
-            nostd::enable_if_t<common::detail::is_key_value_iterable<T>::value> * = nullptr,
-            nostd::enable_if_t<common::detail::is_key_value_iterable<U>::value> * = nullptr>
-  OPENTELEMETRY_DEPRECATED_MESSAGE("resource is removed and ignored")
   void Log(Severity severity,
            nostd::string_view name,
            nostd::string_view body,
-           OPENTELEMETRY_MAYBE_UNUSED const T &resource,
-           const U &attributes,
-           trace::TraceId trace_id,
-           trace::SpanId span_id,
-           trace::TraceFlags trace_flags,
-           common::SystemTimestamp timestamp) noexcept
-  {
-    Log(severity, name, body, common::KeyValueIterableView<U>(attributes), trace_id, span_id,
-        trace_flags, timestamp);
-  }
-
-  void Log(Severity severity,
-           nostd::string_view name,
-           nostd::string_view body,
-           std::initializer_list<std::pair<nostd::string_view, common::AttributeValue>> attributes,
-           trace::TraceId trace_id,
-           trace::SpanId span_id,
-           trace::TraceFlags trace_flags,
-           common::SystemTimestamp timestamp) noexcept
-  {
-    return this->Log(severity, name, body,
-                     nostd::span<const std::pair<nostd::string_view, common::AttributeValue>>{
-                         attributes.begin(), attributes.end()},
-                     trace_id, span_id, trace_flags, timestamp);
-  }
-
-  OPENTELEMETRY_DEPRECATED_MESSAGE("resource is removed and ignored")
-  void Log(Severity severity,
-           nostd::string_view name,
-           nostd::string_view body,
-           OPENTELEMETRY_MAYBE_UNUSED std::initializer_list<
-               std::pair<nostd::string_view, common::AttributeValue>> resource,
            std::initializer_list<std::pair<nostd::string_view, common::AttributeValue>> attributes,
            trace::TraceId trace_id,
            trace::SpanId span_id,

--- a/api/include/opentelemetry/logs/logger.h
+++ b/api/include/opentelemetry/logs/logger.h
@@ -66,7 +66,7 @@ public:
                    trace::TraceFlags trace_flags,
                    common::SystemTimestamp timestamp) noexcept = 0;
 
-  OPENTELEMETRY_DEPRECATED_MSG("resource is removed and ignored")
+  OPENTELEMETRY_DEPRECATED_MESSAGE("resource is removed and ignored")
   void Log(Severity severity,
            nostd::string_view name,
            nostd::string_view body,
@@ -104,7 +104,7 @@ public:
             class U,
             nostd::enable_if_t<common::detail::is_key_value_iterable<T>::value> * = nullptr,
             nostd::enable_if_t<common::detail::is_key_value_iterable<U>::value> * = nullptr>
-  OPENTELEMETRY_DEPRECATED_MSG("resource is removed and ignored")
+  OPENTELEMETRY_DEPRECATED_MESSAGE("resource is removed and ignored")
   void Log(Severity severity,
            nostd::string_view name,
            nostd::string_view body,
@@ -134,7 +134,7 @@ public:
                      trace_id, span_id, trace_flags, timestamp);
   }
 
-  OPENTELEMETRY_DEPRECATED_MSG("resource is removed and ignored")
+  OPENTELEMETRY_DEPRECATED_MESSAGE("resource is removed and ignored")
   void Log(Severity severity,
            nostd::string_view name,
            nostd::string_view body,

--- a/api/include/opentelemetry/logs/noop.h
+++ b/api/include/opentelemetry/logs/noop.h
@@ -44,7 +44,6 @@ public:
   void Log(Severity severity,
            nostd::string_view name,
            nostd::string_view body,
-           const common::KeyValueIterable &resource,
            const common::KeyValueIterable &attributes,
            trace::TraceId trace_id,
            trace::SpanId span_id,

--- a/api/test/logs/logger_test.cc
+++ b/api/test/logs/logger_test.cc
@@ -80,7 +80,6 @@ class TestLogger : public Logger
   void Log(Severity severity,
            string_view name,
            string_view body,
-           const common::KeyValueIterable &resource,
            const common::KeyValueIterable &attributes,
            trace::TraceId trace_id,
            trace::SpanId span_id,

--- a/bazel/repository.bzl
+++ b/bazel/repository.bzl
@@ -9,10 +9,10 @@ def opentelemetry_cpp_deps():
     maybe(
         http_archive,
         name = "com_github_google_benchmark",
-        sha256 = "dccbdab796baa1043f04982147e67bb6e118fe610da2c65f88912d73987e700c",
-        strip_prefix = "benchmark-1.5.2",
+        sha256 = "1f71c72ce08d2c1310011ea6436b31e39ccab8c2db94186d26657d41747c85d6",
+        strip_prefix = "benchmark-1.6.0",
         urls = [
-            "https://github.com/google/benchmark/archive/v1.5.2.tar.gz",
+            "https://github.com/google/benchmark/archive/v1.6.0.tar.gz",
         ],
     )
 

--- a/examples/common/logs_foo_library/foo_library.cc
+++ b/examples/common/logs_foo_library/foo_library.cc
@@ -32,7 +32,7 @@ void foo_library()
   auto scoped_span = trace::Scope(get_tracer()->StartSpan("foo_library"));
   auto ctx         = span->GetContext();
   auto logger      = get_logger();
-  logger->Log(opentelemetry::logs::Severity::kDebug, "name", "body", {}, {}, ctx.trace_id(),
+  logger->Log(opentelemetry::logs::Severity::kDebug, "name", "body", {}, ctx.trace_id(),
               ctx.span_id(), ctx.trace_flags(), opentelemetry::common::SystemTimestamp());
 }
 #endif

--- a/examples/otlp/grpc_log_main.cc
+++ b/examples/otlp/grpc_log_main.cc
@@ -44,11 +44,10 @@ void InitTracer()
 void InitLogger()
 {
   // Create OTLP exporter instance
-  auto exporter  = std::unique_ptr<logs_sdk::LogExporter>(new otlp::OtlpGrpcLogExporter(opts));
-  auto processor = std::shared_ptr<logs_sdk::LogProcessor>(
-      new logs_sdk::SimpleLogProcessor(std::move(exporter)));
-  auto sdkProvider = std::shared_ptr<logs_sdk::LoggerProvider>(new logs_sdk::LoggerProvider());
-  sdkProvider->SetProcessor(processor);
+  auto exporter    = std::unique_ptr<logs_sdk::LogExporter>(new otlp::OtlpGrpcLogExporter(opts));
+  auto sdkProvider = std::shared_ptr<logs_sdk::LoggerProvider>(
+      new logs_sdk::LoggerProvider(std::unique_ptr<logs_sdk::LogProcessor>(
+          new logs_sdk::SimpleLogProcessor(std::move(exporter)))));
   auto apiProvider = nostd::shared_ptr<logs::LoggerProvider>(sdkProvider);
   auto provider    = nostd::shared_ptr<logs::LoggerProvider>(apiProvider);
   opentelemetry::logs::Provider::SetLoggerProvider(provider);

--- a/examples/otlp/http_log_main.cc
+++ b/examples/otlp/http_log_main.cc
@@ -49,10 +49,9 @@ void InitLogger()
   // Create OTLP exporter instance
   auto exporter =
       std::unique_ptr<logs_sdk::LogExporter>(new otlp::OtlpHttpLogExporter(logger_opts));
-  auto processor = std::shared_ptr<logs_sdk::LogProcessor>(
-      new logs_sdk::SimpleLogProcessor(std::move(exporter)));
-  auto sdkProvider = std::shared_ptr<logs_sdk::LoggerProvider>(new logs_sdk::LoggerProvider());
-  sdkProvider->SetProcessor(processor);
+  auto sdkProvider = std::shared_ptr<logs_sdk::LoggerProvider>(
+      new logs_sdk::LoggerProvider(std::unique_ptr<logs_sdk::LogProcessor>(
+          new logs_sdk::SimpleLogProcessor(std::move(exporter)))));
   auto apiProvider = nostd::shared_ptr<logs::LoggerProvider>(sdkProvider);
   auto provider    = nostd::shared_ptr<logs::LoggerProvider>(apiProvider);
   opentelemetry::logs::Provider::SetLoggerProvider(provider);

--- a/exporters/elasticsearch/CMakeLists.txt
+++ b/exporters/elasticsearch/CMakeLists.txt
@@ -8,8 +8,9 @@ target_include_directories(
   PUBLIC "$<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}/include>"
          "$<INSTALL_INTERFACE:include>")
 
-target_link_libraries(opentelemetry_exporter_elasticsearch_logs
-                      PUBLIC opentelemetry_trace http_client_curl)
+target_link_libraries(
+  opentelemetry_exporter_elasticsearch_logs
+  PUBLIC opentelemetry_trace opentelemetry_logs http_client_curl)
 
 install(
   TARGETS opentelemetry_exporter_elasticsearch_logs

--- a/exporters/elasticsearch/include/opentelemetry/exporters/elasticsearch/es_log_recordable.h
+++ b/exporters/elasticsearch/include/opentelemetry/exporters/elasticsearch/es_log_recordable.h
@@ -5,7 +5,10 @@
 #ifdef ENABLE_LOGS_PREVIEW
 
 #  include <map>
+#  include <sstream>
+#  include <type_traits>
 #  include <unordered_map>
+
 #  include "nlohmann/json.hpp"
 #  include "opentelemetry/sdk/common/attribute_utils.h"
 #  include "opentelemetry/sdk/logs/recordable.h"
@@ -108,7 +111,18 @@ public:
   void SetSeverity(opentelemetry::logs::Severity severity) noexcept override
   {
     // Convert the severity enum to a string
-    json_["severity"] = opentelemetry::logs::SeverityNumToText[static_cast<int>(severity)];
+    int severity_index = static_cast<int>(severity);
+    if (severity_index < 0 ||
+        severity_index >= std::extent<decltype(opentelemetry::logs::SeverityNumToText)>::value)
+    {
+      std::stringstream sout;
+      sout << "Invalid severity(" << severity_index << ")";
+      json_["severity"] = sout.str();
+    }
+    else
+    {
+      json_["severity"] = opentelemetry::logs::SeverityNumToText[severity_index];
+    }
   }
 
   /**

--- a/exporters/elasticsearch/include/opentelemetry/exporters/elasticsearch/es_log_recordable.h
+++ b/exporters/elasticsearch/include/opentelemetry/exporters/elasticsearch/es_log_recordable.h
@@ -91,14 +91,15 @@ public:
   void SetBody(nostd::string_view message) noexcept override { json_["body"] = message.data(); }
 
   /**
-   * Set a resource for this log.
-   * @param name the name of the resource
-   * @param value the resource value
+   * Set Resource of this log
+   * @param Resource the resource to set
    */
-  void SetResource(nostd::string_view key,
-                   const opentelemetry::common::AttributeValue &value) noexcept override
+  void SetResource(const opentelemetry::sdk::resource::Resource &resource) noexcept override
   {
-    WriteKeyValue(key, value, "resource");
+    for (auto &kv : resource.GetAttributes())
+    {
+      WriteKeyValue(kv.first, kv.second, "resource");
+    }
   }
 
   /**

--- a/exporters/elasticsearch/include/opentelemetry/exporters/elasticsearch/es_log_recordable.h
+++ b/exporters/elasticsearch/include/opentelemetry/exporters/elasticsearch/es_log_recordable.h
@@ -67,6 +67,39 @@ private:
     }
   }
 
+  void WriteKeyValue(nostd::string_view key,
+                     const opentelemetry::sdk::common::OwnedAttributeValue &value,
+                     std::string name)
+  {
+    namespace common = opentelemetry::sdk::common;
+    switch (value.index())
+    {
+      case common::kTypeBool:
+        json_[name][key.data()] = opentelemetry::nostd::get<bool>(value) ? true : false;
+        return;
+      case common::kTypeInt:
+        json_[name][key.data()] = opentelemetry::nostd::get<int>(value);
+        return;
+      case common::kTypeInt64:
+        json_[name][key.data()] = opentelemetry::nostd::get<int64_t>(value);
+        return;
+      case common::kTypeUInt:
+        json_[name][key.data()] = opentelemetry::nostd::get<unsigned int>(value);
+        return;
+      case common::kTypeUInt64:
+        json_[name][key.data()] = opentelemetry::nostd::get<uint64_t>(value);
+        return;
+      case common::kTypeDouble:
+        json_[name][key.data()] = opentelemetry::nostd::get<double>(value);
+        return;
+      case common::kTypeString:
+        json_[name][key.data()] = opentelemetry::nostd::get<std::string>(value).data();
+        return;
+      default:
+        return;
+    }
+  }
+
 public:
   /**
    * Set the severity for this log.

--- a/exporters/elasticsearch/test/es_log_exporter_test.cc
+++ b/exporters/elasticsearch/test/es_log_exporter_test.cc
@@ -77,8 +77,9 @@ TEST(ElasticsearchLogsExporterTests, RecordableCreation)
   // Attributes and resource support different types
   record->SetAttribute("key0", false);
   record->SetAttribute("key1", "1");
-  record->SetResource("key2", 2);
-  record->SetResource("key3", 3.142);
+
+  auto resource = opentelemetry::sdk::resource::Resource::Create({{"key2", 2}, {"key3", 3142}});
+  record->SetResource(resource);
 
   exporter->Export(nostd::span<std::unique_ptr<sdklogs::Recordable>>(&record, 1));
 }

--- a/exporters/etw/include/opentelemetry/exporters/etw/etw_logger.h
+++ b/exporters/etw/include/opentelemetry/exporters/etw/etw_logger.h
@@ -9,6 +9,8 @@
 #  include <cstdint>
 #  include <cstdio>
 #  include <cstdlib>
+#  include <sstream>
+#  include <type_traits>
 
 #  include <fstream>
 
@@ -166,8 +168,19 @@ public:
     int64_t tsMs =
         std::chrono::duration_cast<std::chrono::milliseconds>(ts.time_since_epoch()).count();
     evt[ETW_FIELD_TIMESTAMP] = utils::formatUtcTimestampMsAsISO8601(tsMs);
-    evt[ETW_FIELD_LOG_SEVERITY_TEXT] =
-        opentelemetry::logs::SeverityNumToText[static_cast<int>(severity)].data();
+    int severity_index       = static_cast<int>(severity);
+    if (severity_index < 0 ||
+        severity_index >= std::extent<decltype(opentelemetry::logs::SeverityNumToText)>::value)
+    {
+      std::stringstream sout;
+      sout << "Invalid severity(" << severity_index << ")";
+      evt[ETW_FIELD_LOG_SEVERITY_TEXT] = sout.str();
+    }
+    else
+    {
+      evt[ETW_FIELD_LOG_SEVERITY_TEXT] =
+          opentelemetry::logs::SeverityNumToText[severity_index].data();
+    }
     evt[ETW_FIELD_LOG_SEVERITY_NUM] = static_cast<uint32_t>(severity);
     evt[ETW_FIELD_LOG_BODY]         = std::string(body.data(), body.length());
     etwProvider().write(provHandle, evt, nullptr, nullptr, 0, encoding);

--- a/exporters/etw/include/opentelemetry/exporters/etw/etw_logger.h
+++ b/exporters/etw/include/opentelemetry/exporters/etw/etw_logger.h
@@ -101,7 +101,6 @@ public:
   void Log(opentelemetry::logs::Severity severity,
            nostd::string_view name,
            nostd::string_view body,
-           const common::KeyValueIterable &resource,
            const common::KeyValueIterable &attributes,
            opentelemetry::trace::TraceId trace_id,
            opentelemetry::trace::SpanId span_id,
@@ -111,8 +110,7 @@ public:
 
 #  ifdef RTTI_ENABLED
     common::KeyValueIterable &attribs = const_cast<common::KeyValueIterable &>(attributes);
-    // common::KeyValueIterable &resr = const_cast<common::KeyValueIterable &>(resource);
-    Properties *evt = dynamic_cast<Properties *>(&attribs);
+    Properties *evt                   = dynamic_cast<Properties *>(&attribs);
     // Properties *res                   = dynamic_cast<Properties *>(&resr);
 
     if (evt != nullptr)
@@ -122,7 +120,6 @@ public:
     }
 #  endif
     Properties evtCopy = attributes;
-    // Properties resCopy = resource;
     return Log(severity, name, body, evtCopy, trace_id, span_id, trace_flags, timestamp);
   }
 

--- a/exporters/ostream/src/log_exporter.cc
+++ b/exporters/ostream/src/log_exporter.cc
@@ -7,6 +7,7 @@
 #  include "opentelemetry/sdk_config.h"
 
 #  include <iostream>
+#  include <type_traits>
 
 namespace nostd   = opentelemetry::nostd;
 namespace sdklogs = opentelemetry::sdk::logs;
@@ -146,10 +147,20 @@ sdk::common::ExportResult OStreamLogExporter::Export(
     sout_ << "{\n"
           << "  timestamp     : " << log_record->GetTimestamp().time_since_epoch().count() << "\n"
           << "  severity_num  : " << static_cast<int>(log_record->GetSeverity()) << "\n"
-          << "  severity_text : "
-          << opentelemetry::logs::SeverityNumToText[static_cast<int>(log_record->GetSeverity())]
-          << "\n"
-          << "  name          : " << log_record->GetName() << "\n"
+          << "  severity_text : ";
+
+    int severity_index = static_cast<int>(log_record->GetSeverity());
+    if (severity_index < 0 ||
+        severity_index >= std::extent<decltype(opentelemetry::logs::SeverityNumToText)>::value)
+    {
+      sout_ << "Invalid severity(" << severity_index << ")\n";
+    }
+    else
+    {
+      sout_ << opentelemetry::logs::SeverityNumToText[severity_index] << "\n";
+    }
+
+    sout_ << "  name          : " << log_record->GetName() << "\n"
           << "  body          : " << log_record->GetBody() << "\n"
           << "  resource      : ";
 

--- a/exporters/ostream/src/log_exporter.cc
+++ b/exporters/ostream/src/log_exporter.cc
@@ -153,7 +153,7 @@ sdk::common::ExportResult OStreamLogExporter::Export(
           << "  body          : " << log_record->GetBody() << "\n"
           << "  resource      : ";
 
-    printMap(log_record->GetResource(), sout_);
+    printMap(log_record->GetResource().GetAttributes(), sout_);
 
     sout_ << "\n"
           << "  attributes    : ";

--- a/exporters/ostream/test/ostream_log_test.cc
+++ b/exporters/ostream/test/ostream_log_test.cc
@@ -157,7 +157,8 @@ TEST(OStreamLogExporter, LogWithStringAttributesToCerr)
   auto record = exporter->MakeRecordable();
 
   // Set resources for this log record only of type <string, string>
-  record->SetResource("key1", "val1");
+  auto resource = opentelemetry::sdk::resource::Resource::Create({{"key1", "val1"}});
+  record->SetResource(resource);
 
   // Set attributes to this log record of type <string, AttributeValue>
   record->SetAttribute("a", true);
@@ -206,7 +207,9 @@ TEST(OStreamLogExporter, LogWithVariantTypesToClog)
   // Set resources for this log record of only integer types as the value
   std::array<int, 3> array1 = {1, 2, 3};
   nostd::span<int> data1{array1.data(), array1.size()};
-  record->SetResource("res1", data1);
+
+  auto resource = opentelemetry::sdk::resource::Resource::Create({{"res1", data1}});
+  record->SetResource(resource);
 
   // Set resources for this log record of bool types as the value
   // e.g. key/value is a par of type <string, array of bools>
@@ -242,11 +245,10 @@ TEST(OStreamLogExporter, LogWithVariantTypesToClog)
 TEST(OStreamLogExporter, IntegrationTest)
 {
   // Initialize a logger
-  auto exporter = std::unique_ptr<sdklogs::LogExporter>(new exporterlogs::OStreamLogExporter);
-  auto processor =
-      std::shared_ptr<sdklogs::LogProcessor>(new sdklogs::SimpleLogProcessor(std::move(exporter)));
+  auto exporter    = std::unique_ptr<sdklogs::LogExporter>(new exporterlogs::OStreamLogExporter);
   auto sdkProvider = std::shared_ptr<sdklogs::LoggerProvider>(new sdklogs::LoggerProvider());
-  sdkProvider->SetProcessor(processor);
+  sdkProvider->AddProcessor(
+      std::unique_ptr<sdklogs::LogProcessor>(new sdklogs::SimpleLogProcessor(std::move(exporter))));
   auto apiProvider = nostd::shared_ptr<logs_api::LoggerProvider>(sdkProvider);
   auto provider    = nostd::shared_ptr<logs_api::LoggerProvider>(apiProvider);
   logs_api::Provider::SetLoggerProvider(provider);

--- a/exporters/ostream/test/ostream_log_test.cc
+++ b/exporters/ostream/test/ostream_log_test.cc
@@ -129,7 +129,9 @@ TEST(OStreamLogExporter, SimpleLogToCout)
       "  severity_text : TRACE\n"
       "  name          : Name\n"
       "  body          : Message\n"
-      "  resource      : {}\n"
+      "  resource      : {{telemetry.sdk.version: " OPENTELEMETRY_VERSION
+      "}, {telemetry.sdk.name: opentelemetry}, "
+      "{telemetry.sdk.language: cpp}}\n"
       "  attributes    : {}\n"
       "  trace_id      : 00000000000000000000000000000000\n"
       "  span_id       : 0000000000000000\n"
@@ -176,7 +178,9 @@ TEST(OStreamLogExporter, LogWithStringAttributesToCerr)
       "  severity_text : INVALID\n"
       "  name          : \n"
       "  body          : \n"
-      "  resource      : {{key1: val1}}\n"
+      "  resource      : {{telemetry.sdk.version: " OPENTELEMETRY_VERSION
+      "}, {telemetry.sdk.name: opentelemetry}, {telemetry.sdk.language: cpp}, {service.name: "
+      "unknown_service}, {key1: val1}}\n"
       "  attributes    : {{a: 1}}\n"
       "  trace_id      : 00000000000000000000000000000000\n"
       "  span_id       : 0000000000000000\n"
@@ -229,7 +233,9 @@ TEST(OStreamLogExporter, LogWithVariantTypesToClog)
       "  severity_text : INVALID\n"
       "  name          : \n"
       "  body          : \n"
-      "  resource      : {{res1: [1, 2, 3]}}\n"
+      "  resource      : {{service.name: unknown_service}, "
+      "{telemetry.sdk.version: " OPENTELEMETRY_VERSION
+      "}, {telemetry.sdk.name: opentelemetry}, {telemetry.sdk.language: cpp}, {res1: [1, 2, 3]}}\n"
       "  attributes    : {{attr1: [0, 1, 0]}}\n"
       "  trace_id      : 00000000000000000000000000000000\n"
       "  span_id       : 0000000000000000\n"
@@ -263,7 +269,7 @@ TEST(OStreamLogExporter, IntegrationTest)
 
   // Write a log to ostream exporter
   common::SystemTimestamp now(std::chrono::system_clock::now());
-  logger->Log(logs_api::Severity::kDebug, "", "Hello", {}, {}, {}, {}, {}, now);
+  logger->Log(logs_api::Severity::kDebug, "", "Hello", {}, {}, {}, {}, now);
 
   // Restore cout's original streambuf
   std::cout.rdbuf(original);

--- a/exporters/ostream/test/ostream_log_test.cc
+++ b/exporters/ostream/test/ostream_log_test.cc
@@ -81,7 +81,8 @@ TEST(OstreamLogExporter, DefaultLogRecordToCout)
       "  severity_text : INVALID\n"
       "  name          : \n"
       "  body          : \n"
-      "  resource      : {}\n"
+      "  resource      : {{telemetry.sdk.version: " OPENTELEMETRY_VERSION
+      "}, {telemetry.sdk.name: opentelemetry}, {telemetry.sdk.language: cpp}}\n"
       "  attributes    : {}\n"
       "  trace_id      : 00000000000000000000000000000000\n"
       "  span_id       : 0000000000000000\n"
@@ -284,7 +285,9 @@ TEST(OStreamLogExporter, IntegrationTest)
       "  severity_text : DEBUG\n"
       "  name          : \n"
       "  body          : Hello\n"
-      "  resource      : {}\n"
+      "  resource      : {{service.name: unknown_service}, "
+      "{telemetry.sdk.version: " OPENTELEMETRY_VERSION
+      "}, {telemetry.sdk.name: opentelemetry}, {telemetry.sdk.language: cpp}}\n"
       "  attributes    : {}\n"
       "  trace_id      : 00000000000000000000000000000000\n"
       "  span_id       : 0000000000000000\n"

--- a/exporters/otlp/include/opentelemetry/exporters/otlp/otlp_log_recordable.h
+++ b/exporters/otlp/include/opentelemetry/exporters/otlp/otlp_log_recordable.h
@@ -40,63 +40,61 @@ public:
    * Set the timestamp for this log.
    * @param timestamp the timestamp to set
    */
-  virtual void SetTimestamp(opentelemetry::common::SystemTimestamp timestamp) noexcept override;
+  void SetTimestamp(opentelemetry::common::SystemTimestamp timestamp) noexcept override;
 
   /**
    * Set the severity for this log.
    * @param severity the severity of the event
    */
-  virtual void SetSeverity(opentelemetry::logs::Severity severity) noexcept override;
+  void SetSeverity(opentelemetry::logs::Severity severity) noexcept override;
 
   /**
    * Set name for this log
    * @param name the name to set
    */
-  virtual void SetName(nostd::string_view name) noexcept override;
+  void SetName(nostd::string_view name) noexcept override;
 
   /**
    * Set body field for this log.
    * @param message the body to set
    */
-  virtual void SetBody(nostd::string_view message) noexcept override;
+  void SetBody(nostd::string_view message) noexcept override;
 
   /**
-   * Set a single resource of a log record.
-   * @param key the name of the resource to set
-   * @param value the resource value to set
+   * Set Resource of this log
+   * @param Resource the resource to set
    */
-  virtual void SetResource(nostd::string_view key,
-                           const opentelemetry::common::AttributeValue &value) noexcept override;
+  void SetResource(const opentelemetry::sdk::resource::Resource &resource) noexcept override;
 
   /**
    * Set an attribute of a log.
    * @param key the name of the attribute
    * @param value the attribute value
    */
-  virtual void SetAttribute(nostd::string_view key,
-                            const opentelemetry::common::AttributeValue &value) noexcept override;
+  void SetAttribute(nostd::string_view key,
+                    const opentelemetry::common::AttributeValue &value) noexcept override;
 
   /**
    * Set the trace id for this log.
    * @param trace_id the trace id to set
    */
-  virtual void SetTraceId(opentelemetry::trace::TraceId trace_id) noexcept override;
+  void SetTraceId(opentelemetry::trace::TraceId trace_id) noexcept override;
 
   /**
    * Set the span id for this log.
    * @param span_id the span id to set
    */
-  virtual void SetSpanId(opentelemetry::trace::SpanId span_id) noexcept override;
+  void SetSpanId(opentelemetry::trace::SpanId span_id) noexcept override;
 
   /**
    * Inject trace_flags for this log.
    * @param trace_flags the trace flags to set
    */
-  virtual void SetTraceFlags(opentelemetry::trace::TraceFlags trace_flags) noexcept override;
+  void SetTraceFlags(opentelemetry::trace::TraceFlags trace_flags) noexcept override;
 
 private:
   proto::logs::v1::LogRecord log_record_;
-  opentelemetry::sdk::common::AttributeMap resource_attributes_;
+  const opentelemetry::sdk::resource::Resource *resource_ = nullptr;
   // TODO shared resource
   // const opentelemetry::sdk::resource::Resource *resource_ = nullptr;
   // TODO InstrumentationLibrary

--- a/exporters/otlp/src/otlp_log_recordable.cc
+++ b/exporters/otlp/src/otlp_log_recordable.cc
@@ -18,8 +18,15 @@ namespace otlp
 proto::resource::v1::Resource OtlpLogRecordable::ProtoResource() const noexcept
 {
   proto::resource::v1::Resource proto;
-  OtlpRecordableUtils::PopulateAttribute(
-      &proto, opentelemetry::sdk::resource::Resource::Create(resource_attributes_));
+  if (nullptr == resource_)
+  {
+    OtlpRecordableUtils::PopulateAttribute(&proto, sdk::resource::Resource::GetDefault());
+  }
+  else
+  {
+    OtlpRecordableUtils::PopulateAttribute(&proto, *resource_);
+  }
+
   return proto;
 }
 
@@ -170,10 +177,9 @@ void OtlpLogRecordable::SetBody(nostd::string_view message) noexcept
   log_record_.mutable_body()->set_string_value(message.data(), message.size());
 }
 
-void OtlpLogRecordable::SetResource(nostd::string_view key,
-                                    const opentelemetry::common::AttributeValue &value) noexcept
+void OtlpLogRecordable::SetResource(const opentelemetry::sdk::resource::Resource &resource) noexcept
 {
-  resource_attributes_.SetAttribute(key, value);
+  resource_ = &resource;
 }
 
 void OtlpLogRecordable::SetAttribute(nostd::string_view key,

--- a/exporters/otlp/test/otlp_grpc_log_exporter_test.cc
+++ b/exporters/otlp/test/otlp_grpc_log_exporter_test.cc
@@ -123,7 +123,7 @@ TEST_F(OtlpGrpcLogExporterTestPeer, ExportIntegrationTest)
   std::string resource_storage_string_value[] = {"vector", "string"};
 
   auto provider = nostd::shared_ptr<sdk::logs::LoggerProvider>(new sdk::logs::LoggerProvider());
-  provider->SetProcessor(std::unique_ptr<sdk::logs::LogProcessor>(
+  provider->AddProcessor(std::unique_ptr<sdk::logs::LogProcessor>(
       new sdk::logs::BatchLogProcessor(std::move(exporter), 5, std::chrono::milliseconds(256), 1)));
 
   EXPECT_CALL(*mock_stub, Export(_, _, _))

--- a/exporters/otlp/test/otlp_grpc_log_exporter_test.cc
+++ b/exporters/otlp/test/otlp_grpc_log_exporter_test.cc
@@ -114,13 +114,13 @@ TEST_F(OtlpGrpcLogExporterTestPeer, ExportIntegrationTest)
 
   auto exporter = GetExporter(stub_interface);
 
-  bool resource_storage_bool_value[]          = {true, false, true};
-  int32_t resource_storage_int32_value[]      = {1, 2};
-  uint32_t resource_storage_uint32_value[]    = {3, 4};
-  int64_t resource_storage_int64_value[]      = {5, 6};
-  uint64_t resource_storage_uint64_value[]    = {7, 8};
-  double resource_storage_double_value[]      = {3.2, 3.3};
-  std::string resource_storage_string_value[] = {"vector", "string"};
+  bool attribute_storage_bool_value[]          = {true, false, true};
+  int32_t attribute_storage_int32_value[]      = {1, 2};
+  uint32_t attribute_storage_uint32_value[]    = {3, 4};
+  int64_t attribute_storage_int64_value[]      = {5, 6};
+  uint64_t attribute_storage_uint64_value[]    = {7, 8};
+  double attribute_storage_double_value[]      = {3.2, 3.3};
+  std::string attribute_storage_string_value[] = {"vector", "string"};
 
   auto provider = nostd::shared_ptr<sdk::logs::LoggerProvider>(new sdk::logs::LoggerProvider());
   provider->AddProcessor(std::unique_ptr<sdk::logs::LogProcessor>(
@@ -147,14 +147,14 @@ TEST_F(OtlpGrpcLogExporterTestPeer, ExportIntegrationTest)
                {"int64_value", static_cast<int64_t>(0x1100000000LL)},
                {"uint64_value", static_cast<uint64_t>(0x1200000000ULL)},
                {"double_value", static_cast<double>(3.1)},
-               {"vec_bool_value", resource_storage_bool_value},
-               {"vec_int32_value", resource_storage_int32_value},
-               {"vec_uint32_value", resource_storage_uint32_value},
-               {"vec_int64_value", resource_storage_int64_value},
-               {"vec_uint64_value", resource_storage_uint64_value},
-               {"vec_double_value", resource_storage_double_value},
-               {"vec_string_value", resource_storage_string_value}},
-              {{"log_attribute", "test_value"}}, trace_id, span_id,
+               {"vec_bool_value", attribute_storage_bool_value},
+               {"vec_int32_value", attribute_storage_int32_value},
+               {"vec_uint32_value", attribute_storage_uint32_value},
+               {"vec_int64_value", attribute_storage_int64_value},
+               {"vec_uint64_value", attribute_storage_uint64_value},
+               {"vec_double_value", attribute_storage_double_value},
+               {"vec_string_value", attribute_storage_string_value}},
+              trace_id, span_id,
               opentelemetry::trace::TraceFlags{opentelemetry::trace::TraceFlags::kIsSampled},
               std::chrono::system_clock::now());
 }

--- a/exporters/otlp/test/otlp_http_log_exporter_test.cc
+++ b/exporters/otlp/test/otlp_http_log_exporter_test.cc
@@ -199,13 +199,13 @@ TEST_F(OtlpHttpLogExporterTestPeer, ExportJsonIntegrationTest)
   size_t old_count = getCurrentRequestCount();
   auto exporter    = GetExporter(HttpRequestContentType::kJson);
 
-  bool resource_storage_bool_value[]          = {true, false, true};
-  int32_t resource_storage_int32_value[]      = {1, 2};
-  uint32_t resource_storage_uint32_value[]    = {3, 4};
-  int64_t resource_storage_int64_value[]      = {5, 6};
-  uint64_t resource_storage_uint64_value[]    = {7, 8};
-  double resource_storage_double_value[]      = {3.2, 3.3};
-  std::string resource_storage_string_value[] = {"vector", "string"};
+  bool attribute_storage_bool_value[]          = {true, false, true};
+  int32_t attribute_storage_int32_value[]      = {1, 2};
+  uint32_t attribute_storage_uint32_value[]    = {3, 4};
+  int64_t attribute_storage_int64_value[]      = {5, 6};
+  uint64_t attribute_storage_uint64_value[]    = {7, 8};
+  double attribute_storage_double_value[]      = {3.2, 3.3};
+  std::string attribute_storage_string_value[] = {"vector", "string"};
 
   auto provider = nostd::shared_ptr<sdk::logs::LoggerProvider>(new sdk::logs::LoggerProvider());
   provider->AddProcessor(std::unique_ptr<sdk::logs::LogProcessor>(
@@ -233,14 +233,14 @@ TEST_F(OtlpHttpLogExporterTestPeer, ExportJsonIntegrationTest)
                  {"int64_value", static_cast<int64_t>(0x1100000000LL)},
                  {"uint64_value", static_cast<uint64_t>(0x1200000000ULL)},
                  {"double_value", static_cast<double>(3.1)},
-                 {"vec_bool_value", resource_storage_bool_value},
-                 {"vec_int32_value", resource_storage_int32_value},
-                 {"vec_uint32_value", resource_storage_uint32_value},
-                 {"vec_int64_value", resource_storage_int64_value},
-                 {"vec_uint64_value", resource_storage_uint64_value},
-                 {"vec_double_value", resource_storage_double_value},
-                 {"vec_string_value", resource_storage_string_value}},
-                {{"log_attribute", "test_value"}}, trace_id, span_id,
+                 {"vec_bool_value", attribute_storage_bool_value},
+                 {"vec_int32_value", attribute_storage_int32_value},
+                 {"vec_uint32_value", attribute_storage_uint32_value},
+                 {"vec_int64_value", attribute_storage_int64_value},
+                 {"vec_uint64_value", attribute_storage_uint64_value},
+                 {"vec_double_value", attribute_storage_double_value},
+                 {"vec_string_value", attribute_storage_string_value}},
+                trace_id, span_id,
                 opentelemetry::trace::TraceFlags{opentelemetry::trace::TraceFlags::kIsSampled},
                 std::chrono::system_clock::now());
 
@@ -262,10 +262,9 @@ TEST_F(OtlpHttpLogExporterTestPeer, ExportJsonIntegrationTest)
   EXPECT_EQ(received_span_id, report_span_id);
   EXPECT_EQ("Log name", log["name"].get<std::string>());
   EXPECT_EQ("Log message", log["body"]["string_value"].get<std::string>());
-  EXPECT_EQ("test_value", (*log["attributes"].begin())["value"]["string_value"].get<std::string>());
-  EXPECT_LE(15, resource_logs["resource"]["attributes"].size());
+  EXPECT_LE(15, log["attributes"].size());
   bool check_service_name = false;
-  for (auto attribute : resource_logs["resource"]["attributes"])
+  for (auto attribute : log["attributes"])
   {
     if ("service.name" == attribute["key"].get<std::string>())
     {
@@ -292,13 +291,13 @@ TEST_F(OtlpHttpLogExporterTestPeer, ExportBinaryIntegrationTest)
 
   auto exporter = GetExporter(HttpRequestContentType::kBinary);
 
-  bool resource_storage_bool_value[]          = {true, false, true};
-  int32_t resource_storage_int32_value[]      = {1, 2};
-  uint32_t resource_storage_uint32_value[]    = {3, 4};
-  int64_t resource_storage_int64_value[]      = {5, 6};
-  uint64_t resource_storage_uint64_value[]    = {7, 8};
-  double resource_storage_double_value[]      = {3.2, 3.3};
-  std::string resource_storage_string_value[] = {"vector", "string"};
+  bool attribute_storage_bool_value[]          = {true, false, true};
+  int32_t attribute_storage_int32_value[]      = {1, 2};
+  uint32_t attribute_storage_uint32_value[]    = {3, 4};
+  int64_t attribute_storage_int64_value[]      = {5, 6};
+  uint64_t attribute_storage_uint64_value[]    = {7, 8};
+  double attribute_storage_double_value[]      = {3.2, 3.3};
+  std::string attribute_storage_string_value[] = {"vector", "string"};
 
   auto provider = nostd::shared_ptr<sdk::logs::LoggerProvider>(new sdk::logs::LoggerProvider());
   provider->AddProcessor(std::unique_ptr<sdk::logs::LogProcessor>(
@@ -324,14 +323,14 @@ TEST_F(OtlpHttpLogExporterTestPeer, ExportBinaryIntegrationTest)
                  {"int64_value", static_cast<int64_t>(0x1100000000LL)},
                  {"uint64_value", static_cast<uint64_t>(0x1200000000ULL)},
                  {"double_value", static_cast<double>(3.1)},
-                 {"vec_bool_value", resource_storage_bool_value},
-                 {"vec_int32_value", resource_storage_int32_value},
-                 {"vec_uint32_value", resource_storage_uint32_value},
-                 {"vec_int64_value", resource_storage_int64_value},
-                 {"vec_uint64_value", resource_storage_uint64_value},
-                 {"vec_double_value", resource_storage_double_value},
-                 {"vec_string_value", resource_storage_string_value}},
-                {{"log_attribute", "test_value"}}, trace_id, span_id,
+                 {"vec_bool_value", attribute_storage_bool_value},
+                 {"vec_int32_value", attribute_storage_int32_value},
+                 {"vec_uint32_value", attribute_storage_uint32_value},
+                 {"vec_int64_value", attribute_storage_int64_value},
+                 {"vec_uint64_value", attribute_storage_uint64_value},
+                 {"vec_double_value", attribute_storage_double_value},
+                 {"vec_string_value", attribute_storage_string_value}},
+                trace_id, span_id,
                 opentelemetry::trace::TraceFlags{opentelemetry::trace::TraceFlags::kIsSampled},
                 std::chrono::system_clock::now());
 
@@ -346,10 +345,9 @@ TEST_F(OtlpHttpLogExporterTestPeer, ExportBinaryIntegrationTest)
   EXPECT_EQ(received_log.span_id(), report_span_id);
   EXPECT_EQ("Log name", received_log.name());
   EXPECT_EQ("Log message", received_log.body().string_value());
-  EXPECT_EQ("test_value", received_log.attributes(0).value().string_value());
-  EXPECT_LE(15, received_requests_binary_.back().resource_logs(0).resource().attributes_size());
+  EXPECT_LE(15, received_log.attributes_size());
   bool check_service_name = false;
-  for (auto &attribute : received_requests_binary_.back().resource_logs(0).resource().attributes())
+  for (auto &attribute : received_log.attributes())
   {
     if ("service.name" == attribute.key())
     {

--- a/exporters/otlp/test/otlp_http_log_exporter_test.cc
+++ b/exporters/otlp/test/otlp_http_log_exporter_test.cc
@@ -208,7 +208,7 @@ TEST_F(OtlpHttpLogExporterTestPeer, ExportJsonIntegrationTest)
   std::string resource_storage_string_value[] = {"vector", "string"};
 
   auto provider = nostd::shared_ptr<sdk::logs::LoggerProvider>(new sdk::logs::LoggerProvider());
-  provider->SetProcessor(std::unique_ptr<sdk::logs::LogProcessor>(
+  provider->AddProcessor(std::unique_ptr<sdk::logs::LogProcessor>(
       new sdk::logs::BatchLogProcessor(std::move(exporter), 5, std::chrono::milliseconds(256), 1)));
 
   std::string report_trace_id;
@@ -301,7 +301,7 @@ TEST_F(OtlpHttpLogExporterTestPeer, ExportBinaryIntegrationTest)
   std::string resource_storage_string_value[] = {"vector", "string"};
 
   auto provider = nostd::shared_ptr<sdk::logs::LoggerProvider>(new sdk::logs::LoggerProvider());
-  provider->SetProcessor(std::unique_ptr<sdk::logs::LogProcessor>(
+  provider->AddProcessor(std::unique_ptr<sdk::logs::LogProcessor>(
       new sdk::logs::BatchLogProcessor(std::move(exporter), 5, std::chrono::milliseconds(256), 1)));
 
   std::string report_trace_id;

--- a/exporters/otlp/test/otlp_log_recordable_test.cc
+++ b/exporters/otlp/test/otlp_log_recordable_test.cc
@@ -86,7 +86,9 @@ TEST(OtlpLogRecordable, SetResource)
   OtlpLogRecordable rec;
   const std::string service_name_key = "service.name";
   std::string service_name           = "test-otlp";
-  rec.SetResource(service_name_key, service_name);
+  auto resource =
+      opentelemetry::sdk::resource::Resource::Create({{service_name_key, service_name}});
+  rec.SetResource(resource);
 
   auto proto_resource     = rec.ProtoResource();
   bool found_service_name = false;

--- a/sdk/include/opentelemetry/sdk/common/empty_attributes.h
+++ b/sdk/include/opentelemetry/sdk/common/empty_attributes.h
@@ -4,6 +4,7 @@
 #pragma once
 
 #include "opentelemetry/common/key_value_iterable_view.h"
+#include "opentelemetry/common/macros.h"
 
 #include <array>
 #include <map>
@@ -18,7 +19,8 @@ namespace sdk
  * This helps to avoid constructing a new empty container every time a call is made
  * with default attributes.
  */
-static const opentelemetry::common::KeyValueIterableView<std::array<std::pair<std::string, int>, 0>>
+OPENTELEMETRY_MAYBE_UNUSED static const opentelemetry::common::KeyValueIterableView<
+    std::array<std::pair<std::string, int>, 0>>
     &GetEmptyAttributes() noexcept
 {
   static const std::array<std::pair<std::string, int>, 0> array{};

--- a/sdk/include/opentelemetry/sdk/logs/log_record.h
+++ b/sdk/include/opentelemetry/sdk/logs/log_record.h
@@ -8,6 +8,7 @@
 #  include <unordered_map>
 #  include "opentelemetry/sdk/common/attribute_utils.h"
 #  include "opentelemetry/sdk/logs/recordable.h"
+#  include "opentelemetry/sdk/resource/resource.h"
 #  include "opentelemetry/version.h"
 
 OPENTELEMETRY_BEGIN_NAMESPACE
@@ -27,8 +28,8 @@ class LogRecord final : public Recordable
 private:
   // Default values are set by the respective data structures' constructors for all fields,
   // except the severity field, which must be set manually (an enum with no default value).
-  opentelemetry::logs::Severity severity_ = opentelemetry::logs::Severity::kInvalid;
-  common::AttributeMap resource_map_;
+  opentelemetry::logs::Severity severity_                 = opentelemetry::logs::Severity::kInvalid;
+  const opentelemetry::sdk::resource::Resource *resource_ = nullptr;
   common::AttributeMap attributes_map_;
   std::string name_;
   std::string body_;  // Currently a simple string, but should be changed to "Any" type
@@ -62,14 +63,12 @@ public:
   void SetBody(nostd::string_view message) noexcept override { body_ = std::string(message); }
 
   /**
-   * Set a resource for this log.
-   * @param name the name of the resource
-   * @param value the resource value
+   * Set Resource of this log
+   * @param Resource the resource to set
    */
-  void SetResource(nostd::string_view key,
-                   const opentelemetry::common::AttributeValue &value) noexcept override
+  void SetResource(const opentelemetry::sdk::resource::Resource &resource) noexcept override
   {
-    resource_map_.SetAttribute(key, value);
+    resource_ = &resource;
   }
 
   /**
@@ -141,12 +140,16 @@ public:
   std::string GetBody() const noexcept { return body_; }
 
   /**
-   * Get the resource field for this log
-   * @return the resource field for this log
+   * Get the resource for this log
+   * @return the resource for this log
    */
-  const std::unordered_map<std::string, common::OwnedAttributeValue> &GetResource() const noexcept
+  const opentelemetry::sdk::resource::Resource &GetResource() const noexcept
   {
-    return resource_map_.GetAttributes();
+    if (nullptr == resource_)
+    {
+      return sdk::resource::Resource::GetDefault();
+    }
+    return *resource_;
   }
 
   /**

--- a/sdk/include/opentelemetry/sdk/logs/logger.h
+++ b/sdk/include/opentelemetry/sdk/logs/logger.h
@@ -23,10 +23,10 @@ public:
   /**
    * Initialize a new logger.
    * @param name The name of this logger instance
-   * @param logger_provider The logger provider that owns this logger.
+   * @param context The logger provider that owns this logger.
    */
   explicit Logger(opentelemetry::nostd::string_view name,
-                  std::shared_ptr<LoggerContext> logger_provider) noexcept;
+                  std::shared_ptr<LoggerContext> context) noexcept;
 
   /**
    * Returns the name of this logger.

--- a/sdk/include/opentelemetry/sdk/logs/logger.h
+++ b/sdk/include/opentelemetry/sdk/logs/logger.h
@@ -5,8 +5,8 @@
 #ifdef ENABLE_LOGS_PREVIEW
 
 #  include "opentelemetry/logs/logger.h"
+#  include "opentelemetry/sdk/logs/logger_context.h"
 #  include "opentelemetry/sdk/logs/logger_provider.h"
-#  include "opentelemetry/sdk/logs/processor.h"
 
 #  include <vector>
 
@@ -26,7 +26,7 @@ public:
    * @param logger_provider The logger provider that owns this logger.
    */
   explicit Logger(opentelemetry::nostd::string_view name,
-                  std::shared_ptr<LoggerProvider> logger_provider) noexcept;
+                  std::shared_ptr<LoggerContext> logger_provider) noexcept;
 
   /**
    * Returns the name of this logger.
@@ -63,7 +63,7 @@ private:
 
   // The logger provider of this Logger. Uses a weak_ptr to avoid cyclic dependency issues the with
   // logger provider
-  std::weak_ptr<LoggerProvider> logger_provider_;
+  std::weak_ptr<LoggerContext> context_;
 };
 
 }  // namespace logs

--- a/sdk/include/opentelemetry/sdk/logs/logger.h
+++ b/sdk/include/opentelemetry/sdk/logs/logger.h
@@ -38,7 +38,6 @@ public:
    * @param severity the severity level of the log event.
    * @param name the name of the log event.
    * @param message the string message of the log (perhaps support std::fmt or fmt-lib format).
-   * @param resource the resources, stored as a 2D list of key/value pairs, that are associated
    * with the log event.
    * @param attributes the attributes, stored as a 2D list of key/value pairs, that are associated
    * with the log event.
@@ -50,7 +49,6 @@ public:
   void Log(opentelemetry::logs::Severity severity,
            nostd::string_view name,
            nostd::string_view body,
-           const opentelemetry::common::KeyValueIterable &resource,
            const opentelemetry::common::KeyValueIterable &attributes,
            opentelemetry::trace::TraceId trace_id,
            opentelemetry::trace::SpanId span_id,

--- a/sdk/include/opentelemetry/sdk/logs/logger_context.h
+++ b/sdk/include/opentelemetry/sdk/logs/logger_context.h
@@ -1,0 +1,81 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#ifdef ENABLE_LOGS_PREVIEW
+
+#  include "opentelemetry/sdk/logs/processor.h"
+#  include "opentelemetry/sdk/resource/resource.h"
+#  include "opentelemetry/version.h"
+
+OPENTELEMETRY_BEGIN_NAMESPACE
+namespace sdk
+{
+namespace logs
+{
+/**
+ * A class which stores the LoggerContext context.
+ *
+ * This class meets the following design criteria:
+ * - A shared reference between LoggerProvider and Logger instantiated.
+ * - A thread-safe class that allows updating/altering processor/exporter pipelines
+ *   and sampling config.
+ * - The owner/destroyer of Processors/Exporters.  These will remain active until
+ *   this class is destroyed.  I.e. Sampling, Exporting, flushing, Custom Iterator etc. are all ok
+ * if this object is alive, and they will work together. If this object is destroyed, then no shared
+ * references to Processor, Exporter, Recordable, Custom Iterator etc. should exist, and all
+ *   associated pipelines will have been flushed.
+ */
+class LoggerContext
+{
+public:
+  explicit LoggerContext(std::vector<std::unique_ptr<LogProcessor>> &&processors,
+                         opentelemetry::sdk::resource::Resource resource =
+                             opentelemetry::sdk::resource::Resource::Create({})) noexcept;
+
+  /**
+   * Attaches a log processor to list of configured processors to this tracer context.
+   * Processor once attached can't be removed.
+   * @param processor The new log processor for this tracer. This must not be
+   * a nullptr. Ownership is given to the `TracerContext`.
+   *
+   * Note: This method is not thread safe.
+   */
+  void AddProcessor(std::unique_ptr<LogProcessor> processor) noexcept;
+
+  /**
+   * Obtain the configured (composite) processor.
+   *
+   * Note: When more than one processor is active, this will
+   * return an "aggregate" processor
+   */
+  LogProcessor &GetProcessor() const noexcept;
+
+  /**
+   * Obtain the resource associated with this tracer context.
+   * @return The resource for this tracer context.
+   */
+  const opentelemetry::sdk::resource::Resource &GetResource() const noexcept;
+
+  /**
+   * Force all active LogProcessors to flush any buffered logs
+   * within the given timeout.
+   */
+  bool ForceFlush(std::chrono::microseconds timeout = (std::chrono::microseconds::max)()) noexcept;
+
+  /**
+   * Shutdown the log processor associated with this tracer provider.
+   */
+  bool Shutdown(std::chrono::microseconds timeout = std::chrono::microseconds::max()) noexcept;
+
+private:
+  //  order of declaration is important here - resource object should be destroyed after processor.
+  opentelemetry::sdk::resource::Resource resource_;
+  std::unique_ptr<LogProcessor> processor_;
+};
+}  // namespace logs
+}  // namespace sdk
+
+OPENTELEMETRY_END_NAMESPACE
+#endif

--- a/sdk/include/opentelemetry/sdk/logs/multi_log_processor.h
+++ b/sdk/include/opentelemetry/sdk/logs/multi_log_processor.h
@@ -1,0 +1,69 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#ifdef ENABLE_LOGS_PREVIEW
+
+#  include <memory>
+#  include <vector>
+
+#  include "opentelemetry/sdk/logs/multi_recordable.h"
+#  include "opentelemetry/sdk/logs/processor.h"
+#  include "opentelemetry/sdk/resource/resource.h"
+#  include "opentelemetry/version.h"
+
+OPENTELEMETRY_BEGIN_NAMESPACE
+namespace sdk
+{
+namespace logs
+{
+
+/**
+ * Log processor allow hooks for receive method invocations.
+ *
+ * Built-in log processors are responsible for batching and conversion of
+ * logs to exportable representation and passing batches to exporters.
+ */
+class MultiLogProcessor : public LogProcessor
+{
+public:
+  MultiLogProcessor(std::vector<std::unique_ptr<LogProcessor>> &&processors);
+  ~MultiLogProcessor();
+
+  void AddProcessor(std::unique_ptr<LogProcessor> &&processor);
+
+  std::unique_ptr<Recordable> MakeRecordable() noexcept override;
+
+  /**
+   * OnReceive is called by the SDK once a log record has been successfully created.
+   * @param record the log record
+   */
+  void OnReceive(std::unique_ptr<Recordable> &&record) noexcept override;
+
+  /**
+   * Exports all log records that have not yet been exported to the configured Exporter.
+   * @param timeout that the forceflush is required to finish within.
+   * @return a result code indicating whether it succeeded, failed or timed out
+   */
+  bool ForceFlush(
+      std::chrono::microseconds timeout = std::chrono::microseconds::max()) noexcept override;
+
+  /**
+   * Shuts down the processor and does any cleanup required.
+   * ShutDown should only be called once for each processor.
+   * @param timeout minimum amount of microseconds to wait for
+   * shutdown before giving up and returning failure.
+   * @return true if the shutdown succeeded, false otherwise
+   */
+  bool Shutdown(
+      std::chrono::microseconds timeout = std::chrono::microseconds::max()) noexcept override;
+
+private:
+  std::vector<std::unique_ptr<LogProcessor>> processors_;
+};
+}  // namespace logs
+}  // namespace sdk
+
+OPENTELEMETRY_END_NAMESPACE
+#endif

--- a/sdk/include/opentelemetry/sdk/logs/multi_recordable.h
+++ b/sdk/include/opentelemetry/sdk/logs/multi_recordable.h
@@ -1,0 +1,98 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#ifdef ENABLE_LOGS_PREVIEW
+
+#  include <cstddef>
+#  include <memory>
+#  include <unordered_map>
+
+#  include "opentelemetry/sdk/logs/processor.h"
+#  include "opentelemetry/sdk/logs/recordable.h"
+#  include "opentelemetry/sdk/resource/resource.h"
+#  include "opentelemetry/version.h"
+
+OPENTELEMETRY_BEGIN_NAMESPACE
+namespace sdk
+{
+namespace logs
+{
+class MultiRecordable final : public Recordable
+{
+public:
+  void AddRecordable(const LogProcessor &processor,
+                     std::unique_ptr<Recordable> recordable) noexcept;
+
+  const std::unique_ptr<Recordable> &GetRecordable(const LogProcessor &processor) const noexcept;
+
+  std::unique_ptr<Recordable> ReleaseRecordable(const LogProcessor &processor) noexcept;
+
+  /**
+   * Set the timestamp for this log.
+   * @param timestamp the timestamp to set
+   */
+  void SetTimestamp(opentelemetry::common::SystemTimestamp timestamp) noexcept override;
+
+  /**
+   * Set the severity for this log.
+   * @param severity the severity of the event
+   */
+  void SetSeverity(opentelemetry::logs::Severity severity) noexcept override;
+
+  /**
+   * Set name for this log
+   * @param name the name to set
+   */
+  void SetName(nostd::string_view name) noexcept override;
+
+  /**
+   * Set body field for this log.
+   * @param message the body to set
+   */
+  void SetBody(nostd::string_view message) noexcept override;
+
+  /**
+   * Set a single resource of a log record.
+   * @param key the name of the resource to set
+   * @param value the resource value to set
+   */
+  void SetResource(nostd::string_view key,
+                   const opentelemetry::common::AttributeValue &value) noexcept override;
+
+  /**
+   * Set an attribute of a log.
+   * @param key the name of the attribute
+   * @param value the attribute value
+   */
+  void SetAttribute(nostd::string_view key,
+                    const opentelemetry::common::AttributeValue &value) noexcept override;
+
+  /**
+   * Set the trace id for this log.
+   * @param trace_id the trace id to set
+   */
+  void SetTraceId(opentelemetry::trace::TraceId trace_id) noexcept override;
+
+  /**
+   * Set the span id for this log.
+   * @param span_id the span id to set
+   */
+  void SetSpanId(opentelemetry::trace::SpanId span_id) noexcept override;
+
+  /**
+   * Inject trace_flags for this log.
+   * @param trace_flags the trace flags to set
+   */
+  void SetTraceFlags(opentelemetry::trace::TraceFlags trace_flags) noexcept override;
+
+private:
+  std::unordered_map<std::size_t, std::unique_ptr<Recordable>> recordables_;
+};
+}  // namespace logs
+}  // namespace sdk
+
+OPENTELEMETRY_END_NAMESPACE
+
+#endif

--- a/sdk/include/opentelemetry/sdk/logs/multi_recordable.h
+++ b/sdk/include/opentelemetry/sdk/logs/multi_recordable.h
@@ -54,12 +54,10 @@ public:
   void SetBody(nostd::string_view message) noexcept override;
 
   /**
-   * Set a single resource of a log record.
-   * @param key the name of the resource to set
-   * @param value the resource value to set
+   * Set Resource of this log
+   * @param Resource the resource to set
    */
-  void SetResource(nostd::string_view key,
-                   const opentelemetry::common::AttributeValue &value) noexcept override;
+  void SetResource(const opentelemetry::sdk::resource::Resource &resource) noexcept override;
 
   /**
    * Set an attribute of a log.

--- a/sdk/include/opentelemetry/sdk/logs/recordable.h
+++ b/sdk/include/opentelemetry/sdk/logs/recordable.h
@@ -18,8 +18,6 @@
 #  include "opentelemetry/trace/trace_id.h"
 #  include "opentelemetry/version.h"
 
-#  include <map>
-
 OPENTELEMETRY_BEGIN_NAMESPACE
 namespace sdk
 {
@@ -60,12 +58,10 @@ public:
   virtual void SetBody(nostd::string_view message) noexcept = 0;
 
   /**
-   * Set a single resource of a log record.
-   * @param key the name of the resource to set
-   * @param value the resource value to set
+   * Set Resource of this log
+   * @param Resource the resource to set
    */
-  virtual void SetResource(nostd::string_view key,
-                           const opentelemetry::common::AttributeValue &value) noexcept = 0;
+  virtual void SetResource(const opentelemetry::sdk::resource::Resource &resource) noexcept = 0;
 
   /**
    * Set an attribute of a log.

--- a/sdk/include/opentelemetry/sdk/trace/tracer_provider.h
+++ b/sdk/include/opentelemetry/sdk/trace/tracer_provider.h
@@ -81,12 +81,6 @@ public:
   const opentelemetry::sdk::resource::Resource &GetResource() const noexcept;
 
   /**
-   * Obtain the span processor associated with this tracer provider.
-   * @return The span processor for this tracer provider.
-   */
-  std::shared_ptr<SpanProcessor> GetProcessor() const noexcept;
-
-  /**
    * Shutdown the span processor associated with this tracer provider.
    */
   bool Shutdown() noexcept;

--- a/sdk/src/logs/BUILD
+++ b/sdk/src/logs/BUILD
@@ -22,5 +22,6 @@ cc_library(
     deps = [
         "//api",
         "//sdk:headers",
+        "//sdk/src/resource",
     ],
 )

--- a/sdk/src/logs/CMakeLists.txt
+++ b/sdk/src/logs/CMakeLists.txt
@@ -1,5 +1,12 @@
-add_library(opentelemetry_logs logger_provider.cc logger.cc
-                               simple_log_processor.cc batch_log_processor.cc)
+add_library(
+  opentelemetry_logs
+  logger_provider.cc
+  logger.cc
+  simple_log_processor.cc
+  batch_log_processor.cc
+  logger_context.cc
+  multi_log_processor.cc
+  multi_recordable.cc)
 
 set_target_properties(opentelemetry_logs PROPERTIES EXPORT_NAME logs)
 

--- a/sdk/src/logs/CMakeLists.txt
+++ b/sdk/src/logs/CMakeLists.txt
@@ -10,7 +10,8 @@ add_library(
 
 set_target_properties(opentelemetry_logs PROPERTIES EXPORT_NAME logs)
 
-target_link_libraries(opentelemetry_logs opentelemetry_common)
+target_link_libraries(opentelemetry_logs PUBLIC opentelemetry_resources
+                                                opentelemetry_common)
 
 target_include_directories(
   opentelemetry_logs

--- a/sdk/src/logs/logger.cc
+++ b/sdk/src/logs/logger.cc
@@ -33,7 +33,6 @@ const nostd::string_view Logger::GetName() noexcept
 void Logger::Log(opentelemetry::logs::Severity severity,
                  nostd::string_view name,
                  nostd::string_view body,
-                 const common::KeyValueIterable &resource,
                  const common::KeyValueIterable &attributes,
                  trace_api::TraceId trace_id,
                  trace_api::SpanId span_id,

--- a/sdk/src/logs/logger.cc
+++ b/sdk/src/logs/logger.cc
@@ -16,8 +16,8 @@ namespace trace_api = opentelemetry::trace;
 namespace nostd     = opentelemetry::nostd;
 namespace common    = opentelemetry::common;
 
-Logger::Logger(nostd::string_view name, std::shared_ptr<LoggerProvider> logger_provider) noexcept
-    : logger_name_(std::string(name)), logger_provider_(logger_provider)
+Logger::Logger(nostd::string_view name, std::shared_ptr<LoggerContext> context) noexcept
+    : logger_name_(std::string(name)), context_(context)
 {}
 
 const nostd::string_view Logger::GetName() noexcept
@@ -41,15 +41,16 @@ void Logger::Log(opentelemetry::logs::Severity severity,
                  common::SystemTimestamp timestamp) noexcept
 {
   // If this logger does not have a processor, no need to create a log record
-  auto processor = logger_provider_.lock()->GetProcessor();
-  if (processor == nullptr)
+  auto context = context_.lock();
+  if (!context)
   {
     return;
   }
+  auto &processor = context->GetProcessor();
 
   // TODO: Sampler (should include check for minSeverity)
 
-  auto recordable = processor->MakeRecordable();
+  auto recordable = processor.MakeRecordable();
   if (recordable == nullptr)
   {
     OTEL_INTERNAL_LOG_ERROR("[LOGGER] Recordable creation failed");
@@ -62,10 +63,7 @@ void Logger::Log(opentelemetry::logs::Severity severity,
   recordable->SetName(name);
   recordable->SetBody(body);
 
-  resource.ForEachKeyValue([&](nostd::string_view key, common::AttributeValue value) noexcept {
-    recordable->SetResource(key, value);
-    return true;
-  });
+  recordable->SetResource(context->GetResource());
 
   attributes.ForEachKeyValue([&](nostd::string_view key, common::AttributeValue value) noexcept {
     recordable->SetAttribute(key, value);
@@ -111,7 +109,7 @@ void Logger::Log(opentelemetry::logs::Severity severity,
   }
 
   // Send the log record to the processor
-  processor->OnReceive(std::move(recordable));
+  processor.OnReceive(std::move(recordable));
 }
 
 }  // namespace logs

--- a/sdk/src/logs/logger_context.cc
+++ b/sdk/src/logs/logger_context.cc
@@ -1,8 +1,6 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-#pragma once
-
 #ifdef ENABLE_LOGS_PREVIEW
 
 #  include "opentelemetry/sdk/logs/logger_context.h"

--- a/sdk/src/logs/logger_context.cc
+++ b/sdk/src/logs/logger_context.cc
@@ -1,0 +1,56 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#ifdef ENABLE_LOGS_PREVIEW
+
+#  include "opentelemetry/sdk/logs/logger_context.h"
+#  include "opentelemetry/sdk/logs/multi_log_processor.h"
+
+#  include <memory>
+#  include <vector>
+
+OPENTELEMETRY_BEGIN_NAMESPACE
+namespace sdk
+{
+namespace logs
+{
+
+LoggerContext::LoggerContext(std::vector<std::unique_ptr<LogProcessor>> &&processors,
+                             opentelemetry::sdk::resource::Resource resource) noexcept
+    : resource_(resource),
+      processor_(std::unique_ptr<LogProcessor>(new MultiLogProcessor(std::move(processors))))
+{}
+
+void LoggerContext::AddProcessor(std::unique_ptr<LogProcessor> processor) noexcept
+{
+  auto multi_processor = static_cast<MultiLogProcessor *>(processor_.get());
+  multi_processor->AddProcessor(std::move(processor));
+}
+
+LogProcessor &LoggerContext::GetProcessor() const noexcept
+{
+  return *processor_;
+}
+
+const opentelemetry::sdk::resource::Resource &LoggerContext::GetResource() const noexcept
+{
+  return resource_;
+}
+
+bool LoggerContext::ForceFlush(std::chrono::microseconds timeout) noexcept
+{
+  return processor_->ForceFlush(timeout);
+}
+
+bool LoggerContext::Shutdown(std::chrono::microseconds timeout) noexcept
+{
+  return processor_->ForceFlush(timeout);
+}
+
+}  // namespace logs
+}  // namespace sdk
+
+OPENTELEMETRY_END_NAMESPACE
+#endif

--- a/sdk/src/logs/multi_log_processor.cc
+++ b/sdk/src/logs/multi_log_processor.cc
@@ -61,7 +61,7 @@ void MultiLogProcessor::OnReceive(std::unique_ptr<Recordable> &&record) noexcept
     auto recordable = multi_recordable->ReleaseRecordable(*processor);
     if (recordable)
     {
-      processor->OnReceive(std::move(record));
+      processor->OnReceive(std::move(recordable));
     }
   }
 }

--- a/sdk/src/logs/multi_log_processor.cc
+++ b/sdk/src/logs/multi_log_processor.cc
@@ -1,0 +1,123 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#ifdef ENABLE_LOGS_PREVIEW
+
+#  include "opentelemetry/sdk/logs/multi_log_processor.h"
+
+#  include <chrono>
+#  include <memory>
+#  include <vector>
+
+OPENTELEMETRY_BEGIN_NAMESPACE
+namespace sdk
+{
+namespace logs
+{
+
+MultiLogProcessor::MultiLogProcessor(std::vector<std::unique_ptr<LogProcessor>> &&processors)
+{
+  for (auto &processor : processors)
+  {
+    AddProcessor(std::move(processor));
+  }
+}
+MultiLogProcessor::~MultiLogProcessor()
+{
+  ForceFlush();
+  Shutdown();
+}
+
+void MultiLogProcessor::AddProcessor(std::unique_ptr<LogProcessor> &&processor)
+{
+  // Add preocessor to end of the list.
+  if (processor)
+  {
+    processors_.emplace_back(std::move(processor));
+  }
+}
+
+std::unique_ptr<Recordable> MultiLogProcessor::MakeRecordable() noexcept
+{
+  auto recordable       = std::unique_ptr<Recordable>(new MultiRecordable);
+  auto multi_recordable = static_cast<MultiRecordable *>(recordable.get());
+  for (auto &processor : processors_)
+  {
+    multi_recordable->AddRecordable(*processor, processor->MakeRecordable());
+  }
+  return recordable;
+}
+
+void MultiLogProcessor::OnReceive(std::unique_ptr<Recordable> &&record) noexcept
+{
+  if (!record)
+  {
+    return;
+  }
+  auto multi_recordable = static_cast<MultiRecordable *>(record.get());
+
+  for (auto &processor : processors_)
+  {
+    auto recordable = multi_recordable->ReleaseRecordable(*processor);
+    if (recordable)
+    {
+      processor->OnReceive(std::move(record));
+    }
+  }
+}
+
+bool MultiLogProcessor::ForceFlush(std::chrono::microseconds timeout) noexcept
+{
+  bool result      = true;
+  auto start_time  = std::chrono::system_clock::now();
+  auto expire_time = start_time + timeout;
+  for (auto &processor : processors_)
+  {
+    if (!processor->ForceFlush(timeout))
+    {
+      result = false;
+    }
+    start_time = std::chrono::system_clock::now();
+    if (expire_time > start_time)
+    {
+      timeout = std::chrono::duration_cast<std::chrono::microseconds>(expire_time - start_time);
+    }
+    else
+    {
+      timeout = std::chrono::microseconds::zero();
+    }
+  }
+  return result;
+}
+
+bool MultiLogProcessor::Shutdown(std::chrono::microseconds timeout) noexcept
+{
+  bool result      = true;
+  auto start_time  = std::chrono::system_clock::now();
+  auto expire_time = start_time + timeout;
+  for (auto &processor : processors_)
+  {
+    if (!processor->Shutdown(timeout))
+    {
+      result = false;
+    }
+    start_time = std::chrono::system_clock::now();
+    if (expire_time > start_time)
+    {
+      timeout = std::chrono::duration_cast<std::chrono::microseconds>(expire_time - start_time);
+    }
+    else
+    {
+      timeout = std::chrono::microseconds::zero();
+    }
+  }
+  return result;
+}
+
+}  // namespace logs
+}  // namespace sdk
+
+OPENTELEMETRY_END_NAMESPACE
+#endif

--- a/sdk/src/logs/multi_log_processor.cc
+++ b/sdk/src/logs/multi_log_processor.cc
@@ -1,8 +1,6 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-#pragma once
-
 #ifdef ENABLE_LOGS_PREVIEW
 
 #  include "opentelemetry/sdk/logs/multi_log_processor.h"

--- a/sdk/src/logs/multi_recordable.cc
+++ b/sdk/src/logs/multi_recordable.cc
@@ -1,0 +1,139 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#ifdef ENABLE_LOGS_PREVIEW
+
+#  include "opentelemetry/sdk/logs/multi_recordable.h"
+
+#  include <cstddef>
+#  include <memory>
+#  include <unordered_map>
+
+OPENTELEMETRY_BEGIN_NAMESPACE
+namespace sdk
+{
+namespace logs
+{
+
+namespace
+{
+std::size_t MakeKey(const opentelemetry::sdk::logs::LogProcessor &processor)
+{
+  return reinterpret_cast<std::size_t>(&processor);
+}
+
+}  // namespace
+
+void MultiRecordable::AddRecordable(const LogProcessor &processor,
+                                    std::unique_ptr<Recordable> recordable) noexcept
+{
+  recordables_[MakeKey(processor)] = std::move(recordable);
+}
+
+const std::unique_ptr<Recordable> &MultiRecordable::GetRecordable(
+    const LogProcessor &processor) const noexcept
+{
+  // TODO - return nullptr ref on failed lookup?
+  auto i = recordables_.find(MakeKey(processor));
+  if (i != recordables_.end())
+  {
+    return i->second;
+  }
+  static std::unique_ptr<Recordable> empty(nullptr);
+  return empty;
+}
+
+std::unique_ptr<Recordable> MultiRecordable::ReleaseRecordable(
+    const LogProcessor &processor) noexcept
+{
+  auto i = recordables_.find(MakeKey(processor));
+  if (i != recordables_.end())
+  {
+    std::unique_ptr<Recordable> result(i->second.release());
+    recordables_.erase(MakeKey(processor));
+    return result;
+  }
+  return std::unique_ptr<Recordable>(nullptr);
+}
+
+void MultiRecordable::SetTimestamp(opentelemetry::common::SystemTimestamp timestamp) noexcept
+{
+  for (auto &recordable : recordables_)
+  {
+    recordable.second->SetTimestamp(timestamp);
+  }
+}
+
+void MultiRecordable::SetSeverity(opentelemetry::logs::Severity severity) noexcept
+{
+  for (auto &recordable : recordables_)
+  {
+    recordable.second->SetSeverity(severity);
+  }
+}
+
+void MultiRecordable::SetName(nostd::string_view name) noexcept
+{
+  for (auto &recordable : recordables_)
+  {
+    recordable.second->SetName(name);
+  }
+}
+
+void MultiRecordable::SetBody(nostd::string_view message) noexcept
+{
+  for (auto &recordable : recordables_)
+  {
+    recordable.second->SetBody(message);
+  }
+}
+
+void MultiRecordable::SetResource(nostd::string_view key,
+                                  const opentelemetry::common::AttributeValue &value) noexcept
+{
+  for (auto &recordable : recordables_)
+  {
+    recordable.second->SetResource(key, value);
+  }
+}
+
+void MultiRecordable::SetAttribute(nostd::string_view key,
+                                   const opentelemetry::common::AttributeValue &value) noexcept
+{
+  for (auto &recordable : recordables_)
+  {
+    recordable.second->SetAttribute(key, value);
+  }
+}
+
+void MultiRecordable::SetTraceId(opentelemetry::trace::TraceId trace_id) noexcept
+{
+  for (auto &recordable : recordables_)
+  {
+    recordable.second->SetTraceId(trace_id);
+  }
+}
+
+void MultiRecordable::SetSpanId(opentelemetry::trace::SpanId span_id) noexcept
+{
+  for (auto &recordable : recordables_)
+  {
+    recordable.second->SetSpanId(span_id);
+  }
+}
+
+void MultiRecordable::SetTraceFlags(opentelemetry::trace::TraceFlags trace_flags) noexcept
+{
+  for (auto &recordable : recordables_)
+  {
+    recordable.second->SetTraceFlags(trace_flags);
+  }
+}
+
+}  // namespace logs
+}  // namespace sdk
+
+OPENTELEMETRY_END_NAMESPACE
+#endif

--- a/sdk/src/logs/multi_recordable.cc
+++ b/sdk/src/logs/multi_recordable.cc
@@ -1,8 +1,6 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-#pragma once
-
 #ifdef ENABLE_LOGS_PREVIEW
 
 #  include "opentelemetry/sdk/logs/multi_recordable.h"
@@ -90,12 +88,11 @@ void MultiRecordable::SetBody(nostd::string_view message) noexcept
   }
 }
 
-void MultiRecordable::SetResource(nostd::string_view key,
-                                  const opentelemetry::common::AttributeValue &value) noexcept
+void MultiRecordable::SetResource(const opentelemetry::sdk::resource::Resource &resource) noexcept
 {
   for (auto &recordable : recordables_)
   {
-    recordable.second->SetResource(key, value);
+    recordable.second->SetResource(resource);
   }
 }
 

--- a/sdk/test/logs/log_record_test.cc
+++ b/sdk/test/logs/log_record_test.cc
@@ -26,7 +26,7 @@ TEST(LogRecord, GetDefaultValues)
   ASSERT_EQ(record.GetSeverity(), logs_api::Severity::kInvalid);
   ASSERT_EQ(record.GetName(), "");
   ASSERT_EQ(record.GetBody(), "");
-  ASSERT_EQ(record.GetResource().size(), 0);
+  ASSERT_NE(record.GetResource().GetAttributes().size(), 0);
   ASSERT_EQ(record.GetAttributes().size(), 0);
   ASSERT_EQ(record.GetTraceId(), zero_trace_id);
   ASSERT_EQ(record.GetSpanId(), zero_span_id);
@@ -44,10 +44,11 @@ TEST(LogRecord, SetAndGet)
 
   // Set all fields of the LogRecord
   LogRecord record;
+  auto resource = opentelemetry::sdk::resource::Resource::Create({{"res1", true}});
   record.SetSeverity(logs_api::Severity::kInvalid);
   record.SetName("Log name");
   record.SetBody("Message");
-  record.SetResource("res1", (bool)true);
+  record.SetResource(resource);
   record.SetAttribute("attr1", (int64_t)314159);
   record.SetTraceId(trace_id);
   record.SetSpanId(span_id);
@@ -58,7 +59,7 @@ TEST(LogRecord, SetAndGet)
   ASSERT_EQ(record.GetSeverity(), logs_api::Severity::kInvalid);
   ASSERT_EQ(record.GetName(), "Log name");
   ASSERT_EQ(record.GetBody(), "Message");
-  ASSERT_EQ(nostd::get<bool>(record.GetResource().at("res1")), 1);
+  ASSERT_TRUE(nostd::get<bool>(record.GetResource().GetAttributes().at("res1")));
   ASSERT_EQ(nostd::get<int64_t>(record.GetAttributes().at("attr1")), 314159);
   ASSERT_EQ(record.GetTraceId(), trace_id);
   ASSERT_EQ(record.GetSpanId(), span_id);

--- a/sdk/test/logs/logger_provider_sdk_test.cc
+++ b/sdk/test/logs/logger_provider_sdk_test.cc
@@ -79,15 +79,11 @@ class DummyProcessor : public LogProcessor
   }
 };
 
-TEST(LoggerProviderSDK, GetAndSetProcessor)
+TEST(LoggerProviderSDK, GetResource)
 {
   // Create a LoggerProvider without a processor
-  LoggerProvider lp;
-  ASSERT_EQ(lp.GetProcessor(), nullptr);
-
-  // Create a new processor and check if it is pushed correctly
-  std::shared_ptr<LogProcessor> proc2 = std::shared_ptr<LogProcessor>(new DummyProcessor());
-  lp.SetProcessor(proc2);
-  ASSERT_EQ(proc2, lp.GetProcessor());
+  auto resource = opentelemetry::sdk::resource::Resource::Create({{"key", "value"}});
+  LoggerProvider lp{nullptr, resource};
+  ASSERT_EQ(nostd::get<std::string>(lp.GetResource().GetAttributes().at("key")), "value");
 }
 #endif

--- a/sdk/test/logs/logger_sdk_test.cc
+++ b/sdk/test/logs/logger_sdk_test.cc
@@ -77,9 +77,7 @@ TEST(LoggerSDK, LogToAProcessor)
 
   // Set a processor for the LoggerProvider
   auto shared_recordable = std::shared_ptr<LogRecord>(new LogRecord());
-  auto processor         = std::shared_ptr<LogProcessor>(new MockProcessor(shared_recordable));
-  lp->SetProcessor(processor);
-  ASSERT_EQ(processor, lp->GetProcessor());
+  lp->AddProcessor(std::unique_ptr<LogProcessor>(new MockProcessor(shared_recordable)));
 
   // Check that the recordable created by the Log() statement is set properly
   logger->Log(logs_api::Severity::kWarn, "Log Name", "Log Message");


### PR DESCRIPTION
Signed-off-by: owentou <owentou@tencent.com>

Fixes #1086 

## Changes

+ Add `logs::LoggerContext`, `logs::MultiLogProcessor`, `logs::MultiRecordable`
+ Remove resource from `Logger::Log`
+ Remove `TracerProvider::GetProcessor` (Without implementation before.)
+ \[BREAK CHANGES\] Change the declaration of `sdk::logs::Recordable::SetResource`
+ \[BREAK CHANGES\] Change the `LoggerProvider::SetProcessor` to `LoggerProvider::AddProcessor`
+ Share `LoggerContext` between loggers
+ Add `api/include/opentelemetry/common/macros.h` to provide `OPENTELEMETRY_DEPRECATED`, `OPENTELEMETRY_DEPRECATED_MESSAGE` and `OPENTELEMETRY_MAYBE_UNUSED`

Is there any way to convert `opentelemetry::sdk::common::OwnedAttributeValue` into `opentelemetry::common::AttributeValue` ?
It's difficult to reuse and dump data from `opentelemetry::sdk::common::OwnedAttributeValue`.

For significant contributions please make sure you have completed the following items:

* [x] `CHANGELOG.md` updated for non-trivial changes
* [x] Unit tests have been added
* [ ] Changes in public API reviewed