### PR TITLE
Add explicit type cast in baggage UrlDecode

### DIFF
--- a/api/include/opentelemetry/baggage/baggage.h
+++ b/api/include/opentelemetry/baggage/baggage.h
@@ -249,7 +249,9 @@ private:
     };
 
     auto from_hex = [](char c) -> char {
-      return std::isdigit(c) ? c - '0' : std::toupper(c) - 'A' + 10;
+      // c - '0' produces integer type which could trigger error/warning when casting to char,
+      // but the cast is safe here.
+      return static_cast<char>(std::isdigit(c) ? c - '0' : std::toupper(c) - 'A' + 10);
     };
 
     std::string ret;


### PR DESCRIPTION
Fixes C4244 warning in baggage.

## Changes

Added explicit type cast to declare below conversion is safe in the specific code.

> api\include\opentelemetry\baggage\baggage.h(252,26): warning C4244: 'return': conversion from 'int' to 'char', possible loss of data

For significant contributions please make sure you have completed the following items:

* [ ] `CHANGELOG.md` updated for non-trivial changes
* [ ] Unit tests have been added
* [ ] Changes in public API reviewed