### PR TITLE
fix: WaitOnSocket select error when sockfd above FD_SETSIZE

### DIFF
--- a/ext/include/opentelemetry/ext/http/client/curl/http_operation_curl.h
+++ b/ext/include/opentelemetry/ext/http/client/curl/http_operation_curl.h
@@ -489,7 +489,7 @@ protected:
       }
     }
 
-#else 
+#else
 
     struct pollfd fds[1];
     ::memset(fds, 0, sizeof(fds));

--- a/ext/include/opentelemetry/ext/http/client/curl/http_operation_curl.h
+++ b/ext/include/opentelemetry/ext/http/client/curl/http_operation_curl.h
@@ -481,11 +481,11 @@ protected:
     {
       if (for_recv)
       {
-        res = FD_ISSET(sockfd, &infd);
+        res = (0 != FD_ISSET(sockfd, &infd));
       }
       else
       {
-        res = FD_ISSET(sockfd, &outfd);
+        res = (0 != FD_ISSET(sockfd, &outfd));
       }
     }
 
@@ -508,11 +508,11 @@ protected:
     {
       if (for_recv) 
       {
-        res = fds[0].revents & POLLIN;
+        res = (0 != (fds[0].revents & POLLIN));
       } 
       else
       {
-        res = fds[0].revents & POLLOUT;
+        res = (0 != (fds[0].revents & POLLOUT));
       }
     }
 

--- a/ext/include/opentelemetry/ext/http/client/curl/http_operation_curl.h
+++ b/ext/include/opentelemetry/ext/http/client/curl/http_operation_curl.h
@@ -18,6 +18,7 @@
 #  include <winsock2.h>
 #else
 #  include <unistd.h>
+#  include <poll.h>
 #endif
 #include <curl/curl.h>
 
@@ -443,13 +444,19 @@ protected:
    * @param sockfd
    * @param for_recv
    * @param timeout_ms
-   * @return
+   * @return true if expected events occur, false if timeout or error happen
    */
-  static int WaitOnSocket(curl_socket_t sockfd, int for_recv, long timeout_ms)
+  static bool WaitOnSocket(curl_socket_t sockfd, int for_recv, long timeout_ms)
   {
+    bool res = false;
+
+#if defined(_WIN32)
+
+    if (sockfd > FD_SETSIZE)
+      return false;
+
     struct timeval tv;
     fd_set infd, outfd, errfd;
-    int res;
 
     tv.tv_sec  = timeout_ms / 1000;
     tv.tv_usec = (timeout_ms % 1000) * 1000;
@@ -470,7 +477,47 @@ protected:
     }
 
     /* select() returns the number of signalled sockets or -1 */
-    res = select((int)sockfd + 1, &infd, &outfd, &errfd, &tv);
+    if (select((int)sockfd + 1, &infd, &outfd, &errfd, &tv) > 0)
+    {
+      if (for_recv)
+      {
+        res = FD_ISSET(sockfd, &infd);
+      }
+      else
+      {
+        res = FD_ISSET(sockfd, &outfd);
+      }
+    }
+
+#else 
+
+    struct pollfd fds[1];
+    ::memset(fds, 0 , sizeof(fds));
+
+    fds[0].fd = sockfd;
+    if (for_recv)
+    {
+      fds[0].events = POLLIN;
+    }
+    else
+    {
+      fds[0].events = POLLOUT;
+    }
+
+    if (poll(fds, 1, timeout_ms) > 0)
+    {
+      if (for_recv) 
+      {
+        res = fds[0].revents & POLLIN;
+      } 
+      else
+      {
+        res = fds[0].revents & POLLOUT;
+      }
+    }
+
+#endif 
+
     return res;
   }
 

--- a/ext/include/opentelemetry/ext/http/client/curl/http_operation_curl.h
+++ b/ext/include/opentelemetry/ext/http/client/curl/http_operation_curl.h
@@ -17,8 +17,8 @@
 #  include <io.h>
 #  include <winsock2.h>
 #else
-#  include <unistd.h>
 #  include <poll.h>
+#  include <unistd.h>
 #endif
 #include <curl/curl.h>
 
@@ -492,7 +492,7 @@ protected:
 #else 
 
     struct pollfd fds[1];
-    ::memset(fds, 0 , sizeof(fds));
+    ::memset(fds, 0, sizeof(fds));
 
     fds[0].fd = sockfd;
     if (for_recv)
@@ -506,17 +506,17 @@ protected:
 
     if (poll(fds, 1, timeout_ms) > 0)
     {
-      if (for_recv) 
+      if (for_recv)
       {
         res = (0 != (fds[0].revents & POLLIN));
-      } 
+      }
       else
       {
         res = (0 != (fds[0].revents & POLLOUT));
       }
     }
 
-#endif 
+#endif
 
     return res;
   }


### PR DESCRIPTION
Fixes select return code is not well handled, and when curl sockfd above FD_SETSIZE (1024), select can not handle it.

Changes:
1. According docs, select return -1 on error, 0 when timeout, and >0 for expected events return. The original cast the int code to bool, so when invalid sock provided, the procedure treat as good, the following procedure crash. So the code carefully check the select return code, and the really events we get.
2. Even though select is POSIX standard and cross platform, but can not handle the case when fd above FD_SETSIZE. In our production environment, we see CURL sock fd far more above it, so when Linux environment possible, we use poll instead of select.
 

