### PR TITLE
Don't show coverage annotation for pull requests

### DIFF
--- a/.github/.codecov.yaml
+++ b/.github/.codecov.yaml
@@ -12,11 +12,7 @@ coverage:
         informational: true
         target: auto
         threshold: 10%
-    patch:
-      default:
-        informational: true
-        target: auto
-        threshold: 10%
+    patch: false
 
 parsers:
   gcov:


### PR DESCRIPTION
## Changes

Annotate pull request with coverage data could distract code review process on web UI, disable it for now. We'll need triage coverage data separately.

For significant contributions please make sure you have completed the following items:

* [ ] `CHANGELOG.md` updated for non-trivial changes
* [ ] Unit tests have been added
* [ ] Changes in public API reviewed