### PR TITLE
[Metrics] Add OTLP http metric exporter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ Increment the:
 
 * [TRACE SDK] Add trace sdk builders (#1393) [#1471](https://github.com/open-telemetry/opentelemetry-cpp/pull/1471)
 * [EXAMPLE] Fix memory ownership of InMemorySpanExporter (#1473) [#1471](https://github.com/open-telemetry/opentelemetry-cpp/pull/1471)
+* [EXPORTER] Add metrics OTLP/HTTP exporter [#1487](https://github.com/open-telemetry/opentelemetry-cpp/pull/1487)
 * [EXPORTER] OTLP http exporter allow concurrency session ([#1209](https://github.com/open-telemetry/opentelemetry-cpp/pull/1209))
 * [EXT] `curl::HttpClient` use `curl_multi_handle` instead of creating a thread
   for every request and it's able to reuse connections now. ([#1317](https://github.com/open-telemetry/opentelemetry-cpp/pull/1317))

--- a/cmake/opentelemetry-cpp-config.cmake.in
+++ b/cmake/opentelemetry-cpp-config.cmake.in
@@ -32,9 +32,11 @@
 #   opentelemetry-cpp::otlp_recordable                - Imported target of opentelemetry-cpp::otlp_recordable
 #   opentelemetry-cpp::otlp_grpc_exporter             - Imported target of opentelemetry-cpp::otlp_grpc_exporter
 #   opentelemetry-cpp::otlp_grpc_log_exporter         - Imported target of opentelemetry-cpp::otlp_grpc_log_exporter
+#   opentelemetry-cpp::otlp_grpc_metrics_exporter     - Imported target of opentelemetry-cpp::otlp_grpc_metrics_exporter
 #   opentelemetry-cpp::otlp_http_client               - Imported target of opentelemetry-cpp::otlp_http_client
 #   opentelemetry-cpp::otlp_http_exporter             - Imported target of opentelemetry-cpp::otlp_http_exporter
 #   opentelemetry-cpp::otlp_http_log_exporter         - Imported target of opentelemetry-cpp::otlp_http_log_exporter
+#   opentelemetry-cpp::otlp_http_metric_exporter      - Imported target of opentelemetry-cpp::otlp_http_metric_exporter
 #   opentelemetry-cpp::ostream_log_exporter           - Imported target of opentelemetry-cpp::ostream_log_exporter
 #   opentelemetry-cpp::ostream_metrics_exporter       - Imported target of opentelemetry-cpp::ostream_metrics_exporter
 #   opentelemetry-cpp::ostream_span_exporter          - Imported target of opentelemetry-cpp::ostream_span_exporter
@@ -84,9 +86,12 @@ set(_OPENTELEMETRY_CPP_LIBRARIES_TEST_TARGETS
     in_memory_span_exporter
     otlp_recordable
     otlp_grpc_exporter
+    otlp_grpc_log_exporter
+    otlp_grpc_metrics_exporter
     otlp_http_client
     otlp_http_exporter
     otlp_http_log_exporter
+    otlp_http_metric_exporter
     ostream_log_exporter
     ostream_metrics_exporter
     ostream_span_exporter

--- a/exporters/otlp/BUILD
+++ b/exporters/otlp/BUILD
@@ -231,7 +231,10 @@ cc_test(
 
 cc_test(
     name = "otlp_log_recordable_test",
-    srcs = ["test/otlp_log_recordable_test.cc"],
+    srcs = [
+        "test/otlp_log_recordable_test.cc",
+        "test/otlp_metrics_serialization_test.cc",
+    ],
     tags = [
         "otlp",
         "test",

--- a/exporters/otlp/BUILD
+++ b/exporters/otlp/BUILD
@@ -41,6 +41,7 @@ cc_library(
         "//sdk/src/resource",
         "//sdk/src/trace",
         "@com_github_opentelemetry_proto//:logs_service_proto_cc",
+        "@com_github_opentelemetry_proto//:metrics_service_proto_cc",
         "@com_github_opentelemetry_proto//:trace_service_proto_cc",
     ],
 )

--- a/exporters/otlp/BUILD
+++ b/exporters/otlp/BUILD
@@ -20,12 +20,14 @@ cc_library(
     name = "otlp_recordable",
     srcs = [
         "src/otlp_log_recordable.cc",
+        "src/otlp_metric_utils.cc",
         "src/otlp_populate_attribute_utils.cc",
         "src/otlp_recordable.cc",
         "src/otlp_recordable_utils.cc",
     ],
     hdrs = [
         "include/opentelemetry/exporters/otlp/otlp_log_recordable.h",
+        "include/opentelemetry/exporters/otlp/otlp_metric_utils.h",
         "include/opentelemetry/exporters/otlp/otlp_populate_attribute_utils.h",
         "include/opentelemetry/exporters/otlp/otlp_recordable.h",
         "include/opentelemetry/exporters/otlp/otlp_recordable_utils.h",
@@ -162,6 +164,30 @@ cc_library(
 )
 
 cc_library(
+    name = "otlp_http_metric_exporter",
+    srcs = [
+        "src/otlp_http_metric_exporter.cc",
+    ],
+    hdrs = [
+        "include/opentelemetry/exporters/otlp/otlp_environment.h",
+        "include/opentelemetry/exporters/otlp/otlp_http_metric_exporter.h",
+        "include/opentelemetry/exporters/otlp/protobuf_include_prefix.h",
+        "include/opentelemetry/exporters/otlp/protobuf_include_suffix.h",
+    ],
+    strip_include_prefix = "include",
+    tags = [
+        "otlp",
+        "otlp_http_metric",
+    ],
+    deps = [
+        ":otlp_http_client",
+        ":otlp_recordable",
+        "//sdk/src/metrics",
+        "@com_github_opentelemetry_proto//:metrics_service_proto_cc",
+    ],
+)
+
+cc_library(
     name = "otlp_grpc_log_exporter",
     srcs = [
         "src/otlp_grpc_log_exporter.cc",
@@ -288,6 +314,22 @@ cc_test(
     ],
     deps = [
         ":otlp_http_log_exporter",
+        "//api",
+        "//ext/src/http/client/nosend:http_client_nosend",
+        "@com_google_googletest//:gtest_main",
+    ],
+)
+
+cc_test(
+    name = "otlp_http_metric_exporter_test",
+    srcs = ["test/otlp_http_metric_exporter_test.cc"],
+    tags = [
+        "otlp",
+        "otlp_http_metric",
+        "test",
+    ],
+    deps = [
+        ":otlp_http_metric_exporter",
         "//api",
         "//ext/src/http/client/nosend:http_client_nosend",
         "@com_google_googletest//:gtest_main",

--- a/exporters/otlp/CMakeLists.txt
+++ b/exporters/otlp/CMakeLists.txt
@@ -255,5 +255,22 @@ if(BUILD_TESTING)
         TEST_PREFIX exporter.otlp.
         TEST_LIST otlp_http_log_exporter_test)
     endif()
+
+    if(NOT WITH_METRICS_PREVIEW)
+      add_executable(otlp_http_metric_exporter_test
+                     test/otlp_http_metric_exporter_test.cc)
+      target_link_libraries(
+        otlp_http_metric_exporter_test
+        ${GTEST_BOTH_LIBRARIES}
+        ${CMAKE_THREAD_LIBS_INIT}
+        ${GMOCK_LIB}
+        opentelemetry_exporter_otlp_http_metric
+        opentelemetry_metrics
+        http_client_nosend)
+      gtest_add_tests(
+        TARGET otlp_http_metric_exporter_test
+        TEST_PREFIX exporter.otlp.
+        TEST_LIST otlp_http_metric_exporter_test)
+    endif()
   endif()
 endif() # BUILD_TESTING

--- a/exporters/otlp/CMakeLists.txt
+++ b/exporters/otlp/CMakeLists.txt
@@ -104,6 +104,21 @@ if(WITH_OTLP_HTTP)
     list(APPEND OPENTELEMETRY_OTLP_TARGETS opentelemetry_exporter_otlp_http_log)
 
   endif()
+  if(NOT WITH_METRICS_PREVIEW)
+    add_library(opentelemetry_exporter_otlp_http_metric
+                src/otlp_http_metric_exporter.cc)
+
+    set_target_properties(opentelemetry_exporter_otlp_http_metric
+                          PROPERTIES EXPORT_NAME otlp_http_metric_exporter)
+
+    target_link_libraries(
+      opentelemetry_exporter_otlp_http_metric
+      PUBLIC opentelemetry_otlp_recordable
+             opentelemetry_exporter_otlp_http_client)
+
+    list(APPEND OPENTELEMETRY_OTLP_TARGETS
+         opentelemetry_exporter_otlp_http_metric)
+  endif()
 endif()
 
 install(

--- a/exporters/otlp/include/opentelemetry/exporters/otlp/otlp_environment.h
+++ b/exporters/otlp/include/opentelemetry/exporters/otlp/otlp_environment.h
@@ -266,6 +266,53 @@ inline OtlpHeaders GetOtlpDefaultLogHeaders()
 
   return result;
 }
+
+inline const std::string GetOtlpDefaultHttpMetricEndpoint()
+{
+  constexpr char kOtlpMetricsEndpointEnv[] = "OTEL_EXPORTER_OTLP_METRICS_ENDPOINT";
+  constexpr char kOtlpEndpointEnv[]        = "OTEL_EXPORTER_OTLP_ENDPOINT";
+  constexpr char kOtlpEndpointDefault[]    = "http://localhost:4318/v1/metrics";
+
+  auto endpoint = opentelemetry::sdk::common::GetEnvironmentVariable(kOtlpMetricsEndpointEnv);
+  if (endpoint.empty())
+  {
+    endpoint = opentelemetry::sdk::common::GetEnvironmentVariable(kOtlpEndpointEnv);
+    if (!endpoint.empty())
+    {
+      endpoint += "/v1/metrics";
+    }
+  }
+  return endpoint.size() ? endpoint : kOtlpEndpointDefault;
+}
+
+inline const std::chrono::system_clock::duration GetOtlpDefaultMetricTimeout()
+{
+  constexpr char kOtlpMetricsTimeoutEnv[] = "OTEL_EXPORTER_OTLP_METRICS_TIMEOUT";
+  constexpr char kOtlpTimeoutEnv[]        = "OTEL_EXPORTER_OTLP_TIMEOUT";
+
+  auto timeout = opentelemetry::sdk::common::GetEnvironmentVariable(kOtlpMetricsTimeoutEnv);
+  if (timeout.empty())
+  {
+    timeout = opentelemetry::sdk::common::GetEnvironmentVariable(kOtlpTimeoutEnv);
+  }
+  return GetOtlpTimeoutFromString(timeout.c_str());
+}
+
+inline OtlpHeaders GetOtlpDefaultMetricHeaders()
+{
+  constexpr char kOtlpMetricsHeadersEnv[] = "OTEL_EXPORTER_OTLP_METRICS_HEADERS";
+  constexpr char kOtlpHeadersEnv[]        = "OTEL_EXPORTER_OTLP_HEADERS";
+
+  OtlpHeaders result;
+  std::unordered_set<std::string> metric_remove_cache;
+  DumpOtlpHeaders(result, kOtlpHeadersEnv, metric_remove_cache);
+
+  metric_remove_cache.clear();
+  DumpOtlpHeaders(result, kOtlpMetricsHeadersEnv, metric_remove_cache);
+
+  return result;
+}
+
 }  // namespace otlp
 }  // namespace exporter
 OPENTELEMETRY_END_NAMESPACE

--- a/exporters/otlp/include/opentelemetry/exporters/otlp/otlp_http_client.h
+++ b/exporters/otlp/include/opentelemetry/exporters/otlp/otlp_http_client.h
@@ -139,6 +139,11 @@ public:
       std::size_t max_running_requests) noexcept;
 
   /**
+   * Force flush the HTTP client.
+   */
+  bool ForceFlush(std::chrono::microseconds timeout = (std::chrono::microseconds::max)()) noexcept;
+
+  /**
    * Shut down the HTTP client.
    * @param timeout an optional timeout, the default timeout of 0 means that no
    * timeout is applied.
@@ -158,6 +163,12 @@ public:
    * @return options of current OTLP http client.
    */
   inline const OtlpHttpClientOptions &GetOptions() const noexcept { return options_; }
+
+  /**
+   * Get if this OTLP http client is shutdown.
+   * @return return true after Shutdown is called.
+   */
+  bool IsShutdown() const noexcept;
 
 private:
   struct HttpSessionData
@@ -212,11 +223,11 @@ private:
    */
   bool cleanupGCSessions() noexcept;
 
-  bool isShutdown() const noexcept;
-
   // For testing
   friend class OtlpHttpExporterTestPeer;
   friend class OtlpHttpLogExporterTestPeer;
+  friend class OtlpHttpMetricExporterTestPeer;
+
   /**
    * Create an OtlpHttpClient using the specified http client.
    * Only tests can call this constructor directly.

--- a/exporters/otlp/include/opentelemetry/exporters/otlp/otlp_http_exporter.h
+++ b/exporters/otlp/include/opentelemetry/exporters/otlp/otlp_http_exporter.h
@@ -59,7 +59,8 @@ public:
    * timeout is applied.
    * @return return the status of this operation
    */
-  bool Shutdown(std::chrono::microseconds timeout = std::chrono::microseconds(0)) noexcept override;
+  bool Shutdown(
+      std::chrono::microseconds timeout = std::chrono::microseconds::max()) noexcept override;
 
 private:
   // The configuration options associated with this exporter.

--- a/exporters/otlp/include/opentelemetry/exporters/otlp/otlp_http_metric_exporter.h
+++ b/exporters/otlp/include/opentelemetry/exporters/otlp/otlp_http_metric_exporter.h
@@ -82,6 +82,12 @@ public:
   opentelemetry::sdk::common::ExportResult Export(
       const opentelemetry::sdk::metrics::ResourceMetrics &data) noexcept override;
 
+  /**
+   * Force flush the exporter.
+   */
+  bool ForceFlush(
+      std::chrono::microseconds timeout = (std::chrono::microseconds::max)()) noexcept override;
+
   bool Shutdown(
       std::chrono::microseconds timeout = (std::chrono::microseconds::max)()) noexcept override;
 

--- a/exporters/otlp/include/opentelemetry/exporters/otlp/otlp_http_metric_exporter.h
+++ b/exporters/otlp/include/opentelemetry/exporters/otlp/otlp_http_metric_exporter.h
@@ -2,9 +2,9 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #pragma once
-#ifdef ENABLE_LOGS_PREVIEW
+#ifndef ENABLE_METRICS_PREVIEW
 
-#  include "opentelemetry/sdk/logs/exporter.h"
+#  include "opentelemetry/sdk/metrics/metric_exporter.h"
 
 #  include "opentelemetry/exporters/otlp/otlp_http_client.h"
 
@@ -24,13 +24,13 @@ namespace otlp
 /**
  * Struct to hold OTLP exporter options.
  */
-struct OtlpHttpLogExporterOptions
+struct OtlpHttpMetricExporterOptions
 {
   // The endpoint to export to. By default
   // @see
   // https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/protocol/otlp.md
   // @see https://github.com/open-telemetry/opentelemetry-collector/tree/main/receiver/otlpreceiver
-  std::string url = GetOtlpDefaultHttpLogEndpoint();
+  std::string url = GetOtlpDefaultHttpMetricEndpoint();
 
   // By default, post json data
   HttpRequestContentType content_type = HttpRequestContentType::kJson;
@@ -47,10 +47,10 @@ struct OtlpHttpLogExporterOptions
   bool console_debug = false;
 
   // TODO: Enable/disable to verify SSL certificate
-  std::chrono::system_clock::duration timeout = GetOtlpDefaultLogTimeout();
+  std::chrono::system_clock::duration timeout = GetOtlpDefaultMetricTimeout();
 
   // Additional HTTP headers
-  OtlpHeaders http_headers = GetOtlpDefaultLogHeaders();
+  OtlpHeaders http_headers = GetOtlpDefaultMetricHeaders();
 
 #  ifdef ENABLE_ASYNC_EXPORT
   // Concurrent requests
@@ -63,57 +63,43 @@ struct OtlpHttpLogExporterOptions
 };
 
 /**
- * The OTLP exporter exports log data in OpenTelemetry Protocol (OTLP) format.
+ * The OTLP exporter exports metrics data in OpenTelemetry Protocol (OTLP) format in HTTP.
  */
-class OtlpHttpLogExporter final : public opentelemetry::sdk::logs::LogExporter
+class OtlpHttpMetricExporter final : public opentelemetry::sdk::metrics::MetricExporter
 {
 public:
   /**
-   * Create an OtlpHttpLogExporter with default exporter options.
+   * Create an OtlpHttpMetricExporter with default exporter options.
    */
-  OtlpHttpLogExporter();
+  OtlpHttpMetricExporter();
 
   /**
-   * Create an OtlpHttpLogExporter with user specified options.
+   * Create an OtlpHttpMetricExporter with user specified options.
    * @param options An object containing the user's configuration options.
    */
-  OtlpHttpLogExporter(const OtlpHttpLogExporterOptions &options);
+  OtlpHttpMetricExporter(const OtlpHttpMetricExporterOptions &options);
 
-  /**
-   * Creates a recordable that stores the data in a JSON object
-   */
-  std::unique_ptr<opentelemetry::sdk::logs::Recordable> MakeRecordable() noexcept override;
-
-  /**
-   * Exports a vector of log records to the Elasticsearch instance. Guaranteed to return after a
-   * timeout specified from the options passed from the constructor.
-   * @param records A list of log records to send to Elasticsearch.
-   */
   opentelemetry::sdk::common::ExportResult Export(
-      const nostd::span<std::unique_ptr<opentelemetry::sdk::logs::Recordable>> &records) noexcept
-      override;
+      const opentelemetry::sdk::metrics::ResourceMetrics &data) noexcept override;
 
-  /**
-   * Shutdown this exporter.
-   * @param timeout The maximum time to wait for the shutdown method to return
-   */
   bool Shutdown(
-      std::chrono::microseconds timeout = std::chrono::microseconds::max()) noexcept override;
+      std::chrono::microseconds timeout = (std::chrono::microseconds::max)()) noexcept override;
 
 private:
   // Configuration options for the exporter
-  const OtlpHttpLogExporterOptions options_;
+  const OtlpHttpMetricExporterOptions options_;
 
   // Object that stores the HTTP sessions that have been created
   std::unique_ptr<OtlpHttpClient> http_client_;
   // For testing
-  friend class OtlpHttpLogExporterTestPeer;
+  friend class OtlpHttpMetricExporterTestPeer;
+
   /**
-   * Create an OtlpHttpLogExporter using the specified http client.
+   * Create an OtlpHttpMetricExporter using the specified http client.
    * Only tests can call this constructor directly.
    * @param http_client the http client to be used for exporting
    */
-  OtlpHttpLogExporter(std::unique_ptr<OtlpHttpClient> http_client);
+  OtlpHttpMetricExporter(std::unique_ptr<OtlpHttpClient> http_client);
 };
 }  // namespace otlp
 }  // namespace exporter

--- a/exporters/otlp/include/opentelemetry/exporters/otlp/otlp_metric_utils.h
+++ b/exporters/otlp/include/opentelemetry/exporters/otlp/otlp_metric_utils.h
@@ -38,6 +38,9 @@ public:
   static void ConvertHistogramMetric(const opentelemetry::sdk::metrics::MetricData &metric_data,
                                      proto::metrics::v1::Histogram *const histogram) noexcept;
 
+  static void ConvertGaugeMetric(const opentelemetry::sdk::metrics::MetricData &metric_data,
+                                 proto::metrics::v1::Gauge *const gauge) noexcept;
+
   static void PopulateInstrumentationInfoMetric(
       const opentelemetry::sdk::metrics::MetricData &metric_data,
       proto::metrics::v1::Metric *metric) noexcept;

--- a/exporters/otlp/src/otlp_http_exporter.cc
+++ b/exporters/otlp/src/otlp_http_exporter.cc
@@ -67,6 +67,11 @@ std::unique_ptr<opentelemetry::sdk::trace::Recordable> OtlpHttpExporter::MakeRec
 opentelemetry::sdk::common::ExportResult OtlpHttpExporter::Export(
     const nostd::span<std::unique_ptr<opentelemetry::sdk::trace::Recordable>> &spans) noexcept
 {
+  if (http_client_->IsShutdown())
+  {
+    return opentelemetry::sdk::common::ExportResult::kFailure;
+  }
+
   if (spans.empty())
   {
     return opentelemetry::sdk::common::ExportResult::kSuccess;

--- a/exporters/otlp/src/otlp_http_exporter.cc
+++ b/exporters/otlp/src/otlp_http_exporter.cc
@@ -69,6 +69,9 @@ opentelemetry::sdk::common::ExportResult OtlpHttpExporter::Export(
 {
   if (http_client_->IsShutdown())
   {
+    std::size_t span_count = spans.size();
+    OTEL_INTERNAL_LOG_ERROR("[OTLP HTTP Client] ERROR: Export "
+                            << span_count << " trace span(s) failed, exporter is shutdown");
     return opentelemetry::sdk::common::ExportResult::kFailure;
   }
 

--- a/exporters/otlp/src/otlp_http_log_exporter.cc
+++ b/exporters/otlp/src/otlp_http_log_exporter.cc
@@ -71,6 +71,9 @@ opentelemetry::sdk::common::ExportResult OtlpHttpLogExporter::Export(
 {
   if (http_client_->IsShutdown())
   {
+    std::size_t log_count = logs.size();
+    OTEL_INTERNAL_LOG_ERROR("[OTLP HTTP Client] ERROR: Export "
+                            << log_count << " log(s) failed, exporter is shutdown");
     return opentelemetry::sdk::common::ExportResult::kFailure;
   }
 

--- a/exporters/otlp/src/otlp_http_log_exporter.cc
+++ b/exporters/otlp/src/otlp_http_log_exporter.cc
@@ -69,6 +69,11 @@ std::unique_ptr<opentelemetry::sdk::logs::Recordable> OtlpHttpLogExporter::MakeR
 opentelemetry::sdk::common::ExportResult OtlpHttpLogExporter::Export(
     const nostd::span<std::unique_ptr<opentelemetry::sdk::logs::Recordable>> &logs) noexcept
 {
+  if (http_client_->IsShutdown())
+  {
+    return opentelemetry::sdk::common::ExportResult::kFailure;
+  }
+
   if (logs.empty())
   {
     return opentelemetry::sdk::common::ExportResult::kSuccess;

--- a/exporters/otlp/src/otlp_http_metric_exporter.cc
+++ b/exporters/otlp/src/otlp_http_metric_exporter.cc
@@ -1,0 +1,115 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef ENABLE_METRICS_PREVIEW
+
+#  include "opentelemetry/exporters/otlp/otlp_http_metric_exporter.h"
+#  include "opentelemetry/exporters/otlp/otlp_metrics_utils.h"
+
+#  include "opentelemetry/exporters/otlp/protobuf_include_prefix.h"
+
+#  include "opentelemetry/proto/collector/metrics/v1/metrics_service.pb.h"
+
+#  include "opentelemetry/exporters/otlp/protobuf_include_suffix.h"
+
+#  include "opentelemetry/sdk/common/global_log_handler.h"
+
+namespace nostd = opentelemetry::nostd;
+
+OPENTELEMETRY_BEGIN_NAMESPACE
+namespace exporter
+{
+namespace otlp
+{
+
+OtlpHttpMetricExporter::OtlpHttpMetricExporter()
+    : OtlpHttpMetricExporter(OtlpHttpMetricExporterOptions())
+{}
+
+OtlpHttpMetricExporter::OtlpHttpMetricExporter(const OtlpHttpMetricExporterOptions &options)
+    : options_(options),
+      http_client_(new OtlpHttpClient(OtlpHttpClientOptions(options.url,
+                                                            options.content_type,
+                                                            options.json_bytes_mapping,
+                                                            options.use_json_name,
+                                                            options.console_debug,
+                                                            options.timeout,
+                                                            options.http_headers
+#  ifdef ENABLE_ASYNC_EXPORT
+                                                            ,
+                                                            options.max_concurrent_requests,
+                                                            options.max_requests_per_connection
+#  endif
+                                                            )))
+{}
+
+OtlpHttpMetricExporter::OtlpHttpMetricExporter(std::unique_ptr<OtlpHttpClient> http_client)
+    : options_(OtlpHttpMetricExporterOptions()), http_client_(std::move(http_client))
+{
+  OtlpHttpMetricExporterOptions &options = const_cast<OtlpHttpMetricExporterOptions &>(options_);
+  options.url                            = http_client_->GetOptions().url;
+  options.content_type                   = http_client_->GetOptions().content_type;
+  options.json_bytes_mapping             = http_client_->GetOptions().json_bytes_mapping;
+  options.use_json_name                  = http_client_->GetOptions().use_json_name;
+  options.console_debug                  = http_client_->GetOptions().console_debug;
+  options.timeout                        = http_client_->GetOptions().timeout;
+  options.http_headers                   = http_client_->GetOptions().http_headers;
+#  ifdef ENABLE_ASYNC_EXPORT
+  options.max_concurrent_requests     = http_client_->GetOptions().max_concurrent_requests;
+  options.max_requests_per_connection = http_client_->GetOptions().max_requests_per_connection;
+#  endif
+}
+// ----------------------------- Exporter methods ------------------------------
+
+opentelemetry::sdk::common::ExportResult OtlpHttpMetricExporter::Export(
+    const opentelemetry::sdk::metrics::ResourceMetrics &data) noexcept
+{
+  if (data.instrumentation_info_metric_data_.empty())
+  {
+    return opentelemetry::sdk::common::ExportResult::kSuccess;
+  }
+  proto::collector::metrics::v1::ExportMetricsServiceRequest service_request;
+  OtlpMetricsUtils::PopulateRequest(data, &service_request);
+  std::size_t metric_count = data.instrumentation_info_metric_data_.size();
+#  ifdef ENABLE_ASYNC_EXPORT
+  http_client_->Export(service_request, [metric_count](
+                                            opentelemetry::sdk::common::ExportResult result) {
+    if (result != opentelemetry::sdk::common::ExportResult::kSuccess)
+    {
+      OTEL_INTERNAL_LOG_ERROR("[OTLP HTTP Client] ERROR: Export "
+                              << metric_count << " metric(s) error: " << static_cast<int>(result));
+    }
+    else
+    {
+      OTEL_INTERNAL_LOG_DEBUG("[OTLP HTTP Client] DEBUG: Export " << metric_count
+                                                                  << " metric(s) success");
+    }
+    return true;
+  });
+  return opentelemetry::sdk::common::ExportResult::kSuccess;
+#  else
+  opentelemetry::sdk::common::ExportResult result = http_client_->Export(service_request);
+  if (result != opentelemetry::sdk::common::ExportResult::kSuccess)
+  {
+    OTEL_INTERNAL_LOG_ERROR("[OTLP HTTP Client] ERROR: Export "
+                            << metric_count << " metric(s) error: " << static_cast<int>(result));
+  }
+  else
+  {
+    OTEL_INTERNAL_LOG_DEBUG("[OTLP HTTP Client] DEBUG: Export " << metric_count
+                                                                << " metric(s) success");
+  }
+  return opentelemetry::sdk::common::ExportResult::kSuccess;
+#  endif
+}
+
+bool OtlpHttpMetricExporter::Shutdown(std::chrono::microseconds timeout) noexcept
+{
+  return http_client_->Shutdown(timeout);
+}
+
+}  // namespace otlp
+}  // namespace exporter
+OPENTELEMETRY_END_NAMESPACE
+
+#endif

--- a/exporters/otlp/src/otlp_http_metric_exporter.cc
+++ b/exporters/otlp/src/otlp_http_metric_exporter.cc
@@ -66,6 +66,9 @@ opentelemetry::sdk::common::ExportResult OtlpHttpMetricExporter::Export(
 {
   if (http_client_->IsShutdown())
   {
+    std::size_t metric_count = data.instrumentation_info_metric_data_.size();
+    OTEL_INTERNAL_LOG_ERROR("[OTLP HTTP Client] ERROR: Export "
+                            << metric_count << " metric(s) failed, exporter is shutdown");
     return opentelemetry::sdk::common::ExportResult::kFailure;
   }
 

--- a/exporters/otlp/src/otlp_metric_utils.cc
+++ b/exporters/otlp/src/otlp_metric_utils.cc
@@ -147,7 +147,8 @@ void OtlpMetricUtils::ConvertGaugeMetric(const opentelemetry::sdk::metrics::Metr
     proto::metrics::v1::NumberDataPoint *proto_gauge_point_data = gauge->add_data_points();
     proto_gauge_point_data->set_start_time_unix_nano(start_ts);
     proto_gauge_point_data->set_time_unix_nano(ts);
-    auto gauge_data = nostd::get<sdk::metrics::LastValuePointData>(point_data_with_attributes.point_data);
+    auto gauge_data =
+        nostd::get<sdk::metrics::LastValuePointData>(point_data_with_attributes.point_data);
 
     if ((nostd::holds_alternative<long>(gauge_data.value_)))
     {
@@ -197,7 +198,8 @@ void OtlpMetricUtils::PopulateResourceMetrics(
     const opentelemetry::sdk::metrics::ResourceMetrics &data,
     proto::metrics::v1::ResourceMetrics *resource_metrics) noexcept
 {
-  OtlpPopulateAttributeUtils::PopulateAttribute(resource_metrics->mutable_resource(), *(data.resource_));
+  OtlpPopulateAttributeUtils::PopulateAttribute(resource_metrics->mutable_resource(),
+                                                *(data.resource_));
 
   for (auto &instrumentation_metrics : data.instrumentation_info_metric_data_)
   {
@@ -206,7 +208,8 @@ void OtlpMetricUtils::PopulateResourceMetrics(
       continue;
     }
     auto instrumentation_lib_metrics = resource_metrics->add_instrumentation_library_metrics();
-    proto::common::v1::InstrumentationLibrary* instrumentation_library = instrumentation_lib_metrics->mutable_instrumentation_library();
+    proto::common::v1::InstrumentationLibrary *instrumentation_library =
+        instrumentation_lib_metrics->mutable_instrumentation_library();
     instrumentation_library->set_name(instrumentation_metrics.instrumentation_library_->GetName());
     instrumentation_library->set_version(
         instrumentation_metrics.instrumentation_library_->GetVersion());

--- a/exporters/otlp/test/otlp_http_exporter_test.cc
+++ b/exporters/otlp/test/otlp_http_exporter_test.cc
@@ -431,6 +431,17 @@ public:
 #  endif
 };
 
+TEST(OtlpHttpExporterTest, Shutdown)
+{
+  auto exporter = std::unique_ptr<opentelemetry::sdk::trace::SpanExporter>(new OtlpHttpExporter());
+  ASSERT_TRUE(exporter->Shutdown());
+
+  nostd::span<std::unique_ptr<opentelemetry::sdk::trace::Recordable>> spans = {};
+
+  auto result = exporter->Export(spans);
+  EXPECT_EQ(result, opentelemetry::sdk::common::ExportResult::kFailure);
+}
+
 // Create spans, let processor call Export()
 TEST_F(OtlpHttpExporterTestPeer, ExportJsonIntegrationTestSync)
 {

--- a/exporters/otlp/test/otlp_http_log_exporter_test.cc
+++ b/exporters/otlp/test/otlp_http_log_exporter_test.cc
@@ -482,6 +482,17 @@ public:
 #    endif
 };
 
+TEST(OtlpHttpLogExporterTest, Shutdown)
+{
+  auto exporter = std::unique_ptr<opentelemetry::sdk::logs::LogExporter>(new OtlpHttpLogExporter());
+  ASSERT_TRUE(exporter->Shutdown());
+
+  nostd::span<std::unique_ptr<opentelemetry::sdk::logs::Recordable>> logs = {};
+
+  auto result = exporter->Export(logs);
+  EXPECT_EQ(result, opentelemetry::sdk::common::ExportResult::kFailure);
+}
+
 // Create log records, let processor call Export()
 TEST_F(OtlpHttpLogExporterTestPeer, ExportJsonIntegrationTestSync)
 {

--- a/exporters/otlp/test/otlp_http_metric_exporter_test.cc
+++ b/exporters/otlp/test/otlp_http_metric_exporter_test.cc
@@ -4,6 +4,7 @@
 #ifndef ENABLE_METRICS_PREVIEW
 
 #  include <chrono>
+#  include <cstdlib>
 #  include <thread>
 
 #  include "opentelemetry/exporters/otlp/otlp_http_metric_exporter.h"
@@ -43,10 +44,15 @@ namespace exporter
 namespace otlp
 {
 
-template <class T, size_t N>
-static nostd::span<T, N> MakeSpan(T (&array)[N])
+template <class IntegerType>
+static IntegerType JsonToInteger(nlohmann::json value)
 {
-  return nostd::span<T, N>(array);
+  if (value.is_string())
+  {
+    return static_cast<IntegerType>(strtol(value.get<std::string>().c_str(), nullptr, 10));
+  }
+
+  return value.get<IntegerType>();
 }
 
 OtlpHttpClientOptions MakeOtlpHttpClientOptions(HttpRequestContentType content_type,
@@ -139,7 +145,7 @@ public:
     auto mock_session =
         std::static_pointer_cast<http_client::nosend::Session>(no_send_client->session_);
     EXPECT_CALL(*mock_session, SendRequest)
-        .WillOnce([&mock_session, &data, &resource](
+        .WillOnce([&mock_session](
                       std::shared_ptr<opentelemetry::ext::http::client::EventHandler> callback) {
           auto check_json =
               nlohmann::json::parse(mock_session->GetRequest()->body_, nullptr, false);
@@ -236,7 +242,7 @@ public:
         std::static_pointer_cast<http_client::nosend::Session>(no_send_client->session_);
 
     EXPECT_CALL(*mock_session, SendRequest)
-        .WillOnce([&mock_session, &data, &resource](
+        .WillOnce([&mock_session](
                       std::shared_ptr<opentelemetry::ext::http::client::EventHandler> callback) {
           opentelemetry::proto::collector::metrics::v1::ExportMetricsServiceRequest request_body;
           request_body.ParseFromArray(&mock_session->GetRequest()->body_[0],
@@ -289,6 +295,503 @@ public:
 
     exporter->ForceFlush();
   }
+
+  void ExportJsonIntegrationTestExportLastValuePointData(
+#  ifdef ENABLE_ASYNC_EXPORT
+      bool async_mode
+#  endif
+  )
+  {
+    auto mock_otlp_client =
+        OtlpHttpMetricExporterTestPeer::GetMockOtlpHttpClient(HttpRequestContentType::kJson
+#  ifdef ENABLE_ASYNC_EXPORT
+                                                              ,
+                                                              async_mode
+#  endif
+        );
+    auto mock_otlp_http_client = mock_otlp_client.first;
+    auto client                = mock_otlp_client.second;
+    auto exporter = GetExporter(std::unique_ptr<OtlpHttpClient>{mock_otlp_http_client});
+
+    opentelemetry::sdk::metrics::LastValuePointData last_value_point_data{};
+    last_value_point_data.value_              = 10.0;
+    last_value_point_data.is_lastvalue_valid_ = true;
+    last_value_point_data.sample_ts_          = opentelemetry::common::SystemTimestamp{};
+    opentelemetry::sdk::metrics::LastValuePointData last_value_point_data2{};
+    last_value_point_data2.value_              = 20l;
+    last_value_point_data2.is_lastvalue_valid_ = true;
+    last_value_point_data2.sample_ts_          = opentelemetry::common::SystemTimestamp{};
+    opentelemetry::sdk::metrics::MetricData metric_data{
+        opentelemetry::sdk::metrics::InstrumentDescriptor{
+            "metrics_library_name", "metrics_description", "metrics_unit",
+            opentelemetry::sdk::metrics::InstrumentType::kObservableGauge,
+            opentelemetry::sdk::metrics::InstrumentValueType::kDouble},
+        opentelemetry::sdk::metrics::AggregationTemporality::kDelta,
+        opentelemetry::common::SystemTimestamp{}, opentelemetry::common::SystemTimestamp{},
+        std::vector<opentelemetry::sdk::metrics::PointDataAttributes>{
+            {opentelemetry::sdk::metrics::PointAttributes{{"a1", "b1"}}, last_value_point_data},
+            {opentelemetry::sdk::metrics::PointAttributes{{"a2", "b2"}}, last_value_point_data2}}};
+
+    opentelemetry::sdk::metrics::ResourceMetrics data;
+    auto resource = opentelemetry::sdk::resource::Resource::Create(
+        opentelemetry::sdk::resource::ResourceAttributes{});
+    data.resource_ = &resource;
+    auto instrumentation_library =
+        opentelemetry::sdk::instrumentationlibrary::InstrumentationLibrary::Create("library_name",
+                                                                                   "1.5.0");
+    data.instrumentation_info_metric_data_ =
+        std::vector<opentelemetry::sdk::metrics::InstrumentationInfoMetrics>{
+            {instrumentation_library.get(),
+             std::vector<opentelemetry::sdk::metrics::MetricData>{metric_data}}};
+
+    auto no_send_client = std::static_pointer_cast<http_client::nosend::HttpClient>(client);
+    auto mock_session =
+        std::static_pointer_cast<http_client::nosend::Session>(no_send_client->session_);
+    EXPECT_CALL(*mock_session, SendRequest)
+        .WillOnce([&mock_session](
+                      std::shared_ptr<opentelemetry::ext::http::client::EventHandler> callback) {
+          auto check_json =
+              nlohmann::json::parse(mock_session->GetRequest()->body_, nullptr, false);
+
+          auto resource_metrics = *check_json["resource_metrics"].begin();
+          // auto scope_metrics    = *resource_metrics["scope_metrics"].begin();
+          // auto scope = scope_metrics["scope"];
+          auto instrumentation_library_metrics =
+              *resource_metrics["instrumentation_library_metrics"].begin();
+          auto scope = instrumentation_library_metrics["instrumentation_library"];
+          EXPECT_EQ("library_name", scope["name"].get<std::string>());
+          EXPECT_EQ("1.5.0", scope["version"].get<std::string>());
+
+          // auto metric = *scope_metrics["metrics"].begin();
+          auto metric = *instrumentation_library_metrics["metrics"].begin();
+          EXPECT_EQ("metrics_library_name", metric["name"].get<std::string>());
+          EXPECT_EQ("metrics_description", metric["description"].get<std::string>());
+          EXPECT_EQ("metrics_unit", metric["unit"].get<std::string>());
+
+          auto data_points = metric["gauge"]["data_points"];
+          EXPECT_EQ(10.0, data_points[0]["as_double"].get<double>());
+          EXPECT_EQ(20l, JsonToInteger<int64_t>(data_points[1]["as_int"]));
+
+          auto custom_header = mock_session->GetRequest()->headers_.find("Custom-Header-Key");
+          ASSERT_TRUE(custom_header != mock_session->GetRequest()->headers_.end());
+          if (custom_header != mock_session->GetRequest()->headers_.end())
+          {
+            EXPECT_EQ("Custom-Header-Value", custom_header->second);
+          }
+
+          http_client::nosend::Response response;
+          response.Finish(*callback.get());
+        });
+
+    auto result = exporter->Export(data);
+    EXPECT_EQ(result, opentelemetry::sdk::common::ExportResult::kSuccess);
+
+    exporter->ForceFlush();
+  }
+
+  void ExportBinaryIntegrationTestExportLastValuePointData(
+#  ifdef ENABLE_ASYNC_EXPORT
+      bool async_mode
+#  endif
+  )
+  {
+    auto mock_otlp_client =
+        OtlpHttpMetricExporterTestPeer::GetMockOtlpHttpClient(HttpRequestContentType::kBinary
+#  ifdef ENABLE_ASYNC_EXPORT
+                                                              ,
+                                                              async_mode
+#  endif
+        );
+    auto mock_otlp_http_client = mock_otlp_client.first;
+    auto client                = mock_otlp_client.second;
+    auto exporter = GetExporter(std::unique_ptr<OtlpHttpClient>{mock_otlp_http_client});
+
+    bool attribute_storage_bool_value[]          = {true, false, true};
+    int32_t attribute_storage_int32_value[]      = {1, 2};
+    uint32_t attribute_storage_uint32_value[]    = {3, 4};
+    int64_t attribute_storage_int64_value[]      = {5, 6};
+    uint64_t attribute_storage_uint64_value[]    = {7, 8};
+    double attribute_storage_double_value[]      = {3.2, 3.3};
+    std::string attribute_storage_string_value[] = {"vector", "string"};
+
+    opentelemetry::sdk::metrics::SumPointData sum_point_data{};
+    sum_point_data.value_ = 10.0;
+    opentelemetry::sdk::metrics::SumPointData sum_point_data2{};
+    sum_point_data2.value_ = 20.0;
+    opentelemetry::sdk::metrics::ResourceMetrics data;
+    auto resource = opentelemetry::sdk::resource::Resource::Create(
+        opentelemetry::sdk::resource::ResourceAttributes{});
+    data.resource_ = &resource;
+    auto instrumentation_library =
+        opentelemetry::sdk::instrumentationlibrary::InstrumentationLibrary::Create("library_name",
+                                                                                   "1.5.0");
+    opentelemetry::sdk::metrics::LastValuePointData last_value_point_data{};
+    last_value_point_data.value_              = 10.0;
+    last_value_point_data.is_lastvalue_valid_ = true;
+    last_value_point_data.sample_ts_          = opentelemetry::common::SystemTimestamp{};
+    opentelemetry::sdk::metrics::LastValuePointData last_value_point_data2{};
+    last_value_point_data2.value_              = 20l;
+    last_value_point_data2.is_lastvalue_valid_ = true;
+    last_value_point_data2.sample_ts_          = opentelemetry::common::SystemTimestamp{};
+    opentelemetry::sdk::metrics::MetricData metric_data{
+        opentelemetry::sdk::metrics::InstrumentDescriptor{
+            "metrics_library_name", "metrics_description", "metrics_unit",
+            opentelemetry::sdk::metrics::InstrumentType::kObservableGauge,
+            opentelemetry::sdk::metrics::InstrumentValueType::kDouble},
+        opentelemetry::sdk::metrics::AggregationTemporality::kDelta,
+        opentelemetry::common::SystemTimestamp{}, opentelemetry::common::SystemTimestamp{},
+        std::vector<opentelemetry::sdk::metrics::PointDataAttributes>{
+            {opentelemetry::sdk::metrics::PointAttributes{{"a1", "b1"}}, last_value_point_data},
+            {opentelemetry::sdk::metrics::PointAttributes{{"a2", "b2"}}, last_value_point_data2}}};
+
+    data.instrumentation_info_metric_data_ =
+        std::vector<opentelemetry::sdk::metrics::InstrumentationInfoMetrics>{
+            {instrumentation_library.get(),
+             std::vector<opentelemetry::sdk::metrics::MetricData>{metric_data}}};
+
+    auto no_send_client = std::static_pointer_cast<http_client::nosend::HttpClient>(client);
+    auto mock_session =
+        std::static_pointer_cast<http_client::nosend::Session>(no_send_client->session_);
+
+    EXPECT_CALL(*mock_session, SendRequest)
+        .WillOnce([&mock_session](
+                      std::shared_ptr<opentelemetry::ext::http::client::EventHandler> callback) {
+          opentelemetry::proto::collector::metrics::v1::ExportMetricsServiceRequest request_body;
+          request_body.ParseFromArray(&mock_session->GetRequest()->body_[0],
+                                      static_cast<int>(mock_session->GetRequest()->body_.size()));
+          // auto &scope_metrics = request_body.resource_metrics(0).scope_metrics(0);
+          // auto &scope = instrumentation_library_metrics.scope();
+          auto &instrumentation_library_metrics =
+              request_body.resource_metrics(0).instrumentation_library_metrics(0);
+          auto &scope = instrumentation_library_metrics.instrumentation_library();
+          EXPECT_EQ("library_name", scope.name());
+          EXPECT_EQ("1.5.0", scope.version());
+
+          // auto metric = *scope_metrics["metrics"].begin();
+          auto &metric = instrumentation_library_metrics.metrics(0);
+          EXPECT_EQ("metrics_library_name", metric.name());
+          EXPECT_EQ("metrics_description", metric.description());
+          EXPECT_EQ("metrics_unit", metric.unit());
+
+          auto &data_points = metric.gauge().data_points();
+          EXPECT_EQ(10.0, data_points.Get(0).as_double());
+          bool has_attributes = false;
+          for (auto &kv : data_points.Get(0).attributes())
+          {
+            if (kv.key() == "a1")
+            {
+              EXPECT_EQ("b1", kv.value().string_value());
+              has_attributes = true;
+            }
+          }
+          EXPECT_TRUE(has_attributes);
+
+          EXPECT_EQ(20, data_points.Get(1).as_int());
+          has_attributes = false;
+          for (auto &kv : data_points.Get(1).attributes())
+          {
+            if (kv.key() == "a2")
+            {
+              EXPECT_EQ("b2", kv.value().string_value());
+              has_attributes = true;
+            }
+          }
+          EXPECT_TRUE(has_attributes);
+
+          http_client::nosend::Response response;
+          response.Finish(*callback.get());
+        });
+
+    auto result = exporter->Export(data);
+    EXPECT_EQ(result, opentelemetry::sdk::common::ExportResult::kSuccess);
+
+    exporter->ForceFlush();
+  }
+
+  void ExportJsonIntegrationTestExportHistogramPointData(
+#  ifdef ENABLE_ASYNC_EXPORT
+      bool async_mode
+#  endif
+  )
+  {
+    auto mock_otlp_client =
+        OtlpHttpMetricExporterTestPeer::GetMockOtlpHttpClient(HttpRequestContentType::kJson
+#  ifdef ENABLE_ASYNC_EXPORT
+                                                              ,
+                                                              async_mode
+#  endif
+        );
+    auto mock_otlp_http_client = mock_otlp_client.first;
+    auto client                = mock_otlp_client.second;
+    auto exporter = GetExporter(std::unique_ptr<OtlpHttpClient>{mock_otlp_http_client});
+
+    opentelemetry::sdk::metrics::HistogramPointData histogram_point_data{};
+    histogram_point_data.boundaries_ = std::list<double>{10.1, 20.2, 30.2};
+    histogram_point_data.count_      = 3;
+    histogram_point_data.counts_     = {200, 300, 400, 500};
+    histogram_point_data.sum_        = 900.5;
+    opentelemetry::sdk::metrics::HistogramPointData histogram_point_data2{};
+    histogram_point_data2.boundaries_ = std::list<long>{10, 20, 30};
+    histogram_point_data2.count_      = 3;
+    histogram_point_data2.counts_     = {200, 300, 400, 500};
+    histogram_point_data2.sum_        = 900l;
+
+    opentelemetry::sdk::metrics::MetricData metric_data{
+        opentelemetry::sdk::metrics::InstrumentDescriptor{
+            "metrics_library_name", "metrics_description", "metrics_unit",
+            opentelemetry::sdk::metrics::InstrumentType::kHistogram,
+            opentelemetry::sdk::metrics::InstrumentValueType::kDouble},
+        opentelemetry::sdk::metrics::AggregationTemporality::kDelta,
+        opentelemetry::common::SystemTimestamp{}, opentelemetry::common::SystemTimestamp{},
+        std::vector<opentelemetry::sdk::metrics::PointDataAttributes>{
+            {opentelemetry::sdk::metrics::PointAttributes{{"a1", "b1"}}, histogram_point_data},
+            {opentelemetry::sdk::metrics::PointAttributes{{"a2", "b2"}}, histogram_point_data2}}};
+
+    opentelemetry::sdk::metrics::ResourceMetrics data;
+    auto resource = opentelemetry::sdk::resource::Resource::Create(
+        opentelemetry::sdk::resource::ResourceAttributes{});
+    data.resource_ = &resource;
+    auto instrumentation_library =
+        opentelemetry::sdk::instrumentationlibrary::InstrumentationLibrary::Create("library_name",
+                                                                                   "1.5.0");
+    data.instrumentation_info_metric_data_ =
+        std::vector<opentelemetry::sdk::metrics::InstrumentationInfoMetrics>{
+            {instrumentation_library.get(),
+             std::vector<opentelemetry::sdk::metrics::MetricData>{metric_data}}};
+
+    auto no_send_client = std::static_pointer_cast<http_client::nosend::HttpClient>(client);
+    auto mock_session =
+        std::static_pointer_cast<http_client::nosend::Session>(no_send_client->session_);
+    EXPECT_CALL(*mock_session, SendRequest)
+        .WillOnce([&mock_session](
+                      std::shared_ptr<opentelemetry::ext::http::client::EventHandler> callback) {
+          auto check_json =
+              nlohmann::json::parse(mock_session->GetRequest()->body_, nullptr, false);
+
+          auto resource_metrics = *check_json["resource_metrics"].begin();
+          // auto scope_metrics    = *resource_metrics["scope_metrics"].begin();
+          // auto scope = scope_metrics["scope"];
+          auto instrumentation_library_metrics =
+              *resource_metrics["instrumentation_library_metrics"].begin();
+          auto scope = instrumentation_library_metrics["instrumentation_library"];
+          EXPECT_EQ("library_name", scope["name"].get<std::string>());
+          EXPECT_EQ("1.5.0", scope["version"].get<std::string>());
+
+          // auto metric = *scope_metrics["metrics"].begin();
+          auto metric = *instrumentation_library_metrics["metrics"].begin();
+          EXPECT_EQ("metrics_library_name", metric["name"].get<std::string>());
+          EXPECT_EQ("metrics_description", metric["description"].get<std::string>());
+          EXPECT_EQ("metrics_unit", metric["unit"].get<std::string>());
+
+          auto data_points = metric["histogram"]["data_points"];
+          EXPECT_EQ(3, JsonToInteger<int64_t>(data_points[0]["count"]));
+          EXPECT_EQ(900.5, data_points[0]["sum"].get<double>());
+          EXPECT_EQ(4, data_points[0]["bucket_counts"].size());
+          if (4 == data_points[0]["bucket_counts"].size())
+          {
+            EXPECT_EQ(200, JsonToInteger<int64_t>(data_points[0]["bucket_counts"][0]));
+            EXPECT_EQ(300, JsonToInteger<int64_t>(data_points[0]["bucket_counts"][1]));
+            EXPECT_EQ(400, JsonToInteger<int64_t>(data_points[0]["bucket_counts"][2]));
+            EXPECT_EQ(500, JsonToInteger<int64_t>(data_points[0]["bucket_counts"][3]));
+          }
+          EXPECT_EQ(3, data_points[0]["explicit_bounds"].size());
+          if (3 == data_points[0]["explicit_bounds"].size())
+          {
+            EXPECT_EQ(10.1, data_points[0]["explicit_bounds"][0].get<double>());
+            EXPECT_EQ(20.2, data_points[0]["explicit_bounds"][1].get<double>());
+            EXPECT_EQ(30.2, data_points[0]["explicit_bounds"][2].get<double>());
+          }
+
+          EXPECT_EQ(3, JsonToInteger<int64_t>(data_points[1]["count"]));
+          EXPECT_EQ(900.0, data_points[1]["sum"].get<double>());
+          EXPECT_EQ(4, data_points[1]["bucket_counts"].size());
+          if (4 == data_points[1]["bucket_counts"].size())
+          {
+            EXPECT_EQ(200, JsonToInteger<int64_t>(data_points[1]["bucket_counts"][0]));
+            EXPECT_EQ(300, JsonToInteger<int64_t>(data_points[1]["bucket_counts"][1]));
+            EXPECT_EQ(400, JsonToInteger<int64_t>(data_points[1]["bucket_counts"][2]));
+            EXPECT_EQ(500, JsonToInteger<int64_t>(data_points[1]["bucket_counts"][3]));
+          }
+          EXPECT_EQ(3, data_points[1]["explicit_bounds"].size());
+          if (3 == data_points[1]["explicit_bounds"].size())
+          {
+            EXPECT_EQ(10.0, data_points[1]["explicit_bounds"][0].get<double>());
+            EXPECT_EQ(20.0, data_points[1]["explicit_bounds"][1].get<double>());
+            EXPECT_EQ(30.0, data_points[1]["explicit_bounds"][2].get<double>());
+          }
+
+          auto custom_header = mock_session->GetRequest()->headers_.find("Custom-Header-Key");
+          ASSERT_TRUE(custom_header != mock_session->GetRequest()->headers_.end());
+          if (custom_header != mock_session->GetRequest()->headers_.end())
+          {
+            EXPECT_EQ("Custom-Header-Value", custom_header->second);
+          }
+
+          http_client::nosend::Response response;
+          response.Finish(*callback.get());
+        });
+
+    auto result = exporter->Export(data);
+    EXPECT_EQ(result, opentelemetry::sdk::common::ExportResult::kSuccess);
+
+    exporter->ForceFlush();
+  }
+
+  void ExportBinaryIntegrationTestExportHistogramPointData(
+#  ifdef ENABLE_ASYNC_EXPORT
+      bool async_mode
+#  endif
+  )
+  {
+    auto mock_otlp_client =
+        OtlpHttpMetricExporterTestPeer::GetMockOtlpHttpClient(HttpRequestContentType::kBinary
+#  ifdef ENABLE_ASYNC_EXPORT
+                                                              ,
+                                                              async_mode
+#  endif
+        );
+    auto mock_otlp_http_client = mock_otlp_client.first;
+    auto client                = mock_otlp_client.second;
+    auto exporter = GetExporter(std::unique_ptr<OtlpHttpClient>{mock_otlp_http_client});
+
+    bool attribute_storage_bool_value[]          = {true, false, true};
+    int32_t attribute_storage_int32_value[]      = {1, 2};
+    uint32_t attribute_storage_uint32_value[]    = {3, 4};
+    int64_t attribute_storage_int64_value[]      = {5, 6};
+    uint64_t attribute_storage_uint64_value[]    = {7, 8};
+    double attribute_storage_double_value[]      = {3.2, 3.3};
+    std::string attribute_storage_string_value[] = {"vector", "string"};
+
+    opentelemetry::sdk::metrics::SumPointData sum_point_data{};
+    sum_point_data.value_ = 10.0;
+    opentelemetry::sdk::metrics::SumPointData sum_point_data2{};
+    sum_point_data2.value_ = 20.0;
+    opentelemetry::sdk::metrics::ResourceMetrics data;
+    auto resource = opentelemetry::sdk::resource::Resource::Create(
+        opentelemetry::sdk::resource::ResourceAttributes{});
+    data.resource_ = &resource;
+    auto instrumentation_library =
+        opentelemetry::sdk::instrumentationlibrary::InstrumentationLibrary::Create("library_name",
+                                                                                   "1.5.0");
+
+    opentelemetry::sdk::metrics::HistogramPointData histogram_point_data{};
+    histogram_point_data.boundaries_ = std::list<double>{10.1, 20.2, 30.2};
+    histogram_point_data.count_      = 3;
+    histogram_point_data.counts_     = {200, 300, 400, 500};
+    histogram_point_data.sum_        = 900.5;
+    opentelemetry::sdk::metrics::HistogramPointData histogram_point_data2{};
+    histogram_point_data2.boundaries_ = std::list<long>{10, 20, 30};
+    histogram_point_data2.count_      = 3;
+    histogram_point_data2.counts_     = {200, 300, 400, 500};
+    histogram_point_data2.sum_        = 900l;
+
+    opentelemetry::sdk::metrics::MetricData metric_data{
+        opentelemetry::sdk::metrics::InstrumentDescriptor{
+            "metrics_library_name", "metrics_description", "metrics_unit",
+            opentelemetry::sdk::metrics::InstrumentType::kHistogram,
+            opentelemetry::sdk::metrics::InstrumentValueType::kDouble},
+        opentelemetry::sdk::metrics::AggregationTemporality::kDelta,
+        opentelemetry::common::SystemTimestamp{}, opentelemetry::common::SystemTimestamp{},
+        std::vector<opentelemetry::sdk::metrics::PointDataAttributes>{
+            {opentelemetry::sdk::metrics::PointAttributes{{"a1", "b1"}}, histogram_point_data},
+            {opentelemetry::sdk::metrics::PointAttributes{{"a2", "b2"}}, histogram_point_data2}}};
+
+    data.instrumentation_info_metric_data_ =
+        std::vector<opentelemetry::sdk::metrics::InstrumentationInfoMetrics>{
+            {instrumentation_library.get(),
+             std::vector<opentelemetry::sdk::metrics::MetricData>{metric_data}}};
+
+    auto no_send_client = std::static_pointer_cast<http_client::nosend::HttpClient>(client);
+    auto mock_session =
+        std::static_pointer_cast<http_client::nosend::Session>(no_send_client->session_);
+
+    EXPECT_CALL(*mock_session, SendRequest)
+        .WillOnce([&mock_session](
+                      std::shared_ptr<opentelemetry::ext::http::client::EventHandler> callback) {
+          opentelemetry::proto::collector::metrics::v1::ExportMetricsServiceRequest request_body;
+          request_body.ParseFromArray(&mock_session->GetRequest()->body_[0],
+                                      static_cast<int>(mock_session->GetRequest()->body_.size()));
+          // auto &scope_metrics = request_body.resource_metrics(0).scope_metrics(0);
+          // auto &scope = instrumentation_library_metrics.scope();
+          auto &instrumentation_library_metrics =
+              request_body.resource_metrics(0).instrumentation_library_metrics(0);
+          auto &scope = instrumentation_library_metrics.instrumentation_library();
+          EXPECT_EQ("library_name", scope.name());
+          EXPECT_EQ("1.5.0", scope.version());
+
+          // auto metric = *scope_metrics["metrics"].begin();
+          auto &metric = instrumentation_library_metrics.metrics(0);
+          EXPECT_EQ("metrics_library_name", metric.name());
+          EXPECT_EQ("metrics_description", metric.description());
+          EXPECT_EQ("metrics_unit", metric.unit());
+
+          auto &data_points = metric.histogram().data_points();
+          EXPECT_EQ(3, data_points.Get(0).count());
+          EXPECT_EQ(900.5, data_points.Get(0).sum());
+          EXPECT_EQ(4, data_points.Get(0).bucket_counts_size());
+          if (4 == data_points.Get(0).bucket_counts_size())
+          {
+            EXPECT_EQ(200, data_points.Get(0).bucket_counts(0));
+            EXPECT_EQ(300, data_points.Get(0).bucket_counts(1));
+            EXPECT_EQ(400, data_points.Get(0).bucket_counts(2));
+            EXPECT_EQ(500, data_points.Get(0).bucket_counts(3));
+          }
+          EXPECT_EQ(3, data_points.Get(0).explicit_bounds_size());
+          if (3 == data_points.Get(0).explicit_bounds_size())
+          {
+            EXPECT_EQ(10.1, data_points.Get(0).explicit_bounds(0));
+            EXPECT_EQ(20.2, data_points.Get(0).explicit_bounds(1));
+            EXPECT_EQ(30.2, data_points.Get(0).explicit_bounds(2));
+          }
+
+          bool has_attributes = false;
+          for (auto &kv : data_points.Get(0).attributes())
+          {
+            if (kv.key() == "a1")
+            {
+              EXPECT_EQ("b1", kv.value().string_value());
+              has_attributes = true;
+            }
+          }
+          EXPECT_TRUE(has_attributes);
+
+          EXPECT_EQ(3, data_points.Get(1).count());
+          EXPECT_EQ(900l, data_points.Get(1).sum());
+          EXPECT_EQ(4, data_points.Get(1).bucket_counts_size());
+          if (4 == data_points.Get(1).bucket_counts_size())
+          {
+            EXPECT_EQ(200, data_points.Get(1).bucket_counts(0));
+            EXPECT_EQ(300, data_points.Get(1).bucket_counts(1));
+            EXPECT_EQ(400, data_points.Get(1).bucket_counts(2));
+            EXPECT_EQ(500, data_points.Get(1).bucket_counts(3));
+          }
+          EXPECT_EQ(3, data_points.Get(1).explicit_bounds_size());
+          if (3 == data_points.Get(1).explicit_bounds_size())
+          {
+            EXPECT_EQ(10, data_points.Get(1).explicit_bounds(0));
+            EXPECT_EQ(20, data_points.Get(1).explicit_bounds(1));
+            EXPECT_EQ(30, data_points.Get(1).explicit_bounds(2));
+          }
+          has_attributes = false;
+          for (auto &kv : data_points.Get(1).attributes())
+          {
+            if (kv.key() == "a2")
+            {
+              EXPECT_EQ("b2", kv.value().string_value());
+              has_attributes = true;
+            }
+          }
+          EXPECT_TRUE(has_attributes);
+
+          http_client::nosend::Response response;
+          response.Finish(*callback.get());
+        });
+
+    auto result = exporter->Export(data);
+    EXPECT_EQ(result, opentelemetry::sdk::common::ExportResult::kSuccess);
+
+    exporter->ForceFlush();
+  }
 };
 
 TEST(OtlpHttpMetricExporterTest, Shutdown)
@@ -317,6 +820,41 @@ TEST_F(OtlpHttpMetricExporterTestPeer, ExportBinaryIntegrationTestSumPointDataSy
 {
   ExportBinaryIntegrationTestExportSumPointData(false);
 }
+
+TEST_F(OtlpHttpMetricExporterTestPeer, ExportJsonIntegrationTestLastValuePointDataAsync)
+{
+  ExportJsonIntegrationTestExportLastValuePointData(true);
+}
+TEST_F(OtlpHttpMetricExporterTestPeer, ExportJsonIntegrationTestLastValuePointDataSync)
+{
+  ExportJsonIntegrationTestExportLastValuePointData(false);
+}
+TEST_F(OtlpHttpMetricExporterTestPeer, ExportBinaryIntegrationTestLastValuePointDataAsync)
+{
+  ExportBinaryIntegrationTestExportLastValuePointData(true);
+}
+TEST_F(OtlpHttpMetricExporterTestPeer, ExportBinaryIntegrationTestLastValuePointDataSync)
+{
+  ExportBinaryIntegrationTestExportLastValuePointData(false);
+}
+
+TEST_F(OtlpHttpMetricExporterTestPeer, ExportJsonIntegrationTestHistogramPointDataAsync)
+{
+  ExportJsonIntegrationTestExportHistogramPointData(true);
+}
+TEST_F(OtlpHttpMetricExporterTestPeer, ExportJsonIntegrationTestHistogramPointDataSync)
+{
+  ExportJsonIntegrationTestExportHistogramPointData(false);
+}
+TEST_F(OtlpHttpMetricExporterTestPeer, ExportBinaryIntegrationTestHistogramPointDataAsync)
+{
+  ExportBinaryIntegrationTestExportHistogramPointData(true);
+}
+TEST_F(OtlpHttpMetricExporterTestPeer, ExportBinaryIntegrationTestHistogramPointDataSync)
+{
+  ExportBinaryIntegrationTestExportHistogramPointData(false);
+}
+
 #  else
 TEST_F(OtlpHttpMetricExporterTestPeer, ExportJsonIntegrationTestSumPointData)
 {
@@ -325,6 +863,24 @@ TEST_F(OtlpHttpMetricExporterTestPeer, ExportJsonIntegrationTestSumPointData)
 TEST_F(OtlpHttpMetricExporterTestPeer, ExportBinaryIntegrationTestSumPointData)
 {
   ExportBinaryIntegrationTestExportSumPointData();
+}
+
+TEST_F(OtlpHttpMetricExporterTestPeer, ExportJsonIntegrationTestLastValuePointData)
+{
+  ExportJsonIntegrationTestExportLastValuePointData();
+}
+TEST_F(OtlpHttpMetricExporterTestPeer, ExportBinaryIntegrationTestLastValuePointData)
+{
+  ExportBinaryIntegrationTestExportLastValuePointData();
+}
+
+TEST_F(OtlpHttpMetricExporterTestPeer, ExportJsonIntegrationTestHistogramPointData)
+{
+  ExportJsonIntegrationTestExportHistogramPointData();
+}
+TEST_F(OtlpHttpMetricExporterTestPeer, ExportBinaryIntegrationTestHistogramPointData)
+{
+  ExportBinaryIntegrationTestExportHistogramPointData();
 }
 #  endif
 

--- a/exporters/otlp/test/otlp_http_metric_exporter_test.cc
+++ b/exporters/otlp/test/otlp_http_metric_exporter_test.cc
@@ -1,0 +1,451 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef ENABLE_METRICS_PREVIEW
+
+#  include <chrono>
+#  include <thread>
+
+#  include "opentelemetry/exporters/otlp/otlp_http_metric_exporter.h"
+
+#  include "opentelemetry/exporters/otlp/protobuf_include_prefix.h"
+
+#  include "opentelemetry/proto/collector/metrics/v1/metrics_service.pb.h"
+
+#  include "opentelemetry/exporters/otlp/protobuf_include_suffix.h"
+
+#  include "opentelemetry/common/key_value_iterable_view.h"
+#  include "opentelemetry/ext/http/client/http_client_factory.h"
+#  include "opentelemetry/ext/http/client/nosend/http_client_nosend.h"
+#  include "opentelemetry/ext/http/server/http_server.h"
+#  include "opentelemetry/sdk/metrics/aggregation/default_aggregation.h"
+#  include "opentelemetry/sdk/metrics/aggregation/histogram_aggregation.h"
+#  include "opentelemetry/sdk/metrics/data/metric_data.h"
+#  include "opentelemetry/sdk/metrics/instruments.h"
+#  include "opentelemetry/sdk/resource/resource.h"
+
+#  include <gtest/gtest.h>
+#  include "gmock/gmock.h"
+
+#  include "nlohmann/json.hpp"
+
+#  if defined(_MSC_VER)
+#    include "opentelemetry/sdk/common/env_variables.h"
+using opentelemetry::sdk::common::setenv;
+using opentelemetry::sdk::common::unsetenv;
+#  endif
+
+using namespace testing;
+
+OPENTELEMETRY_BEGIN_NAMESPACE
+namespace exporter
+{
+namespace otlp
+{
+
+template <class T, size_t N>
+static nostd::span<T, N> MakeSpan(T (&array)[N])
+{
+  return nostd::span<T, N>(array);
+}
+
+OtlpHttpClientOptions MakeOtlpHttpClientOptions(HttpRequestContentType content_type,
+                                                bool async_mode)
+{
+  OtlpHttpMetricExporterOptions options;
+  options.content_type  = content_type;
+  options.console_debug = true;
+  options.http_headers.insert(
+      std::make_pair<const std::string, std::string>("Custom-Header-Key", "Custom-Header-Value"));
+  OtlpHttpClientOptions otlp_http_client_options(
+      options.url, options.content_type, options.json_bytes_mapping, options.use_json_name,
+      options.console_debug, options.timeout, options.http_headers);
+  if (!async_mode)
+  {
+    otlp_http_client_options.max_concurrent_requests = 0;
+  }
+  return otlp_http_client_options;
+}
+
+namespace http_client = opentelemetry::ext::http::client;
+
+class OtlpHttpMetricExporterTestPeer : public ::testing::Test
+{
+public:
+  std::unique_ptr<opentelemetry::sdk::metrics::MetricExporter> GetExporter(
+      std::unique_ptr<OtlpHttpClient> http_client)
+  {
+    return std::unique_ptr<opentelemetry::sdk::metrics::MetricExporter>(
+        new OtlpHttpMetricExporter(std::move(http_client)));
+  }
+
+  // Get the options associated with the given exporter.
+  const OtlpHttpMetricExporterOptions &GetOptions(std::unique_ptr<OtlpHttpMetricExporter> &exporter)
+  {
+    return exporter->options_;
+  }
+  static std::pair<OtlpHttpClient *, std::shared_ptr<http_client::HttpClient>>
+  GetMockOtlpHttpClient(HttpRequestContentType content_type, bool async_mode = false)
+  {
+    auto http_client = http_client::HttpClientFactory::CreateNoSend();
+    return {new OtlpHttpClient(MakeOtlpHttpClientOptions(content_type, async_mode), http_client),
+            http_client};
+  }
+
+  void ExportJsonIntegrationTestExportSumPointData(
+#  ifdef ENABLE_ASYNC_EXPORT
+      bool async_mode
+#  endif
+  )
+  {
+    auto mock_otlp_client =
+        OtlpHttpMetricExporterTestPeer::GetMockOtlpHttpClient(HttpRequestContentType::kJson
+#  ifdef ENABLE_ASYNC_EXPORT
+                                                              ,
+                                                              async_mode
+#  endif
+        );
+    auto mock_otlp_http_client = mock_otlp_client.first;
+    auto client                = mock_otlp_client.second;
+    auto exporter = GetExporter(std::unique_ptr<OtlpHttpClient>{mock_otlp_http_client});
+
+    opentelemetry::sdk::metrics::SumPointData sum_point_data{};
+    sum_point_data.value_ = 10.0;
+    opentelemetry::sdk::metrics::SumPointData sum_point_data2{};
+    sum_point_data2.value_ = 20.0;
+    opentelemetry::sdk::metrics::ResourceMetrics data;
+    auto resource = opentelemetry::sdk::resource::Resource::Create(
+        opentelemetry::sdk::resource::ResourceAttributes{});
+    data.resource_ = &resource;
+    auto instrumentation_library =
+        opentelemetry::sdk::instrumentationlibrary::InstrumentationLibrary::Create("library_name",
+                                                                                   "1.5.0");
+    opentelemetry::sdk::metrics::MetricData metric_data{
+        opentelemetry::sdk::metrics::InstrumentDescriptor{
+            "metrics_library_name", "metrics_description", "metrics_unit",
+            opentelemetry::sdk::metrics::InstrumentType::kCounter,
+            opentelemetry::sdk::metrics::InstrumentValueType::kDouble},
+        opentelemetry::sdk::metrics::AggregationTemporality::kDelta,
+        opentelemetry::common::SystemTimestamp{}, opentelemetry::common::SystemTimestamp{},
+        std::vector<opentelemetry::sdk::metrics::PointDataAttributes>{
+            {opentelemetry::sdk::metrics::PointAttributes{{"a1", "b1"}}, sum_point_data},
+            {opentelemetry::sdk::metrics::PointAttributes{{"a2", "b2"}}, sum_point_data2}}};
+    data.instrumentation_info_metric_data_ =
+        std::vector<opentelemetry::sdk::metrics::InstrumentationInfoMetrics>{
+            {instrumentation_library.get(),
+             std::vector<opentelemetry::sdk::metrics::MetricData>{metric_data}}};
+
+    auto no_send_client = std::static_pointer_cast<http_client::nosend::HttpClient>(client);
+    auto mock_session =
+        std::static_pointer_cast<http_client::nosend::Session>(no_send_client->session_);
+    EXPECT_CALL(*mock_session, SendRequest)
+        .WillOnce([&mock_session, &data, &resource](
+                      std::shared_ptr<opentelemetry::ext::http::client::EventHandler> callback) {
+          auto check_json =
+              nlohmann::json::parse(mock_session->GetRequest()->body_, nullptr, false);
+
+          auto resource_metrics = *check_json["resource_metrics"].begin();
+          // auto scope_metrics    = *resource_metrics["scope_metrics"].begin();
+          // auto scope = scope_metrics["scope"];
+          auto instrumentation_library_metrics =
+              *resource_metrics["instrumentation_library_metrics"].begin();
+          auto scope = instrumentation_library_metrics["instrumentation_library"];
+          EXPECT_EQ("library_name", scope["name"].get<std::string>());
+          EXPECT_EQ("1.5.0", scope["version"].get<std::string>());
+
+          // auto metric = *scope_metrics["metrics"].begin();
+          auto metric = *instrumentation_library_metrics["metrics"].begin();
+          EXPECT_EQ("metrics_library_name", metric["name"].get<std::string>());
+          EXPECT_EQ("metrics_description", metric["description"].get<std::string>());
+          EXPECT_EQ("metrics_unit", metric["unit"].get<std::string>());
+
+          auto data_points = metric["sum"]["data_points"];
+          EXPECT_EQ(10.0, data_points[0]["as_double"].get<double>());
+          EXPECT_EQ(20.0, data_points[1]["as_double"].get<double>());
+
+          auto custom_header = mock_session->GetRequest()->headers_.find("Custom-Header-Key");
+          ASSERT_TRUE(custom_header != mock_session->GetRequest()->headers_.end());
+          if (custom_header != mock_session->GetRequest()->headers_.end())
+          {
+            EXPECT_EQ("Custom-Header-Value", custom_header->second);
+          }
+
+          http_client::nosend::Response response;
+          response.Finish(*callback.get());
+        });
+
+    auto result = exporter->Export(data);
+    EXPECT_EQ(result, opentelemetry::sdk::common::ExportResult::kSuccess);
+
+    exporter->ForceFlush();
+  }
+
+  void ExportBinaryIntegrationTestExportSumPointData(
+#  ifdef ENABLE_ASYNC_EXPORT
+      bool async_mode
+#  endif
+  )
+  {
+    auto mock_otlp_client =
+        OtlpHttpMetricExporterTestPeer::GetMockOtlpHttpClient(HttpRequestContentType::kBinary
+#  ifdef ENABLE_ASYNC_EXPORT
+                                                              ,
+                                                              async_mode
+#  endif
+        );
+    auto mock_otlp_http_client = mock_otlp_client.first;
+    auto client                = mock_otlp_client.second;
+    auto exporter = GetExporter(std::unique_ptr<OtlpHttpClient>{mock_otlp_http_client});
+
+    bool attribute_storage_bool_value[]          = {true, false, true};
+    int32_t attribute_storage_int32_value[]      = {1, 2};
+    uint32_t attribute_storage_uint32_value[]    = {3, 4};
+    int64_t attribute_storage_int64_value[]      = {5, 6};
+    uint64_t attribute_storage_uint64_value[]    = {7, 8};
+    double attribute_storage_double_value[]      = {3.2, 3.3};
+    std::string attribute_storage_string_value[] = {"vector", "string"};
+
+    opentelemetry::sdk::metrics::SumPointData sum_point_data{};
+    sum_point_data.value_ = 10.0;
+    opentelemetry::sdk::metrics::SumPointData sum_point_data2{};
+    sum_point_data2.value_ = 20.0;
+    opentelemetry::sdk::metrics::ResourceMetrics data;
+    auto resource = opentelemetry::sdk::resource::Resource::Create(
+        opentelemetry::sdk::resource::ResourceAttributes{});
+    data.resource_ = &resource;
+    auto instrumentation_library =
+        opentelemetry::sdk::instrumentationlibrary::InstrumentationLibrary::Create("library_name",
+                                                                                   "1.5.0");
+    opentelemetry::sdk::metrics::MetricData metric_data{
+        opentelemetry::sdk::metrics::InstrumentDescriptor{
+            "metrics_library_name", "metrics_description", "metrics_unit",
+            opentelemetry::sdk::metrics::InstrumentType::kCounter,
+            opentelemetry::sdk::metrics::InstrumentValueType::kDouble},
+        opentelemetry::sdk::metrics::AggregationTemporality::kDelta,
+        opentelemetry::common::SystemTimestamp{}, opentelemetry::common::SystemTimestamp{},
+        std::vector<opentelemetry::sdk::metrics::PointDataAttributes>{
+            {opentelemetry::sdk::metrics::PointAttributes{{"a1", "b1"}}, sum_point_data},
+            {opentelemetry::sdk::metrics::PointAttributes{{"a2", "b2"}}, sum_point_data2}}};
+    data.instrumentation_info_metric_data_ =
+        std::vector<opentelemetry::sdk::metrics::InstrumentationInfoMetrics>{
+            {instrumentation_library.get(),
+             std::vector<opentelemetry::sdk::metrics::MetricData>{metric_data}}};
+
+    auto no_send_client = std::static_pointer_cast<http_client::nosend::HttpClient>(client);
+    auto mock_session =
+        std::static_pointer_cast<http_client::nosend::Session>(no_send_client->session_);
+
+    EXPECT_CALL(*mock_session, SendRequest)
+        .WillOnce([&mock_session, &data, &resource](
+                      std::shared_ptr<opentelemetry::ext::http::client::EventHandler> callback) {
+          opentelemetry::proto::collector::metrics::v1::ExportMetricsServiceRequest request_body;
+          request_body.ParseFromArray(&mock_session->GetRequest()->body_[0],
+                                      static_cast<int>(mock_session->GetRequest()->body_.size()));
+          // auto &scope_metrics = request_body.resource_metrics(0).scope_metrics(0);
+          // auto &scope = instrumentation_library_metrics.scope();
+          auto &instrumentation_library_metrics =
+              request_body.resource_metrics(0).instrumentation_library_metrics(0);
+          auto &scope = instrumentation_library_metrics.instrumentation_library();
+          EXPECT_EQ("library_name", scope.name());
+          EXPECT_EQ("1.5.0", scope.version());
+
+          // auto metric = *scope_metrics["metrics"].begin();
+          auto &metric = instrumentation_library_metrics.metrics(0);
+          EXPECT_EQ("metrics_library_name", metric.name());
+          EXPECT_EQ("metrics_description", metric.description());
+          EXPECT_EQ("metrics_unit", metric.unit());
+
+          auto &data_points = metric.sum().data_points();
+          EXPECT_EQ(10.0, data_points.Get(0).as_double());
+          bool has_attributes = false;
+          for (auto &kv : data_points.Get(0).attributes())
+          {
+            if (kv.key() == "a1")
+            {
+              EXPECT_EQ("b1", kv.value().string_value());
+              has_attributes = true;
+            }
+          }
+          EXPECT_TRUE(has_attributes);
+
+          EXPECT_EQ(20.0, data_points.Get(1).as_double());
+          has_attributes = false;
+          for (auto &kv : data_points.Get(1).attributes())
+          {
+            if (kv.key() == "a2")
+            {
+              EXPECT_EQ("b2", kv.value().string_value());
+              has_attributes = true;
+            }
+          }
+          EXPECT_TRUE(has_attributes);
+
+          http_client::nosend::Response response;
+          response.Finish(*callback.get());
+        });
+
+    auto result = exporter->Export(data);
+    EXPECT_EQ(result, opentelemetry::sdk::common::ExportResult::kSuccess);
+
+    exporter->ForceFlush();
+  }
+};
+
+TEST(OtlpHttpMetricExporterTest, Shutdown)
+{
+  auto exporter =
+      std::unique_ptr<opentelemetry::sdk::metrics::MetricExporter>(new OtlpHttpMetricExporter());
+  ASSERT_TRUE(exporter->Shutdown());
+  auto result = exporter->Export(opentelemetry::sdk::metrics::ResourceMetrics{});
+  EXPECT_EQ(result, opentelemetry::sdk::common::ExportResult::kFailure);
+}
+
+#  ifdef ENABLE_ASYNC_EXPORT
+TEST_F(OtlpHttpMetricExporterTestPeer, ExportJsonIntegrationTestSumPointDataAsync)
+{
+  ExportJsonIntegrationTestExportSumPointData(true);
+}
+TEST_F(OtlpHttpMetricExporterTestPeer, ExportJsonIntegrationTestSumPointDataSync)
+{
+  ExportJsonIntegrationTestExportSumPointData(false);
+}
+TEST_F(OtlpHttpMetricExporterTestPeer, ExportBinaryIntegrationTestSumPointDataAsync)
+{
+  ExportBinaryIntegrationTestExportSumPointData(true);
+}
+TEST_F(OtlpHttpMetricExporterTestPeer, ExportBinaryIntegrationTestSumPointDataSync)
+{
+  ExportBinaryIntegrationTestExportSumPointData(false);
+}
+#  else
+TEST_F(OtlpHttpMetricExporterTestPeer, ExportJsonIntegrationTestSumPointData)
+{
+  ExportJsonIntegrationTestExportSumPointData();
+}
+TEST_F(OtlpHttpMetricExporterTestPeer, ExportBinaryIntegrationTestSumPointData)
+{
+  ExportBinaryIntegrationTestExportSumPointData();
+}
+#  endif
+
+// Test exporter configuration options
+TEST_F(OtlpHttpMetricExporterTestPeer, ConfigTest)
+{
+  OtlpHttpMetricExporterOptions opts;
+  opts.url = "http://localhost:45456/v1/metrics";
+  std::unique_ptr<OtlpHttpMetricExporter> exporter(new OtlpHttpMetricExporter(opts));
+  EXPECT_EQ(GetOptions(exporter).url, "http://localhost:45456/v1/metrics");
+}
+
+// Test exporter configuration options with use_json_name
+TEST_F(OtlpHttpMetricExporterTestPeer, ConfigUseJsonNameTest)
+{
+  OtlpHttpMetricExporterOptions opts;
+  opts.use_json_name = true;
+  std::unique_ptr<OtlpHttpMetricExporter> exporter(new OtlpHttpMetricExporter(opts));
+  EXPECT_EQ(GetOptions(exporter).use_json_name, true);
+}
+
+// Test exporter configuration options with json_bytes_mapping=JsonBytesMappingKind::kHex
+TEST_F(OtlpHttpMetricExporterTestPeer, ConfigJsonBytesMappingTest)
+{
+  OtlpHttpMetricExporterOptions opts;
+  opts.json_bytes_mapping = JsonBytesMappingKind::kHex;
+  std::unique_ptr<OtlpHttpMetricExporter> exporter(new OtlpHttpMetricExporter(opts));
+  EXPECT_EQ(GetOptions(exporter).json_bytes_mapping, JsonBytesMappingKind::kHex);
+}
+
+#  ifndef NO_GETENV
+// Test exporter configuration options with use_ssl_credentials
+TEST_F(OtlpHttpMetricExporterTestPeer, ConfigFromEnv)
+{
+  const std::string url = "http://localhost:9999/v1/metrics";
+  setenv("OTEL_EXPORTER_OTLP_ENDPOINT", "http://localhost:9999", 1);
+  setenv("OTEL_EXPORTER_OTLP_TIMEOUT", "20s", 1);
+  setenv("OTEL_EXPORTER_OTLP_HEADERS", "k1=v1,k2=v2", 1);
+  setenv("OTEL_EXPORTER_OTLP_METRICS_HEADERS", "k1=v3,k1=v4", 1);
+
+  std::unique_ptr<OtlpHttpMetricExporter> exporter(new OtlpHttpMetricExporter());
+  EXPECT_EQ(GetOptions(exporter).url, url);
+  EXPECT_EQ(
+      GetOptions(exporter).timeout.count(),
+      std::chrono::duration_cast<std::chrono::system_clock::duration>(std::chrono::seconds{20})
+          .count());
+  EXPECT_EQ(GetOptions(exporter).http_headers.size(), 3);
+  {
+    // Test k2
+    auto range = GetOptions(exporter).http_headers.equal_range("k2");
+    EXPECT_TRUE(range.first != range.second);
+    EXPECT_EQ(range.first->second, std::string("v2"));
+    ++range.first;
+    EXPECT_TRUE(range.first == range.second);
+  }
+  {
+    // k1
+    auto range = GetOptions(exporter).http_headers.equal_range("k1");
+    EXPECT_TRUE(range.first != range.second);
+    EXPECT_EQ(range.first->second, std::string("v3"));
+    ++range.first;
+    EXPECT_EQ(range.first->second, std::string("v4"));
+    ++range.first;
+    EXPECT_TRUE(range.first == range.second);
+  }
+
+  unsetenv("OTEL_EXPORTER_OTLP_ENDPOINT");
+  unsetenv("OTEL_EXPORTER_OTLP_TIMEOUT");
+  unsetenv("OTEL_EXPORTER_OTLP_HEADERS");
+  unsetenv("OTEL_EXPORTER_OTLP_METRICS_HEADERS");
+}
+
+TEST_F(OtlpHttpMetricExporterTestPeer, ConfigFromMetricsEnv)
+{
+  const std::string url = "http://localhost:9999/v1/metrics";
+  setenv("OTEL_EXPORTER_OTLP_METRICS_ENDPOINT", url.c_str(), 1);
+  setenv("OTEL_EXPORTER_OTLP_TIMEOUT", "20s", 1);
+  setenv("OTEL_EXPORTER_OTLP_HEADERS", "k1=v1,k2=v2", 1);
+  setenv("OTEL_EXPORTER_OTLP_METRICS_HEADERS", "k1=v3,k1=v4", 1);
+
+  std::unique_ptr<OtlpHttpMetricExporter> exporter(new OtlpHttpMetricExporter());
+  EXPECT_EQ(GetOptions(exporter).url, url);
+  EXPECT_EQ(
+      GetOptions(exporter).timeout.count(),
+      std::chrono::duration_cast<std::chrono::system_clock::duration>(std::chrono::seconds{20})
+          .count());
+  EXPECT_EQ(GetOptions(exporter).http_headers.size(), 3);
+  {
+    // Test k2
+    auto range = GetOptions(exporter).http_headers.equal_range("k2");
+    EXPECT_TRUE(range.first != range.second);
+    EXPECT_EQ(range.first->second, std::string("v2"));
+    ++range.first;
+    EXPECT_TRUE(range.first == range.second);
+  }
+  {
+    // k1
+    auto range = GetOptions(exporter).http_headers.equal_range("k1");
+    EXPECT_TRUE(range.first != range.second);
+    EXPECT_EQ(range.first->second, std::string("v3"));
+    ++range.first;
+    EXPECT_EQ(range.first->second, std::string("v4"));
+    ++range.first;
+    EXPECT_TRUE(range.first == range.second);
+  }
+
+  unsetenv("OTEL_EXPORTER_OTLP_METRICS_ENDPOINT");
+  unsetenv("OTEL_EXPORTER_OTLP_TIMEOUT");
+  unsetenv("OTEL_EXPORTER_OTLP_HEADERS");
+  unsetenv("OTEL_EXPORTER_OTLP_METRICS_HEADERS");
+}
+
+TEST_F(OtlpHttpMetricExporterTestPeer, DefaultEndpoint)
+{
+  EXPECT_EQ("http://localhost:4318/v1/metrics", GetOtlpDefaultHttpMetricEndpoint());
+}
+
+#  endif
+
+}  // namespace otlp
+}  // namespace exporter
+OPENTELEMETRY_END_NAMESPACE
+
+#endif

--- a/exporters/otlp/test/otlp_metrics_serialization_test.cc
+++ b/exporters/otlp/test/otlp_metrics_serialization_test.cc
@@ -85,7 +85,7 @@ static metrics_sdk::MetricData CreateObservableGaugeAggregationData()
   metrics_sdk::InstrumentDescriptor inst_desc = {"LastValue", "desc", "unit",
                                                  metrics_sdk::InstrumentType::kObservableGauge,
                                                  metrics_sdk::InstrumentValueType::kDouble};
-  metrics_sdk::SumPointData s_data_1, s_data_2;
+  metrics_sdk::LastValuePointData s_data_1, s_data_2;
   s_data_1.value_ = 30.2;
   s_data_2.value_ = 50.2;
 


### PR DESCRIPTION
Fixes #1371 

## Changes

- [x] Add OTLP HTTP Metrics exporter
  - [x] CMake target
  - [x] Bazel target
- [x] Unit test
- [x] Add `Shutdown` test for all OTLP HTTP exporters
- [x] Add `ForceFlush` for  `OtlpHttpClient`
- [x] Add `Gauge` support for `OtlpMetricUtils::PopulateRequest`

For significant contributions please make sure you have completed the following items:

* [x] `CHANGELOG.md` updated for non-trivial changes
* [x] Unit tests have been added
* [ ] Changes in public API reviewed