### PR TITLE
Fix build test of Zipkin exporter on Windows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -408,7 +408,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: install docfx
-      run: choco install docfx -y
+      run: choco install docfx -y --version=2.58.5
     - name: run ./ci/docfx.cmd
       shell: cmd
       run: ./ci/docfx.cmd

--- a/.gitignore
+++ b/.gitignore
@@ -48,3 +48,5 @@
 /bazel-*
 /plugin
 /build
+
+tags

--- a/api/include/opentelemetry/common/spin_lock_mutex.h
+++ b/api/include/opentelemetry/common/spin_lock_mutex.h
@@ -13,6 +13,7 @@
 #  ifndef NOMINMAX
 #    define NOMINMAX
 #  endif
+#  define _WINSOCKAPI_ // stops including winsock.h
 #  include <windows.h>
 #elif defined(__i386__) || defined(__x86_64__)
 #  if defined(__clang__)

--- a/api/include/opentelemetry/common/spin_lock_mutex.h
+++ b/api/include/opentelemetry/common/spin_lock_mutex.h
@@ -13,7 +13,7 @@
 #  ifndef NOMINMAX
 #    define NOMINMAX
 #  endif
-#  define _WINSOCKAPI_ // stops including winsock.h
+#  define _WINSOCKAPI_  // stops including winsock.h
 #  include <windows.h>
 #elif defined(__i386__) || defined(__x86_64__)
 #  if defined(__clang__)

--- a/exporters/jaeger/CMakeLists.txt
+++ b/exporters/jaeger/CMakeLists.txt
@@ -58,6 +58,8 @@ install(
   PATTERN "recordable.h" EXCLUDE)
 
 if(BUILD_TESTING)
+  add_definitions(-DGTEST_LINKED_AS_SHARED_LIBRARY=1)
+
   add_executable(jaeger_recordable_test test/jaeger_recordable_test.cc)
   target_link_libraries(
     jaeger_recordable_test ${GTEST_BOTH_LIBRARIES} ${CMAKE_THREAD_LIBS_INIT}
@@ -69,7 +71,6 @@ if(BUILD_TESTING)
     TEST_LIST jaeger_recordable_test)
 
   add_executable(jaeger_exporter_test test/jaeger_exporter_test.cc)
-  add_definitions(-DGTEST_LINKED_AS_SHARED_LIBRARY=1)
   if(MSVC)
     if(GMOCK_LIB)
       unset(GMOCK_LIB CACHE)

--- a/exporters/jaeger/test/jaeger_exporter_test.cc
+++ b/exporters/jaeger/test/jaeger_exporter_test.cc
@@ -14,7 +14,7 @@
 #endif
 
 #include <gtest/gtest.h>
-#include "gmock/gmock.h"
+#include <gmock/gmock.h>
 
 namespace trace      = opentelemetry::trace;
 namespace nostd      = opentelemetry::nostd;

--- a/exporters/jaeger/test/jaeger_exporter_test.cc
+++ b/exporters/jaeger/test/jaeger_exporter_test.cc
@@ -14,7 +14,7 @@
 #endif
 
 #include <gtest/gtest.h>
-#include <gmock/gmock.h>
+#include "gmock/gmock.h"
 
 namespace trace      = opentelemetry::trace;
 namespace nostd      = opentelemetry::nostd;

--- a/exporters/zipkin/CMakeLists.txt
+++ b/exporters/zipkin/CMakeLists.txt
@@ -37,6 +37,8 @@ install(
   PATTERN "recordable.h" EXCLUDE)
 
 if(BUILD_TESTING)
+  add_definitions(-DGTEST_LINKED_AS_SHARED_LIBRARY=1)
+
   add_executable(zipkin_recordable_test test/zipkin_recordable_test.cc)
 
   target_link_libraries(

--- a/exporters/zipkin/test/zipkin_exporter_test.cc
+++ b/exporters/zipkin/test/zipkin_exporter_test.cc
@@ -12,7 +12,7 @@
 #  include "opentelemetry/trace/provider.h"
 
 #  include <gtest/gtest.h>
-#  include <gmock/gmock.h>
+#  include "gmock/gmock.h"
 
 #  include "nlohmann/json.hpp"
 

--- a/exporters/zipkin/test/zipkin_exporter_test.cc
+++ b/exporters/zipkin/test/zipkin_exporter_test.cc
@@ -3,7 +3,6 @@
 
 #ifndef HAVE_CPP_STDLIB
 
-#  define _WINSOCKAPI_  // stops including winsock.h
 #  include "opentelemetry/exporters/zipkin/zipkin_exporter.h"
 #  include <string>
 #  include "opentelemetry/ext/http/client/curl/http_client_curl.h"
@@ -13,7 +12,7 @@
 #  include "opentelemetry/trace/provider.h"
 
 #  include <gtest/gtest.h>
-#  include "gmock/gmock.h"
+#  include <gmock/gmock.h>
 
 #  include "nlohmann/json.hpp"
 

--- a/ext/include/opentelemetry/ext/http/client/curl/http_operation_curl.h
+++ b/ext/include/opentelemetry/ext/http/client/curl/http_operation_curl.h
@@ -7,7 +7,6 @@
 #include "opentelemetry/ext/http/client/http_client.h"
 #include "opentelemetry/version.h"
 
-#include <curl/curl.h>
 #include <future>
 #include <map>
 #include <regex>
@@ -16,9 +15,11 @@
 #include <vector>
 #ifdef _WIN32
 #  include <io.h>
+#  include <winsock2.h>
 #else
 #  include <unistd.h>
 #endif
+#include <curl/curl.h>
 
 OPENTELEMETRY_BEGIN_NAMESPACE
 namespace ext


### PR DESCRIPTION
## Changes

Zipkin exporter doesn't build on Windows but Jaeger exporter builds fine. This PR ports the necessary Jaeger build scripts to Zipkin exporter as well.

For significant contributions please make sure you have completed the following items:

* [ ] `CHANGELOG.md` updated for non-trivial changes
* [ ] Unit tests have been added
* [ ] Changes in public API reviewed