### PR TITLE
Link opentelemetry_api to ETW exporter test

### DIFF
--- a/exporters/etw/CMakeLists.txt
+++ b/exporters/etw/CMakeLists.txt
@@ -9,7 +9,7 @@ set_target_properties(opentelemetry_exporter_etw PROPERTIES EXPORT_NAME
                                                             etw_exporter)
 
 target_link_libraries(opentelemetry_exporter_etw
-                      INTERFACE nlohmann_json::nlohmann_json)
+                      INTERFACE opentelemetry_api nlohmann_json::nlohmann_json)
 if(nlohmann_json_clone)
   add_dependencies(opentelemetry_exporter_etw nlohmann_json::nlohmann_json)
 endif()


### PR DESCRIPTION
Fixes building ETW log exporter test.

The macro `ENABLE_LOGS_PREVIEW` is defined [here](https://github.com/open-telemetry/opentelemetry-cpp/blob/main/api/CMakeLists.txt#L78) as opentelemetry_api, the ETW exporter test need to link to this target to get the macro definition either as defined or undefined.

## Changes

Please provide a brief description of the changes here.

For significant contributions please make sure you have completed the following items:

* [ ] `CHANGELOG.md` updated for non-trivial changes
* [ ] Unit tests have been added
* [ ] Changes in public API reviewed