### PR TITLE
[Metrics SDK] Metric aggregation temporality controls 

### DIFF
--- a/exporters/ostream/include/opentelemetry/exporters/ostream/metric_exporter.h
+++ b/exporters/ostream/include/opentelemetry/exporters/ostream/metric_exporter.h
@@ -9,7 +9,6 @@
 #  include "opentelemetry/common/spin_lock_mutex.h"
 #  include "opentelemetry/sdk/metrics/data/metric_data.h"
 #  include "opentelemetry/sdk/metrics/instruments.h"
-#  include "opentelemetry/sdk/metrics/instruments.h"
 #  include "opentelemetry/sdk/metrics/metric_exporter.h"
 #  include "opentelemetry/version.h"
 

--- a/exporters/ostream/include/opentelemetry/exporters/ostream/metric_exporter.h
+++ b/exporters/ostream/include/opentelemetry/exporters/ostream/metric_exporter.h
@@ -9,6 +9,7 @@
 #  include "opentelemetry/common/spin_lock_mutex.h"
 #  include "opentelemetry/sdk/metrics/data/metric_data.h"
 #  include "opentelemetry/sdk/metrics/instruments.h"
+#  include "opentelemetry/sdk/metrics/instruments.h"
 #  include "opentelemetry/sdk/metrics/metric_exporter.h"
 #  include "opentelemetry/version.h"
 
@@ -29,13 +30,23 @@ public:
    * export() function will send metrics data into.
    * The default ostream is set to stdout
    */
-  explicit OStreamMetricExporter(std::ostream &sout = std::cout) noexcept;
+  explicit OStreamMetricExporter(std::ostream &sout = std::cout,
+                                 sdk::metrics::AggregationTemporality aggregation_temporality =
+                                     sdk::metrics::AggregationTemporality::kCumulative) noexcept;
 
   /**
    * Export
    * @param data metrics data
    */
   sdk::common::ExportResult Export(const sdk::metrics::ResourceMetrics &data) noexcept override;
+
+  /**
+   * Get the AggregationTemporality for ostream exporter
+   *
+   * @return AggregationTemporality
+   */
+  sdk::metrics::AggregationTemporality GetAggregationTemporality(
+      sdk::metrics::InstrumentType instrument_type) const noexcept override;
 
   /**
    * Force flush the exporter.
@@ -55,6 +66,7 @@ private:
   std::ostream &sout_;
   bool is_shutdown_ = false;
   mutable opentelemetry::common::SpinLockMutex lock_;
+  sdk::metrics::AggregationTemporality aggregation_temporality_;
   bool isShutdown() const noexcept;
   void printInstrumentationInfoMetricData(const sdk::metrics::ScopeMetrics &info_metrics);
   void printPointData(const opentelemetry::sdk::metrics::PointType &point_data);

--- a/exporters/ostream/src/metric_exporter.cc
+++ b/exporters/ostream/src/metric_exporter.cc
@@ -64,7 +64,17 @@ inline void printVec(std::ostream &os, Container &vec)
   os << ']';
 }
 
-OStreamMetricExporter::OStreamMetricExporter(std::ostream &sout) noexcept : sout_(sout) {}
+OStreamMetricExporter::OStreamMetricExporter(
+    std::ostream &sout,
+    sdk::metrics::AggregationTemporality aggregation_temporality) noexcept
+    : sout_(sout), aggregation_temporality_(aggregation_temporality)
+{}
+
+sdk::metrics::AggregationTemporality OStreamMetricExporter::GetAggregationTemporality(
+    sdk::metrics::InstrumentType instrument_type) const noexcept
+{
+  return aggregation_temporality_;
+}
 
 sdk::common::ExportResult OStreamMetricExporter::Export(
     const sdk::metrics::ResourceMetrics &data) noexcept

--- a/exporters/otlp/include/opentelemetry/exporters/otlp/otlp_grpc_metric_exporter.h
+++ b/exporters/otlp/include/opentelemetry/exporters/otlp/otlp_grpc_metric_exporter.h
@@ -60,6 +60,9 @@ private:
   // The configuration options associated with this exporter.
   const OtlpGrpcMetricExporterOptions options_;
 
+  // Aggregation Temporality selector
+  const sdk::metrics::AggregationTemporalitySelector aggregation_temporality_selector_;
+
   // For testing
   friend class OtlpGrpcExporterTestPeer;
 

--- a/exporters/otlp/include/opentelemetry/exporters/otlp/otlp_grpc_metric_exporter.h
+++ b/exporters/otlp/include/opentelemetry/exporters/otlp/otlp_grpc_metric_exporter.h
@@ -39,6 +39,14 @@ public:
    */
   explicit OtlpGrpcMetricExporter(const OtlpGrpcMetricExporterOptions &options);
 
+  /**
+   * Get the AggregationTemporality for exporter
+   *
+   * @return AggregationTemporality
+   */
+  sdk::metrics::AggregationTemporality GetAggregationTemporality(
+      sdk::metrics::InstrumentType instrument_type) const noexcept override;
+
   opentelemetry::sdk::common::ExportResult Export(
       const opentelemetry::sdk::metrics::ResourceMetrics &data) noexcept override;
 

--- a/exporters/otlp/include/opentelemetry/exporters/otlp/otlp_grpc_metric_exporter_options.h
+++ b/exporters/otlp/include/opentelemetry/exporters/otlp/otlp_grpc_metric_exporter_options.h
@@ -19,11 +19,13 @@ namespace otlp
  */
 struct OtlpGrpcMetricExporterOptions : public OtlpGrpcExporterOptions
 {
-  opentelemetry::sdk::metrics::AggregationTemporality aggregation_temporality =
-      opentelemetry::sdk::metrics::AggregationTemporality::kDelta;
 
-  opentelemetry::sdk::metrics::AggregationTemporalitySelector aggregation_temporality_selector =
-      OtlpMetricUtils::ChooseTemporalitySelector();
+  // Preferred Aggregation Temporality
+  sdk::metrics::AggregationTemporality aggregation_temporality =
+      sdk::metrics::AggregationTemporality::kCumulative;
+
+  // opentelemetry::sdk::metrics::AggregationTemporalitySelector aggregation_temporality_selector =
+  //    OtlpMetricUtils::ChooseTemporalitySelector();
 };
 
 }  // namespace otlp

--- a/exporters/otlp/include/opentelemetry/exporters/otlp/otlp_grpc_metric_exporter_options.h
+++ b/exporters/otlp/include/opentelemetry/exporters/otlp/otlp_grpc_metric_exporter_options.h
@@ -21,6 +21,9 @@ struct OtlpGrpcMetricExporterOptions : public OtlpGrpcExporterOptions
 {
   opentelemetry::sdk::metrics::AggregationTemporality aggregation_temporality =
       opentelemetry::sdk::metrics::AggregationTemporality::kDelta;
+
+  opentelemetry::sdk::metrics::AggregationTemporalitySelector aggregation_temporality_selector =
+      OtlpMetricUtils::ChooseTemporalitySelector();
 };
 
 }  // namespace otlp

--- a/exporters/otlp/include/opentelemetry/exporters/otlp/otlp_grpc_metric_exporter_options.h
+++ b/exporters/otlp/include/opentelemetry/exporters/otlp/otlp_grpc_metric_exporter_options.h
@@ -23,9 +23,6 @@ struct OtlpGrpcMetricExporterOptions : public OtlpGrpcExporterOptions
   // Preferred Aggregation Temporality
   sdk::metrics::AggregationTemporality aggregation_temporality =
       sdk::metrics::AggregationTemporality::kCumulative;
-
-  // opentelemetry::sdk::metrics::AggregationTemporalitySelector aggregation_temporality_selector =
-  //    OtlpMetricUtils::ChooseTemporalitySelector();
 };
 
 }  // namespace otlp

--- a/exporters/otlp/include/opentelemetry/exporters/otlp/otlp_http_metric_exporter.h
+++ b/exporters/otlp/include/opentelemetry/exporters/otlp/otlp_http_metric_exporter.h
@@ -52,6 +52,11 @@ struct OtlpHttpMetricExporterOptions
   // Additional HTTP headers
   OtlpHeaders http_headers = GetOtlpDefaultMetricHeaders();
 
+  // Preferred Aggregation Temporality
+
+  sdk::metrics::AggregationTemporalitySelector aggregation_temporality_selector =
+      otlp::OtlpMetricUtils::ChooseTemporalitySelector();
+
 #  ifdef ENABLE_ASYNC_EXPORT
   // Concurrent requests
   // https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/protocol/otlp.md#otlpgrpc-concurrent-requests
@@ -79,6 +84,14 @@ public:
    */
   OtlpHttpMetricExporter(const OtlpHttpMetricExporterOptions &options);
 
+  /**
+   * Get the AggregationTemporality for exporter
+   *
+   * @return AggregationTemporality
+   */
+  sdk::metrics::AggregationTemporality GetAggregationTemporality(
+      sdk::metrics::InstrumentType instrument_type) const noexcept override;
+
   opentelemetry::sdk::common::ExportResult Export(
       const opentelemetry::sdk::metrics::ResourceMetrics &data) noexcept override;
 
@@ -94,6 +107,9 @@ public:
 private:
   // Configuration options for the exporter
   const OtlpHttpMetricExporterOptions options_;
+
+  // Aggregation Temporality Selector
+  const sdk::metrics::AggregationTemporalitySelector aggregation_temporality_selector_;
 
   // Object that stores the HTTP sessions that have been created
   std::unique_ptr<OtlpHttpClient> http_client_;

--- a/exporters/otlp/include/opentelemetry/exporters/otlp/otlp_http_metric_exporter.h
+++ b/exporters/otlp/include/opentelemetry/exporters/otlp/otlp_http_metric_exporter.h
@@ -9,6 +9,7 @@
 #  include "opentelemetry/exporters/otlp/otlp_http_client.h"
 
 #  include "opentelemetry/exporters/otlp/otlp_environment.h"
+#  include "opentelemetry/exporters/otlp/otlp_metric_utils.h"
 
 #  include <chrono>
 #  include <cstddef>
@@ -53,9 +54,8 @@ struct OtlpHttpMetricExporterOptions
   OtlpHeaders http_headers = GetOtlpDefaultMetricHeaders();
 
   // Preferred Aggregation Temporality
-
-  sdk::metrics::AggregationTemporalitySelector aggregation_temporality_selector =
-      otlp::OtlpMetricUtils::ChooseTemporalitySelector();
+  sdk::metrics::AggregationTemporality aggregation_temporality =
+      sdk::metrics::AggregationTemporality::kCumulative;
 
 #  ifdef ENABLE_ASYNC_EXPORT
   // Concurrent requests

--- a/exporters/otlp/include/opentelemetry/exporters/otlp/otlp_metric_utils.h
+++ b/exporters/otlp/include/opentelemetry/exporters/otlp/otlp_metric_utils.h
@@ -52,6 +52,13 @@ public:
   static void PopulateRequest(
       const opentelemetry::sdk::metrics::ResourceMetrics &data,
       proto::collector::metrics::v1::ExportMetricsServiceRequest *request) noexcept;
+
+  static sdk::metrics::AggregationTemporalitySelector ChooseTemporalitySelector(
+      sdk::metrics::AggregationTemporality preferred_aggregation_temporality) noexcept;
+  static sdk::metrics::AggregationTemporality DeltaTemporalitySelector(
+      InstrumentType instrument_type) noexcept;
+  static sdk::metrics::AggregationTemporality CumulativeTemporalitySelector(
+      InstumentType instrument_type) noexcept;
 };
 
 }  // namespace otlp

--- a/exporters/otlp/include/opentelemetry/exporters/otlp/otlp_metric_utils.h
+++ b/exporters/otlp/include/opentelemetry/exporters/otlp/otlp_metric_utils.h
@@ -56,9 +56,9 @@ public:
   static sdk::metrics::AggregationTemporalitySelector ChooseTemporalitySelector(
       sdk::metrics::AggregationTemporality preferred_aggregation_temporality) noexcept;
   static sdk::metrics::AggregationTemporality DeltaTemporalitySelector(
-      InstrumentType instrument_type) noexcept;
+      sdk::metrics::InstrumentType instrument_type) noexcept;
   static sdk::metrics::AggregationTemporality CumulativeTemporalitySelector(
-      InstumentType instrument_type) noexcept;
+      sdk::metrics::InstrumentType instrument_type) noexcept;
 };
 
 }  // namespace otlp

--- a/exporters/otlp/src/otlp_grpc_metric_exporter.cc
+++ b/exporters/otlp/src/otlp_grpc_metric_exporter.cc
@@ -90,20 +90,26 @@ OtlpGrpcMetricExporter::OtlpGrpcMetricExporter()
 {}
 
 OtlpGrpcMetricExporter::OtlpGrpcMetricExporter(const OtlpGrpcMetricExporterOptions &options)
-    : options_(options), metrics_service_stub_(MakeMetricsServiceStub(options))
+    : options_(options),
+      aggregation_temporality_selector_{
+          OtlpMetricUtils::ChooseTemporalitySelector(options_.aggregation_temporality)},
+      metrics_service_stub_(MakeMetricsServiceStub(options))
 {}
 
 OtlpGrpcMetricExporter::OtlpGrpcMetricExporter(
     std::unique_ptr<proto::collector::metrics::v1::MetricsService::StubInterface> stub)
-    : options_(OtlpGrpcMetricExporterOptions()), metrics_service_stub_(std::move(stub))
+    : options_(OtlpGrpcMetricExporterOptions()),
+      aggregation_temporality_selector_{
+          OtlpMetricUtils::ChooseTemporalitySelector(options_.aggregation_temporality)},
+      metrics_service_stub_(std::move(stub))
 {}
 
 // ----------------------------- Exporter methods ------------------------------
 
-sdk::metrics::AggregationTemporality OtlpHttpMetricExporter::GetAggregationTemporality(
+sdk::metrics::AggregationTemporality OtlpGrpcMetricExporter::GetAggregationTemporality(
     sdk::metrics::InstrumentType instrument_type) const noexcept
 {
-  return options_.aggregation_temporality_selector(instrument_type);
+  return aggregation_temporality_selector_(instrument_type);
 }
 
 opentelemetry::sdk::common::ExportResult OtlpGrpcMetricExporter::Export(

--- a/exporters/otlp/src/otlp_grpc_metric_exporter.cc
+++ b/exporters/otlp/src/otlp_grpc_metric_exporter.cc
@@ -100,6 +100,12 @@ OtlpGrpcMetricExporter::OtlpGrpcMetricExporter(
 
 // ----------------------------- Exporter methods ------------------------------
 
+sdk::metrics::AggregationTemporality OtlpHttpMetricExporter::GetAggregationTemporality(
+    sdk::metrics::InstrumentType instrument_type) const noexcept
+{
+  return options_.aggregation_temporality_selector(instrument_type);
+}
+
 opentelemetry::sdk::common::ExportResult OtlpGrpcMetricExporter::Export(
     const opentelemetry::sdk::metrics::ResourceMetrics &data) noexcept
 {

--- a/exporters/otlp/src/otlp_http_metric_exporter.cc
+++ b/exporters/otlp/src/otlp_http_metric_exporter.cc
@@ -43,7 +43,7 @@ OtlpHttpMetricExporter::OtlpHttpMetricExporter(const OtlpHttpMetricExporterOptio
                                                             )))
 {}
 
-OtlpHttpMetricExporter::OtlpHttpMetricExporter(std::unique_ptr<OtlpHttpClient> http_client)
+OtlpHttpMetricExporter::(std::unique_ptr<OtlpHttpClient> http_client)
     : options_(OtlpHttpMetricExporterOptions()), http_client_(std::move(http_client))
 {
   OtlpHttpMetricExporterOptions &options = const_cast<OtlpHttpMetricExporterOptions &>(options_);
@@ -60,6 +60,12 @@ OtlpHttpMetricExporter::OtlpHttpMetricExporter(std::unique_ptr<OtlpHttpClient> h
 #  endif
 }
 // ----------------------------- Exporter methods ------------------------------
+
+sdk::metrics::AggregationTemporality OtlpHttpMetricExporter::GetAggregationTemporality(
+    sdk::metrics::InstrumentType instrument_type) const noexcept
+{
+  return options_.aggregation_temporality_selector(instrument_type);
+}
 
 opentelemetry::sdk::common::ExportResult OtlpHttpMetricExporter::Export(
     const opentelemetry::sdk::metrics::ResourceMetrics &data) noexcept

--- a/exporters/otlp/src/otlp_metric_utils.cc
+++ b/exporters/otlp/src/otlp_metric_utils.cc
@@ -214,6 +214,7 @@ void OtlpMetricUtils::PopulateResourceMetrics(
 
     for (auto &metric_data : scope_metrics.metric_data_)
     {
+      PopulateInstrumentInfoMetrics(metric_data, scope_lib_metrics->add_metrics());
     }
   }
 }

--- a/exporters/otlp/src/otlp_metric_utils.cc
+++ b/exporters/otlp/src/otlp_metric_utils.cc
@@ -252,7 +252,6 @@ sdk::metrics::AggregationTemporality OtlpMetricUtils::DeltaTemporalitySelector(
     case sdk::metrics::InstrumentType::kHistogram:
     case sdk::metrics::InstrumentType::kObservableGauge:
       return sdk::metrics::AggregationTemporality::kDelta;
-      break;
     case sdk::metrics::InstrumentType::kUpDownCounter:
     case sdk::metrics::InstrumentType::kObservableUpDownCounter:
       return sdk::metrics::AggregationTemporality::kCumulative;

--- a/exporters/otlp/src/otlp_metric_utils.cc
+++ b/exporters/otlp/src/otlp_metric_utils.cc
@@ -214,7 +214,6 @@ void OtlpMetricUtils::PopulateResourceMetrics(
 
     for (auto &metric_data : scope_metrics.metric_data_)
     {
-      PopulateInstrumentInfoMetrics(metric_data, scope_lib_metrics->add_metrics());
     }
   }
 }
@@ -231,6 +230,40 @@ void OtlpMetricUtils::PopulateRequest(
   auto resource_metrics = request->add_resource_metrics();
   PopulateResourceMetrics(data, resource_metrics);
 }
+
+sdk::metrics::AggregationTemporalitySelector OtlpMetricUtils::ChooseTemporalitySelector(
+    sdk::metrics::AggregationTemporality preferred_aggregation_temporality) noexcept
+{
+  if (preferred_aggregation_temporality == sdk::metrics::AggregationTemporality::kDelta)
+  {
+    return DeltaTemporalitySelector;
+  }
+  return CumulativeTemporalitySelector;
+}
+
+sdk::metrics::AggregationTemporality OtlpMetricUtils::DeltaTemporalitySelector(
+    InstrumentType instrument_type) noexcept
+{
+  switch (instrument_type)
+  {
+    case sdk::metrics::InstrumentType::kCounter:
+    case sdk::metrics::InstrumentType::kObservableCounter:
+    case sdk::metrics::InstrumentType::kHistogram:
+    case sdk::metrics::InstrumentType::kObservableGauge:
+      return sdk::metrics::AggregationTemporality::kDelta;
+      break;
+    case sdk::metrics::InstrumentType::kUpDownCounter:
+    case sdk::metrics::InstrumentType::kObservableUpDownCounter:
+      return sdk::metrics::AggregationTemporality::kCumulative;
+  }
+}
+
+sdk::metrics::AggregationTemporality OtlpMetricUtils::CumulativeTemporalitySelector(
+    InstumentType instrument_type) noexcept
+{
+  return sdk::metrics::AggregationTemporality::kCumulative;
+}
+
 }  // namespace otlp
 }  // namespace exporter
 OPENTELEMETRY_END_NAMESPACE

--- a/exporters/otlp/src/otlp_metric_utils.cc
+++ b/exporters/otlp/src/otlp_metric_utils.cc
@@ -242,7 +242,7 @@ sdk::metrics::AggregationTemporalitySelector OtlpMetricUtils::ChooseTemporalityS
 }
 
 sdk::metrics::AggregationTemporality OtlpMetricUtils::DeltaTemporalitySelector(
-    InstrumentType instrument_type) noexcept
+    sdk::metrics::InstrumentType instrument_type) noexcept
 {
   switch (instrument_type)
   {
@@ -256,10 +256,11 @@ sdk::metrics::AggregationTemporality OtlpMetricUtils::DeltaTemporalitySelector(
     case sdk::metrics::InstrumentType::kObservableUpDownCounter:
       return sdk::metrics::AggregationTemporality::kCumulative;
   }
+  return sdk::metrics::AggregationTemporality::kUnspecified;
 }
 
 sdk::metrics::AggregationTemporality OtlpMetricUtils::CumulativeTemporalitySelector(
-    InstumentType instrument_type) noexcept
+    sdk::metrics::InstrumentType instrument_type) noexcept
 {
   return sdk::metrics::AggregationTemporality::kCumulative;
 }

--- a/exporters/prometheus/include/opentelemetry/exporters/prometheus/exporter.h
+++ b/exporters/prometheus/include/opentelemetry/exporters/prometheus/exporter.h
@@ -57,6 +57,14 @@ public:
   PrometheusExporter(const PrometheusExporterOptions &options);
 
   /**
+   * Get the AggregationTemporality for Prometheus exporter
+   *
+   * @return AggregationTemporality
+   */
+  sdk::metrics::AggregationTemporality GetAggregationTemporality(
+      sdk::metrics::InstrumentType instrument_type) const noexcept override;
+
+  /**
    * Exports a batch of Metric Records.
    * @param records: a collection of records to export
    * @return: returns a ReturnCode detailing a success, or type of failure

--- a/exporters/prometheus/src/exporter.cc
+++ b/exporters/prometheus/src/exporter.cc
@@ -33,6 +33,13 @@ PrometheusExporter::PrometheusExporter() : is_shutdown_(false)
   collector_ = std::unique_ptr<PrometheusCollector>(new PrometheusCollector(3));
 }
 
+sdk::metrics::AggregationTemporality PrometheusExporter::GetAggregationTemporality(
+    sdk::metrics::InstrumentType instrument_type) const noexcept
+{
+  // Prometheus exporter only support Cumulative
+  return sdk::metrics::AggregationTemporality::kCumulative;
+}
+
 /**
  * Exports a batch of Metric Records.
  * @param records: a collection of records to export

--- a/sdk/include/opentelemetry/sdk/metrics/export/periodic_exporting_metric_reader.h
+++ b/sdk/include/opentelemetry/sdk/metrics/export/periodic_exporting_metric_reader.h
@@ -40,10 +40,11 @@ class PeriodicExportingMetricReader : public MetricReader
 {
 
 public:
-  PeriodicExportingMetricReader(
-      std::unique_ptr<MetricExporter> exporter,
-      const PeriodicExportingMetricReaderOptions &option,
-      AggregationTemporality aggregation_temporality = AggregationTemporality::kCumulative);
+  PeriodicExportingMetricReader(std::unique_ptr<MetricExporter> exporter,
+                                const PeriodicExportingMetricReaderOptions &option);
+
+  AggregationTemporality GetAggregationTemporality(
+      InstrumentType instrument_type) const noexcept override;
 
 private:
   bool OnForceFlush(std::chrono::microseconds timeout) noexcept override;

--- a/sdk/include/opentelemetry/sdk/metrics/instruments.h
+++ b/sdk/include/opentelemetry/sdk/metrics/instruments.h
@@ -52,7 +52,8 @@ struct InstrumentDescriptor
   InstrumentValueType value_type_;
 };
 
-using MetricAttributes = opentelemetry::sdk::common::OrderedAttributeMap;
+using MetricAttributes               = opentelemetry::sdk::common::OrderedAttributeMap;
+using AggregationTemporalitySelector = std::function<AggregationTemporality(InstrumentType)>;
 
 /*class InstrumentSelector {
 public:

--- a/sdk/include/opentelemetry/sdk/metrics/metric_exporter.h
+++ b/sdk/include/opentelemetry/sdk/metrics/metric_exporter.h
@@ -36,6 +36,14 @@ public:
   virtual opentelemetry::sdk::common::ExportResult Export(const ResourceMetrics &data) noexcept = 0;
 
   /**
+   * Get the AggregationTemporality for given Instrument Type for this exporter.
+   *
+   * @return AggregationTemporality
+   */
+  virtual AggregationTemporality GetAggregationTemporality(
+      InstrumentType instrument_type) const noexcept = 0;
+
+  /**
    * Force flush the exporter.
    */
   virtual bool ForceFlush(

--- a/sdk/include/opentelemetry/sdk/metrics/metric_reader.h
+++ b/sdk/include/opentelemetry/sdk/metrics/metric_reader.h
@@ -25,8 +25,7 @@ namespace metrics
 class MetricReader
 {
 public:
-  MetricReader(
-      AggregationTemporality aggregation_temporality = AggregationTemporality::kCumulative);
+  MetricReader();
 
   void SetMetricProducer(MetricProducer *metric_producer);
 
@@ -36,7 +35,14 @@ public:
    */
   bool Collect(nostd::function_ref<bool(ResourceMetrics &metric_data)> callback) noexcept;
 
-  AggregationTemporality GetAggregationTemporality() const noexcept;
+  /**
+   * Get the AggregationTemporality for given Instrument Type for this reader.
+   *
+   * @return AggregationTemporality
+   */
+
+  virtual AggregationTemporality GetAggregationTemporality(
+      InstrumentType instrument_type) const noexcept = 0;
 
   /**
    * Shutdown the meter reader.
@@ -62,7 +68,6 @@ protected:
 
 private:
   MetricProducer *metric_producer_;
-  AggregationTemporality aggregation_temporality_;
   mutable opentelemetry::common::SpinLockMutex lock_;
   bool shutdown_;
 };

--- a/sdk/include/opentelemetry/sdk/metrics/state/metric_collector.h
+++ b/sdk/include/opentelemetry/sdk/metrics/state/metric_collector.h
@@ -18,7 +18,8 @@ class MeterContext;
 class CollectorHandle
 {
 public:
-  virtual AggregationTemporality GetAggregationTemporality() noexcept = 0;
+  virtual AggregationTemporality GetAggregationTemporality(
+      InstrumentType instrument_type) noexcept = 0;
 };
 
 /**
@@ -33,7 +34,8 @@ public:
   MetricCollector(std::shared_ptr<MeterContext> &&context,
                   std::unique_ptr<MetricReader> metric_reader);
 
-  AggregationTemporality GetAggregationTemporality() noexcept override;
+  AggregationTemporality GetAggregationTemporality(
+      InstrumentType instrument_type) noexcept override;
 
   /**
    * The callback to be called for each metric exporter. This will only be those

--- a/sdk/src/metrics/export/periodic_exporting_metric_reader.cc
+++ b/sdk/src/metrics/export/periodic_exporting_metric_reader.cc
@@ -17,10 +17,8 @@ namespace metrics
 
 PeriodicExportingMetricReader::PeriodicExportingMetricReader(
     std::unique_ptr<MetricExporter> exporter,
-    const PeriodicExportingMetricReaderOptions &option,
-    AggregationTemporality aggregation_temporality)
-    : MetricReader(aggregation_temporality),
-      exporter_{std::move(exporter)},
+    const PeriodicExportingMetricReaderOptions &option)
+    : exporter_{std::move(exporter)},
       export_interval_millis_{option.export_interval_millis},
       export_timeout_millis_{option.export_timeout_millis}
 {
@@ -34,6 +32,11 @@ PeriodicExportingMetricReader::PeriodicExportingMetricReader(
   }
 }
 
+AggregationTemporality PeriodicExportingMetricReader::GetAggregationTemporality(
+    InstrumentType instrument_type) const noexcept
+{
+  return exporter_->GetAggregationTemporality(instrument_type);
+}
 void PeriodicExportingMetricReader::OnInitialized() noexcept
 {
   worker_thread_ = std::thread(&PeriodicExportingMetricReader::DoBackgroundWork, this);

--- a/sdk/src/metrics/metric_reader.cc
+++ b/sdk/src/metrics/metric_reader.cc
@@ -13,19 +13,12 @@ namespace sdk
 namespace metrics
 {
 
-MetricReader::MetricReader(AggregationTemporality aggregation_temporality)
-    : metric_producer_(nullptr), aggregation_temporality_(aggregation_temporality), shutdown_(false)
-{}
+MetricReader::MetricReader() : metric_producer_(nullptr), shutdown_(false) {}
 
 void MetricReader::SetMetricProducer(MetricProducer *metric_producer)
 {
   metric_producer_ = metric_producer;
   OnInitialized();
-}
-
-AggregationTemporality MetricReader::GetAggregationTemporality() const noexcept
-{
-  return aggregation_temporality_;
 }
 
 bool MetricReader::Collect(

--- a/sdk/src/metrics/state/metric_collector.cc
+++ b/sdk/src/metrics/state/metric_collector.cc
@@ -24,9 +24,10 @@ MetricCollector::MetricCollector(
   metric_reader_->SetMetricProducer(this);
 }
 
-AggregationTemporality MetricCollector::GetAggregationTemporality() noexcept
+AggregationTemporality MetricCollector::GetAggregationTemporality(
+    InstrumentType instrument_type) noexcept
 {
-  return metric_reader_->GetAggregationTemporality();
+  return metric_reader_->GetAggregationTemporality(instrument_type);
 }
 
 bool MetricCollector::Collect(

--- a/sdk/src/metrics/state/temporal_metric_storage.cc
+++ b/sdk/src/metrics/state/temporal_metric_storage.cc
@@ -32,7 +32,8 @@ bool TemporalMetricStorage::buildMetrics(CollectorHandle *collector,
 {
   std::lock_guard<opentelemetry::common::SpinLockMutex> guard(lock_);
   opentelemetry::common::SystemTimestamp last_collection_ts = sdk_start_ts;
-  auto aggregation_temporarily = collector->GetAggregationTemporality();
+  AggregationTemporality aggregation_temporarily =
+      collector->GetAggregationTemporality(instrument_descriptor_.type_);
   for (auto &col : collectors)
   {
     unreported_metrics_[col.get()].push_back(delta_metrics);

--- a/sdk/test/metrics/async_metric_storage_test.cc
+++ b/sdk/test/metrics/async_metric_storage_test.cc
@@ -29,7 +29,10 @@ class MockCollectorHandle : public CollectorHandle
 public:
   MockCollectorHandle(AggregationTemporality temp) : temporality(temp) {}
 
-  AggregationTemporality GetAggregationTemporality() noexcept override { return temporality; }
+  AggregationTemporality GetAggregationTemporality(InstrumentType instrument_type) noexcept override
+  {
+    return temporality;
+  }
 
 private:
   AggregationTemporality temporality;

--- a/sdk/test/metrics/meter_provider_sdk_test.cc
+++ b/sdk/test/metrics/meter_provider_sdk_test.cc
@@ -23,6 +23,12 @@ public:
     return opentelemetry::sdk::common::ExportResult::kSuccess;
   }
 
+  AggregationTemporality GetAggregationTemporality(
+      InstrumentType instrument_type) const noexcept override
+  {
+    return AggregationTemporality::kCumulative;
+  }
+
   bool ForceFlush(
       std::chrono::microseconds timeout = (std::chrono::microseconds::max)()) noexcept override
   {
@@ -39,6 +45,11 @@ class MockMetricReader : public MetricReader
 {
 public:
   MockMetricReader(std::unique_ptr<MetricExporter> exporter) : exporter_(std::move(exporter)) {}
+  AggregationTemporality GetAggregationTemporality(
+      InstrumentType instrument_type) const noexcept override
+  {
+    return exporter_->GetAggregationTemporality(instrument_type);
+  }
   virtual bool OnForceFlush(std::chrono::microseconds timeout) noexcept override { return true; }
   virtual bool OnShutDown(std::chrono::microseconds timeout) noexcept override { return true; }
   virtual void OnInitialized() noexcept override {}

--- a/sdk/test/metrics/periodic_exporting_metric_reader_test.cc
+++ b/sdk/test/metrics/periodic_exporting_metric_reader_test.cc
@@ -28,6 +28,12 @@ public:
     return false;
   }
 
+  sdk::metrics::AggregationTemporality GetAggregationTemporality(
+      sdk::metrics::InstrumentType instrument_type) const noexcept override
+  {
+    return sdk::metrics::AggregationTemporality::kCumulative;
+  }
+
   bool Shutdown(std::chrono::microseconds timeout = std::chrono::microseconds(0)) noexcept override
   {
     return true;

--- a/sdk/test/metrics/sync_metric_storage_test.cc
+++ b/sdk/test/metrics/sync_metric_storage_test.cc
@@ -23,7 +23,10 @@ class MockCollectorHandle : public CollectorHandle
 public:
   MockCollectorHandle(AggregationTemporality temp) : temporality(temp) {}
 
-  AggregationTemporality GetAggregationTemporality() noexcept override { return temporality; }
+  AggregationTemporality GetAggregationTemporality(InstrumentType instrument_type) noexcept override
+  {
+    return temporality;
+  }
 
 private:
   AggregationTemporality temporality;


### PR DESCRIPTION
Fixes #1339

## Changes

As preferred aggregation temporality concept is removed from specs, and is made as function of instrument-kind (see section here - https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/metrics/sdk.md#metricreader) , following changes are done -

- Modify `GetAggregationTemporality()` method in MetricReader. The methods now take in instrument type/kind, that lets exporter find which temporality to use based on the instrument.
- Add  `GetAggregationTemporality()` method in MetricExporter. This method takes the instrument type/kind, and returns the correct temporality to use based on the exporter used - 
    - OTLP exporter can be configured with a preferred temporality
    - Prometheus only uses cumulative (as it doesn't support delta).

For significant contributions please make sure you have completed the following items:

* [ ] `CHANGELOG.md` updated for non-trivial changes
* [x] Unit tests have been added
* [x] Changes in public API reviewed