### PR TITLE
Move public definitions to `opentelemetry_api`.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -125,24 +125,11 @@ if(NOT DEFINED CMAKE_CXX_STANDARD)
   endif()
 endif()
 
-if(WITH_ABSEIL)
-  find_package(absl CONFIG REQUIRED)
-
-  set(CORE_RUNTIME_LIBS absl::bad_variant_access absl::any absl::base
-                        absl::bits absl::city)
-
-  # target_link_libraries(main PRIVATE absl::any absl::base absl::bits
-  # absl::city)
-endif()
-
 if(WITH_STL)
   # These definitions are needed for test projects that do not link against
   # opentelemetry-api library directly. We ensure that variant implementation
   # (absl::variant or std::variant) in variant unit test code is consistent with
-  # the global project build definitions.
-  add_definitions(-DHAVE_CPP_STDLIB)
-
-  # Optimize for speed to reduce the hops
+  # the global project build definitions. Optimize for speed to reduce the hops
   if(CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
     if(CMAKE_BUILD_TYPE MATCHES Debug)
       # Turn off optimizations for DEBUG
@@ -154,20 +141,6 @@ if(WITH_STL)
       endif()
     endif()
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${MSVC_CXX_OPT_FLAG}")
-  endif()
-endif()
-
-if(WITH_GSL)
-  add_definitions(-DHAVE_GSL)
-
-  # Guidelines Support Library path. Used if we are not on not get C++20.
-  #
-  find_package(Microsoft.GSL QUIET)
-  if(TARGET Microsoft.GSL::GSL)
-    list(APPEND CORE_RUNTIME_LIBS Microsoft.GSL::GSL)
-  else()
-    set(GSL_DIR third_party/ms-gsl)
-    include_directories(${GSL_DIR}/include)
   endif()
 endif()
 
@@ -190,12 +163,7 @@ option(BUILD_TESTING "Whether to enable tests" ON)
 
 option(BUILD_W3CTRACECONTEXT_TEST "Whether to build w3c trace context" OFF)
 
-if(WITH_NO_GENENV)
-  add_definitions(-DNO_GETENV)
-endif()
-
 if(WIN32)
-  add_definitions(-DNOMINMAX)
   if(BUILD_TESTING)
     if(MSVC)
       # GTest bug: https://github.com/google/googletest/issues/860
@@ -203,9 +171,6 @@ if(WIN32)
     endif()
   endif()
   option(WITH_ETW "Whether to include the ETW Exporter in the SDK" ON)
-  if(WITH_ETW)
-    add_definitions(-DHAVE_MSGPACK)
-  endif(WITH_ETW)
 endif(WIN32)
 
 option(
@@ -215,16 +180,7 @@ option(
 option(WITH_EXAMPLES "Whether to build examples" ON)
 
 option(WITH_METRICS_PREVIEW "Whether to build metrics preview" OFF)
-
-if(WITH_METRICS_PREVIEW)
-  add_definitions(-DENABLE_METRICS_PREVIEW)
-endif()
-
 option(WITH_LOGS_PREVIEW "Whether to build logs preview" OFF)
-
-if(WITH_LOGS_PREVIEW)
-  add_definitions(-DENABLE_LOGS_PREVIEW)
-endif()
 
 find_package(Threads)
 

--- a/api/CMakeLists.txt
+++ b/api/CMakeLists.txt
@@ -42,7 +42,14 @@ if(BUILD_TESTING)
 endif()
 
 if(WITH_ABSEIL)
+
+  find_package(absl CONFIG REQUIRED)
+
   target_compile_definitions(opentelemetry_api INTERFACE HAVE_ABSEIL)
+  target_link_libraries(
+    opentelemetry_api INTERFACE absl::bad_variant_access absl::any absl::base
+                                absl::bits absl::city)
+
 endif()
 
 if(WITH_STL)
@@ -50,6 +57,21 @@ if(WITH_STL)
   target_compile_definitions(opentelemetry_api INTERFACE HAVE_CPP_STDLIB)
 else()
   message("Building with nostd types...")
+endif()
+
+if(WITH_GSL)
+  target_compile_definitions(opentelemetry_api INTERFACE HAVE_GSL)
+
+  # Guidelines Support Library path. Used if we are not on not get C++20.
+  #
+  find_package(Microsoft.GSL QUIET)
+  if(TARGET Microsoft.GSL::GSL)
+    target_link_libraries(opentelemetry_api INTERFACE Microsoft.GSL::GSL)
+  else()
+    set(GSL_DIR third_party/ms-gsl)
+    target_include_directories(
+      opentelemetry_api INTERFACE "$<BUILD_INTERFACE:${GSL_DIR}/include>")
+  endif()
 endif()
 
 if(WITH_METRICS_PREVIEW)
@@ -60,6 +82,13 @@ if(WITH_LOGS_PREVIEW)
   target_compile_definitions(opentelemetry_api INTERFACE ENABLE_LOGS_PREVIEW)
 endif()
 
-if(CORE_RUNTIME_LIBS)
-  target_link_libraries(opentelemetry_api INTERFACE ${CORE_RUNTIME_LIBS})
+if(WITH_NO_GENENV)
+  target_compile_definitions(opentelemetry_api INTERFACE NO_GETENV)
+endif()
+
+if(WIN32)
+  target_compile_definitions(opentelemetry_api INTERFACE NOMINMAX)
+  if(WITH_ETW)
+    target_compile_definitions(opentelemetry_api INTERFACE HAVE_MSGPACK)
+  endif()
 endif()


### PR DESCRIPTION
Signed-off-by: owent <admin@owent.net>

Fixes #1311 

## Changes

Move definitions to `opentelemetry_api` and set them as `INTERFACE` definitions.

For significant contributions please make sure you have completed the following items:

* [ ] `CHANGELOG.md` updated for non-trivial changes
* [ ] Unit tests have been added
* [x] Changes in public API reviewed