### PR TITLE
[BUILD] fix nlohmann_json's (third party) include dir

### DIFF
--- a/cmake/nlohmann-json.cmake
+++ b/cmake/nlohmann-json.cmake
@@ -26,7 +26,7 @@ ExternalProject_Add(nlohmann_json_download
 )
 
 ExternalProject_Get_Property(nlohmann_json_download INSTALL_DIR)
-SET(NLOHMANN_JSON_INCLUDE_DIR ${INSTALL_DIR}/third_party/src/nlohmann_json_download/single_include)
+SET(NLOHMANN_JSON_INCLUDE_DIR ${INSTALL_DIR}/src/nlohmann_json_download/single_include)
 add_library(nlohmann_json_ INTERFACE)
 target_include_directories(nlohmann_json_ INTERFACE
     "$<BUILD_INTERFACE:${NLOHMANN_JSON_INCLUDE_DIR}>"


### PR DESCRIPTION
Signed-off-by: Leonardo Di Donato <leodidonato@gmail.com>

Fixes: could not build with nlohmann_json from third_party

## Changes

Please provide a brief description of the changes here.

_Fixes `nlohmann_json` include directory for building it from third party._

For significant contributions please make sure you have completed the following items:

* [ ] `CHANGELOG.md` updated for non-trivial changes
* [ ] Unit tests have been added
* [ ] Changes in public API reviewed