### PR TITLE
Fix build warnings about missing aggregates

### DIFF
--- a/sdk/src/trace/samplers/trace_id_ratio.cc
+++ b/sdk/src/trace/samplers/trace_id_ratio.cc
@@ -92,14 +92,14 @@ SamplingResult TraceIdRatioBasedSampler::ShouldSample(
     const trace_api::SpanContextKeyValueIterable & /*links*/) noexcept
 {
   if (threshold_ == 0)
-    return {Decision::DROP, nullptr};
+    return {Decision::DROP, nullptr, {}};
 
   if (CalculateThresholdFromBuffer(trace_id) <= threshold_)
   {
-    return {Decision::RECORD_AND_SAMPLE, nullptr};
+    return {Decision::RECORD_AND_SAMPLE, nullptr, {}};
   }
 
-  return {Decision::DROP, nullptr};
+  return {Decision::DROP, nullptr, {}};
 }
 
 nostd::string_view TraceIdRatioBasedSampler::GetDescription() const noexcept


### PR DESCRIPTION
Fixes # (issue)

## Changes

Fixing a build warning about missing initialize for aggregate initialization. 
