### PR TITLE
Run apt update before install thrift dependencies

### DIFF
--- a/ci/setup_thrift.sh
+++ b/ci/setup_thrift.sh
@@ -4,6 +4,8 @@ set -e
 export DEBIAN_FRONTEND=noninteractive
 export THRIFT_VERSION=0.14.1
 
+apt update
+
 if ! type cmake > /dev/null; then
     #cmake not installed, exiting
     exit 1


### PR DESCRIPTION
## Changes

The current apt cache could be stale when running `setup_thrift.sh`, so update the cache before installing any dependency.

Fixes build error like https://github.com/open-telemetry/opentelemetry-cpp/runs/5255793986?check_suite_focus=true.

For significant contributions please make sure you have completed the following items:

* [ ] `CHANGELOG.md` updated for non-trivial changes
* [ ] Unit tests have been added
* [ ] Changes in public API reviewed