### PR TITLE
fix: use CURLOPT_TIMEOUT_MS to config OtlpHttpExporter's timeout instead of CURLOPT_TIMEOUT

### DIFF
--- a/ext/include/opentelemetry/ext/http/client/curl/http_operation_curl.h
+++ b/ext/include/opentelemetry/ext/http/client/curl/http_operation_curl.h
@@ -186,7 +186,7 @@ public:
 
     // Perform initial connect, handling the timeout if needed
     curl_easy_setopt(curl_, CURLOPT_CONNECT_ONLY, 1L);
-    curl_easy_setopt(curl_, CURLOPT_TIMEOUT, http_conn_timeout_.count() / 1000);
+    curl_easy_setopt(curl_, CURLOPT_TIMEOUT_MS, http_conn_timeout_.count());
     DispatchEvent(opentelemetry::ext::http::client::SessionState::Connecting);
     res_ = curl_easy_perform(curl_);
     if (CURLE_OK != res_)


### PR DESCRIPTION
Fixes #1258

## Changes

Support OtlpHttpExporter's timeout less than 1s.