### PR TITLE
fix: missing link to nlohmann_json

### DIFF
--- a/exporters/elasticsearch/CMakeLists.txt
+++ b/exporters/elasticsearch/CMakeLists.txt
@@ -10,7 +10,8 @@ target_include_directories(
 
 target_link_libraries(
   opentelemetry_exporter_elasticsearch_logs
-  PUBLIC opentelemetry_trace opentelemetry_logs opentelemetry_http_client_curl)
+  PUBLIC opentelemetry_trace opentelemetry_logs opentelemetry_http_client_curl
+         nlohmann_json::nlohmann_json)
 
 install(
   TARGETS opentelemetry_exporter_elasticsearch_logs


### PR DESCRIPTION
Fixes: `es_log_exporter.h` includes "nlohmann/json.hpp".

## Changes

Please provide a brief description of the changes here.

For significant contributions please make sure you have completed the following items:

* [ ] `CHANGELOG.md` updated for non-trivial changes
* [ ] Unit tests have been added
* [ ] Changes in public API reviewed