### PR TITLE
Prepare v1.4.1 patch release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,25 @@ Increment the:
 
 ## [Unreleased]
 
+## [1.4.1] 2022-06-19
+
+* [METRICS SDK] Fix variables inizialization [#1430](https://github.com/open-telemetry/opentelemetry-cpp/pull/1430)
+* [DOCS] Fixed broken link to OpenTelemetry.io (#1445) [#1446](https://github.com/open-telemetry/opentelemetry-cpp/pull/1446)
+* [BUILD] Upgrade nlohmann_json to 3.10.5 (#1438) [#1441](https://github.com/open-telemetry/opentelemetry-cpp/pull/1441)
+* [METRICS SDK] fix histogram [#1440](https://github.com/open-telemetry/opentelemetry-cpp/pull/1440)
+* [DOCS] Fix GettingStarted documentation for Jaeger HTTP exporter (#1347) [#1439](https://github.com/open-telemetry/opentelemetry-cpp/pull/1439)
+* [BUILD] install sdk-config.h [#1419](https://github.com/open-telemetry/opentelemetry-cpp/pull/1419)
+* [EXAMPLE] Log current timestamp instead of epoch time [#1434](https://github.com/open-telemetry/opentelemetry-cpp/pull/1434)
+* [METRICS SDK] Add attributes/dimensions to metrics ostream exporter [#1400](https://github.com/open-telemetry/opentelemetry-cpp/pull/1400)
+* [SDK] Fix global log handle symbols when using dlopen [#1420](https://github.com/open-telemetry/opentelemetry-cpp/pull/1420)
 * [METRICS] Only record non-negative / finite / Non-NAN histogram values([#1427](https://github.com/open-telemetry/opentelemetry-cpp/pull/1427))
+* [ETW EXPORTER] Fix ETW log exporter header inclusion [#1426](https://github.com/open-telemetry/opentelemetry-cpp/pull/1426)
+* [ETW EXPORTER] Copy string_view passed to ETW exporter in PropertyVariant [#1425](https://github.com/open-telemetry/opentelemetry-cpp/pull/1425)
+* [METRICS API/SDK] Pass state to async callback function. [#1408](https://github.com/open-telemetry/opentelemetry-cpp/pull/1408)
+* [BUILD] fix nlohmann_json's (third party) include dir [#1415](https://github.com/open-telemetry/opentelemetry-cpp/pull/1415)
+* [SDK] fix: WaitOnSocket select error when sockfd above FD_SETSIZE [#1410](https://github.com/open-telemetry/opentelemetry-cpp/pull/1410)
+* [SDK] fix OTEL_INTERNAL_LOG_INFO [#1407](https://github.com/open-telemetry/opentelemetry-cpp/pull/1407)
+* [DOCS] Document Getting Started with Prometheus and Grafana [#1396](https://github.com/open-telemetry/opentelemetry-cpp/pull/1396)
 
 ## [1.4.0] 2022-05-17
 

--- a/api/include/opentelemetry/version.h
+++ b/api/include/opentelemetry/version.h
@@ -6,7 +6,7 @@
 #include "opentelemetry/detail/preprocessor.h"
 
 #define OPENTELEMETRY_ABI_VERSION_NO 1
-#define OPENTELEMETRY_VERSION "1.4.0"
+#define OPENTELEMETRY_VERSION "1.4.1"
 #define OPENTELEMETRY_ABI_VERSION OPENTELEMETRY_STRINGIFY(OPENTELEMETRY_ABI_VERSION_NO)
 
 // clang-format off

--- a/docs/public/conf.py
+++ b/docs/public/conf.py
@@ -21,7 +21,7 @@ copyright = '2021, OpenTelemetry authors'
 author = 'OpenTelemetry authors'
 
 # The full version, including alpha/beta/rc tags
-release = '1.4.0'
+release = '1.4.1'
 
 # Run sphinx on subprojects and copy output
 # -----------------------------------------

--- a/sdk/include/opentelemetry/sdk/version/version.h
+++ b/sdk/include/opentelemetry/sdk/version/version.h
@@ -5,7 +5,7 @@
 
 #include "opentelemetry/detail/preprocessor.h"
 
-#define OPENTELEMETRY_SDK_VERSION "1.4.0"
+#define OPENTELEMETRY_SDK_VERSION "1.4.1"
 
 #include "opentelemetry/version.h"
 

--- a/sdk/src/version/version.cc
+++ b/sdk/src/version/version.cc
@@ -1,5 +1,5 @@
 // Please DONOT touch this file.
-// Any changes done here would be overwritten during release/build.
+// Any changes done here would be overwritten by pre-commit git hook
 
 #include "opentelemetry/sdk/version/version.h"
 
@@ -8,17 +8,17 @@ namespace sdk
 {
 namespace version
 {
-const int MAJOR_VERSION     = 1;
-const int MINOR_VERSION     = 4;
-const int PATCH_VERSION     = 0;
-const char *PRE_RELEASE     = "";
-const char *BUILD_METADATA  = "";
-const int COUNT_NEW_COMMITS = 0;
-const char *BRANCH          = "";
-const char *COMMIT_HASH     = "";
-const char *SHORT_VERSION   = "";
-const char *FULL_VERSION    = "";
-const char *BUILD_DATE      = "";
-}  // namespace version
-}  // namespace sdk
+    const int MAJOR_VERSION = 1;
+    const int MINOR_VERSION = 4;
+    const int PATCH_VERSION = 1;
+    const char* PRE_RELEASE = "NONE";
+    const char* BUILD_METADATA = "NONE";
+    const int COUNT_NEW_COMMITS = 20;
+    const char* BRANCH = "pre_release_1.4.1";
+    const char* COMMIT_HASH = "7f4eaac3c296d5198e5b4be3a2222ade85551759";
+    const char* SHORT_VERSION = "1.4.0";
+    const char* FULL_VERSION = "1.4.0-NONE-NONE-20-pre_release_1.4.1-7f4eaac3c296d5198e5b4be3a2222ade85551759";
+    const char* BUILD_DATE = "Sun Jun 19 16:34:17 UTC 2022";
+}
+}
 OPENTELEMETRY_END_NAMESPACE

--- a/sdk/src/version/version.cc
+++ b/sdk/src/version/version.cc
@@ -16,9 +16,9 @@ const char *BUILD_METADATA  = "NONE";
 const int COUNT_NEW_COMMITS = 20;
 const char *BRANCH          = "pre_release_1.4.1";
 const char *COMMIT_HASH     = "7f4eaac3c296d5198e5b4be3a2222ade85551759";
-const char *SHORT_VERSION   = "1.4.0";
+const char *SHORT_VERSION   = "1.4.1";
 const char *FULL_VERSION =
-    "1.4.0-NONE-NONE-20-pre_release_1.4.1-7f4eaac3c296d5198e5b4be3a2222ade85551759";
+    "1.4.1-NONE-NONE-20-pre_release_1.4.1-7f4eaac3c296d5198e5b4be3a2222ade85551759";
 const char *BUILD_DATE = "Sun Jun 19 16:34:17 UTC 2022";
 }  // namespace version
 }  // namespace sdk

--- a/sdk/src/version/version.cc
+++ b/sdk/src/version/version.cc
@@ -8,17 +8,18 @@ namespace sdk
 {
 namespace version
 {
-    const int MAJOR_VERSION = 1;
-    const int MINOR_VERSION = 4;
-    const int PATCH_VERSION = 1;
-    const char* PRE_RELEASE = "NONE";
-    const char* BUILD_METADATA = "NONE";
-    const int COUNT_NEW_COMMITS = 20;
-    const char* BRANCH = "pre_release_1.4.1";
-    const char* COMMIT_HASH = "7f4eaac3c296d5198e5b4be3a2222ade85551759";
-    const char* SHORT_VERSION = "1.4.0";
-    const char* FULL_VERSION = "1.4.0-NONE-NONE-20-pre_release_1.4.1-7f4eaac3c296d5198e5b4be3a2222ade85551759";
-    const char* BUILD_DATE = "Sun Jun 19 16:34:17 UTC 2022";
-}
-}
+const int MAJOR_VERSION     = 1;
+const int MINOR_VERSION     = 4;
+const int PATCH_VERSION     = 1;
+const char *PRE_RELEASE     = "NONE";
+const char *BUILD_METADATA  = "NONE";
+const int COUNT_NEW_COMMITS = 20;
+const char *BRANCH          = "pre_release_1.4.1";
+const char *COMMIT_HASH     = "7f4eaac3c296d5198e5b4be3a2222ade85551759";
+const char *SHORT_VERSION   = "1.4.0";
+const char *FULL_VERSION =
+    "1.4.0-NONE-NONE-20-pre_release_1.4.1-7f4eaac3c296d5198e5b4be3a2222ade85551759";
+const char *BUILD_DATE = "Sun Jun 19 16:34:17 UTC 2022";
+}  // namespace version
+}  // namespace sdk
 OPENTELEMETRY_END_NAMESPACE


### PR DESCRIPTION
## Changes

Prepare for v1.4.1 patch release.

For significant contributions please make sure you have completed the following items:

* [x] `CHANGELOG.md` updated for non-trivial changes
* [ ] Unit tests have been added
* [ ] Changes in public API reviewed