### PR TITLE
Don't create NoopMeterProvider for GetProvider

### DIFF
--- a/api/include/opentelemetry/_metrics/provider.h
+++ b/api/include/opentelemetry/_metrics/provider.h
@@ -43,7 +43,7 @@ public:
 private:
   static nostd::shared_ptr<MeterProvider> &GetProvider() noexcept
   {
-    static nostd::shared_ptr<MeterProvider> provider(new NoopMeterProvider);
+    static nostd::shared_ptr<MeterProvider> provider{};
     return provider;
   }
 


### PR DESCRIPTION
## Changes

In legacy metrics implementation, `GetProvider` is not exposed, and it returns `shared_ptr` only for `SetMeterProvider` which always overwrites the stored provider, so no need to create `NoopMeterProvider`, because it is never used.

For significant contributions please make sure you have completed the following items:

* [ ] `CHANGELOG.md` updated for non-trivial changes
* [ ] Unit tests have been added
* [ ] Changes in public API reviewed