### PR TITLE
Exempt should be applied on issue instead of PR

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -13,4 +13,4 @@ jobs:
           close-issue-message: 'Closed as inactive. Feel free to reopen if this is still an issue.'
           days-before-issue-stale: 60
           days-before-issue-close: 7
-          exempt-pr-labels: 'do-not-stale'
+          exempt-issue-labels: 'do-not-stale'


### PR DESCRIPTION
## Changes

`do-not-stale` was incorrectly applied to PR instead of issue which forced some issue to be staled like https://github.com/open-telemetry/opentelemetry-cpp/issues/1027.

For significant contributions please make sure you have completed the following items:

* [ ] `CHANGELOG.md` updated for non-trivial changes
* [ ] Unit tests have been added
* [ ] Changes in public API reviewed