### PR TITLE
Added changes for async callback mechanism from Processor to Exporter

### DIFF
--- a/exporters/elasticsearch/include/opentelemetry/exporters/elasticsearch/es_log_exporter.h
+++ b/exporters/elasticsearch/include/opentelemetry/exporters/elasticsearch/es_log_exporter.h
@@ -95,8 +95,10 @@ public:
    * @param result_callback callback function accepting ExportResult as argument
    */
   void Export(
-      const opentelemetry::nostd::span<std::unique_ptr<opentelemetry::sdk::logs::Recordable>> &records,
-      nostd::function_ref<bool(opentelemetry::sdk::common::ExportResult)> result_callback) noexcept override;
+      const opentelemetry::nostd::span<std::unique_ptr<opentelemetry::sdk::logs::Recordable>>
+          &records,
+      nostd::function_ref<bool(opentelemetry::sdk::common::ExportResult)> result_callback) noexcept
+      override;
 
   /**
    * Shutdown this exporter.

--- a/exporters/elasticsearch/include/opentelemetry/exporters/elasticsearch/es_log_exporter.h
+++ b/exporters/elasticsearch/include/opentelemetry/exporters/elasticsearch/es_log_exporter.h
@@ -90,6 +90,14 @@ public:
           &records) noexcept override;
 
   /**
+   *
+   *
+   */
+  void Export(
+      const opentelemetry::nostd::span<std::unique_ptr<opentelemetry::sdk::logs::Recordable>> &records,
+      nostd::function_ref<bool(opentelemetry::sdk::common::ExportResult)> result_callback) noexcept override;
+
+  /**
    * Shutdown this exporter.
    * @param timeout The maximum time to wait for the shutdown method to return
    */

--- a/exporters/elasticsearch/include/opentelemetry/exporters/elasticsearch/es_log_exporter.h
+++ b/exporters/elasticsearch/include/opentelemetry/exporters/elasticsearch/es_log_exporter.h
@@ -90,8 +90,9 @@ public:
           &records) noexcept override;
 
   /**
-   *
-   *
+   * Exports a vector of log records to the Elasticsearch instance asynchronously.
+   * @param records A list of log records to send to Elasticsearch.
+   * @param result_callback callback function accepting ExportResult as argument
    */
   void Export(
       const opentelemetry::nostd::span<std::unique_ptr<opentelemetry::sdk::logs::Recordable>> &records,

--- a/exporters/elasticsearch/src/es_log_exporter.cc
+++ b/exporters/elasticsearch/src/es_log_exporter.cc
@@ -110,7 +110,6 @@ private:
   bool console_debug_ = false;
 };
 
-
 /**
  * This class handles the async response message from the Elasticsearch request
  */
@@ -121,20 +120,18 @@ public:
    * Creates a response handler, that by default doesn't display to console
    */
   AsyncResponseHandler(
-    std::shared_ptr<ext::http::client::Session> session,
-    nostd::function_ref<bool(opentelemetry::sdk::common::ExportResult)> result_callback,
-    bool console_debug = false)
-    : console_debug_{console_debug}
-    , session_{std::move(session)}
-    , result_callback_{result_callback} {}
+      std::shared_ptr<ext::http::client::Session> session,
+      nostd::function_ref<bool(opentelemetry::sdk::common::ExportResult)> result_callback,
+      bool console_debug = false)
+      : console_debug_{console_debug},
+        session_{std::move(session)},
+        result_callback_{result_callback}
+  {}
 
   /**
    * Cleans up the session in the destructor.
    */
-  ~AsyncResponseHandler()
-  {
-    session_->FinishSession();
-  }
+  ~AsyncResponseHandler() { session_->FinishSession(); }
 
   /**
    * Automatically called when the response is received
@@ -147,10 +144,12 @@ public:
     if (body_.find("\"failed\" : 0") == std::string::npos)
     {
       OTEL_INTERNAL_LOG_ERROR(
-        "[ES Trace Exporter] Logs were not written to Elasticsearch correctly, response body: "
-        << body_);
+          "[ES Trace Exporter] Logs were not written to Elasticsearch correctly, response body: "
+          << body_);
       result_callback_(sdk::common::ExportResult::kFailure);
-    } else {
+    }
+    else
+    {
       result_callback_(sdk::common::ExportResult::kSuccess);
     }
   }
@@ -193,7 +192,6 @@ private:
   // Whether to print the results from the callback
   bool console_debug_ = false;
 };
-
 
 ElasticsearchLogExporter::ElasticsearchLogExporter()
     : options_{ElasticsearchExporterOptions()},
@@ -284,8 +282,9 @@ sdk::common::ExportResult ElasticsearchLogExporter::Export(
 }
 
 void ElasticsearchLogExporter::Export(
-      const opentelemetry::nostd::span<std::unique_ptr<opentelemetry::sdk::logs::Recordable>> &records,
-      nostd::function_ref<bool(opentelemetry::sdk::common::ExportResult)> result_callback) noexcept
+    const opentelemetry::nostd::span<std::unique_ptr<opentelemetry::sdk::logs::Recordable>>
+        &records,
+    nostd::function_ref<bool(opentelemetry::sdk::common::ExportResult)> result_callback) noexcept
 {
   // Return failure if this exporter has been shutdown
   if (isShutdown())
@@ -322,8 +321,8 @@ void ElasticsearchLogExporter::Export(
   request->SetBody(body_vec);
 
   // Send the request
-  auto handler = std::make_shared<AsyncResponseHandler>(
-    session, result_callback, options_.console_debug_);
+  auto handler =
+      std::make_shared<AsyncResponseHandler>(session, result_callback, options_.console_debug_);
   session->SendRequest(handler);
 }
 

--- a/exporters/elasticsearch/src/es_log_exporter.cc
+++ b/exporters/elasticsearch/src/es_log_exporter.cc
@@ -175,6 +175,8 @@ public:
       case http_client::SessionState::NetworkError:
         OTEL_INTERNAL_LOG_ERROR("[ES Trace Exporter] Network error to elasticsearch");
         break;
+      default:
+        break;
     }
     result_callback_(sdk::common::ExportResult::kFailure);
   }

--- a/exporters/elasticsearch/src/es_log_exporter.cc
+++ b/exporters/elasticsearch/src/es_log_exporter.cc
@@ -129,6 +129,14 @@ public:
     , result_callback_{result_callback} {}
 
   /**
+   * Cleans up the session in the destructor.
+   */
+  ~AsyncResponseHandler()
+  {
+    session_->FinishSession();
+  }
+
+  /**
    * Automatically called when the response is received
    */
   void OnResponse(http_client::Response &response) noexcept override
@@ -136,7 +144,6 @@ public:
 
     // Store the body of the request
     body_ = std::string(response.GetBody().begin(), response.GetBody().end());
-    session_->FinishSession();
     if (body_.find("\"failed\" : 0") == std::string::npos)
     {
       OTEL_INTERNAL_LOG_ERROR(

--- a/exporters/jaeger/include/opentelemetry/exporters/jaeger/jaeger_exporter.h
+++ b/exporters/jaeger/include/opentelemetry/exporters/jaeger/jaeger_exporter.h
@@ -62,6 +62,17 @@ public:
       override;
 
   /**
+   * Exports a batch of span recordables asynchronously.
+   * @param spans a span of unique pointers to span recordables
+   * @param result_callback callback function accepting ExportResult as argument
+   */
+  void Export(
+      const nostd::span<std::unique_ptr<opentelemetry::sdk::trace::Recordable>> &spans,
+      nostd::function_ref<bool(opentelemetry::sdk::common::ExportResult)> result_callback)
+      noexcept override;
+
+
+  /**
    * Shutdown the exporter.
    * @param timeout an option timeout, default to max.
    */

--- a/exporters/jaeger/include/opentelemetry/exporters/jaeger/jaeger_exporter.h
+++ b/exporters/jaeger/include/opentelemetry/exporters/jaeger/jaeger_exporter.h
@@ -66,11 +66,9 @@ public:
    * @param spans a span of unique pointers to span recordables
    * @param result_callback callback function accepting ExportResult as argument
    */
-  void Export(
-      const nostd::span<std::unique_ptr<opentelemetry::sdk::trace::Recordable>> &spans,
-      nostd::function_ref<bool(opentelemetry::sdk::common::ExportResult)> result_callback)
-      noexcept override;
-
+  void Export(const nostd::span<std::unique_ptr<opentelemetry::sdk::trace::Recordable>> &spans,
+              nostd::function_ref<bool(opentelemetry::sdk::common::ExportResult)>
+                  result_callback) noexcept override;
 
   /**
    * Shutdown the exporter.

--- a/exporters/jaeger/src/jaeger_exporter.cc
+++ b/exporters/jaeger/src/jaeger_exporter.cc
@@ -70,6 +70,14 @@ sdk_common::ExportResult JaegerExporter::Export(
   return sdk_common::ExportResult::kSuccess;
 }
 
+void JaegerExporter::Export(
+  const nostd::span<std::unique_ptr<sdk::trace::Recordable>> &spans,
+  nostd::function_ref<bool(sdk::common::ExportResult)> result_callback)
+  noexcept
+{
+
+}
+
 void JaegerExporter::InitializeEndpoint()
 {
   if (options_.transport_format == TransportFormat::kThriftUdpCompact)

--- a/exporters/jaeger/src/jaeger_exporter.cc
+++ b/exporters/jaeger/src/jaeger_exporter.cc
@@ -71,14 +71,12 @@ sdk_common::ExportResult JaegerExporter::Export(
 }
 
 void JaegerExporter::Export(
-  const nostd::span<std::unique_ptr<sdk::trace::Recordable>> &spans,
-  nostd::function_ref<bool(sdk::common::ExportResult)> result_callback)
-  noexcept
+    const nostd::span<std::unique_ptr<sdk::trace::Recordable>> &spans,
+    nostd::function_ref<bool(sdk::common::ExportResult)> result_callback) noexcept
 {
   OTEL_INTERNAL_LOG_WARN(" async not supported. Making sync interface call");
   auto status = Export(spans);
   result_callback(status);
-
 }
 
 void JaegerExporter::InitializeEndpoint()

--- a/exporters/jaeger/src/jaeger_exporter.cc
+++ b/exporters/jaeger/src/jaeger_exporter.cc
@@ -75,6 +75,9 @@ void JaegerExporter::Export(
   nostd::function_ref<bool(sdk::common::ExportResult)> result_callback)
   noexcept
 {
+  OTEL_INTERNAL_LOG_WARN(" async not supported. Making sync interface call");
+  auto status = Export(spans);
+  result_callback(status);
 
 }
 

--- a/exporters/memory/include/opentelemetry/exporters/memory/in_memory_span_exporter.h
+++ b/exporters/memory/include/opentelemetry/exporters/memory/in_memory_span_exporter.h
@@ -65,6 +65,20 @@ public:
   }
 
   /**
+   *
+   *
+   */
+  void Export(
+      const nostd::span<std::unique_ptr<sdk::trace::Recordable>> &spans,
+      nostd::function_ref<bool(sdk::common::ExportResult)> result_callback)
+      noexcept override
+  {
+    auto result = Export(spans);
+    result_callback(result);
+
+  }
+
+  /**
    * @param timeout an optional value containing the timeout of the exporter
    * note: passing custom timeout values is not currently supported for this exporter
    * @return Returns the status of the operation

--- a/exporters/memory/include/opentelemetry/exporters/memory/in_memory_span_exporter.h
+++ b/exporters/memory/include/opentelemetry/exporters/memory/in_memory_span_exporter.h
@@ -71,8 +71,7 @@ public:
    */
   void Export(
       const nostd::span<std::unique_ptr<sdk::trace::Recordable>> &spans,
-      nostd::function_ref<bool(sdk::common::ExportResult)> result_callback)
-      noexcept override
+      nostd::function_ref<bool(sdk::common::ExportResult)> result_callback) noexcept override
   {
     OTEL_INTERNAL_LOG_WARN(" async not supported. Making sync interface call");
     auto status = Export(spans);

--- a/exporters/memory/include/opentelemetry/exporters/memory/in_memory_span_exporter.h
+++ b/exporters/memory/include/opentelemetry/exporters/memory/in_memory_span_exporter.h
@@ -73,9 +73,9 @@ public:
       nostd::function_ref<bool(sdk::common::ExportResult)> result_callback)
       noexcept override
   {
-    auto result = Export(spans);
-    result_callback(result);
-
+    OTEL_INTERNAL_LOG_WARN(" async not supported. Making sync interface call");
+    auto status = Export(spans);
+    result_callback(status);
   }
 
   /**

--- a/exporters/memory/include/opentelemetry/exporters/memory/in_memory_span_exporter.h
+++ b/exporters/memory/include/opentelemetry/exporters/memory/in_memory_span_exporter.h
@@ -65,8 +65,9 @@ public:
   }
 
   /**
-   *
-   *
+   * Exports a batch of span recordables asynchronously.
+   * @param spans a span of unique pointers to span recordables
+   * @param result_callback callback function accepting ExportResult as argument
    */
   void Export(
       const nostd::span<std::unique_ptr<sdk::trace::Recordable>> &spans,

--- a/exporters/ostream/include/opentelemetry/exporters/ostream/log_exporter.h
+++ b/exporters/ostream/include/opentelemetry/exporters/ostream/log_exporter.h
@@ -42,10 +42,9 @@ public:
   /**
    * Exports a span of logs sent from the processor asynchronously.
    */
-  void Export(
-      const opentelemetry::nostd::span<std::unique_ptr<sdk::logs::Recordable>> &records,
-      opentelemetry::nostd::function_ref<bool(opentelemetry::sdk::common::ExportResult)> result_callback)
-      noexcept;
+  void Export(const opentelemetry::nostd::span<std::unique_ptr<sdk::logs::Recordable>> &records,
+              opentelemetry::nostd::function_ref<bool(opentelemetry::sdk::common::ExportResult)>
+                  result_callback) noexcept;
 
   /**
    * Marks the OStream Log Exporter as shut down.

--- a/exporters/ostream/include/opentelemetry/exporters/ostream/log_exporter.h
+++ b/exporters/ostream/include/opentelemetry/exporters/ostream/log_exporter.h
@@ -40,6 +40,14 @@ public:
       override;
 
   /**
+   * Exports a span of logs sent from the processor asynchronously.
+   */
+  void Export(
+      const opentelemetry::nostd::span<std::unique_ptr<sdk::logs::Recordable>> &records,
+      opentelemetry::nostd::function_ref<bool(opentelemetry::sdk::common::ExportResult)> result_callback)
+      noexcept;
+
+  /**
    * Marks the OStream Log Exporter as shut down.
    */
   bool Shutdown(

--- a/exporters/ostream/include/opentelemetry/exporters/ostream/span_exporter.h
+++ b/exporters/ostream/include/opentelemetry/exporters/ostream/span_exporter.h
@@ -39,9 +39,10 @@ public:
           &spans) noexcept override;
 
   void Export(
-      const opentelemetry::nostd::span<std::unique_ptr<opentelemetry::sdk::trace::Recordable>> &spans,
-      opentelemetry::nostd::function_ref<bool(opentelemetry::sdk::common::ExportResult)> result_callback)
-      noexcept override;
+      const opentelemetry::nostd::span<std::unique_ptr<opentelemetry::sdk::trace::Recordable>>
+          &spans,
+      opentelemetry::nostd::function_ref<bool(opentelemetry::sdk::common::ExportResult)>
+          result_callback) noexcept override;
 
   bool Shutdown(
       std::chrono::microseconds timeout = std::chrono::microseconds::max()) noexcept override;

--- a/exporters/ostream/include/opentelemetry/exporters/ostream/span_exporter.h
+++ b/exporters/ostream/include/opentelemetry/exporters/ostream/span_exporter.h
@@ -38,6 +38,11 @@ public:
       const opentelemetry::nostd::span<std::unique_ptr<opentelemetry::sdk::trace::Recordable>>
           &spans) noexcept override;
 
+  void Export(
+      const opentelemetry::nostd::span<std::unique_ptr<opentelemetry::sdk::trace::Recordable>> &spans,
+      opentelemetry::nostd::function_ref<bool(opentelemetry::sdk::common::ExportResult)> result_callback)
+      noexcept override;
+
   bool Shutdown(
       std::chrono::microseconds timeout = std::chrono::microseconds::max()) noexcept override;
 

--- a/exporters/ostream/src/log_exporter.cc
+++ b/exporters/ostream/src/log_exporter.cc
@@ -180,6 +180,16 @@ sdk::common::ExportResult OStreamLogExporter::Export(
   return sdk::common::ExportResult::kSuccess;
 }
 
+void OStreamLogExporter::Export(
+  const opentelemetry::nostd::span<std::unique_ptr<sdk::logs::Recordable>> &records,
+  opentelemetry::nostd::function_ref<bool(opentelemetry::sdk::common::ExportResult)> result_callback)
+  noexcept
+{
+  // Do not have async support
+  auto result = Export(records);
+  result_callback(result);
+}
+
 bool OStreamLogExporter::Shutdown(std::chrono::microseconds timeout) noexcept
 {
   const std::lock_guard<opentelemetry::common::SpinLockMutex> locked(lock_);

--- a/exporters/ostream/src/log_exporter.cc
+++ b/exporters/ostream/src/log_exporter.cc
@@ -181,9 +181,9 @@ sdk::common::ExportResult OStreamLogExporter::Export(
 }
 
 void OStreamLogExporter::Export(
-  const opentelemetry::nostd::span<std::unique_ptr<sdk::logs::Recordable>> &records,
-  opentelemetry::nostd::function_ref<bool(opentelemetry::sdk::common::ExportResult)> result_callback)
-  noexcept
+    const opentelemetry::nostd::span<std::unique_ptr<sdk::logs::Recordable>> &records,
+    opentelemetry::nostd::function_ref<bool(opentelemetry::sdk::common::ExportResult)>
+        result_callback) noexcept
 {
   // Do not have async support
   auto result = Export(records);

--- a/exporters/ostream/src/span_exporter.cc
+++ b/exporters/ostream/src/span_exporter.cc
@@ -96,6 +96,14 @@ sdk::common::ExportResult OStreamSpanExporter::Export(
   return sdk::common::ExportResult::kSuccess;
 }
 
+void OStreamSpanExporter::Export(
+      const opentelemetry::nostd::span<std::unique_ptr<opentelemetry::sdk::trace::Recordable>> &spans,
+      opentelemetry::nostd::function_ref<bool(opentelemetry::sdk::common::ExportResult)> result_callback) noexcept
+{
+  auto result = Export(spans);
+  result_callback(result);
+}
+
 bool OStreamSpanExporter::Shutdown(std::chrono::microseconds timeout) noexcept
 {
   const std::lock_guard<opentelemetry::common::SpinLockMutex> locked(lock_);

--- a/exporters/ostream/src/span_exporter.cc
+++ b/exporters/ostream/src/span_exporter.cc
@@ -97,8 +97,9 @@ sdk::common::ExportResult OStreamSpanExporter::Export(
 }
 
 void OStreamSpanExporter::Export(
-      const opentelemetry::nostd::span<std::unique_ptr<opentelemetry::sdk::trace::Recordable>> &spans,
-      opentelemetry::nostd::function_ref<bool(opentelemetry::sdk::common::ExportResult)> result_callback) noexcept
+    const opentelemetry::nostd::span<std::unique_ptr<opentelemetry::sdk::trace::Recordable>> &spans,
+    opentelemetry::nostd::function_ref<bool(opentelemetry::sdk::common::ExportResult)>
+        result_callback) noexcept
 {
   auto result = Export(spans);
   result_callback(result);

--- a/exporters/otlp/include/opentelemetry/exporters/otlp/otlp_grpc_exporter.h
+++ b/exporters/otlp/include/opentelemetry/exporters/otlp/otlp_grpc_exporter.h
@@ -53,6 +53,15 @@ public:
       const nostd::span<std::unique_ptr<sdk::trace::Recordable>> &spans) noexcept override;
 
   /**
+   * Exports a batch of span recordables asynchronously.
+   * @param spans a span of unique pointers to span recordables
+   * @param result_callback callback function accepting ExportResult as argument
+   */
+  virtual void Export(
+      const nostd::span<std::unique_ptr<sdk::trace::Recordable>> &spans,
+      nostd::function_ref<bool(sdk::common::ExportResult)> result_callback) noexcept override;
+
+  /**
    * Shut down the exporter.
    * @param timeout an optional timeout, the default timeout of 0 means that no
    * timeout is applied.

--- a/exporters/otlp/include/opentelemetry/exporters/otlp/otlp_grpc_log_exporter.h
+++ b/exporters/otlp/include/opentelemetry/exporters/otlp/otlp_grpc_log_exporter.h
@@ -56,6 +56,16 @@ public:
       override;
 
   /**
+   * Exports a vector of log records asynchronously.
+   * @param records A list of log records.
+   * @param result_callback callback function accepting ExportResult as argument
+   */
+  virtual void Export(
+      const nostd::span<std::unique_ptr<opentelemetry::sdk::logs::Recordable>> &records,
+      nostd::function_ref<bool(opentelemetry::sdk::common::ExportResult)> result_callback) noexcept
+      override;
+
+  /**
    * Shutdown this exporter.
    * @param timeout The maximum time to wait for the shutdown method to return.
    */

--- a/exporters/otlp/include/opentelemetry/exporters/otlp/otlp_http_exporter.h
+++ b/exporters/otlp/include/opentelemetry/exporters/otlp/otlp_http_exporter.h
@@ -83,6 +83,16 @@ public:
       override;
 
   /**
+   * Exports a batch of span recordables asynchronously.
+   * @param spans a span of unique pointers to span recordables
+   * @param result_callback callback function accepting ExportResult as argument
+   */
+  virtual void Export(
+      const nostd::span<std::unique_ptr<opentelemetry::sdk::trace::Recordable>> &spans,
+      nostd::function_ref<bool(opentelemetry::sdk::common::ExportResult)> result_callback) noexcept
+      override;
+
+  /**
    * Shut down the exporter.
    * @param timeout an optional timeout, the default timeout of 0 means that no
    * timeout is applied.

--- a/exporters/otlp/include/opentelemetry/exporters/otlp/otlp_http_log_exporter.h
+++ b/exporters/otlp/include/opentelemetry/exporters/otlp/otlp_http_log_exporter.h
@@ -84,6 +84,16 @@ public:
       override;
 
   /**
+   * Exports a vector of log records asynchronously.
+   * @param records A list of log records.
+   * @param result_callback callback function accepting ExportResult as argument
+   */
+  virtual void Export(
+      const nostd::span<std::unique_ptr<opentelemetry::sdk::logs::Recordable>> &records,
+      nostd::function_ref<bool(opentelemetry::sdk::common::ExportResult)> result_callback) noexcept
+      override;
+
+  /**
    * Shutdown this exporter.
    * @param timeout The maximum time to wait for the shutdown method to return
    */

--- a/exporters/otlp/src/otlp_grpc_exporter.cc
+++ b/exporters/otlp/src/otlp_grpc_exporter.cc
@@ -144,14 +144,13 @@ sdk::common::ExportResult OtlpGrpcExporter::Export(
 }
 
 void OtlpGrpcExporter::Export(
-  const nostd::span<std::unique_ptr<sdk::trace::Recordable>> &spans,
-  nostd::function_ref<bool(sdk::common::ExportResult)> result_callback)
-  noexcept
+    const nostd::span<std::unique_ptr<sdk::trace::Recordable>> &spans,
+    nostd::function_ref<bool(sdk::common::ExportResult)> result_callback) noexcept
 {
-  OTEL_INTERNAL_LOG_WARN("[OTLP TRACE GRPC Exporter] async not supported. Making sync interface call");
+  OTEL_INTERNAL_LOG_WARN(
+      "[OTLP TRACE GRPC Exporter] async not supported. Making sync interface call");
   auto status = Export(spans);
   result_callback(status);
-
 }
 
 bool OtlpGrpcExporter::Shutdown(std::chrono::microseconds timeout) noexcept

--- a/exporters/otlp/src/otlp_grpc_exporter.cc
+++ b/exporters/otlp/src/otlp_grpc_exporter.cc
@@ -148,6 +148,9 @@ void OtlpGrpcExporter::Export(
   nostd::function_ref<bool(sdk::common::ExportResult)> result_callback)
   noexcept
 {
+  OTEL_INTERNAL_LOG_WARN("[OTLP TRACE GRPC Exporter] async not supported. Making sync interface call");
+  auto status = Export(spans);
+  result_callback(status);
 
 }
 

--- a/exporters/otlp/src/otlp_grpc_exporter.cc
+++ b/exporters/otlp/src/otlp_grpc_exporter.cc
@@ -143,6 +143,14 @@ sdk::common::ExportResult OtlpGrpcExporter::Export(
   return sdk::common::ExportResult::kSuccess;
 }
 
+void OtlpGrpcExporter::Export(
+  const nostd::span<std::unique_ptr<sdk::trace::Recordable>> &spans,
+  nostd::function_ref<bool(sdk::common::ExportResult)> result_callback)
+  noexcept
+{
+
+}
+
 bool OtlpGrpcExporter::Shutdown(std::chrono::microseconds timeout) noexcept
 {
   const std::lock_guard<opentelemetry::common::SpinLockMutex> locked(lock_);

--- a/exporters/otlp/src/otlp_grpc_log_exporter.cc
+++ b/exporters/otlp/src/otlp_grpc_log_exporter.cc
@@ -165,7 +165,9 @@ void OtlpGrpcLogExporter::Export(
   const nostd::span<std::unique_ptr<opentelemetry::sdk::logs::Recordable>> &logs,
   nostd::function_ref<bool(opentelemetry::sdk::common::ExportResult)> result_callback) noexcept
 {
-
+  OTEL_INTERNAL_LOG_WARN("[OTLP LOG GRPC Exporter] async not supported. Making sync interface call");
+  auto status = Export(logs);
+  result_callback(status);
 }
 
 bool OtlpGrpcLogExporter::Shutdown(std::chrono::microseconds timeout) noexcept

--- a/exporters/otlp/src/otlp_grpc_log_exporter.cc
+++ b/exporters/otlp/src/otlp_grpc_log_exporter.cc
@@ -162,10 +162,11 @@ opentelemetry::sdk::common::ExportResult OtlpGrpcLogExporter::Export(
 }
 
 void OtlpGrpcLogExporter::Export(
-  const nostd::span<std::unique_ptr<opentelemetry::sdk::logs::Recordable>> &logs,
-  nostd::function_ref<bool(opentelemetry::sdk::common::ExportResult)> result_callback) noexcept
+    const nostd::span<std::unique_ptr<opentelemetry::sdk::logs::Recordable>> &logs,
+    nostd::function_ref<bool(opentelemetry::sdk::common::ExportResult)> result_callback) noexcept
 {
-  OTEL_INTERNAL_LOG_WARN("[OTLP LOG GRPC Exporter] async not supported. Making sync interface call");
+  OTEL_INTERNAL_LOG_WARN(
+      "[OTLP LOG GRPC Exporter] async not supported. Making sync interface call");
   auto status = Export(logs);
   result_callback(status);
 }

--- a/exporters/otlp/src/otlp_grpc_log_exporter.cc
+++ b/exporters/otlp/src/otlp_grpc_log_exporter.cc
@@ -161,6 +161,13 @@ opentelemetry::sdk::common::ExportResult OtlpGrpcLogExporter::Export(
   return sdk::common::ExportResult::kSuccess;
 }
 
+void OtlpGrpcLogExporter::Export(
+  const nostd::span<std::unique_ptr<opentelemetry::sdk::logs::Recordable>> &logs,
+  nostd::function_ref<bool(opentelemetry::sdk::common::ExportResult)> result_callback) noexcept
+{
+
+}
+
 bool OtlpGrpcLogExporter::Shutdown(std::chrono::microseconds timeout) noexcept
 {
   const std::lock_guard<opentelemetry::common::SpinLockMutex> locked(lock_);

--- a/exporters/otlp/src/otlp_http_client.cc
+++ b/exporters/otlp/src/otlp_http_client.cc
@@ -668,8 +668,8 @@ opentelemetry::sdk::common::ExportResult OtlpHttpClient::Export(
   request->ReplaceHeader("Content-Type", content_type);
 
   // Send the request
-  std::unique_ptr<ResponseHandler> handler(new ResponseHandler(options_.console_debug));
-  session->SendRequest(*handler);
+  auto handler = std::make_shared<ResponseHandler>(options_.console_debug);
+  session->SendRequest(handler);
 
   // Wait for the response to be received
   if (options_.console_debug)

--- a/exporters/otlp/src/otlp_http_exporter.cc
+++ b/exporters/otlp/src/otlp_http_exporter.cc
@@ -56,6 +56,13 @@ opentelemetry::sdk::common::ExportResult OtlpHttpExporter::Export(
   return http_client_->Export(service_request);
 }
 
+void OtlpHttpExporter::Export(
+  const nostd::span<std::unique_ptr<opentelemetry::sdk::trace::Recordable>> &spans,
+  nostd::function_ref<bool(opentelemetry::sdk::common::ExportResult)> result_callback) noexcept
+{
+
+}
+
 bool OtlpHttpExporter::Shutdown(std::chrono::microseconds timeout) noexcept
 {
   return http_client_->Shutdown(timeout);

--- a/exporters/otlp/src/otlp_http_exporter.cc
+++ b/exporters/otlp/src/otlp_http_exporter.cc
@@ -13,7 +13,6 @@
 
 #include "opentelemetry/sdk/common/global_log_handler.h"
 
-
 namespace nostd = opentelemetry::nostd;
 
 OPENTELEMETRY_BEGIN_NAMESPACE
@@ -60,8 +59,8 @@ opentelemetry::sdk::common::ExportResult OtlpHttpExporter::Export(
 }
 
 void OtlpHttpExporter::Export(
-  const nostd::span<std::unique_ptr<opentelemetry::sdk::trace::Recordable>> &spans,
-  nostd::function_ref<bool(opentelemetry::sdk::common::ExportResult)> result_callback) noexcept
+    const nostd::span<std::unique_ptr<opentelemetry::sdk::trace::Recordable>> &spans,
+    nostd::function_ref<bool(opentelemetry::sdk::common::ExportResult)> result_callback) noexcept
 {
   OTEL_INTERNAL_LOG_WARN(" async not supported. Making sync interface call");
   auto status = Export(spans);

--- a/exporters/otlp/src/otlp_http_exporter.cc
+++ b/exporters/otlp/src/otlp_http_exporter.cc
@@ -11,6 +11,9 @@
 
 #include "opentelemetry/exporters/otlp/protobuf_include_suffix.h"
 
+#include "opentelemetry/sdk/common/global_log_handler.h"
+
+
 namespace nostd = opentelemetry::nostd;
 
 OPENTELEMETRY_BEGIN_NAMESPACE
@@ -60,7 +63,9 @@ void OtlpHttpExporter::Export(
   const nostd::span<std::unique_ptr<opentelemetry::sdk::trace::Recordable>> &spans,
   nostd::function_ref<bool(opentelemetry::sdk::common::ExportResult)> result_callback) noexcept
 {
-
+  OTEL_INTERNAL_LOG_WARN(" async not supported. Making sync interface call");
+  auto status = Export(spans);
+  result_callback(status);
 }
 
 bool OtlpHttpExporter::Shutdown(std::chrono::microseconds timeout) noexcept

--- a/exporters/otlp/src/otlp_http_log_exporter.cc
+++ b/exporters/otlp/src/otlp_http_log_exporter.cc
@@ -60,8 +60,8 @@ opentelemetry::sdk::common::ExportResult OtlpHttpLogExporter::Export(
 }
 
 void OtlpHttpLogExporter::Export(
-  const nostd::span<std::unique_ptr<opentelemetry::sdk::logs::Recordable>> &logs,
-  nostd::function_ref<bool(opentelemetry::sdk::common::ExportResult)> result_callback) noexcept
+    const nostd::span<std::unique_ptr<opentelemetry::sdk::logs::Recordable>> &logs,
+    nostd::function_ref<bool(opentelemetry::sdk::common::ExportResult)> result_callback) noexcept
 {
   OTEL_INTERNAL_LOG_WARN(" async not supported. Making sync interface call");
   auto status = Export(logs);

--- a/exporters/otlp/src/otlp_http_log_exporter.cc
+++ b/exporters/otlp/src/otlp_http_log_exporter.cc
@@ -13,6 +13,8 @@
 
 #  include "opentelemetry/exporters/otlp/protobuf_include_suffix.h"
 
+#  include "opentelemetry/sdk/common/global_log_handler.h"
+
 namespace nostd = opentelemetry::nostd;
 
 OPENTELEMETRY_BEGIN_NAMESPACE
@@ -61,7 +63,9 @@ void OtlpHttpLogExporter::Export(
   const nostd::span<std::unique_ptr<opentelemetry::sdk::logs::Recordable>> &logs,
   nostd::function_ref<bool(opentelemetry::sdk::common::ExportResult)> result_callback) noexcept
 {
-
+  OTEL_INTERNAL_LOG_WARN(" async not supported. Making sync interface call");
+  auto status = Export(logs);
+  result_callback(status);
 }
 
 bool OtlpHttpLogExporter::Shutdown(std::chrono::microseconds timeout) noexcept

--- a/exporters/otlp/src/otlp_http_log_exporter.cc
+++ b/exporters/otlp/src/otlp_http_log_exporter.cc
@@ -57,6 +57,13 @@ opentelemetry::sdk::common::ExportResult OtlpHttpLogExporter::Export(
   return http_client_->Export(service_request);
 }
 
+void OtlpHttpLogExporter::Export(
+  const nostd::span<std::unique_ptr<opentelemetry::sdk::logs::Recordable>> &logs,
+  nostd::function_ref<bool(opentelemetry::sdk::common::ExportResult)> result_callback) noexcept
+{
+
+}
+
 bool OtlpHttpLogExporter::Shutdown(std::chrono::microseconds timeout) noexcept
 {
   return http_client_->Shutdown(timeout);

--- a/exporters/otlp/test/otlp_http_exporter_test.cc
+++ b/exporters/otlp/test/otlp_http_exporter_test.cc
@@ -139,7 +139,7 @@ TEST_F(OtlpHttpExporterTestPeer, ExportJsonIntegrationTest)
       std::static_pointer_cast<http_client::nosend::Session>(no_send_client->session_);
   EXPECT_CALL(*mock_session, SendRequest)
       .WillOnce([&mock_session,
-                 report_trace_id](opentelemetry::ext::http::client::EventHandler &callback) {
+                 report_trace_id](std::shared_ptr<opentelemetry::ext::http::client::EventHandler> callback) {
         auto check_json = nlohmann::json::parse(mock_session->GetRequest()->body_, nullptr, false);
         auto resource_span                = *check_json["resource_spans"].begin();
         auto instrumentation_library_span = *resource_span["instrumentation_library_spans"].begin();
@@ -155,7 +155,7 @@ TEST_F(OtlpHttpExporterTestPeer, ExportJsonIntegrationTest)
         }
         // let the otlp_http_client to continue
         http_client::nosend::Response response;
-        callback.OnResponse(response);
+        callback->OnResponse(response);
       });
 
   child_span->End();
@@ -218,7 +218,7 @@ TEST_F(OtlpHttpExporterTestPeer, ExportBinaryIntegrationTest)
       std::static_pointer_cast<http_client::nosend::Session>(no_send_client->session_);
   EXPECT_CALL(*mock_session, SendRequest)
       .WillOnce([&mock_session,
-                 report_trace_id](opentelemetry::ext::http::client::EventHandler &callback) {
+                 report_trace_id](std::shared_ptr<opentelemetry::ext::http::client::EventHandler> callback) {
         opentelemetry::proto::collector::trace::v1::ExportTraceServiceRequest request_body;
         request_body.ParseFromArray(&mock_session->GetRequest()->body_[0],
                                     static_cast<int>(mock_session->GetRequest()->body_.size()));
@@ -234,7 +234,7 @@ TEST_F(OtlpHttpExporterTestPeer, ExportBinaryIntegrationTest)
         }
         // let the otlp_http_client to continue
         http_client::nosend::Response response;
-        callback.OnResponse(response);
+        callback->OnResponse(response);
       });
 
   child_span->End();

--- a/exporters/otlp/test/otlp_http_exporter_test.cc
+++ b/exporters/otlp/test/otlp_http_exporter_test.cc
@@ -138,8 +138,8 @@ TEST_F(OtlpHttpExporterTestPeer, ExportJsonIntegrationTest)
   auto mock_session =
       std::static_pointer_cast<http_client::nosend::Session>(no_send_client->session_);
   EXPECT_CALL(*mock_session, SendRequest)
-      .WillOnce([&mock_session,
-                 report_trace_id](std::shared_ptr<opentelemetry::ext::http::client::EventHandler> callback) {
+      .WillOnce([&mock_session, report_trace_id](
+                    std::shared_ptr<opentelemetry::ext::http::client::EventHandler> callback) {
         auto check_json = nlohmann::json::parse(mock_session->GetRequest()->body_, nullptr, false);
         auto resource_span                = *check_json["resource_spans"].begin();
         auto instrumentation_library_span = *resource_span["instrumentation_library_spans"].begin();
@@ -217,8 +217,8 @@ TEST_F(OtlpHttpExporterTestPeer, ExportBinaryIntegrationTest)
   auto mock_session =
       std::static_pointer_cast<http_client::nosend::Session>(no_send_client->session_);
   EXPECT_CALL(*mock_session, SendRequest)
-      .WillOnce([&mock_session,
-                 report_trace_id](std::shared_ptr<opentelemetry::ext::http::client::EventHandler> callback) {
+      .WillOnce([&mock_session, report_trace_id](
+                    std::shared_ptr<opentelemetry::ext::http::client::EventHandler> callback) {
         opentelemetry::proto::collector::trace::v1::ExportTraceServiceRequest request_body;
         request_body.ParseFromArray(&mock_session->GetRequest()->body_[0],
                                     static_cast<int>(mock_session->GetRequest()->body_.size()));

--- a/exporters/otlp/test/otlp_http_log_exporter_test.cc
+++ b/exporters/otlp/test/otlp_http_log_exporter_test.cc
@@ -148,8 +148,8 @@ TEST_F(OtlpHttpLogExporterTestPeer, ExportJsonIntegrationTest)
   auto mock_session =
       std::static_pointer_cast<http_client::nosend::Session>(no_send_client->session_);
   EXPECT_CALL(*mock_session, SendRequest)
-      .WillOnce([&mock_session, report_trace_id,
-                 report_span_id](std::shared_ptr<opentelemetry::ext::http::client::EventHandler> callback) {
+      .WillOnce([&mock_session, report_trace_id, report_span_id](
+                    std::shared_ptr<opentelemetry::ext::http::client::EventHandler> callback) {
         auto check_json = nlohmann::json::parse(mock_session->GetRequest()->body_, nullptr, false);
         auto resource_logs                = *check_json["resource_logs"].begin();
         auto instrumentation_library_span = *resource_logs["instrumentation_library_logs"].begin();
@@ -232,8 +232,8 @@ TEST_F(OtlpHttpLogExporterTestPeer, ExportBinaryIntegrationTest)
   auto mock_session =
       std::static_pointer_cast<http_client::nosend::Session>(no_send_client->session_);
   EXPECT_CALL(*mock_session, SendRequest)
-      .WillOnce([&mock_session, report_trace_id,
-                 report_span_id](std::shared_ptr<opentelemetry::ext::http::client::EventHandler> callback) {
+      .WillOnce([&mock_session, report_trace_id, report_span_id](
+                    std::shared_ptr<opentelemetry::ext::http::client::EventHandler> callback) {
         opentelemetry::proto::collector::logs::v1::ExportLogsServiceRequest request_body;
         request_body.ParseFromArray(&mock_session->GetRequest()->body_[0],
                                     static_cast<int>(mock_session->GetRequest()->body_.size()));

--- a/exporters/otlp/test/otlp_http_log_exporter_test.cc
+++ b/exporters/otlp/test/otlp_http_log_exporter_test.cc
@@ -149,7 +149,7 @@ TEST_F(OtlpHttpLogExporterTestPeer, ExportJsonIntegrationTest)
       std::static_pointer_cast<http_client::nosend::Session>(no_send_client->session_);
   EXPECT_CALL(*mock_session, SendRequest)
       .WillOnce([&mock_session, report_trace_id,
-                 report_span_id](opentelemetry::ext::http::client::EventHandler &callback) {
+                 report_span_id](std::shared_ptr<opentelemetry::ext::http::client::EventHandler> callback) {
         auto check_json = nlohmann::json::parse(mock_session->GetRequest()->body_, nullptr, false);
         auto resource_logs                = *check_json["resource_logs"].begin();
         auto instrumentation_library_span = *resource_logs["instrumentation_library_logs"].begin();
@@ -169,7 +169,7 @@ TEST_F(OtlpHttpLogExporterTestPeer, ExportJsonIntegrationTest)
         }
         // let the otlp_http_client to continue
         http_client::nosend::Response response;
-        callback.OnResponse(response);
+        callback->OnResponse(response);
       });
 }
 
@@ -233,7 +233,7 @@ TEST_F(OtlpHttpLogExporterTestPeer, ExportBinaryIntegrationTest)
       std::static_pointer_cast<http_client::nosend::Session>(no_send_client->session_);
   EXPECT_CALL(*mock_session, SendRequest)
       .WillOnce([&mock_session, report_trace_id,
-                 report_span_id](opentelemetry::ext::http::client::EventHandler &callback) {
+                 report_span_id](std::shared_ptr<opentelemetry::ext::http::client::EventHandler> callback) {
         opentelemetry::proto::collector::logs::v1::ExportLogsServiceRequest request_body;
         request_body.ParseFromArray(&mock_session->GetRequest()->body_[0],
                                     static_cast<int>(mock_session->GetRequest()->body_.size()));
@@ -254,7 +254,7 @@ TEST_F(OtlpHttpLogExporterTestPeer, ExportBinaryIntegrationTest)
         }
         ASSERT_TRUE(check_service_name);
         http_client::nosend::Response response;
-        callback.OnResponse(response);
+        callback->OnResponse(response);
       });
 }
 

--- a/exporters/zipkin/include/opentelemetry/exporters/zipkin/zipkin_exporter.h
+++ b/exporters/zipkin/include/opentelemetry/exporters/zipkin/zipkin_exporter.h
@@ -83,10 +83,9 @@ public:
    * @param spans a span of unique pointers to span recordables
    * @param result_callback callback function accepting ExportResult as argument
    */
-  void Export(
-      const nostd::span<std::unique_ptr<opentelemetry::sdk::trace::Recordable>> &spans,
-      nostd::function_ref<bool(opentelemetry::sdk::common::ExportResult)> result_callback)
-      noexcept override;
+  void Export(const nostd::span<std::unique_ptr<opentelemetry::sdk::trace::Recordable>> &spans,
+              nostd::function_ref<bool(opentelemetry::sdk::common::ExportResult)>
+                  result_callback) noexcept override;
 
   /**
    * Shut down the exporter.

--- a/exporters/zipkin/include/opentelemetry/exporters/zipkin/zipkin_exporter.h
+++ b/exporters/zipkin/include/opentelemetry/exporters/zipkin/zipkin_exporter.h
@@ -79,6 +79,15 @@ public:
       override;
 
   /**
+   *
+   *
+   */
+  void Export(
+      const nostd::span<std::unique_ptr<opentelemetry::sdk::trace::Recordable>> &spans,
+      nostd::function_ref<bool(opentelemetry::sdk::common::ExportResult)> result_callback)
+      noexcept override;
+
+  /**
    * Shut down the exporter.
    * @param timeout an optional timeout, default to max.
    */

--- a/exporters/zipkin/include/opentelemetry/exporters/zipkin/zipkin_exporter.h
+++ b/exporters/zipkin/include/opentelemetry/exporters/zipkin/zipkin_exporter.h
@@ -79,8 +79,9 @@ public:
       override;
 
   /**
-   *
-   *
+   * Export asynchronosly a batch of span recordables in JSON format
+   * @param spans a span of unique pointers to span recordables
+   * @param result_callback callback function accepting ExportResult as argument
    */
   void Export(
       const nostd::span<std::unique_ptr<opentelemetry::sdk::trace::Recordable>> &spans,

--- a/exporters/zipkin/src/zipkin_exporter.cc
+++ b/exporters/zipkin/src/zipkin_exporter.cc
@@ -94,9 +94,8 @@ sdk::common::ExportResult ZipkinExporter::Export(
 }
 
 void ZipkinExporter::Export(
-  const nostd::span<std::unique_ptr<sdk::trace::Recordable>> &spans,
-  nostd::function_ref<bool(sdk::common::ExportResult)> result_callback)
-  noexcept
+    const nostd::span<std::unique_ptr<sdk::trace::Recordable>> &spans,
+    nostd::function_ref<bool(sdk::common::ExportResult)> result_callback) noexcept
 {
   OTEL_INTERNAL_LOG_WARN("[ZIPKIN EXPORTER] async not supported. Making sync interface call");
   auto status = Export(spans);

--- a/exporters/zipkin/src/zipkin_exporter.cc
+++ b/exporters/zipkin/src/zipkin_exporter.cc
@@ -93,6 +93,14 @@ sdk::common::ExportResult ZipkinExporter::Export(
   return sdk::common::ExportResult::kSuccess;
 }
 
+void ZipkinExporter::Export(
+  const nostd::span<std::unique_ptr<sdk::trace::Recordable>> &spans,
+  nostd::function_ref<bool(sdk::common::ExportResult)> result_callback)
+  noexcept
+{
+
+}
+
 void ZipkinExporter::InitializeLocalEndpoint()
 {
   if (options_.service_name.length())

--- a/exporters/zipkin/src/zipkin_exporter.cc
+++ b/exporters/zipkin/src/zipkin_exporter.cc
@@ -98,7 +98,9 @@ void ZipkinExporter::Export(
   nostd::function_ref<bool(sdk::common::ExportResult)> result_callback)
   noexcept
 {
-
+  OTEL_INTERNAL_LOG_WARN("[ZIPKIN EXPORTER] async not supported. Making sync interface call");
+  auto status = Export(spans);
+  result_callback(status);
 }
 
 void ZipkinExporter::InitializeLocalEndpoint()

--- a/ext/include/opentelemetry/ext/http/client/http_client.h
+++ b/ext/include/opentelemetry/ext/http/client/http_client.h
@@ -212,7 +212,7 @@ class Session
 public:
   virtual std::shared_ptr<Request> CreateRequest() noexcept = 0;
 
-  virtual void SendRequest(EventHandler &) noexcept = 0;
+  virtual void SendRequest(std::shared_ptr<EventHandler>) noexcept = 0;
 
   virtual bool IsSessionActive() noexcept = 0;
 

--- a/ext/include/opentelemetry/ext/http/client/nosend/http_client_nosend.h
+++ b/ext/include/opentelemetry/ext/http/client/nosend/http_client_nosend.h
@@ -121,7 +121,7 @@ public:
 
   MOCK_METHOD(void,
               SendRequest,
-              (opentelemetry::ext::http::client::EventHandler &),
+              (std::shared_ptr<opentelemetry::ext::http::client::EventHandler>),
               (noexcept, override));
 
   virtual bool CancelSession() noexcept override;

--- a/ext/test/http/curl_http_test.cc
+++ b/ext/test/http/curl_http_test.cc
@@ -226,7 +226,6 @@ TEST_F(BasicCurlHttpTests, SendPostRequest)
 
   session_manager->CancelAllSessions();
   session_manager->FinishAllSessions();
-
 }
 
 TEST_F(BasicCurlHttpTests, RequestTimeout)

--- a/ext/test/http/curl_http_test.cc
+++ b/ext/test/http/curl_http_test.cc
@@ -196,12 +196,11 @@ TEST_F(BasicCurlHttpTests, SendGetRequest)
   auto session = session_manager->CreateSession("http://127.0.0.1:19000");
   auto request = session->CreateRequest();
   request->SetUri("get/");
-  GetEventHandler *handler = new GetEventHandler();
-  session->SendRequest(*handler);
+  auto handler = std::make_shared<GetEventHandler>();
+  session->SendRequest(handler);
   ASSERT_TRUE(waitForRequests(30, 1));
   session->FinishSession();
   ASSERT_TRUE(handler->is_called_);
-  delete handler;
 }
 
 TEST_F(BasicCurlHttpTests, SendPostRequest)
@@ -219,8 +218,8 @@ TEST_F(BasicCurlHttpTests, SendPostRequest)
   http_client::Body body = {b, b + strlen(b)};
   request->SetBody(body);
   request->AddHeader("Content-Type", "text/plain");
-  PostEventHandler *handler = new PostEventHandler();
-  session->SendRequest(*handler);
+  auto handler = std::make_shared<PostEventHandler>();
+  session->SendRequest(handler);
   ASSERT_TRUE(waitForRequests(30, 1));
   session->FinishSession();
   ASSERT_TRUE(handler->is_called_);
@@ -228,7 +227,6 @@ TEST_F(BasicCurlHttpTests, SendPostRequest)
   session_manager->CancelAllSessions();
   session_manager->FinishAllSessions();
 
-  delete handler;
 }
 
 TEST_F(BasicCurlHttpTests, RequestTimeout)
@@ -240,11 +238,10 @@ TEST_F(BasicCurlHttpTests, RequestTimeout)
   auto session = session_manager->CreateSession("222.222.222.200:19000");  // Non Existing address
   auto request = session->CreateRequest();
   request->SetUri("get/");
-  GetEventHandler *handler = new GetEventHandler();
-  session->SendRequest(*handler);
+  auto handler = std::make_shared<GetEventHandler>();
+  session->SendRequest(handler);
   session->FinishSession();
   ASSERT_FALSE(handler->is_called_);
-  delete handler;
 }
 
 TEST_F(BasicCurlHttpTests, CurlHttpOperations)

--- a/ext/test/w3c_tracecontext_test/main.cc
+++ b/ext/test/w3c_tracecontext_test/main.cc
@@ -100,7 +100,7 @@ public:
 // Sends an HTTP POST request to the given url, with the given body.
 void send_request(curl::HttpClient &client, const std::string &url, const std::string &body)
 {
-  static std::unique_ptr<http_client::EventHandler> handler(new NoopEventHandler());
+  static std::shared_ptr<http_client::EventHandler> handler(new NoopEventHandler());
 
   auto request_span = get_tracer()->StartSpan(__func__);
   trace_api::Scope scope(request_span);
@@ -126,7 +126,7 @@ void send_request(curl::HttpClient &client, const std::string &url, const std::s
     request->AddHeader(hdr.first, hdr.second);
   }
 
-  session->SendRequest(*handler);
+  session->SendRequest(handler);
   session->FinishSession();
 }
 

--- a/sdk/include/opentelemetry/sdk/logs/batch_log_processor.h
+++ b/sdk/include/opentelemetry/sdk/logs/batch_log_processor.h
@@ -123,7 +123,6 @@ private:
 
   /* Synchronization primitives */
   std::condition_variable cv_, force_flush_cv_, async_shutdown_cv_;
-  ;
   std::mutex cv_m_, force_flush_cv_m_, shutdown_m_, async_shutdown_m_;
 
   /* The buffer/queue to which the ended logs are added */

--- a/sdk/include/opentelemetry/sdk/logs/batch_log_processor.h
+++ b/sdk/include/opentelemetry/sdk/logs/batch_log_processor.h
@@ -122,7 +122,8 @@ private:
   const bool is_export_async_;
 
   /* Synchronization primitives */
-  std::condition_variable cv_, force_flush_cv_, async_shutdown_cv_;;
+  std::condition_variable cv_, force_flush_cv_, async_shutdown_cv_;
+  ;
   std::mutex cv_m_, force_flush_cv_m_, shutdown_m_, async_shutdown_m_;
 
   /* The buffer/queue to which the ended logs are added */

--- a/sdk/include/opentelemetry/sdk/logs/batch_log_processor.h
+++ b/sdk/include/opentelemetry/sdk/logs/batch_log_processor.h
@@ -99,6 +99,19 @@ private:
    */
   void DrainQueue();
 
+  /**
+   * Should be called from Export to notify the main thread on Force Flush Completion
+   * @param was_force_flush_called - A flag to check if the current export is the result
+   *                                 of a call to ForceFlush method. If true, then we have to
+   *                                 notify the main thread to wake it up in the ForceFlush
+   *                                 method.
+   */
+  void NotifyForceFlushCompletion(const bool was_for_flush_called);
+
+  /* In case of async export, wait and notify for shutdown to be completed.*/
+  void WaitForShutdownCompletion();
+  void NotifyShutdownCompletion();
+
   /* The configured backend log exporter */
   std::unique_ptr<LogExporter> exporter_;
 
@@ -109,8 +122,8 @@ private:
   const bool is_export_async_;
 
   /* Synchronization primitives */
-  std::condition_variable cv_, force_flush_cv_;
-  std::mutex cv_m_, force_flush_cv_m_, shutdown_m_;
+  std::condition_variable cv_, force_flush_cv_, async_shutdown_cv_;;
+  std::mutex cv_m_, force_flush_cv_m_, shutdown_m_, async_shutdown_m_;
 
   /* The buffer/queue to which the ended logs are added */
   common::CircularBuffer<Recordable> buffer_;
@@ -119,6 +132,7 @@ private:
   std::atomic<bool> is_shutdown_{false};
   std::atomic<bool> is_force_flush_{false};
   std::atomic<bool> is_force_flush_notified_{false};
+  std::atomic<bool> is_async_shutdown_notified_{false};
 
   /* The background worker thread */
   std::thread worker_thread_;

--- a/sdk/include/opentelemetry/sdk/logs/batch_log_processor.h
+++ b/sdk/include/opentelemetry/sdk/logs/batch_log_processor.h
@@ -41,7 +41,8 @@ public:
       std::unique_ptr<LogExporter> &&exporter,
       const size_t max_queue_size                            = 2048,
       const std::chrono::milliseconds scheduled_delay_millis = std::chrono::milliseconds(5000),
-      const size_t max_export_batch_size                     = 512);
+      const size_t max_export_batch_size                     = 512,
+      const bool is_export_async                             = false);
 
   /** Makes a new recordable **/
   std::unique_ptr<Recordable> MakeRecordable() noexcept override;
@@ -105,6 +106,7 @@ private:
   const size_t max_queue_size_;
   const std::chrono::milliseconds scheduled_delay_millis_;
   const size_t max_export_batch_size_;
+  const bool is_export_async_;
 
   /* Synchronization primitives */
   std::condition_variable cv_, force_flush_cv_;

--- a/sdk/include/opentelemetry/sdk/logs/exporter.h
+++ b/sdk/include/opentelemetry/sdk/logs/exporter.h
@@ -46,6 +46,17 @@ public:
   virtual sdk::common::ExportResult Export(
       const nostd::span<std::unique_ptr<Recordable>> &records) noexcept = 0;
 
+
+  /**
+   * Exports the batch of log records to their export destination
+   *
+   *
+   *
+   */
+  virtual void Export(
+      const nostd::span<std::unique_ptr<Recordable>> &records,
+      nostd::function_ref<bool(sdk::common::ExportResult)> result_callback) noexcept = 0;
+
   /**
    * Marks the exporter as ShutDown and cleans up any resources as required.
    * Shutdown should be called only once for each Exporter instance.

--- a/sdk/include/opentelemetry/sdk/logs/exporter.h
+++ b/sdk/include/opentelemetry/sdk/logs/exporter.h
@@ -48,10 +48,9 @@ public:
 
 
   /**
-   * Exports the batch of log records to their export destination
-   *
-   *
-   *
+   * Exports asynchronously the batch of log records to their export destination
+   * @param records a span of unique pointers to log records
+   * @param result_callback callback function accepting ExportResult as argument
    */
   virtual void Export(
       const nostd::span<std::unique_ptr<Recordable>> &records,

--- a/sdk/include/opentelemetry/sdk/logs/exporter.h
+++ b/sdk/include/opentelemetry/sdk/logs/exporter.h
@@ -46,7 +46,6 @@ public:
   virtual sdk::common::ExportResult Export(
       const nostd::span<std::unique_ptr<Recordable>> &records) noexcept = 0;
 
-
   /**
    * Exports asynchronously the batch of log records to their export destination
    * @param records a span of unique pointers to log records

--- a/sdk/include/opentelemetry/sdk/logs/simple_log_processor.h
+++ b/sdk/include/opentelemetry/sdk/logs/simple_log_processor.h
@@ -28,7 +28,8 @@ class SimpleLogProcessor : public LogProcessor
 {
 
 public:
-  explicit SimpleLogProcessor(std::unique_ptr<LogExporter> &&exporter, bool is_export_async = false);
+  explicit SimpleLogProcessor(std::unique_ptr<LogExporter> &&exporter,
+                              bool is_export_async = false);
   virtual ~SimpleLogProcessor() = default;
 
   std::unique_ptr<Recordable> MakeRecordable() noexcept override;
@@ -48,7 +49,7 @@ private:
   opentelemetry::common::SpinLockMutex lock_;
   // The atomic boolean flag to ensure the ShutDown() function is only called once
   std::atomic_flag shutdown_latch_ = ATOMIC_FLAG_INIT;
-  bool is_export_async_ = false;
+  bool is_export_async_            = false;
 };
 }  // namespace logs
 }  // namespace sdk

--- a/sdk/include/opentelemetry/sdk/logs/simple_log_processor.h
+++ b/sdk/include/opentelemetry/sdk/logs/simple_log_processor.h
@@ -28,7 +28,7 @@ class SimpleLogProcessor : public LogProcessor
 {
 
 public:
-  explicit SimpleLogProcessor(std::unique_ptr<LogExporter> &&exporter);
+  explicit SimpleLogProcessor(std::unique_ptr<LogExporter> &&exporter, bool is_export_async = false);
   virtual ~SimpleLogProcessor() = default;
 
   std::unique_ptr<Recordable> MakeRecordable() noexcept override;
@@ -48,6 +48,7 @@ private:
   opentelemetry::common::SpinLockMutex lock_;
   // The atomic boolean flag to ensure the ShutDown() function is only called once
   std::atomic_flag shutdown_latch_ = ATOMIC_FLAG_INIT;
+  bool is_export_async_ = false;
 };
 }  // namespace logs
 }  // namespace sdk

--- a/sdk/include/opentelemetry/sdk/trace/batch_span_processor.h
+++ b/sdk/include/opentelemetry/sdk/trace/batch_span_processor.h
@@ -135,6 +135,19 @@ private:
    */
   void DrainQueue();
 
+  /**
+   * Should be called from Export to notify the main thread on Force Flush Completion
+   * @param was_force_flush_called - A flag to check if the current export is the result
+   *                                 of a call to ForceFlush method. If true, then we have to
+   *                                 notify the main thread to wake it up in the ForceFlush
+   *                                 method.
+   */
+  void NotifyForceFlushCompletion(const bool was_for_flush_called);
+
+  /* In case of async export, wait and notify for shutdown to be completed.*/
+  void WaitForShutdownCompletion();
+  void NotifyShutdownCompletion();
+
   /* The configured backend exporter */
   std::unique_ptr<SpanExporter> exporter_;
 
@@ -145,8 +158,8 @@ private:
   const bool is_export_async_;
 
   /* Synchronization primitives */
-  std::condition_variable cv_, force_flush_cv_;
-  std::mutex cv_m_, force_flush_cv_m_, shutdown_m_;
+  std::condition_variable cv_, force_flush_cv_, async_shutdown_cv_;
+  std::mutex cv_m_, force_flush_cv_m_, shutdown_m_, async_shutdown_m_;
 
   /* The buffer/queue to which the ended spans are added */
   common::CircularBuffer<Recordable> buffer_;
@@ -155,6 +168,7 @@ private:
   std::atomic<bool> is_shutdown_{false};
   std::atomic<bool> is_force_flush_{false};
   std::atomic<bool> is_force_flush_notified_{false};
+  std::atomic<bool> is_async_shutdown_notified_{false};
 
   /* The background worker thread */
   std::thread worker_thread_;

--- a/sdk/include/opentelemetry/sdk/trace/batch_span_processor.h
+++ b/sdk/include/opentelemetry/sdk/trace/batch_span_processor.h
@@ -37,6 +37,12 @@ struct BatchSpanProcessorOptions
    * equal to max_queue_size.
    */
   size_t max_export_batch_size = 512;
+
+  /**
+   * Determines whether the export happens asynchronously.
+   * Default implementation is synchronous.
+   */
+  bool is_export_async = false;
 };
 
 /**
@@ -136,6 +142,7 @@ private:
   const size_t max_queue_size_;
   const std::chrono::milliseconds schedule_delay_millis_;
   const size_t max_export_batch_size_;
+  const bool is_export_async_;
 
   /* Synchronization primitives */
   std::condition_variable cv_, force_flush_cv_;

--- a/sdk/include/opentelemetry/sdk/trace/exporter.h
+++ b/sdk/include/opentelemetry/sdk/trace/exporter.h
@@ -43,10 +43,9 @@ public:
           &spans) noexcept = 0;
 
   /**
-   * Exports a batch of span recordables.
-   *
-   *
-   *
+   * Exports a batch of span recordables asynchronously.
+   * @param spans a span of unique pointers to span recordables
+   * @param result_callback callback function accepting ExportResult as argument
    */
   virtual void Export(
       const nostd::span<std::unique_ptr<opentelemetry::sdk::trace::Recordable>> &spans,

--- a/sdk/include/opentelemetry/sdk/trace/exporter.h
+++ b/sdk/include/opentelemetry/sdk/trace/exporter.h
@@ -43,6 +43,16 @@ public:
           &spans) noexcept = 0;
 
   /**
+   * Exports a batch of span recordables.
+   *
+   *
+   *
+   */
+  virtual void Export(
+      const nostd::span<std::unique_ptr<opentelemetry::sdk::trace::Recordable>> &spans,
+      nostd::function_ref<bool(sdk::common::ExportResult)> result_callback) noexcept = 0;
+
+  /**
    * Shut down the exporter.
    * @param timeout an optional timeout.
    * @return return the status of the operation.

--- a/sdk/include/opentelemetry/sdk/trace/simple_processor.h
+++ b/sdk/include/opentelemetry/sdk/trace/simple_processor.h
@@ -31,9 +31,9 @@ public:
    * Initialize a simple span processor.
    * @param exporter the exporter used by the span processor
    */
-  explicit SimpleSpanProcessor(std::unique_ptr<SpanExporter> &&exporter, bool is_export_async = false) noexcept
-      : exporter_(std::move(exporter))
-      , is_export_async_(is_export_async)
+  explicit SimpleSpanProcessor(std::unique_ptr<SpanExporter> &&exporter,
+                               bool is_export_async = false) noexcept
+      : exporter_(std::move(exporter)), is_export_async_(is_export_async)
   {}
 
   std::unique_ptr<Recordable> MakeRecordable() noexcept override
@@ -49,16 +49,19 @@ public:
   {
     nostd::span<std::unique_ptr<Recordable>> batch(&span, 1);
     const std::lock_guard<opentelemetry::common::SpinLockMutex> locked(lock_);
-    if (is_export_async_ == false) {
+    if (is_export_async_ == false)
+    {
       if (exporter_->Export(batch) == sdk::common::ExportResult::kFailure)
       {
         /* Once it is defined how the SDK does logging, an error should be
          * logged in this case. */
       }
-    } else {
-      exporter_->Export(batch, [](sdk::common::ExportResult result){
+    }
+    else
+    {
+      exporter_->Export(batch, [](sdk::common::ExportResult result) {
         /* Log the result
-        */
+         */
         return true;
       });
     }
@@ -87,7 +90,7 @@ private:
   std::unique_ptr<SpanExporter> exporter_;
   opentelemetry::common::SpinLockMutex lock_;
   std::atomic_flag shutdown_latch_ = ATOMIC_FLAG_INIT;
-  bool is_export_async_ = false;
+  bool is_export_async_            = false;
 };
 }  // namespace trace
 }  // namespace sdk

--- a/sdk/include/opentelemetry/sdk/trace/simple_processor.h
+++ b/sdk/include/opentelemetry/sdk/trace/simple_processor.h
@@ -31,8 +31,9 @@ public:
    * Initialize a simple span processor.
    * @param exporter the exporter used by the span processor
    */
-  explicit SimpleSpanProcessor(std::unique_ptr<SpanExporter> &&exporter) noexcept
+  explicit SimpleSpanProcessor(std::unique_ptr<SpanExporter> &&exporter, bool is_export_async = false) noexcept
       : exporter_(std::move(exporter))
+      , is_export_async_(is_export_async)
   {}
 
   std::unique_ptr<Recordable> MakeRecordable() noexcept override
@@ -48,10 +49,18 @@ public:
   {
     nostd::span<std::unique_ptr<Recordable>> batch(&span, 1);
     const std::lock_guard<opentelemetry::common::SpinLockMutex> locked(lock_);
-    if (exporter_->Export(batch) == sdk::common::ExportResult::kFailure)
-    {
-      /* Once it is defined how the SDK does logging, an error should be
-       * logged in this case. */
+    if (is_export_async_ == false) {
+      if (exporter_->Export(batch) == sdk::common::ExportResult::kFailure)
+      {
+        /* Once it is defined how the SDK does logging, an error should be
+         * logged in this case. */
+      }
+    } else {
+      exporter_->Export(batch, [](sdk::common::ExportResult result){
+        /* Log the result
+        */
+        return true;
+      });
     }
   }
 
@@ -78,6 +87,7 @@ private:
   std::unique_ptr<SpanExporter> exporter_;
   opentelemetry::common::SpinLockMutex lock_;
   std::atomic_flag shutdown_latch_ = ATOMIC_FLAG_INIT;
+  bool is_export_async_ = false;
 };
 }  // namespace trace
 }  // namespace sdk

--- a/sdk/src/logs/batch_log_processor.cc
+++ b/sdk/src/logs/batch_log_processor.cc
@@ -154,12 +154,14 @@ void BatchLogProcessor::Export(const bool was_force_flush_called)
                     });
                   });
 
-  if (is_export_async_ == false) {
+  if (is_export_async_ == false)
+  {
     exporter_->Export(
         nostd::span<std::unique_ptr<Recordable>>(records_arr.data(), records_arr.size()));
     NotifyForceFlushCompletion(was_force_flush_called);
   }
-  else {
+  else
+  {
     exporter_->Export(
         nostd::span<std::unique_ptr<Recordable>>(records_arr.data(), records_arr.size()),
         [this, was_force_flush_called](sdk::common::ExportResult result) {
@@ -203,7 +205,8 @@ void BatchLogProcessor::WaitForShutdownCompletion()
 void BatchLogProcessor::NotifyShutdownCompletion()
 {
   // Notify the thread which is waiting on shutdown to complete.
-  if (is_shutdown_.load() == true) {
+  if (is_shutdown_.load() == true)
+  {
     is_async_shutdown_notified_.store(true);
     async_shutdown_cv_.notify_one();
   }

--- a/sdk/src/logs/simple_log_processor.cc
+++ b/sdk/src/logs/simple_log_processor.cc
@@ -16,9 +16,9 @@ namespace logs
  * Initialize a simple log processor.
  * @param exporter the configured exporter where log records are sent
  */
-SimpleLogProcessor::SimpleLogProcessor(std::unique_ptr<LogExporter> &&exporter, bool is_export_async)
-    : exporter_(std::move(exporter))
-    , is_export_async_(is_export_async)
+SimpleLogProcessor::SimpleLogProcessor(std::unique_ptr<LogExporter> &&exporter,
+                                       bool is_export_async)
+    : exporter_(std::move(exporter)), is_export_async_(is_export_async)
 {}
 
 std::unique_ptr<Recordable> SimpleLogProcessor::MakeRecordable() noexcept
@@ -36,15 +36,18 @@ void SimpleLogProcessor::OnReceive(std::unique_ptr<Recordable> &&record) noexcep
   // Get lock to ensure Export() is never called concurrently
   const std::lock_guard<opentelemetry::common::SpinLockMutex> locked(lock_);
 
-  if (is_export_async_ == false) {
+  if (is_export_async_ == false)
+  {
     if (exporter_->Export(batch) != sdk::common::ExportResult::kSuccess)
     {
       /* Alert user of the failed export */
     }
-  } else {
-    exporter_->Export(batch, [](sdk::common::ExportResult result){
+  }
+  else
+  {
+    exporter_->Export(batch, [](sdk::common::ExportResult result) {
       /* Log the result
-      */
+       */
       return true;
     });
   }

--- a/sdk/src/trace/batch_span_processor.cc
+++ b/sdk/src/trace/batch_span_processor.cc
@@ -164,22 +164,53 @@ void BatchSpanProcessor::Export(const bool was_force_flush_called)
   if (is_export_async_ == false || was_force_flush_called == true) {
     exporter_->Export(nostd::span<std::unique_ptr<Recordable>>(spans_arr.data(), spans_arr.size()));
 
-    // Notify the main thread in case this export was the result of a force flush.
-    if (was_force_flush_called == true)
-    {
-      is_force_flush_notified_ = true;
-      while (is_force_flush_notified_.load() == true)
-      {
-        force_flush_cv_.notify_one();
-      }
-    }
+    NotifyForceFlushCompletion(was_force_flush_called);
   }
   else {
     exporter_->Export(nostd::span<std::unique_ptr<Recordable>>(spans_arr.data(), spans_arr.size()),
-      [](sdk::common::ExportResult result) {
+      [this, was_force_flush_called](sdk::common::ExportResult result) {
         // TODO: Print result
+        NotifyForceFlushCompletion(was_force_flush_called);
+        // If export was called due to shutdown, notify the worker thread
+        NotifyShutdownCompletion();
         return true;
       });
+  }
+}
+
+void BatchSpanProcessor::NotifyForceFlushCompletion(const bool was_force_flush_called)
+{
+  // Notify the main thread in case this export was the result of a force flush.
+  if (was_force_flush_called == true)
+  {
+    is_force_flush_notified_ = true;
+    while (is_force_flush_notified_.load() == true)
+    {
+      force_flush_cv_.notify_one();
+    }
+  }
+}
+
+void BatchSpanProcessor::WaitForShutdownCompletion()
+{
+  // Since async export is invoked due to shutdown, need to wait
+  // for async thread to complete.
+  if (is_export_async_)
+  {
+    std::unique_lock<std::mutex> lk(async_shutdown_m_);
+    while (is_async_shutdown_notified_.load() == false)
+    {
+      async_shutdown_cv_.wait(lk);
+    }
+  }
+}
+
+void BatchSpanProcessor::NotifyShutdownCompletion()
+{
+  // Notify the thread which is waiting on shutdown to complete.
+  if (is_shutdown_.load() == true) {
+    is_async_shutdown_notified_.store(true);
+    async_shutdown_cv_.notify_one();
   }
 }
 
@@ -188,6 +219,7 @@ void BatchSpanProcessor::DrainQueue()
   while (buffer_.empty() == false)
   {
     Export(false);
+    WaitForShutdownCompletion();
   }
 }
 

--- a/sdk/src/trace/batch_span_processor.cc
+++ b/sdk/src/trace/batch_span_processor.cc
@@ -161,20 +161,22 @@ void BatchSpanProcessor::Export(const bool was_force_flush_called)
   /* Call the sync Export when force flush was called, even if
      is_export_async_ is true.
   */
-  if (is_export_async_ == false || was_force_flush_called == true) {
+  if (is_export_async_ == false || was_force_flush_called == true)
+  {
     exporter_->Export(nostd::span<std::unique_ptr<Recordable>>(spans_arr.data(), spans_arr.size()));
 
     NotifyForceFlushCompletion(was_force_flush_called);
   }
-  else {
+  else
+  {
     exporter_->Export(nostd::span<std::unique_ptr<Recordable>>(spans_arr.data(), spans_arr.size()),
-      [this, was_force_flush_called](sdk::common::ExportResult result) {
-        // TODO: Print result
-        NotifyForceFlushCompletion(was_force_flush_called);
-        // If export was called due to shutdown, notify the worker thread
-        NotifyShutdownCompletion();
-        return true;
-      });
+                      [this, was_force_flush_called](sdk::common::ExportResult result) {
+                        // TODO: Print result
+                        NotifyForceFlushCompletion(was_force_flush_called);
+                        // If export was called due to shutdown, notify the worker thread
+                        NotifyShutdownCompletion();
+                        return true;
+                      });
   }
 }
 
@@ -208,7 +210,8 @@ void BatchSpanProcessor::WaitForShutdownCompletion()
 void BatchSpanProcessor::NotifyShutdownCompletion()
 {
   // Notify the thread which is waiting on shutdown to complete.
-  if (is_shutdown_.load() == true) {
+  if (is_shutdown_.load() == true)
+  {
     is_async_shutdown_notified_.store(true);
     async_shutdown_cv_.notify_one();
   }

--- a/sdk/src/trace/batch_span_processor.cc
+++ b/sdk/src/trace/batch_span_processor.cc
@@ -161,7 +161,7 @@ void BatchSpanProcessor::Export(const bool was_force_flush_called)
   /* Call the sync Export when force flush was called, even if
      is_export_async_ is true.
   */
-  if (is_export_async_ == false || was_force_flush_called == true)
+  if (is_export_async_ == false)
   {
     exporter_->Export(nostd::span<std::unique_ptr<Recordable>>(spans_arr.data(), spans_arr.size()));
 

--- a/sdk/test/logs/batch_log_processor_test.cc
+++ b/sdk/test/logs/batch_log_processor_test.cc
@@ -55,10 +55,11 @@ public:
     return ExportResult::kSuccess;
   }
 
-  void Export(const opentelemetry::nostd::span<std::unique_ptr<Recordable>> &records,
-    opentelemetry::nostd::function_ref<bool(ExportResult)> result_callback) noexcept override
+  void Export(
+      const opentelemetry::nostd::span<std::unique_ptr<Recordable>> &records,
+      opentelemetry::nostd::function_ref<bool(ExportResult)> result_callback) noexcept override
   {
-    auto th = std::thread([this, records, result_callback](){
+    auto th = std::thread([this, records, result_callback]() {
       auto result = Export(records);
       result_callback(result);
     });
@@ -99,11 +100,10 @@ public:
       const size_t max_export_batch_size                     = 512,
       const bool is_export_async                             = false)
   {
-    return std::shared_ptr<LogProcessor>(
-        new BatchLogProcessor(std::unique_ptr<LogExporter>(new MockLogExporter(
-                                  logs_received, is_shutdown, is_export_completed, export_delay)),
-                              max_queue_size, scheduled_delay_millis, max_export_batch_size,
-                              is_export_async));
+    return std::shared_ptr<LogProcessor>(new BatchLogProcessor(
+        std::unique_ptr<LogExporter>(
+            new MockLogExporter(logs_received, is_shutdown, is_export_completed, export_delay)),
+        max_queue_size, scheduled_delay_millis, max_export_batch_size, is_export_async));
   }
 };
 
@@ -156,12 +156,12 @@ TEST_F(BatchLogProcessorTest, TestAsyncShutdown)
   const std::chrono::milliseconds export_delay(0);
   const std::chrono::milliseconds scheduled_delay_millis(5000);
   const size_t max_export_batch_size = 512;
-  const size_t max_queue_size = 2048;
-  const bool is_export_async = true;
+  const size_t max_queue_size        = 2048;
+  const bool is_export_async         = true;
 
   auto batch_processor = GetMockProcessor(logs_received, is_shutdown, is_export_completed,
-      export_delay, scheduled_delay_millis, max_queue_size, max_export_batch_size,
-      is_export_async);
+                                          export_delay, scheduled_delay_millis, max_queue_size,
+                                          max_export_batch_size, is_export_async);
 
   // Create a few test log records and send them to the processor
   const int num_logs = 3;
@@ -243,14 +243,14 @@ TEST_F(BatchLogProcessorTest, TestAsyncForceFlush)
   const std::chrono::milliseconds export_delay(0);
   const std::chrono::milliseconds scheduled_delay_millis(5000);
   const size_t max_export_batch_size = 512;
-  const size_t max_queue_size = 2048;
-  const bool is_export_async = true;
+  const size_t max_queue_size        = 2048;
+  const bool is_export_async         = true;
 
   auto batch_processor = GetMockProcessor(logs_received, is_shutdown, is_export_completed,
-      export_delay, scheduled_delay_millis, max_queue_size, max_export_batch_size,
-      is_export_async);
+                                          export_delay, scheduled_delay_millis, max_queue_size,
+                                          max_export_batch_size, is_export_async);
 
-  const int num_logs   = 2048;
+  const int num_logs = 2048;
 
   for (int i = 0; i < num_logs; ++i)
   {

--- a/sdk/test/logs/batch_log_processor_test.cc
+++ b/sdk/test/logs/batch_log_processor_test.cc
@@ -58,8 +58,11 @@ public:
   void Export(const opentelemetry::nostd::span<std::unique_ptr<Recordable>> &records,
     opentelemetry::nostd::function_ref<bool(ExportResult)> result_callback) noexcept override
   {
-    auto result = Export(records);
-    result_callback(result);
+    auto th = std::thread([this, records, result_callback](){
+      auto result = Export(records);
+      result_callback(result);
+    });
+    th.join();
   }
 
   // toggles the boolean flag marking this exporter as shut down
@@ -93,12 +96,14 @@ public:
       const std::chrono::milliseconds export_delay           = std::chrono::milliseconds(0),
       const std::chrono::milliseconds scheduled_delay_millis = std::chrono::milliseconds(5000),
       const size_t max_queue_size                            = 2048,
-      const size_t max_export_batch_size                     = 512)
+      const size_t max_export_batch_size                     = 512,
+      const bool is_export_async                             = false)
   {
     return std::shared_ptr<LogProcessor>(
         new BatchLogProcessor(std::unique_ptr<LogExporter>(new MockLogExporter(
                                   logs_received, is_shutdown, is_export_completed, export_delay)),
-                              max_queue_size, scheduled_delay_millis, max_export_batch_size));
+                              max_queue_size, scheduled_delay_millis, max_export_batch_size,
+                              is_export_async));
   }
 };
 
@@ -140,6 +145,53 @@ TEST_F(BatchLogProcessorTest, TestShutdown)
   EXPECT_TRUE(is_shutdown->load());
 }
 
+TEST_F(BatchLogProcessorTest, TestAsyncShutdown)
+{
+  // initialize a batch log processor with the test exporter
+  std::shared_ptr<std::vector<std::unique_ptr<LogRecord>>> logs_received(
+      new std::vector<std::unique_ptr<LogRecord>>);
+  std::shared_ptr<std::atomic<bool>> is_shutdown(new std::atomic<bool>(false));
+  std::shared_ptr<std::atomic<bool>> is_export_completed(new std::atomic<bool>(false));
+
+  const std::chrono::milliseconds export_delay(0);
+  const std::chrono::milliseconds scheduled_delay_millis(5000);
+  const size_t max_export_batch_size = 512;
+  const size_t max_queue_size = 2048;
+  const bool is_export_async = true;
+
+  auto batch_processor = GetMockProcessor(logs_received, is_shutdown, is_export_completed,
+      export_delay, scheduled_delay_millis, max_queue_size, max_export_batch_size,
+      is_export_async);
+
+  // Create a few test log records and send them to the processor
+  const int num_logs = 3;
+
+  for (int i = 0; i < num_logs; ++i)
+  {
+    auto log = batch_processor->MakeRecordable();
+    log->SetName("Log" + std::to_string(i));
+    batch_processor->OnReceive(std::move(log));
+  }
+
+  // Test that shutting down the processor will first wait for the
+  // current batch of logs to be sent to the log exporter
+  // by checking the number of logs sent and the names of the logs sent
+  EXPECT_EQ(true, batch_processor->Shutdown());
+  // It's safe to shutdown again
+  EXPECT_TRUE(batch_processor->Shutdown());
+
+  EXPECT_EQ(num_logs, logs_received->size());
+
+  // Assume logs are received by exporter in same order as sent by processor
+  for (int i = 0; i < num_logs; ++i)
+  {
+    EXPECT_EQ("Log" + std::to_string(i), logs_received->at(i)->GetName());
+  }
+
+  // Also check that the processor is shut down at the end
+  EXPECT_TRUE(is_shutdown->load());
+}
+
 TEST_F(BatchLogProcessorTest, TestForceFlush)
 {
   std::shared_ptr<std::atomic<bool>> is_shutdown(new std::atomic<bool>(false));
@@ -147,6 +199,57 @@ TEST_F(BatchLogProcessorTest, TestForceFlush)
       new std::vector<std::unique_ptr<LogRecord>>);
 
   auto batch_processor = GetMockProcessor(logs_received, is_shutdown);
+  const int num_logs   = 2048;
+
+  for (int i = 0; i < num_logs; ++i)
+  {
+    auto log = batch_processor->MakeRecordable();
+    log->SetName("Log" + std::to_string(i));
+    batch_processor->OnReceive(std::move(log));
+  }
+
+  EXPECT_TRUE(batch_processor->ForceFlush());
+
+  EXPECT_EQ(num_logs, logs_received->size());
+  for (int i = 0; i < num_logs; ++i)
+  {
+    EXPECT_EQ("Log" + std::to_string(i), logs_received->at(i)->GetName());
+  }
+
+  // Create some more logs to make sure that the processor still works
+  for (int i = 0; i < num_logs; ++i)
+  {
+    auto log = batch_processor->MakeRecordable();
+    log->SetName("Log" + std::to_string(i));
+    batch_processor->OnReceive(std::move(log));
+  }
+
+  EXPECT_TRUE(batch_processor->ForceFlush());
+
+  EXPECT_EQ(num_logs * 2, logs_received->size());
+  for (int i = 0; i < num_logs * 2; ++i)
+  {
+    EXPECT_EQ("Log" + std::to_string(i % num_logs), logs_received->at(i)->GetName());
+  }
+}
+
+TEST_F(BatchLogProcessorTest, TestAsyncForceFlush)
+{
+  std::shared_ptr<std::atomic<bool>> is_shutdown(new std::atomic<bool>(false));
+  std::shared_ptr<std::vector<std::unique_ptr<LogRecord>>> logs_received(
+      new std::vector<std::unique_ptr<LogRecord>>);
+  std::shared_ptr<std::atomic<bool>> is_export_completed(new std::atomic<bool>(false));
+
+  const std::chrono::milliseconds export_delay(0);
+  const std::chrono::milliseconds scheduled_delay_millis(5000);
+  const size_t max_export_batch_size = 512;
+  const size_t max_queue_size = 2048;
+  const bool is_export_async = true;
+
+  auto batch_processor = GetMockProcessor(logs_received, is_shutdown, is_export_completed,
+      export_delay, scheduled_delay_millis, max_queue_size, max_export_batch_size,
+      is_export_async);
+
   const int num_logs   = 2048;
 
   for (int i = 0; i < num_logs; ++i)

--- a/sdk/test/logs/batch_log_processor_test.cc
+++ b/sdk/test/logs/batch_log_processor_test.cc
@@ -55,6 +55,13 @@ public:
     return ExportResult::kSuccess;
   }
 
+  void Export(const opentelemetry::nostd::span<std::unique_ptr<Recordable>> &records,
+    opentelemetry::nostd::function_ref<bool(ExportResult)> result_callback) noexcept override
+  {
+    auto result = Export(records);
+    result_callback(result);
+  }
+
   // toggles the boolean flag marking this exporter as shut down
   bool Shutdown(
       std::chrono::microseconds timeout = std::chrono::microseconds::max()) noexcept override

--- a/sdk/test/logs/simple_log_processor_test.cc
+++ b/sdk/test/logs/simple_log_processor_test.cc
@@ -55,7 +55,7 @@ public:
 
   // Dummy Async Export implementation
   void Export(const nostd::span<std::unique_ptr<Recordable>> &records,
-    nostd::function_ref<bool(ExportResult)> result_callback) noexcept override
+              nostd::function_ref<bool(ExportResult)> result_callback) noexcept override
   {
     auto result = Export(records);
     result_callback(result);
@@ -146,7 +146,7 @@ public:
   }
 
   void Export(const nostd::span<std::unique_ptr<Recordable>> &records,
-    nostd::function_ref<bool(ExportResult)> result_callback) noexcept override
+              nostd::function_ref<bool(ExportResult)> result_callback) noexcept override
   {
     result_callback(ExportResult::kSuccess);
   }

--- a/sdk/test/logs/simple_log_processor_test.cc
+++ b/sdk/test/logs/simple_log_processor_test.cc
@@ -53,6 +53,14 @@ public:
     return ExportResult::kSuccess;
   }
 
+  // Dummy Async Export implementation
+  void Export(const nostd::span<std::unique_ptr<Recordable>> &records,
+    nostd::function_ref<bool(ExportResult)> result_callback) noexcept override
+  {
+    auto result = Export(records);
+    result_callback(result);
+  }
+
   // Increment the shutdown counter everytime this method is called
   bool Shutdown(std::chrono::microseconds timeout) noexcept override
   {
@@ -135,6 +143,12 @@ public:
   ExportResult Export(const nostd::span<std::unique_ptr<Recordable>> &records) noexcept override
   {
     return ExportResult::kSuccess;
+  }
+
+  void Export(const nostd::span<std::unique_ptr<Recordable>> &records,
+    nostd::function_ref<bool(ExportResult)> result_callback) noexcept override
+  {
+    result_callback(ExportResult::kSuccess);
   }
 
   bool Shutdown(std::chrono::microseconds timeout) noexcept override { return false; }

--- a/sdk/test/trace/batch_span_processor_test.cc
+++ b/sdk/test/trace/batch_span_processor_test.cc
@@ -56,6 +56,14 @@ public:
     return sdk::common::ExportResult::kSuccess;
   }
 
+  void Export(
+      const nostd::span<std::unique_ptr<sdk::trace::Recordable>> &spans,
+      nostd::function_ref<bool(sdk::common::ExportResult)> result_callback) noexcept override
+  {
+    auto result = Export(spans);
+    result_callback(result);
+  }
+
   bool Shutdown(
       std::chrono::microseconds timeout = std::chrono::microseconds::max()) noexcept override
   {

--- a/sdk/test/trace/batch_span_processor_test.cc
+++ b/sdk/test/trace/batch_span_processor_test.cc
@@ -60,7 +60,7 @@ public:
       const nostd::span<std::unique_ptr<sdk::trace::Recordable>> &spans,
       nostd::function_ref<bool(sdk::common::ExportResult)> result_callback) noexcept override
   {
-    auto th = std::thread([this, spans, result_callback](){
+    auto th = std::thread([this, spans, result_callback]() {
       auto result = Export(spans);
       result_callback(result);
     });

--- a/sdk/test/trace/batch_span_processor_test.cc
+++ b/sdk/test/trace/batch_span_processor_test.cc
@@ -60,8 +60,11 @@ public:
       const nostd::span<std::unique_ptr<sdk::trace::Recordable>> &spans,
       nostd::function_ref<bool(sdk::common::ExportResult)> result_callback) noexcept override
   {
-    auto result = Export(spans);
-    result_callback(result);
+    auto th = std::thread([this, spans, result_callback](){
+      auto result = Export(spans);
+      result_callback(result);
+    });
+    th.join();
   }
 
   bool Shutdown(
@@ -139,7 +142,95 @@ TEST_F(BatchSpanProcessorTestPeer, TestShutdown)
   EXPECT_TRUE(is_shutdown->load());
 }
 
+TEST_F(BatchSpanProcessorTestPeer, TestAsyncShutdown)
+{
+  std::shared_ptr<std::atomic<bool>> is_shutdown(new std::atomic<bool>(false));
+  std::shared_ptr<std::vector<std::unique_ptr<sdk::trace::SpanData>>> spans_received(
+      new std::vector<std::unique_ptr<sdk::trace::SpanData>>);
+
+  sdk::trace::BatchSpanProcessorOptions options{};
+  options.is_export_async = true;
+
+  auto batch_processor =
+      std::shared_ptr<sdk::trace::BatchSpanProcessor>(new sdk::trace::BatchSpanProcessor(
+          std::unique_ptr<MockSpanExporter>(new MockSpanExporter(spans_received, is_shutdown)),
+          options));
+  const int num_spans = 3;
+
+  auto test_spans = GetTestSpans(batch_processor, num_spans);
+
+  for (int i = 0; i < num_spans; ++i)
+  {
+    batch_processor->OnEnd(std::move(test_spans->at(i)));
+  }
+
+  EXPECT_TRUE(batch_processor->Shutdown());
+  // It's safe to shutdown again
+  EXPECT_TRUE(batch_processor->Shutdown());
+
+  EXPECT_EQ(num_spans, spans_received->size());
+  for (int i = 0; i < num_spans; ++i)
+  {
+    EXPECT_EQ("Span " + std::to_string(i), spans_received->at(i)->GetName());
+  }
+
+  EXPECT_TRUE(is_shutdown->load());
+}
+
 TEST_F(BatchSpanProcessorTestPeer, TestForceFlush)
+{
+  std::shared_ptr<std::atomic<bool>> is_shutdown(new std::atomic<bool>(false));
+  std::shared_ptr<std::vector<std::unique_ptr<sdk::trace::SpanData>>> spans_received(
+      new std::vector<std::unique_ptr<sdk::trace::SpanData>>);
+
+  sdk::trace::BatchSpanProcessorOptions options{};
+  options.is_export_async = true;
+
+  auto batch_processor =
+      std::shared_ptr<sdk::trace::BatchSpanProcessor>(new sdk::trace::BatchSpanProcessor(
+          std::unique_ptr<MockSpanExporter>(new MockSpanExporter(spans_received, is_shutdown)),
+          options));
+  const int num_spans = 2048;
+
+  auto test_spans = GetTestSpans(batch_processor, num_spans);
+
+  for (int i = 0; i < num_spans; ++i)
+  {
+    batch_processor->OnEnd(std::move(test_spans->at(i)));
+  }
+
+  // Give some time to export
+  std::this_thread::sleep_for(std::chrono::milliseconds(50));
+
+  EXPECT_TRUE(batch_processor->ForceFlush());
+
+  EXPECT_EQ(num_spans, spans_received->size());
+  for (int i = 0; i < num_spans; ++i)
+  {
+    EXPECT_EQ("Span " + std::to_string(i), spans_received->at(i)->GetName());
+  }
+
+  // Create some more spans to make sure that the processor still works
+  auto more_test_spans = GetTestSpans(batch_processor, num_spans);
+  for (int i = 0; i < num_spans; ++i)
+  {
+    batch_processor->OnEnd(std::move(more_test_spans->at(i)));
+  }
+
+  // Give some time to export the spans
+  std::this_thread::sleep_for(std::chrono::milliseconds(50));
+
+  EXPECT_TRUE(batch_processor->ForceFlush());
+
+  EXPECT_EQ(num_spans * 2, spans_received->size());
+  for (int i = 0; i < num_spans; ++i)
+  {
+    EXPECT_EQ("Span " + std::to_string(i % num_spans),
+              spans_received->at(num_spans + i)->GetName());
+  }
+}
+
+TEST_F(BatchSpanProcessorTestPeer, TestAsyncForceFlush)
 {
   std::shared_ptr<std::atomic<bool>> is_shutdown(new std::atomic<bool>(false));
   std::shared_ptr<std::vector<std::unique_ptr<sdk::trace::SpanData>>> spans_received(

--- a/sdk/test/trace/simple_processor_test.cc
+++ b/sdk/test/trace/simple_processor_test.cc
@@ -51,10 +51,9 @@ public:
     return ExportResult::kSuccess;
   }
 
-  void Export(
-      const opentelemetry::nostd::span<std::unique_ptr<Recordable>> &spans,
-      opentelemetry::nostd::function_ref<bool(opentelemetry::sdk::common::ExportResult)> result_callback)
-      noexcept override
+  void Export(const opentelemetry::nostd::span<std::unique_ptr<Recordable>> &spans,
+              opentelemetry::nostd::function_ref<bool(opentelemetry::sdk::common::ExportResult)>
+                  result_callback) noexcept override
   {
     result_callback(ExportResult::kSuccess);
   }

--- a/sdk/test/trace/simple_processor_test.cc
+++ b/sdk/test/trace/simple_processor_test.cc
@@ -51,6 +51,14 @@ public:
     return ExportResult::kSuccess;
   }
 
+  void Export(
+      const opentelemetry::nostd::span<std::unique_ptr<Recordable>> &spans,
+      opentelemetry::nostd::function_ref<bool(opentelemetry::sdk::common::ExportResult)> result_callback)
+      noexcept override
+  {
+    result_callback(ExportResult::kSuccess);
+  }
+
   bool Shutdown(
       std::chrono::microseconds timeout = std::chrono::microseconds::max()) noexcept override
   {


### PR DESCRIPTION
…porters

Fixes # (https://github.com/open-telemetry/opentelemetry-cpp/issues/1239)

## Changes
Includes changes related to interface between processor to exporter such that async callback can be handled in the processor.

For significant contributions please make sure you have completed the following items:

* [ ] `CHANGELOG.md` updated for non-trivial changes
* [ ] Unit tests have been added
* [ ] Changes in public API reviewed