### PR TITLE
Add CI jobs for new and deprecated metrics

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -114,28 +114,6 @@ jobs:
         CC: /usr/bin/gcc-4.8
         CXX: /usr/bin/g++-4.8
 
-  cmake_gcc_48_otlp_exporter_deprecated_metrics_test:
-    name: CMake gcc 4.8 (with otlp exporter and deprecated metrics)
-    runs-on: ubuntu-18.04
-    steps:
-    - uses: actions/checkout@v3
-      with:
-        submodules: 'recursive'
-    - name: setup
-      run: |
-        sudo ./ci/setup_ci_environment.sh
-        sudo ./ci/install_gcc48.sh
-    - name: setup cmake
-      run: |
-        sudo CC=/usr/bin/gcc-4.8 CXX=/usr/bin/g++-4.8 ./ci/setup_cmake.sh
-    - name: setup grpc
-      run: |
-        sudo CC=/usr/bin/gcc-4.8 CXX=/usr/bin/g++-4.8 ./ci/setup_grpc.sh -v 4.8
-    - name: run tests
-      run: ./ci/do_ci.sh cmake.legacy.exporter.otprotocol.deprecated_metrics.test
-      env:
-        CC: /usr/bin/gcc-4.8
-        CXX: /usr/bin/g++-4.8
   cmake_test_cxx20:
     name: CMake C++20 test
     runs-on: ubuntu-20.04

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,22 @@ jobs:
         sudo ./ci/setup_thrift.sh
         ./ci/do_ci.sh cmake.test
 
+  cmake_deprecated_metrics_test:
+    name: CMake test (without otlp-exporter and deprecated metrics)
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        submodules: 'recursive'
+    - name: setup
+      run: |
+        sudo ./ci/setup_cmake.sh
+        sudo ./ci/setup_ci_environment.sh
+    - name: run cmake tests (without otlp-exporter)
+      run: |
+        sudo ./ci/setup_thrift.sh
+        ./ci/do_ci.sh cmake.deprecated_metrics.test
+
   cmake_with_async_export_test:
     name: CMake test (without otlp-exporter and with async export)
     runs-on: ubuntu-latest
@@ -98,6 +114,28 @@ jobs:
         CC: /usr/bin/gcc-4.8
         CXX: /usr/bin/g++-4.8
 
+  cmake_gcc_48_otlp_exporter_deprecated_metrics_test:
+    name: CMake gcc 4.8 (with otlp exporter and deprecated metrics)
+    runs-on: ubuntu-18.04
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        submodules: 'recursive'
+    - name: setup
+      run: |
+        sudo ./ci/setup_ci_environment.sh
+        sudo ./ci/install_gcc48.sh
+    - name: setup cmake
+      run: |
+        sudo CC=/usr/bin/gcc-4.8 CXX=/usr/bin/g++-4.8 ./ci/setup_cmake.sh
+    - name: setup grpc
+      run: |
+        sudo CC=/usr/bin/gcc-4.8 CXX=/usr/bin/g++-4.8 ./ci/setup_grpc.sh -v 4.8
+    - name: run tests
+      run: ./ci/do_ci.sh cmake.legacy.exporter.otprotocol.deprecated_metrics.test
+      env:
+        CC: /usr/bin/gcc-4.8
+        CXX: /usr/bin/g++-4.8
   cmake_test_cxx20:
     name: CMake C++20 test
     runs-on: ubuntu-20.04
@@ -165,7 +203,27 @@ jobs:
         sudo ./ci/install_bazelisk.sh
     - name: run tests
       run: ./ci/do_ci.sh bazel.test
-
+  bazel_deprecated_metrics_test:
+    name: Bazel deprecated metrics
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        submodules: 'recursive'
+    - name: Mount Bazel Cache
+      uses: actions/cache@v3
+      env:
+        cache-name: bazel_cache
+      with:
+        path: /home/runner/.cache/bazel
+        key: bazel_test
+    - name: setup
+      run: |
+        sudo ./ci/setup_thrift.sh dependencies_only
+        sudo ./ci/setup_ci_environment.sh
+        sudo ./ci/install_bazelisk.sh
+    - name: run tests
+      run: ./ci/do_ci.sh bazel.deprecated_metrics.test
   bazel_test_async:
     name: Bazel with async export
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -203,7 +203,7 @@ jobs:
         sudo ./ci/install_bazelisk.sh
     - name: run tests
       run: ./ci/do_ci.sh bazel.deprecated_metrics.test
-  
+
   bazel_test_async:
     name: Bazel with async export
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
         ./ci/do_ci.sh cmake.test
 
   cmake_deprecated_metrics_test:
-    name: CMake test (without otlp-exporter and deprecated metrics)
+    name: CMake test (without otlp-exporter and with deprecated metrics)
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -181,6 +181,7 @@ jobs:
         sudo ./ci/install_bazelisk.sh
     - name: run tests
       run: ./ci/do_ci.sh bazel.test
+
   bazel_deprecated_metrics_test:
     name: Bazel deprecated metrics
     runs-on: ubuntu-latest
@@ -202,6 +203,7 @@ jobs:
         sudo ./ci/install_bazelisk.sh
     - name: run tests
       run: ./ci/do_ci.sh bazel.deprecated_metrics.test
+  
   bazel_test_async:
     name: Bazel with async export
     runs-on: ubuntu-latest

--- a/ci/do_ci.sh
+++ b/ci/do_ci.sh
@@ -171,25 +171,6 @@ elif [[ "$1" == "cmake.legacy.test" ]]; then
   make
   make test
   exit 0
-elif [[ "$1" == "cmake.legacy.exporter.otprotocol.deprecated_metrics.test" ]]; then
-  cd "${BUILD_DIR}"
-  rm -rf *
-  export BUILD_ROOT="${BUILD_DIR}"
-  ${SRC_DIR}/tools/build-gtest.sh
-  ${SRC_DIR}/tools/build-benchmark.sh
-  cmake -DCMAKE_BUILD_TYPE=Debug  \
-        -DCMAKE_CXX_STANDARD=11 \
-        -DWITH_OTLP=ON \
-        -DWITH_PROMETHEUS=ON \
-        -DWITH_METRICS_PREVIEW=ON \
-        -DWITH_ASYNC_EXPORT_PREVIEW=ON \
-        "${SRC_DIR}"
-  grpc_cpp_plugin=`which grpc_cpp_plugin`
-  proto_make_file="CMakeFiles/opentelemetry_proto.dir/build.make"
-  sed -i "s~gRPC_CPP_PLUGIN_EXECUTABLE-NOTFOUND~$grpc_cpp_plugin~" ${proto_make_file} #fixme
-  make -j $(nproc)
-  cd exporters/otlp && make test
-  exit 0
 elif [[ "$1" == "cmake.legacy.exporter.otprotocol.test" ]]; then
   cd "${BUILD_DIR}"
   rm -rf *

--- a/ci/do_ci.sh
+++ b/ci/do_ci.sh
@@ -100,8 +100,24 @@ elif [[ "$1" == "cmake.with_async_export.test" ]]; then
         -DWITH_ZIPKIN=ON \
         -DWITH_JAEGER=ON \
         -DWITH_ELASTICSEARCH=ON \
-        -DWITH_METRICS_PREVIEW=ON \
+        -DWITH_METRICS_PREVIEW=OFF \
         -DWITH_LOGS_PREVIEW=ON \
+        -DCMAKE_CXX_FLAGS="-Werror" \
+        -DWITH_ASYNC_EXPORT_PREVIEW=ON \
+        "${SRC_DIR}"
+  make
+  make test
+  exit 0
+elif [[ "$1" == "cmake.deprecated_metrics.test" ]]; then
+  cd "${BUILD_DIR}"
+  rm -rf *
+  cmake -DCMAKE_BUILD_TYPE=Debug  \
+        -DWITH_PROMETHEUS=ON \
+        -DWITH_ZIPKIN=OFF \
+        -DWITH_JAEGER=OFF \
+        -DWITH_ELASTICSEARCH=OFF \
+        -DWITH_METRICS_PREVIEW=ON \
+        -DWITH_LOGS_PREVIEW=OFF \
         -DCMAKE_CXX_FLAGS="-Werror" \
         -DWITH_ASYNC_EXPORT_PREVIEW=ON \
         "${SRC_DIR}"
@@ -112,7 +128,7 @@ elif [[ "$1" == "cmake.abseil.test" ]]; then
   cd "${BUILD_DIR}"
   rm -rf *
   cmake -DCMAKE_BUILD_TYPE=Debug  \
-        -DWITH_METRICS_PREVIEW=ON \
+        -DWITH_METRICS_PREVIEW=OFF \
         -DWITH_LOGS_PREVIEW=ON \
         -DCMAKE_CXX_FLAGS="-Werror" \
         -DWITH_ASYNC_EXPORT_PREVIEW=ON \
@@ -136,7 +152,7 @@ elif [[ "$1" == "cmake.c++20.stl.test" ]]; then
   cd "${BUILD_DIR}"
   rm -rf *
   cmake -DCMAKE_BUILD_TYPE=Debug  \
-        -DWITH_METRICS_PREVIEW=ON \
+        -DWITH_METRICS_PREVIEW=OFF \
         -DWITH_LOGS_PREVIEW=ON \
         -DCMAKE_CXX_FLAGS="-Werror" \
         -DWITH_ASYNC_EXPORT_PREVIEW=ON \
@@ -157,6 +173,25 @@ elif [[ "$1" == "cmake.legacy.test" ]]; then
         "${SRC_DIR}"
   make
   make test
+  exit 0
+elif [[ "$1" == "cmake.legacy.exporter.otprotocol.deprecated_metrics.test" ]]; then
+  cd "${BUILD_DIR}"
+  rm -rf *
+  export BUILD_ROOT="${BUILD_DIR}"
+  ${SRC_DIR}/tools/build-gtest.sh
+  ${SRC_DIR}/tools/build-benchmark.sh
+  cmake -DCMAKE_BUILD_TYPE=Debug  \
+        -DCMAKE_CXX_STANDARD=11 \
+        -DWITH_OTLP=ON \
+        -DWITH_PROMETHEUS=ON \
+        -DWITH_METRICS_PREVIEW=ON \
+        -DWITH_ASYNC_EXPORT_PREVIEW=ON \
+        "${SRC_DIR}"
+  grpc_cpp_plugin=`which grpc_cpp_plugin`
+  proto_make_file="CMakeFiles/opentelemetry_proto.dir/build.make"
+  sed -i "s~gRPC_CPP_PLUGIN_EXECUTABLE-NOTFOUND~$grpc_cpp_plugin~" ${proto_make_file} #fixme
+  make -j $(nproc)
+  cd exporters/otlp && make test
   exit 0
 elif [[ "$1" == "cmake.legacy.exporter.otprotocol.test" ]]; then
   cd "${BUILD_DIR}"
@@ -241,6 +276,10 @@ EOF
 elif [[ "$1" == "bazel.test" ]]; then
   bazel $BAZEL_STARTUP_OPTIONS build $BAZEL_OPTIONS //...
   bazel $BAZEL_STARTUP_OPTIONS test $BAZEL_TEST_OPTIONS //...
+  exit 0
+elif [[ "$1" == "bazel.deprecated_metrics.test" ]]; then
+  bazel $BAZEL_STARTUP_OPTIONS build $BAZEL_OPTIONS --copt=-DENABLE_METRICS_PREVIEW //...
+  bazel $BAZEL_STARTUP_OPTIONS test $BAZEL_TEST_OPTIONS --copt=-DENABLE_METRICS_PREVIEW //...
   exit 0
 elif [[ "$1" == "bazel.with_async_export.test" ]]; then
   bazel $BAZEL_STARTUP_OPTIONS build $BAZEL_OPTIONS_ASYNC //...

--- a/ci/do_ci.sh
+++ b/ci/do_ci.sh
@@ -298,8 +298,8 @@ elif [[ "$1" == "bazel.legacy.test" ]]; then
 elif [[ "$1" == "bazel.noexcept" ]]; then
   # there are some exceptions and error handling code from the Prometheus and Jaeger Clients
   # that make this test always fail. ignore Prometheus and Jaeger exporters in the noexcept here.
-  bazel $BAZEL_STARTUP_OPTIONS build --copt=-fno-exceptions --build_tag_filters=-jaeger $BAZEL_OPTIONS_ASYNC -- //... -//exporters/prometheus/... -//exporters/jaeger/... -//examples/prometheus/...
-  bazel $BAZEL_STARTUP_OPTIONS test --copt=-fno-exceptions --build_tag_filters=-jaeger $BAZEL_TEST_OPTIONS_ASYNC -- //... -//exporters/prometheus/... -//exporters/jaeger/... -//examples/prometheus/...
+  bazel $BAZEL_STARTUP_OPTIONS build --copt=-fno-exceptions --build_tag_filters=-jaeger $BAZEL_OPTIONS_ASYNC -- //... -//exporters/prometheus/... -//exporters/jaeger/... -//examples/prometheus/... -//sdk/test/metrics:attributes_hashmap_test
+  bazel $BAZEL_STARTUP_OPTIONS test --copt=-fno-exceptions --build_tag_filters=-jaeger $BAZEL_TEST_OPTIONS_ASYNC -- //... -//exporters/prometheus/... -//exporters/jaeger/... -//examples/prometheus/... -//sdk/test/metrics:attributes_hashmap_test
   exit 0
 elif [[ "$1" == "bazel.nortti" ]]; then
   # there are some exceptions and error handling code from the Prometheus and Jaeger Clients

--- a/ci/do_ci.sh
+++ b/ci/do_ci.sh
@@ -60,10 +60,7 @@ mkdir -p "${BUILD_DIR}"
 mkdir -p "${PLUGIN_DIR}"
 
 BAZEL_OPTIONS="--copt=-DENABLE_LOGS_PREVIEW --copt=-DENABLE_TEST"
-# Previous legacy metrics use virtual drive, which can not be used without RTTI
-if [[ "$1" != "bazel.nortti" ]]; then
-  BAZEL_OPTIONS="$BAZEL_OPTIONS --copt=-DENABLE_METRICS_PREVIEW"
-fi
+
 BAZEL_TEST_OPTIONS="$BAZEL_OPTIONS --test_output=errors"
 
 BAZEL_OPTIONS_ASYNC="$BAZEL_OPTIONS --copt=-DENABLE_ASYNC_EXPORT"


### PR DESCRIPTION
Fixes #1494 (issue)

## Changes

makes all jobs testing the new metrics and adds `bazel` and `cmake`, <del>`gcc 4.8`</del> jobs for testing deprecated metrics.

For significant contributions please make sure you have completed the following items:

* [ ] `CHANGELOG.md` updated for non-trivial changes
* [ ] Unit tests have been added
* [ ] Changes in public API reviewed