### PR TITLE
fix(metrics): ostream exporter should print out resource attributes

### DIFF
--- a/exporters/ostream/include/opentelemetry/exporters/ostream/metric_exporter.h
+++ b/exporters/ostream/include/opentelemetry/exporters/ostream/metric_exporter.h
@@ -56,13 +56,12 @@ private:
   bool is_shutdown_ = false;
   mutable opentelemetry::common::SpinLockMutex lock_;
   bool isShutdown() const noexcept;
-  void printInstrumentationInfoMetricData(
-      const sdk::metrics::ScopeMetrics &info_metrics, const sdk::metrics::ResourceMetrics &data);
+  void printInstrumentationInfoMetricData(const sdk::metrics::ScopeMetrics &info_metrics,
+                                          const sdk::metrics::ResourceMetrics &data);
   void printPointData(const opentelemetry::sdk::metrics::PointType &point_data);
   void printPointAttributes(const opentelemetry::sdk::metrics::PointAttributes &point_attributes);
-  void printAttributes(
-      const std::unordered_map<std::string, sdk::common::OwnedAttributeValue> &map,
-      const std::string prefix);
+  void printAttributes(const std::unordered_map<std::string, sdk::common::OwnedAttributeValue> &map,
+                       const std::string prefix);
   void printResources(const opentelemetry::sdk::resource::Resource &resources);
 };
 }  // namespace metrics

--- a/exporters/ostream/include/opentelemetry/exporters/ostream/metric_exporter.h
+++ b/exporters/ostream/include/opentelemetry/exporters/ostream/metric_exporter.h
@@ -56,9 +56,14 @@ private:
   bool is_shutdown_ = false;
   mutable opentelemetry::common::SpinLockMutex lock_;
   bool isShutdown() const noexcept;
-  void printInstrumentationInfoMetricData(const sdk::metrics::ScopeMetrics &info_metrics);
+  void printInstrumentationInfoMetricData(
+      const sdk::metrics::ScopeMetrics &info_metrics, const sdk::metrics::ResourceMetrics &data);
   void printPointData(const opentelemetry::sdk::metrics::PointType &point_data);
   void printPointAttributes(const opentelemetry::sdk::metrics::PointAttributes &point_attributes);
+  void printAttributes(
+      const std::unordered_map<std::string, sdk::common::OwnedAttributeValue> &map,
+      const std::string prefix);
+  void printResources(const opentelemetry::sdk::resource::Resource &resources);
 };
 }  // namespace metrics
 }  // namespace exporter

--- a/exporters/ostream/include/opentelemetry/exporters/ostream/metric_exporter.h
+++ b/exporters/ostream/include/opentelemetry/exporters/ostream/metric_exporter.h
@@ -60,7 +60,7 @@ private:
                                           const sdk::metrics::ResourceMetrics &data);
   void printPointData(const opentelemetry::sdk::metrics::PointType &point_data);
   void printPointAttributes(const opentelemetry::sdk::metrics::PointAttributes &point_attributes);
-  void printAttributes(const std::unordered_map<std::string, sdk::common::OwnedAttributeValue> &map,
+  void printAttributes(const std::map<std::string, sdk::common::OwnedAttributeValue> &map,
                        const std::string prefix);
   void printResources(const opentelemetry::sdk::resource::Resource &resources);
 };

--- a/exporters/ostream/src/metric_exporter.cc
+++ b/exporters/ostream/src/metric_exporter.cc
@@ -4,6 +4,7 @@
 #include <chrono>
 #ifndef ENABLE_METRICS_PREVIEW
 #  include <algorithm>
+#  include <map>
 #  include "opentelemetry/exporters/ostream/common_utils.h"
 #  include "opentelemetry/exporters/ostream/metric_exporter.h"
 #  include "opentelemetry/sdk/metrics/aggregation/default_aggregation.h"
@@ -85,7 +86,7 @@ sdk::common::ExportResult OStreamMetricExporter::Export(
 }
 
 void OStreamMetricExporter::printAttributes(
-    const std::unordered_map<std::string, sdk::common::OwnedAttributeValue> &map,
+    const std::map<std::string, sdk::common::OwnedAttributeValue> &map,
     const std::string prefix)
 {
   for (const auto &kv : map)
@@ -100,7 +101,12 @@ void OStreamMetricExporter::printResources(const opentelemetry::sdk::resource::R
   auto attributes = resources.GetAttributes();
   if (attributes.size())
   {
-    printAttributes(attributes, "\n\t");
+    // Convert unordered_map to map for printing so that iteration
+    // order is guaranteed.
+    std::map<std::string, sdk::common::OwnedAttributeValue> attr_map;
+    for (auto &kv : attributes)
+      attr_map[kv.first] = std::move(kv.second);
+    printAttributes(attr_map, "\n\t");
   }
 }
 

--- a/exporters/ostream/src/metric_exporter.cc
+++ b/exporters/ostream/src/metric_exporter.cc
@@ -105,7 +105,8 @@ void OStreamMetricExporter::printResources(const opentelemetry::sdk::resource::R
 }
 
 void OStreamMetricExporter::printInstrumentationInfoMetricData(
-    const sdk::metrics::ScopeMetrics &info_metric, const sdk::metrics::ResourceMetrics &data)
+    const sdk::metrics::ScopeMetrics &info_metric,
+    const sdk::metrics::ResourceMetrics &data)
 {
   // sout_ is shared
   const std::lock_guard<opentelemetry::common::SpinLockMutex> locked(lock_);

--- a/exporters/ostream/test/ostream_metric_test.cc
+++ b/exporters/ostream/test/ostream_metric_test.cc
@@ -81,6 +81,11 @@ TEST(OStreamMetricsExporter, ExportSumPointData)
       "\n  value\t\t: 20"
       "\n  attributes\t\t: "
       "\n\ta1: b1"
+      "\n  resources\t:"
+      "\n\tservice.name: unknown_service"
+      "\n\ttelemetry.sdk.version: 1.4.1"
+      "\n\ttelemetry.sdk.name: opentelemetry"
+      "\n\ttelemetry.sdk.language: cpp"
       "\n}\n";
   ASSERT_EQ(stdoutOutput.str(), expected_output);
 }
@@ -151,6 +156,11 @@ TEST(OStreamMetricsExporter, ExportHistogramPointData)
       "\n  counts     : [200, 300, 400, 500, ]"
       "\n  attributes\t\t: "
       "\n\ta1: b1"
+      "\n  resources\t:"
+      "\n\tservice.name: unknown_service"
+      "\n\ttelemetry.sdk.version: 1.4.1"
+      "\n\ttelemetry.sdk.name: opentelemetry"
+      "\n\ttelemetry.sdk.language: cpp"
       "\n}\n";
   ASSERT_EQ(stdoutOutput.str(), expected_output);
 }
@@ -214,6 +224,11 @@ TEST(OStreamMetricsExporter, ExportLastValuePointData)
       "\n  valid     : true"
       "\n  value     : 20"
       "\n  attributes\t\t: "
+      "\n  resources\t:"
+      "\n\tservice.name: unknown_service"
+      "\n\ttelemetry.sdk.version: 1.4.1"
+      "\n\ttelemetry.sdk.name: opentelemetry"
+      "\n\ttelemetry.sdk.language: cpp"
       "\n}\n";
   ASSERT_EQ(stdoutOutput.str(), expected_output);
 }
@@ -261,6 +276,11 @@ TEST(OStreamMetricsExporter, ExportDropPointData)
       "\n  name\t\t: library_name"
       "\n  description\t: description"
       "\n  unit\t\t: unit"
+      "\n  resources\t:"
+      "\n\tservice.name: unknown_service"
+      "\n\ttelemetry.sdk.version: 1.4.1"
+      "\n\ttelemetry.sdk.name: opentelemetry"
+      "\n\ttelemetry.sdk.language: cpp"
       "\n}\n";
 
   ASSERT_EQ(stdoutOutput.str(), expected_output);

--- a/exporters/ostream/test/ostream_metric_test.cc
+++ b/exporters/ostream/test/ostream_metric_test.cc
@@ -7,6 +7,7 @@
 #  include <vector>
 #  include "opentelemetry/sdk/metrics/instruments.h"
 #  include "opentelemetry/sdk/resource/resource_detector.h"
+#  include "opentelemetry/sdk/version/version.h"
 
 #  include <iostream>
 #  include "opentelemetry/exporters/ostream/metric_exporter.h"
@@ -83,7 +84,9 @@ TEST(OStreamMetricsExporter, ExportSumPointData)
       "\n\ta1: b1"
       "\n  resources\t:"
       "\n\tservice.name: unknown_service"
-      "\n\ttelemetry.sdk.version: 1.5.0"
+      "\n\ttelemetry.sdk.version: ";
+  expected_output += OPENTELEMETRY_SDK_VERSION;
+  expected_output +=
       "\n\ttelemetry.sdk.name: opentelemetry"
       "\n\ttelemetry.sdk.language: cpp"
       "\n}\n";
@@ -158,7 +161,9 @@ TEST(OStreamMetricsExporter, ExportHistogramPointData)
       "\n\ta1: b1"
       "\n  resources\t:"
       "\n\tservice.name: unknown_service"
-      "\n\ttelemetry.sdk.version: 1.5.0"
+      "\n\ttelemetry.sdk.version: ";
+  expected_output += OPENTELEMETRY_SDK_VERSION;
+  expected_output +=
       "\n\ttelemetry.sdk.name: opentelemetry"
       "\n\ttelemetry.sdk.language: cpp"
       "\n}\n";
@@ -226,7 +231,9 @@ TEST(OStreamMetricsExporter, ExportLastValuePointData)
       "\n  attributes\t\t: "
       "\n  resources\t:"
       "\n\tservice.name: unknown_service"
-      "\n\ttelemetry.sdk.version: 1.5.0"
+      "\n\ttelemetry.sdk.version: ";
+  expected_output += OPENTELEMETRY_SDK_VERSION;
+  expected_output +=
       "\n\ttelemetry.sdk.name: opentelemetry"
       "\n\ttelemetry.sdk.language: cpp"
       "\n}\n";
@@ -278,7 +285,9 @@ TEST(OStreamMetricsExporter, ExportDropPointData)
       "\n  unit\t\t: unit"
       "\n  resources\t:"
       "\n\tservice.name: unknown_service"
-      "\n\ttelemetry.sdk.version: 1.5.0"
+      "\n\ttelemetry.sdk.version: ";
+  expected_output += OPENTELEMETRY_SDK_VERSION;
+  expected_output +=
       "\n\ttelemetry.sdk.name: opentelemetry"
       "\n\ttelemetry.sdk.language: cpp"
       "\n}\n";

--- a/exporters/ostream/test/ostream_metric_test.cc
+++ b/exporters/ostream/test/ostream_metric_test.cc
@@ -84,12 +84,11 @@ TEST(OStreamMetricsExporter, ExportSumPointData)
       "\n\ta1: b1"
       "\n  resources\t:"
       "\n\tservice.name: unknown_service"
+      "\n\ttelemetry.sdk.language: cpp"
+      "\n\ttelemetry.sdk.name: opentelemetry"
       "\n\ttelemetry.sdk.version: ";
   expected_output += OPENTELEMETRY_SDK_VERSION;
-  expected_output +=
-      "\n\ttelemetry.sdk.name: opentelemetry"
-      "\n\ttelemetry.sdk.language: cpp"
-      "\n}\n";
+  expected_output += "\n}\n";
   ASSERT_EQ(stdoutOutput.str(), expected_output);
 }
 
@@ -161,12 +160,11 @@ TEST(OStreamMetricsExporter, ExportHistogramPointData)
       "\n\ta1: b1"
       "\n  resources\t:"
       "\n\tservice.name: unknown_service"
+      "\n\ttelemetry.sdk.language: cpp"
+      "\n\ttelemetry.sdk.name: opentelemetry"
       "\n\ttelemetry.sdk.version: ";
   expected_output += OPENTELEMETRY_SDK_VERSION;
-  expected_output +=
-      "\n\ttelemetry.sdk.name: opentelemetry"
-      "\n\ttelemetry.sdk.language: cpp"
-      "\n}\n";
+  expected_output += "\n}\n";
   ASSERT_EQ(stdoutOutput.str(), expected_output);
 }
 
@@ -231,12 +229,11 @@ TEST(OStreamMetricsExporter, ExportLastValuePointData)
       "\n  attributes\t\t: "
       "\n  resources\t:"
       "\n\tservice.name: unknown_service"
+      "\n\ttelemetry.sdk.language: cpp"
+      "\n\ttelemetry.sdk.name: opentelemetry"
       "\n\ttelemetry.sdk.version: ";
   expected_output += OPENTELEMETRY_SDK_VERSION;
-  expected_output +=
-      "\n\ttelemetry.sdk.name: opentelemetry"
-      "\n\ttelemetry.sdk.language: cpp"
-      "\n}\n";
+  expected_output += "\n}\n";
   ASSERT_EQ(stdoutOutput.str(), expected_output);
 }
 
@@ -285,12 +282,11 @@ TEST(OStreamMetricsExporter, ExportDropPointData)
       "\n  unit\t\t: unit"
       "\n  resources\t:"
       "\n\tservice.name: unknown_service"
+      "\n\ttelemetry.sdk.language: cpp"
+      "\n\ttelemetry.sdk.name: opentelemetry"
       "\n\ttelemetry.sdk.version: ";
   expected_output += OPENTELEMETRY_SDK_VERSION;
-  expected_output +=
-      "\n\ttelemetry.sdk.name: opentelemetry"
-      "\n\ttelemetry.sdk.language: cpp"
-      "\n}\n";
+  expected_output += "\n}\n";
 
   ASSERT_EQ(stdoutOutput.str(), expected_output);
 }

--- a/exporters/ostream/test/ostream_metric_test.cc
+++ b/exporters/ostream/test/ostream_metric_test.cc
@@ -83,7 +83,7 @@ TEST(OStreamMetricsExporter, ExportSumPointData)
       "\n\ta1: b1"
       "\n  resources\t:"
       "\n\tservice.name: unknown_service"
-      "\n\ttelemetry.sdk.version: 1.4.1"
+      "\n\ttelemetry.sdk.version: 1.5.0"
       "\n\ttelemetry.sdk.name: opentelemetry"
       "\n\ttelemetry.sdk.language: cpp"
       "\n}\n";
@@ -158,7 +158,7 @@ TEST(OStreamMetricsExporter, ExportHistogramPointData)
       "\n\ta1: b1"
       "\n  resources\t:"
       "\n\tservice.name: unknown_service"
-      "\n\ttelemetry.sdk.version: 1.4.1"
+      "\n\ttelemetry.sdk.version: 1.5.0"
       "\n\ttelemetry.sdk.name: opentelemetry"
       "\n\ttelemetry.sdk.language: cpp"
       "\n}\n";
@@ -226,7 +226,7 @@ TEST(OStreamMetricsExporter, ExportLastValuePointData)
       "\n  attributes\t\t: "
       "\n  resources\t:"
       "\n\tservice.name: unknown_service"
-      "\n\ttelemetry.sdk.version: 1.4.1"
+      "\n\ttelemetry.sdk.version: 1.5.0"
       "\n\ttelemetry.sdk.name: opentelemetry"
       "\n\ttelemetry.sdk.language: cpp"
       "\n}\n";
@@ -278,7 +278,7 @@ TEST(OStreamMetricsExporter, ExportDropPointData)
       "\n  unit\t\t: unit"
       "\n  resources\t:"
       "\n\tservice.name: unknown_service"
-      "\n\ttelemetry.sdk.version: 1.4.1"
+      "\n\ttelemetry.sdk.version: 1.5.0"
       "\n\ttelemetry.sdk.name: opentelemetry"
       "\n\ttelemetry.sdk.language: cpp"
       "\n}\n";


### PR DESCRIPTION
While debugging my `Resource` definition for a metrics exporter, I realized
the `OStreamExporter` did not support printing out `Resource` contents. 

I plan on expanding upon the existing unit(s) for checking the resource
attributes, but wanted to "test the waters" first. 

My goal was to attach git branch/sha information to metrics that are collected
for easier A/B testing, and a `Resource` seemed like a natural place for that. 

For example, using the attributes:
```
service.git.branch
service.git.commit_sha
service.git.commit_sha_short
```

However, there seems to be some debate around [using resources and metrics
with prometheus](https://github.com/open-telemetry/opentelemetry-specification/issues/2640), which is what led me down my debugging path of using the ostream exporter first.