### PR TITLE
Fixed broken link to OpenTelemetry.io (#1445)

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -89,5 +89,5 @@ should include all the release notes from the Changelog for this release.
 ## Post Release
 
 Update the OpenTelemetry.io document
-[here](https://github.com/open-telemetry/opentelemetry.io/tree/main/content/en/docs/cpp)
+[here](https://github.com/open-telemetry/opentelemetry.io/tree/main/content/en/docs/instrumentation/cpp)
 by sending a Pull Request.


### PR DESCRIPTION
Fixes #1445 (issue)

## Changes

Fixed broken link to OpenTelemetry.io

For significant contributions please make sure you have completed the following items:

* [ ] `CHANGELOG.md` updated for non-trivial changes
* [ ] Unit tests have been added
* [ ] Changes in public API reviewed