### PR TITLE
 Add owent as an Approver

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,7 @@ For edit access, get in touch on
 ([@open-telemetry/cpp-approvers](https://github.com/orgs/open-telemetry/teams/cpp-approvers)):
 
 * [Josh Suereth](https://github.com/jsuereth), Google
+* [WenTao Ou](https://github.com/owent), Tencent
 * [Reiley Yang](https://github.com/reyang), Microsoft
 
 [Emeritus

--- a/README.md
+++ b/README.md
@@ -118,8 +118,8 @@ For edit access, get in touch on
 ([@open-telemetry/cpp-approvers](https://github.com/orgs/open-telemetry/teams/cpp-approvers)):
 
 * [Josh Suereth](https://github.com/jsuereth), Google
-* [WenTao Ou](https://github.com/owent), Tencent
 * [Reiley Yang](https://github.com/reyang), Microsoft
+* [WenTao Ou](https://github.com/owent), Tencent
 
 [Emeritus
 Maintainer/Approver/Triager](https://github.com/open-telemetry/community/blob/main/community-membership.md#emeritus-maintainerapprovertriager):


### PR DESCRIPTION
As discussed in the community meeting, and separately with @owent

@owent has been actively contributing to OpenTelemetry C++ across many modules as well as focusing on performance improvements of SDK.

Some of the PRs @owent has authored:

* #1274 
* #1245
* #1172 
* #1082 
* #1026 
* #983 
* #915 
* #810 

Some of the PRs @owent has reviewed:

* #974 
* #858 
* #771 
* #1252 

## Changes

Please provide a brief description of the changes here.

For significant contributions please make sure you have completed the following items:

* [ ] `CHANGELOG.md` updated for non-trivial changes
* [ ] Unit tests have been added
* [ ] Changes in public API reviewed