### PR TITLE
Conditional include for codecvt header

### DIFF
--- a/exporters/etw/include/opentelemetry/exporters/etw/utils.h
+++ b/exporters/etw/include/opentelemetry/exporters/etw/utils.h
@@ -5,7 +5,6 @@
 
 #include <algorithm>
 #include <chrono>
-#include <codecvt>
 #include <ctime>
 #include <iomanip>
 #include <locale>
@@ -24,6 +23,8 @@
 #  pragma comment(lib, "Rpcrt4.lib")
 #  include <Objbase.h>
 #  pragma comment(lib, "Ole32.Lib")
+#else
+#  include <codecvt>
 #endif
 
 OPENTELEMETRY_BEGIN_NAMESPACE


### PR DESCRIPTION
[std::codecvt](https://en.cppreference.com/w/cpp/locale/codecvt) is deprecated in C++17, and probably removed from C++20. It is used in ETW exporter for multibyte string conversions of non-windows code. So this can be safely excluded when building for Windows.
Also, ETW exporter is only usable in Windows, we can later cleanup the non-windows code from "etw/utils.h", and remove this header file altogether.