### PR TITLE
Replace deprecated googletest API

### DIFF
--- a/sdk/test/metrics/sync_metric_storage_test.cc
+++ b/sdk/test/metrics/sync_metric_storage_test.cc
@@ -130,7 +130,7 @@ TEST_P(WritableMetricStorageTestFixture, LongSumAggregation)
         return true;
       });
 }
-INSTANTIATE_TEST_CASE_P(WritableMetricStorageTestLong,
+INSTANTIATE_TEST_SUITE_P(WritableMetricStorageTestLong,
                         WritableMetricStorageTestFixture,
                         ::testing::Values(AggregationTemporality::kCumulative,
                                           AggregationTemporality::kDelta));
@@ -238,7 +238,7 @@ TEST_P(WritableMetricStorageTestFixture, DoubleSumAggregation)
         return true;
       });
 }
-INSTANTIATE_TEST_CASE_P(WritableMetricStorageTestDouble,
+INSTANTIATE_TEST_SUITE_P(WritableMetricStorageTestDouble,
                         WritableMetricStorageTestFixture,
                         ::testing::Values(AggregationTemporality::kCumulative,
                                           AggregationTemporality::kDelta));

--- a/sdk/test/metrics/sync_metric_storage_test.cc
+++ b/sdk/test/metrics/sync_metric_storage_test.cc
@@ -131,9 +131,9 @@ TEST_P(WritableMetricStorageTestFixture, LongSumAggregation)
       });
 }
 INSTANTIATE_TEST_SUITE_P(WritableMetricStorageTestLong,
-                        WritableMetricStorageTestFixture,
-                        ::testing::Values(AggregationTemporality::kCumulative,
-                                          AggregationTemporality::kDelta));
+                         WritableMetricStorageTestFixture,
+                         ::testing::Values(AggregationTemporality::kCumulative,
+                                           AggregationTemporality::kDelta));
 
 TEST_P(WritableMetricStorageTestFixture, DoubleSumAggregation)
 {
@@ -239,8 +239,8 @@ TEST_P(WritableMetricStorageTestFixture, DoubleSumAggregation)
       });
 }
 INSTANTIATE_TEST_SUITE_P(WritableMetricStorageTestDouble,
-                        WritableMetricStorageTestFixture,
-                        ::testing::Values(AggregationTemporality::kCumulative,
-                                          AggregationTemporality::kDelta));
+                         WritableMetricStorageTestFixture,
+                         ::testing::Values(AggregationTemporality::kCumulative,
+                                           AggregationTemporality::kDelta));
 
 #endif


### PR DESCRIPTION
## Changes

`INSTANTIATE_TEST_CASE_P` is deprecated in googletest, instead, `INSTANTIATE_TEST_SUITE_P` should be used.

https://github.com/google/googletest/blob/80600e56cc9afe7ee02737429f9177aa87025054/googletest/include/gtest/internal/gtest-internal.h#L1302

For significant contributions please make sure you have completed the following items:

* [ ] `CHANGELOG.md` updated for non-trivial changes
* [ ] Unit tests have been added
* [ ] Changes in public API reviewed