### PR TITLE
Fix #1484 (Rename OTLP gRPC metric exporter)

### DIFF
--- a/exporters/otlp/CMakeLists.txt
+++ b/exporters/otlp/CMakeLists.txt
@@ -2,7 +2,7 @@ add_library(
   opentelemetry_otlp_recordable
   src/otlp_log_recordable.cc src/otlp_recordable.cc
   src/otlp_populate_attribute_utils.cc src/otlp_recordable_utils.cc
-  src/otlp_metrics_utils.cc)
+  src/otlp_metric_utils.cc)
 set_target_properties(opentelemetry_otlp_recordable PROPERTIES EXPORT_NAME
                                                                otlp_recordable)
 

--- a/exporters/otlp/include/opentelemetry/exporters/otlp/otlp_grpc_metric_exporter.h
+++ b/exporters/otlp/include/opentelemetry/exporters/otlp/otlp_grpc_metric_exporter.h
@@ -26,18 +26,18 @@ namespace otlp
 /**
  * The OTLP exporter exports metrics data in OpenTelemetry Protocol (OTLP) format in gRPC.
  */
-class OtlpGrpcMetricsExporter : public opentelemetry::sdk::metrics::MetricExporter
+class OtlpGrpcMetricExporter : public opentelemetry::sdk::metrics::MetricExporter
 {
 public:
   /**
-   * Create an OtlpGrpcMetricsExporter using all default options.
+   * Create an OtlpGrpcMetricExporter using all default options.
    */
-  OtlpGrpcMetricsExporter();
+  OtlpGrpcMetricExporter();
 
   /**
-   * Create an OtlpGrpcMetricsExporter using the given options.
+   * Create an OtlpGrpcMetricExporter using the given options.
    */
-  explicit OtlpGrpcMetricsExporter(const OtlpGrpcMetricsExporterOptions &options);
+  explicit OtlpGrpcMetricExporter(const OtlpGrpcMetricExporterOptions &options);
 
   opentelemetry::sdk::common::ExportResult Export(
       const opentelemetry::sdk::metrics::ResourceMetrics &data) noexcept override;
@@ -50,7 +50,7 @@ public:
 
 private:
   // The configuration options associated with this exporter.
-  const OtlpGrpcMetricsExporterOptions options_;
+  const OtlpGrpcMetricExporterOptions options_;
 
   // For testing
   friend class OtlpGrpcExporterTestPeer;
@@ -60,11 +60,11 @@ private:
       metrics_service_stub_;
 
   /**
-   * Create an OtlpGrpcMetricsExporter using the specified service stub.
+   * Create an OtlpGrpcMetricExporter using the specified service stub.
    * Only tests can call this constructor directly.
    * @param stub the service stub to be used for exporting
    */
-  OtlpGrpcMetricsExporter(
+  OtlpGrpcMetricExporter(
       std::unique_ptr<proto::collector::metrics::v1::MetricsService::StubInterface> stub);
   bool is_shutdown_ = false;
   mutable opentelemetry::common::SpinLockMutex lock_;

--- a/exporters/otlp/include/opentelemetry/exporters/otlp/otlp_grpc_metric_exporter_options.h
+++ b/exporters/otlp/include/opentelemetry/exporters/otlp/otlp_grpc_metric_exporter_options.h
@@ -17,7 +17,7 @@ namespace otlp
 /**
  * Struct to hold OTLP metrics exporter options.
  */
-struct OtlpGrpcMetricsExporterOptions : public OtlpGrpcExporterOptions
+struct OtlpGrpcMetricExporterOptions : public OtlpGrpcExporterOptions
 {
   opentelemetry::sdk::metrics::AggregationTemporality aggregation_temporality =
       opentelemetry::sdk::metrics::AggregationTemporality::kDelta;

--- a/exporters/otlp/include/opentelemetry/exporters/otlp/otlp_metric_utils.h
+++ b/exporters/otlp/include/opentelemetry/exporters/otlp/otlp_metric_utils.h
@@ -21,9 +21,9 @@ namespace exporter
 namespace otlp
 {
 /**
- * The OtlpMetricsUtils contains utility functions for OTLP metrics
+ * The OtlpMetricUtils contains utility functions for OTLP metrics
  */
-class OtlpMetricsUtils
+class OtlpMetricUtils
 {
 public:
   static opentelemetry::sdk::metrics::AggregationType GetAggregationType(

--- a/exporters/otlp/src/otlp_grpc_metric_exporter.cc
+++ b/exporters/otlp/src/otlp_grpc_metric_exporter.cc
@@ -4,7 +4,7 @@
 #ifndef ENABLE_METRICS_PREVIEW
 
 #  include "opentelemetry/exporters/otlp/otlp_grpc_metric_exporter.h"
-#  include "opentelemetry/exporters/otlp/otlp_metrics_utils.h"
+#  include "opentelemetry/exporters/otlp/otlp_metric_utils.h"
 
 #  include <mutex>
 #  include "opentelemetry/ext/http/common/url_parser.h"
@@ -33,7 +33,7 @@ static std::string get_file_contents(const char *fpath)
 /**
  * Create gRPC channel from the exporter options.
  */
-static std::shared_ptr<grpc::Channel> MakeGrpcChannel(const OtlpGrpcMetricsExporterOptions &options)
+static std::shared_ptr<grpc::Channel> MakeGrpcChannel(const OtlpGrpcMetricExporterOptions &options)
 {
   std::shared_ptr<grpc::Channel> channel;
 
@@ -78,29 +78,29 @@ static std::shared_ptr<grpc::Channel> MakeGrpcChannel(const OtlpGrpcMetricsExpor
  * Create metrics service stub to communicate with the OpenTelemetry Collector.
  */
 std::unique_ptr<::opentelemetry::proto::collector::metrics::v1::MetricsService::Stub>
-MakeMetricsServiceStub(const OtlpGrpcMetricsExporterOptions &options)
+MakeMetricsServiceStub(const OtlpGrpcMetricExporterOptions &options)
 {
   return proto::collector::metrics::v1::MetricsService::NewStub(MakeGrpcChannel(options));
 }
 
 // -------------------------------- Constructors --------------------------------
 
-OtlpGrpcMetricsExporter::OtlpGrpcMetricsExporter()
-    : OtlpGrpcMetricsExporter(OtlpGrpcMetricsExporterOptions())
+OtlpGrpcMetricExporter::OtlpGrpcMetricExporter()
+    : OtlpGrpcMetricExporter(OtlpGrpcMetricExporterOptions())
 {}
 
-OtlpGrpcMetricsExporter::OtlpGrpcMetricsExporter(const OtlpGrpcMetricsExporterOptions &options)
+OtlpGrpcMetricExporter::OtlpGrpcMetricExporter(const OtlpGrpcMetricExporterOptions &options)
     : options_(options), metrics_service_stub_(MakeMetricsServiceStub(options))
 {}
 
-OtlpGrpcMetricsExporter::OtlpGrpcMetricsExporter(
+OtlpGrpcMetricExporter::OtlpGrpcMetricExporter(
     std::unique_ptr<proto::collector::metrics::v1::MetricsService::StubInterface> stub)
-    : options_(OtlpGrpcMetricsExporterOptions()), metrics_service_stub_(std::move(stub))
+    : options_(OtlpGrpcMetricExporterOptions()), metrics_service_stub_(std::move(stub))
 {}
 
 // ----------------------------- Exporter methods ------------------------------
 
-opentelemetry::sdk::common::ExportResult OtlpGrpcMetricsExporter::Export(
+opentelemetry::sdk::common::ExportResult OtlpGrpcMetricExporter::Export(
     const opentelemetry::sdk::metrics::ResourceMetrics &data) noexcept
 {
 
@@ -117,7 +117,7 @@ opentelemetry::sdk::common::ExportResult OtlpGrpcMetricsExporter::Export(
   }
 
   proto::collector::metrics::v1::ExportMetricsServiceRequest request;
-  OtlpMetricsUtils::PopulateRequest(data, &request);
+  OtlpMetricUtils::PopulateRequest(data, &request);
 
   grpc::ClientContext context;
   proto::collector::metrics::v1::ExportMetricsServiceResponse response;

--- a/exporters/otlp/src/otlp_metric_utils.cc
+++ b/exporters/otlp/src/otlp_metric_utils.cc
@@ -1,7 +1,7 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-#include "opentelemetry/exporters/otlp/otlp_metrics_utils.h"
+#include "opentelemetry/exporters/otlp/otlp_metric_utils.h"
 #include "opentelemetry/exporters/otlp/otlp_populate_attribute_utils.h"
 
 #ifndef ENABLE_METRICS_PREVIEW
@@ -14,7 +14,7 @@ namespace otlp
 {
 namespace metric_sdk = opentelemetry::sdk::metrics;
 
-proto::metrics::v1::AggregationTemporality OtlpMetricsUtils::GetProtoAggregationTemporality(
+proto::metrics::v1::AggregationTemporality OtlpMetricUtils::GetProtoAggregationTemporality(
     const opentelemetry::sdk::metrics::AggregationTemporality &aggregation_temporality) noexcept
 {
   if (aggregation_temporality == opentelemetry::sdk::metrics::AggregationTemporality::kCumulative)
@@ -25,7 +25,7 @@ proto::metrics::v1::AggregationTemporality OtlpMetricsUtils::GetProtoAggregation
     return proto::metrics::v1::AggregationTemporality::AGGREGATION_TEMPORALITY_UNSPECIFIED;
 }
 
-metric_sdk::AggregationType OtlpMetricsUtils::GetAggregationType(
+metric_sdk::AggregationType OtlpMetricUtils::GetAggregationType(
     const opentelemetry::sdk::metrics::InstrumentType &instrument_type) noexcept
 {
 
@@ -47,8 +47,8 @@ metric_sdk::AggregationType OtlpMetricsUtils::GetAggregationType(
   return metric_sdk::AggregationType::kDrop;
 }
 
-void OtlpMetricsUtils::ConvertSumMetric(const metric_sdk::MetricData &metric_data,
-                                        proto::metrics::v1::Sum *const sum) noexcept
+void OtlpMetricUtils::ConvertSumMetric(const metric_sdk::MetricData &metric_data,
+                                       proto::metrics::v1::Sum *const sum) noexcept
 {
   sum->set_aggregation_temporality(
       GetProtoAggregationTemporality(metric_data.aggregation_temporality));
@@ -80,7 +80,7 @@ void OtlpMetricsUtils::ConvertSumMetric(const metric_sdk::MetricData &metric_dat
   }
 }
 
-void OtlpMetricsUtils::ConvertHistogramMetric(
+void OtlpMetricUtils::ConvertHistogramMetric(
     const metric_sdk::MetricData &metric_data,
     proto::metrics::v1::Histogram *const histogram) noexcept
 {
@@ -138,7 +138,7 @@ void OtlpMetricsUtils::ConvertHistogramMetric(
   }
 }
 
-void OtlpMetricsUtils::PopulateInstrumentationInfoMetric(
+void OtlpMetricUtils::PopulateInstrumentationInfoMetric(
     const opentelemetry::sdk::metrics::MetricData &metric_data,
     proto::metrics::v1::Metric *metric) noexcept
 {
@@ -160,7 +160,7 @@ void OtlpMetricsUtils::PopulateInstrumentationInfoMetric(
   }
 }
 
-void OtlpMetricsUtils::PopulateResourceMetrics(
+void OtlpMetricUtils::PopulateResourceMetrics(
     const opentelemetry::sdk::metrics::ResourceMetrics &data,
     proto::metrics::v1::ResourceMetrics *resource_metrics) noexcept
 {
@@ -190,7 +190,7 @@ void OtlpMetricsUtils::PopulateResourceMetrics(
   }
 }
 
-void OtlpMetricsUtils::PopulateRequest(
+void OtlpMetricUtils::PopulateRequest(
     const opentelemetry::sdk::metrics::ResourceMetrics &data,
     proto::collector::metrics::v1::ExportMetricsServiceRequest *request) noexcept
 {

--- a/exporters/otlp/test/otlp_metrics_serialization_test.cc
+++ b/exporters/otlp/test/otlp_metrics_serialization_test.cc
@@ -3,7 +3,7 @@
 
 #ifndef ENABLE_METRICS_PREVIEW
 
-#  include "opentelemetry/exporters/otlp/otlp_metrics_utils.h"
+#  include "opentelemetry/exporters/otlp/otlp_metric_utils.h"
 #  include "opentelemetry/proto/metrics/v1/metrics.pb.h"
 
 #  include <gtest/gtest.h>
@@ -78,11 +78,11 @@ metrics_sdk::MetricData CreateHistogramAggregationData()
   return data;
 }
 
-TEST(OtlpMetricsSerializationTest, Counter)
+TEST(OtlpMetricSerializationTest, Counter)
 {
   metrics_sdk::MetricData data = CreateSumAggregationData();
   opentelemetry::proto::metrics::v1::Sum sum;
-  otlp_exporter::OtlpMetricsUtils::ConvertSumMetric(data, &sum);
+  otlp_exporter::OtlpMetricUtils::ConvertSumMetric(data, &sum);
   EXPECT_EQ(sum.aggregation_temporality(),
             proto::metrics::v1::AggregationTemporality::AGGREGATION_TEMPORALITY_CUMULATIVE);
   EXPECT_EQ(sum.is_monotonic(), true);
@@ -95,11 +95,11 @@ TEST(OtlpMetricsSerializationTest, Counter)
   EXPECT_EQ(1, 1);
 }
 
-TEST(OtlpMetricsSerializationTest, Histogram)
+TEST(OtlpMetricSerializationTest, Histogram)
 {
   metrics_sdk::MetricData data = CreateHistogramAggregationData();
   opentelemetry::proto::metrics::v1::Histogram histogram;
-  otlp_exporter::OtlpMetricsUtils::ConvertHistogramMetric(data, &histogram);
+  otlp_exporter::OtlpMetricUtils::ConvertHistogramMetric(data, &histogram);
   EXPECT_EQ(histogram.aggregation_temporality(),
             proto::metrics::v1::AggregationTemporality::AGGREGATION_TEMPORALITY_CUMULATIVE);
   for (size_t i = 0; i < 1; i++)


### PR DESCRIPTION
Fixes #1484 

## Changes

Rename 
 - OtlpGrpcMetricsExporter to OtlpGrpcMetricExporter
 - OtlpGrpcMetricsExporterOptions to OtlpGrpcMetricExporterOptions
 - OtlpMetricsUtils to OtlpMetricUtils
  
For significant contributions please make sure you have completed the following items:

* [ ] `CHANGELOG.md` updated for non-trivial changes
* [ ] Unit tests have been added
* [ ] Changes in public API reviewed