### PR TITLE
Don't require applications using jaeger exporter to know about libcurl

### DIFF
--- a/ext/src/http/client/curl/CMakeLists.txt
+++ b/ext/src/http/client/curl/CMakeLists.txt
@@ -8,13 +8,17 @@ if(CURL_FOUND)
                         PROPERTIES EXPORT_NAME http_client_curl)
 
   if(TARGET CURL::libcurl)
-    target_link_libraries(opentelemetry_http_client_curl
-                          PUBLIC opentelemetry_ext CURL::libcurl)
+    target_link_libraries(
+      opentelemetry_http_client_curl
+      PUBLIC opentelemetry_ext
+      PRIVATE CURL::libcurl)
   else()
     target_include_directories(opentelemetry_http_client_curl
                                INTERFACE "${CURL_INCLUDE_DIRS}")
-    target_link_libraries(opentelemetry_http_client_curl
-                          PUBLIC opentelemetry_ext ${CURL_LIBRARIES})
+    target_link_libraries(
+      opentelemetry_http_client_curl
+      PUBLIC opentelemetry_ext
+      PRIVATE ${CURL_LIBRARIES})
   endif()
 
   install(


### PR DESCRIPTION
Fixes #1517

## Changes

Changed link of libcurl (CMake CURL::libcurl) to opentelemetry_http_client_curl to be PRIVATE. This fixes the build issue for me on my Linux system using shared libraries, however I've not tested this anywhere else.