### PR TITLE
Fix for #1292

### DIFF
--- a/tools/build.cmd
+++ b/tools/build.cmd
@@ -170,5 +170,5 @@ REM
 REM ##########################################################################################
 :build_config_ninja
 cmake -G "Ninja" -DCMAKE_MAKE_PROGRAM="!NINJA!" -DCMAKE_TOOLCHAIN_FILE="!VCPKG_CMAKE!" !CONFIG! "!ROOT!"
-%NINJA%
+"%NINJA%"
 exit /b


### PR DESCRIPTION
Fixes #1292

This fix just wrap %NINJA% with quotes to be able to call ninja binary when it is located in a path with spaces