### PR TITLE
MetricStorage dtors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,3 +50,4 @@
 /build
 
 tags
+.cache/clangd/*

--- a/sdk/include/opentelemetry/sdk/metrics/state/metric_storage.h
+++ b/sdk/include/opentelemetry/sdk/metrics/state/metric_storage.h
@@ -24,6 +24,8 @@ public:
       opentelemetry::sdk::instrumentationlibrary::InstrumentationLibrary *instrumentation_library,
       opentelemetry::sdk::resource::Resource *resource,
       nostd::function_ref<bool(MetricData &)> callback) noexcept = 0;
+
+  virtual ~MetricStorage() = default;
 };
 
 class WritableMetricStorage
@@ -38,6 +40,7 @@ public:
 
   virtual void RecordDouble(double value,
                             const opentelemetry::common::KeyValueIterable &attributes) noexcept = 0;
+  virtual ~WritableMetricStorage() = default;
 };
 
 class NoopMetricStorage : public MetricStorage


### PR DESCRIPTION
Adds missing MetricStorage virtual dtors

Please provide a brief description of the changes here.

Also adds clangd cache to gitignore.

For significant contributions please make sure you have completed the following items:

* [ ] `CHANGELOG.md` updated for non-trivial changes
* [ ] Unit tests have been added
* [ ] Changes in public API reviewed