### PR TITLE
Simplifying SDK Configuration: Removing Exporter Registration from Meter Provider

### DIFF
--- a/examples/metrics_simple/metrics_ostream.cc
+++ b/examples/metrics_simple/metrics_ostream.cc
@@ -30,7 +30,6 @@ namespace
 void initMetrics(const std::string &name)
 {
   std::unique_ptr<metric_sdk::MetricExporter> exporter{new exportermetrics::OStreamMetricExporter};
-  std::vector<std::unique_ptr<metric_sdk::MetricExporter>> exporters;
 
   std::string version{"1.2.0"};
   std::string schema{"https://opentelemetry.io/schemas/1.2.0"};
@@ -41,9 +40,8 @@ void initMetrics(const std::string &name)
   options.export_timeout_millis  = std::chrono::milliseconds(500);
   std::unique_ptr<metric_sdk::MetricReader> reader{
       new metric_sdk::PeriodicExportingMetricReader(std::move(exporter), options)};
-  auto provider = std::shared_ptr<metrics_api::MeterProvider>(
-      new metric_sdk::MeterProvider(std::move(exporters)));
-  auto p = std::static_pointer_cast<metric_sdk::MeterProvider>(provider);
+  auto provider = std::shared_ptr<metrics_api::MeterProvider>(new metric_sdk::MeterProvider());
+  auto p        = std::static_pointer_cast<metric_sdk::MeterProvider>(provider);
   p->AddMetricReader(std::move(reader));
 
   // counter view

--- a/sdk/include/opentelemetry/sdk/metrics/meter_context.h
+++ b/sdk/include/opentelemetry/sdk/metrics/meter_context.h
@@ -24,7 +24,6 @@ namespace metrics
 
 // forward declaration
 class Meter;
-class MetricExporter;
 class MetricReader;
 
 /**
@@ -36,13 +35,11 @@ class MeterContext : public std::enable_shared_from_this<MeterContext>
 public:
   /**
    * Initialize a new meter provider
-   * @param exporters The exporters to be configured with meter context
    * @param readers The readers to be configured with meter context.
    * @param views The views to be configured with meter context.
    * @param resource  The resource for this meter context.
    */
   MeterContext(
-      std::vector<std::unique_ptr<sdk::metrics::MetricExporter>> &&exporters,
       std::unique_ptr<ViewRegistry> views = std::unique_ptr<ViewRegistry>(new ViewRegistry()),
       opentelemetry::sdk::resource::Resource resource =
           opentelemetry::sdk::resource::Resource::Create({})) noexcept;
@@ -78,16 +75,6 @@ public:
   opentelemetry::common::SystemTimestamp GetSDKStartTime() noexcept;
 
   /**
-   * Attaches a metric exporter to list of configured exporters for this Meter context.
-   * @param exporter The metric exporter for this meter context. This
-   * must not be a nullptr.
-   *
-   * Note: This exporter may not receive any in-flight meter data, but will get newly created meter
-   * data. Note: This method is not thread safe, and should ideally be called from main thread.
-   */
-  void AddMetricExporter(std::unique_ptr<MetricExporter> exporter) noexcept;
-
-  /**
    * Attaches a metric reader to list of configured readers for this Meter context.
    * @param reader The metric reader for this meter context. This
    * must not be a nullptr.
@@ -118,20 +105,19 @@ public:
   void AddMeter(std::shared_ptr<Meter> meter);
 
   /**
-   * Force all active Exporters and Collectors to flush any buffered meter data
+   * Force all active Collectors to flush any buffered meter data
    * within the given timeout.
    */
 
   bool ForceFlush(std::chrono::microseconds timeout = (std::chrono::microseconds::max)()) noexcept;
 
   /**
-   * Shutdown the Exporters and Collectors associated with this meter provider.
+   * Shutdown the Collectors associated with this meter provider.
    */
   bool Shutdown() noexcept;
 
 private:
   opentelemetry::sdk::resource::Resource resource_;
-  std::vector<std::unique_ptr<MetricExporter>> exporters_;
   std::vector<std::shared_ptr<CollectorHandle>> collectors_;
   std::unique_ptr<ViewRegistry> views_;
   opentelemetry::common::SystemTimestamp sdk_start_ts_;

--- a/sdk/include/opentelemetry/sdk/metrics/meter_provider.h
+++ b/sdk/include/opentelemetry/sdk/metrics/meter_provider.h
@@ -22,7 +22,6 @@ namespace metrics
 
 // forward declaration
 class MetricCollector;
-class MetricExporter;
 class MetricReader;
 
 class MeterProvider final : public opentelemetry::metrics::MeterProvider
@@ -30,12 +29,10 @@ class MeterProvider final : public opentelemetry::metrics::MeterProvider
 public:
   /**
    * Initialize a new meter provider
-   * @param exporters The span exporters for this meter provider
    * @param views The views for this meter provider
    * @param resource  The resources for this meter provider.
    */
   MeterProvider(
-      std::vector<std::unique_ptr<MetricExporter>> &&exporters,
       std::unique_ptr<ViewRegistry> views = std::unique_ptr<ViewRegistry>(new ViewRegistry()),
       sdk::resource::Resource resource    = sdk::resource::Resource::Create({})) noexcept;
 
@@ -55,16 +52,6 @@ public:
    * @return The resource for this meter provider.
    */
   const sdk::resource::Resource &GetResource() const noexcept;
-
-  /**
-   * Attaches a metric exporter to list of configured exporters for this Meter provider.
-   * @param exporter The metric exporter for this meter provider. This
-   * must not be a nullptr.
-   *
-   * Note: This exporter may not receive any in-flight meter data, but will get newly created meter
-   * data. Note: This method is not thread safe, and should ideally be called from main thread.
-   */
-  void AddMetricExporter(std::unique_ptr<MetricExporter> exporter) noexcept;
 
   /**
    * Attaches a metric reader to list of configured readers for this Meter providers.

--- a/sdk/src/metrics/meter_provider.cc
+++ b/sdk/src/metrics/meter_provider.cc
@@ -4,7 +4,6 @@
 #ifndef ENABLE_METRICS_PREVIEW
 #  include "opentelemetry/sdk/metrics/meter_provider.h"
 #  include "opentelemetry/metrics/meter.h"
-#  include "opentelemetry/sdk/metrics/metric_exporter.h"
 #  include "opentelemetry/sdk/metrics/metric_reader.h"
 
 #  include "opentelemetry/sdk/common/global_log_handler.h"
@@ -23,10 +22,9 @@ namespace metrics_api = opentelemetry::metrics;
 
 MeterProvider::MeterProvider(std::shared_ptr<MeterContext> context) noexcept : context_{context} {}
 
-MeterProvider::MeterProvider(std::vector<std::unique_ptr<MetricExporter>> &&exporters,
-                             std::unique_ptr<ViewRegistry> views,
+MeterProvider::MeterProvider(std::unique_ptr<ViewRegistry> views,
                              sdk::resource::Resource resource) noexcept
-    : context_(std::make_shared<MeterContext>(std::move(exporters), std::move(views), resource))
+    : context_(std::make_shared<MeterContext>(std::move(views), resource))
 {}
 
 nostd::shared_ptr<metrics_api::Meter> MeterProvider::GetMeter(
@@ -59,11 +57,6 @@ nostd::shared_ptr<metrics_api::Meter> MeterProvider::GetMeter(
 const resource::Resource &MeterProvider::GetResource() const noexcept
 {
   return context_->GetResource();
-}
-
-void MeterProvider::AddMetricExporter(std::unique_ptr<MetricExporter> exporter) noexcept
-{
-  return context_->AddMetricExporter(std::move(exporter));
 }
 
 void MeterProvider::AddMetricReader(std::unique_ptr<MetricReader> reader) noexcept

--- a/sdk/test/metrics/async_metric_storage_test.cc
+++ b/sdk/test/metrics/async_metric_storage_test.cc
@@ -46,8 +46,7 @@ TEST(AsyncMetricStorageTest, BasicTests)
   // Some computation here
   auto collection_ts = std::chrono::system_clock::now() + std::chrono::seconds(5);
 
-  std::vector<std::unique_ptr<opentelemetry::sdk::metrics::MetricExporter>> exporters;
-  std::shared_ptr<MeterContext> meter_context(new MeterContext(std::move(exporters)));
+  std::shared_ptr<MeterContext> meter_context(new MeterContext());
   std::unique_ptr<MetricReader> metric_reader(new MockMetricReader(AggregationTemporality::kDelta));
 
   std::shared_ptr<CollectorHandle> collector = std::shared_ptr<CollectorHandle>(

--- a/sdk/test/metrics/metric_reader_test.cc
+++ b/sdk/test/metrics/metric_reader_test.cc
@@ -27,12 +27,11 @@ TEST(MetricReaderTest, BasicTests)
   std::unique_ptr<MetricReader> metric_reader1(new MockMetricReader(aggr_temporality));
   EXPECT_EQ(metric_reader1->GetAggregationTemporality(), aggr_temporality);
 
-  std::vector<std::unique_ptr<sdk::metrics::MetricExporter>> exporters;
-  std::shared_ptr<MeterContext> meter_context1(new MeterContext(std::move(exporters)));
+  std::shared_ptr<MeterContext> meter_context1(new MeterContext());
   EXPECT_NO_THROW(meter_context1->AddMetricReader(std::move(metric_reader1)));
 
   std::unique_ptr<MetricReader> metric_reader2(new MockMetricReader(aggr_temporality));
-  std::shared_ptr<MeterContext> meter_context2(new MeterContext(std::move(exporters)));
+  std::shared_ptr<MeterContext> meter_context2(new MeterContext());
   MetricProducer *metric_producer =
       new MetricCollector(std::move(meter_context2), std::move(metric_reader2));
   EXPECT_NO_THROW(metric_producer->Collect([](ResourceMetrics &metric_data) { return true; }));


### PR DESCRIPTION
Fixes # (issue)

## Changes

Currently we [register ](https://github.com/open-telemetry/opentelemetry-cpp/blob/bf8f433cae41ad682cf9e390650158a2751373c1/sdk/include/opentelemetry/sdk/metrics/meter_provider.h#L38)MetricExporter(s) to MeterProvider, but it is never used. This registration is un-necessary in current implementation as the life-cycle of MetricExporter is managed by MetricReader as [here](https://github.com/open-telemetry/opentelemetry-cpp/blob/e6fb935f75c9c5a34ca3422ebdb47bb7e620f405/sdk/include/opentelemetry/sdk/metrics/export/periodic_exporting_metric_reader.h#L44).

This PR removes the MetricExporter registration from MeterProvider, and let the registration be managed through MetricReader.

For significant contributions please make sure you have completed the following items:

* [ ] `CHANGELOG.md` updated for non-trivial changes
* [ ] Unit tests have been added
* [ ] Changes in public API reviewed