### PR TITLE
fix: otlp http exporter block thread (#1141)

### DIFF
--- a/exporters/otlp/src/otlp_http_client.cc
+++ b/exporters/otlp/src/otlp_http_client.cc
@@ -100,7 +100,7 @@ public:
 
       // Set the response_received_ flag to true and notify any threads waiting on this result
       response_received_ = true;
-      stop_waiting_ = true;
+      stop_waiting_      = true;
     }
     cv_.notify_all();
   }
@@ -112,7 +112,7 @@ public:
   bool waitForResponse()
   {
     std::unique_lock<std::mutex> lk(mutex_);
-    cv_.wait(lk, [this]{ return stop_waiting_; });
+    cv_.wait(lk, [this] { return stop_waiting_; });
     return response_received_;
   }
 
@@ -139,12 +139,11 @@ public:
       case http_client::SessionState::SSLHandshakeFailed:
       case http_client::SessionState::TimedOut:
       case http_client::SessionState::NetworkError:
-      case http_client::SessionState::Cancelled:
-        {
-          std::unique_lock<std::mutex> lk(mutex_);
-          stop_waiting_ = true;
-        }
-        break;
+      case http_client::SessionState::Cancelled: {
+        std::unique_lock<std::mutex> lk(mutex_);
+        stop_waiting_ = true;
+      }
+      break;
 
       default:
         break;
@@ -257,7 +256,7 @@ private:
   // Whether notify has been called
   bool stop_waiting_ = false;
 
-  // Whether the response from Elasticsearch has been received
+  // Whether the response has been received
   bool response_received_ = false;
 
   // A string to store the response body

--- a/exporters/otlp/src/otlp_http_client.cc
+++ b/exporters/otlp/src/otlp_http_client.cc
@@ -100,6 +100,7 @@ public:
 
       // Set the response_received_ flag to true and notify any threads waiting on this result
       response_received_ = true;
+      stop_waiting_ = true;
     }
     cv_.notify_all();
   }
@@ -111,7 +112,7 @@ public:
   bool waitForResponse()
   {
     std::unique_lock<std::mutex> lk(mutex_);
-    cv_.wait(lk);
+    cv_.wait(lk, [this]{ return stop_waiting_; });
     return response_received_;
   }
 
@@ -129,6 +130,26 @@ public:
   void OnEvent(http_client::SessionState state,
                opentelemetry::nostd::string_view reason) noexcept override
   {
+    // need to modify stop_waiting_ under lock before calling notify_all
+    switch (state)
+    {
+      case http_client::SessionState::CreateFailed:
+      case http_client::SessionState::ConnectFailed:
+      case http_client::SessionState::SendFailed:
+      case http_client::SessionState::SSLHandshakeFailed:
+      case http_client::SessionState::TimedOut:
+      case http_client::SessionState::NetworkError:
+      case http_client::SessionState::Cancelled:
+        {
+          std::unique_lock<std::mutex> lk(mutex_);
+          stop_waiting_ = true;
+        }
+        break;
+
+      default:
+        break;
+    }
+
     // If any failure event occurs, release the condition variable to unblock main thread
     switch (state)
     {
@@ -232,6 +253,9 @@ private:
   // Define a condition variable and mutex
   std::condition_variable cv_;
   std::mutex mutex_;
+
+  // Whether notify has been called
+  bool stop_waiting_ = false;
 
   // Whether the response from Elasticsearch has been received
   bool response_received_ = false;


### PR DESCRIPTION
Fixes #1141

## Changes

fix deadlock when notify_all() called before wait().