### PR TITLE
Enable bazel build for metrics proto files

### DIFF
--- a/bazel/opentelemetry_proto.BUILD
+++ b/bazel/opentelemetry_proto.BUILD
@@ -121,3 +121,43 @@ cc_grpc_library(
     grpc_only = True,
     deps = [":logs_service_proto_cc"],
 )
+
+proto_library(
+    name = "metrics_proto",
+    srcs = [
+        "opentelemetry/proto/trace/v1/metrics.proto",
+    ],
+    deps = [
+        ":common_proto",
+        ":resource_proto",
+    ],
+)
+
+cc_proto_library(
+    name = "metrics_proto_cc",
+    deps = [":metrics_proto"],
+)
+
+proto_library(
+    name = "metrics_service_proto",
+    srcs = [
+        "opentelemetry/proto/collector/metrics/v1/metrics_service.proto",
+    ],
+    deps = [
+        ":metrics_proto",
+    ],
+)
+
+cc_proto_library(
+    name = "metrics_service_proto_cc",
+    deps = [":metrics_service_proto"],
+)
+
+cc_grpc_library(
+    name = "metrics_service_grpc_cc",
+    srcs = [":metrics_service_proto"],
+    generate_mocks = True,
+    grpc_only = True,
+    deps = [":metrics_service_proto_cc"],
+)
+

--- a/bazel/opentelemetry_proto.BUILD
+++ b/bazel/opentelemetry_proto.BUILD
@@ -125,7 +125,7 @@ cc_grpc_library(
 proto_library(
     name = "metrics_proto",
     srcs = [
-        "opentelemetry/proto/trace/v1/metrics.proto",
+        "opentelemetry/proto/metrics/v1/metrics.proto",
     ],
     deps = [
         ":common_proto",


### PR DESCRIPTION
## Changes

`~/bazel/opentelemetry_proto.BUILD` file only contains the build rules for traces and logs. Adding build rules for metrics too.

Please provide a brief description of the changes here.

For significant contributions please make sure you have completed the following items:

* [ ] `CHANGELOG.md` updated for non-trivial changes
* [ ] Unit tests have been added
* [ ] Changes in public API reviewed