### PR TITLE
Fix metrics unit test memory leack

### DIFF
--- a/sdk/test/metrics/async_metric_storage_test.cc
+++ b/sdk/test/metrics/async_metric_storage_test.cc
@@ -94,9 +94,11 @@ TEST_P(WritableMetricStorageTestFixture, TestAggregation)
   collectors.push_back(collector);
   size_t count_attributes = 0;
 
+  std::unique_ptr<DefaultAttributesProcessor> default_attributes_rocessor{
+      new DefaultAttributesProcessor{}};
   opentelemetry::sdk::metrics::AsyncMetricStorage<long> storage(instr_desc, AggregationType::kSum,
                                                                 MeasurementFetcher::Fetcher,
-                                                                new DefaultAttributesProcessor());
+                                                                default_attributes_rocessor.get());
 
   storage.Collect(collector.get(), collectors, sdk_start_ts, collection_ts,
                   [&](const MetricData data) {

--- a/sdk/test/metrics/metric_reader_test.cc
+++ b/sdk/test/metrics/metric_reader_test.cc
@@ -32,8 +32,8 @@ TEST(MetricReaderTest, BasicTests)
 
   std::unique_ptr<MetricReader> metric_reader2(new MockMetricReader(aggr_temporality));
   std::shared_ptr<MeterContext> meter_context2(new MeterContext());
-  MetricProducer *metric_producer =
-      new MetricCollector(std::move(meter_context2), std::move(metric_reader2));
+  std::shared_ptr<MetricProducer> metric_producer{
+      new MetricCollector(std::move(meter_context2), std::move(metric_reader2))};
   EXPECT_NO_THROW(metric_producer->Collect([](ResourceMetrics &metric_data) { return true; }));
 }
 #endif

--- a/sdk/test/metrics/sync_metric_storage_test.cc
+++ b/sdk/test/metrics/sync_metric_storage_test.cc
@@ -1,11 +1,12 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
+#include <memory>
 #ifndef ENABLE_METRICS_PREVIEW
-#  include "opentelemetry/sdk/metrics/state/sync_metric_storage.h"
 #  include "opentelemetry/common/key_value_iterable_view.h"
 #  include "opentelemetry/sdk/metrics/exemplar/no_exemplar_reservoir.h"
 #  include "opentelemetry/sdk/metrics/instruments.h"
+#  include "opentelemetry/sdk/metrics/state/sync_metric_storage.h"
 #  include "opentelemetry/sdk/metrics/view/attributes_processor.h"
 
 #  include <gtest/gtest.h>
@@ -40,8 +41,10 @@ TEST_P(WritableMetricStorageTestFixture, LongSumAggregation)
   std::map<std::string, std::string> attributes_get = {{"RequestType", "GET"}};
   std::map<std::string, std::string> attributes_put = {{"RequestType", "PUT"}};
 
+  std::unique_ptr<DefaultAttributesProcessor> default_attributes_processor{
+      new DefaultAttributesProcessor{}};
   opentelemetry::sdk::metrics::SyncMetricStorage storage(
-      instr_desc, AggregationType::kSum, new DefaultAttributesProcessor(),
+      instr_desc, AggregationType::kSum, default_attributes_processor.get(),
       NoExemplarReservoir::GetNoExemplarReservoir());
 
   storage.RecordLong(10l, KeyValueIterableView<std::map<std::string, std::string>>(attributes_get),
@@ -146,8 +149,10 @@ TEST_P(WritableMetricStorageTestFixture, DoubleSumAggregation)
   std::map<std::string, std::string> attributes_get = {{"RequestType", "GET"}};
   std::map<std::string, std::string> attributes_put = {{"RequestType", "PUT"}};
 
+  std::unique_ptr<DefaultAttributesProcessor> default_attributes_processor{
+      new DefaultAttributesProcessor{}};
   opentelemetry::sdk::metrics::SyncMetricStorage storage(
-      instr_desc, AggregationType::kSum, new DefaultAttributesProcessor(),
+      instr_desc, AggregationType::kSum, default_attributes_processor.get(),
       NoExemplarReservoir::GetNoExemplarReservoir());
 
   storage.RecordDouble(10.0,


### PR DESCRIPTION
Fixes #1532 (issue)

## Changes

fixes the leaks by using smart pointer.

For significant contributions please make sure you have completed the following items:

* [ ] `CHANGELOG.md` updated for non-trivial changes
* [ ] Unit tests have been added
* [ ] Changes in public API reviewed