### PR TITLE
upgrade opentelemetry-proto from v0.11.0 to v0.15.0

### DIFF
--- a/bazel/repository.bzl
+++ b/bazel/repository.bzl
@@ -74,10 +74,10 @@ def opentelemetry_cpp_deps():
         http_archive,
         name = "com_github_opentelemetry_proto",
         build_file = "@io_opentelemetry_cpp//bazel:opentelemetry_proto.BUILD",
-        sha256 = "985367f8905e91018e636cbf0d83ab3f834b665c4f5899a27d10cae9657710e2",
-        strip_prefix = "opentelemetry-proto-0.11.0",
+        sha256 = "893fc2134fb639d3ebf6982189e677d6da6f350d7ebbb85871e47ef9a21db37b",
+        strip_prefix = "opentelemetry-proto-0.15.0",
         urls = [
-            "https://github.com/open-telemetry/opentelemetry-proto/archive/v0.11.0.tar.gz",
+            "https://github.com/open-telemetry/opentelemetry-proto/archive/v0.15.0.tar.gz",
         ],
     )
 

--- a/third_party_release
+++ b/third_party_release
@@ -5,6 +5,6 @@ benchmark=v1.5.3
 googletest=release-1.8.0-2523-ga6dfd3ac
 ms-gsl=v1.0.0-393-g6f45293
 nlohmann-json=v3.9.1
-opentelemetry-proto=v0.11.0
+opentelemetry-proto=v0.11.0-16-g3c2915c
 prometheus-cpp=v1.0.0
 vcpkg=2020.04-2702-g5568f110b


### PR DESCRIPTION
upgrade opentelemetry-proto to the latest release

## Changes

upgrade opentelemetry-proto to v0.15.0

For significant contributions please make sure you have completed the following items:

* [ ] `CHANGELOG.md` updated for non-trivial changes
* [ ] Unit tests have been added
* [ ] Changes in public API reviewed