### PR TITLE
 codecov ignore

### DIFF
--- a/.github/.codecov.yaml
+++ b/.github/.codecov.yaml
@@ -33,3 +33,10 @@ comment:
 # to coverage report file paths.
 fixes:
   - "/home/runner/::"
+
+ignore:
+  - "docs/**/*"
+  - "docker/**/*"
+  - "examples/**/*"
+  - "**/test/**/*"
+  - "**.md"


### PR DESCRIPTION
Adds codecov ignore

Please provide a brief description of the changes here.

We can ignore `docs docker examples test` folder and `md` files. 

For significant contributions please make sure you have completed the following items:

* [ ] `CHANGELOG.md` updated for non-trivial changes
* [ ] Unit tests have been added
* [ ] Changes in public API reviewed