### PR TITLE
thrift boost deps

### DIFF
--- a/ci/setup_thrift.sh
+++ b/ci/setup_thrift.sh
@@ -12,7 +12,7 @@ export BUILD_DIR=/tmp/
 export INSTALL_DIR=/usr/local/
 
 apt install -y --no-install-recommends \
-      libboost-all-dev \
+      libboost-locale-dev \
       libevent-dev \
       libssl-dev \
       ninja-build
@@ -38,6 +38,10 @@ cmake -G Ninja .. \
     -DBUILD_JAVA=OFF \
     -DBUILD_TESTING=OFF \
     -DBUILD_TUTORIALS=OFF \
+    -DWITH_STDTHREADS=ON \
+    -DWITH_BOOSTTHREADS=OFF \
+    -DWITH_BOOST_FUNCTIONAL=OFF \
+    -DWITH_BOOST_SMART_PTR=OFF \
     ..
 
 ninja -j $(nproc)


### PR DESCRIPTION
No need to install  libboost-all-dev for CI
This should also fix CI bazel build failures happening [recently]( libboost-all-dev install from the CI).
## Changes

We need `boost locale` only for building thrift. This PR installs boost locale and removes `libboost-all-dev` install from the CI.


For significant contributions please make sure you have completed the following items:

* [ ] `CHANGELOG.md` updated for non-trivial changes
* [ ] Unit tests have been added
* [ ] Changes in public API reviewed