### PR TITLE
[Metrics API/SDK] - Pass state to async callback function.

### DIFF
--- a/api/include/opentelemetry/metrics/meter.h
+++ b/api/include/opentelemetry/metrics/meter.h
@@ -52,21 +52,21 @@ public:
    *
    * @param name the name of the new Observable Counter.
    * @param callback the function to be observed by the instrument.
-   * @param state to be passed back to callback
    * @param description a brief description of what the Observable Counter is used for.
    * @param unit the unit of metric values following https://unitsofmeasure.org/ucum.html.
+   * @param state to be passed back to callback
    */
   virtual void CreateLongObservableCounter(nostd::string_view name,
                                            void (*callback)(ObserverResult<long> &, void *),
-                                           void *state = nullptr,
                                            nostd::string_view description = "",
-                                           nostd::string_view unit        = "") noexcept = 0;
+                                           nostd::string_view unit        = "",
+                                           void *state                    = nullptr) noexcept = 0;
 
   virtual void CreateDoubleObservableCounter(nostd::string_view name,
                                              void (*callback)(ObserverResult<double> &, void *),
-                                             void *state = nullptr,
                                              nostd::string_view description = "",
-                                             nostd::string_view unit        = "") noexcept = 0;
+                                             nostd::string_view unit        = "",
+                                             void *state                    = nullptr) noexcept = 0;
 
   /**
    * Creates a Histogram with the passed characteristics and returns a shared_ptr to that Histogram.
@@ -92,21 +92,21 @@ public:
    *
    * @param name the name of the new Observable Gauge.
    * @param callback the function to be observed by the instrument.
-   * @param state to be passed back to callback
    * @param description a brief description of what the Observable Gauge is used for.
    * @param unit the unit of metric values following https://unitsofmeasure.org/ucum.html.
+   * @param state to be passed back to callback
    */
   virtual void CreateLongObservableGauge(nostd::string_view name,
                                          void (*callback)(ObserverResult<long> &, void *),
-                                         void *state = nullptr,
                                          nostd::string_view description = "",
-                                         nostd::string_view unit        = "") noexcept = 0;
+                                         nostd::string_view unit        = "",
+                                         void *state                    = nullptr) noexcept = 0;
 
   virtual void CreateDoubleObservableGauge(nostd::string_view name,
                                            void (*callback)(ObserverResult<double> &, void *),
-                                           void *state = nullptr,
                                            nostd::string_view description = "",
-                                           nostd::string_view unit        = "") noexcept = 0;
+                                           nostd::string_view unit        = "",
+                                           void *state                    = nullptr) noexcept = 0;
 
   /**
    * Creates an UpDownCounter with the passed characteristics and returns a shared_ptr to that
@@ -133,21 +133,22 @@ public:
    *
    * @param name the name of the new Observable UpDownCounter.
    * @param callback the function to be observed by the instrument.
-   * @param state to be passed back to callback
    * @param description a brief description of what the Observable UpDownCounter is used for.
    * @param unit the unit of metric values following https://unitsofmeasure.org/ucum.html.
+   * @param state to be passed back to callback
    */
   virtual void CreateLongObservableUpDownCounter(nostd::string_view name,
                                                  void (*callback)(ObserverResult<long> &, void *),
-                                                 void *state = nullptr,
                                                  nostd::string_view description = "",
-                                                 nostd::string_view unit        = "") noexcept = 0;
+                                                 nostd::string_view unit        = "",
+                                                 void *state = nullptr) noexcept = 0;
 
   virtual void CreateDoubleObservableUpDownCounter(nostd::string_view name,
-                                                   void (*callback)(ObserverResult<double> &, void *),
-                                                   void *state = nullptr,
+                                                   void (*callback)(ObserverResult<double> &,
+                                                                    void *),
                                                    nostd::string_view description = "",
-                                                   nostd::string_view unit = "") noexcept = 0;
+                                                   nostd::string_view unit        = "",
+                                                   void *state = nullptr) noexcept = 0;
 };
 }  // namespace metrics
 OPENTELEMETRY_END_NAMESPACE

--- a/api/include/opentelemetry/metrics/meter.h
+++ b/api/include/opentelemetry/metrics/meter.h
@@ -51,18 +51,20 @@ public:
    * shared_ptr to that Observable Counter
    *
    * @param name the name of the new Observable Counter.
+   * @param callback the function to be observed by the instrument.
+   * @param state to be passed back to callback
    * @param description a brief description of what the Observable Counter is used for.
    * @param unit the unit of metric values following https://unitsofmeasure.org/ucum.html.
-   * @param callback the function to be observed by the instrument.
-   * @return a shared pointer to the created Observable Counter.
    */
   virtual void CreateLongObservableCounter(nostd::string_view name,
-                                           void (*callback)(ObserverResult<long> &),
+                                           void (*callback)(ObserverResult<long> &, void *),
+                                           void *state = nullptr,
                                            nostd::string_view description = "",
                                            nostd::string_view unit        = "") noexcept = 0;
 
   virtual void CreateDoubleObservableCounter(nostd::string_view name,
-                                             void (*callback)(ObserverResult<double> &),
+                                             void (*callback)(ObserverResult<double> &, void *),
+                                             void *state = nullptr,
                                              nostd::string_view description = "",
                                              nostd::string_view unit        = "") noexcept = 0;
 
@@ -89,18 +91,20 @@ public:
    * shared_ptr to that Observable Counter
    *
    * @param name the name of the new Observable Gauge.
+   * @param callback the function to be observed by the instrument.
+   * @param state to be passed back to callback
    * @param description a brief description of what the Observable Gauge is used for.
    * @param unit the unit of metric values following https://unitsofmeasure.org/ucum.html.
-   * @param callback the function to be observed by the instrument.
-   * @return a shared pointer to the created Observable Gauge.
    */
   virtual void CreateLongObservableGauge(nostd::string_view name,
-                                         void (*callback)(ObserverResult<long> &),
+                                         void (*callback)(ObserverResult<long> &, void *),
+                                         void *state = nullptr,
                                          nostd::string_view description = "",
                                          nostd::string_view unit        = "") noexcept = 0;
 
   virtual void CreateDoubleObservableGauge(nostd::string_view name,
-                                           void (*callback)(ObserverResult<double> &),
+                                           void (*callback)(ObserverResult<double> &, void *),
+                                           void *state = nullptr,
                                            nostd::string_view description = "",
                                            nostd::string_view unit        = "") noexcept = 0;
 
@@ -128,18 +132,20 @@ public:
    * a shared_ptr to that Observable UpDownCounter
    *
    * @param name the name of the new Observable UpDownCounter.
+   * @param callback the function to be observed by the instrument.
+   * @param state to be passed back to callback
    * @param description a brief description of what the Observable UpDownCounter is used for.
    * @param unit the unit of metric values following https://unitsofmeasure.org/ucum.html.
-   * @param callback the function to be observed by the instrument.
-   * @return a shared pointer to the created Observable UpDownCounter.
    */
   virtual void CreateLongObservableUpDownCounter(nostd::string_view name,
-                                                 void (*callback)(ObserverResult<long> &),
+                                                 void (*callback)(ObserverResult<long> &, void *),
+                                                 void *state = nullptr,
                                                  nostd::string_view description = "",
                                                  nostd::string_view unit        = "") noexcept = 0;
 
   virtual void CreateDoubleObservableUpDownCounter(nostd::string_view name,
-                                                   void (*callback)(ObserverResult<double> &),
+                                                   void (*callback)(ObserverResult<double> &, void *),
+                                                   void *state = nullptr,
                                                    nostd::string_view description = "",
                                                    nostd::string_view unit = "") noexcept = 0;
 };

--- a/api/include/opentelemetry/metrics/noop.h
+++ b/api/include/opentelemetry/metrics/noop.h
@@ -138,17 +138,17 @@ public:
   }
 
   void CreateLongObservableCounter(nostd::string_view name,
-                                   void *state,
                                    void (*callback)(ObserverResult<long> &, void *),
                                    nostd::string_view description = "",
-                                   nostd::string_view unit        = "") noexcept override
+                                   nostd::string_view unit        = "",
+                                   void *state                    = nullptr) noexcept override
   {}
 
   void CreateDoubleObservableCounter(nostd::string_view name,
-                                     void *state,
                                      void (*callback)(ObserverResult<double> &, void *),
                                      nostd::string_view description = "",
-                                     nostd::string_view unit        = "") noexcept override
+                                     nostd::string_view unit        = "",
+                                     void *state                    = nullptr) noexcept override
   {}
 
   nostd::shared_ptr<Histogram<long>> CreateLongHistogram(
@@ -168,17 +168,17 @@ public:
   }
 
   void CreateLongObservableGauge(nostd::string_view name,
-                                void *state,
                                  void (*callback)(ObserverResult<long> &, void *),
                                  nostd::string_view description = "",
-                                 nostd::string_view unit        = "") noexcept override
+                                 nostd::string_view unit        = "",
+                                 void *state                    = nullptr) noexcept override
   {}
 
   void CreateDoubleObservableGauge(nostd::string_view name,
-                                   void *state,
                                    void (*callback)(ObserverResult<double> &, void *),
                                    nostd::string_view description = "",
-                                   nostd::string_view unit        = "") noexcept override
+                                   nostd::string_view unit        = "",
+                                   void *state                    = nullptr) noexcept override
   {}
 
   nostd::shared_ptr<UpDownCounter<long>> CreateLongUpDownCounter(
@@ -200,17 +200,17 @@ public:
   }
 
   void CreateLongObservableUpDownCounter(nostd::string_view name,
-                                         void *state,
                                          void (*callback)(ObserverResult<long> &, void *),
                                          nostd::string_view description = "",
-                                         nostd::string_view unit        = "") noexcept override
+                                         nostd::string_view unit        = "",
+                                         void *state                    = nullptr) noexcept override
   {}
 
   void CreateDoubleObservableUpDownCounter(nostd::string_view name,
-                                           void *state,
                                            void (*callback)(ObserverResult<double> &, void *),
                                            nostd::string_view description = "",
-                                           nostd::string_view unit        = "") noexcept override
+                                           nostd::string_view unit        = "",
+                                           void *state = nullptr) noexcept override
   {}
 };
 

--- a/api/include/opentelemetry/metrics/noop.h
+++ b/api/include/opentelemetry/metrics/noop.h
@@ -138,13 +138,15 @@ public:
   }
 
   void CreateLongObservableCounter(nostd::string_view name,
-                                   void (*callback)(ObserverResult<long> &),
+                                   void *state,
+                                   void (*callback)(ObserverResult<long> &, void *),
                                    nostd::string_view description = "",
                                    nostd::string_view unit        = "") noexcept override
   {}
 
   void CreateDoubleObservableCounter(nostd::string_view name,
-                                     void (*callback)(ObserverResult<double> &),
+                                     void *state,
+                                     void (*callback)(ObserverResult<double> &, void *),
                                      nostd::string_view description = "",
                                      nostd::string_view unit        = "") noexcept override
   {}
@@ -166,13 +168,15 @@ public:
   }
 
   void CreateLongObservableGauge(nostd::string_view name,
-                                 void (*callback)(ObserverResult<long> &),
+                                void *state,
+                                 void (*callback)(ObserverResult<long> &, void *),
                                  nostd::string_view description = "",
                                  nostd::string_view unit        = "") noexcept override
   {}
 
   void CreateDoubleObservableGauge(nostd::string_view name,
-                                   void (*callback)(ObserverResult<double> &),
+                                   void *state,
+                                   void (*callback)(ObserverResult<double> &, void *),
                                    nostd::string_view description = "",
                                    nostd::string_view unit        = "") noexcept override
   {}
@@ -196,13 +200,15 @@ public:
   }
 
   void CreateLongObservableUpDownCounter(nostd::string_view name,
-                                         void (*callback)(ObserverResult<long> &),
+                                         void *state,
+                                         void (*callback)(ObserverResult<long> &, void *),
                                          nostd::string_view description = "",
                                          nostd::string_view unit        = "") noexcept override
   {}
 
   void CreateDoubleObservableUpDownCounter(nostd::string_view name,
-                                           void (*callback)(ObserverResult<double> &),
+                                           void *state,
+                                           void (*callback)(ObserverResult<double> &, void *),
                                            nostd::string_view description = "",
                                            nostd::string_view unit        = "") noexcept override
   {}

--- a/examples/common/metrics_foo_library/foo_library.cc
+++ b/examples/common/metrics_foo_library/foo_library.cc
@@ -30,7 +30,7 @@ std::map<std::string, std::string> get_random_attr()
 class MeasurementFetcher
 {
 public:
-  static void Fetcher(opentelemetry::metrics::ObserverResult<double> &observer_result)
+  static void Fetcher(opentelemetry::metrics::ObserverResult<double> &observer_result, void *state)
   {
     double val                                = (rand() % 700) + 1.1;
     std::map<std::string, std::string> labels = get_random_attr();

--- a/sdk/include/opentelemetry/sdk/metrics/meter.h
+++ b/sdk/include/opentelemetry/sdk/metrics/meter.h
@@ -43,13 +43,15 @@ public:
       nostd::string_view unit        = "") noexcept override;
 
   void CreateLongObservableCounter(nostd::string_view name,
-                                   void (*callback)(opentelemetry::metrics::ObserverResult<long> &),
+                                   void *state,
+                                   void (*callback)(opentelemetry::metrics::ObserverResult<long> &, void *),
                                    nostd::string_view description = "",
                                    nostd::string_view unit        = "") noexcept override;
 
   void CreateDoubleObservableCounter(
       nostd::string_view name,
-      void (*callback)(opentelemetry::metrics::ObserverResult<double> &),
+      void *state,
+      void (*callback)(opentelemetry::metrics::ObserverResult<double> &, void *),
       nostd::string_view description = "",
       nostd::string_view unit        = "") noexcept override;
 
@@ -64,13 +66,15 @@ public:
       nostd::string_view unit        = "") noexcept override;
 
   void CreateLongObservableGauge(nostd::string_view name,
-                                 void (*callback)(opentelemetry::metrics::ObserverResult<long> &),
+                                 void *state,
+                                 void (*callback)(opentelemetry::metrics::ObserverResult<long> &, void *),
                                  nostd::string_view description = "",
                                  nostd::string_view unit        = "") noexcept override;
 
   void CreateDoubleObservableGauge(
       nostd::string_view name,
-      void (*callback)(opentelemetry::metrics::ObserverResult<double> &),
+      void *state,
+      void (*callback)(opentelemetry::metrics::ObserverResult<double> &, void *),
       nostd::string_view description = "",
       nostd::string_view unit        = "") noexcept override;
 
@@ -86,13 +90,15 @@ public:
 
   void CreateLongObservableUpDownCounter(
       nostd::string_view name,
-      void (*callback)(opentelemetry::metrics::ObserverResult<long> &),
+      void *state,
+      void (*callback)(opentelemetry::metrics::ObserverResult<long> &, void *),
       nostd::string_view description = "",
       nostd::string_view unit        = "") noexcept override;
 
   void CreateDoubleObservableUpDownCounter(
       nostd::string_view name,
-      void (*callback)(opentelemetry::metrics::ObserverResult<double> &),
+      void *state,
+      void (*callback)(opentelemetry::metrics::ObserverResult<double> &, void *),
       nostd::string_view description = "",
       nostd::string_view unit        = "") noexcept override;
 
@@ -117,7 +123,8 @@ private:
 
   template <class T>
   void RegisterAsyncMetricStorage(InstrumentDescriptor &instrument_descriptor,
-                                  void (*callback)(opentelemetry::metrics::ObserverResult<T> &))
+                                  void (*callback)(opentelemetry::metrics::ObserverResult<T> &),
+                                  void *state = nullptr)
   {
     auto view_registry = meter_context_->GetViewRegistry();
     auto success       = view_registry->FindViews(
@@ -128,7 +135,7 @@ private:
           view_instr_desc.description_ = view.GetDescription();
           auto storage                 = std::shared_ptr<AsyncMetricStorage<T>>(
               new AsyncMetricStorage<T>(view_instr_desc, view.GetAggregationType(), callback,
-                                        &view.GetAttributesProcessor()));
+                                        &view.GetAttributesProcessor(), state));
           storage_registry_[instrument_descriptor.name_] = storage;
           return true;
         });

--- a/sdk/include/opentelemetry/sdk/metrics/meter.h
+++ b/sdk/include/opentelemetry/sdk/metrics/meter.h
@@ -43,17 +43,18 @@ public:
       nostd::string_view unit        = "") noexcept override;
 
   void CreateLongObservableCounter(nostd::string_view name,
-                                   void *state,
-                                   void (*callback)(opentelemetry::metrics::ObserverResult<long> &, void *),
+                                   void (*callback)(opentelemetry::metrics::ObserverResult<long> &,
+                                                    void *),
                                    nostd::string_view description = "",
-                                   nostd::string_view unit        = "") noexcept override;
+                                   nostd::string_view unit        = "",
+                                   void *state                    = nullptr) noexcept override;
 
   void CreateDoubleObservableCounter(
       nostd::string_view name,
-      void *state,
       void (*callback)(opentelemetry::metrics::ObserverResult<double> &, void *),
       nostd::string_view description = "",
-      nostd::string_view unit        = "") noexcept override;
+      nostd::string_view unit        = "",
+      void *state                    = nullptr) noexcept override;
 
   nostd::shared_ptr<opentelemetry::metrics::Histogram<long>> CreateLongHistogram(
       nostd::string_view name,
@@ -66,17 +67,18 @@ public:
       nostd::string_view unit        = "") noexcept override;
 
   void CreateLongObservableGauge(nostd::string_view name,
-                                 void *state,
-                                 void (*callback)(opentelemetry::metrics::ObserverResult<long> &, void *),
+                                 void (*callback)(opentelemetry::metrics::ObserverResult<long> &,
+                                                  void *),
                                  nostd::string_view description = "",
-                                 nostd::string_view unit        = "") noexcept override;
+                                 nostd::string_view unit        = "",
+                                 void *state                    = nullptr) noexcept override;
 
   void CreateDoubleObservableGauge(
       nostd::string_view name,
-      void *state,
       void (*callback)(opentelemetry::metrics::ObserverResult<double> &, void *),
       nostd::string_view description = "",
-      nostd::string_view unit        = "") noexcept override;
+      nostd::string_view unit        = "",
+      void *state                    = nullptr) noexcept override;
 
   nostd::shared_ptr<opentelemetry::metrics::UpDownCounter<long>> CreateLongUpDownCounter(
       nostd::string_view name,
@@ -90,17 +92,17 @@ public:
 
   void CreateLongObservableUpDownCounter(
       nostd::string_view name,
-      void *state,
       void (*callback)(opentelemetry::metrics::ObserverResult<long> &, void *),
       nostd::string_view description = "",
-      nostd::string_view unit        = "") noexcept override;
+      nostd::string_view unit        = "",
+      void *state                    = nullptr) noexcept override;
 
   void CreateDoubleObservableUpDownCounter(
       nostd::string_view name,
-      void *state,
       void (*callback)(opentelemetry::metrics::ObserverResult<double> &, void *),
       nostd::string_view description = "",
-      nostd::string_view unit        = "") noexcept override;
+      nostd::string_view unit        = "",
+      void *state                    = nullptr) noexcept override;
 
   /** Returns the associated instruementation library */
   const sdk::instrumentationlibrary::InstrumentationLibrary *GetInstrumentationLibrary()
@@ -123,13 +125,14 @@ private:
 
   template <class T>
   void RegisterAsyncMetricStorage(InstrumentDescriptor &instrument_descriptor,
-                                  void (*callback)(opentelemetry::metrics::ObserverResult<T> &),
+                                  void (*callback)(opentelemetry::metrics::ObserverResult<T> &,
+                                                   void *),
                                   void *state = nullptr)
   {
     auto view_registry = meter_context_->GetViewRegistry();
     auto success       = view_registry->FindViews(
         instrument_descriptor, *instrumentation_library_,
-        [this, &instrument_descriptor, callback](const View &view) {
+        [this, &instrument_descriptor, callback, state](const View &view) {
           auto view_instr_desc         = instrument_descriptor;
           view_instr_desc.name_        = view.GetName();
           view_instr_desc.description_ = view.GetDescription();

--- a/sdk/include/opentelemetry/sdk/metrics/state/async_metric_storage.h
+++ b/sdk/include/opentelemetry/sdk/metrics/state/async_metric_storage.h
@@ -27,7 +27,8 @@ class AsyncMetricStorage : public MetricStorage
 public:
   AsyncMetricStorage(InstrumentDescriptor instrument_descriptor,
                      const AggregationType aggregation_type,
-                     void (*measurement_callback)(opentelemetry::metrics::ObserverResult<T> &),
+                     void (*measurement_callback)(opentelemetry::metrics::ObserverResult<T> &,
+                                                  void *),
                      const AttributesProcessor *attributes_processor,
                      void *state = nullptr)
       : instrument_descriptor_(instrument_descriptor),
@@ -81,7 +82,7 @@ public:
 private:
   InstrumentDescriptor instrument_descriptor_;
   AggregationType aggregation_type_;
-  void (*measurement_collection_callback_)(opentelemetry::metrics::ObserverResult<T> &);
+  void (*measurement_collection_callback_)(opentelemetry::metrics::ObserverResult<T> &, void *);
   const AttributesProcessor *attributes_processor_;
   void *state_;
   std::unique_ptr<AttributesHashMap> cumulative_hash_map_;

--- a/sdk/include/opentelemetry/sdk/metrics/state/async_metric_storage.h
+++ b/sdk/include/opentelemetry/sdk/metrics/state/async_metric_storage.h
@@ -28,11 +28,13 @@ public:
   AsyncMetricStorage(InstrumentDescriptor instrument_descriptor,
                      const AggregationType aggregation_type,
                      void (*measurement_callback)(opentelemetry::metrics::ObserverResult<T> &),
-                     const AttributesProcessor *attributes_processor)
+                     const AttributesProcessor *attributes_processor,
+                     void *state = nullptr)
       : instrument_descriptor_(instrument_descriptor),
         aggregation_type_{aggregation_type},
         measurement_collection_callback_{measurement_callback},
         attributes_processor_{attributes_processor},
+        state_{state},
         cumulative_hash_map_(new AttributesHashMap()),
         temporal_metric_storage_(instrument_descriptor)
   {}
@@ -46,7 +48,7 @@ public:
     opentelemetry::sdk::metrics::ObserverResult<T> ob_res(attributes_processor_);
 
     // read the measurement using configured callback
-    measurement_collection_callback_(ob_res);
+    measurement_collection_callback_(ob_res, state_);
     std::shared_ptr<AttributesHashMap> delta_hash_map(new AttributesHashMap());
     // process the read measurements - aggregate and store in hashmap
     for (auto &measurement : ob_res.GetMeasurements())
@@ -81,6 +83,7 @@ private:
   AggregationType aggregation_type_;
   void (*measurement_collection_callback_)(opentelemetry::metrics::ObserverResult<T> &);
   const AttributesProcessor *attributes_processor_;
+  void *state_;
   std::unique_ptr<AttributesHashMap> cumulative_hash_map_;
   TemporalMetricStorage temporal_metric_storage_;
 };

--- a/sdk/src/metrics/meter.cc
+++ b/sdk/src/metrics/meter.cc
@@ -58,7 +58,8 @@ nostd::shared_ptr<metrics::Counter<double>> Meter::CreateDoubleCounter(
 }
 
 void Meter::CreateLongObservableCounter(nostd::string_view name,
-                                        void (*callback)(metrics::ObserverResult<long> &),
+                                        void *state,
+                                        void (*callback)(metrics::ObserverResult<long> &, void *),
                                         nostd::string_view description,
                                         nostd::string_view unit) noexcept
 {
@@ -66,11 +67,12 @@ void Meter::CreateLongObservableCounter(nostd::string_view name,
       std::string{name.data(), name.size()}, std::string{description.data(), description.size()},
       std::string{unit.data(), unit.size()}, InstrumentType::kObservableCounter,
       InstrumentValueType::kLong};
-  RegisterAsyncMetricStorage<long>(instrument_descriptor, callback);
+  RegisterAsyncMetricStorage<long>(instrument_descriptor, callback, state);
 }
 
 void Meter::CreateDoubleObservableCounter(nostd::string_view name,
-                                          void (*callback)(metrics::ObserverResult<double> &),
+                                          void *state,
+                                          void (*callback)(metrics::ObserverResult<double> &, void *),
                                           nostd::string_view description,
                                           nostd::string_view unit) noexcept
 {
@@ -78,7 +80,7 @@ void Meter::CreateDoubleObservableCounter(nostd::string_view name,
       std::string{name.data(), name.size()}, std::string{description.data(), description.size()},
       std::string{unit.data(), unit.size()}, InstrumentType::kObservableCounter,
       InstrumentValueType::kDouble};
-  RegisterAsyncMetricStorage<double>(instrument_descriptor, callback);
+  RegisterAsyncMetricStorage<double>(instrument_descriptor, callback, state);
 }
 
 nostd::shared_ptr<metrics::Histogram<long>> Meter::CreateLongHistogram(
@@ -110,7 +112,8 @@ nostd::shared_ptr<metrics::Histogram<double>> Meter::CreateDoubleHistogram(
 }
 
 void Meter::CreateLongObservableGauge(nostd::string_view name,
-                                      void (*callback)(metrics::ObserverResult<long> &),
+                                      void *state,
+                                      void (*callback)(metrics::ObserverResult<long> &, void *),
                                       nostd::string_view description,
                                       nostd::string_view unit) noexcept
 {
@@ -118,11 +121,12 @@ void Meter::CreateLongObservableGauge(nostd::string_view name,
       std::string{name.data(), name.size()}, std::string{description.data(), description.size()},
       std::string{unit.data(), unit.size()}, InstrumentType::kObservableGauge,
       InstrumentValueType::kLong};
-  RegisterAsyncMetricStorage<long>(instrument_descriptor, callback);
+  RegisterAsyncMetricStorage<long>(instrument_descriptor, callback, state);
 }
 
 void Meter::CreateDoubleObservableGauge(nostd::string_view name,
-                                        void (*callback)(metrics::ObserverResult<double> &),
+                                        void *state,
+                                        void (*callback)(metrics::ObserverResult<double> &, void *),
                                         nostd::string_view description,
                                         nostd::string_view unit) noexcept
 {
@@ -130,7 +134,7 @@ void Meter::CreateDoubleObservableGauge(nostd::string_view name,
       std::string{name.data(), name.size()}, std::string{description.data(), description.size()},
       std::string{unit.data(), unit.size()}, InstrumentType::kObservableGauge,
       InstrumentValueType::kDouble};
-  RegisterAsyncMetricStorage<double>(instrument_descriptor, callback);
+  RegisterAsyncMetricStorage<double>(instrument_descriptor, callback, state);
 }
 
 nostd::shared_ptr<metrics::UpDownCounter<long>> Meter::CreateLongUpDownCounter(
@@ -162,7 +166,8 @@ nostd::shared_ptr<metrics::UpDownCounter<double>> Meter::CreateDoubleUpDownCount
 }
 
 void Meter::CreateLongObservableUpDownCounter(nostd::string_view name,
-                                              void (*callback)(metrics::ObserverResult<long> &),
+                                              void *state,
+                                              void (*callback)(metrics::ObserverResult<long> &, void *),
                                               nostd::string_view description,
                                               nostd::string_view unit) noexcept
 {
@@ -170,11 +175,12 @@ void Meter::CreateLongObservableUpDownCounter(nostd::string_view name,
       std::string{name.data(), name.size()}, std::string{description.data(), description.size()},
       std::string{unit.data(), unit.size()}, InstrumentType::kObservableUpDownCounter,
       InstrumentValueType::kLong};
-  RegisterAsyncMetricStorage<long>(instrument_descriptor, callback);
+  RegisterAsyncMetricStorage<long>(instrument_descriptor, callback, state);
 }
 
 void Meter::CreateDoubleObservableUpDownCounter(nostd::string_view name,
-                                                void (*callback)(metrics::ObserverResult<double> &),
+                                                void *state,
+                                                void (*callback)(metrics::ObserverResult<double> &, void *),
                                                 nostd::string_view description,
                                                 nostd::string_view unit) noexcept
 {
@@ -182,7 +188,7 @@ void Meter::CreateDoubleObservableUpDownCounter(nostd::string_view name,
       std::string{name.data(), name.size()}, std::string{description.data(), description.size()},
       std::string{unit.data(), unit.size()}, InstrumentType::kObservableUpDownCounter,
       InstrumentValueType::kDouble};
-  RegisterAsyncMetricStorage<double>(instrument_descriptor, callback);
+  RegisterAsyncMetricStorage<double>(instrument_descriptor, callback, state);
 }
 
 const sdk::instrumentationlibrary::InstrumentationLibrary *Meter::GetInstrumentationLibrary()

--- a/sdk/src/metrics/meter.cc
+++ b/sdk/src/metrics/meter.cc
@@ -58,10 +58,10 @@ nostd::shared_ptr<metrics::Counter<double>> Meter::CreateDoubleCounter(
 }
 
 void Meter::CreateLongObservableCounter(nostd::string_view name,
-                                        void *state,
                                         void (*callback)(metrics::ObserverResult<long> &, void *),
                                         nostd::string_view description,
-                                        nostd::string_view unit) noexcept
+                                        nostd::string_view unit,
+                                        void *state) noexcept
 {
   InstrumentDescriptor instrument_descriptor = {
       std::string{name.data(), name.size()}, std::string{description.data(), description.size()},
@@ -71,10 +71,11 @@ void Meter::CreateLongObservableCounter(nostd::string_view name,
 }
 
 void Meter::CreateDoubleObservableCounter(nostd::string_view name,
-                                          void *state,
-                                          void (*callback)(metrics::ObserverResult<double> &, void *),
+                                          void (*callback)(metrics::ObserverResult<double> &,
+                                                           void *),
                                           nostd::string_view description,
-                                          nostd::string_view unit) noexcept
+                                          nostd::string_view unit,
+                                          void *state) noexcept
 {
   InstrumentDescriptor instrument_descriptor = {
       std::string{name.data(), name.size()}, std::string{description.data(), description.size()},
@@ -112,10 +113,10 @@ nostd::shared_ptr<metrics::Histogram<double>> Meter::CreateDoubleHistogram(
 }
 
 void Meter::CreateLongObservableGauge(nostd::string_view name,
-                                      void *state,
                                       void (*callback)(metrics::ObserverResult<long> &, void *),
                                       nostd::string_view description,
-                                      nostd::string_view unit) noexcept
+                                      nostd::string_view unit,
+                                      void *state) noexcept
 {
   InstrumentDescriptor instrument_descriptor = {
       std::string{name.data(), name.size()}, std::string{description.data(), description.size()},
@@ -125,10 +126,10 @@ void Meter::CreateLongObservableGauge(nostd::string_view name,
 }
 
 void Meter::CreateDoubleObservableGauge(nostd::string_view name,
-                                        void *state,
                                         void (*callback)(metrics::ObserverResult<double> &, void *),
                                         nostd::string_view description,
-                                        nostd::string_view unit) noexcept
+                                        nostd::string_view unit,
+                                        void *state) noexcept
 {
   InstrumentDescriptor instrument_descriptor = {
       std::string{name.data(), name.size()}, std::string{description.data(), description.size()},
@@ -166,10 +167,11 @@ nostd::shared_ptr<metrics::UpDownCounter<double>> Meter::CreateDoubleUpDownCount
 }
 
 void Meter::CreateLongObservableUpDownCounter(nostd::string_view name,
-                                              void *state,
-                                              void (*callback)(metrics::ObserverResult<long> &, void *),
+                                              void (*callback)(metrics::ObserverResult<long> &,
+                                                               void *),
                                               nostd::string_view description,
-                                              nostd::string_view unit) noexcept
+                                              nostd::string_view unit,
+                                              void *state) noexcept
 {
   InstrumentDescriptor instrument_descriptor = {
       std::string{name.data(), name.size()}, std::string{description.data(), description.size()},
@@ -179,10 +181,11 @@ void Meter::CreateLongObservableUpDownCounter(nostd::string_view name,
 }
 
 void Meter::CreateDoubleObservableUpDownCounter(nostd::string_view name,
-                                                void *state,
-                                                void (*callback)(metrics::ObserverResult<double> &, void *),
+                                                void (*callback)(metrics::ObserverResult<double> &,
+                                                                 void *),
                                                 nostd::string_view description,
-                                                nostd::string_view unit) noexcept
+                                                nostd::string_view unit,
+                                                void *state) noexcept
 {
   InstrumentDescriptor instrument_descriptor = {
       std::string{name.data(), name.size()}, std::string{description.data(), description.size()},

--- a/sdk/test/metrics/async_metric_storage_test.cc
+++ b/sdk/test/metrics/async_metric_storage_test.cc
@@ -39,7 +39,7 @@ class WritableMetricStorageTestFixture : public ::testing::TestWithParam<Aggrega
 class MeasurementFetcher
 {
 public:
-  static void Fetcher(opentelemetry::metrics::ObserverResult<long> &observer_result)
+  static void Fetcher(opentelemetry::metrics::ObserverResult<long> &observer_result, void *state)
   {
     fetch_count++;
     if (fetch_count == 1)


### PR DESCRIPTION
Fixes #1389 

## Changes

Changes to pass the state to the async callback function.

For significant contributions please make sure you have completed the following items:

* [ ] `CHANGELOG.md` updated for non-trivial changes
* [x] Unit tests have been added
* [x] Changes in public API reviewed