### PR TITLE
Concurrency HTTP sessions for `OtlpHttpClient`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ Increment the:
 ## [Unreleased]
 
 * [EXPORTER] Jaeger Exporter - Populate Span Links ([#1251](https://github.com/open-telemetry/opentelemetry-cpp/pull/1251))
+* [EXPORTER] OTLP http exporter allow concurrency session ([#1209](https://github.com/open-telemetry/opentelemetry-cpp/pull/1209))
 
 ## [1.2.0] 2022-01-31
 

--- a/exporters/elasticsearch/include/opentelemetry/exporters/elasticsearch/es_log_exporter.h
+++ b/exporters/elasticsearch/include/opentelemetry/exporters/elasticsearch/es_log_exporter.h
@@ -90,6 +90,17 @@ public:
           &records) noexcept override;
 
   /**
+   * Exports a vector of log records to the Elasticsearch instance asynchronously.
+   * @param records A list of log records to send to Elasticsearch.
+   * @param result_callback callback function accepting ExportResult as argument
+   */
+  void Export(
+      const opentelemetry::nostd::span<std::unique_ptr<opentelemetry::sdk::logs::Recordable>>
+          &records,
+      nostd::function_ref<bool(opentelemetry::sdk::common::ExportResult)> result_callback) noexcept
+      override;
+
+  /**
    * Shutdown this exporter.
    * @param timeout The maximum time to wait for the shutdown method to return
    */

--- a/exporters/elasticsearch/include/opentelemetry/exporters/elasticsearch/es_log_exporter.h
+++ b/exporters/elasticsearch/include/opentelemetry/exporters/elasticsearch/es_log_exporter.h
@@ -97,7 +97,7 @@ public:
   void Export(
       const opentelemetry::nostd::span<std::unique_ptr<opentelemetry::sdk::logs::Recordable>>
           &records,
-      nostd::function_ref<bool(opentelemetry::sdk::common::ExportResult)> result_callback) noexcept
+      std::function<bool(opentelemetry::sdk::common::ExportResult)> &&result_callback) noexcept
       override;
 
   /**

--- a/exporters/elasticsearch/src/es_log_exporter.cc
+++ b/exporters/elasticsearch/src/es_log_exporter.cc
@@ -110,6 +110,89 @@ private:
   bool console_debug_ = false;
 };
 
+/**
+ * This class handles the async response message from the Elasticsearch request
+ */
+class AsyncResponseHandler : public http_client::EventHandler
+{
+public:
+  /**
+   * Creates a response handler, that by default doesn't display to console
+   */
+  AsyncResponseHandler(
+      std::shared_ptr<ext::http::client::Session> session,
+      nostd::function_ref<bool(opentelemetry::sdk::common::ExportResult)> result_callback,
+      bool console_debug = false)
+      : console_debug_{console_debug},
+        session_{std::move(session)},
+        result_callback_{result_callback}
+  {}
+
+  /**
+   * Cleans up the session in the destructor.
+   */
+  ~AsyncResponseHandler() { session_->FinishSession(); }
+
+  /**
+   * Automatically called when the response is received
+   */
+  void OnResponse(http_client::Response &response) noexcept override
+  {
+
+    // Store the body of the request
+    body_ = std::string(response.GetBody().begin(), response.GetBody().end());
+    if (body_.find("\"failed\" : 0") == std::string::npos)
+    {
+      OTEL_INTERNAL_LOG_ERROR(
+          "[ES Trace Exporter] Logs were not written to Elasticsearch correctly, response body: "
+          << body_);
+      result_callback_(sdk::common::ExportResult::kFailure);
+    }
+    else
+    {
+      result_callback_(sdk::common::ExportResult::kSuccess);
+    }
+  }
+
+  // Callback method when an http event occurs
+  void OnEvent(http_client::SessionState state, nostd::string_view reason) noexcept override
+  {
+    // If any failure event occurs, release the condition variable to unblock main thread
+    switch (state)
+    {
+      case http_client::SessionState::ConnectFailed:
+        OTEL_INTERNAL_LOG_ERROR("[ES Trace Exporter] Connection to elasticsearch failed");
+        break;
+      case http_client::SessionState::SendFailed:
+        OTEL_INTERNAL_LOG_ERROR("[ES Trace Exporter] Request failed to be sent to elasticsearch");
+
+        break;
+      case http_client::SessionState::TimedOut:
+        OTEL_INTERNAL_LOG_ERROR("[ES Trace Exporter] Request to elasticsearch timed out");
+
+        break;
+      case http_client::SessionState::NetworkError:
+        OTEL_INTERNAL_LOG_ERROR("[ES Trace Exporter] Network error to elasticsearch");
+        break;
+      default:
+        break;
+    }
+    result_callback_(sdk::common::ExportResult::kFailure);
+  }
+
+private:
+  // Stores the session object for the request
+  std::shared_ptr<ext::http::client::Session> session_;
+  // Callback to call to on receiving events
+  nostd::function_ref<bool(opentelemetry::sdk::common::ExportResult)> result_callback_;
+
+  // A string to store the response body
+  std::string body_ = "";
+
+  // Whether to print the results from the callback
+  bool console_debug_ = false;
+};
+
 ElasticsearchLogExporter::ElasticsearchLogExporter()
     : options_{ElasticsearchExporterOptions()},
       http_client_{new ext::http::client::curl::HttpClient()}
@@ -162,8 +245,8 @@ sdk::common::ExportResult ElasticsearchLogExporter::Export(
   request->SetBody(body_vec);
 
   // Send the request
-  std::unique_ptr<ResponseHandler> handler(new ResponseHandler(options_.console_debug_));
-  session->SendRequest(*handler);
+  auto handler = std::make_shared<ResponseHandler>(options_.console_debug_);
+  session->SendRequest(handler);
 
   // Wait for the response to be received
   if (options_.console_debug_)
@@ -196,6 +279,51 @@ sdk::common::ExportResult ElasticsearchLogExporter::Export(
   }
 
   return sdk::common::ExportResult::kSuccess;
+}
+
+void ElasticsearchLogExporter::Export(
+    const opentelemetry::nostd::span<std::unique_ptr<opentelemetry::sdk::logs::Recordable>>
+        &records,
+    nostd::function_ref<bool(opentelemetry::sdk::common::ExportResult)> result_callback) noexcept
+{
+  // Return failure if this exporter has been shutdown
+  if (isShutdown())
+  {
+    OTEL_INTERNAL_LOG_ERROR("[ES Log Exporter] Exporting "
+                            << records.size() << " log(s) failed, exporter is shutdown");
+    return;
+  }
+
+  // Create a connection to the ElasticSearch instance
+  auto session = http_client_->CreateSession(options_.host_ + std::to_string(options_.port_));
+  auto request = session->CreateRequest();
+
+  // Populate the request with headers and methods
+  request->SetUri(options_.index_ + "/_bulk?pretty");
+  request->SetMethod(http_client::Method::Post);
+  request->AddHeader("Content-Type", "application/json");
+  request->SetTimeoutMs(std::chrono::milliseconds(1000 * options_.response_timeout_));
+
+  // Create the request body
+  std::string body = "";
+  for (auto &record : records)
+  {
+    // Append {"index":{}} before JSON body, which tells Elasticsearch to write to index specified
+    // in URI
+    body += "{\"index\" : {}}\n";
+
+    // Add the context of the Recordable
+    auto json_record = std::unique_ptr<ElasticSearchRecordable>(
+        static_cast<ElasticSearchRecordable *>(record.release()));
+    body += json_record->GetJSON().dump() + "\n";
+  }
+  std::vector<uint8_t> body_vec(body.begin(), body.end());
+  request->SetBody(body_vec);
+
+  // Send the request
+  auto handler =
+      std::make_shared<AsyncResponseHandler>(session, result_callback, options_.console_debug_);
+  session->SendRequest(handler);
 }
 
 bool ElasticsearchLogExporter::Shutdown(std::chrono::microseconds timeout) noexcept

--- a/exporters/jaeger/include/opentelemetry/exporters/jaeger/jaeger_exporter.h
+++ b/exporters/jaeger/include/opentelemetry/exporters/jaeger/jaeger_exporter.h
@@ -67,8 +67,8 @@ public:
    * @param result_callback callback function accepting ExportResult as argument
    */
   void Export(const nostd::span<std::unique_ptr<opentelemetry::sdk::trace::Recordable>> &spans,
-              nostd::function_ref<bool(opentelemetry::sdk::common::ExportResult)>
-                  result_callback) noexcept override;
+              std::function<bool(opentelemetry::sdk::common::ExportResult)>
+                  &&result_callback) noexcept override;
 
   /**
    * Shutdown the exporter.

--- a/exporters/jaeger/include/opentelemetry/exporters/jaeger/jaeger_exporter.h
+++ b/exporters/jaeger/include/opentelemetry/exporters/jaeger/jaeger_exporter.h
@@ -62,6 +62,15 @@ public:
       override;
 
   /**
+   * Exports a batch of span recordables asynchronously.
+   * @param spans a span of unique pointers to span recordables
+   * @param result_callback callback function accepting ExportResult as argument
+   */
+  void Export(const nostd::span<std::unique_ptr<opentelemetry::sdk::trace::Recordable>> &spans,
+              nostd::function_ref<bool(opentelemetry::sdk::common::ExportResult)>
+                  result_callback) noexcept override;
+
+  /**
    * Shutdown the exporter.
    * @param timeout an option timeout, default to max.
    */

--- a/exporters/jaeger/src/jaeger_exporter.cc
+++ b/exporters/jaeger/src/jaeger_exporter.cc
@@ -72,7 +72,7 @@ sdk_common::ExportResult JaegerExporter::Export(
 
 void JaegerExporter::Export(
     const nostd::span<std::unique_ptr<sdk::trace::Recordable>> &spans,
-    nostd::function_ref<bool(sdk::common::ExportResult)> result_callback) noexcept
+    std::function<bool(opentelemetry::sdk::common::ExportResult)> &&result_callback) noexcept
 {
   OTEL_INTERNAL_LOG_WARN(" async not supported. Making sync interface call");
   auto status = Export(spans);

--- a/exporters/jaeger/src/jaeger_exporter.cc
+++ b/exporters/jaeger/src/jaeger_exporter.cc
@@ -70,6 +70,15 @@ sdk_common::ExportResult JaegerExporter::Export(
   return sdk_common::ExportResult::kSuccess;
 }
 
+void JaegerExporter::Export(
+    const nostd::span<std::unique_ptr<sdk::trace::Recordable>> &spans,
+    nostd::function_ref<bool(sdk::common::ExportResult)> result_callback) noexcept
+{
+  OTEL_INTERNAL_LOG_WARN(" async not supported. Making sync interface call");
+  auto status = Export(spans);
+  result_callback(status);
+}
+
 void JaegerExporter::InitializeEndpoint()
 {
   if (options_.transport_format == TransportFormat::kThriftUdpCompact)

--- a/exporters/memory/include/opentelemetry/exporters/memory/in_memory_span_exporter.h
+++ b/exporters/memory/include/opentelemetry/exporters/memory/in_memory_span_exporter.h
@@ -65,6 +65,20 @@ public:
   }
 
   /**
+   * Exports a batch of span recordables asynchronously.
+   * @param spans a span of unique pointers to span recordables
+   * @param result_callback callback function accepting ExportResult as argument
+   */
+  void Export(
+      const nostd::span<std::unique_ptr<sdk::trace::Recordable>> &spans,
+      nostd::function_ref<bool(sdk::common::ExportResult)> result_callback) noexcept override
+  {
+    OTEL_INTERNAL_LOG_WARN(" async not supported. Making sync interface call");
+    auto status = Export(spans);
+    result_callback(status);
+  }
+
+  /**
    * @param timeout an optional value containing the timeout of the exporter
    * note: passing custom timeout values is not currently supported for this exporter
    * @return Returns the status of the operation

--- a/exporters/memory/include/opentelemetry/exporters/memory/in_memory_span_exporter.h
+++ b/exporters/memory/include/opentelemetry/exporters/memory/in_memory_span_exporter.h
@@ -69,9 +69,9 @@ public:
    * @param spans a span of unique pointers to span recordables
    * @param result_callback callback function accepting ExportResult as argument
    */
-  void Export(
-      const nostd::span<std::unique_ptr<sdk::trace::Recordable>> &spans,
-      nostd::function_ref<bool(sdk::common::ExportResult)> result_callback) noexcept override
+  void Export(const nostd::span<std::unique_ptr<sdk::trace::Recordable>> &spans,
+              std::function<bool(opentelemetry::sdk::common::ExportResult)>
+                  &&result_callback) noexcept override
   {
     OTEL_INTERNAL_LOG_WARN(" async not supported. Making sync interface call");
     auto status = Export(spans);

--- a/exporters/ostream/include/opentelemetry/exporters/ostream/log_exporter.h
+++ b/exporters/ostream/include/opentelemetry/exporters/ostream/log_exporter.h
@@ -42,9 +42,9 @@ public:
   /**
    * Exports a span of logs sent from the processor asynchronously.
    */
-  void Export(const opentelemetry::nostd::span<std::unique_ptr<sdk::logs::Recordable>> &records,
-              opentelemetry::nostd::function_ref<bool(opentelemetry::sdk::common::ExportResult)>
-                  result_callback) noexcept;
+  void Export(
+      const opentelemetry::nostd::span<std::unique_ptr<sdk::logs::Recordable>> &records,
+      std::function<bool(opentelemetry::sdk::common::ExportResult)> &&result_callback) noexcept;
 
   /**
    * Marks the OStream Log Exporter as shut down.

--- a/exporters/ostream/include/opentelemetry/exporters/ostream/log_exporter.h
+++ b/exporters/ostream/include/opentelemetry/exporters/ostream/log_exporter.h
@@ -40,6 +40,13 @@ public:
       override;
 
   /**
+   * Exports a span of logs sent from the processor asynchronously.
+   */
+  void Export(const opentelemetry::nostd::span<std::unique_ptr<sdk::logs::Recordable>> &records,
+              opentelemetry::nostd::function_ref<bool(opentelemetry::sdk::common::ExportResult)>
+                  result_callback) noexcept;
+
+  /**
    * Marks the OStream Log Exporter as shut down.
    */
   bool Shutdown(

--- a/exporters/ostream/include/opentelemetry/exporters/ostream/span_exporter.h
+++ b/exporters/ostream/include/opentelemetry/exporters/ostream/span_exporter.h
@@ -41,8 +41,8 @@ public:
   void Export(
       const opentelemetry::nostd::span<std::unique_ptr<opentelemetry::sdk::trace::Recordable>>
           &spans,
-      opentelemetry::nostd::function_ref<bool(opentelemetry::sdk::common::ExportResult)>
-          result_callback) noexcept override;
+      std::function<bool(opentelemetry::sdk::common::ExportResult)> &&result_callback) noexcept
+      override;
 
   bool Shutdown(
       std::chrono::microseconds timeout = std::chrono::microseconds::max()) noexcept override;

--- a/exporters/ostream/include/opentelemetry/exporters/ostream/span_exporter.h
+++ b/exporters/ostream/include/opentelemetry/exporters/ostream/span_exporter.h
@@ -38,6 +38,12 @@ public:
       const opentelemetry::nostd::span<std::unique_ptr<opentelemetry::sdk::trace::Recordable>>
           &spans) noexcept override;
 
+  void Export(
+      const opentelemetry::nostd::span<std::unique_ptr<opentelemetry::sdk::trace::Recordable>>
+          &spans,
+      opentelemetry::nostd::function_ref<bool(opentelemetry::sdk::common::ExportResult)>
+          result_callback) noexcept override;
+
   bool Shutdown(
       std::chrono::microseconds timeout = std::chrono::microseconds::max()) noexcept override;
 

--- a/exporters/ostream/src/log_exporter.cc
+++ b/exporters/ostream/src/log_exporter.cc
@@ -180,6 +180,16 @@ sdk::common::ExportResult OStreamLogExporter::Export(
   return sdk::common::ExportResult::kSuccess;
 }
 
+void OStreamLogExporter::Export(
+    const opentelemetry::nostd::span<std::unique_ptr<sdk::logs::Recordable>> &records,
+    opentelemetry::nostd::function_ref<bool(opentelemetry::sdk::common::ExportResult)>
+        result_callback) noexcept
+{
+  // Do not have async support
+  auto result = Export(records);
+  result_callback(result);
+}
+
 bool OStreamLogExporter::Shutdown(std::chrono::microseconds) noexcept
 {
   const std::lock_guard<opentelemetry::common::SpinLockMutex> locked(lock_);

--- a/exporters/ostream/src/log_exporter.cc
+++ b/exporters/ostream/src/log_exporter.cc
@@ -180,7 +180,7 @@ sdk::common::ExportResult OStreamLogExporter::Export(
   return sdk::common::ExportResult::kSuccess;
 }
 
-bool OStreamLogExporter::Shutdown(std::chrono::microseconds timeout) noexcept
+bool OStreamLogExporter::Shutdown(std::chrono::microseconds) noexcept
 {
   const std::lock_guard<opentelemetry::common::SpinLockMutex> locked(lock_);
   is_shutdown_ = true;

--- a/exporters/ostream/src/log_exporter.cc
+++ b/exporters/ostream/src/log_exporter.cc
@@ -182,8 +182,7 @@ sdk::common::ExportResult OStreamLogExporter::Export(
 
 void OStreamLogExporter::Export(
     const opentelemetry::nostd::span<std::unique_ptr<sdk::logs::Recordable>> &records,
-    opentelemetry::nostd::function_ref<bool(opentelemetry::sdk::common::ExportResult)>
-        result_callback) noexcept
+    std::function<bool(opentelemetry::sdk::common::ExportResult)> &&result_callback) noexcept
 {
   // Do not have async support
   auto result = Export(records);

--- a/exporters/ostream/src/span_exporter.cc
+++ b/exporters/ostream/src/span_exporter.cc
@@ -98,8 +98,7 @@ sdk::common::ExportResult OStreamSpanExporter::Export(
 
 void OStreamSpanExporter::Export(
     const opentelemetry::nostd::span<std::unique_ptr<opentelemetry::sdk::trace::Recordable>> &spans,
-    opentelemetry::nostd::function_ref<bool(opentelemetry::sdk::common::ExportResult)>
-        result_callback) noexcept
+    std::function<bool(opentelemetry::sdk::common::ExportResult)> &&result_callback) noexcept
 {
   auto result = Export(spans);
   result_callback(result);

--- a/exporters/ostream/src/span_exporter.cc
+++ b/exporters/ostream/src/span_exporter.cc
@@ -96,6 +96,15 @@ sdk::common::ExportResult OStreamSpanExporter::Export(
   return sdk::common::ExportResult::kSuccess;
 }
 
+void OStreamSpanExporter::Export(
+    const opentelemetry::nostd::span<std::unique_ptr<opentelemetry::sdk::trace::Recordable>> &spans,
+    opentelemetry::nostd::function_ref<bool(opentelemetry::sdk::common::ExportResult)>
+        result_callback) noexcept
+{
+  auto result = Export(spans);
+  result_callback(result);
+}
+
 bool OStreamSpanExporter::Shutdown(std::chrono::microseconds timeout) noexcept
 {
   const std::lock_guard<opentelemetry::common::SpinLockMutex> locked(lock_);

--- a/exporters/otlp/include/opentelemetry/exporters/otlp/otlp_grpc_exporter.h
+++ b/exporters/otlp/include/opentelemetry/exporters/otlp/otlp_grpc_exporter.h
@@ -57,9 +57,9 @@ public:
    * @param spans a span of unique pointers to span recordables
    * @param result_callback callback function accepting ExportResult as argument
    */
-  virtual void Export(
-      const nostd::span<std::unique_ptr<sdk::trace::Recordable>> &spans,
-      nostd::function_ref<bool(sdk::common::ExportResult)> result_callback) noexcept override;
+  virtual void Export(const nostd::span<std::unique_ptr<sdk::trace::Recordable>> &spans,
+                      std::function<bool(opentelemetry::sdk::common::ExportResult)>
+                          &&result_callback) noexcept override;
 
   /**
    * Shut down the exporter.

--- a/exporters/otlp/include/opentelemetry/exporters/otlp/otlp_grpc_exporter.h
+++ b/exporters/otlp/include/opentelemetry/exporters/otlp/otlp_grpc_exporter.h
@@ -53,6 +53,15 @@ public:
       const nostd::span<std::unique_ptr<sdk::trace::Recordable>> &spans) noexcept override;
 
   /**
+   * Exports a batch of span recordables asynchronously.
+   * @param spans a span of unique pointers to span recordables
+   * @param result_callback callback function accepting ExportResult as argument
+   */
+  virtual void Export(
+      const nostd::span<std::unique_ptr<sdk::trace::Recordable>> &spans,
+      nostd::function_ref<bool(sdk::common::ExportResult)> result_callback) noexcept override;
+
+  /**
    * Shut down the exporter.
    * @param timeout an optional timeout, the default timeout of 0 means that no
    * timeout is applied.

--- a/exporters/otlp/include/opentelemetry/exporters/otlp/otlp_grpc_log_exporter.h
+++ b/exporters/otlp/include/opentelemetry/exporters/otlp/otlp_grpc_log_exporter.h
@@ -56,6 +56,16 @@ public:
       override;
 
   /**
+   * Exports a vector of log records asynchronously.
+   * @param records A list of log records.
+   * @param result_callback callback function accepting ExportResult as argument
+   */
+  virtual void Export(
+      const nostd::span<std::unique_ptr<opentelemetry::sdk::logs::Recordable>> &records,
+      nostd::function_ref<bool(opentelemetry::sdk::common::ExportResult)> result_callback) noexcept
+      override;
+
+  /**
    * Shutdown this exporter.
    * @param timeout The maximum time to wait for the shutdown method to return.
    */

--- a/exporters/otlp/include/opentelemetry/exporters/otlp/otlp_grpc_log_exporter.h
+++ b/exporters/otlp/include/opentelemetry/exporters/otlp/otlp_grpc_log_exporter.h
@@ -62,7 +62,7 @@ public:
    */
   virtual void Export(
       const nostd::span<std::unique_ptr<opentelemetry::sdk::logs::Recordable>> &records,
-      nostd::function_ref<bool(opentelemetry::sdk::common::ExportResult)> result_callback) noexcept
+      std::function<bool(opentelemetry::sdk::common::ExportResult)> &&result_callback) noexcept
       override;
 
   /**

--- a/exporters/otlp/include/opentelemetry/exporters/otlp/otlp_http_client.h
+++ b/exporters/otlp/include/opentelemetry/exporters/otlp/otlp_http_client.h
@@ -141,7 +141,7 @@ private:
    */
   void addSession(
       std::shared_ptr<opentelemetry::ext::http::client::Session> session,
-      std::unique_ptr<opentelemetry::ext::http::client::EventHandler> &&event_handle) noexcept;
+      std::shared_ptr<opentelemetry::ext::http::client::EventHandler> event_handle) noexcept;
 
   /**
    * @brief Real delete all sessions and event handles.
@@ -168,13 +168,13 @@ private:
   struct HttpSessionData
   {
     std::shared_ptr<opentelemetry::ext::http::client::Session> session;
-    std::unique_ptr<opentelemetry::ext::http::client::EventHandler> event_handle;
+    std::shared_ptr<opentelemetry::ext::http::client::EventHandler> event_handle;
 
     inline HttpSessionData() = default;
 
     inline explicit HttpSessionData(
         std::shared_ptr<opentelemetry::ext::http::client::Session> &&input_session,
-        std::unique_ptr<opentelemetry::ext::http::client::EventHandler> &&input_handle)
+        std::shared_ptr<opentelemetry::ext::http::client::EventHandler> &&input_handle)
     {
       session.swap(input_session);
       event_handle.swap(input_handle);

--- a/exporters/otlp/include/opentelemetry/exporters/otlp/otlp_http_client.h
+++ b/exporters/otlp/include/opentelemetry/exporters/otlp/otlp_http_client.h
@@ -15,10 +15,15 @@
 
 #include "opentelemetry/exporters/otlp/otlp_environment.h"
 
+#include <atomic>
 #include <chrono>
+#include <condition_variable>
+#include <cstddef>
+#include <list>
 #include <memory>
 #include <mutex>
 #include <string>
+#include <unordered_map>
 
 OPENTELEMETRY_BEGIN_NAMESPACE
 namespace exporter
@@ -71,20 +76,25 @@ struct OtlpHttpClientOptions
   // Additional HTTP headers
   OtlpHeaders http_headers = GetOtlpDefaultHeaders();
 
+  // Concurrent sessions
+  std::size_t concurrent_sessions = 8;
+
   inline OtlpHttpClientOptions(nostd::string_view input_url,
                                HttpRequestContentType input_content_type,
                                JsonBytesMappingKind input_json_bytes_mapping,
                                bool input_use_json_name,
                                bool input_console_debug,
                                std::chrono::system_clock::duration input_timeout,
-                               const OtlpHeaders &input_http_headers)
+                               const OtlpHeaders &input_http_headers,
+                               std::size_t input_concurrent_sessions = 8)
       : url(input_url),
         content_type(input_content_type),
         json_bytes_mapping(input_json_bytes_mapping),
         use_json_name(input_use_json_name),
         console_debug(input_console_debug),
         timeout(input_timeout),
-        http_headers(input_http_headers)
+        http_headers(input_http_headers),
+        concurrent_sessions(input_concurrent_sessions)
   {}
 };
 
@@ -98,6 +108,8 @@ public:
    * Create an OtlpHttpClient using the given options.
    */
   explicit OtlpHttpClient(OtlpHttpClientOptions &&options);
+
+  ~OtlpHttpClient();
 
   /**
    * Export
@@ -114,19 +126,33 @@ public:
    */
   bool Shutdown(std::chrono::microseconds timeout = std::chrono::microseconds(0)) noexcept;
 
+  /**
+   * @brief Release the lifetime of specify session.
+   *
+   * @param session the session to release
+   */
+  void ReleaseSession(const opentelemetry::ext::http::client::Session &session) noexcept;
+
 private:
-  // Stores if this HTTP client had its Shutdown() method called
-  bool is_shutdown_ = false;
+  /**
+   * Add http session and hold it's lifetime.
+   * @param session the session to add
+   * @param event_handle the event handle of this session
+   */
+  void addSession(
+      std::shared_ptr<opentelemetry::ext::http::client::Session> session,
+      std::unique_ptr<opentelemetry::ext::http::client::EventHandler> &&event_handle) noexcept;
 
-  // The configuration options associated with this HTTP client.
-  const OtlpHttpClientOptions options_;
+  /**
+   * @brief Real delete all sessions and event handles.
+   * @note This function is called in the same thread where we create sessions and handles
+   *
+   * @return return true if there are more sessions to delete
+   */
+  bool cleanupGCSessions() noexcept;
 
-  // Object that stores the HTTP sessions that have been created
-  std::shared_ptr<ext::http::client::HttpClient> http_client_;
-  // Cached parsed URI
-  std::string http_uri_;
-  mutable opentelemetry::common::SpinLockMutex lock_;
   bool isShutdown() const noexcept;
+
   // For testing
   friend class OtlpHttpExporterTestPeer;
   friend class OtlpHttpLogExporterTestPeer;
@@ -138,6 +164,51 @@ private:
    */
   OtlpHttpClient(OtlpHttpClientOptions &&options,
                  std::shared_ptr<ext::http::client::HttpClient> http_client);
+
+  struct HttpSessionData
+  {
+    std::shared_ptr<opentelemetry::ext::http::client::Session> session;
+    std::unique_ptr<opentelemetry::ext::http::client::EventHandler> event_handle;
+
+    inline HttpSessionData() = default;
+
+    inline explicit HttpSessionData(
+        std::shared_ptr<opentelemetry::ext::http::client::Session> &&input_session,
+        std::unique_ptr<opentelemetry::ext::http::client::EventHandler> &&input_handle)
+    {
+      session.swap(input_session);
+      event_handle.swap(input_handle);
+    }
+
+    inline explicit HttpSessionData(HttpSessionData &&other)
+    {
+      session.swap(other.session);
+      event_handle.swap(other.event_handle);
+    }
+  };
+
+  // Stores if this HTTP client had its Shutdown() method called
+  bool is_shutdown_;
+
+  // The configuration options associated with this HTTP client.
+  const OtlpHttpClientOptions options_;
+
+  // Object that stores the HTTP sessions that have been created
+  std::shared_ptr<ext::http::client::HttpClient> http_client_;
+
+  // Cached parsed URI
+  std::string http_uri_;
+
+  // Running sessions and event handles
+  std::unordered_map<const opentelemetry::ext::http::client::Session *, HttpSessionData>
+      running_sessions_;
+  // Sessions and event handles that are waiting to be deleted
+  std::list<HttpSessionData> gc_sessions_;
+  // Lock for running_sessions_, gc_sessions_ and http_client_
+  std::recursive_mutex session_manager_lock_;
+  // Condition variable and mutex to control the concurrency count of running sessions
+  std::mutex session_waker_lock_;
+  std::condition_variable session_waker_;
 };
 }  // namespace otlp
 }  // namespace exporter

--- a/exporters/otlp/include/opentelemetry/exporters/otlp/otlp_http_exporter.h
+++ b/exporters/otlp/include/opentelemetry/exporters/otlp/otlp_http_exporter.h
@@ -11,6 +11,7 @@
 #include "opentelemetry/exporters/otlp/otlp_environment.h"
 
 #include <chrono>
+#include <cstddef>
 #include <memory>
 #include <string>
 
@@ -50,6 +51,9 @@ struct OtlpHttpExporterOptions
 
   // Additional HTTP headers
   OtlpHeaders http_headers = GetOtlpDefaultHeaders();
+
+  // Concurrent sessions
+  std::size_t concurrent_sessions = 8;
 };
 
 /**

--- a/exporters/otlp/include/opentelemetry/exporters/otlp/otlp_http_exporter.h
+++ b/exporters/otlp/include/opentelemetry/exporters/otlp/otlp_http_exporter.h
@@ -87,6 +87,16 @@ public:
       override;
 
   /**
+   * Exports a batch of span recordables asynchronously.
+   * @param spans a span of unique pointers to span recordables
+   * @param result_callback callback function accepting ExportResult as argument
+   */
+  virtual void Export(
+      const nostd::span<std::unique_ptr<opentelemetry::sdk::trace::Recordable>> &spans,
+      nostd::function_ref<bool(opentelemetry::sdk::common::ExportResult)> result_callback) noexcept
+      override;
+
+  /**
    * Shut down the exporter.
    * @param timeout an optional timeout, the default timeout of 0 means that no
    * timeout is applied.

--- a/exporters/otlp/include/opentelemetry/exporters/otlp/otlp_http_exporter.h
+++ b/exporters/otlp/include/opentelemetry/exporters/otlp/otlp_http_exporter.h
@@ -93,7 +93,7 @@ public:
    */
   virtual void Export(
       const nostd::span<std::unique_ptr<opentelemetry::sdk::trace::Recordable>> &spans,
-      nostd::function_ref<bool(opentelemetry::sdk::common::ExportResult)> result_callback) noexcept
+      std::function<bool(opentelemetry::sdk::common::ExportResult)> &&result_callback) noexcept
       override;
 
   /**

--- a/exporters/otlp/include/opentelemetry/exporters/otlp/otlp_http_log_exporter.h
+++ b/exporters/otlp/include/opentelemetry/exporters/otlp/otlp_http_log_exporter.h
@@ -88,6 +88,16 @@ public:
       override;
 
   /**
+   * Exports a vector of log records asynchronously.
+   * @param records A list of log records.
+   * @param result_callback callback function accepting ExportResult as argument
+   */
+  virtual void Export(
+      const nostd::span<std::unique_ptr<opentelemetry::sdk::logs::Recordable>> &records,
+      nostd::function_ref<bool(opentelemetry::sdk::common::ExportResult)> result_callback) noexcept
+      override;
+
+  /**
    * Shutdown this exporter.
    * @param timeout The maximum time to wait for the shutdown method to return
    */

--- a/exporters/otlp/include/opentelemetry/exporters/otlp/otlp_http_log_exporter.h
+++ b/exporters/otlp/include/opentelemetry/exporters/otlp/otlp_http_log_exporter.h
@@ -11,6 +11,7 @@
 #  include "opentelemetry/exporters/otlp/otlp_environment.h"
 
 #  include <chrono>
+#  include <cstddef>
 #  include <memory>
 #  include <string>
 
@@ -50,6 +51,9 @@ struct OtlpHttpLogExporterOptions
 
   // Additional HTTP headers
   OtlpHeaders http_headers = GetOtlpDefaultLogHeaders();
+
+  // Concurrent sessions
+  std::size_t concurrent_sessions = 8;
 };
 
 /**

--- a/exporters/otlp/include/opentelemetry/exporters/otlp/otlp_http_log_exporter.h
+++ b/exporters/otlp/include/opentelemetry/exporters/otlp/otlp_http_log_exporter.h
@@ -94,7 +94,7 @@ public:
    */
   virtual void Export(
       const nostd::span<std::unique_ptr<opentelemetry::sdk::logs::Recordable>> &records,
-      nostd::function_ref<bool(opentelemetry::sdk::common::ExportResult)> result_callback) noexcept
+      std::function<bool(opentelemetry::sdk::common::ExportResult)> &&result_callback) noexcept
       override;
 
   /**

--- a/exporters/otlp/src/otlp_grpc_exporter.cc
+++ b/exporters/otlp/src/otlp_grpc_exporter.cc
@@ -145,7 +145,7 @@ sdk::common::ExportResult OtlpGrpcExporter::Export(
 
 void OtlpGrpcExporter::Export(
     const nostd::span<std::unique_ptr<sdk::trace::Recordable>> &spans,
-    nostd::function_ref<bool(sdk::common::ExportResult)> result_callback) noexcept
+    std::function<bool(opentelemetry::sdk::common::ExportResult)> &&result_callback) noexcept
 {
   OTEL_INTERNAL_LOG_WARN(
       "[OTLP TRACE GRPC Exporter] async not supported. Making sync interface call");

--- a/exporters/otlp/src/otlp_grpc_exporter.cc
+++ b/exporters/otlp/src/otlp_grpc_exporter.cc
@@ -143,6 +143,16 @@ sdk::common::ExportResult OtlpGrpcExporter::Export(
   return sdk::common::ExportResult::kSuccess;
 }
 
+void OtlpGrpcExporter::Export(
+    const nostd::span<std::unique_ptr<sdk::trace::Recordable>> &spans,
+    nostd::function_ref<bool(sdk::common::ExportResult)> result_callback) noexcept
+{
+  OTEL_INTERNAL_LOG_WARN(
+      "[OTLP TRACE GRPC Exporter] async not supported. Making sync interface call");
+  auto status = Export(spans);
+  result_callback(status);
+}
+
 bool OtlpGrpcExporter::Shutdown(std::chrono::microseconds timeout) noexcept
 {
   const std::lock_guard<opentelemetry::common::SpinLockMutex> locked(lock_);

--- a/exporters/otlp/src/otlp_grpc_log_exporter.cc
+++ b/exporters/otlp/src/otlp_grpc_log_exporter.cc
@@ -161,6 +161,16 @@ opentelemetry::sdk::common::ExportResult OtlpGrpcLogExporter::Export(
   return sdk::common::ExportResult::kSuccess;
 }
 
+void OtlpGrpcLogExporter::Export(
+    const nostd::span<std::unique_ptr<opentelemetry::sdk::logs::Recordable>> &logs,
+    nostd::function_ref<bool(opentelemetry::sdk::common::ExportResult)> result_callback) noexcept
+{
+  OTEL_INTERNAL_LOG_WARN(
+      "[OTLP LOG GRPC Exporter] async not supported. Making sync interface call");
+  auto status = Export(logs);
+  result_callback(status);
+}
+
 bool OtlpGrpcLogExporter::Shutdown(std::chrono::microseconds timeout) noexcept
 {
   const std::lock_guard<opentelemetry::common::SpinLockMutex> locked(lock_);

--- a/exporters/otlp/src/otlp_grpc_log_exporter.cc
+++ b/exporters/otlp/src/otlp_grpc_log_exporter.cc
@@ -163,7 +163,7 @@ opentelemetry::sdk::common::ExportResult OtlpGrpcLogExporter::Export(
 
 void OtlpGrpcLogExporter::Export(
     const nostd::span<std::unique_ptr<opentelemetry::sdk::logs::Recordable>> &logs,
-    nostd::function_ref<bool(opentelemetry::sdk::common::ExportResult)> result_callback) noexcept
+    std::function<bool(opentelemetry::sdk::common::ExportResult)> &&result_callback) noexcept
 {
   OTEL_INTERNAL_LOG_WARN(
       "[OTLP LOG GRPC Exporter] async not supported. Making sync interface call");

--- a/exporters/otlp/src/otlp_http_client.cc
+++ b/exporters/otlp/src/otlp_http_client.cc
@@ -71,7 +71,9 @@ public:
   /**
    * Creates a response handler, that by default doesn't display to console
    */
-  ResponseHandler(bool console_debug = false) : console_debug_{console_debug}
+  ResponseHandler(std::function<bool(opentelemetry::sdk::common::ExportResult)> &&callback,
+                  bool console_debug = false)
+      : result_callback_{std::move(callback)}, console_debug_{console_debug}
   {
     stoping_.store(false);
   }
@@ -110,7 +112,7 @@ public:
       bool expected = false;
       if (stoping_.compare_exchange_strong(expected, true, std::memory_order_release))
       {
-        Unbind();
+        Unbind(sdk::common::ExportResult::kSuccess);
       }
     }
   }
@@ -293,12 +295,12 @@ public:
       bool expected = false;
       if (stoping_.compare_exchange_strong(expected, true, std::memory_order_release))
       {
-        Unbind();
+        Unbind(sdk::common::ExportResult::kFailure);
       }
     }
   }
 
-  void Unbind()
+  void Unbind(sdk::common::ExportResult result)
   {
     // ReleaseSession may destroy this object, so we need to move owner and session into stack
     // first.
@@ -312,6 +314,11 @@ public:
     {
       // Release the session at last
       owner->ReleaseSession(*session);
+
+      if (result_callback_)
+      {
+        result_callback_(result);
+      }
     }
   }
 
@@ -336,6 +343,9 @@ private:
 
   // A string to store the response body
   std::string body_ = "";
+
+  // Result callback when in async mode
+  std::function<bool(opentelemetry::sdk::common::ExportResult)> result_callback_;
 
   // Whether to print the results from the callback
   bool console_debug_ = false;
@@ -668,6 +678,154 @@ OtlpHttpClient::OtlpHttpClient(OtlpHttpClientOptions &&options,
 opentelemetry::sdk::common::ExportResult OtlpHttpClient::Export(
     const google::protobuf::Message &message) noexcept
 {
+  opentelemetry::sdk::common::ExportResult result =
+      opentelemetry::sdk::common::ExportResult::kSuccess;
+  auto session =
+      createSession(message, [&result](opentelemetry::sdk::common::ExportResult export_result) {
+        result = export_result;
+        return export_result == opentelemetry::sdk::common::ExportResult::kSuccess;
+      });
+
+  if (opentelemetry::nostd::holds_alternative<sdk::common::ExportResult>(session))
+  {
+    return opentelemetry::nostd::get<sdk::common::ExportResult>(session);
+  }
+
+  // Wait for the response to be received
+  if (options_.console_debug)
+  {
+    OTEL_INTERNAL_LOG_DEBUG(
+        "[OTLP HTTP Client] DEBUG: Waiting for response from "
+        << options_.url << " (timeout = "
+        << std::chrono::duration_cast<std::chrono::milliseconds>(options_.timeout).count()
+        << " milliseconds)");
+  }
+
+  addSession(std::move(opentelemetry::nostd::get<HttpSessionData>(session)));
+
+  // Wait for any session to finish if there are to many sessions
+  std::unique_lock<std::mutex> lock(session_waker_lock_);
+  bool wait_successful = session_waker_.wait_for(lock, options_.timeout, [this] {
+    std::lock_guard<std::recursive_mutex> guard{session_manager_lock_};
+    return running_sessions_.size() <= 0;
+  });
+
+  cleanupGCSessions();
+
+  // If an error occurred with the HTTP request
+  if (!wait_successful)
+  {
+    return opentelemetry::sdk::common::ExportResult::kFailure;
+  }
+
+  return result;
+}
+
+void OtlpHttpClient::Export(
+    const google::protobuf::Message &message,
+    std::function<bool(opentelemetry::sdk::common::ExportResult)> &&result_callback) noexcept
+{
+  auto session = createSession(message, std::move(result_callback));
+  if (opentelemetry::nostd::holds_alternative<sdk::common::ExportResult>(session))
+  {
+    if (result_callback)
+    {
+      result_callback(opentelemetry::nostd::get<sdk::common::ExportResult>(session));
+    }
+    return;
+  }
+
+  addSession(std::move(opentelemetry::nostd::get<HttpSessionData>(session)));
+
+  // Wait for the response to be received
+  if (options_.console_debug)
+  {
+    OTEL_INTERNAL_LOG_DEBUG(
+        "[OTLP HTTP Client] DEBUG: Waiting for response from "
+        << options_.url << " (timeout = "
+        << std::chrono::duration_cast<std::chrono::milliseconds>(options_.timeout).count()
+        << " milliseconds)");
+  }
+
+  // Wait for any session to finish if there are to many sessions
+  std::unique_lock<std::mutex> lock(session_waker_lock_);
+  session_waker_.wait_for(lock, options_.timeout, [this] {
+    std::lock_guard<std::recursive_mutex> guard{session_manager_lock_};
+    return running_sessions_.size() <= options_.concurrent_sessions;
+  });
+
+  cleanupGCSessions();
+}
+
+bool OtlpHttpClient::Shutdown(std::chrono::microseconds timeout) noexcept
+{
+  {
+    std::lock_guard<std::recursive_mutex> guard{session_manager_lock_};
+    is_shutdown_ = true;
+
+    // Shutdown the session manager
+    http_client_->CancelAllSessions();
+    http_client_->FinishAllSessions();
+  }
+
+  // ASAN will report chrono: runtime error: signed integer overflow: A + B cannot be represented
+  //   in type 'long int' here. So we reset timeout to meet signed long int limit here.
+  timeout = opentelemetry::common::DurationUtil::AdjustWaitForTimeout(
+      timeout, std::chrono::microseconds::zero());
+
+  // Wait for all the sessions to finish
+  std::unique_lock<std::mutex> lock(session_waker_lock_);
+  if (timeout <= std::chrono::microseconds::zero())
+  {
+    session_waker_.wait(lock, [this] {
+      std::lock_guard<std::recursive_mutex> guard{session_manager_lock_};
+      return running_sessions_.empty();
+    });
+  }
+  else
+  {
+    session_waker_.wait_for(lock, timeout, [this] {
+      std::lock_guard<std::recursive_mutex> guard{session_manager_lock_};
+      return running_sessions_.empty();
+    });
+  }
+
+  while (cleanupGCSessions())
+    ;
+  return true;
+}
+
+void OtlpHttpClient::ReleaseSession(
+    const opentelemetry::ext::http::client::Session &session) noexcept
+{
+  bool has_session = false;
+
+  {
+    std::lock_guard<std::recursive_mutex> guard{session_manager_lock_};
+
+    auto session_iter = running_sessions_.find(&session);
+    if (session_iter != running_sessions_.end())
+    {
+      // Move session and handle into gc list, and they will be destroyed later
+      gc_sessions_.emplace_back(std::move(session_iter->second));
+      running_sessions_.erase(session_iter);
+
+      has_session = true;
+    }
+  }
+
+  if (has_session)
+  {
+    session_waker_.notify_all();
+  }
+}
+
+opentelemetry::nostd::variant<opentelemetry::sdk::common::ExportResult,
+                              OtlpHttpClient::HttpSessionData>
+OtlpHttpClient::createSession(
+    const google::protobuf::Message &message,
+    std::function<bool(opentelemetry::sdk::common::ExportResult)> &&result_callback) noexcept
+{
   // Parse uri and store it to cache
   if (http_uri_.empty())
   {
@@ -735,150 +893,57 @@ opentelemetry::sdk::common::ExportResult OtlpHttpClient::Export(
   }
 
   // Send the request
+  std::lock_guard<std::recursive_mutex> guard{session_manager_lock_};
+  // Return failure if this exporter has been shutdown
+  if (isShutdown())
   {
-    std::lock_guard<std::recursive_mutex> guard{session_manager_lock_};
-    // Return failure if this exporter has been shutdown
-    if (isShutdown())
+    const char *error_message = "[OTLP HTTP Client] Export failed, exporter is shutdown";
+    if (options_.console_debug)
     {
-      const char *error_message = "[OTLP HTTP Client] Export failed, exporter is shutdown";
-      if (options_.console_debug)
-      {
-        std::cerr << error_message << std::endl;
-      }
-      OTEL_INTERNAL_LOG_ERROR(error_message);
-
-      return opentelemetry::sdk::common::ExportResult::kFailure;
+      std::cerr << error_message << std::endl;
     }
+    OTEL_INTERNAL_LOG_ERROR(error_message);
 
-    auto session = http_client_->CreateSession(options_.url);
-    auto request = session->CreateRequest();
-
-    for (auto &header : options_.http_headers)
-    {
-      request->AddHeader(header.first, header.second);
-    }
-    request->SetUri(http_uri_);
-    request->SetTimeoutMs(std::chrono::duration_cast<std::chrono::milliseconds>(options_.timeout));
-    request->SetMethod(http_client::Method::Post);
-    request->SetBody(body_vec);
-    request->ReplaceHeader("Content-Type", content_type);
-
-    // Send the request
-    addSession(std::move(session), std::shared_ptr<opentelemetry::ext::http::client::EventHandler>{
-                                       new ResponseHandler(options_.console_debug)});
-  }
-
-  // Wait for the response to be received
-  if (options_.console_debug)
-  {
-    OTEL_INTERNAL_LOG_DEBUG(
-        "[OTLP HTTP Client] DEBUG: Waiting for response from "
-        << options_.url << " (timeout = "
-        << std::chrono::duration_cast<std::chrono::milliseconds>(options_.timeout).count()
-        << " milliseconds)");
-  }
-
-  // Wait for any session to finish if there are to many sessions
-  std::unique_lock<std::mutex> lock(session_waker_lock_);
-  bool wait_successful = session_waker_.wait_for(lock, options_.timeout, [this] {
-    std::lock_guard<std::recursive_mutex> guard{session_manager_lock_};
-    return running_sessions_.size() <= options_.concurrent_sessions;
-  });
-
-  cleanupGCSessions();
-
-  // If an error occurred with the HTTP request
-  if (!wait_successful)
-  {
     return opentelemetry::sdk::common::ExportResult::kFailure;
   }
 
-  return opentelemetry::sdk::common::ExportResult::kSuccess;
+  auto session = http_client_->CreateSession(options_.url);
+  auto request = session->CreateRequest();
+
+  for (auto &header : options_.http_headers)
+  {
+    request->AddHeader(header.first, header.second);
+  }
+  request->SetUri(http_uri_);
+  request->SetTimeoutMs(std::chrono::duration_cast<std::chrono::milliseconds>(options_.timeout));
+  request->SetMethod(http_client::Method::Post);
+  request->SetBody(body_vec);
+  request->ReplaceHeader("Content-Type", content_type);
+
+  // Send the request
+  return HttpSessionData{
+      std::move(session),
+      std::shared_ptr<opentelemetry::ext::http::client::EventHandler>{
+          new ResponseHandler(std::move(result_callback), options_.console_debug)}};
 }
 
-bool OtlpHttpClient::Shutdown(std::chrono::microseconds timeout) noexcept
+void OtlpHttpClient::addSession(HttpSessionData &&session_data) noexcept
 {
-  {
-    std::lock_guard<std::recursive_mutex> guard{session_manager_lock_};
-    is_shutdown_ = true;
-
-    // Shutdown the session manager
-    http_client_->CancelAllSessions();
-    http_client_->FinishAllSessions();
-  }
-
-  // ASAN will report chrono: runtime error: signed integer overflow: A + B cannot be represented
-  //   in type 'long int' here. So we reset timeout to meet signed long int limit here.
-  timeout = opentelemetry::common::DurationUtil::AdjustWaitForTimeout(
-      timeout, std::chrono::microseconds::zero());
-
-  // Wait for all the sessions to finish
-  std::unique_lock<std::mutex> lock(session_waker_lock_);
-  if (timeout <= std::chrono::microseconds::zero())
-  {
-    session_waker_.wait(lock, [this] {
-      std::lock_guard<std::recursive_mutex> guard{session_manager_lock_};
-      return running_sessions_.empty();
-    });
-  }
-  else
-  {
-    session_waker_.wait_for(lock, timeout, [this] {
-      std::lock_guard<std::recursive_mutex> guard{session_manager_lock_};
-      return running_sessions_.empty();
-    });
-  }
-
-  while (cleanupGCSessions())
-    ;
-  return true;
-}
-
-void OtlpHttpClient::ReleaseSession(
-    const opentelemetry::ext::http::client::Session &session) noexcept
-{
-  bool has_session = false;
-
-  {
-    std::lock_guard<std::recursive_mutex> guard{session_manager_lock_};
-
-    auto seesion_iter = running_sessions_.find(&session);
-    if (seesion_iter != running_sessions_.end())
-    {
-      // Move session and handle into gc list, and they will be destroyed later
-      gc_sessions_.emplace_back(std::move(seesion_iter->second));
-      running_sessions_.erase(seesion_iter);
-
-      has_session = true;
-    }
-  }
-
-  if (has_session)
-  {
-    session_waker_.notify_all();
-  }
-}
-
-void OtlpHttpClient::addSession(
-    std::shared_ptr<opentelemetry::ext::http::client::Session> session,
-    std::shared_ptr<opentelemetry::ext::http::client::EventHandler> event_handle) noexcept
-{
-  if (!session || !event_handle)
+  if (!session_data.session || !session_data.event_handle)
   {
     return;
   }
 
-  opentelemetry::ext::http::client::Session *key = session.get();
-  ResponseHandler *handle = static_cast<ResponseHandler *>(event_handle.get());
+  opentelemetry::ext::http::client::Session *key = session_data.session.get();
+  ResponseHandler *handle = static_cast<ResponseHandler *>(session_data.event_handle.get());
 
   handle->Bind(this, *key);
 
-  HttpSessionData &session_data = running_sessions_[key];
-  session_data.session.swap(session);
-  session_data.event_handle.swap(event_handle);
+  HttpSessionData &store_session_data = running_sessions_[key];
+  store_session_data                  = std::move(session_data);
 
   // Send request after the session is added
-  key->SendRequest(session_data.event_handle);
+  key->SendRequest(store_session_data.event_handle);
 }
 
 bool OtlpHttpClient::cleanupGCSessions() noexcept

--- a/exporters/otlp/src/otlp_http_client.cc
+++ b/exporters/otlp/src/otlp_http_client.cc
@@ -764,7 +764,7 @@ opentelemetry::sdk::common::ExportResult OtlpHttpClient::Export(
     request->ReplaceHeader("Content-Type", content_type);
 
     // Send the request
-    addSession(std::move(session), std::unique_ptr<opentelemetry::ext::http::client::EventHandler>{
+    addSession(std::move(session), std::shared_ptr<opentelemetry::ext::http::client::EventHandler>{
                                        new ResponseHandler(options_.console_debug)});
   }
 
@@ -861,7 +861,7 @@ void OtlpHttpClient::ReleaseSession(
 
 void OtlpHttpClient::addSession(
     std::shared_ptr<opentelemetry::ext::http::client::Session> session,
-    std::unique_ptr<opentelemetry::ext::http::client::EventHandler> &&event_handle) noexcept
+    std::shared_ptr<opentelemetry::ext::http::client::EventHandler> event_handle) noexcept
 {
   if (!session || !event_handle)
   {
@@ -878,7 +878,7 @@ void OtlpHttpClient::addSession(
   session_data.event_handle.swap(event_handle);
 
   // Send request after the session is added
-  key->SendRequest(*handle);
+  key->SendRequest(session_data.event_handle);
 }
 
 bool OtlpHttpClient::cleanupGCSessions() noexcept

--- a/exporters/otlp/src/otlp_http_client.cc
+++ b/exporters/otlp/src/otlp_http_client.cc
@@ -14,7 +14,6 @@
 
 #include "opentelemetry/exporters/otlp/protobuf_include_prefix.h"
 
-#include <mutex>
 #include "google/protobuf/message.h"
 #include "google/protobuf/reflection.h"
 #include "google/protobuf/stubs/common.h"
@@ -35,9 +34,11 @@ LIBPROTOBUF_EXPORT void Base64Escape(StringPiece src, std::string *dest);
 
 #include "opentelemetry/exporters/otlp/protobuf_include_suffix.h"
 
+#include "opentelemetry/common/timestamp.h"
 #include "opentelemetry/sdk/common/global_log_handler.h"
 #include "opentelemetry/sdk_config.h"
 
+#include <atomic>
 #include <condition_variable>
 #include <fstream>
 #include <mutex>
@@ -70,7 +71,10 @@ public:
   /**
    * Creates a response handler, that by default doesn't display to console
    */
-  ResponseHandler(bool console_debug = false) : console_debug_{console_debug} {}
+  ResponseHandler(bool console_debug = false) : console_debug_{console_debug}
+  {
+    stoping_.store(false);
+  }
 
   /**
    * Automatically called when the response is received, store the body into a string and notify any
@@ -100,20 +104,15 @@ public:
 
       // Set the response_received_ flag to true and notify any threads waiting on this result
       response_received_ = true;
-      stop_waiting_      = true;
     }
-    cv_.notify_all();
-  }
 
-  /**resource
-   * A method the user calls to block their thread until the response is received. The longest
-   * duration is the timeout of the request, set by SetTimeoutMs()
-   */
-  bool waitForResponse()
-  {
-    std::unique_lock<std::mutex> lk(mutex_);
-    cv_.wait(lk, [this] { return stop_waiting_; });
-    return response_received_;
+    {
+      bool expected = false;
+      if (stoping_.compare_exchange_strong(expected, true, std::memory_order_release))
+      {
+        Unbind();
+      }
+    }
   }
 
   /**
@@ -130,7 +129,8 @@ public:
   void OnEvent(http_client::SessionState state,
                opentelemetry::nostd::string_view reason) noexcept override
   {
-    // need to modify stop_waiting_ under lock before calling notify_all
+    // need to modify stoping_ under lock before calling notify_all
+    bool need_stop = false;
     switch (state)
     {
       case http_client::SessionState::CreateFailed:
@@ -140,8 +140,7 @@ public:
       case http_client::SessionState::TimedOut:
       case http_client::SessionState::NetworkError:
       case http_client::SessionState::Cancelled: {
-        std::unique_lock<std::mutex> lk(mutex_);
-        stop_waiting_ = true;
+        need_stop = true;
       }
       break;
 
@@ -152,10 +151,16 @@ public:
     // If any failure event occurs, release the condition variable to unblock main thread
     switch (state)
     {
-      case http_client::SessionState::CreateFailed:
-        OTEL_INTERNAL_LOG_ERROR("[OTLP HTTP Client] Session state: session create failed");
-        cv_.notify_all();
-        break;
+      case http_client::SessionState::CreateFailed: {
+        std::stringstream error_message;
+        error_message << "[OTLP HTTP Client] Session state: session create failed.";
+        if (!reason.empty())
+        {
+          error_message.write(reason.data(), reason.size());
+        }
+        OTEL_INTERNAL_LOG_ERROR(error_message.str());
+      }
+      break;
 
       case http_client::SessionState::Created:
         if (console_debug_)
@@ -178,10 +183,16 @@ public:
         }
         break;
 
-      case http_client::SessionState::ConnectFailed:
-        OTEL_INTERNAL_LOG_ERROR("[OTLP HTTP Client] Session state: connection failed");
-        cv_.notify_all();
-        break;
+      case http_client::SessionState::ConnectFailed: {
+        std::stringstream error_message;
+        error_message << "[OTLP HTTP Client] Session state: connection failed.";
+        if (!reason.empty())
+        {
+          error_message.write(reason.data(), reason.size());
+        }
+        OTEL_INTERNAL_LOG_ERROR(error_message.str());
+      }
+      break;
 
       case http_client::SessionState::Connected:
         if (console_debug_)
@@ -197,10 +208,16 @@ public:
         }
         break;
 
-      case http_client::SessionState::SendFailed:
-        OTEL_INTERNAL_LOG_ERROR("[OTLP HTTP Client] Session state: request send failed");
-        cv_.notify_all();
-        break;
+      case http_client::SessionState::SendFailed: {
+        std::stringstream error_message;
+        error_message << "[OTLP HTTP Client] Session state: request send failed.";
+        if (!reason.empty())
+        {
+          error_message.write(reason.data(), reason.size());
+        }
+        OTEL_INTERNAL_LOG_ERROR(error_message.str());
+      }
+      break;
 
       case http_client::SessionState::Response:
         if (console_debug_)
@@ -209,20 +226,38 @@ public:
         }
         break;
 
-      case http_client::SessionState::SSLHandshakeFailed:
-        OTEL_INTERNAL_LOG_ERROR("[OTLP HTTP Client] Session state: SSL handshake failed");
-        cv_.notify_all();
-        break;
+      case http_client::SessionState::SSLHandshakeFailed: {
+        std::stringstream error_message;
+        error_message << "[OTLP HTTP Client] Session state: SSL handshake failed.";
+        if (!reason.empty())
+        {
+          error_message.write(reason.data(), reason.size());
+        }
+        OTEL_INTERNAL_LOG_ERROR(error_message.str());
+      }
+      break;
 
-      case http_client::SessionState::TimedOut:
-        OTEL_INTERNAL_LOG_ERROR("[OTLP HTTP Client] Session state: request time out");
-        cv_.notify_all();
-        break;
+      case http_client::SessionState::TimedOut: {
+        std::stringstream error_message;
+        error_message << "[OTLP HTTP Client] Session state: request time out.";
+        if (!reason.empty())
+        {
+          error_message.write(reason.data(), reason.size());
+        }
+        OTEL_INTERNAL_LOG_ERROR(error_message.str());
+      }
+      break;
 
-      case http_client::SessionState::NetworkError:
-        OTEL_INTERNAL_LOG_ERROR("[OTLP HTTP Client] Session state: network error");
-        cv_.notify_all();
-        break;
+      case http_client::SessionState::NetworkError: {
+        std::stringstream error_message;
+        error_message << "[OTLP HTTP Client] Session state: network error.";
+        if (!reason.empty())
+        {
+          error_message.write(reason.data(), reason.size());
+        }
+        OTEL_INTERNAL_LOG_ERROR(error_message.str());
+      }
+      break;
 
       case http_client::SessionState::ReadError:
         if (console_debug_)
@@ -238,23 +273,63 @@ public:
         }
         break;
 
-      case http_client::SessionState::Cancelled:
-        OTEL_INTERNAL_LOG_ERROR("[OTLP HTTP Client] Session state: (manually) cancelled\n");
-        cv_.notify_all();
-        break;
+      case http_client::SessionState::Cancelled: {
+        std::stringstream error_message;
+        error_message << "[OTLP HTTP Client] Session state: (manually) cancelled.";
+        if (!reason.empty())
+        {
+          error_message.write(reason.data(), reason.size());
+        }
+        OTEL_INTERNAL_LOG_ERROR(error_message.str());
+      }
+      break;
 
       default:
         break;
     }
+
+    if (need_stop)
+    {
+      bool expected = false;
+      if (stoping_.compare_exchange_strong(expected, true, std::memory_order_release))
+      {
+        Unbind();
+      }
+    }
   }
+
+  void Unbind()
+  {
+    // ReleaseSession may destroy this object, so we need to move owner and session into stack
+    // first.
+    OtlpHttpClient *owner                                    = owner_;
+    const opentelemetry::ext::http::client::Session *session = session_;
+
+    owner_   = nullptr;
+    session_ = nullptr;
+
+    if (nullptr != owner && nullptr != session)
+    {
+      // Release the session at last
+      owner->ReleaseSession(*session);
+    }
+  }
+
+  void Bind(OtlpHttpClient *owner,
+            const opentelemetry::ext::http::client::Session &session) noexcept
+  {
+    session_ = &session;
+    owner_   = owner;
+  };
 
 private:
   // Define a condition variable and mutex
-  std::condition_variable cv_;
   std::mutex mutex_;
+  OtlpHttpClient *owner_                                    = nullptr;
+  const opentelemetry::ext::http::client::Session *session_ = nullptr;
 
   // Whether notify has been called
-  bool stop_waiting_ = false;
+  std::atomic<bool> stoping_;
 
   // Whether the response has been received
   bool response_received_ = false;
@@ -562,31 +637,37 @@ void ConvertListFieldToJson(nlohmann::json &value,
 }  // namespace
 
 OtlpHttpClient::OtlpHttpClient(OtlpHttpClientOptions &&options)
-    : options_(options), http_client_(http_client::HttpClientFactory::Create())
+    : is_shutdown_(false), options_(options), http_client_(http_client::HttpClientFactory::Create())
 {}
+
+OtlpHttpClient::~OtlpHttpClient()
+{
+  if (!isShutdown())
+  {
+    Shutdown();
+  }
+
+  // Wait for all the sessions to finish
+  std::unique_lock<std::mutex> lock(session_waker_lock_);
+  session_waker_.wait(lock, [this] {
+    std::lock_guard<std::recursive_mutex> guard{session_manager_lock_};
+    return running_sessions_.empty();
+  });
+
+  // And then remove all session datas
+  while (cleanupGCSessions())
+    ;
+}
 
 OtlpHttpClient::OtlpHttpClient(OtlpHttpClientOptions &&options,
                                std::shared_ptr<ext::http::client::HttpClient> http_client)
-    : options_(options), http_client_(http_client)
+    : is_shutdown_(false), options_(options), http_client_(http_client)
 {}
 
 // ----------------------------- HTTP Client methods ------------------------------
 opentelemetry::sdk::common::ExportResult OtlpHttpClient::Export(
     const google::protobuf::Message &message) noexcept
 {
-  // Return failure if this exporter has been shutdown
-  if (isShutdown())
-  {
-    const char *error_message = "[OTLP HTTP Client] Export failed, exporter is shutdown";
-    if (options_.console_debug)
-    {
-      std::cerr << error_message << std::endl;
-    }
-    OTEL_INTERNAL_LOG_ERROR(error_message);
-
-    return opentelemetry::sdk::common::ExportResult::kFailure;
-  }
-
   // Parse uri and store it to cache
   if (http_uri_.empty())
   {
@@ -654,22 +735,38 @@ opentelemetry::sdk::common::ExportResult OtlpHttpClient::Export(
   }
 
   // Send the request
-  auto session = http_client_->CreateSession(options_.url);
-  auto request = session->CreateRequest();
-
-  for (auto &header : options_.http_headers)
   {
-    request->AddHeader(header.first, header.second);
-  }
-  request->SetUri(http_uri_);
-  request->SetTimeoutMs(std::chrono::duration_cast<std::chrono::milliseconds>(options_.timeout));
-  request->SetMethod(http_client::Method::Post);
-  request->SetBody(body_vec);
-  request->ReplaceHeader("Content-Type", content_type);
+    std::lock_guard<std::recursive_mutex> guard{session_manager_lock_};
+    // Return failure if this exporter has been shutdown
+    if (isShutdown())
+    {
+      const char *error_message = "[OTLP HTTP Client] Export failed, exporter is shutdown";
+      if (options_.console_debug)
+      {
+        std::cerr << error_message << std::endl;
+      }
+      OTEL_INTERNAL_LOG_ERROR(error_message);
 
-  // Send the request
-  std::unique_ptr<ResponseHandler> handler(new ResponseHandler(options_.console_debug));
-  session->SendRequest(*handler);
+      return opentelemetry::sdk::common::ExportResult::kFailure;
+    }
+
+    auto session = http_client_->CreateSession(options_.url);
+    auto request = session->CreateRequest();
+
+    for (auto &header : options_.http_headers)
+    {
+      request->AddHeader(header.first, header.second);
+    }
+    request->SetUri(http_uri_);
+    request->SetTimeoutMs(std::chrono::duration_cast<std::chrono::milliseconds>(options_.timeout));
+    request->SetMethod(http_client::Method::Post);
+    request->SetBody(body_vec);
+    request->ReplaceHeader("Content-Type", content_type);
+
+    // Send the request
+    addSession(std::move(session), std::unique_ptr<opentelemetry::ext::http::client::EventHandler>{
+                                       new ResponseHandler(options_.console_debug)});
+  }
 
   // Wait for the response to be received
   if (options_.console_debug)
@@ -680,38 +777,130 @@ opentelemetry::sdk::common::ExportResult OtlpHttpClient::Export(
         << std::chrono::duration_cast<std::chrono::milliseconds>(options_.timeout).count()
         << " milliseconds)");
   }
-  bool write_successful = handler->waitForResponse();
 
-  // End the session
-  session->FinishSession();
+  // Wait for any session to finish if there are to many sessions
+  std::unique_lock<std::mutex> lock(session_waker_lock_);
+  bool wait_successful = session_waker_.wait_for(lock, options_.timeout, [this] {
+    std::lock_guard<std::recursive_mutex> guard{session_manager_lock_};
+    return running_sessions_.size() <= options_.concurrent_sessions;
+  });
+
+  cleanupGCSessions();
 
   // If an error occurred with the HTTP request
-  if (!write_successful)
+  if (!wait_successful)
   {
-    // TODO: retry logic
     return opentelemetry::sdk::common::ExportResult::kFailure;
   }
 
   return opentelemetry::sdk::common::ExportResult::kSuccess;
 }
 
-bool OtlpHttpClient::Shutdown(std::chrono::microseconds) noexcept
+bool OtlpHttpClient::Shutdown(std::chrono::microseconds timeout) noexcept
 {
   {
-    const std::lock_guard<opentelemetry::common::SpinLockMutex> locked(lock_);
+    std::lock_guard<std::recursive_mutex> guard{session_manager_lock_};
     is_shutdown_ = true;
+
+    // Shutdown the session manager
+    http_client_->CancelAllSessions();
+    http_client_->FinishAllSessions();
   }
 
-  // Shutdown the session manager
-  http_client_->CancelAllSessions();
-  http_client_->FinishAllSessions();
+  // ASAN will report chrono: runtime error: signed integer overflow: A + B cannot be represented
+  //   in type 'long int' here. So we reset timeout to meet signed long int limit here.
+  timeout = opentelemetry::common::DurationUtil::AdjustWaitForTimeout(
+      timeout, std::chrono::microseconds::zero());
 
+  // Wait for all the sessions to finish
+  std::unique_lock<std::mutex> lock(session_waker_lock_);
+  if (timeout <= std::chrono::microseconds::zero())
+  {
+    session_waker_.wait(lock, [this] {
+      std::lock_guard<std::recursive_mutex> guard{session_manager_lock_};
+      return running_sessions_.empty();
+    });
+  }
+  else
+  {
+    session_waker_.wait_for(lock, timeout, [this] {
+      std::lock_guard<std::recursive_mutex> guard{session_manager_lock_};
+      return running_sessions_.empty();
+    });
+  }
+
+  while (cleanupGCSessions())
+    ;
   return true;
+}
+
+void OtlpHttpClient::ReleaseSession(
+    const opentelemetry::ext::http::client::Session &session) noexcept
+{
+  bool has_session = false;
+
+  {
+    std::lock_guard<std::recursive_mutex> guard{session_manager_lock_};
+
+    auto seesion_iter = running_sessions_.find(&session);
+    if (seesion_iter != running_sessions_.end())
+    {
+      // Move session and handle into gc list, and they will be destroyed later
+      gc_sessions_.emplace_back(std::move(seesion_iter->second));
+      running_sessions_.erase(seesion_iter);
+
+      has_session = true;
+    }
+  }
+
+  if (has_session)
+  {
+    session_waker_.notify_all();
+  }
+}
+
+void OtlpHttpClient::addSession(
+    std::shared_ptr<opentelemetry::ext::http::client::Session> session,
+    std::unique_ptr<opentelemetry::ext::http::client::EventHandler> &&event_handle) noexcept
+{
+  if (!session || !event_handle)
+  {
+    return;
+  }
+
+  opentelemetry::ext::http::client::Session *key = session.get();
+  ResponseHandler *handle = static_cast<ResponseHandler *>(event_handle.get());
+
+  handle->Bind(this, *key);
+
+  HttpSessionData &session_data = running_sessions_[key];
+  session_data.session.swap(session);
+  session_data.event_handle.swap(event_handle);
+
+  // Send request after the session is added
+  key->SendRequest(*handle);
+}
+
+bool OtlpHttpClient::cleanupGCSessions() noexcept
+{
+  std::lock_guard<std::recursive_mutex> guard{session_manager_lock_};
+  std::list<HttpSessionData> gc_sessions;
+  gc_sessions_.swap(gc_sessions);
+
+  for (auto &session_data : gc_sessions)
+  {
+    // FinishSession must be called with same thread and before the session is destroyed
+    if (session_data.session)
+    {
+      session_data.session->FinishSession();
+    }
+  }
+
+  return !gc_sessions_.empty();
 }
 
 bool OtlpHttpClient::isShutdown() const noexcept
 {
-  const std::lock_guard<opentelemetry::common::SpinLockMutex> locked(lock_);
   return is_shutdown_;
 }
 

--- a/exporters/otlp/src/otlp_http_exporter.cc
+++ b/exporters/otlp/src/otlp_http_exporter.cc
@@ -29,7 +29,8 @@ OtlpHttpExporter::OtlpHttpExporter(const OtlpHttpExporterOptions &options)
                                                             options.use_json_name,
                                                             options.console_debug,
                                                             options.timeout,
-                                                            options.http_headers)))
+                                                            options.http_headers,
+                                                            options.concurrent_sessions)))
 {}
 
 OtlpHttpExporter::OtlpHttpExporter(std::unique_ptr<OtlpHttpClient> http_client)

--- a/exporters/otlp/src/otlp_http_exporter.cc
+++ b/exporters/otlp/src/otlp_http_exporter.cc
@@ -11,6 +11,8 @@
 
 #include "opentelemetry/exporters/otlp/protobuf_include_suffix.h"
 
+#include "opentelemetry/sdk/common/global_log_handler.h"
+
 namespace nostd = opentelemetry::nostd;
 
 OPENTELEMETRY_BEGIN_NAMESPACE
@@ -55,6 +57,15 @@ opentelemetry::sdk::common::ExportResult OtlpHttpExporter::Export(
   proto::collector::trace::v1::ExportTraceServiceRequest service_request;
   OtlpRecordableUtils::PopulateRequest(spans, &service_request);
   return http_client_->Export(service_request);
+}
+
+void OtlpHttpExporter::Export(
+    const nostd::span<std::unique_ptr<opentelemetry::sdk::trace::Recordable>> &spans,
+    nostd::function_ref<bool(opentelemetry::sdk::common::ExportResult)> result_callback) noexcept
+{
+  OTEL_INTERNAL_LOG_WARN(" async not supported. Making sync interface call");
+  auto status = Export(spans);
+  result_callback(status);
 }
 
 bool OtlpHttpExporter::Shutdown(std::chrono::microseconds timeout) noexcept

--- a/exporters/otlp/src/otlp_http_exporter.cc
+++ b/exporters/otlp/src/otlp_http_exporter.cc
@@ -61,7 +61,7 @@ opentelemetry::sdk::common::ExportResult OtlpHttpExporter::Export(
 
 void OtlpHttpExporter::Export(
     const nostd::span<std::unique_ptr<opentelemetry::sdk::trace::Recordable>> &spans,
-    nostd::function_ref<bool(opentelemetry::sdk::common::ExportResult)> result_callback) noexcept
+    std::function<bool(opentelemetry::sdk::common::ExportResult)> &&result_callback) noexcept
 {
   OTEL_INTERNAL_LOG_WARN(" async not supported. Making sync interface call");
   auto status = Export(spans);

--- a/exporters/otlp/src/otlp_http_exporter.cc
+++ b/exporters/otlp/src/otlp_http_exporter.cc
@@ -70,7 +70,7 @@ void OtlpHttpExporter::Export(
 
   proto::collector::trace::v1::ExportTraceServiceRequest service_request;
   OtlpRecordableUtils::PopulateRequest(spans, &service_request);
-  http_client_->Export(service_request, result_callback);
+  http_client_->Export(service_request, std::move(result_callback));
 }
 
 bool OtlpHttpExporter::Shutdown(std::chrono::microseconds timeout) noexcept

--- a/exporters/otlp/src/otlp_http_exporter.cc
+++ b/exporters/otlp/src/otlp_http_exporter.cc
@@ -63,9 +63,14 @@ void OtlpHttpExporter::Export(
     const nostd::span<std::unique_ptr<opentelemetry::sdk::trace::Recordable>> &spans,
     std::function<bool(opentelemetry::sdk::common::ExportResult)> &&result_callback) noexcept
 {
-  OTEL_INTERNAL_LOG_WARN(" async not supported. Making sync interface call");
-  auto status = Export(spans);
-  result_callback(status);
+  if (spans.empty())
+  {
+    return;
+  }
+
+  proto::collector::trace::v1::ExportTraceServiceRequest service_request;
+  OtlpRecordableUtils::PopulateRequest(spans, &service_request);
+  http_client_->Export(service_request, result_callback);
 }
 
 bool OtlpHttpExporter::Shutdown(std::chrono::microseconds timeout) noexcept

--- a/exporters/otlp/src/otlp_http_log_exporter.cc
+++ b/exporters/otlp/src/otlp_http_log_exporter.cc
@@ -13,6 +13,8 @@
 
 #  include "opentelemetry/exporters/otlp/protobuf_include_suffix.h"
 
+#  include "opentelemetry/sdk/common/global_log_handler.h"
+
 namespace nostd = opentelemetry::nostd;
 
 OPENTELEMETRY_BEGIN_NAMESPACE
@@ -56,6 +58,15 @@ opentelemetry::sdk::common::ExportResult OtlpHttpLogExporter::Export(
   proto::collector::logs::v1::ExportLogsServiceRequest service_request;
   OtlpRecordableUtils::PopulateRequest(logs, &service_request);
   return http_client_->Export(service_request);
+}
+
+void OtlpHttpLogExporter::Export(
+    const nostd::span<std::unique_ptr<opentelemetry::sdk::logs::Recordable>> &logs,
+    nostd::function_ref<bool(opentelemetry::sdk::common::ExportResult)> result_callback) noexcept
+{
+  OTEL_INTERNAL_LOG_WARN(" async not supported. Making sync interface call");
+  auto status = Export(logs);
+  result_callback(status);
 }
 
 bool OtlpHttpLogExporter::Shutdown(std::chrono::microseconds timeout) noexcept

--- a/exporters/otlp/src/otlp_http_log_exporter.cc
+++ b/exporters/otlp/src/otlp_http_log_exporter.cc
@@ -70,7 +70,7 @@ void OtlpHttpLogExporter::Export(
   }
   proto::collector::logs::v1::ExportLogsServiceRequest service_request;
   OtlpRecordableUtils::PopulateRequest(logs, &service_request);
-  http_client_->Export(service_request, result_callback);
+  http_client_->Export(service_request, std::move(result_callback));
 }
 
 bool OtlpHttpLogExporter::Shutdown(std::chrono::microseconds timeout) noexcept

--- a/exporters/otlp/src/otlp_http_log_exporter.cc
+++ b/exporters/otlp/src/otlp_http_log_exporter.cc
@@ -62,7 +62,7 @@ opentelemetry::sdk::common::ExportResult OtlpHttpLogExporter::Export(
 
 void OtlpHttpLogExporter::Export(
     const nostd::span<std::unique_ptr<opentelemetry::sdk::logs::Recordable>> &logs,
-    nostd::function_ref<bool(opentelemetry::sdk::common::ExportResult)> result_callback) noexcept
+    std::function<bool(opentelemetry::sdk::common::ExportResult)> &&result_callback) noexcept
 {
   OTEL_INTERNAL_LOG_WARN(" async not supported. Making sync interface call");
   auto status = Export(logs);

--- a/exporters/otlp/src/otlp_http_log_exporter.cc
+++ b/exporters/otlp/src/otlp_http_log_exporter.cc
@@ -31,7 +31,8 @@ OtlpHttpLogExporter::OtlpHttpLogExporter(const OtlpHttpLogExporterOptions &optio
                                                             options.use_json_name,
                                                             options.console_debug,
                                                             options.timeout,
-                                                            options.http_headers)))
+                                                            options.http_headers,
+                                                            options.concurrent_sessions)))
 {}
 
 OtlpHttpLogExporter::OtlpHttpLogExporter(std::unique_ptr<OtlpHttpClient> http_client)

--- a/exporters/otlp/src/otlp_http_log_exporter.cc
+++ b/exporters/otlp/src/otlp_http_log_exporter.cc
@@ -64,9 +64,13 @@ void OtlpHttpLogExporter::Export(
     const nostd::span<std::unique_ptr<opentelemetry::sdk::logs::Recordable>> &logs,
     std::function<bool(opentelemetry::sdk::common::ExportResult)> &&result_callback) noexcept
 {
-  OTEL_INTERNAL_LOG_WARN(" async not supported. Making sync interface call");
-  auto status = Export(logs);
-  result_callback(status);
+  if (logs.empty())
+  {
+    return;
+  }
+  proto::collector::logs::v1::ExportLogsServiceRequest service_request;
+  OtlpRecordableUtils::PopulateRequest(logs, &service_request);
+  http_client_->Export(service_request, result_callback);
 }
 
 bool OtlpHttpLogExporter::Shutdown(std::chrono::microseconds timeout) noexcept

--- a/exporters/otlp/test/otlp_http_exporter_test.cc
+++ b/exporters/otlp/test/otlp_http_exporter_test.cc
@@ -138,8 +138,8 @@ TEST_F(OtlpHttpExporterTestPeer, ExportJsonIntegrationTest)
   auto mock_session =
       std::static_pointer_cast<http_client::nosend::Session>(no_send_client->session_);
   EXPECT_CALL(*mock_session, SendRequest)
-      .WillOnce([&mock_session,
-                 report_trace_id](opentelemetry::ext::http::client::EventHandler &callback) {
+      .WillOnce([&mock_session, report_trace_id](
+                    std::shared_ptr<opentelemetry::ext::http::client::EventHandler> callback) {
         auto check_json = nlohmann::json::parse(mock_session->GetRequest()->body_, nullptr, false);
         auto resource_span                = *check_json["resource_spans"].begin();
         auto instrumentation_library_span = *resource_span["instrumentation_library_spans"].begin();
@@ -155,7 +155,7 @@ TEST_F(OtlpHttpExporterTestPeer, ExportJsonIntegrationTest)
         }
         // let the otlp_http_client to continue
         http_client::nosend::Response response;
-        callback.OnResponse(response);
+        callback->OnResponse(response);
       });
 
   child_span->End();
@@ -219,8 +219,8 @@ TEST_F(OtlpHttpExporterTestPeer, ExportBinaryIntegrationTest)
   auto mock_session =
       std::static_pointer_cast<http_client::nosend::Session>(no_send_client->session_);
   EXPECT_CALL(*mock_session, SendRequest)
-      .WillOnce([&mock_session,
-                 report_trace_id](opentelemetry::ext::http::client::EventHandler &callback) {
+      .WillOnce([&mock_session, report_trace_id](
+                    std::shared_ptr<opentelemetry::ext::http::client::EventHandler> callback) {
         opentelemetry::proto::collector::trace::v1::ExportTraceServiceRequest request_body;
         request_body.ParseFromArray(&mock_session->GetRequest()->body_[0],
                                     static_cast<int>(mock_session->GetRequest()->body_.size()));
@@ -237,7 +237,8 @@ TEST_F(OtlpHttpExporterTestPeer, ExportBinaryIntegrationTest)
 
         // let the otlp_http_client to continue
         http_client::nosend::Response response;
-        response.Finish(callback);
+
+        response.Finish(*callback.get());
       });
 
   child_span->End();

--- a/exporters/otlp/test/otlp_http_exporter_test.cc
+++ b/exporters/otlp/test/otlp_http_exporter_test.cc
@@ -3,6 +3,9 @@
 
 #ifndef HAVE_CPP_STDLIB
 
+#  include <chrono>
+#  include <thread>
+
 #  include "opentelemetry/exporters/otlp/otlp_http_exporter.h"
 
 #  include "opentelemetry/exporters/otlp/protobuf_include_prefix.h"
@@ -81,170 +84,218 @@ public:
     auto http_client = http_client::HttpClientFactory::CreateNoSend();
     return {new OtlpHttpClient(MakeOtlpHttpClientOptions(content_type), http_client), http_client};
   }
+
+  void ExportJsonIntegrationTest(bool is_async)
+  {
+    auto mock_otlp_client =
+        OtlpHttpExporterTestPeer::GetMockOtlpHttpClient(HttpRequestContentType::kJson);
+    auto mock_otlp_http_client = mock_otlp_client.first;
+    auto client                = mock_otlp_client.second;
+    auto exporter = GetExporter(std::unique_ptr<OtlpHttpClient>{mock_otlp_http_client});
+
+    resource::ResourceAttributes resource_attributes = {{"service.name", "unit_test_service"},
+                                                        {"tenant.id", "test_user"}};
+    resource_attributes["bool_value"]                = true;
+    resource_attributes["int32_value"]               = static_cast<int32_t>(1);
+    resource_attributes["uint32_value"]              = static_cast<uint32_t>(2);
+    resource_attributes["int64_value"]               = static_cast<int64_t>(0x1100000000LL);
+    resource_attributes["uint64_value"]              = static_cast<uint64_t>(0x1200000000ULL);
+    resource_attributes["double_value"]              = static_cast<double>(3.1);
+    resource_attributes["vec_bool_value"]            = std::vector<bool>{true, false, true};
+    resource_attributes["vec_int32_value"]           = std::vector<int32_t>{1, 2};
+    resource_attributes["vec_uint32_value"]          = std::vector<uint32_t>{3, 4};
+    resource_attributes["vec_int64_value"]           = std::vector<int64_t>{5, 6};
+    resource_attributes["vec_uint64_value"]          = std::vector<uint64_t>{7, 8};
+    resource_attributes["vec_double_value"]          = std::vector<double>{3.2, 3.3};
+    resource_attributes["vec_string_value"]          = std::vector<std::string>{"vector", "string"};
+    auto resource = resource::Resource::Create(resource_attributes);
+
+    auto processor_opts                  = sdk::trace::BatchSpanProcessorOptions();
+    processor_opts.max_export_batch_size = 5;
+    processor_opts.max_queue_size        = 5;
+    processor_opts.schedule_delay_millis = std::chrono::milliseconds(256);
+    processor_opts.is_export_async       = is_async;
+    auto processor                       = std::unique_ptr<sdk::trace::SpanProcessor>(
+        new sdk::trace::BatchSpanProcessor(std::move(exporter), processor_opts));
+    auto provider = nostd::shared_ptr<trace::TracerProvider>(
+        new sdk::trace::TracerProvider(std::move(processor), resource));
+
+    std::string report_trace_id;
+
+    char trace_id_hex[2 * trace_api::TraceId::kSize] = {0};
+    auto tracer                                      = provider->GetTracer("test");
+    auto parent_span                                 = tracer->StartSpan("Test parent span");
+
+    trace_api::StartSpanOptions child_span_opts = {};
+    child_span_opts.parent                      = parent_span->GetContext();
+
+    auto child_span = tracer->StartSpan("Test child span", child_span_opts);
+
+    nostd::get<trace_api::SpanContext>(child_span_opts.parent)
+        .trace_id()
+        .ToLowerBase16(MakeSpan(trace_id_hex));
+    report_trace_id.assign(trace_id_hex, sizeof(trace_id_hex));
+
+    auto no_send_client = std::static_pointer_cast<http_client::nosend::HttpClient>(client);
+    auto mock_session =
+        std::static_pointer_cast<http_client::nosend::Session>(no_send_client->session_);
+    EXPECT_CALL(*mock_session, SendRequest)
+        .WillOnce([&mock_session, report_trace_id, is_async](
+                      std::shared_ptr<opentelemetry::ext::http::client::EventHandler> callback) {
+          auto check_json =
+              nlohmann::json::parse(mock_session->GetRequest()->body_, nullptr, false);
+          auto resource_span = *check_json["resource_spans"].begin();
+          auto instrumentation_library_span =
+              *resource_span["instrumentation_library_spans"].begin();
+          auto span              = *instrumentation_library_span["spans"].begin();
+          auto received_trace_id = span["trace_id"].get<std::string>();
+          EXPECT_EQ(received_trace_id, report_trace_id);
+
+          auto custom_header = mock_session->GetRequest()->headers_.find("Custom-Header-Key");
+          ASSERT_TRUE(custom_header != mock_session->GetRequest()->headers_.end());
+          if (custom_header != mock_session->GetRequest()->headers_.end())
+          {
+            EXPECT_EQ("Custom-Header-Value", custom_header->second);
+          }
+
+          // let the otlp_http_client to continue
+          if (is_async)
+          {
+            std::thread async_finish{[callback]() {
+              std::this_thread::sleep_for(std::chrono::milliseconds(100));
+              http_client::nosend::Response response;
+              response.Finish(*callback.get());
+            }};
+            async_finish.detach();
+          }
+          else
+          {
+            http_client::nosend::Response response;
+            response.Finish(*callback.get());
+          }
+        });
+
+    child_span->End();
+    parent_span->End();
+
+    static_cast<sdk::trace::TracerProvider *>(provider.get())->ForceFlush();
+  }
+
+  void ExportBinaryIntegrationTest(bool is_async)
+  {
+    auto mock_otlp_client =
+        OtlpHttpExporterTestPeer::GetMockOtlpHttpClient(HttpRequestContentType::kBinary);
+    auto mock_otlp_http_client = mock_otlp_client.first;
+    auto client                = mock_otlp_client.second;
+    auto exporter = GetExporter(std::unique_ptr<OtlpHttpClient>{mock_otlp_http_client});
+
+    resource::ResourceAttributes resource_attributes = {{"service.name", "unit_test_service"},
+                                                        {"tenant.id", "test_user"}};
+    resource_attributes["bool_value"]                = true;
+    resource_attributes["int32_value"]               = static_cast<int32_t>(1);
+    resource_attributes["uint32_value"]              = static_cast<uint32_t>(2);
+    resource_attributes["int64_value"]               = static_cast<int64_t>(0x1100000000LL);
+    resource_attributes["uint64_value"]              = static_cast<uint64_t>(0x1200000000ULL);
+    resource_attributes["double_value"]              = static_cast<double>(3.1);
+    resource_attributes["vec_bool_value"]            = std::vector<bool>{true, false, true};
+    resource_attributes["vec_int32_value"]           = std::vector<int32_t>{1, 2};
+    resource_attributes["vec_uint32_value"]          = std::vector<uint32_t>{3, 4};
+    resource_attributes["vec_int64_value"]           = std::vector<int64_t>{5, 6};
+    resource_attributes["vec_uint64_value"]          = std::vector<uint64_t>{7, 8};
+    resource_attributes["vec_double_value"]          = std::vector<double>{3.2, 3.3};
+    resource_attributes["vec_string_value"]          = std::vector<std::string>{"vector", "string"};
+    auto resource = resource::Resource::Create(resource_attributes);
+
+    auto processor_opts                  = sdk::trace::BatchSpanProcessorOptions();
+    processor_opts.max_export_batch_size = 5;
+    processor_opts.max_queue_size        = 5;
+    processor_opts.schedule_delay_millis = std::chrono::milliseconds(256);
+    processor_opts.is_export_async       = is_async;
+
+    auto processor = std::unique_ptr<sdk::trace::SpanProcessor>(
+        new sdk::trace::BatchSpanProcessor(std::move(exporter), processor_opts));
+    auto provider = nostd::shared_ptr<trace::TracerProvider>(
+        new sdk::trace::TracerProvider(std::move(processor), resource));
+
+    std::string report_trace_id;
+
+    uint8_t trace_id_binary[trace_api::TraceId::kSize] = {0};
+    auto tracer                                        = provider->GetTracer("test");
+    auto parent_span                                   = tracer->StartSpan("Test parent span");
+
+    trace_api::StartSpanOptions child_span_opts = {};
+    child_span_opts.parent                      = parent_span->GetContext();
+
+    auto child_span = tracer->StartSpan("Test child span", child_span_opts);
+    nostd::get<trace_api::SpanContext>(child_span_opts.parent)
+        .trace_id()
+        .CopyBytesTo(MakeSpan(trace_id_binary));
+    report_trace_id.assign(reinterpret_cast<char *>(trace_id_binary), sizeof(trace_id_binary));
+
+    auto no_send_client = std::static_pointer_cast<http_client::nosend::HttpClient>(client);
+    auto mock_session =
+        std::static_pointer_cast<http_client::nosend::Session>(no_send_client->session_);
+    EXPECT_CALL(*mock_session, SendRequest)
+        .WillOnce([&mock_session, report_trace_id, is_async](
+                      std::shared_ptr<opentelemetry::ext::http::client::EventHandler> callback) {
+          opentelemetry::proto::collector::trace::v1::ExportTraceServiceRequest request_body;
+          request_body.ParseFromArray(&mock_session->GetRequest()->body_[0],
+                                      static_cast<int>(mock_session->GetRequest()->body_.size()));
+          auto received_trace_id =
+              request_body.resource_spans(0).instrumentation_library_spans(0).spans(0).trace_id();
+          EXPECT_EQ(received_trace_id, report_trace_id);
+
+          auto custom_header = mock_session->GetRequest()->headers_.find("Custom-Header-Key");
+          ASSERT_TRUE(custom_header != mock_session->GetRequest()->headers_.end());
+          if (custom_header != mock_session->GetRequest()->headers_.end())
+          {
+            EXPECT_EQ("Custom-Header-Value", custom_header->second);
+          }
+
+          // let the otlp_http_client to continue
+          if (is_async)
+          {
+            std::thread async_finish{[callback]() {
+              std::this_thread::sleep_for(std::chrono::milliseconds(100));
+              http_client::nosend::Response response;
+              response.Finish(*callback.get());
+            }};
+            async_finish.detach();
+          }
+          else
+          {
+            http_client::nosend::Response response;
+            response.Finish(*callback.get());
+          }
+        });
+
+    child_span->End();
+    parent_span->End();
+
+    static_cast<sdk::trace::TracerProvider *>(provider.get())->ForceFlush();
+  }
 };
 
 // Create spans, let processor call Export()
-TEST_F(OtlpHttpExporterTestPeer, ExportJsonIntegrationTest)
+TEST_F(OtlpHttpExporterTestPeer, ExportJsonIntegrationTestSync)
 {
-  auto mock_otlp_client =
-      OtlpHttpExporterTestPeer::GetMockOtlpHttpClient(HttpRequestContentType::kJson);
-  auto mock_otlp_http_client = mock_otlp_client.first;
-  auto client                = mock_otlp_client.second;
-  auto exporter              = GetExporter(std::unique_ptr<OtlpHttpClient>{mock_otlp_http_client});
+  ExportJsonIntegrationTest(false);
+}
 
-  resource::ResourceAttributes resource_attributes = {{"service.name", "unit_test_service"},
-                                                      {"tenant.id", "test_user"}};
-  resource_attributes["bool_value"]                = true;
-  resource_attributes["int32_value"]               = static_cast<int32_t>(1);
-  resource_attributes["uint32_value"]              = static_cast<uint32_t>(2);
-  resource_attributes["int64_value"]               = static_cast<int64_t>(0x1100000000LL);
-  resource_attributes["uint64_value"]              = static_cast<uint64_t>(0x1200000000ULL);
-  resource_attributes["double_value"]              = static_cast<double>(3.1);
-  resource_attributes["vec_bool_value"]            = std::vector<bool>{true, false, true};
-  resource_attributes["vec_int32_value"]           = std::vector<int32_t>{1, 2};
-  resource_attributes["vec_uint32_value"]          = std::vector<uint32_t>{3, 4};
-  resource_attributes["vec_int64_value"]           = std::vector<int64_t>{5, 6};
-  resource_attributes["vec_uint64_value"]          = std::vector<uint64_t>{7, 8};
-  resource_attributes["vec_double_value"]          = std::vector<double>{3.2, 3.3};
-  resource_attributes["vec_string_value"]          = std::vector<std::string>{"vector", "string"};
-  auto resource = resource::Resource::Create(resource_attributes);
-
-  auto processor_opts                  = sdk::trace::BatchSpanProcessorOptions();
-  processor_opts.max_export_batch_size = 5;
-  processor_opts.max_queue_size        = 5;
-  processor_opts.schedule_delay_millis = std::chrono::milliseconds(256);
-  auto processor                       = std::unique_ptr<sdk::trace::SpanProcessor>(
-      new sdk::trace::BatchSpanProcessor(std::move(exporter), processor_opts));
-  auto provider = nostd::shared_ptr<trace::TracerProvider>(
-      new sdk::trace::TracerProvider(std::move(processor), resource));
-
-  std::string report_trace_id;
-
-  char trace_id_hex[2 * trace_api::TraceId::kSize] = {0};
-  auto tracer                                      = provider->GetTracer("test");
-  auto parent_span                                 = tracer->StartSpan("Test parent span");
-
-  trace_api::StartSpanOptions child_span_opts = {};
-  child_span_opts.parent                      = parent_span->GetContext();
-
-  auto child_span = tracer->StartSpan("Test child span", child_span_opts);
-
-  nostd::get<trace_api::SpanContext>(child_span_opts.parent)
-      .trace_id()
-      .ToLowerBase16(MakeSpan(trace_id_hex));
-  report_trace_id.assign(trace_id_hex, sizeof(trace_id_hex));
-
-  auto no_send_client = std::static_pointer_cast<http_client::nosend::HttpClient>(client);
-  auto mock_session =
-      std::static_pointer_cast<http_client::nosend::Session>(no_send_client->session_);
-  EXPECT_CALL(*mock_session, SendRequest)
-      .WillOnce([&mock_session, report_trace_id](
-                    std::shared_ptr<opentelemetry::ext::http::client::EventHandler> callback) {
-        auto check_json = nlohmann::json::parse(mock_session->GetRequest()->body_, nullptr, false);
-        auto resource_span                = *check_json["resource_spans"].begin();
-        auto instrumentation_library_span = *resource_span["instrumentation_library_spans"].begin();
-        auto span                         = *instrumentation_library_span["spans"].begin();
-        auto received_trace_id            = span["trace_id"].get<std::string>();
-        EXPECT_EQ(received_trace_id, report_trace_id);
-
-        auto custom_header = mock_session->GetRequest()->headers_.find("Custom-Header-Key");
-        ASSERT_TRUE(custom_header != mock_session->GetRequest()->headers_.end());
-        if (custom_header != mock_session->GetRequest()->headers_.end())
-        {
-          EXPECT_EQ("Custom-Header-Value", custom_header->second);
-        }
-        // let the otlp_http_client to continue
-        http_client::nosend::Response response;
-        callback->OnResponse(response);
-      });
-
-  child_span->End();
-  parent_span->End();
-
-  static_cast<sdk::trace::TracerProvider *>(provider.get())->ForceFlush();
+TEST_F(OtlpHttpExporterTestPeer, ExportJsonIntegrationTestAsync)
+{
+  ExportJsonIntegrationTest(true);
 }
 
 // Create spans, let processor call Export()
-TEST_F(OtlpHttpExporterTestPeer, ExportBinaryIntegrationTest)
+TEST_F(OtlpHttpExporterTestPeer, ExportBinaryIntegrationTestSync)
 {
-  auto mock_otlp_client =
-      OtlpHttpExporterTestPeer::GetMockOtlpHttpClient(HttpRequestContentType::kBinary);
-  auto mock_otlp_http_client = mock_otlp_client.first;
-  auto client                = mock_otlp_client.second;
-  auto exporter              = GetExporter(std::unique_ptr<OtlpHttpClient>{mock_otlp_http_client});
+  ExportBinaryIntegrationTest(false);
+}
 
-  resource::ResourceAttributes resource_attributes = {{"service.name", "unit_test_service"},
-                                                      {"tenant.id", "test_user"}};
-  resource_attributes["bool_value"]                = true;
-  resource_attributes["int32_value"]               = static_cast<int32_t>(1);
-  resource_attributes["uint32_value"]              = static_cast<uint32_t>(2);
-  resource_attributes["int64_value"]               = static_cast<int64_t>(0x1100000000LL);
-  resource_attributes["uint64_value"]              = static_cast<uint64_t>(0x1200000000ULL);
-  resource_attributes["double_value"]              = static_cast<double>(3.1);
-  resource_attributes["vec_bool_value"]            = std::vector<bool>{true, false, true};
-  resource_attributes["vec_int32_value"]           = std::vector<int32_t>{1, 2};
-  resource_attributes["vec_uint32_value"]          = std::vector<uint32_t>{3, 4};
-  resource_attributes["vec_int64_value"]           = std::vector<int64_t>{5, 6};
-  resource_attributes["vec_uint64_value"]          = std::vector<uint64_t>{7, 8};
-  resource_attributes["vec_double_value"]          = std::vector<double>{3.2, 3.3};
-  resource_attributes["vec_string_value"]          = std::vector<std::string>{"vector", "string"};
-  auto resource = resource::Resource::Create(resource_attributes);
-
-  auto processor_opts                  = sdk::trace::BatchSpanProcessorOptions();
-  processor_opts.max_export_batch_size = 5;
-  processor_opts.max_queue_size        = 5;
-  processor_opts.schedule_delay_millis = std::chrono::milliseconds(256);
-
-  auto processor = std::unique_ptr<sdk::trace::SpanProcessor>(
-      new sdk::trace::BatchSpanProcessor(std::move(exporter), processor_opts));
-  auto provider = nostd::shared_ptr<trace::TracerProvider>(
-      new sdk::trace::TracerProvider(std::move(processor), resource));
-
-  std::string report_trace_id;
-
-  uint8_t trace_id_binary[trace_api::TraceId::kSize] = {0};
-  auto tracer                                        = provider->GetTracer("test");
-  auto parent_span                                   = tracer->StartSpan("Test parent span");
-
-  trace_api::StartSpanOptions child_span_opts = {};
-  child_span_opts.parent                      = parent_span->GetContext();
-
-  auto child_span = tracer->StartSpan("Test child span", child_span_opts);
-  nostd::get<trace_api::SpanContext>(child_span_opts.parent)
-      .trace_id()
-      .CopyBytesTo(MakeSpan(trace_id_binary));
-  report_trace_id.assign(reinterpret_cast<char *>(trace_id_binary), sizeof(trace_id_binary));
-
-  auto no_send_client = std::static_pointer_cast<http_client::nosend::HttpClient>(client);
-  auto mock_session =
-      std::static_pointer_cast<http_client::nosend::Session>(no_send_client->session_);
-  EXPECT_CALL(*mock_session, SendRequest)
-      .WillOnce([&mock_session, report_trace_id](
-                    std::shared_ptr<opentelemetry::ext::http::client::EventHandler> callback) {
-        opentelemetry::proto::collector::trace::v1::ExportTraceServiceRequest request_body;
-        request_body.ParseFromArray(&mock_session->GetRequest()->body_[0],
-                                    static_cast<int>(mock_session->GetRequest()->body_.size()));
-        auto received_trace_id =
-            request_body.resource_spans(0).instrumentation_library_spans(0).spans(0).trace_id();
-        EXPECT_EQ(received_trace_id, report_trace_id);
-
-        auto custom_header = mock_session->GetRequest()->headers_.find("Custom-Header-Key");
-        ASSERT_TRUE(custom_header != mock_session->GetRequest()->headers_.end());
-        if (custom_header != mock_session->GetRequest()->headers_.end())
-        {
-          EXPECT_EQ("Custom-Header-Value", custom_header->second);
-        }
-
-        // let the otlp_http_client to continue
-        http_client::nosend::Response response;
-
-        response.Finish(*callback.get());
-      });
-
-  child_span->End();
-  parent_span->End();
-
-  static_cast<sdk::trace::TracerProvider *>(provider.get())->ForceFlush();
+TEST_F(OtlpHttpExporterTestPeer, ExportBinaryIntegrationTestAsync)
+{
+  ExportBinaryIntegrationTest(true);
 }
 
 // Test exporter configuration options

--- a/exporters/otlp/test/otlp_http_exporter_test.cc
+++ b/exporters/otlp/test/otlp_http_exporter_test.cc
@@ -160,6 +160,8 @@ TEST_F(OtlpHttpExporterTestPeer, ExportJsonIntegrationTest)
 
   child_span->End();
   parent_span->End();
+
+  static_cast<sdk::trace::TracerProvider *>(provider.get())->ForceFlush();
 }
 
 // Create spans, let processor call Export()
@@ -232,13 +234,16 @@ TEST_F(OtlpHttpExporterTestPeer, ExportBinaryIntegrationTest)
         {
           EXPECT_EQ("Custom-Header-Value", custom_header->second);
         }
+
         // let the otlp_http_client to continue
         http_client::nosend::Response response;
-        callback.OnResponse(response);
+        response.Finish(callback);
       });
 
   child_span->End();
   parent_span->End();
+
+  static_cast<sdk::trace::TracerProvider *>(provider.get())->ForceFlush();
 }
 
 // Test exporter configuration options

--- a/exporters/otlp/test/otlp_http_log_exporter_test.cc
+++ b/exporters/otlp/test/otlp_http_log_exporter_test.cc
@@ -118,25 +118,6 @@ TEST_F(OtlpHttpLogExporterTestPeer, ExportJsonIntegrationTest)
 
   const std::string schema_url{"https://opentelemetry.io/schemas/1.2.0"};
   auto logger = provider->GetLogger("test", "", "opentelelemtry_library", "", schema_url);
-  logger->Log(opentelemetry::logs::Severity::kInfo, "Log name", "Log message",
-              {{"service.name", "unit_test_service"},
-               {"tenant.id", "test_user"},
-               {"bool_value", true},
-               {"int32_value", static_cast<int32_t>(1)},
-               {"uint32_value", static_cast<uint32_t>(2)},
-               {"int64_value", static_cast<int64_t>(0x1100000000LL)},
-               {"uint64_value", static_cast<uint64_t>(0x1200000000ULL)},
-               {"double_value", static_cast<double>(3.1)},
-               {"vec_bool_value", attribute_storage_bool_value},
-               {"vec_int32_value", attribute_storage_int32_value},
-               {"vec_uint32_value", attribute_storage_uint32_value},
-               {"vec_int64_value", attribute_storage_int64_value},
-               {"vec_uint64_value", attribute_storage_uint64_value},
-               {"vec_double_value", attribute_storage_double_value},
-               {"vec_string_value", attribute_storage_string_value}},
-              trace_id, span_id,
-              opentelemetry::trace::TraceFlags{opentelemetry::trace::TraceFlags::kIsSampled},
-              std::chrono::system_clock::now());
 
   trace_id.ToLowerBase16(MakeSpan(trace_id_hex));
   report_trace_id.assign(trace_id_hex, sizeof(trace_id_hex));
@@ -167,10 +148,33 @@ TEST_F(OtlpHttpLogExporterTestPeer, ExportJsonIntegrationTest)
         {
           EXPECT_EQ("Custom-Header-Value", custom_header->second);
         }
+
         // let the otlp_http_client to continue
         http_client::nosend::Response response;
-        callback.OnResponse(response);
+        response.Finish(callback);
       });
+
+  logger->Log(opentelemetry::logs::Severity::kInfo, "Log name", "Log message",
+              {{"service.name", "unit_test_service"},
+               {"tenant.id", "test_user"},
+               {"bool_value", true},
+               {"int32_value", static_cast<int32_t>(1)},
+               {"uint32_value", static_cast<uint32_t>(2)},
+               {"int64_value", static_cast<int64_t>(0x1100000000LL)},
+               {"uint64_value", static_cast<uint64_t>(0x1200000000ULL)},
+               {"double_value", static_cast<double>(3.1)},
+               {"vec_bool_value", attribute_storage_bool_value},
+               {"vec_int32_value", attribute_storage_int32_value},
+               {"vec_uint32_value", attribute_storage_uint32_value},
+               {"vec_int64_value", attribute_storage_int64_value},
+               {"vec_uint64_value", attribute_storage_uint64_value},
+               {"vec_double_value", attribute_storage_double_value},
+               {"vec_string_value", attribute_storage_string_value}},
+              trace_id, span_id,
+              opentelemetry::trace::TraceFlags{opentelemetry::trace::TraceFlags::kIsSampled},
+              std::chrono::system_clock::now());
+
+  provider->ForceFlush();
 }
 
 // Create log records, let processor call Export()
@@ -205,25 +209,6 @@ TEST_F(OtlpHttpLogExporterTestPeer, ExportBinaryIntegrationTest)
 
   const std::string schema_url{"https://opentelemetry.io/schemas/1.2.0"};
   auto logger = provider->GetLogger("test", "", "opentelelemtry_library", "", schema_url);
-  logger->Log(opentelemetry::logs::Severity::kInfo, "Log name", "Log message",
-              {{"service.name", "unit_test_service"},
-               {"tenant.id", "test_user"},
-               {"bool_value", true},
-               {"int32_value", static_cast<int32_t>(1)},
-               {"uint32_value", static_cast<uint32_t>(2)},
-               {"int64_value", static_cast<int64_t>(0x1100000000LL)},
-               {"uint64_value", static_cast<uint64_t>(0x1200000000ULL)},
-               {"double_value", static_cast<double>(3.1)},
-               {"vec_bool_value", attribute_storage_bool_value},
-               {"vec_int32_value", attribute_storage_int32_value},
-               {"vec_uint32_value", attribute_storage_uint32_value},
-               {"vec_int64_value", attribute_storage_int64_value},
-               {"vec_uint64_value", attribute_storage_uint64_value},
-               {"vec_double_value", attribute_storage_double_value},
-               {"vec_string_value", attribute_storage_string_value}},
-              trace_id, span_id,
-              opentelemetry::trace::TraceFlags{opentelemetry::trace::TraceFlags::kIsSampled},
-              std::chrono::system_clock::now());
 
   report_trace_id.assign(reinterpret_cast<const char *>(trace_id_bin), sizeof(trace_id_bin));
   report_span_id.assign(reinterpret_cast<const char *>(span_id_bin), sizeof(span_id_bin));
@@ -256,6 +241,28 @@ TEST_F(OtlpHttpLogExporterTestPeer, ExportBinaryIntegrationTest)
         http_client::nosend::Response response;
         callback.OnResponse(response);
       });
+
+  logger->Log(opentelemetry::logs::Severity::kInfo, "Log name", "Log message",
+              {{"service.name", "unit_test_service"},
+               {"tenant.id", "test_user"},
+               {"bool_value", true},
+               {"int32_value", static_cast<int32_t>(1)},
+               {"uint32_value", static_cast<uint32_t>(2)},
+               {"int64_value", static_cast<int64_t>(0x1100000000LL)},
+               {"uint64_value", static_cast<uint64_t>(0x1200000000ULL)},
+               {"double_value", static_cast<double>(3.1)},
+               {"vec_bool_value", attribute_storage_bool_value},
+               {"vec_int32_value", attribute_storage_int32_value},
+               {"vec_uint32_value", attribute_storage_uint32_value},
+               {"vec_int64_value", attribute_storage_int64_value},
+               {"vec_uint64_value", attribute_storage_uint64_value},
+               {"vec_double_value", attribute_storage_double_value},
+               {"vec_string_value", attribute_storage_string_value}},
+              trace_id, span_id,
+              opentelemetry::trace::TraceFlags{opentelemetry::trace::TraceFlags::kIsSampled},
+              std::chrono::system_clock::now());
+
+  provider->ForceFlush();
 }
 
 // Test exporter configuration options

--- a/exporters/zipkin/include/opentelemetry/exporters/zipkin/zipkin_exporter.h
+++ b/exporters/zipkin/include/opentelemetry/exporters/zipkin/zipkin_exporter.h
@@ -79,6 +79,15 @@ public:
       override;
 
   /**
+   * Export asynchronosly a batch of span recordables in JSON format
+   * @param spans a span of unique pointers to span recordables
+   * @param result_callback callback function accepting ExportResult as argument
+   */
+  void Export(const nostd::span<std::unique_ptr<opentelemetry::sdk::trace::Recordable>> &spans,
+              nostd::function_ref<bool(opentelemetry::sdk::common::ExportResult)>
+                  result_callback) noexcept override;
+
+  /**
    * Shut down the exporter.
    * @param timeout an optional timeout, default to max.
    */

--- a/exporters/zipkin/include/opentelemetry/exporters/zipkin/zipkin_exporter.h
+++ b/exporters/zipkin/include/opentelemetry/exporters/zipkin/zipkin_exporter.h
@@ -84,8 +84,8 @@ public:
    * @param result_callback callback function accepting ExportResult as argument
    */
   void Export(const nostd::span<std::unique_ptr<opentelemetry::sdk::trace::Recordable>> &spans,
-              nostd::function_ref<bool(opentelemetry::sdk::common::ExportResult)>
-                  result_callback) noexcept override;
+              std::function<bool(opentelemetry::sdk::common::ExportResult)>
+                  &&result_callback) noexcept override;
 
   /**
    * Shut down the exporter.

--- a/exporters/zipkin/src/zipkin_exporter.cc
+++ b/exporters/zipkin/src/zipkin_exporter.cc
@@ -95,7 +95,7 @@ sdk::common::ExportResult ZipkinExporter::Export(
 
 void ZipkinExporter::Export(
     const nostd::span<std::unique_ptr<sdk::trace::Recordable>> &spans,
-    nostd::function_ref<bool(sdk::common::ExportResult)> result_callback) noexcept
+    std::function<bool(opentelemetry::sdk::common::ExportResult)> &&result_callback) noexcept
 {
   OTEL_INTERNAL_LOG_WARN("[ZIPKIN EXPORTER] async not supported. Making sync interface call");
   auto status = Export(spans);

--- a/exporters/zipkin/src/zipkin_exporter.cc
+++ b/exporters/zipkin/src/zipkin_exporter.cc
@@ -93,6 +93,15 @@ sdk::common::ExportResult ZipkinExporter::Export(
   return sdk::common::ExportResult::kSuccess;
 }
 
+void ZipkinExporter::Export(
+    const nostd::span<std::unique_ptr<sdk::trace::Recordable>> &spans,
+    nostd::function_ref<bool(sdk::common::ExportResult)> result_callback) noexcept
+{
+  OTEL_INTERNAL_LOG_WARN("[ZIPKIN EXPORTER] async not supported. Making sync interface call");
+  auto status = Export(spans);
+  result_callback(status);
+}
+
 void ZipkinExporter::InitializeLocalEndpoint()
 {
   if (options_.service_name.length())

--- a/ext/include/opentelemetry/ext/http/client/curl/http_client_curl.h
+++ b/ext/include/opentelemetry/ext/http/client/curl/http_client_curl.h
@@ -280,18 +280,30 @@ public:
 
   bool CancelAllSessions() noexcept override
   {
-    for (auto &session : sessions_)
+    // CancelSession may change sessions_, we can not change a container while iterating it.
+    while (!sessions_.empty())
     {
-      session.second->CancelSession();
+      std::map<uint64_t, std::shared_ptr<Session>> sessions;
+      sessions.swap(sessions_);
+      for (auto &session : sessions)
+      {
+        session.second->CancelSession();
+      }
     }
     return true;
   }
 
   bool FinishAllSessions() noexcept override
   {
-    for (auto &session : sessions_)
+    // FinishSession may change sessions_, we can not change a container while iterating it.
+    while (!sessions_.empty())
     {
-      session.second->FinishSession();
+      std::map<uint64_t, std::shared_ptr<Session>> sessions;
+      sessions.swap(sessions_);
+      for (auto &session : sessions)
+      {
+        session.second->FinishSession();
+      }
     }
     return true;
   }

--- a/ext/include/opentelemetry/ext/http/client/http_client.h
+++ b/ext/include/opentelemetry/ext/http/client/http_client.h
@@ -212,7 +212,7 @@ class Session
 public:
   virtual std::shared_ptr<Request> CreateRequest() noexcept = 0;
 
-  virtual void SendRequest(EventHandler &) noexcept = 0;
+  virtual void SendRequest(std::shared_ptr<EventHandler>) noexcept = 0;
 
   virtual bool IsSessionActive() noexcept = 0;
 

--- a/ext/include/opentelemetry/ext/http/client/nosend/http_client_nosend.h
+++ b/ext/include/opentelemetry/ext/http/client/nosend/http_client_nosend.h
@@ -93,6 +93,19 @@ public:
     return status_code_;
   }
 
+  void Finish(opentelemetry::ext::http::client::EventHandler &callback) noexcept
+  {
+    callback.OnEvent(opentelemetry::ext::http::client::SessionState::Created, "");
+    callback.OnEvent(opentelemetry::ext::http::client::SessionState::Connecting, "");
+    callback.OnEvent(opentelemetry::ext::http::client::SessionState::Connected, "");
+    callback.OnEvent(opentelemetry::ext::http::client::SessionState::Sending, "");
+
+    // let the otlp_http_client to continue
+    callback.OnResponse(*this);
+
+    callback.OnEvent(opentelemetry::ext::http::client::SessionState::Response, "");
+  }
+
 public:
   Headers headers_;
   opentelemetry::ext::http::client::Body body_;

--- a/ext/include/opentelemetry/ext/http/client/nosend/http_client_nosend.h
+++ b/ext/include/opentelemetry/ext/http/client/nosend/http_client_nosend.h
@@ -134,7 +134,7 @@ public:
 
   MOCK_METHOD(void,
               SendRequest,
-              (opentelemetry::ext::http::client::EventHandler &),
+              (std::shared_ptr<opentelemetry::ext::http::client::EventHandler>),
               (noexcept, override));
 
   virtual bool CancelSession() noexcept override;

--- a/ext/test/http/curl_http_test.cc
+++ b/ext/test/http/curl_http_test.cc
@@ -196,12 +196,11 @@ TEST_F(BasicCurlHttpTests, SendGetRequest)
   auto session = session_manager->CreateSession("http://127.0.0.1:19000");
   auto request = session->CreateRequest();
   request->SetUri("get/");
-  GetEventHandler *handler = new GetEventHandler();
-  session->SendRequest(*handler);
+  auto handler = std::make_shared<GetEventHandler>();
+  session->SendRequest(handler);
   ASSERT_TRUE(waitForRequests(30, 1));
   session->FinishSession();
   ASSERT_TRUE(handler->is_called_);
-  delete handler;
 }
 
 TEST_F(BasicCurlHttpTests, SendPostRequest)
@@ -219,16 +218,14 @@ TEST_F(BasicCurlHttpTests, SendPostRequest)
   http_client::Body body = {b, b + strlen(b)};
   request->SetBody(body);
   request->AddHeader("Content-Type", "text/plain");
-  PostEventHandler *handler = new PostEventHandler();
-  session->SendRequest(*handler);
+  auto handler = std::make_shared<PostEventHandler>();
+  session->SendRequest(handler);
   ASSERT_TRUE(waitForRequests(30, 1));
   session->FinishSession();
   ASSERT_TRUE(handler->is_called_);
 
   session_manager->CancelAllSessions();
   session_manager->FinishAllSessions();
-
-  delete handler;
 }
 
 TEST_F(BasicCurlHttpTests, RequestTimeout)
@@ -240,11 +237,10 @@ TEST_F(BasicCurlHttpTests, RequestTimeout)
   auto session = session_manager->CreateSession("222.222.222.200:19000");  // Non Existing address
   auto request = session->CreateRequest();
   request->SetUri("get/");
-  GetEventHandler *handler = new GetEventHandler();
-  session->SendRequest(*handler);
+  auto handler = std::make_shared<GetEventHandler>();
+  session->SendRequest(handler);
   session->FinishSession();
   ASSERT_FALSE(handler->is_called_);
-  delete handler;
 }
 
 TEST_F(BasicCurlHttpTests, CurlHttpOperations)

--- a/ext/test/w3c_tracecontext_test/main.cc
+++ b/ext/test/w3c_tracecontext_test/main.cc
@@ -100,7 +100,7 @@ public:
 // Sends an HTTP POST request to the given url, with the given body.
 void send_request(curl::HttpClient &client, const std::string &url, const std::string &body)
 {
-  static std::unique_ptr<http_client::EventHandler> handler(new NoopEventHandler());
+  static std::shared_ptr<http_client::EventHandler> handler(new NoopEventHandler());
 
   auto request_span = get_tracer()->StartSpan(__func__);
   trace_api::Scope scope(request_span);
@@ -126,7 +126,7 @@ void send_request(curl::HttpClient &client, const std::string &url, const std::s
     request->AddHeader(hdr.first, hdr.second);
   }
 
-  session->SendRequest(*handler);
+  session->SendRequest(handler);
   session->FinishSession();
 }
 

--- a/sdk/include/opentelemetry/sdk/logs/batch_log_processor.h
+++ b/sdk/include/opentelemetry/sdk/logs/batch_log_processor.h
@@ -138,12 +138,8 @@ private:
 
   /**
    * Should be called from Export to notify the main thread on Force Flush Completion
-   * @param was_force_flush_called - A flag to check if the current export is the result
-   *                                 of a call to ForceFlush method. If true, then we have to
-   *                                 notify the main thread to wake it up in the ForceFlush
-   *                                 method.
    */
-  void NotifyForceFlushCompletion(const bool was_for_flush_called);
+  void NotifyForceFlushCompletion();
 
   /* In case of async export, wait and notify for shutdown to be completed.*/
   void WaitForShutdownCompletion();

--- a/sdk/include/opentelemetry/sdk/logs/batch_log_processor.h
+++ b/sdk/include/opentelemetry/sdk/logs/batch_log_processor.h
@@ -10,6 +10,7 @@
 
 #  include <atomic>
 #  include <condition_variable>
+#  include <memory>
 #  include <thread>
 
 OPENTELEMETRY_BEGIN_NAMESPACE
@@ -136,14 +137,31 @@ private:
    */
   void DrainQueue();
 
-  /**
-   * Should be called from Export to notify the main thread on Force Flush Completion
-   */
-  void NotifyForceFlushCompletion();
-
   /* In case of async export, wait and notify for shutdown to be completed.*/
   void WaitForShutdownCompletion();
-  void NotifyShutdownCompletion();
+
+  struct SynchronizationData
+  {
+    /* Synchronization primitives */
+    std::condition_variable cv_, force_flush_cv_, async_shutdown_cv_;
+    std::mutex cv_m_, force_flush_cv_m_, shutdown_m_, async_shutdown_m_;
+
+    /* Important boolean flags to handle the workflow of the processor */
+    std::atomic<bool> is_shutdown_;
+    std::atomic<bool> is_force_flush_;
+    std::atomic<bool> is_force_flush_notified_;
+    std::atomic<bool> is_async_shutdown_notified_;
+  };
+
+  /**
+   * @brief Notify completion of shutdown and force flush. This may be called from the any thread at
+   * any time
+   *
+   * @param notify_force_flush Flag to indicate whether to notify force flush completion.
+   * @param synchronization_data Synchronization data to be notified.
+   */
+  static void NotifyCompletion(bool notify_force_flush,
+                               const std::shared_ptr<SynchronizationData> &synchronization_data);
 
   /* The configured backend log exporter */
   std::unique_ptr<LogExporter> exporter_;
@@ -154,18 +172,10 @@ private:
   const size_t max_export_batch_size_;
   const bool is_export_async_;
 
-  /* Synchronization primitives */
-  std::condition_variable cv_, force_flush_cv_, async_shutdown_cv_;
-  std::mutex cv_m_, force_flush_cv_m_, shutdown_m_, async_shutdown_m_;
-
   /* The buffer/queue to which the ended logs are added */
   common::CircularBuffer<Recordable> buffer_;
 
-  /* Important boolean flags to handle the workflow of the processor */
-  std::atomic<bool> is_shutdown_;
-  std::atomic<bool> is_force_flush_;
-  std::atomic<bool> is_force_flush_notified_;
-  std::atomic<bool> is_async_shutdown_notified_;
+  std::shared_ptr<SynchronizationData> synchronization_data_;
 
   /* The background worker thread */
   std::thread worker_thread_;

--- a/sdk/include/opentelemetry/sdk/logs/batch_log_processor.h
+++ b/sdk/include/opentelemetry/sdk/logs/batch_log_processor.h
@@ -20,6 +20,33 @@ namespace logs
 {
 
 /**
+ * Struct to hold batch SpanProcessor options.
+ */
+struct BatchLogProcessorOptions
+{
+  /**
+   * The maximum buffer/queue size. After the size is reached, spans are
+   * dropped.
+   */
+  size_t max_queue_size = 2048;
+
+  /* The time interval between two consecutive exports. */
+  std::chrono::milliseconds schedule_delay_millis = std::chrono::milliseconds(5000);
+
+  /**
+   * The maximum batch size of every export. It must be smaller or
+   * equal to max_queue_size.
+   */
+  size_t max_export_batch_size = 512;
+
+  /**
+   * Determines whether the export happens asynchronously.
+   * Default implementation is synchronous.
+   */
+  bool is_export_async = false;
+};
+
+/**
  * This is an implementation of the LogProcessor which creates batches of finished logs and passes
  * the export-friendly log data representations to the configured LogExporter.
  */
@@ -43,6 +70,16 @@ public:
       const std::chrono::milliseconds scheduled_delay_millis = std::chrono::milliseconds(5000),
       const size_t max_export_batch_size                     = 512,
       const bool is_export_async                             = false);
+
+  /**
+   * Creates a batch log processor by configuring the specified exporter and other parameters
+   * as per the official, language-agnostic opentelemetry specs.
+   *
+   * @param exporter - The backend exporter to pass the logs to
+   * @param options - The batch SpanProcessor options.
+   */
+  explicit BatchLogProcessor(std::unique_ptr<LogExporter> &&exporter,
+                             const BatchLogProcessorOptions &options);
 
   /** Makes a new recordable **/
   std::unique_ptr<Recordable> MakeRecordable() noexcept override;

--- a/sdk/include/opentelemetry/sdk/logs/batch_log_processor.h
+++ b/sdk/include/opentelemetry/sdk/logs/batch_log_processor.h
@@ -114,9 +114,9 @@ private:
   common::CircularBuffer<Recordable> buffer_;
 
   /* Important boolean flags to handle the workflow of the processor */
-  std::atomic<bool> is_shutdown_{false};
-  std::atomic<bool> is_force_flush_{false};
-  std::atomic<bool> is_force_flush_notified_{false};
+  std::atomic<bool> is_shutdown_;
+  std::atomic<bool> is_force_flush_;
+  std::atomic<bool> is_force_flush_notified_;
 
   /* The background worker thread */
   std::thread worker_thread_;

--- a/sdk/include/opentelemetry/sdk/logs/exporter.h
+++ b/sdk/include/opentelemetry/sdk/logs/exporter.h
@@ -53,7 +53,7 @@ public:
    */
   virtual void Export(
       const nostd::span<std::unique_ptr<Recordable>> &records,
-      nostd::function_ref<bool(sdk::common::ExportResult)> result_callback) noexcept = 0;
+      std::function<bool(opentelemetry::sdk::common::ExportResult)> &&result_callback) noexcept = 0;
 
   /**
    * Marks the exporter as ShutDown and cleans up any resources as required.

--- a/sdk/include/opentelemetry/sdk/logs/exporter.h
+++ b/sdk/include/opentelemetry/sdk/logs/exporter.h
@@ -47,6 +47,15 @@ public:
       const nostd::span<std::unique_ptr<Recordable>> &records) noexcept = 0;
 
   /**
+   * Exports asynchronously the batch of log records to their export destination
+   * @param records a span of unique pointers to log records
+   * @param result_callback callback function accepting ExportResult as argument
+   */
+  virtual void Export(
+      const nostd::span<std::unique_ptr<Recordable>> &records,
+      nostd::function_ref<bool(sdk::common::ExportResult)> result_callback) noexcept = 0;
+
+  /**
    * Marks the exporter as ShutDown and cleans up any resources as required.
    * Shutdown should be called only once for each Exporter instance.
    * @param timeout minimum amount of microseconds to wait for shutdown before giving up and

--- a/sdk/include/opentelemetry/sdk/logs/simple_log_processor.h
+++ b/sdk/include/opentelemetry/sdk/logs/simple_log_processor.h
@@ -28,7 +28,8 @@ class SimpleLogProcessor : public LogProcessor
 {
 
 public:
-  explicit SimpleLogProcessor(std::unique_ptr<LogExporter> &&exporter);
+  explicit SimpleLogProcessor(std::unique_ptr<LogExporter> &&exporter,
+                              bool is_export_async = false);
   virtual ~SimpleLogProcessor() = default;
 
   std::unique_ptr<Recordable> MakeRecordable() noexcept override;
@@ -48,6 +49,7 @@ private:
   opentelemetry::common::SpinLockMutex lock_;
   // The atomic boolean flag to ensure the ShutDown() function is only called once
   std::atomic_flag shutdown_latch_ = ATOMIC_FLAG_INIT;
+  bool is_export_async_            = false;
 };
 }  // namespace logs
 }  // namespace sdk

--- a/sdk/include/opentelemetry/sdk/trace/batch_span_processor.h
+++ b/sdk/include/opentelemetry/sdk/trace/batch_span_processor.h
@@ -145,9 +145,9 @@ private:
   common::CircularBuffer<Recordable> buffer_;
 
   /* Important boolean flags to handle the workflow of the processor */
-  std::atomic<bool> is_shutdown_{false};
-  std::atomic<bool> is_force_flush_{false};
-  std::atomic<bool> is_force_flush_notified_{false};
+  std::atomic<bool> is_shutdown_;
+  std::atomic<bool> is_force_flush_;
+  std::atomic<bool> is_force_flush_notified_;
 
   /* The background worker thread */
   std::thread worker_thread_;

--- a/sdk/include/opentelemetry/sdk/trace/batch_span_processor.h
+++ b/sdk/include/opentelemetry/sdk/trace/batch_span_processor.h
@@ -137,12 +137,8 @@ private:
 
   /**
    * Should be called from Export to notify the main thread on Force Flush Completion
-   * @param was_force_flush_called - A flag to check if the current export is the result
-   *                                 of a call to ForceFlush method. If true, then we have to
-   *                                 notify the main thread to wake it up in the ForceFlush
-   *                                 method.
    */
-  void NotifyForceFlushCompletion(const bool was_for_flush_called);
+  void NotifyForceFlushCompletion();
 
   /* In case of async export, wait and notify for shutdown to be completed.*/
   void WaitForShutdownCompletion();

--- a/sdk/include/opentelemetry/sdk/trace/exporter.h
+++ b/sdk/include/opentelemetry/sdk/trace/exporter.h
@@ -43,6 +43,15 @@ public:
           &spans) noexcept = 0;
 
   /**
+   * Exports a batch of span recordables asynchronously.
+   * @param spans a span of unique pointers to span recordables
+   * @param result_callback callback function accepting ExportResult as argument
+   */
+  virtual void Export(
+      const nostd::span<std::unique_ptr<opentelemetry::sdk::trace::Recordable>> &spans,
+      nostd::function_ref<bool(sdk::common::ExportResult)> result_callback) noexcept = 0;
+
+  /**
    * Shut down the exporter.
    * @param timeout an optional timeout.
    * @return return the status of the operation.

--- a/sdk/include/opentelemetry/sdk/trace/exporter.h
+++ b/sdk/include/opentelemetry/sdk/trace/exporter.h
@@ -49,7 +49,7 @@ public:
    */
   virtual void Export(
       const nostd::span<std::unique_ptr<opentelemetry::sdk::trace::Recordable>> &spans,
-      nostd::function_ref<bool(sdk::common::ExportResult)> result_callback) noexcept = 0;
+      std::function<bool(opentelemetry::sdk::common::ExportResult)> &&result_callback) noexcept = 0;
 
   /**
    * Shut down the exporter.

--- a/sdk/include/opentelemetry/sdk/trace/simple_processor.h
+++ b/sdk/include/opentelemetry/sdk/trace/simple_processor.h
@@ -31,8 +31,9 @@ public:
    * Initialize a simple span processor.
    * @param exporter the exporter used by the span processor
    */
-  explicit SimpleSpanProcessor(std::unique_ptr<SpanExporter> &&exporter) noexcept
-      : exporter_(std::move(exporter))
+  explicit SimpleSpanProcessor(std::unique_ptr<SpanExporter> &&exporter,
+                               bool is_export_async = false) noexcept
+      : exporter_(std::move(exporter)), is_export_async_(is_export_async)
   {}
 
   std::unique_ptr<Recordable> MakeRecordable() noexcept override
@@ -48,10 +49,21 @@ public:
   {
     nostd::span<std::unique_ptr<Recordable>> batch(&span, 1);
     const std::lock_guard<opentelemetry::common::SpinLockMutex> locked(lock_);
-    if (exporter_->Export(batch) == sdk::common::ExportResult::kFailure)
+    if (is_export_async_ == false)
     {
-      /* Once it is defined how the SDK does logging, an error should be
-       * logged in this case. */
+      if (exporter_->Export(batch) == sdk::common::ExportResult::kFailure)
+      {
+        /* Once it is defined how the SDK does logging, an error should be
+         * logged in this case. */
+      }
+    }
+    else
+    {
+      exporter_->Export(batch, [](sdk::common::ExportResult result) {
+        /* Log the result
+         */
+        return true;
+      });
     }
   }
 
@@ -78,6 +90,7 @@ private:
   std::unique_ptr<SpanExporter> exporter_;
   opentelemetry::common::SpinLockMutex lock_;
   std::atomic_flag shutdown_latch_ = ATOMIC_FLAG_INIT;
+  bool is_export_async_            = false;
 };
 }  // namespace trace
 }  // namespace sdk

--- a/sdk/src/logs/batch_log_processor.cc
+++ b/sdk/src/logs/batch_log_processor.cc
@@ -32,6 +32,22 @@ BatchLogProcessor::BatchLogProcessor(std::unique_ptr<LogExporter> &&exporter,
   is_async_shutdown_notified_.store(false);
 }
 
+BatchLogProcessor::BatchLogProcessor(std::unique_ptr<LogExporter> &&exporter,
+                                     const BatchLogProcessorOptions &options)
+    : exporter_(std::move(exporter)),
+      max_queue_size_(options.max_queue_size),
+      scheduled_delay_millis_(options.schedule_delay_millis),
+      max_export_batch_size_(options.max_export_batch_size),
+      buffer_(options.max_queue_size),
+      is_export_async_(options.is_export_async),
+      worker_thread_(&BatchLogProcessor::DoBackgroundWork, this)
+{
+  is_shutdown_.store(false);
+  is_force_flush_.store(false);
+  is_force_flush_notified_.store(false);
+  is_async_shutdown_notified_.store(false);
+}
+
 std::unique_ptr<Recordable> BatchLogProcessor::MakeRecordable() noexcept
 {
   return exporter_->MakeRecordable();

--- a/sdk/src/logs/simple_log_processor.cc
+++ b/sdk/src/logs/simple_log_processor.cc
@@ -16,8 +16,9 @@ namespace logs
  * Initialize a simple log processor.
  * @param exporter the configured exporter where log records are sent
  */
-SimpleLogProcessor::SimpleLogProcessor(std::unique_ptr<LogExporter> &&exporter)
-    : exporter_(std::move(exporter))
+SimpleLogProcessor::SimpleLogProcessor(std::unique_ptr<LogExporter> &&exporter,
+                                       bool is_export_async)
+    : exporter_(std::move(exporter)), is_export_async_(is_export_async)
 {}
 
 std::unique_ptr<Recordable> SimpleLogProcessor::MakeRecordable() noexcept
@@ -35,9 +36,20 @@ void SimpleLogProcessor::OnReceive(std::unique_ptr<Recordable> &&record) noexcep
   // Get lock to ensure Export() is never called concurrently
   const std::lock_guard<opentelemetry::common::SpinLockMutex> locked(lock_);
 
-  if (exporter_->Export(batch) != sdk::common::ExportResult::kSuccess)
+  if (is_export_async_ == false)
   {
-    /* Alert user of the failed export */
+    if (exporter_->Export(batch) != sdk::common::ExportResult::kSuccess)
+    {
+      /* Alert user of the failed export */
+    }
+  }
+  else
+  {
+    exporter_->Export(batch, [](sdk::common::ExportResult result) {
+      /* Log the result
+       */
+      return true;
+    });
   }
 }
 /**

--- a/sdk/src/trace/batch_span_processor.cc
+++ b/sdk/src/trace/batch_span_processor.cc
@@ -22,7 +22,11 @@ BatchSpanProcessor::BatchSpanProcessor(std::unique_ptr<SpanExporter> &&exporter,
       max_export_batch_size_(options.max_export_batch_size),
       buffer_(max_queue_size_),
       worker_thread_(&BatchSpanProcessor::DoBackgroundWork, this)
-{}
+{
+  is_shutdown_.store(false);
+  is_force_flush_.store(false);
+  is_force_flush_notified_.store(false);
+}
 
 std::unique_ptr<Recordable> BatchSpanProcessor::MakeRecordable() noexcept
 {
@@ -48,7 +52,8 @@ void BatchSpanProcessor::OnEnd(std::unique_ptr<Recordable> &&span) noexcept
 
   // If the queue gets at least half full a preemptive notification is
   // sent to the worker thread to start a new export cycle.
-  if (buffer_.size() >= max_queue_size_ / 2)
+  size_t buffer_size = buffer_.size();
+  if (buffer_size >= max_queue_size_ / 2 || buffer_size >= max_export_batch_size_)
   {
     // signal the worker thread
     cv_.notify_one();
@@ -62,25 +67,37 @@ bool BatchSpanProcessor::ForceFlush(std::chrono::microseconds timeout) noexcept
     return false;
   }
 
-  is_force_flush_ = true;
-
-  // Keep attempting to wake up the worker thread
-  while (is_force_flush_.load() == true)
-  {
-    cv_.notify_one();
-  }
-
   // Now wait for the worker thread to signal back from the Export method
   std::unique_lock<std::mutex> lk(force_flush_cv_m_);
-  while (is_force_flush_notified_.load() == false)
+
+  is_force_flush_notified_.store(false, std::memory_order_release);
+  auto break_condition = [this]() {
+    if (is_shutdown_.load() == true)
+    {
+      return true;
+    }
+
+    // Wake up the worker thread once.
+    if (is_force_flush_.exchange(true) == false)
+    {
+      cv_.notify_one();
+    }
+
+    return is_force_flush_notified_.load(std::memory_order_acquire);
+  };
+
+  // Fix timeout to meet requirement of wait_for
+  timeout = opentelemetry::common::DurationUtil::AdjustWaitForTimeout(
+      timeout, std::chrono::microseconds::zero());
+  if (timeout <= std::chrono::microseconds::zero())
   {
-    force_flush_cv_.wait(lk);
+    force_flush_cv_.wait(lk, break_condition);
+    return true;
   }
-
-  // Notify the worker thread
-  is_force_flush_notified_ = false;
-
-  return true;
+  else
+  {
+    return force_flush_cv_.wait_for(lk, timeout, break_condition);
+  }
 }
 
 void BatchSpanProcessor::DoBackgroundWork()
@@ -95,20 +112,16 @@ void BatchSpanProcessor::DoBackgroundWork()
 
     if (is_shutdown_.load() == true)
     {
+      // Break loop if another thread call ForceFlush
+      is_force_flush_ = false;
       DrainQueue();
       return;
     }
 
-    bool was_force_flush_called = is_force_flush_.load();
+    bool was_force_flush_called = is_force_flush_.exchange(false);
 
     // Check if this export was the result of a force flush.
-    if (was_force_flush_called == true)
-    {
-      // Since this export was the result of a force flush, signal the
-      // main thread that the worker thread has been notified
-      is_force_flush_ = false;
-    }
-    else
+    if (!was_force_flush_called)
     {
       // If the buffer was empty during the entire `timeout` time interval,
       // go back to waiting. If this was a spurious wake-up, we export only if
@@ -133,39 +146,44 @@ void BatchSpanProcessor::DoBackgroundWork()
 
 void BatchSpanProcessor::Export(const bool was_force_flush_called)
 {
-  std::vector<std::unique_ptr<Recordable>> spans_arr;
-
-  size_t num_spans_to_export;
-
-  if (was_force_flush_called == true)
+  do
   {
-    num_spans_to_export = buffer_.size();
-  }
-  else
-  {
-    num_spans_to_export =
-        buffer_.size() >= max_export_batch_size_ ? max_export_batch_size_ : buffer_.size();
-  }
+    std::vector<std::unique_ptr<Recordable>> spans_arr;
+    size_t num_spans_to_export;
 
-  buffer_.Consume(num_spans_to_export,
-                  [&](CircularBufferRange<AtomicUniquePtr<Recordable>> range) noexcept {
-                    range.ForEach([&](AtomicUniquePtr<Recordable> &ptr) {
-                      std::unique_ptr<Recordable> swap_ptr = std::unique_ptr<Recordable>(nullptr);
-                      ptr.Swap(swap_ptr);
-                      spans_arr.push_back(std::unique_ptr<Recordable>(swap_ptr.release()));
-                      return true;
+    if (was_force_flush_called == true)
+    {
+      num_spans_to_export = buffer_.size();
+    }
+    else
+    {
+      num_spans_to_export =
+          buffer_.size() >= max_export_batch_size_ ? max_export_batch_size_ : buffer_.size();
+    }
+
+    if (num_spans_to_export == 0)
+    {
+      break;
+    }
+    buffer_.Consume(num_spans_to_export,
+                    [&](CircularBufferRange<AtomicUniquePtr<Recordable>> range) noexcept {
+                      range.ForEach([&](AtomicUniquePtr<Recordable> &ptr) {
+                        std::unique_ptr<Recordable> swap_ptr = std::unique_ptr<Recordable>(nullptr);
+                        ptr.Swap(swap_ptr);
+                        spans_arr.push_back(std::unique_ptr<Recordable>(swap_ptr.release()));
+                        return true;
+                      });
                     });
-                  });
 
-  exporter_->Export(nostd::span<std::unique_ptr<Recordable>>(spans_arr.data(), spans_arr.size()));
+    exporter_->Export(nostd::span<std::unique_ptr<Recordable>>(spans_arr.data(), spans_arr.size()));
+  } while (was_force_flush_called);
 
   // Notify the main thread in case this export was the result of a force flush.
   if (was_force_flush_called == true)
   {
-    is_force_flush_notified_ = true;
-    while (is_force_flush_notified_.load() == true)
+    if (is_force_flush_notified_.exchange(true, std::memory_order_acq_rel) == false)
     {
-      force_flush_cv_.notify_one();
+      force_flush_cv_.notify_all();
     }
   }
 }
@@ -180,6 +198,7 @@ void BatchSpanProcessor::DrainQueue()
 
 bool BatchSpanProcessor::Shutdown(std::chrono::microseconds timeout) noexcept
 {
+  auto start_time = std::chrono::system_clock::now();
   std::lock_guard<std::mutex> shutdown_guard{shutdown_m_};
   bool already_shutdown = is_shutdown_.exchange(true);
 
@@ -189,10 +208,26 @@ bool BatchSpanProcessor::Shutdown(std::chrono::microseconds timeout) noexcept
     worker_thread_.join();
   }
 
+  auto worker_end_time = std::chrono::system_clock::now();
+  auto offset = std::chrono::duration_cast<std::chrono::microseconds>(worker_end_time - start_time);
+
+  // Fix timeout to meet requirement of wait_for
+  timeout = opentelemetry::common::DurationUtil::AdjustWaitForTimeout(
+      timeout, std::chrono::microseconds::zero());
+  if (timeout > offset && timeout > std::chrono::microseconds::zero())
+  {
+    timeout -= offset;
+  }
+  else
+  {
+    // Some module use zero as indefinite timeout.So we can not reset timeout to zero here
+    timeout = std::chrono::microseconds(1);
+  }
+
   // Should only shutdown exporter ONCE.
   if (!already_shutdown && exporter_ != nullptr)
   {
-    return exporter_->Shutdown();
+    return exporter_->Shutdown(timeout);
   }
 
   return true;

--- a/sdk/test/logs/batch_log_processor_test.cc
+++ b/sdk/test/logs/batch_log_processor_test.cc
@@ -59,11 +59,14 @@ public:
               std::function<bool(opentelemetry::sdk::common::ExportResult)>
                   &&result_callback) noexcept override
   {
-    auto th = std::thread([this, records, result_callback]() {
-      auto result = Export(records);
-      result_callback(result);
-    });
-    th.join();
+    auto th = std::thread(
+        [this,
+         records](std::function<bool(opentelemetry::sdk::common::ExportResult)> &&result_callback) {
+          auto result = Export(records);
+          result_callback(result);
+        },
+        std::move(result_callback));
+    th.detach();
   }
 
   // toggles the boolean flag marking this exporter as shut down

--- a/sdk/test/logs/batch_log_processor_test.cc
+++ b/sdk/test/logs/batch_log_processor_test.cc
@@ -55,9 +55,9 @@ public:
     return ExportResult::kSuccess;
   }
 
-  void Export(
-      const opentelemetry::nostd::span<std::unique_ptr<Recordable>> &records,
-      opentelemetry::nostd::function_ref<bool(ExportResult)> result_callback) noexcept override
+  void Export(const opentelemetry::nostd::span<std::unique_ptr<Recordable>> &records,
+              std::function<bool(opentelemetry::sdk::common::ExportResult)>
+                  &&result_callback) noexcept override
   {
     auto th = std::thread([this, records, result_callback]() {
       auto result = Export(records);

--- a/sdk/test/logs/batch_log_processor_test.cc
+++ b/sdk/test/logs/batch_log_processor_test.cc
@@ -59,19 +59,13 @@ public:
               std::function<bool(opentelemetry::sdk::common::ExportResult)>
                   &&result_callback) noexcept override
   {
-    std::vector<std::unique_ptr<Recordable>> records_to_export;
-    records_to_export.reserve(records.size());
-    for (auto &record : records)
-    {
-      records_to_export.emplace_back(std::move(record));
-    }
-    auto th = std::thread(
-        [this](std::function<bool(opentelemetry::sdk::common::ExportResult)> &&result_callback,
-               std::vector<std::unique_ptr<Recordable>> &&records) {
-          auto result = Export(records);
+    // We should keep the order of test records
+    auto result = Export(records);
+    auto th     = std::thread(
+            [result](std::function<bool(opentelemetry::sdk::common::ExportResult)> &&result_callback) {
           result_callback(result);
-        },
-        std::move(result_callback), std::move(records_to_export));
+            },
+            std::move(result_callback));
     th.detach();
   }
 

--- a/sdk/test/logs/simple_log_processor_test.cc
+++ b/sdk/test/logs/simple_log_processor_test.cc
@@ -55,7 +55,8 @@ public:
 
   // Dummy Async Export implementation
   void Export(const nostd::span<std::unique_ptr<Recordable>> &records,
-              nostd::function_ref<bool(ExportResult)> result_callback) noexcept override
+              std::function<bool(opentelemetry::sdk::common::ExportResult)>
+                  &&result_callback) noexcept override
   {
     auto result = Export(records);
     result_callback(result);
@@ -146,7 +147,8 @@ public:
   }
 
   void Export(const nostd::span<std::unique_ptr<Recordable>> &records,
-              nostd::function_ref<bool(ExportResult)> result_callback) noexcept override
+              std::function<bool(opentelemetry::sdk::common::ExportResult)>
+                  &&result_callback) noexcept override
   {
     result_callback(ExportResult::kSuccess);
   }

--- a/sdk/test/logs/simple_log_processor_test.cc
+++ b/sdk/test/logs/simple_log_processor_test.cc
@@ -53,6 +53,14 @@ public:
     return ExportResult::kSuccess;
   }
 
+  // Dummy Async Export implementation
+  void Export(const nostd::span<std::unique_ptr<Recordable>> &records,
+              nostd::function_ref<bool(ExportResult)> result_callback) noexcept override
+  {
+    auto result = Export(records);
+    result_callback(result);
+  }
+
   // Increment the shutdown counter everytime this method is called
   bool Shutdown(std::chrono::microseconds timeout) noexcept override
   {
@@ -135,6 +143,12 @@ public:
   ExportResult Export(const nostd::span<std::unique_ptr<Recordable>> &records) noexcept override
   {
     return ExportResult::kSuccess;
+  }
+
+  void Export(const nostd::span<std::unique_ptr<Recordable>> &records,
+              nostd::function_ref<bool(ExportResult)> result_callback) noexcept override
+  {
+    result_callback(ExportResult::kSuccess);
   }
 
   bool Shutdown(std::chrono::microseconds timeout) noexcept override { return false; }

--- a/sdk/test/trace/batch_span_processor_test.cc
+++ b/sdk/test/trace/batch_span_processor_test.cc
@@ -56,17 +56,23 @@ public:
     return sdk::common::ExportResult::kSuccess;
   }
 
-  void Export(const nostd::span<std::unique_ptr<sdk::trace::Recordable>> &spans,
+  void Export(const nostd::span<std::unique_ptr<sdk::trace::Recordable>> &records,
               std::function<bool(opentelemetry::sdk::common::ExportResult)>
                   &&result_callback) noexcept override
   {
+    std::vector<std::unique_ptr<sdk::trace::Recordable>> records_to_export;
+    records_to_export.reserve(records.size());
+    for (auto &record : records)
+    {
+      records_to_export.emplace_back(std::move(record));
+    }
     auto th = std::thread(
-        [this, spans, result_callback](
-            std::function<bool(opentelemetry::sdk::common::ExportResult)> &&result_callback) {
-          auto result = Export(spans);
+        [this](std::function<bool(opentelemetry::sdk::common::ExportResult)> &&result_callback,
+               std::vector<std::unique_ptr<sdk::trace::Recordable>> &&records) {
+          auto result = Export(records);
           result_callback(result);
         },
-        std::move(result_callback));
+        std::move(result_callback), std::move(records_to_export));
     th.detach();
   }
 

--- a/sdk/test/trace/batch_span_processor_test.cc
+++ b/sdk/test/trace/batch_span_processor_test.cc
@@ -60,19 +60,13 @@ public:
               std::function<bool(opentelemetry::sdk::common::ExportResult)>
                   &&result_callback) noexcept override
   {
-    std::vector<std::unique_ptr<sdk::trace::Recordable>> records_to_export;
-    records_to_export.reserve(records.size());
-    for (auto &record : records)
-    {
-      records_to_export.emplace_back(std::move(record));
-    }
-    auto th = std::thread(
-        [this](std::function<bool(opentelemetry::sdk::common::ExportResult)> &&result_callback,
-               std::vector<std::unique_ptr<sdk::trace::Recordable>> &&records) {
-          auto result = Export(records);
+    // We should keep the order of test records
+    auto result = Export(records);
+    auto th     = std::thread(
+            [result](std::function<bool(opentelemetry::sdk::common::ExportResult)> &&result_callback) {
           result_callback(result);
-        },
-        std::move(result_callback), std::move(records_to_export));
+            },
+            std::move(result_callback));
     th.detach();
   }
 

--- a/sdk/test/trace/batch_span_processor_test.cc
+++ b/sdk/test/trace/batch_span_processor_test.cc
@@ -56,9 +56,9 @@ public:
     return sdk::common::ExportResult::kSuccess;
   }
 
-  void Export(
-      const nostd::span<std::unique_ptr<sdk::trace::Recordable>> &spans,
-      nostd::function_ref<bool(sdk::common::ExportResult)> result_callback) noexcept override
+  void Export(const nostd::span<std::unique_ptr<sdk::trace::Recordable>> &spans,
+              std::function<bool(opentelemetry::sdk::common::ExportResult)>
+                  &&result_callback) noexcept override
   {
     auto th = std::thread([this, spans, result_callback]() {
       auto result = Export(spans);

--- a/sdk/test/trace/simple_processor_test.cc
+++ b/sdk/test/trace/simple_processor_test.cc
@@ -51,6 +51,13 @@ public:
     return ExportResult::kSuccess;
   }
 
+  void Export(const opentelemetry::nostd::span<std::unique_ptr<Recordable>> &spans,
+              opentelemetry::nostd::function_ref<bool(opentelemetry::sdk::common::ExportResult)>
+                  result_callback) noexcept override
+  {
+    result_callback(ExportResult::kSuccess);
+  }
+
   bool Shutdown(
       std::chrono::microseconds timeout = std::chrono::microseconds::max()) noexcept override
   {

--- a/sdk/test/trace/simple_processor_test.cc
+++ b/sdk/test/trace/simple_processor_test.cc
@@ -52,8 +52,8 @@ public:
   }
 
   void Export(const opentelemetry::nostd::span<std::unique_ptr<Recordable>> &spans,
-              opentelemetry::nostd::function_ref<bool(opentelemetry::sdk::common::ExportResult)>
-                  result_callback) noexcept override
+              std::function<bool(opentelemetry::sdk::common::ExportResult)>
+                  &&result_callback) noexcept override
   {
     result_callback(ExportResult::kSuccess);
   }


### PR DESCRIPTION
Fixes #1176 

## Changes

+ Allow multiple running http sessions in `OtlpHttpClient`
+ Add `concurrency_sessions` to control the max concurrency http sessions.

For significant contributions please make sure you have completed the following items:

* [x] `CHANGELOG.md` updated for non-trivial changes
* [x] Unit tests have been added
* [ ] Changes in public API reviewed