### PR TITLE
Removing reference to deprecated InstrumentationLibrary in OTLP

### DIFF
--- a/exporters/otlp/include/opentelemetry/exporters/otlp/otlp_recordable.h
+++ b/exporters/otlp/include/opentelemetry/exporters/otlp/otlp_recordable.h
@@ -30,7 +30,7 @@ public:
   const std::string GetResourceSchemaURL() const noexcept;
   const std::string GetInstrumentationLibrarySchemaURL() const noexcept;
 
-  proto::common::v1::InstrumentationLibrary GetProtoInstrumentationLibrary() const noexcept;
+  proto::common::v1::InstrumentationScope GetProtoInstrumentationScope() const noexcept;
 
   void SetIdentity(const opentelemetry::trace::SpanContext &span_context,
                    opentelemetry::trace::SpanId parent_span_id) noexcept override;

--- a/exporters/otlp/src/otlp_recordable.cc
+++ b/exporters/otlp/src/otlp_recordable.cc
@@ -62,16 +62,16 @@ const std::string OtlpRecordable::GetInstrumentationLibrarySchemaURL() const noe
   return schema_url;
 }
 
-proto::common::v1::InstrumentationLibrary OtlpRecordable::GetProtoInstrumentationLibrary()
+proto::common::v1::InstrumentationScope OtlpRecordable::GetProtoInstrumentationScope()
     const noexcept
 {
-  proto::common::v1::InstrumentationLibrary instrumentation_library;
+  proto::common::v1::InstrumentationScope instrumentation_scope;
   if (instrumentation_library_)
   {
-    instrumentation_library.set_name(instrumentation_library_->GetName());
-    instrumentation_library.set_version(instrumentation_library_->GetVersion());
+    instrumentation_scope.set_name(instrumentation_library_->GetName());
+    instrumentation_scope.set_version(instrumentation_library_->GetVersion());
   }
-  return instrumentation_library;
+  return instrumentation_scope;
 }
 
 void OtlpRecordable::SetResource(const sdk::resource::Resource &resource) noexcept

--- a/exporters/otlp/src/otlp_recordable_utils.cc
+++ b/exporters/otlp/src/otlp_recordable_utils.cc
@@ -60,12 +60,12 @@ void OtlpRecordableUtils::PopulateRequest(
   {
     auto rec = std::unique_ptr<OtlpRecordable>(static_cast<OtlpRecordable *>(recordable.release()));
     auto resource_span       = request->add_resource_spans();
-    auto instrumentation_lib = resource_span->add_instrumentation_library_spans();
+    auto scope_spans = resource_span->add_scope_spans();
 
-    *instrumentation_lib->add_spans()                       = std::move(rec->span());
-    *instrumentation_lib->mutable_instrumentation_library() = rec->GetProtoInstrumentationLibrary();
+    *scope_spans->add_spans()                       = std::move(rec->span());
+    *scope_spans->mutable_scope() = rec->GetProtoInstrumentationScope();
 
-    instrumentation_lib->set_schema_url(rec->GetInstrumentationLibrarySchemaURL());
+    scope_spans->set_schema_url(rec->GetInstrumentationLibrarySchemaURL());
 
     *resource_span->mutable_resource() = rec->ProtoResource();
     resource_span->set_schema_url(rec->GetResourceSchemaURL());

--- a/exporters/otlp/test/otlp_recordable_test.cc
+++ b/exporters/otlp/test/otlp_recordable_test.cc
@@ -64,7 +64,7 @@ TEST(OtlpRecordable, SetInstrumentationLibrary)
   OtlpRecordable rec;
   auto inst_lib = trace_sdk::InstrumentationLibrary::Create("test", "v1");
   rec.SetInstrumentationLibrary(*inst_lib);
-  auto proto_instr_libr = rec.GetProtoInstrumentationLibrary();
+  auto proto_instr_libr = rec.GetProtoInstrumentationScope();
   EXPECT_EQ(proto_instr_libr.name(), inst_lib->GetName());
   EXPECT_EQ(proto_instr_libr.version(), inst_lib->GetVersion());
 }


### PR DESCRIPTION
Fixes #1381 

We upgraded OTLP proto files to 0.17.0, but we are still using `InstrumentationLibrary` in the OTLP message which was marked as deprecated, and this deprecated field is not compatible with previous OTLP message in wired format.

This PR replaces `InstrumentationLibrary` by `InstrumentationScope` in the OTLP exporter to fix the broken compatibility. Fix for the SDK is expected to be in future PR.

## Changes

Please provide a brief description of the changes here.

For significant contributions please make sure you have completed the following items:

* [ ] `CHANGELOG.md` updated for non-trivial changes
* [ ] Unit tests have been added
* [ ] Changes in public API reviewed