### PR TITLE
Copy string_view passed to ETW exporter in PropertyVariant

### DIFF
--- a/api/include/opentelemetry/trace/span_context.h
+++ b/api/include/opentelemetry/trace/span_context.h
@@ -81,7 +81,7 @@ public:
 
   bool IsRemote() const noexcept { return is_remote_; }
 
-  static SpanContext GetInvalid() { return SpanContext(false, false); }
+  static SpanContext GetInvalid() noexcept { return SpanContext(false, false); }
 
   bool IsSampled() const noexcept { return trace_flags_.IsSampled(); }
 

--- a/exporters/etw/include/opentelemetry/exporters/etw/etw_properties.h
+++ b/exporters/etw/include/opentelemetry/exporters/etw/etw_properties.h
@@ -224,7 +224,6 @@ public:
       case common::AttributeType::kTypeString: {
         PropertyVariant::operator=
             (std::string{nostd::string_view(nostd::get<nostd::string_view>(v)).data()});
-
         break;
       }
 

--- a/exporters/etw/include/opentelemetry/exporters/etw/etw_properties.h
+++ b/exporters/etw/include/opentelemetry/exporters/etw/etw_properties.h
@@ -222,7 +222,7 @@ public:
         break;
       }
       case common::AttributeType::kTypeString: {
-        PropertyVariant::operator=(nostd::string_view(nostd::get<nostd::string_view>(v)).data());
+        PropertyVariant::operator=(std::string{nostd::string_view(nostd::get<nostd::string_view>(v)).data()});
         break;
       }
 

--- a/exporters/etw/include/opentelemetry/exporters/etw/etw_properties.h
+++ b/exporters/etw/include/opentelemetry/exporters/etw/etw_properties.h
@@ -222,7 +222,9 @@ public:
         break;
       }
       case common::AttributeType::kTypeString: {
-        PropertyVariant::operator=(std::string{nostd::string_view(nostd::get<nostd::string_view>(v)).data()});
+        PropertyVariant::operator=
+            (std::string{nostd::string_view(nostd::get<nostd::string_view>(v)).data()});
+
         break;
       }
 

--- a/exporters/etw/include/opentelemetry/exporters/etw/etw_properties.h
+++ b/exporters/etw/include/opentelemetry/exporters/etw/etw_properties.h
@@ -192,7 +192,7 @@ public:
   {}
 
   /**
-   * @brief Convert owning PropertyValue to non-owning common::AttributeValue
+   * @brief Convert non-owning common::AttributeValue to owning PropertyValue.
    * @return
    */
   PropertyValue &FromAttributeValue(const common::AttributeValue &v)


### PR DESCRIPTION
ETW exporter doesn't make a copy of the passed in `nostd::string_view` value which could be freed after the call of `SetAttribute` while ETW exporter still holds reference on it.

Also add `noexcept` for `opentelemetry::v1::trace::SpanContext::GetInvalid`.

## Changes

Please provide a brief description of the changes here.

For significant contributions please make sure you have completed the following items:

* [ ] `CHANGELOG.md` updated for non-trivial changes
* [ ] Unit tests have been added
* [ ] Changes in public API reviewed