### PR TITLE
Benchmark documentation

### DIFF
--- a/docs/performance/benchmarks.rst
+++ b/docs/performance/benchmarks.rst
@@ -3,4 +3,4 @@ Performance Tests - Benchmarks
 
 Click `here <https://open-telemetry.github.io/opentelemetry-cpp/benchmarks/index.html>`_ to view the latest performance benchmarks for packages in this repo.
 
-Please note that the flutation in the results are mainly because [machines with different CPUs](https://github.com/benchmark-action/github-action-benchmark/issues/79) are used for tests. 
+Please note that the flutation in the results are mainly because [machines with different CPUs](https://github.com/benchmark-action/github-action-benchmark/issues/79) are used for tests.

--- a/docs/performance/benchmarks.rst
+++ b/docs/performance/benchmarks.rst
@@ -2,3 +2,5 @@ Performance Tests - Benchmarks
 ==============================
 
 Click `here <https://open-telemetry.github.io/opentelemetry-cpp/benchmarks/index.html>`_ to view the latest performance benchmarks for packages in this repo.
+
+Please note that the flutation in the results are mainly because [machines with different CPUs](https://github.com/benchmark-action/github-action-benchmark/issues/79) are used for tests. 

--- a/docs/performance/benchmarks.rst
+++ b/docs/performance/benchmarks.rst
@@ -1,0 +1,4 @@
+Performance Tests - Benchmarks
+==============================
+
+Click `here <https://open-telemetry.github.io/opentelemetry-cpp/benchmarks/index.html>`_ to view the latest performance benchmarks for packages in this repo.

--- a/docs/public/index.rst
+++ b/docs/public/index.rst
@@ -37,6 +37,14 @@ OpenTelemetry C++
    otel_docs/namespace_opentelemetry__sdk__resource
 
 .. toctree::
+    :maxdepth: 1
+    :caption: Performance
+    :name: performance-tests
+    :glob:
+
+    performance/**
+
+.. toctree::
    :maxdepth: 1
    :caption: Further Reading
 


### PR DESCRIPTION
This PR adds the [result of benchmarks](https://open-telemetry.github.io/opentelemetry-cpp/benchmarks/index.html) to the documentation under the performance section.

## Changes

Please provide a brief description of the changes here.

For significant contributions please make sure you have completed the following items:

* [ ] `CHANGELOG.md` updated for non-trivial changes
* [ ] Unit tests have been added
* [ ] Changes in public API reviewed