### PR TITLE
fix: urlParser will incorrect parsing url like http://abc.com/xxx@xxx/a/b

### DIFF
--- a/ext/include/opentelemetry/ext/http/common/url_parser.h
+++ b/ext/include/opentelemetry/ext/http/common/url_parser.h
@@ -52,11 +52,16 @@ public:
     }
 
     // credentials
-    pos = url_.find_first_of("@", cpos);
-    if (pos != std::string::npos)
+    size_t pos1 = url_.find_first_of("@", cpos);
+    size_t pos2 = url_.find_first_of("/", cpos);
+    if (pos1 != std::string::npos)
     {
       // TODO - handle credentials
-      cpos = pos + 1;
+      if (pos2 == std::string::npos || pos1 < pos2)
+      {
+        pos  = pos1;
+        cpos = pos1 + 1;
+      }
     }
     pos          = url_.find_first_of(":", cpos);
     bool is_port = false;

--- a/ext/test/http/url_parser_test.cc
+++ b/ext/test/http/url_parser_test.cc
@@ -113,6 +113,13 @@ TEST(UrlParserTests, BasicTests)
         {"path", "/path1/path2"},
         {"query", "q1=a1&q2=a2"},
         {"success", "true"}}},
+      {"http://www.abc.com/path1@bbb/path2?q1=a1&q2=a2",
+       {{"host", "www.abc.com"},
+        {"port", "80"},
+        {"scheme", "http"},
+        {"path", "/path1@bbb/path2"},
+        {"query", "q1=a1&q2=a2"},
+        {"success", "true"}}},
 
   };
   for (auto &url_map : urls_map)


### PR DESCRIPTION
Fixes  issue #1509

## Changes

urlParser incorrect url which "@" not in first segment, like "http://abc.com/xxx@xxx".
So I modified that it will judge if "@" is in first segment, that means before the first "/",  otherwise ignore handle it.

* [ ] `CHANGELOG.md` updated for non-trivial changes
* [x] Unit tests have been added
* [ ] Changes in public API reviewed