### PR TITLE
Update yield logic for ARM processor

### DIFF
--- a/api/include/opentelemetry/common/spin_lock_mutex.h
+++ b/api/include/opentelemetry/common/spin_lock_mutex.h
@@ -101,9 +101,7 @@ public:
         __builtin_ia32_pause();
 #  endif
 #elif defined(__arm__)
-        // This intrinsic should fail to be found if YIELD is not supported on the current
-        // processor.
-        __yield();
+        __asm__ volatile("yield" ::: "memory");
 #else
         // TODO: Issue PAGE/YIELD on other architectures.
 #endif

--- a/api/test/common/spinlock_benchmark.cc
+++ b/api/test/common/spinlock_benchmark.cc
@@ -93,7 +93,7 @@ static void BM_ProcYieldSpinLockThrashing(benchmark::State &s)
           __builtin_ia32_pause();
 #  endif
 #elif defined(__arm__)
-          __yield();
+          __asm__ volatile("yield" ::: "memory");
 #endif
         }
       },


### PR DESCRIPTION
## Changes

Currently for ARM processor, we are using `__yield` intrinsic to yield processor while waiting in tight spin lock loop. This intrinsic is defined as part of ARM C Language Extension, and its implementation is not provided in GCC library. Being part of the language extension, the ARM Vendor may choose not to implement this intrinsic as part of its compiler toolchain. More details here: https://stackoverflow.com/questions/70069855/is-there-a-yield-intrinsic-on-arm. The otel-cpp build in that case fails with error:

```
/opentelemetry-cpp/api/include/opentelemetry/common/spin_lock_mutex.h: In member function ‘void opentelemetry::v1::common::SpinLockMutex::lock()’:
/opentelemetry-cpp/api/include/opentelemetry/common/spin_lock_mutex.h:105:9: error: ‘__yield’ was not declared in this scope
105 | __yield();
```

The change is to bypass using this intrinsic and directly use the assembly instruction. The changes are inspired from Microsoft [mimalloc](https://github.com/microsoft/mimalloc/blob/0560fc27c08d28d523b7f741a42deb26cd01c0c6/include/mimalloc-atomic.h#L300) library and tested on a board using TI Cortex A9 processor.

For significant contributions please make sure you have completed the following items:

* [ ] `CHANGELOG.md` updated for non-trivial changes
* [ ] Unit tests have been added
* [ ] Changes in public API reviewed