### PR TITLE
Fix otlp grpc exporter example in the documentation

### DIFF
--- a/docs/public/sdk/GettingStarted.rst
+++ b/docs/public/sdk/GettingStarted.rst
@@ -58,7 +58,7 @@ OpenTelemetry offers six tracing exporters out of the box:
 
     // otlp grpc exporter
     opentelemetry::exporter::otlp::OtlpGrpcExporterOptions opts;
-    opts.endpoint = "localhost::4317";
+    opts.endpoint = "localhost:4317";
     opts.use_ssl_credentials = true;
     opts.ssl_credentials_cacert_as_string = "ssl-certificate";
     auto otlp_grpc_exporter =


### PR DESCRIPTION
The value for `opts.endpoint` for otlp grpc exporter had an extra colon that would cause an exception if used as is.

Fixes # (issue)

## Changes

Minor fix to an example in the opentelemetry-cpp documentation.

For significant contributions please make sure you have completed the following items:

* [ ] `CHANGELOG.md` updated for non-trivial changes
* [ ] Unit tests have been added
* [ ] Changes in public API reviewed