### PR TITLE
install sdk-config.h

### DIFF
--- a/sdk/CMakeLists.txt
+++ b/sdk/CMakeLists.txt
@@ -14,7 +14,7 @@ install(
   ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR})
 
 install(
-  DIRECTORY include/opentelemetry
+  DIRECTORY include/opentelemetry/
   DESTINATION include/opentelemetry
   FILES_MATCHING
   PATTERN "*config.h")


### PR DESCRIPTION
Fixes #1272

#1273 install `sdk-config.h` to the wrong directory
```
$ tree /usr/local/include/opentelemetry/opentelemetry/
/usr/local/include/opentelemetry/opentelemetry/
└── sdk_config.h

0 directories, 1 file
``` 

## Changes

Please provide a brief description of the changes here.

For significant contributions please make sure you have completed the following items:

* [ ] `CHANGELOG.md` updated for non-trivial changes
* [ ] Unit tests have been added
* [ ] Changes in public API reviewed