### PR TITLE
Fix GettingStarted documentation for Jaeger HTTP exporter (#1347)

### DIFF
--- a/docs/public/sdk/GettingStarted.rst
+++ b/docs/public/sdk/GettingStarted.rst
@@ -50,9 +50,9 @@ OpenTelemetry offers six tracing exporters out of the box:
     opentelemetry::exporter::jaeger::JaegerExporterOptions opts;
     opts.transport_format  = opentelemetry::exporter::jaeger::TransportFormat::kThriftHttp;
     opts.endpoint = "localhost";
-    opts.server_port =  6831;
+    opts.server_port = 14268;
     opts.headers = {{}}; // optional headers
-    auto jaeger_udp_exporter =
+    auto jaeger_http_exporter =
         std::unique_ptr<sdktrace::SpanExporter>(new opentelemetry::exporter::jaeger::JaegerExporter(opts));
 
 


### PR DESCRIPTION
Fixes #1347 (issue)

## Changes

Fixed the Jaeger HTTP port number in the GettingStarted documentation.

For significant contributions please make sure you have completed the following items:

* [ ] `CHANGELOG.md` updated for non-trivial changes
* [ ] Unit tests have been added
* [ ] Changes in public API reviewed