### PR TITLE
Continuous benchmark tests as part of the CI

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -68,6 +68,5 @@ jobs:
           alert-threshold: '200%'
           comment-on-alert: true
           fail-on-alert: true
-          alert-comment-cc-users: '@esigo'
           gh-pages-branch: gh-pages
           benchmark-data-dir-path: benchmarks

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -1,0 +1,73 @@
+name: OpenTelemetry-cpp benchmarks
+on:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: write
+  deployments: write
+
+jobs:
+  benchmark:
+    name: Run OpenTelemetry-cpp benchmarks
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          submodules: 'recursive'
+      - name: Mount Bazel Cache
+        uses: actions/cache@v2
+        env:
+          cache-name: bazel_cache
+        with:
+          path: /home/runner/.cache/bazel
+          key: bazel_benchmark
+      - name: setup
+        run: |
+          sudo ./ci/setup_cmake.sh
+          sudo ./ci/setup_ci_environment.sh
+      - name: Run benchmark
+        id: run_benchmarks
+        run: |
+          ci/do_ci.sh bazel.benchmark
+          mkdir -p benchmarks
+          mv api-benchmark_result.json benchmarks
+          mv sdk-benchmark_result.json benchmarks
+          mv exporters-benchmark_result.json benchmarks
+      - uses: actions/upload-artifact@master
+        with:
+          name: benchmark_results
+          path: benchmarks
+  store_benchmark:
+    needs: benchmark
+    strategy:
+      matrix:
+        components: ["api", "sdk", "exporters"]
+    name: Store benchmark result
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/download-artifact@master
+        with:
+          name: benchmark_results
+          path: benchmarks
+      - name: Print json files
+        id: print_json
+        run: |
+          cat benchmarks/*
+      - name: Push benchmark result
+        uses: benchmark-action/github-action-benchmark@v1
+        with:
+          name: OpenTelemetry-cpp ${{ matrix.components }} Benchmark
+          tool: 'googlecpp'
+          output-file-path: benchmarks/${{ matrix.components }}-benchmark_result.json
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          auto-push: true
+          # Show alert with commit comment on detecting possible performance regression
+          alert-threshold: '200%'
+          comment-on-alert: true
+          fail-on-alert: true
+          alert-comment-cc-users: '@esigo'
+          gh-pages-branch: gh-pages
+          benchmark-data-dir-path: benchmarks

--- a/bazel/otel_cc_benchmark.bzl
+++ b/bazel/otel_cc_benchmark.bzl
@@ -24,16 +24,17 @@ def otel_cc_benchmark(name, srcs, deps, tags = [""]):
         srcs = srcs,
         deps = deps + ["@com_github_google_benchmark//:benchmark"],
         tags = tags + ["manual"],
+        defines = ["BAZEL_BUILD"],
     )
 
     # The result of running the benchmark, captured into a text file.
     native.genrule(
         name = name + "_result",
-        outs = [name + "_result.txt"],
+        outs = [name + "_result.json"],
         tools = [":" + name],
         tags = tags + ["benchmark_result", "manual"],
         testonly = True,
-        cmd = "$(location :" + name + (") --benchmark_color=false --benchmark_min_time=.1 &> $@"),
+        cmd = "$(location :" + name + (") --benchmark_format=json --benchmark_color=false --benchmark_min_time=.1 &> $@"),
     )
 
     # This is run as part of "bazel test ..." to smoke-test benchmarks. It's
@@ -44,4 +45,5 @@ def otel_cc_benchmark(name, srcs, deps, tags = [""]):
         deps = deps + ["@com_github_google_benchmark//:benchmark"],
         args = ["--benchmark_min_time=0"],
         tags = tags + ["benchmark"],
+        defines = ["BAZEL_BUILD"],
     )

--- a/ci/do_ci.sh
+++ b/ci/do_ci.sh
@@ -164,6 +164,7 @@ elif [[ "$1" == "cmake.exporter.otprotocol.test" ]]; then
 elif [[ "$1" == "bazel.with_abseil" ]]; then
   bazel $BAZEL_STARTUP_OPTIONS build $BAZEL_OPTIONS --//api:with_abseil=true //...
   bazel $BAZEL_STARTUP_OPTIONS test $BAZEL_TEST_OPTIONS --//api:with_abseil=true //...
+  exit 0
 elif [[ "$1" == "cmake.test_example_plugin" ]]; then
   # Build the plugin
   cd "${BUILD_DIR}"

--- a/ci/do_ci.sh
+++ b/ci/do_ci.sh
@@ -37,7 +37,6 @@ function run_benchmarks
   )
 
   # collect benchmark results into one array
-  components=(api sdk exporters)
   pushd $BENCHMARK_DIR
   components=(api sdk exporters)
   for component in "${components[@]}"

--- a/ci/do_ci.sh
+++ b/ci/do_ci.sh
@@ -161,6 +161,9 @@ elif [[ "$1" == "cmake.exporter.otprotocol.test" ]]; then
   make -j $(nproc)
   cd exporters/otlp && make test
   exit 0
+elif [[ "$1" == "bazel.with_abseil" ]]; then
+  bazel $BAZEL_STARTUP_OPTIONS build $BAZEL_OPTIONS --//api:with_abseil=true //...
+  bazel $BAZEL_STARTUP_OPTIONS test $BAZEL_TEST_OPTIONS --//api:with_abseil=true //...
 elif [[ "$1" == "cmake.test_example_plugin" ]]; then
   # Build the plugin
   cd "${BUILD_DIR}"

--- a/exporters/otlp/BUILD
+++ b/exporters/otlp/BUILD
@@ -279,5 +279,6 @@ otel_cc_benchmark(
     ],
     deps = [
         ":otlp_grpc_exporter",
+        "//examples/common/foo_library:common_foo_library",
     ],
 )

--- a/exporters/otlp/test/otlp_grpc_exporter_benchmark.cc
+++ b/exporters/otlp/test/otlp_grpc_exporter_benchmark.cc
@@ -5,7 +5,6 @@
 #include "opentelemetry/exporters/otlp/otlp_recordable.h"
 
 #include <benchmark/benchmark.h>
-#include "opentelemetry/exporters/otlp/otlp_grpc_exporter.h"
 #include "opentelemetry/sdk/trace/simple_processor.h"
 #include "opentelemetry/sdk/trace/tracer_provider.h"
 #include "opentelemetry/trace/provider.h"


### PR DESCRIPTION
Fixes #1170 (issue)

## Changes

Runs  benchmark tests at every push to the `main` branch and pushes the results to `gh-pages` branch. The results are grouped into api, sdk and exporters.

An example of working graphs can be seen [here](https://esigo.github.io/opentelemetry-cpp/benchmarks/index.html).

For significant contributions please make sure you have completed the following items:

* [ ] `CHANGELOG.md` updated for non-trivial changes
* [ ] Unit tests have been added
* [ ] Changes in public API reviewed