### PR TITLE
[NFC] Improve scope/instrument names in metrics ostream exporter

### DIFF
--- a/exporters/ostream/src/metric_exporter.cc
+++ b/exporters/ostream/src/metric_exporter.cc
@@ -117,14 +117,14 @@ void OStreamMetricExporter::printInstrumentationInfoMetricData(
   // sout_ is shared
   const std::lock_guard<opentelemetry::common::SpinLockMutex> locked(lock_);
   sout_ << "{";
-  sout_ << "\n  name\t\t: " << info_metric.scope_->GetName()
+  sout_ << "\n  scope name\t: " << info_metric.scope_->GetName()
         << "\n  schema url\t: " << info_metric.scope_->GetSchemaURL()
         << "\n  version\t: " << info_metric.scope_->GetVersion();
   for (const auto &record : info_metric.metric_data_)
   {
     sout_ << "\n  start time\t: " << timeToString(record.start_ts)
           << "\n  end time\t: " << timeToString(record.end_ts)
-          << "\n  name\t\t: " << record.instrument_descriptor.name_
+          << "\n  instrument name\t: " << record.instrument_descriptor.name_
           << "\n  description\t: " << record.instrument_descriptor.description_
           << "\n  unit\t\t: " << record.instrument_descriptor.unit_;
 

--- a/exporters/ostream/test/ostream_metric_test.cc
+++ b/exporters/ostream/test/ostream_metric_test.cc
@@ -66,12 +66,12 @@ TEST(OStreamMetricsExporter, ExportSumPointData)
 
   std::string expected_output =
       "{"
-      "\n  name\t\t: library_name"
+      "\n  scope name\t: library_name"
       "\n  schema url\t: "
       "\n  version\t: 1.2.0"
       "\n  start time\t: Thu Jan  1 00:00:00 1970"
       "\n  end time\t: Thu Jan  1 00:00:00 1970"
-      "\n  name\t\t: library_name"
+      "\n  instrument name\t: library_name"
       "\n  description\t: description"
       "\n  unit\t\t: unit"
       "\n  type\t\t: SumPointData"
@@ -137,12 +137,12 @@ TEST(OStreamMetricsExporter, ExportHistogramPointData)
 
   std::string expected_output =
       "{"
-      "\n  name\t\t: library_name"
+      "\n  scope name\t: library_name"
       "\n  schema url\t: "
       "\n  version\t: 1.2.0"
       "\n  start time\t: Thu Jan  1 00:00:00 1970"
       "\n  end time\t: Thu Jan  1 00:00:00 1970"
-      "\n  name\t\t: library_name"
+      "\n  instrument name\t: library_name"
       "\n  description\t: description"
       "\n  unit\t\t: unit"
       "\n  type     : HistogramPointData"
@@ -215,12 +215,12 @@ TEST(OStreamMetricsExporter, ExportLastValuePointData)
 
   std::string expected_output =
       "{"
-      "\n  name\t\t: library_name"
+      "\n  scope name\t: library_name"
       "\n  schema url\t: "
       "\n  version\t: 1.2.0"
       "\n  start time\t: Thu Jan  1 00:00:00 1970"
       "\n  end time\t: Thu Jan  1 00:00:00 1970"
-      "\n  name\t\t: library_name"
+      "\n  instrument name\t: library_name"
       "\n  description\t: description"
       "\n  unit\t\t: unit"
       "\n  type     : LastValuePointData"
@@ -278,12 +278,12 @@ TEST(OStreamMetricsExporter, ExportDropPointData)
 
   std::string expected_output =
       "{"
-      "\n  name\t\t: library_name"
+      "\n  scope name\t: library_name"
       "\n  schema url\t: "
       "\n  version\t: 1.2.0"
       "\n  start time\t: Thu Jan  1 00:00:00 1970"
       "\n  end time\t: Thu Jan  1 00:00:00 1970"
-      "\n  name\t\t: library_name"
+      "\n  instrument name\t: library_name"
       "\n  description\t: description"
       "\n  unit\t\t: unit"
       "\n  resources\t:"


### PR DESCRIPTION
Previously, we were overloading the `name` key in the metrics ostream
exporter. This patch qualifies the `name` key with the appropriate prefix
based on the structures they represent.