### PR TITLE
Fix scalar delete against array

### DIFF
--- a/exporters/etw/include/opentelemetry/exporters/etw/utils.h
+++ b/exporters/etw/include/opentelemetry/exporters/etw/utils.h
@@ -193,8 +193,8 @@ static inline GUID GetProviderGuid(const char *providerName)
   guid.Data4[6] = buffer2[14];
   guid.Data4[7] = buffer2[15];
 
-  delete buffer;
-  delete buffer2;
+  delete[] buffer;
+  delete[] buffer2;
 
   return guid;
 }


### PR DESCRIPTION
## Changes

`delete []` should be used for the memory allocated by `new[]`, or it is undefined behavior.

For significant contributions please make sure you have completed the following items:

* [ ] `CHANGELOG.md` updated for non-trivial changes
* [ ] Unit tests have been added
* [ ] Changes in public API reviewed