### PR TITLE
Fix several compiling/linking errors

### DIFF
--- a/exporters/elasticsearch/include/opentelemetry/exporters/elasticsearch/es_log_exporter.h
+++ b/exporters/elasticsearch/include/opentelemetry/exporters/elasticsearch/es_log_exporter.h
@@ -6,7 +6,7 @@
 
 #  include "nlohmann/json.hpp"
 #  include "opentelemetry/common/spin_lock_mutex.h"
-#  include "opentelemetry/ext/http/client/curl/http_client_curl.h"
+#  include "opentelemetry/ext/http/client/http_client_factory.h"
 #  include "opentelemetry/nostd/type_traits.h"
 #  include "opentelemetry/sdk/logs/exporter.h"
 #  include "opentelemetry/sdk/logs/log_record.h"
@@ -104,7 +104,7 @@ private:
   ElasticsearchExporterOptions options_;
 
   // Object that stores the HTTP sessions that have been created
-  std::unique_ptr<ext::http::client::HttpClient> http_client_;
+  std::shared_ptr<ext::http::client::HttpClient> http_client_;
   mutable opentelemetry::common::SpinLockMutex lock_;
   bool isShutdown() const noexcept;
 };

--- a/exporters/elasticsearch/src/es_log_exporter.cc
+++ b/exporters/elasticsearch/src/es_log_exporter.cc
@@ -5,6 +5,7 @@
 
 #  include <sstream>  // std::stringstream
 
+#  include <condition_variable>
 #  include <mutex>
 #  include "opentelemetry/exporters/elasticsearch/es_log_exporter.h"
 #  include "opentelemetry/exporters/elasticsearch/es_log_recordable.h"
@@ -225,11 +226,11 @@ private:
 
 ElasticsearchLogExporter::ElasticsearchLogExporter()
     : options_{ElasticsearchExporterOptions()},
-      http_client_{new ext::http::client::curl::HttpClient()}
+      http_client_{ext::http::client::HttpClientFactory::Create()}
 {}
 
 ElasticsearchLogExporter::ElasticsearchLogExporter(const ElasticsearchExporterOptions &options)
-    : options_{options}, http_client_{new ext::http::client::curl::HttpClient()}
+    : options_{options}, http_client_{ext::http::client::HttpClientFactory::Create()}
 {}
 
 std::unique_ptr<sdklogs::Recordable> ElasticsearchLogExporter::MakeRecordable() noexcept

--- a/exporters/otlp/include/opentelemetry/exporters/otlp/otlp_http_client.h
+++ b/exporters/otlp/include/opentelemetry/exporters/otlp/otlp_http_client.h
@@ -186,7 +186,7 @@ private:
       event_handle.swap(input_handle);
     }
 
-    inline explicit HttpSessionData(HttpSessionData &&other)
+    inline HttpSessionData(HttpSessionData &&other)
     {
       session.swap(other.session);
       event_handle.swap(other.event_handle);

--- a/exporters/otlp/src/otlp_grpc_metric_exporter.cc
+++ b/exporters/otlp/src/otlp_grpc_metric_exporter.cc
@@ -143,6 +143,25 @@ opentelemetry::sdk::common::ExportResult OtlpGrpcMetricExporter::Export(
   return opentelemetry::sdk::common::ExportResult::kSuccess;
 }
 
+bool OtlpGrpcMetricExporter::ForceFlush(std::chrono::microseconds timeout) noexcept
+{
+  // TODO: OTLP gRPC exporter does not support concurrency exporting now.
+  return true;
+}
+
+bool OtlpGrpcMetricExporter::Shutdown(std::chrono::microseconds timeout) noexcept
+{
+  const std::lock_guard<opentelemetry::common::SpinLockMutex> locked(lock_);
+  is_shutdown_ = true;
+  return true;
+}
+
+bool OtlpGrpcMetricExporter::isShutdown() const noexcept
+{
+  const std::lock_guard<opentelemetry::common::SpinLockMutex> locked(lock_);
+  return is_shutdown_;
+}
+
 }  // namespace otlp
 }  // namespace exporter
 OPENTELEMETRY_END_NAMESPACE

--- a/exporters/prometheus/src/collector.cc
+++ b/exporters/prometheus/src/collector.cc
@@ -58,7 +58,8 @@ void PrometheusCollector::AddMetricData(const sdk::metrics::ResourceMetrics &dat
   collection_lock_.lock();
   if (metrics_to_collect_.size() + 1 <= max_collection_size_)
   {
-    metrics_to_collect_.emplace_back(new sdk::metrics::ResourceMetrics{data});
+    // We can not use initializer lists here due to broken variadic capture on GCC 4.8.5
+    metrics_to_collect_.emplace_back(new sdk::metrics::ResourceMetrics(data));
   }
   collection_lock_.unlock();
 }


### PR DESCRIPTION
Signed-off-by: owentou <owentou@tencent.com>

Fixes #1538 

## Changes

+ Optimize header dependency to of `es_log_exporter`.
+ Fix GCC 4.8 compatibility for new metrics implementation and `emplace_back(unique_ptr<HttpSessionData>(...))`.
+ Add implementation of `OtlpGrpcMetricExporter::ForceFlush`, `OtlpGrpcMetricExporter::Shutdown` and `OtlpGrpcMetricExporter::isShutdown`.

For significant contributions please make sure you have completed the following items:

* [ ] `CHANGELOG.md` updated for non-trivial changes
* [ ] Unit tests have been added
* [x] Changes in public API reviewed