### PR TITLE
fix ostream_log_test Mac

### DIFF
--- a/exporters/ostream/test/ostream_log_test.cc
+++ b/exporters/ostream/test/ostream_log_test.cc
@@ -74,22 +74,27 @@ TEST(OstreamLogExporter, DefaultLogRecordToCout)
   // Restore cout's original stringstream
   std::cout.rdbuf(original);
 
-  std::string expectedOutput =
+  std::vector<std::string> expected_output{
       "{\n"
       "  timestamp     : 0\n"
       "  severity_num  : 0\n"
       "  severity_text : INVALID\n"
       "  name          : \n"
-      "  body          : \n"
-      "  resource      : {{telemetry.sdk.version: " OPENTELEMETRY_VERSION
-      "}, {telemetry.sdk.name: opentelemetry}, {telemetry.sdk.language: cpp}}\n"
+      "  body          : \n",
+      "  resource      : {",
+      "{telemetry.sdk.version: " OPENTELEMETRY_VERSION "}",
+      "{telemetry.sdk.name: opentelemetry}",
+      "{telemetry.sdk.language: cpp}",
       "  attributes    : {}\n"
       "  trace_id      : 00000000000000000000000000000000\n"
       "  span_id       : 0000000000000000\n"
       "  trace_flags   : 00\n"
-      "}\n";
+      "}\n"};
 
-  ASSERT_EQ(output.str(), expectedOutput);
+  for (auto &expected : expected_output)
+  {
+    ASSERT_NE(output.str().find(expected), std::string::npos);
+  }
 }
 
 // Testing what a log record with only the "timestamp", "severity", "name" and "message" fields set,
@@ -121,24 +126,29 @@ TEST(OStreamLogExporter, SimpleLogToCout)
   // Reset cout's original stringstream buffer
   std::cout.rdbuf(original);
 
-  std::string expectedOutput =
+  std::vector<std::string> expected_output{
       "{\n"
       "  timestamp     : " +
-      std::to_string(now.time_since_epoch().count()) +
-      "\n"
-      "  severity_num  : 1\n"
-      "  severity_text : TRACE\n"
-      "  name          : Name\n"
-      "  body          : Message\n"
-      "  resource      : {{telemetry.sdk.version: " OPENTELEMETRY_VERSION
-      "}, {telemetry.sdk.name: opentelemetry}, "
-      "{telemetry.sdk.language: cpp}}\n"
+          std::to_string(now.time_since_epoch().count()) +
+          "\n"
+          "  severity_num  : 1\n"
+          "  severity_text : TRACE\n"
+          "  name          : Name\n"
+          "  body          : Message\n",
+      "  resource      : {",
+      "{telemetry.sdk.version: " OPENTELEMETRY_VERSION "}",
+      "{telemetry.sdk.name: opentelemetry}",
+      "{telemetry.sdk.language: cpp}",
       "  attributes    : {}\n"
       "  trace_id      : 00000000000000000000000000000000\n"
       "  span_id       : 0000000000000000\n"
       "  trace_flags   : 00\n"
-      "}\n";
-  ASSERT_EQ(output.str(), expectedOutput);
+      "}\n"};
+
+  for (auto &expected : expected_output)
+  {
+    ASSERT_NE(output.str().find(expected), std::string::npos);
+  }
 }
 
 // ---------------------------------- Print to cerr --------------------------
@@ -172,26 +182,29 @@ TEST(OStreamLogExporter, LogWithStringAttributesToCerr)
   // Reset cerr's original stringstream buffer
   std::cerr.rdbuf(original);
 
-  std::string expectedOutput =
+  std::vector<std::string> expected_output{
       "{\n"
       "  timestamp     : 0\n"
       "  severity_num  : 0\n"
       "  severity_text : INVALID\n"
       "  name          : \n"
-      "  body          : \n"
-      "  resource      : {{telemetry.sdk.version: " OPENTELEMETRY_VERSION
-      "}, {telemetry.sdk.name: opentelemetry}, {telemetry.sdk.language: cpp}, {service.name: "
-      "unknown_service}, {key1: val1}}\n"
+      "  body          : \n",
+      "  resource      : {",
+      "{telemetry.sdk.version: " OPENTELEMETRY_VERSION "}",
+      "{telemetry.sdk.name: opentelemetry}",
+      "{telemetry.sdk.language: cpp}",
+      "{service.name: unknown_service}",
+      "{key1: val1}",
       "  attributes    : {{a: 1}}\n"
       "  trace_id      : 00000000000000000000000000000000\n"
       "  span_id       : 0000000000000000\n"
       "  trace_flags   : 00\n"
-      "}\n";
-// TODO this test fails on Mac
-// issue https://github.com/open-telemetry/opentelemetry-cpp/issues/1187
-#  if !defined(__APPLE__)
-  ASSERT_EQ(stdcerrOutput.str(), expectedOutput);
-#  endif
+      "}\n"};
+
+  for (auto &expected : expected_output)
+  {
+    ASSERT_NE(stdcerrOutput.str().find(expected), std::string::npos);
+  }
 }
 
 // ---------------------------------- Print to clog -------------------------
@@ -231,26 +244,29 @@ TEST(OStreamLogExporter, LogWithVariantTypesToClog)
   // Reset clog's original stringstream buffer
   std::clog.rdbuf(original);
 
-  std::string expectedOutput =
+  std::vector<std::string> expected_output{
       "{\n"
       "  timestamp     : 0\n"
       "  severity_num  : 0\n"
       "  severity_text : INVALID\n"
       "  name          : \n"
-      "  body          : \n"
-      "  resource      : {{service.name: unknown_service}, "
-      "{telemetry.sdk.version: " OPENTELEMETRY_VERSION
-      "}, {telemetry.sdk.name: opentelemetry}, {telemetry.sdk.language: cpp}, {res1: [1, 2, 3]}}\n"
+      "  body          : \n",
+      "  resource      : {",
+      "{service.name: unknown_service}",
+      "{telemetry.sdk.version: " OPENTELEMETRY_VERSION "}",
+      "{telemetry.sdk.name: opentelemetry}",
+      "{telemetry.sdk.language: cpp}",
+      "{res1: [1, 2, 3]}",
       "  attributes    : {{attr1: [0, 1, 0]}}\n"
       "  trace_id      : 00000000000000000000000000000000\n"
       "  span_id       : 0000000000000000\n"
       "  trace_flags   : 00\n"
-      "}\n";
-// TODO this test fails on Mac
-// issue https://github.com/open-telemetry/opentelemetry-cpp/issues/1187
-#  if !defined(__APPLE__)
-  ASSERT_EQ(stdclogOutput.str(), expectedOutput);
-#  endif
+      "}\n"};
+
+  for (auto &expected : expected_output)
+  {
+    ASSERT_NE(stdclogOutput.str().find(expected), std::string::npos);
+  }
 }
 
 // // ---------------------------------- Integration Tests -------------------------
@@ -286,28 +302,30 @@ TEST(OStreamLogExporter, IntegrationTest)
   std::cout.rdbuf(original);
 
   // Compare actual vs expected outputs
-  std::string expectedOutput =
+  std::vector<std::string> expected_output{
       "{\n"
       "  timestamp     : " +
-      std::to_string(now.time_since_epoch().count()) +
-      "\n"
-      "  severity_num  : 5\n"
-      "  severity_text : DEBUG\n"
-      "  name          : \n"
-      "  body          : Hello\n"
-      "  resource      : {{service.name: unknown_service}, "
-      "{telemetry.sdk.version: " OPENTELEMETRY_VERSION
-      "}, {telemetry.sdk.name: opentelemetry}, {telemetry.sdk.language: cpp}}\n"
+          std::to_string(now.time_since_epoch().count()) +
+          "\n"
+          "  severity_num  : 5\n"
+          "  severity_text : DEBUG\n"
+          "  name          : \n"
+          "  body          : Hello\n",
+      "  resource      : {",
+      "{telemetry.sdk.version: " OPENTELEMETRY_VERSION "}",
+      "{service.name: unknown_service}",
+      "{telemetry.sdk.name: opentelemetry}",
+      "{telemetry.sdk.language: cpp}",
       "  attributes    : {}\n"
       "  trace_id      : 00000000000000000000000000000000\n"
       "  span_id       : 0000000000000000\n"
       "  trace_flags   : 00\n"
-      "}\n";
-// TODO this test fails on Mac
-// issue https://github.com/open-telemetry/opentelemetry-cpp/issues/1187
-#  if !defined(__APPLE__)
-  ASSERT_EQ(stdcoutOutput.str(), expectedOutput);
-#  endif
+      "}\n"};
+
+  for (auto &expected : expected_output)
+  {
+    ASSERT_NE(stdcoutOutput.str().find(expected), std::string::npos);
+  }
 }
 
 }  // namespace logs


### PR DESCRIPTION
Fixes #1187 (issue)

## Changes

The issue is because of `std::unordered_map` that is used for [printing](https://github.com/open-telemetry/opentelemetry-cpp/blob/e89e5b3dd65b0e73435c12b9fdeb54f9420f4bb4/exporters/ostream/src/log_exporter.cc#L80) resource attributes. The order in printing is not guaranteed. In this PR the key-value pairs are tested one-by-one.

For significant contributions please make sure you have completed the following items:

* [ ] `CHANGELOG.md` updated for non-trivial changes
* [ ] Unit tests have been added
* [ ] Changes in public API reviewed