### PR TITLE
chore: update prometheus to 1.0 version

### DIFF
--- a/bazel/repository.bzl
+++ b/bazel/repository.bzl
@@ -96,10 +96,10 @@ def opentelemetry_cpp_deps():
     maybe(
         http_archive,
         name = "com_github_jupp0r_prometheus_cpp",
-        sha256 = "aab4ef8342319f631969e01b8c41e355704847cbe76131cb1dd5ea1862000bda",
-        strip_prefix = "prometheus-cpp-0.11.0",
+        sha256 = "07018db604ea3e61f5078583e87c80932ea10c300d979061490ee1b7dc8e3a41",
+        strip_prefix = "prometheus-cpp-1.0.0",
         urls = [
-            "https://github.com/jupp0r/prometheus-cpp/archive/v0.11.0.tar.gz",
+            "https://github.com/jupp0r/prometheus-cpp/archive/refs/tags/v1.0.0.tar.gz",
         ],
     )
 

--- a/third_party_release
+++ b/third_party_release
@@ -6,5 +6,5 @@ googletest=release-1.8.0-2523-ga6dfd3ac
 ms-gsl=v1.0.0-393-g6f45293
 nlohmann-json=v3.9.1
 opentelemetry-proto=v0.11.0
-prometheus-cpp=v0.11.0
+prometheus-cpp=v1.0.0
 vcpkg=2020.04-2702-g5568f110b


### PR DESCRIPTION
Fixes: I didn't file an issue, but the bazel build seems to fail w/o this PR because of an error building prometheus-cpp

```
ERROR: /usr/local/google/home/jgm/.cache/bazel/_bazel_jgm/2be8259a0f7f7767cb8723c5dffd593f/external/com_github_jupp0r_prometheus_cpp/core/BUILD.bazel:9:11: Compiling core/src/histogram.cc failed: (Exit 1): gcc failed: error executing command /usr/bin/gcc -U_FORTIFY_SOURCE -fstack-protector -Wall -Wunused-but-set-parameter -Wno-free-nonheap-object -fno-omit-frame-pointer '-std=c++0x' -MD -MF ... (remaining 19 argument(s) skipped)

Use --sandbox_debug to see verbose messages from the sandbox
external/com_github_jupp0r_prometheus_cpp/core/src/histogram.cc: In member function 'prometheus::ClientMetric prometheus::Histogram::Collect() const':
external/com_github_jupp0r_prometheus_cpp/core/src/histogram.cc:54:38: error: 'numeric_limits' is not a member of 'std'
   54 |                               ? std::numeric_limits<double>::infinity()
...
```
Prometheus-cpp fixed the above issue in https://github.com/jupp0r/prometheus-cpp/pull/442

## Changes

This PR just upgrades the version of prometheus-cpp that is used from v0.11.0 -> v1.0.0. In general, it seems better to use a "1.0" version anyway.

I tested this just by running `bazel test --cxxopt=-DENABLE_TEST  ...` locally. It fails before this PR, and passes w/ this PR.

For significant contributions please make sure you have completed the following items:

* [ ] `CHANGELOG.md` updated for non-trivial changes
* [ ] Unit tests have been added
* [ ] Changes in public API reviewed