### PR TITLE
allow extension of the lifetime of ContextStorage.

### DIFF
--- a/api/include/opentelemetry/context/runtime_context.h
+++ b/api/include/opentelemetry/context/runtime_context.h
@@ -150,6 +150,18 @@ public:
     GetStorage() = storage;
   }
 
+  /**
+   * Provide a pointer to const runtime context storage.
+   *
+   * The returned pointer can only be used for extending the lifetime of the runtime context
+   * storage.
+   *
+   */
+  static nostd::shared_ptr<const RuntimeContextStorage> GetConstRuntimeContextStorage() noexcept
+  {
+    return GetRuntimeContextStorage();
+  }
+
 private:
   static nostd::shared_ptr<RuntimeContextStorage> GetRuntimeContextStorage() noexcept
   {


### PR DESCRIPTION
Fixes #1211 (issue)

## Changes

The specifications require the context to be [immutable](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/context/context.md#overview), but does not talk about whether the users are allowed to have access to the storage.
The change in this PR allows the users to get a shared_ptr to const so they can't do anything with the pointer but extending the lifetime of the storage.
 
For significant contributions please make sure you have completed the following items:

* [ ] `CHANGELOG.md` updated for non-trivial changes
* [ ] Unit tests have been added
* [ ] Changes in public API reviewed