### PR TITLE
Update Maintainers

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,15 +98,15 @@ For edit access, get in touch on
 [Maintainers](https://github.com/open-telemetry/community/blob/main/community-membership.md#maintainer)
 ([@open-telemetry/cpp-maintainers](https://github.com/orgs/open-telemetry/teams/cpp-maintainers)):
 
+* [Ehsan Saei](https://github.com/esigo)
 * [Lalit Kumar Bhasin](https://github.com/lalitb), Microsoft
-* [Reiley Yang](https://github.com/reyang), Microsoft
 * [Tom Tan](https://github.com/ThomsonTan), Microsoft
 
 [Approvers](https://github.com/open-telemetry/community/blob/main/community-membership.md#approver)
 ([@open-telemetry/cpp-approvers](https://github.com/orgs/open-telemetry/teams/cpp-approvers)):
 
-* [Ehsan Saei](https://github.com/esigo)
 * [Josh Suereth](https://github.com/jsuereth), Google
+* [Reiley Yang](https://github.com/reyang), Microsoft
 
 [Emeritus
 Maintainer/Approver/Triager](https://github.com/open-telemetry/community/blob/main/community-membership.md#emeritus-maintainerapprovertriager):


### PR DESCRIPTION
Changes:
* Added @esigo as a maintainer. Ehsan has been actively contributing to the project since Jul. 2021, and he has demonstrated great judgement and technical excellence. Here are the pull requests @Ehsan contributed https://github.com/open-telemetry/opentelemetry-cpp/commits?author=esigo.
* Moved @reyang from Maintainer to Approver.

I volunteered to kick off the OpenTelemetry C++ project after stepped down from OpenTelemetry Python Maintainer. It is great to see the project is now becoming more mature, with many active contributors across different companies / regions. I hope this change would help to make the project more balanced and community driven.