### PR TITLE
Fix ETW log exporter header inclusion

### DIFF
--- a/exporters/etw/include/opentelemetry/exporters/etw/etw_logger_exporter.h
+++ b/exporters/etw/include/opentelemetry/exporters/etw/etw_logger_exporter.h
@@ -15,7 +15,7 @@
 
 #  include "opentelemetry/common/key_value_iterable_view.h"
 
-#  include "opentelemetry/logs/tracer_provider.h"
+#  include "opentelemetry/logs/logger_provider.h"
 #  include "opentelemetry/trace/span_id.h"
 #  include "opentelemetry/trace/trace_id.h"
 

--- a/exporters/etw/test/etw_logger_test.cc
+++ b/exporters/etw/test/etw_logger_test.cc
@@ -8,7 +8,7 @@
 #    include <map>
 #    include <string>
 
-#    include "opentelemetry/exporters/etw/etw_logger.h"
+#    include "opentelemetry/exporters/etw/etw_logger_exporter.h"
 #    include "opentelemetry/sdk/trace/simple_processor.h"
 
 using namespace OPENTELEMETRY_NAMESPACE;


### PR DESCRIPTION
## Changes

Include correct header file `opentelemetry/logs/logger_provider.h`. Also, update the unit-test to catch the error.

For significant contributions please make sure you have completed the following items:

* [ ] `CHANGELOG.md` updated for non-trivial changes
* [ ] Unit tests have been added
* [ ] Changes in public API reviewed