### PR TITLE
[ETW Exporter] - ETW provider handle cleanup

### DIFF
--- a/exporters/etw/include/opentelemetry/exporters/etw/etw_provider.h
+++ b/exporters/etw/include/opentelemetry/exporters/etw/etw_provider.h
@@ -203,6 +203,7 @@ public:
   {
     std::lock_guard<std::mutex> lock(m_providerMapLock);
 
+    // use reference to provider list, NOT it' copy.
     auto &m = providers();
     auto it = m.begin();
     while (it != m.end())

--- a/exporters/etw/include/opentelemetry/exporters/etw/etw_provider.h
+++ b/exporters/etw/include/opentelemetry/exporters/etw/etw_provider.h
@@ -203,7 +203,7 @@ public:
   {
     std::lock_guard<std::mutex> lock(m_providerMapLock);
 
-    auto m  = providers();
+    auto &m = providers();
     auto it = m.begin();
     while (it != m.end())
     {

--- a/exporters/etw/include/opentelemetry/exporters/etw/etw_provider.h
+++ b/exporters/etw/include/opentelemetry/exporters/etw/etw_provider.h
@@ -229,7 +229,10 @@ public:
           }
 
           it->second.providerHandle = INVALID_HANDLE;
-          m.erase(it);
+          if (result == STATUS_OK)
+          {
+            m.erase(it);
+          }
         }
         return result;
       }

--- a/exporters/etw/test/etw_provider_test.cc
+++ b/exporters/etw/test/etw_provider_test.cc
@@ -18,6 +18,7 @@ TEST(ETWProvider, ProviderIsRegisteredSuccessfully)
 
   bool registered = etw.is_registered(providerName);
   ASSERT_TRUE(registered);
+  etw.close(handle);
 }
 
 TEST(ETWProvider, ProviderIsNotRegisteredSuccessfully)
@@ -46,6 +47,7 @@ TEST(ETWProvider, CheckOpenGUIDDataSuccessfully)
   auto guidStrName = uuid_name.to_string();
 
   ASSERT_STREQ(guidStrHandle.c_str(), guidStrName.c_str());
+  etw.close(handle);
 }
 
 TEST(ETWProvider, CheckCloseSuccess)
@@ -53,8 +55,7 @@ TEST(ETWProvider, CheckCloseSuccess)
   std::string providerName = "OpenTelemetry-ETW-Provider";
 
   static ETWProvider etw;
-  auto handle = etw.open(providerName.c_str());
-
+  auto handle = etw.open(providerName.c_str(), ETWProvider::EventFormat::ETW_MANIFEST);
   auto result = etw.close(handle);
   ASSERT_NE(result, etw.STATUS_ERROR);
   ASSERT_FALSE(etw.is_registered(providerName));

--- a/exporters/etw/test/etw_provider_test.cc
+++ b/exporters/etw/test/etw_provider_test.cc
@@ -57,7 +57,7 @@ TEST(ETWProvider, CheckCloseSuccess)
 
   auto result = etw.close(handle);
   ASSERT_NE(result, etw.STATUS_ERROR);
-  ASSERT_FALSE(etw.is_registered(providerName););
+  ASSERT_FALSE(etw.is_registered(providerName));
 }
 
 #endif

--- a/exporters/etw/test/etw_provider_test.cc
+++ b/exporters/etw/test/etw_provider_test.cc
@@ -57,6 +57,7 @@ TEST(ETWProvider, CheckCloseSuccess)
 
   auto result = etw.close(handle);
   ASSERT_NE(result, etw.STATUS_ERROR);
+  ASSERT_FALSE(etw.is_registered(providerName););
 }
 
 #endif


### PR DESCRIPTION
Fixes:

ETW provider `handle` is not cleaned-up properly when ETW logger is destroyed. While the handle is deregistered, it is not removed properly from the list of active providers ( because deletion is done wrongly on the copy of the provider map). The provider map gets corrupted and results in event loss if the logger with the same name is created again.

## Changes

Tiny one character change to ensure deletion of provider handle happens through the reference of the provider list, and not from the copy. 


For significant contributions please make sure you have completed the following items:

* [ ] `CHANGELOG.md` updated for non-trivial changes
* [x] Unit tests have been added
* [ ] Changes in public API reviewed