### PR TITLE
Change Monday's community meeting time (13:00 PT - 14:00 PT)

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ along with build files for CMake and Bazel.
 
 See [CONTRIBUTING.md](CONTRIBUTING.md)
 
-We meet weekly, and the time of the meeting alternates between Monday at 15:00
+We meet weekly, and the time of the meeting alternates between Monday at 13:00
 PT and Wednesday at 10:00 PT. The meeting is subject to change depending on
 contributors' availability. Check the [OpenTelemetry community
 calendar](https://calendar.google.com/calendar/embed?src=google.com_b79e3e90j7bbsa2n2p5an5lf60%40group.calendar.google.com)


### PR DESCRIPTION
## Changes

As agreed in the last couple of community meetings, we are changing Monday's community meeting time to 13:00 PT - 14:00 PT. This will allow members from the European region to join the meeting.

Google calendar is updated too.

For significant contributions please make sure you have completed the following items:

* [ ] `CHANGELOG.md` updated for non-trivial changes
* [ ] Unit tests have been added
* [ ] Changes in public API reviewed