### PR TITLE
Prepare v1.4.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,8 +14,58 @@ Increment the:
 * PATCH version when you make backwards compatible bug fixes.
 
 ## [Unreleased]
+ 
+## [1.4.0] 2022-05-17
 
+* [API SDK] Upgrade proto to v0.17.0, update log data model ([#1383](https://github.com/open-telemetry/opentelemetry-cpp/pull/1383))
+* [BUILD] Alpine image ([#1382](https://github.com/open-telemetry/opentelemetry-cpp/pull/1382))
+* [LOGS SDK] Get span_id from context when Logger::Log received invalid span_id  ([#1398](https://github.com/open-telemetry/opentelemetry-cpp/pull/1398))
+* [METRICS SDK] Connect async storage with async instruments ([#1388](https://github.com/open-telemetry/opentelemetry-cpp/pull/1388))
+* [DOCS] Getting started document using ostream exporter ([#1394](https://github.com/open-telemetry/opentelemetry-cpp/pull/1394))
+* [BUILD] Fix missing link to nlohmann_json ([#1390](https://github.com/open-telemetry/opentelemetry-cpp/pull/1390))
+* [SDK] Fix sharing resource in batched exported spans ([#1386](https://github.com/open-telemetry/opentelemetry-cpp/pull/1386))
 * [PROTOCOL \& LOGS] Upgrade proto to v0.17.0, update log data model ([#1383](https://github.com/open-telemetry/opentelemetry-cpp/pull/1383))
+* [METRICS SDK] Remove un-necessary files. ([#1379](https://github.com/open-telemetry/opentelemetry-cpp/pull/1379))
+* [EXPORTER] Prometheus exporter meters and instrument name ([#1378](https://github.com/open-telemetry/opentelemetry-cpp/pull/1378))
+* [API] Add noexcept/const qualifier at missing places for Trace API. ([#1374](https://github.com/open-telemetry/opentelemetry-cpp/pull/1374))
+* [SDK] Fix empty tracestate header propagation ([#1373](https://github.com/open-telemetry/opentelemetry-cpp/pull/1373))
+* [METRICS SDK] Reuse temporal metric storage for sync storage ([#1369](https://github.com/open-telemetry/opentelemetry-cpp/pull/1369))
+* [SDK] Fix baggage propagation for empty/invalid baggage context ([#1367](https://github.com/open-telemetry/opentelemetry-cpp/pull/1367))
+* [BUILD] Export opentelemetry_otlp_recordable ([#1365](https://github.com/open-telemetry/opentelemetry-cpp/pull/1365))
+* [TESTS] Disable test on prometheus-cpp which not need ([#1363](https://github.com/open-telemetry/opentelemetry-cpp/pull/1363))
+* [METRICS] Fix class member initialization order ([#1360](https://github.com/open-telemetry/opentelemetry-cpp/pull/1360))
+* [METRICS SDK] Simplify SDK Configuration: Use View with default aggregation if no matching View is configured ([#1358](https://github.com/open-telemetry/opentelemetry-cpp/pull/1358))
+* [BUILD] Add missing include guard ([#1357](https://github.com/open-telemetry/opentelemetry-cpp/pull/1357))
+* [ETW EXPORTER] Fix scalar delete against array ([#1356](https://github.com/open-telemetry/opentelemetry-cpp/pull/1356))
+* [ETW EXPORTER] Conditional include for codecvt header ([#1355](https://github.com/open-telemetry/opentelemetry-cpp/pull/1355))
+* [BUILD] Use latest TraceLoggingDynamic.h ([#1354](https://github.com/open-telemetry/opentelemetry-cpp/pull/1354))
+* [SDK] Add explicit type cast in baggage UrlDecode ([#1353](https://github.com/open-telemetry/opentelemetry-cpp/pull/1353))
+* [METRICS SDK] Remove exporter registration to meter provider ([#1350](https://github.com/open-telemetry/opentelemetry-cpp/pull/1350))
+* [METRICS SDK] Fix output time in metrics OStream exporter ([#1346](https://github.com/open-telemetry/opentelemetry-cpp/pull/1346))
+* [BUILD] ostream metrics cmake ([#1344](https://github.com/open-telemetry/opentelemetry-cpp/pull/1344))
+* [BUILD] Link `opentelemetry_ext` with `opentelemetry_api` ([#1336](https://github.com/open-telemetry/opentelemetry-cpp/pull/1336))
+* [METRICS SDK] Enable metric collection for Async Instruments - Delta and Cumulative  ([#1334](https://github.com/open-telemetry/opentelemetry-cpp/pull/1334))
+* [BUILD] Dependencies image as artifact ([#1333](https://github.com/open-telemetry/opentelemetry-cpp/pull/1333))
+* [EXAMPLE] Prometheus example ([#1332](https://github.com/open-telemetry/opentelemetry-cpp/pull/1332))
+* [METRICS EXPORTER] Prometheus exporter ([#1331](https://github.com/open-telemetry/opentelemetry-cpp/pull/1331))
+* [METRICS] Metrics histogram example ([#1330](https://github.com/open-telemetry/opentelemetry-cpp/pull/1330))
+* [TESTS] Replace deprecated googletest API ([#1327](https://github.com/open-telemetry/opentelemetry-cpp/pull/1327))
+* [BUILD] Fix Ninja path ([#1326](https://github.com/open-telemetry/opentelemetry-cpp/pull/1326))
+* [API] Update yield logic for ARM processor ([#1325](https://github.com/open-telemetry/opentelemetry-cpp/pull/1325))
+* [BUILD] Fix metrics compiler warnings ([#1328](https://github.com/open-telemetry/opentelemetry-cpp/pull/1328))
+* [METRICS SDK] Implement Merge and Diff operation for Histogram Aggregation ([#1303](https://github.com/open-telemetry/opentelemetry-cpp/pull/1303))
+
+Notes:
+
+While opentelemetry-cpp Logs are still in experimental stage,
+[#1383](https://github.com/open-telemetry/opentelemetry-cpp/pull/1383) updated
+opentelemetry-proto to 0.17.0, which includes some breaking change in the
+protocol, like
+[this](https://github.com/open-telemetry/opentelemetry-proto/pull/373). This
+makes `name` parameter for our log API unnecessary. However, this parameter is
+marked deprecated instead of being removed in this release, and it will be
+removed in future release.
+
 
 ## [1.3.0] 2022-04-11
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,12 +14,13 @@ Increment the:
 * PATCH version when you make backwards compatible bug fixes.
 
 ## [Unreleased]
- 
+
 ## [1.4.0] 2022-05-17
 
 * [API SDK] Upgrade proto to v0.17.0, update log data model ([#1383](https://github.com/open-telemetry/opentelemetry-cpp/pull/1383))
 * [BUILD] Alpine image ([#1382](https://github.com/open-telemetry/opentelemetry-cpp/pull/1382))
-* [LOGS SDK] Get span_id from context when Logger::Log received invalid span_id  ([#1398](https://github.com/open-telemetry/opentelemetry-cpp/pull/1398))
+* [LOGS SDK] Get span_id from context when Logger::Log received invalid span_id
+  ([#1398](https://github.com/open-telemetry/opentelemetry-cpp/pull/1398))
 * [METRICS SDK] Connect async storage with async instruments ([#1388](https://github.com/open-telemetry/opentelemetry-cpp/pull/1388))
 * [DOCS] Getting started document using ostream exporter ([#1394](https://github.com/open-telemetry/opentelemetry-cpp/pull/1394))
 * [BUILD] Fix missing link to nlohmann_json ([#1390](https://github.com/open-telemetry/opentelemetry-cpp/pull/1390))
@@ -34,7 +35,9 @@ Increment the:
 * [BUILD] Export opentelemetry_otlp_recordable ([#1365](https://github.com/open-telemetry/opentelemetry-cpp/pull/1365))
 * [TESTS] Disable test on prometheus-cpp which not need ([#1363](https://github.com/open-telemetry/opentelemetry-cpp/pull/1363))
 * [METRICS] Fix class member initialization order ([#1360](https://github.com/open-telemetry/opentelemetry-cpp/pull/1360))
-* [METRICS SDK] Simplify SDK Configuration: Use View with default aggregation if no matching View is configured ([#1358](https://github.com/open-telemetry/opentelemetry-cpp/pull/1358))
+* [METRICS SDK] Simplify SDK Configuration: Use View with default aggregation if
+  no matching View is configured
+  ([#1358](https://github.com/open-telemetry/opentelemetry-cpp/pull/1358))
 * [BUILD] Add missing include guard ([#1357](https://github.com/open-telemetry/opentelemetry-cpp/pull/1357))
 * [ETW EXPORTER] Fix scalar delete against array ([#1356](https://github.com/open-telemetry/opentelemetry-cpp/pull/1356))
 * [ETW EXPORTER] Conditional include for codecvt header ([#1355](https://github.com/open-telemetry/opentelemetry-cpp/pull/1355))
@@ -44,7 +47,9 @@ Increment the:
 * [METRICS SDK] Fix output time in metrics OStream exporter ([#1346](https://github.com/open-telemetry/opentelemetry-cpp/pull/1346))
 * [BUILD] ostream metrics cmake ([#1344](https://github.com/open-telemetry/opentelemetry-cpp/pull/1344))
 * [BUILD] Link `opentelemetry_ext` with `opentelemetry_api` ([#1336](https://github.com/open-telemetry/opentelemetry-cpp/pull/1336))
-* [METRICS SDK] Enable metric collection for Async Instruments - Delta and Cumulative  ([#1334](https://github.com/open-telemetry/opentelemetry-cpp/pull/1334))
+* [METRICS SDK] Enable metric collection for Async Instruments - Delta and
+  Cumulative
+  ([#1334](https://github.com/open-telemetry/opentelemetry-cpp/pull/1334))
 * [BUILD] Dependencies image as artifact ([#1333](https://github.com/open-telemetry/opentelemetry-cpp/pull/1333))
 * [EXAMPLE] Prometheus example ([#1332](https://github.com/open-telemetry/opentelemetry-cpp/pull/1332))
 * [METRICS EXPORTER] Prometheus exporter ([#1331](https://github.com/open-telemetry/opentelemetry-cpp/pull/1331))
@@ -65,7 +70,6 @@ protocol, like
 makes `name` parameter for our log API unnecessary. However, this parameter is
 marked deprecated instead of being removed in this release, and it will be
 removed in future release.
-
 
 ## [1.3.0] 2022-04-11
 

--- a/README.md
+++ b/README.md
@@ -13,15 +13,15 @@ The C++ [OpenTelemetry](https://opentelemetry.io/) client.
 | Signal  | Status                 | Project                                                                  |
 | ------- | ---------------------- | ------------------------------------------------------------------------ |
 | Traces  | Public Release         | N/A                                                                      |
-| Metrics | Development  [1]       | N/A                                                                      |
+| Metrics | Alpha        [1]       | N/A                                                                      |
 | Logs    | Experimental [2]       | N/A                                                                      |
 
-* [1]: The development of the metrics API and SDK based on new stable
-      specification is ongoing. The timelines would be available in release
-      milestone. The earlier implementation (based on old specification) can be
-      included in build by setting `ENABLE_METRICS_PREVIEW` preprocessor macro,
-      and is included under `*/_metrics/*` directory. This would be eventually
-      removed once the ongoing implemetation is stable.
+* [1]: The metric collection pipeline is available for testing purpose. Not
+      ready for production. The earlier implementation (based on old
+      specification) can be included in build by setting
+      `ENABLE_METRICS_PREVIEW` preprocessor macro, and is included under
+      `*/_metrics/*` directory. This would be eventually removed once the
+      ongoing implemetation is stable.
 * [2]: The current Log Signal Implementation is Experimental, and will change as
       the current OpenTelemetry Log specification matures. The current
       implementation can be included in build by setting `ENABLE_LOGS_PREVIEW`

--- a/api/include/opentelemetry/version.h
+++ b/api/include/opentelemetry/version.h
@@ -6,7 +6,7 @@
 #include "opentelemetry/detail/preprocessor.h"
 
 #define OPENTELEMETRY_ABI_VERSION_NO 1
-#define OPENTELEMETRY_VERSION "1.3.0"
+#define OPENTELEMETRY_VERSION "1.4.0"
 #define OPENTELEMETRY_ABI_VERSION OPENTELEMETRY_STRINGIFY(OPENTELEMETRY_ABI_VERSION_NO)
 
 // clang-format off

--- a/docs/public/conf.py
+++ b/docs/public/conf.py
@@ -21,7 +21,7 @@ copyright = '2021, OpenTelemetry authors'
 author = 'OpenTelemetry authors'
 
 # The full version, including alpha/beta/rc tags
-release = '1.3.0'
+release = '1.4.0'
 
 # Run sphinx on subprojects and copy output
 # -----------------------------------------

--- a/sdk/include/opentelemetry/sdk/version/version.h
+++ b/sdk/include/opentelemetry/sdk/version/version.h
@@ -5,7 +5,7 @@
 
 #include "opentelemetry/detail/preprocessor.h"
 
-#define OPENTELEMETRY_SDK_VERSION "1.3.0"
+#define OPENTELEMETRY_SDK_VERSION "1.4.0"
 
 #include "opentelemetry/version.h"
 

--- a/sdk/src/version/version.cc
+++ b/sdk/src/version/version.cc
@@ -9,7 +9,7 @@ namespace sdk
 namespace version
 {
 const int MAJOR_VERSION     = 1;
-const int MINOR_VERSION     = 3;
+const int MINOR_VERSION     = 4;
 const int PATCH_VERSION     = 0;
 const char *PRE_RELEASE     = "";
 const char *BUILD_METADATA  = "";


### PR DESCRIPTION
Fixes # (issue)

## Changes

This release includes the alpha support of OpenTelemetry metrics.

For significant contributions please make sure you have completed the following items:

* [ ] `CHANGELOG.md` updated for non-trivial changes
* [ ] Unit tests have been added
* [ ] Changes in public API reviewed