### PR TITLE
Inline print_value() in ostream exporter

### DIFF
--- a/exporters/ostream/include/opentelemetry/exporters/ostream/common_utils.h
+++ b/exporters/ostream/include/opentelemetry/exporters/ostream/common_utils.h
@@ -61,7 +61,8 @@ private:
 
 #endif
 
-inline void print_value(const opentelemetry::sdk::common::OwnedAttributeValue &value, std::ostream &sout)
+inline void print_value(const opentelemetry::sdk::common::OwnedAttributeValue &value,
+                        std::ostream &sout)
 {
 #if __cplusplus < 201402L
   opentelemetry::nostd::visit(OwnedAttributeValueVisitor(sout), value);

--- a/exporters/ostream/include/opentelemetry/exporters/ostream/common_utils.h
+++ b/exporters/ostream/include/opentelemetry/exporters/ostream/common_utils.h
@@ -61,7 +61,7 @@ private:
 
 #endif
 
-void print_value(const opentelemetry::sdk::common::OwnedAttributeValue &value, std::ostream &sout)
+inline void print_value(const opentelemetry::sdk::common::OwnedAttributeValue &value, std::ostream &sout)
 {
 #if __cplusplus < 201402L
   opentelemetry::nostd::visit(OwnedAttributeValueVisitor(sout), value);


### PR DESCRIPTION
## Changes

The common_utils.h header is being used in multiple build targets in the ostream exporter. This header defines the print_value() function, and because it's not inlined, it causes the build to fail in case it tries to link to more than one ostream exporter.

Solution: inline function.