### PR TITLE
Jaeger: ThriftSender unit test

### DIFF
--- a/exporters/jaeger/BUILD
+++ b/exporters/jaeger/BUILD
@@ -129,6 +129,7 @@ cc_test(
     deps = [
         ":opentelemetry_exporter_jaeger_trace",
         "//sdk/src/resource",
+        "//sdk/src/trace",
         "@com_google_googletest//:gtest_main",
     ],
 )

--- a/exporters/jaeger/CMakeLists.txt
+++ b/exporters/jaeger/CMakeLists.txt
@@ -82,7 +82,7 @@ if(BUILD_TESTING)
   endif()
   target_link_libraries(
     jaeger_exporter_test ${GTEST_BOTH_LIBRARIES} ${CMAKE_THREAD_LIBS_INIT}
-    ${GMOCK_LIB} opentelemetry_sdk opentelemetry_exporter_jaeger_trace)
+    ${GMOCK_LIB} opentelemetry_trace opentelemetry_exporter_jaeger_trace)
 
   target_include_directories(jaeger_exporter_test
                              PRIVATE ${CMAKE_CURRENT_LIST_DIR}/src)

--- a/exporters/jaeger/CMakeLists.txt
+++ b/exporters/jaeger/CMakeLists.txt
@@ -82,7 +82,7 @@ if(BUILD_TESTING)
   endif()
   target_link_libraries(
     jaeger_exporter_test ${GTEST_BOTH_LIBRARIES} ${CMAKE_THREAD_LIBS_INIT}
-    ${GMOCK_LIB} opentelemetry_exporter_jaeger_trace)
+    ${GMOCK_LIB} opentelemetry_sdk opentelemetry_exporter_jaeger_trace)
 
   target_include_directories(jaeger_exporter_test
                              PRIVATE ${CMAKE_CURRENT_LIST_DIR}/src)

--- a/exporters/jaeger/test/jaeger_exporter_test.cc
+++ b/exporters/jaeger/test/jaeger_exporter_test.cc
@@ -4,6 +4,9 @@
 #include <opentelemetry/exporters/jaeger/jaeger_exporter.h>
 #include <memory>
 #include <vector>
+#include "opentelemetry/sdk/trace/batch_span_processor.h"
+#include "opentelemetry/sdk/trace/tracer_provider.h"
+#include "opentelemetry/trace/provider.h"
 
 #ifdef BAZEL_BUILD
 #  include "exporters/jaeger/src/thrift_sender.h"
@@ -28,6 +31,15 @@ namespace exporter
 namespace jaeger
 {
 
+namespace trace_api = opentelemetry::trace;
+namespace resource  = opentelemetry::sdk::resource;
+
+template <class T, size_t N>
+static nostd::span<T, N> MakeSpan(T (&array)[N])
+{
+  return nostd::span<T, N>(array);
+}
+
 class JaegerExporterTestPeer : public ::testing::Test
 {
 public:
@@ -48,6 +60,68 @@ class MockThriftSender : public ThriftSender
 public:
   MOCK_METHOD(int, Append, (std::unique_ptr<JaegerRecordable> &&), (noexcept, override));
 };
+
+class MockTransport : public Transport
+{
+public:
+  MOCK_METHOD(int, EmitBatch, (const thrift::Batch &), (override));
+  MOCK_METHOD(uint32_t, MaxPacketSize, (), (const, override));
+};
+
+// Create spans, let processor call Export()
+TEST_F(JaegerExporterTestPeer, ExportIntegrationTest)
+{
+  auto mock_transport     = new MockTransport;
+  auto mock_thrift_sender = new ThriftSender(std::unique_ptr<MockTransport>{mock_transport});
+  auto exporter           = GetExporter(std::unique_ptr<ThriftSender>{mock_thrift_sender});
+
+  resource::ResourceAttributes resource_attributes = {{"service.name", "unit_test_service"},
+                                                      {"tenant.id", "test_user"}};
+  resource_attributes["bool_value"]                = true;
+  resource_attributes["int32_value"]               = static_cast<int32_t>(1);
+  resource_attributes["uint32_value"]              = static_cast<uint32_t>(2);
+  resource_attributes["int64_value"]               = static_cast<int64_t>(0x1100000000LL);
+  resource_attributes["uint64_value"]              = static_cast<uint64_t>(0x1200000000ULL);
+  resource_attributes["double_value"]              = static_cast<double>(3.1);
+  resource_attributes["vec_bool_value"]            = std::vector<bool>{true, false, true};
+  resource_attributes["vec_int32_value"]           = std::vector<int32_t>{1, 2};
+  resource_attributes["vec_uint32_value"]          = std::vector<uint32_t>{3, 4};
+  resource_attributes["vec_int64_value"]           = std::vector<int64_t>{5, 6};
+  resource_attributes["vec_uint64_value"]          = std::vector<uint64_t>{7, 8};
+  resource_attributes["vec_double_value"]          = std::vector<double>{3.2, 3.3};
+  resource_attributes["vec_string_value"]          = std::vector<std::string>{"vector", "string"};
+  auto resource = resource::Resource::Create(resource_attributes);
+
+  auto processor_opts                  = sdk::trace::BatchSpanProcessorOptions();
+  processor_opts.max_export_batch_size = 5;
+  processor_opts.max_queue_size        = 5;
+  processor_opts.schedule_delay_millis = std::chrono::milliseconds(256);
+  auto processor                       = std::unique_ptr<sdk::trace::SpanProcessor>(
+      new sdk::trace::BatchSpanProcessor(std::move(exporter), processor_opts));
+  auto provider = nostd::shared_ptr<trace::TracerProvider>(
+      new sdk::trace::TracerProvider(std::move(processor), resource));
+
+  EXPECT_CALL(*mock_transport, EmitBatch(_)).Times(Exactly(1)).WillOnce(Return(1));
+
+  std::string report_trace_id;
+  {
+    char trace_id_hex[2 * trace_api::TraceId::kSize] = {0};
+    auto tracer                                      = provider->GetTracer("test");
+    auto parent_span                                 = tracer->StartSpan("Test parent span");
+
+    trace_api::StartSpanOptions child_span_opts = {};
+    child_span_opts.parent                      = parent_span->GetContext();
+
+    auto child_span = tracer->StartSpan("Test child span", child_span_opts);
+    child_span->End();
+    parent_span->End();
+
+    nostd::get<trace_api::SpanContext>(child_span_opts.parent)
+        .trace_id()
+        .ToLowerBase16(MakeSpan(trace_id_hex));
+    report_trace_id.assign(trace_id_hex, sizeof(trace_id_hex));
+  }
+}
 
 TEST_F(JaegerExporterTestPeer, ShutdownTest)
 {

--- a/exporters/jaeger/test/jaeger_exporter_test.cc
+++ b/exporters/jaeger/test/jaeger_exporter_test.cc
@@ -81,13 +81,11 @@ TEST_F(JaegerExporterTestPeer, ExportIntegrationTest)
   resource_attributes["int32_value"]               = static_cast<int32_t>(1);
   resource_attributes["uint32_value"]              = static_cast<uint32_t>(2);
   resource_attributes["int64_value"]               = static_cast<int64_t>(0x1100000000LL);
-  resource_attributes["uint64_value"]              = static_cast<uint64_t>(0x1200000000ULL);
   resource_attributes["double_value"]              = static_cast<double>(3.1);
   resource_attributes["vec_bool_value"]            = std::vector<bool>{true, false, true};
   resource_attributes["vec_int32_value"]           = std::vector<int32_t>{1, 2};
   resource_attributes["vec_uint32_value"]          = std::vector<uint32_t>{3, 4};
   resource_attributes["vec_int64_value"]           = std::vector<int64_t>{5, 6};
-  resource_attributes["vec_uint64_value"]          = std::vector<uint64_t>{7, 8};
   resource_attributes["vec_double_value"]          = std::vector<double>{3.2, 3.3};
   resource_attributes["vec_string_value"]          = std::vector<std::string>{"vector", "string"};
   auto resource = resource::Resource::Create(resource_attributes);


### PR DESCRIPTION
Adds unit test to cover the memory leak issue reported in #1160

## Changes

Mocks `Transport` so that we can reach `ThriftSender::Append` when `JaegerExporter::Export` was called.

For significant contributions please make sure you have completed the following items:

* [ ] `CHANGELOG.md` updated for non-trivial changes
* [x] Unit tests have been added
* [ ] Changes in public API reviewed