### PR TITLE
Waiting a longer time when run unit tests of http client, which may take a long time when run under valgrind.

### DIFF
--- a/exporters/otlp/test/otlp_http_exporter_test.cc
+++ b/exporters/otlp/test/otlp_http_exporter_test.cc
@@ -240,7 +240,7 @@ TEST_F(OtlpHttpExporterTestPeer, ExportJsonIntegrationTest)
     report_trace_id.assign(trace_id_hex, sizeof(trace_id_hex));
   }
 
-  ASSERT_TRUE(waitForRequests(8, old_count + 1));
+  ASSERT_TRUE(waitForRequests(30, old_count + 1));
   auto check_json                   = received_requests_json_.back();
   auto resource_span                = *check_json["resource_spans"].begin();
   auto instrumentation_library_span = *resource_span["instrumentation_library_spans"].begin();
@@ -310,7 +310,7 @@ TEST_F(OtlpHttpExporterTestPeer, ExportBinaryIntegrationTest)
     report_trace_id.assign(reinterpret_cast<char *>(trace_id_binary), sizeof(trace_id_binary));
   }
 
-  ASSERT_TRUE(waitForRequests(8, old_count + 1));
+  ASSERT_TRUE(waitForRequests(30, old_count + 1));
 
   auto received_trace_id = received_requests_binary_.back()
                                .resource_spans(0)

--- a/exporters/otlp/test/otlp_http_log_exporter_test.cc
+++ b/exporters/otlp/test/otlp_http_log_exporter_test.cc
@@ -252,7 +252,7 @@ TEST_F(OtlpHttpLogExporterTestPeer, ExportJsonIntegrationTest)
     report_span_id.assign(span_id_hex, sizeof(span_id_hex));
   }
 
-  ASSERT_TRUE(waitForRequests(8, old_count + 1));
+  ASSERT_TRUE(waitForRequests(30, old_count + 1));
   auto check_json                   = received_requests_json_.back();
   auto resource_logs                = *check_json["resource_logs"].begin();
   auto instrumentation_library_span = *resource_logs["instrumentation_library_logs"].begin();
@@ -340,7 +340,7 @@ TEST_F(OtlpHttpLogExporterTestPeer, ExportBinaryIntegrationTest)
     report_span_id.assign(reinterpret_cast<const char *>(span_id_bin), sizeof(span_id_bin));
   }
 
-  ASSERT_TRUE(waitForRequests(8, old_count + 1));
+  ASSERT_TRUE(waitForRequests(30, old_count + 1));
   auto received_log =
       received_requests_binary_.back().resource_logs(0).instrumentation_library_logs(0).logs(0);
   EXPECT_EQ(received_log.trace_id(), report_trace_id);

--- a/exporters/zipkin/test/zipkin_exporter_test.cc
+++ b/exporters/zipkin/test/zipkin_exporter_test.cc
@@ -237,7 +237,7 @@ TEST_F(ZipkinExporterTestPeer, ExportJsonIntegrationTest)
     report_trace_id.assign(trace_id_hex, sizeof(trace_id_hex));
   }
 
-  ASSERT_TRUE(waitForRequests(8, old_count + 1));
+  ASSERT_TRUE(waitForRequests(30, old_count + 1));
   auto check_json        = received_requests_json_.back();
   auto trace_id_kv       = check_json.at(0).find("traceId");
   auto received_trace_id = trace_id_kv.value().get<std::string>();
@@ -257,7 +257,7 @@ TEST_F(ZipkinExporterTestPeer, ShutdownTest)
 {
   auto mock_http_client = new MockHttpClient;
   auto exporter         = GetExporter(
-      std::shared_ptr<opentelemetry::ext::http::client::HttpClientSync>{mock_http_client});
+              std::shared_ptr<opentelemetry::ext::http::client::HttpClientSync>{mock_http_client});
   auto recordable_1 = exporter->MakeRecordable();
   recordable_1->SetName("Test span 1");
   auto recordable_2 = exporter->MakeRecordable();

--- a/exporters/zipkin/test/zipkin_exporter_test.cc
+++ b/exporters/zipkin/test/zipkin_exporter_test.cc
@@ -256,8 +256,9 @@ TEST_F(ZipkinExporterTestPeer, ExportJsonIntegrationTest)
 TEST_F(ZipkinExporterTestPeer, ShutdownTest)
 {
   auto mock_http_client = new MockHttpClient;
-  auto exporter         = GetExporter(
-              std::shared_ptr<opentelemetry::ext::http::client::HttpClientSync>{mock_http_client});
+  // Leave a comment line here or different version of clang-format has a different result here
+  auto exporter = GetExporter(
+      std::shared_ptr<opentelemetry::ext::http::client::HttpClientSync>{mock_http_client});
   auto recordable_1 = exporter->MakeRecordable();
   recordable_1->SetName("Test span 1");
   auto recordable_2 = exporter->MakeRecordable();

--- a/ext/test/http/curl_http_test.cc
+++ b/ext/test/http/curl_http_test.cc
@@ -198,7 +198,7 @@ TEST_F(BasicCurlHttpTests, SendGetRequest)
   request->SetUri("get/");
   GetEventHandler *handler = new GetEventHandler();
   session->SendRequest(*handler);
-  ASSERT_TRUE(waitForRequests(1, 1));
+  ASSERT_TRUE(waitForRequests(30, 1));
   session->FinishSession();
   ASSERT_TRUE(handler->is_called_);
   delete handler;
@@ -221,7 +221,7 @@ TEST_F(BasicCurlHttpTests, SendPostRequest)
   request->AddHeader("Content-Type", "text/plain");
   PostEventHandler *handler = new PostEventHandler();
   session->SendRequest(*handler);
-  ASSERT_TRUE(waitForRequests(1, 1));
+  ASSERT_TRUE(waitForRequests(30, 1));
   session->FinishSession();
   ASSERT_TRUE(handler->is_called_);
 


### PR DESCRIPTION
Signed-off-by: owentou <owentou@tencent.com>

Fixes #1049

## Changes

Increase timeout for http client. We find 8s is not enough sometime.

> https://github.com/open-telemetry/opentelemetry-cpp/runs/4793495501

For significant contributions please make sure you have completed the following items:

* [x] `CHANGELOG.md` updated for non-trivial changes
* [x] Unit tests have been added
* [x] Changes in public API reviewed