### PR TITLE
Remove redundant tail / in DESTINATION in CMake install

### DIFF
--- a/exporters/elasticsearch/CMakeLists.txt
+++ b/exporters/elasticsearch/CMakeLists.txt
@@ -21,7 +21,7 @@ install(
 
 install(
   DIRECTORY include/opentelemetry/exporters/elasticsearch
-  DESTINATION include/opentelemetry/exporters/
+  DESTINATION include/opentelemetry/exporters
   FILES_MATCHING
   PATTERN "*.h"
   PATTERN "es_log_recordable.h" EXCLUDE)

--- a/exporters/etw/CMakeLists.txt
+++ b/exporters/etw/CMakeLists.txt
@@ -23,7 +23,7 @@ install(
 
 install(
   DIRECTORY include/opentelemetry/exporters/etw
-  DESTINATION include/opentelemetry/exporters/
+  DESTINATION include/opentelemetry/exporters
   FILES_MATCHING
   PATTERN "*.h")
 

--- a/exporters/jaeger/CMakeLists.txt
+++ b/exporters/jaeger/CMakeLists.txt
@@ -52,7 +52,7 @@ install(
 
 install(
   DIRECTORY include/opentelemetry/exporters/jaeger
-  DESTINATION include/opentelemetry/exporters/
+  DESTINATION include/opentelemetry/exporters
   FILES_MATCHING
   PATTERN "*.h"
   PATTERN "recordable.h" EXCLUDE)

--- a/exporters/memory/CMakeLists.txt
+++ b/exporters/memory/CMakeLists.txt
@@ -17,7 +17,7 @@ install(
 
 install(
   DIRECTORY include/opentelemetry/exporters/memory
-  DESTINATION include/opentelemetry/exporters/
+  DESTINATION include/opentelemetry/exporters
   FILES_MATCHING
   PATTERN "*.h")
 

--- a/exporters/ostream/CMakeLists.txt
+++ b/exporters/ostream/CMakeLists.txt
@@ -19,7 +19,7 @@ install(
 
 install(
   DIRECTORY include/opentelemetry/exporters/ostream
-  DESTINATION include/opentelemetry/exporters/
+  DESTINATION include/opentelemetry/exporters
   PATTERN "*.h"
   PATTERN "metrics_exporter.h" EXCLUDE
   PATTERN "log_Exporter.h" EXCLUDE)
@@ -52,7 +52,7 @@ if(WITH_METRICS_PREVIEW)
     ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR})
   install(
     DIRECTORY include/opentelemetry/exporters/ostream
-    DESTINATION include/opentelemetry/exporters/
+    DESTINATION include/opentelemetry/exporters
     PATTERN "metrics_exporter.h")
   if(BUILD_TESTING)
     add_executable(ostream_metrics_test test/ostream_metrics_test.cc)
@@ -82,7 +82,7 @@ if(WITH_LOGS_PREVIEW)
     ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR})
   install(
     DIRECTORY include/opentelemetry/exporters/ostream
-    DESTINATION include/opentelemetry/exporters/
+    DESTINATION include/opentelemetry/exporters
     PATTERN "log_exporter.h")
   if(BUILD_TESTING)
     add_executable(ostream_log_test test/ostream_log_test.cc)

--- a/exporters/otlp/CMakeLists.txt
+++ b/exporters/otlp/CMakeLists.txt
@@ -98,7 +98,7 @@ install(
 
 install(
   DIRECTORY include/opentelemetry/exporters/otlp
-  DESTINATION include/opentelemetry/exporters/
+  DESTINATION include/opentelemetry/exporters
   FILES_MATCHING
   PATTERN "*.h"
   PATTERN "otlp_recordable.h" EXCLUDE)

--- a/exporters/prometheus/CMakeLists.txt
+++ b/exporters/prometheus/CMakeLists.txt
@@ -46,7 +46,7 @@ install(
 
 install(
   DIRECTORY include/opentelemetry/exporters/prometheus
-  DESTINATION include/opentelemetry/exporters/
+  DESTINATION include/opentelemetry/exporters
   FILES_MATCHING
   PATTERN "*.h")
 

--- a/exporters/zipkin/CMakeLists.txt
+++ b/exporters/zipkin/CMakeLists.txt
@@ -32,7 +32,7 @@ install(
 
 install(
   DIRECTORY include/opentelemetry/exporters/zipkin
-  DESTINATION include/opentelemetry/exporters/
+  DESTINATION include/opentelemetry/exporters
   FILES_MATCHING
   PATTERN "*.h"
   PATTERN "recordable.h" EXCLUDE)

--- a/sdk/CMakeLists.txt
+++ b/sdk/CMakeLists.txt
@@ -14,8 +14,8 @@ install(
   ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR})
 
 install(
-  DIRECTORY include/opentelemetry/
-  DESTINATION include/opentelemetry/
+  DIRECTORY include/opentelemetry
+  DESTINATION include/opentelemetry
   FILES_MATCHING
   PATTERN "*config.h")
 
@@ -31,16 +31,10 @@ endif()
 
 install(
   DIRECTORY include/opentelemetry/sdk
-  DESTINATION include/opentelemetry/
+  DESTINATION include/opentelemetry
   FILES_MATCHING
   PATTERN "*.h"
-  PATTERN "${METRICS_EXCLUDE_PATTERN}" EXCLUDE)
-
-install(
-  DIRECTORY include/opentelemetry/sdk
-  DESTINATION include/opentelemetry/
-  FILES_MATCHING
-  PATTERN "*.h"
+  PATTERN "${METRICS_EXCLUDE_PATTERN}" EXCLUDE
   PATTERN "${LOGS_EXCLUDE_PATTERN}" EXCLUDE)
 
 add_subdirectory(src)


### PR DESCRIPTION
Remove the redundant `/` at the end of DESTINATION in cmake function `install()`.

Also merged 2 identical CMake `install()` which only diff in exclude pattern.

## Changes

Please provide a brief description of the changes here.

For significant contributions please make sure you have completed the following items:

* [ ] `CHANGELOG.md` updated for non-trivial changes
* [ ] Unit tests have been added
* [ ] Changes in public API reviewed