### PR TITLE
Synchronized calls to Exporter::Export & Shutdown

### DIFF
--- a/exporters/elasticsearch/include/opentelemetry/exporters/elasticsearch/es_log_exporter.h
+++ b/exporters/elasticsearch/include/opentelemetry/exporters/elasticsearch/es_log_exporter.h
@@ -5,6 +5,7 @@
 #ifdef ENABLE_LOGS_PREVIEW
 
 #  include "nlohmann/json.hpp"
+#  include "opentelemetry/common/spin_lock_mutex.h"
 #  include "opentelemetry/ext/http/client/curl/http_client_curl.h"
 #  include "opentelemetry/nostd/type_traits.h"
 #  include "opentelemetry/sdk/logs/exporter.h"
@@ -104,6 +105,8 @@ private:
 
   // Object that stores the HTTP sessions that have been created
   std::unique_ptr<ext::http::client::HttpClient> http_client_;
+  mutable opentelemetry::common::SpinLockMutex lock_;
+  const bool isShutdown() const noexcept;
 };
 }  // namespace logs
 }  // namespace exporter

--- a/exporters/elasticsearch/include/opentelemetry/exporters/elasticsearch/es_log_exporter.h
+++ b/exporters/elasticsearch/include/opentelemetry/exporters/elasticsearch/es_log_exporter.h
@@ -106,7 +106,7 @@ private:
   // Object that stores the HTTP sessions that have been created
   std::unique_ptr<ext::http::client::HttpClient> http_client_;
   mutable opentelemetry::common::SpinLockMutex lock_;
-  const bool isShutdown() const noexcept;
+  bool isShutdown() const noexcept;
 };
 }  // namespace logs
 }  // namespace exporter

--- a/exporters/elasticsearch/src/es_log_exporter.cc
+++ b/exporters/elasticsearch/src/es_log_exporter.cc
@@ -130,8 +130,7 @@ sdk::common::ExportResult ElasticsearchLogExporter::Export(
   // Return failure if this exporter has been shutdown
   if (isShutdown())
   {
-
-    OTEL_INTERNAL_LOG_ERROR("[ES Trace Exporter] Export failed, exporter is shutdown");
+    OTEL_INTERNAL_LOG_ERROR("[ES Log Exporter] Export failed, exporter is shutdown");
     return sdk::common::ExportResult::kFailure;
   }
 

--- a/exporters/elasticsearch/src/es_log_exporter.cc
+++ b/exporters/elasticsearch/src/es_log_exporter.cc
@@ -130,7 +130,8 @@ sdk::common::ExportResult ElasticsearchLogExporter::Export(
   // Return failure if this exporter has been shutdown
   if (isShutdown())
   {
-    OTEL_INTERNAL_LOG_ERROR("[ES Log Exporter] Export failed, exporter is shutdown");
+    OTEL_INTERNAL_LOG_ERROR("[ES Log Exporter] Exporting "
+                            << records.size() << " log(s) failed, exporter is shutdown");
     return sdk::common::ExportResult::kFailure;
   }
 
@@ -209,7 +210,7 @@ bool ElasticsearchLogExporter::Shutdown(std::chrono::microseconds timeout) noexc
   return true;
 }
 
-const bool ElasticsearchLogExporter::isShutdown() const noexcept
+bool ElasticsearchLogExporter::isShutdown() const noexcept
 {
   const std::lock_guard<opentelemetry::common::SpinLockMutex> locked(lock_);
   return is_shutdown_;

--- a/exporters/elasticsearch/src/es_log_exporter.cc
+++ b/exporters/elasticsearch/src/es_log_exporter.cc
@@ -5,6 +5,7 @@
 
 #  include <sstream>  // std::stringstream
 
+#  include <mutex>
 #  include "opentelemetry/exporters/elasticsearch/es_log_exporter.h"
 #  include "opentelemetry/exporters/elasticsearch/es_log_recordable.h"
 #  include "opentelemetry/sdk_config.h"
@@ -127,7 +128,7 @@ sdk::common::ExportResult ElasticsearchLogExporter::Export(
     const nostd::span<std::unique_ptr<sdklogs::Recordable>> &records) noexcept
 {
   // Return failure if this exporter has been shutdown
-  if (is_shutdown_)
+  if (isShutdown())
   {
 
     OTEL_INTERNAL_LOG_ERROR("[ES Trace Exporter] Export failed, exporter is shutdown");
@@ -199,6 +200,7 @@ sdk::common::ExportResult ElasticsearchLogExporter::Export(
 
 bool ElasticsearchLogExporter::Shutdown(std::chrono::microseconds timeout) noexcept
 {
+  const std::lock_guard<opentelemetry::common::SpinLockMutex> locked(lock_);
   is_shutdown_ = true;
 
   // Shutdown the session manager
@@ -206,6 +208,12 @@ bool ElasticsearchLogExporter::Shutdown(std::chrono::microseconds timeout) noexc
   http_client_->FinishAllSessions();
 
   return true;
+}
+
+const bool ElasticsearchLogExporter::isShutdown() const noexcept
+{
+  const std::lock_guard<opentelemetry::common::SpinLockMutex> locked(lock_);
+  return is_shutdown_;
 }
 }  // namespace logs
 }  // namespace exporter

--- a/exporters/jaeger/include/opentelemetry/exporters/jaeger/jaeger_exporter.h
+++ b/exporters/jaeger/include/opentelemetry/exporters/jaeger/jaeger_exporter.h
@@ -3,9 +3,9 @@
 
 #pragma once
 
+#include <opentelemetry/common/spin_lock_mutex.h>
 #include <opentelemetry/ext/http/client/http_client.h>
 #include <opentelemetry/sdk/trace/exporter.h>
-#include "opentelemetry/common/spin_lock_mutex.h"
 
 OPENTELEMETRY_BEGIN_NAMESPACE
 namespace exporter
@@ -77,7 +77,7 @@ private:
   JaegerExporterOptions options_;
   std::unique_ptr<ThriftSender> sender_;
   mutable opentelemetry::common::SpinLockMutex lock_;
-  const bool isShutdown() const noexcept;
+  bool isShutdown() const noexcept;
   // For testing
   friend class JaegerExporterTestPeer;
   /**

--- a/exporters/jaeger/include/opentelemetry/exporters/jaeger/jaeger_exporter.h
+++ b/exporters/jaeger/include/opentelemetry/exporters/jaeger/jaeger_exporter.h
@@ -5,6 +5,7 @@
 
 #include <opentelemetry/ext/http/client/http_client.h>
 #include <opentelemetry/sdk/trace/exporter.h>
+#include "opentelemetry/common/spin_lock_mutex.h"
 
 OPENTELEMETRY_BEGIN_NAMESPACE
 namespace exporter
@@ -75,6 +76,8 @@ private:
   bool is_shutdown_ = false;
   JaegerExporterOptions options_;
   std::unique_ptr<ThriftSender> sender_;
+  mutable opentelemetry::common::SpinLockMutex lock_;
+  const bool isShutdown() const noexcept;
   // For testing
   friend class JaegerExporterTestPeer;
   /**

--- a/exporters/jaeger/src/jaeger_exporter.cc
+++ b/exporters/jaeger/src/jaeger_exporter.cc
@@ -43,7 +43,8 @@ sdk_common::ExportResult JaegerExporter::Export(
 {
   if (isShutdown())
   {
-    OTEL_INTERNAL_LOG_ERROR("[Jaeger Trace Exporter] Export failed, exporter is shutdown");
+    OTEL_INTERNAL_LOG_ERROR("[Jaeger Trace Exporter] Exporting "
+                            << spans.size() << " span(s) failed, exporter is shutdown");
     return sdk_common::ExportResult::kFailure;
   }
 
@@ -99,7 +100,7 @@ bool JaegerExporter::Shutdown(std::chrono::microseconds timeout) noexcept
   return true;
 }
 
-const bool JaegerExporter::isShutdown() const noexcept
+bool JaegerExporter::isShutdown() const noexcept
 {
   const std::lock_guard<opentelemetry::common::SpinLockMutex> locked(lock_);
   return is_shutdown_;

--- a/exporters/jaeger/src/jaeger_exporter.cc
+++ b/exporters/jaeger/src/jaeger_exporter.cc
@@ -4,6 +4,7 @@
 #include <agent_types.h>
 #include <opentelemetry/exporters/jaeger/jaeger_exporter.h>
 #include <opentelemetry/exporters/jaeger/recordable.h>
+#include "opentelemetry/sdk_config.h"
 
 #include "http_transport.h"
 #include "thrift_sender.h"
@@ -42,6 +43,7 @@ sdk_common::ExportResult JaegerExporter::Export(
 {
   if (isShutdown())
   {
+    OTEL_INTERNAL_LOG_ERROR("[Jaeger Trace Exporter] Export failed, exporter is shutdown");
     return sdk_common::ExportResult::kFailure;
   }
 

--- a/exporters/memory/include/opentelemetry/exporters/memory/in_memory_span_exporter.h
+++ b/exporters/memory/include/opentelemetry/exporters/memory/in_memory_span_exporter.h
@@ -69,6 +69,7 @@ public:
   bool Shutdown(
       std::chrono::microseconds timeout = std::chrono::microseconds::max()) noexcept override
   {
+    const std::lock_guard<opentelemetry::common::SpinLockMutex> locked(lock_);
     is_shutdown_ = true;
     return true;
   };

--- a/exporters/memory/include/opentelemetry/exporters/memory/in_memory_span_exporter.h
+++ b/exporters/memory/include/opentelemetry/exporters/memory/in_memory_span_exporter.h
@@ -47,7 +47,8 @@ public:
   {
     if (isShutdown())
     {
-      OTEL_INTERNAL_LOG_ERROR("[In Memory Span Exporter] Export failed, exporter is shutdown");
+      OTEL_INTERNAL_LOG_ERROR("[In Memory Span Exporter] Exporting "
+                              << recordables.size() << " span(s) failed, exporter is shutdown");
       return sdk::common::ExportResult::kFailure;
     }
     for (auto &recordable : recordables)

--- a/exporters/memory/include/opentelemetry/exporters/memory/in_memory_span_exporter.h
+++ b/exporters/memory/include/opentelemetry/exporters/memory/in_memory_span_exporter.h
@@ -42,6 +42,10 @@ public:
   sdk::common::ExportResult Export(
       const nostd::span<std::unique_ptr<sdk::trace::Recordable>> &recordables) noexcept override
   {
+    if (is_shutdown_)
+    {
+      return sdk::common::ExportResult::kFailure;
+    }
     for (auto &recordable : recordables)
     {
       auto span = std::unique_ptr<sdk::trace::SpanData>(
@@ -63,6 +67,7 @@ public:
   bool Shutdown(
       std::chrono::microseconds timeout = std::chrono::microseconds::max()) noexcept override
   {
+    is_shutdown_ = true;
     return true;
   };
 
@@ -76,6 +81,7 @@ public:
 
 private:
   std::shared_ptr<opentelemetry::exporter::memory::InMemorySpanData> data_;
+  bool is_shutdown_ = false;
 };
 }  // namespace memory
 }  // namespace exporter

--- a/exporters/memory/include/opentelemetry/exporters/memory/in_memory_span_exporter.h
+++ b/exporters/memory/include/opentelemetry/exporters/memory/in_memory_span_exporter.h
@@ -6,6 +6,7 @@
 #include "opentelemetry/common/spin_lock_mutex.h"
 #include "opentelemetry/exporters/memory/in_memory_span_data.h"
 #include "opentelemetry/sdk/trace/exporter.h"
+#include "opentelemetry/sdk_config.h"
 
 OPENTELEMETRY_BEGIN_NAMESPACE
 namespace exporter
@@ -46,6 +47,7 @@ public:
   {
     if (isShutdown())
     {
+      OTEL_INTERNAL_LOG_ERROR("[In Memory Span Exporter] Export failed, exporter is shutdown");
       return sdk::common::ExportResult::kFailure;
     }
     for (auto &recordable : recordables)

--- a/exporters/ostream/include/opentelemetry/exporters/ostream/log_exporter.h
+++ b/exporters/ostream/include/opentelemetry/exporters/ostream/log_exporter.h
@@ -51,7 +51,7 @@ private:
   // Whether this exporter has been shut down
   bool is_shutdown_ = false;
   mutable opentelemetry::common::SpinLockMutex lock_;
-  const bool isShutdown() const noexcept;
+  bool isShutdown() const noexcept;
 };
 }  // namespace logs
 }  // namespace exporter

--- a/exporters/ostream/include/opentelemetry/exporters/ostream/log_exporter.h
+++ b/exporters/ostream/include/opentelemetry/exporters/ostream/log_exporter.h
@@ -4,6 +4,7 @@
 #pragma once
 #ifdef ENABLE_LOGS_PREVIEW
 
+#  include "opentelemetry/common/spin_lock_mutex.h"
 #  include "opentelemetry/nostd/type_traits.h"
 #  include "opentelemetry/sdk/logs/exporter.h"
 #  include "opentelemetry/sdk/logs/log_record.h"
@@ -49,6 +50,8 @@ private:
   std::ostream &sout_;
   // Whether this exporter has been shut down
   bool is_shutdown_ = false;
+  mutable opentelemetry::common::SpinLockMutex lock_;
+  const bool isShutdown() const noexcept;
 };
 }  // namespace logs
 }  // namespace exporter

--- a/exporters/ostream/include/opentelemetry/exporters/ostream/span_exporter.h
+++ b/exporters/ostream/include/opentelemetry/exporters/ostream/span_exporter.h
@@ -3,6 +3,7 @@
 
 #pragma once
 
+#include "opentelemetry/common/spin_lock_mutex.h"
 #include "opentelemetry/nostd/type_traits.h"
 #include "opentelemetry/sdk/trace/exporter.h"
 #include "opentelemetry/sdk/trace/span_data.h"
@@ -42,7 +43,9 @@ public:
 
 private:
   std::ostream &sout_;
-  bool isShutdown_ = false;
+  bool is_shutdown_ = false;
+  mutable opentelemetry::common::SpinLockMutex lock_;
+  const bool isShutdown() const noexcept;
 
   // Mapping status number to the string from api/include/opentelemetry/trace/canonical_code.h
   std::map<int, std::string> statusMap{{0, "Unset"}, {1, "Ok"}, {2, "Error"}};

--- a/exporters/ostream/include/opentelemetry/exporters/ostream/span_exporter.h
+++ b/exporters/ostream/include/opentelemetry/exporters/ostream/span_exporter.h
@@ -45,7 +45,7 @@ private:
   std::ostream &sout_;
   bool is_shutdown_ = false;
   mutable opentelemetry::common::SpinLockMutex lock_;
-  const bool isShutdown() const noexcept;
+  bool isShutdown() const noexcept;
 
   // Mapping status number to the string from api/include/opentelemetry/trace/canonical_code.h
   std::map<int, std::string> statusMap{{0, "Unset"}, {1, "Ok"}, {2, "Error"}};

--- a/exporters/ostream/src/log_exporter.cc
+++ b/exporters/ostream/src/log_exporter.cc
@@ -110,6 +110,7 @@ sdk::common::ExportResult OStreamLogExporter::Export(
 {
   if (isShutdown())
   {
+    OTEL_INTERNAL_LOG_ERROR("[Ostream Log Exporter] Export failed, exporter is shutdown");
     return sdk::common::ExportResult::kFailure;
   }
 

--- a/exporters/ostream/src/log_exporter.cc
+++ b/exporters/ostream/src/log_exporter.cc
@@ -4,6 +4,7 @@
 #ifdef ENABLE_LOGS_PREVIEW
 #  include "opentelemetry/exporters/ostream/log_exporter.h"
 #  include <mutex>
+#  include "opentelemetry/sdk_config.h"
 
 #  include <iostream>
 
@@ -110,7 +111,8 @@ sdk::common::ExportResult OStreamLogExporter::Export(
 {
   if (isShutdown())
   {
-    OTEL_INTERNAL_LOG_ERROR("[Ostream Log Exporter] Export failed, exporter is shutdown");
+    OTEL_INTERNAL_LOG_ERROR("[Ostream Log Exporter] Exporting "
+                            << records.size() << " log(s) failed, exporter is shutdown");
     return sdk::common::ExportResult::kFailure;
   }
 
@@ -175,7 +177,7 @@ bool OStreamLogExporter::Shutdown(std::chrono::microseconds timeout) noexcept
   return true;
 }
 
-const bool OStreamLogExporter::isShutdown() const noexcept
+bool OStreamLogExporter::isShutdown() const noexcept
 {
   const std::lock_guard<opentelemetry::common::SpinLockMutex> locked(lock_);
   return is_shutdown_;

--- a/exporters/ostream/src/span_exporter.cc
+++ b/exporters/ostream/src/span_exporter.cc
@@ -47,7 +47,8 @@ sdk::common::ExportResult OStreamSpanExporter::Export(
 {
   if (isShutdown())
   {
-    OTEL_INTERNAL_LOG_ERROR("[Ostream Trace Exporter] Export failed, exporter is shutdown");
+    OTEL_INTERNAL_LOG_ERROR("[Ostream Trace Exporter] Exporting "
+                            << spans.size() << " span(s) failed, exporter is shutdown");
     return sdk::common::ExportResult::kFailure;
   }
 
@@ -102,7 +103,7 @@ bool OStreamSpanExporter::Shutdown(std::chrono::microseconds timeout) noexcept
   return true;
 }
 
-const bool OStreamSpanExporter::isShutdown() const noexcept
+bool OStreamSpanExporter::isShutdown() const noexcept
 {
   const std::lock_guard<opentelemetry::common::SpinLockMutex> locked(lock_);
   return is_shutdown_;

--- a/exporters/ostream/src/span_exporter.cc
+++ b/exporters/ostream/src/span_exporter.cc
@@ -4,6 +4,7 @@
 #include "opentelemetry/exporters/ostream/span_exporter.h"
 #include <iostream>
 #include <mutex>
+#include "opentelemetry/sdk_config.h"
 
 namespace nostd     = opentelemetry::nostd;
 namespace trace_sdk = opentelemetry::sdk::trace;
@@ -46,6 +47,7 @@ sdk::common::ExportResult OStreamSpanExporter::Export(
 {
   if (isShutdown())
   {
+    OTEL_INTERNAL_LOG_ERROR("[Ostream Trace Exporter] Export failed, exporter is shutdown");
     return sdk::common::ExportResult::kFailure;
   }
 

--- a/exporters/ostream/src/span_exporter.cc
+++ b/exporters/ostream/src/span_exporter.cc
@@ -2,8 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "opentelemetry/exporters/ostream/span_exporter.h"
-
 #include <iostream>
+#include <mutex>
 
 namespace nostd     = opentelemetry::nostd;
 namespace trace_sdk = opentelemetry::sdk::trace;
@@ -44,7 +44,7 @@ std::unique_ptr<trace_sdk::Recordable> OStreamSpanExporter::MakeRecordable() noe
 sdk::common::ExportResult OStreamSpanExporter::Export(
     const nostd::span<std::unique_ptr<trace_sdk::Recordable>> &spans) noexcept
 {
-  if (isShutdown_)
+  if (isShutdown())
   {
     return sdk::common::ExportResult::kFailure;
   }
@@ -95,10 +95,16 @@ sdk::common::ExportResult OStreamSpanExporter::Export(
 
 bool OStreamSpanExporter::Shutdown(std::chrono::microseconds timeout) noexcept
 {
-  isShutdown_ = true;
+  const std::lock_guard<opentelemetry::common::SpinLockMutex> locked(lock_);
+  is_shutdown_ = true;
   return true;
 }
 
+const bool OStreamSpanExporter::isShutdown() const noexcept
+{
+  const std::lock_guard<opentelemetry::common::SpinLockMutex> locked(lock_);
+  return is_shutdown_;
+}
 void OStreamSpanExporter::printAttributes(
     const std::unordered_map<std::string, sdkcommon::OwnedAttributeValue> &map,
     const std::string prefix)

--- a/exporters/ostream/test/ostream_log_test.cc
+++ b/exporters/ostream/test/ostream_log_test.cc
@@ -46,8 +46,9 @@ TEST(OStreamLogExporter, Shutdown)
 
   // Restore original stringstream buffer
   std::cout.rdbuf(original);
-
-  ASSERT_EQ(output.str(), "");
+  std::string err_message =
+      "[Ostream Log Exporter] Exporting 1 log(s) failed, exporter is shutdown";
+  EXPECT_TRUE(output.str().find(err_message) != std::string::npos);
 }
 
 // ---------------------------------- Print to cout -------------------------

--- a/exporters/ostream/test/ostream_span_test.cc
+++ b/exporters/ostream/test/ostream_span_test.cc
@@ -47,11 +47,12 @@ TEST(OStreamSpanExporter, Shutdown)
   recordable->SetName("Test Span");
 
   // Capture the output of cout
-  const auto captured     = WithOStreamCapture(std::cout, [&]() {
+  const auto captured = WithOStreamCapture(std::cout, [&]() {
     EXPECT_TRUE(processor->Shutdown());
     processor->OnEnd(std::move(recordable));
   });
-  std::string err_message = "[Ostream Trace Exporter] Export failed, exporter is shutdown";
+  std::string err_message =
+      "[Ostream Trace Exporter] Exporting 1 span(s) failed, exporter is shutdown";
   EXPECT_TRUE(captured.find(err_message) != std::string::npos);
 }
 

--- a/exporters/ostream/test/ostream_span_test.cc
+++ b/exporters/ostream/test/ostream_span_test.cc
@@ -47,12 +47,12 @@ TEST(OStreamSpanExporter, Shutdown)
   recordable->SetName("Test Span");
 
   // Capture the output of cout
-  const auto captured = WithOStreamCapture(std::cout, [&]() {
+  const auto captured     = WithOStreamCapture(std::cout, [&]() {
     EXPECT_TRUE(processor->Shutdown());
     processor->OnEnd(std::move(recordable));
   });
-
-  EXPECT_EQ(captured, "");
+  std::string err_message = "[Ostream Trace Exporter] Export failed, exporter is shutdown";
+  EXPECT_TRUE(captured.find(err_message) != std::string::npos);
 }
 
 constexpr const char *kDefaultSpanPrinted =

--- a/exporters/otlp/include/opentelemetry/exporters/otlp/otlp_grpc_exporter.h
+++ b/exporters/otlp/include/opentelemetry/exporters/otlp/otlp_grpc_exporter.h
@@ -7,6 +7,7 @@
 
 #include "opentelemetry/exporters/otlp/protobuf_include_prefix.h"
 
+#include "opentelemetry/common/spin_lock_mutex.h"
 #include "opentelemetry/proto/collector/trace/v1/trace_service.grpc.pb.h"
 
 #include "opentelemetry/exporters/otlp/protobuf_include_suffix.h"
@@ -77,6 +78,8 @@ private:
    */
   OtlpGrpcExporter(std::unique_ptr<proto::collector::trace::v1::TraceService::StubInterface> stub);
   bool is_shutdown_ = false;
+  mutable opentelemetry::common::SpinLockMutex lock_;
+  const bool isShutdown() const noexcept;
 };
 }  // namespace otlp
 }  // namespace exporter

--- a/exporters/otlp/include/opentelemetry/exporters/otlp/otlp_grpc_exporter.h
+++ b/exporters/otlp/include/opentelemetry/exporters/otlp/otlp_grpc_exporter.h
@@ -79,7 +79,7 @@ private:
   OtlpGrpcExporter(std::unique_ptr<proto::collector::trace::v1::TraceService::StubInterface> stub);
   bool is_shutdown_ = false;
   mutable opentelemetry::common::SpinLockMutex lock_;
-  const bool isShutdown() const noexcept;
+  bool isShutdown() const noexcept;
 };
 }  // namespace otlp
 }  // namespace exporter

--- a/exporters/otlp/include/opentelemetry/exporters/otlp/otlp_grpc_log_exporter.h
+++ b/exporters/otlp/include/opentelemetry/exporters/otlp/otlp_grpc_log_exporter.h
@@ -80,7 +80,7 @@ private:
   OtlpGrpcLogExporter(std::unique_ptr<proto::collector::logs::v1::LogsService::StubInterface> stub);
   bool is_shutdown_ = false;
   mutable opentelemetry::common::SpinLockMutex lock_;
-  const bool isShutdown() const noexcept;
+  bool isShutdown() const noexcept;
 };
 
 }  // namespace otlp

--- a/exporters/otlp/include/opentelemetry/exporters/otlp/otlp_grpc_log_exporter.h
+++ b/exporters/otlp/include/opentelemetry/exporters/otlp/otlp_grpc_log_exporter.h
@@ -8,6 +8,7 @@
 
 #  include "opentelemetry/exporters/otlp/protobuf_include_prefix.h"
 #  include "opentelemetry/proto/collector/logs/v1/logs_service.grpc.pb.h"
+#include "opentelemetry/common/spin_lock_mutex.h"
 #  include "opentelemetry/exporters/otlp/protobuf_include_suffix.h"
 
 // clang-format on
@@ -78,6 +79,8 @@ private:
    */
   OtlpGrpcLogExporter(std::unique_ptr<proto::collector::logs::v1::LogsService::StubInterface> stub);
   bool is_shutdown_ = false;
+  mutable opentelemetry::common::SpinLockMutex lock_;
+  const bool isShutdown() const noexcept;
 };
 
 }  // namespace otlp

--- a/exporters/otlp/include/opentelemetry/exporters/otlp/otlp_grpc_log_exporter.h
+++ b/exporters/otlp/include/opentelemetry/exporters/otlp/otlp_grpc_log_exporter.h
@@ -8,7 +8,7 @@
 
 #  include "opentelemetry/exporters/otlp/protobuf_include_prefix.h"
 #  include "opentelemetry/proto/collector/logs/v1/logs_service.grpc.pb.h"
-#include "opentelemetry/common/spin_lock_mutex.h"
+#  include "opentelemetry/common/spin_lock_mutex.h"
 #  include "opentelemetry/exporters/otlp/protobuf_include_suffix.h"
 
 // clang-format on

--- a/exporters/otlp/include/opentelemetry/exporters/otlp/otlp_http_client.h
+++ b/exporters/otlp/include/opentelemetry/exporters/otlp/otlp_http_client.h
@@ -9,6 +9,7 @@
 
 #include "opentelemetry/exporters/otlp/protobuf_include_suffix.h"
 
+#include "opentelemetry/common/spin_lock_mutex.h"
 #include "opentelemetry/ext/http/client/http_client.h"
 #include "opentelemetry/sdk/common/exporter_utils.h"
 
@@ -124,6 +125,8 @@ private:
   std::shared_ptr<ext::http::client::HttpClient> http_client_;
   // Cached parsed URI
   std::string http_uri_;
+  mutable opentelemetry::common::SpinLockMutex lock_;
+  const bool isShutdown() const noexcept;
 };
 }  // namespace otlp
 }  // namespace exporter

--- a/exporters/otlp/include/opentelemetry/exporters/otlp/otlp_http_client.h
+++ b/exporters/otlp/include/opentelemetry/exporters/otlp/otlp_http_client.h
@@ -126,7 +126,7 @@ private:
   // Cached parsed URI
   std::string http_uri_;
   mutable opentelemetry::common::SpinLockMutex lock_;
-  const bool isShutdown() const noexcept;
+  bool isShutdown() const noexcept;
 };
 }  // namespace otlp
 }  // namespace exporter

--- a/exporters/otlp/src/otlp_grpc_exporter.cc
+++ b/exporters/otlp/src/otlp_grpc_exporter.cc
@@ -106,7 +106,8 @@ sdk::common::ExportResult OtlpGrpcExporter::Export(
 {
   if (isShutdown())
   {
-    OTEL_INTERNAL_LOG_ERROR("[OTLP gRPC] Export failed, exporter is shutdown");
+    OTEL_INTERNAL_LOG_ERROR("[OTLP gRPC] Exporting " << spans.size()
+                                                     << " span(s) failed, exporter is shutdown");
     return sdk::common::ExportResult::kFailure;
   }
   proto::collector::trace::v1::ExportTraceServiceRequest request;
@@ -144,7 +145,7 @@ bool OtlpGrpcExporter::Shutdown(std::chrono::microseconds timeout) noexcept
   return true;
 }
 
-const bool OtlpGrpcExporter::isShutdown() const noexcept
+bool OtlpGrpcExporter::isShutdown() const noexcept
 {
   const std::lock_guard<opentelemetry::common::SpinLockMutex> locked(lock_);
   return is_shutdown_;

--- a/exporters/otlp/src/otlp_grpc_exporter.cc
+++ b/exporters/otlp/src/otlp_grpc_exporter.cc
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "opentelemetry/exporters/otlp/otlp_grpc_exporter.h"
+#include <mutex>
 #include "opentelemetry/exporters/otlp/otlp_recordable.h"
 #include "opentelemetry/exporters/otlp/otlp_recordable_utils.h"
 #include "opentelemetry/ext/http/common/url_parser.h"
@@ -103,7 +104,7 @@ std::unique_ptr<sdk::trace::Recordable> OtlpGrpcExporter::MakeRecordable() noexc
 sdk::common::ExportResult OtlpGrpcExporter::Export(
     const nostd::span<std::unique_ptr<sdk::trace::Recordable>> &spans) noexcept
 {
-  if (is_shutdown_)
+  if (isShutdown())
   {
     OTEL_INTERNAL_LOG_ERROR("[OTLP gRPC] Export failed, exporter is shutdown");
     return sdk::common::ExportResult::kFailure;
@@ -138,8 +139,15 @@ sdk::common::ExportResult OtlpGrpcExporter::Export(
 
 bool OtlpGrpcExporter::Shutdown(std::chrono::microseconds timeout) noexcept
 {
+  const std::lock_guard<opentelemetry::common::SpinLockMutex> locked(lock_);
   is_shutdown_ = true;
   return true;
+}
+
+const bool OtlpGrpcExporter::isShutdown() const noexcept
+{
+  const std::lock_guard<opentelemetry::common::SpinLockMutex> locked(lock_);
+  return is_shutdown_;
 }
 
 }  // namespace otlp

--- a/exporters/otlp/src/otlp_grpc_log_exporter.cc
+++ b/exporters/otlp/src/otlp_grpc_log_exporter.cc
@@ -125,7 +125,7 @@ std::unique_ptr<opentelemetry::sdk::logs::Recordable> OtlpGrpcLogExporter::MakeR
 opentelemetry::sdk::common::ExportResult OtlpGrpcLogExporter::Export(
     const nostd::span<std::unique_ptr<opentelemetry::sdk::logs::Recordable>> &logs) noexcept
 {
-  if (is_shutdown_)
+  if (isShutdown())
   {
     OTEL_INTERNAL_LOG_ERROR("[OTLP gRPC log] Export failed, exporter is shutdown");
     return sdk::common::ExportResult::kFailure;
@@ -157,8 +157,15 @@ opentelemetry::sdk::common::ExportResult OtlpGrpcLogExporter::Export(
 
 bool OtlpGrpcLogExporter::Shutdown(std::chrono::microseconds timeout) noexcept
 {
+  const std::lock_guard<opentelemetry::common::SpinLockMutex> locked(lock_);
   is_shutdown_ = true;
   return true;
+}
+
+const bool OtlpGrpcLogExporter::isShutdown() const noexcept
+{
+  const std::lock_guard<opentelemetry::common::SpinLockMutex> locked(lock_);
+  return is_shutdown_;
 }
 
 }  // namespace otlp

--- a/exporters/otlp/src/otlp_grpc_log_exporter.cc
+++ b/exporters/otlp/src/otlp_grpc_log_exporter.cc
@@ -127,7 +127,8 @@ opentelemetry::sdk::common::ExportResult OtlpGrpcLogExporter::Export(
 {
   if (isShutdown())
   {
-    OTEL_INTERNAL_LOG_ERROR("[OTLP gRPC log] Export failed, exporter is shutdown");
+    OTEL_INTERNAL_LOG_ERROR("[OTLP gRPC log] Exporting " << logs.size()
+                                                         << " log(s) failed, exporter is shutdown");
     return sdk::common::ExportResult::kFailure;
   }
   proto::collector::logs::v1::ExportLogsServiceRequest request;
@@ -162,7 +163,7 @@ bool OtlpGrpcLogExporter::Shutdown(std::chrono::microseconds timeout) noexcept
   return true;
 }
 
-const bool OtlpGrpcLogExporter::isShutdown() const noexcept
+bool OtlpGrpcLogExporter::isShutdown() const noexcept
 {
   const std::lock_guard<opentelemetry::common::SpinLockMutex> locked(lock_);
   return is_shutdown_;

--- a/exporters/otlp/src/otlp_http_client.cc
+++ b/exporters/otlp/src/otlp_http_client.cc
@@ -695,7 +695,7 @@ bool OtlpHttpClient::Shutdown(std::chrono::microseconds) noexcept
   return true;
 }
 
-const bool OtlpHttpClient::isShutdown() const noexcept
+bool OtlpHttpClient::isShutdown() const noexcept
 {
   const std::lock_guard<opentelemetry::common::SpinLockMutex> locked(lock_);
   return is_shutdown_;

--- a/exporters/zipkin/include/opentelemetry/exporters/zipkin/zipkin_exporter.h
+++ b/exporters/zipkin/include/opentelemetry/exporters/zipkin/zipkin_exporter.h
@@ -3,6 +3,7 @@
 
 #pragma once
 
+#include "opentelemetry/common/spin_lock_mutex.h"
 #include "opentelemetry/ext/http/client/http_client_factory.h"
 #include "opentelemetry/ext/http/common/url_parser.h"
 #include "opentelemetry/sdk/common/env_variables.h"
@@ -89,11 +90,13 @@ private:
 
 private:
   // The configuration options associated with this exporter.
-  bool isShutdown_ = false;
+  bool is_shutdown_ = false;
   ZipkinExporterOptions options_;
   std::shared_ptr<opentelemetry::ext::http::client::HttpClientSync> http_client_;
   opentelemetry::ext::http::common::UrlParser url_parser_;
   nlohmann::json local_end_point_;
+  mutable opentelemetry::common::SpinLockMutex lock_;
+  const bool isShutdown() const noexcept;
 };
 }  // namespace zipkin
 }  // namespace exporter

--- a/exporters/zipkin/include/opentelemetry/exporters/zipkin/zipkin_exporter.h
+++ b/exporters/zipkin/include/opentelemetry/exporters/zipkin/zipkin_exporter.h
@@ -96,7 +96,7 @@ private:
   opentelemetry::ext::http::common::UrlParser url_parser_;
   nlohmann::json local_end_point_;
   mutable opentelemetry::common::SpinLockMutex lock_;
-  const bool isShutdown() const noexcept;
+  bool isShutdown() const noexcept;
 };
 }  // namespace zipkin
 }  // namespace exporter

--- a/exporters/zipkin/src/zipkin_exporter.cc
+++ b/exporters/zipkin/src/zipkin_exporter.cc
@@ -44,7 +44,8 @@ sdk::common::ExportResult ZipkinExporter::Export(
 {
   if (isShutdown())
   {
-    OTEL_INTERNAL_LOG_ERROR("[Zipkin Trace Exporter] Export failed, exporter is shutdown");
+    OTEL_INTERNAL_LOG_ERROR("[Zipkin Trace Exporter] Exporting "
+                            << spans.size() << " span(s) failed, exporter is shutdown");
     return sdk::common::ExportResult::kFailure;
   }
   exporter::zipkin::ZipkinSpan json_spans = {};
@@ -108,7 +109,7 @@ bool ZipkinExporter::Shutdown(std::chrono::microseconds timeout) noexcept
   return true;
 }
 
-const bool ZipkinExporter::isShutdown() const noexcept
+bool ZipkinExporter::isShutdown() const noexcept
 {
   const std::lock_guard<opentelemetry::common::SpinLockMutex> locked(lock_);
   return is_shutdown_;

--- a/exporters/zipkin/src/zipkin_exporter.cc
+++ b/exporters/zipkin/src/zipkin_exporter.cc
@@ -44,6 +44,7 @@ sdk::common::ExportResult ZipkinExporter::Export(
 {
   if (isShutdown())
   {
+    OTEL_INTERNAL_LOG_ERROR("[Zipkin Trace Exporter] Export failed, exporter is shutdown");
     return sdk::common::ExportResult::kFailure;
   }
   exporter::zipkin::ZipkinSpan json_spans = {};

--- a/exporters/zipkin/src/zipkin_exporter.cc
+++ b/exporters/zipkin/src/zipkin_exporter.cc
@@ -1,6 +1,7 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
+#define _WINSOCKAPI_  // stops including winsock.h
 #include "opentelemetry/exporters/zipkin/zipkin_exporter.h"
 #include <mutex>
 #include "opentelemetry/exporters/zipkin/recordable.h"


### PR DESCRIPTION
Fixes #1158 (issue)

## Changes

Protects `is_shutdown_` read and writes using `opentelemetry::common::SpinLockMutex`.

For significant contributions please make sure you have completed the following items:

* [ ] `CHANGELOG.md` updated for non-trivial changes
* [ ] Unit tests have been added
* [ ] Changes in public API reviewed