### PR TITLE
Fix Prometheus exporter failure

### DIFF
--- a/exporters/prometheus/src/exporter.cc
+++ b/exporters/prometheus/src/exporter.cc
@@ -30,7 +30,7 @@ PrometheusExporter::PrometheusExporter(const PrometheusExporterOptions &options)
  */
 PrometheusExporter::PrometheusExporter() : is_shutdown_(false)
 {
-  collector_ = std::unique_ptr<PrometheusCollector>(new PrometheusCollector);
+  collector_ = std::unique_ptr<PrometheusCollector>(new PrometheusCollector(3));
 }
 
 /**
@@ -45,9 +45,14 @@ sdk::common::ExportResult PrometheusExporter::Export(
   {
     return sdk::common::ExportResult::kFailure;
   }
-  else if (collector_->GetCollection().size() + 1 > (size_t)collector_->GetMaxCollectionSize())
+  else if (collector_->GetCollection().size() + data.instrumentation_info_metric_data_.size() >
+           (size_t)collector_->GetMaxCollectionSize())
   {
     return sdk::common::ExportResult::kFailureFull;
+  }
+  else if (data.instrumentation_info_metric_data_.empty())
+  {
+    return sdk::common::ExportResult::kFailureInvalidArgument;
   }
   else
   {

--- a/exporters/prometheus/src/exporter_utils.cc
+++ b/exporters/prometheus/src/exporter_utils.cc
@@ -60,9 +60,17 @@ std::vector<prometheus_client::MetricFamily> PrometheusExporterUtils::TranslateT
                 nostd::get<sdk::metrics::HistogramPointData>(point_data_attr.point_data);
             auto boundaries = histogram_point_data.boundaries_;
             auto counts     = histogram_point_data.counts_;
-            SetData(std::vector<double>{nostd::get<double>(histogram_point_data.sum_),
-                                        (double)histogram_point_data.count_},
-                    boundaries, counts, "", time, &metric_family);
+            double sum      = 0.0;
+            if (nostd::holds_alternative<double>(histogram_point_data.sum_))
+            {
+              sum = nostd::get<double>(histogram_point_data.sum_);
+            }
+            else
+            {
+              sum = nostd::get<long>(histogram_point_data.sum_);
+            }
+            SetData(std::vector<double>{sum, (double)histogram_point_data.count_}, boundaries,
+                    counts, "", time, &metric_family);
           }
           else  // Counter, Untyped
           {


### PR DESCRIPTION
Fixes histogram_point_data.sum_ variant access, also limits the max_collection_size of Prometheus collector needed for unit test.

## Changes

Please provide a brief description of the changes here.

For significant contributions please make sure you have completed the following items:

* [ ] `CHANGELOG.md` updated for non-trivial changes
* [ ] Unit tests have been added
* [ ] Changes in public API reviewed