### PR TITLE
Fix variables inizialization

### DIFF
--- a/sdk/src/metrics/metric_reader.cc
+++ b/sdk/src/metrics/metric_reader.cc
@@ -14,7 +14,7 @@ namespace metrics
 {
 
 MetricReader::MetricReader(AggregationTemporality aggregation_temporality)
-    : aggregation_temporality_(aggregation_temporality)
+    : aggregation_temporality_(aggregation_temporality), shutdown_(false), metric_producer_(nullptr)
 {}
 
 void MetricReader::SetMetricProducer(MetricProducer *metric_producer)


### PR DESCRIPTION
Fixes # (issue)
PeriodicExportingMetricReader ::DoBackgroundWork() exited immedialty because of IsShutdown()

## Changes
MetricReader ctor missed shutdown_(false) initialization