### PR TITLE
METRICS SDK - Calling Observable Instruments callback during metrics collection

### DIFF
--- a/sdk/include/opentelemetry/sdk/metrics/async_instruments.h
+++ b/sdk/include/opentelemetry/sdk/metrics/async_instruments.h
@@ -21,7 +21,8 @@ class ObservableInstrument : public opentelemetry::metrics::ObservableInstrument
 {
 public:
   ObservableInstrument(InstrumentDescriptor instrument_descriptor,
-                       std::unique_ptr<AsyncWritableMetricStorage> storage);
+                       std::unique_ptr<AsyncWritableMetricStorage> storage,
+                       std::shared_ptr<ObservableRegistry> observable_registry);
 
   void AddCallback(opentelemetry::metrics::ObservableCallbackPtr callback,
                    void *state) noexcept override;
@@ -36,7 +37,7 @@ public:
 private:
   InstrumentDescriptor instrument_descriptor_;
   std::unique_ptr<AsyncWritableMetricStorage> storage_;
-  std::unique_ptr<ObservableRegistry> observable_registry_;
+  std::shared_ptr<ObservableRegistry> observable_registry_;
 };
 }  // namespace metrics
 }  // namespace sdk

--- a/sdk/include/opentelemetry/sdk/metrics/meter.h
+++ b/sdk/include/opentelemetry/sdk/metrics/meter.h
@@ -24,6 +24,7 @@ namespace metrics
 class MetricStorage;
 class SyncWritableMetricStorage;
 class AsyncWritableMetricsStorge;
+class ObservableRegistry;
 
 class Meter final : public opentelemetry::metrics::Meter
 {
@@ -114,6 +115,7 @@ private:
   std::shared_ptr<sdk::metrics::MeterContext> meter_context_;
   // Mapping between instrument-name and Aggregation Storage.
   std::unordered_map<std::string, std::shared_ptr<MetricStorage>> storage_registry_;
+  std::shared_ptr<ObservableRegistry> observable_registry_;
   std::unique_ptr<SyncWritableMetricStorage> RegisterSyncMetricStorage(
       InstrumentDescriptor &instrument_descriptor);
   std::unique_ptr<AsyncWritableMetricStorage> RegisterAsyncMetricStorage(

--- a/sdk/src/metrics/async_instruments.cc
+++ b/sdk/src/metrics/async_instruments.cc
@@ -15,10 +15,12 @@ namespace metrics
 {
 
 ObservableInstrument::ObservableInstrument(InstrumentDescriptor instrument_descriptor,
-                                           std::unique_ptr<AsyncWritableMetricStorage> storage)
+                                           std::unique_ptr<AsyncWritableMetricStorage> storage,
+                                           std::shared_ptr<ObservableRegistry> observable_registry)
     : instrument_descriptor_(instrument_descriptor),
       storage_(std::move(storage)),
-      observable_registry_{new ObservableRegistry()}
+      observable_registry_{observable_registry}
+
 {}
 
 void ObservableInstrument::AddCallback(opentelemetry::metrics::ObservableCallbackPtr callback,

--- a/sdk/test/metrics/CMakeLists.txt
+++ b/sdk/test/metrics/CMakeLists.txt
@@ -1,6 +1,7 @@
 foreach(
   testname
   meter_provider_sdk_test
+  meter_test
   view_registry_test
   aggregation_test
   attributes_processor_test

--- a/sdk/test/metrics/async_instruments_test.cc
+++ b/sdk/test/metrics/async_instruments_test.cc
@@ -19,8 +19,10 @@ TEST(AsyncInstruments, ObservableInstrument)
   InstrumentDescriptor instrument_descriptor = {"long_counter", "description", "1",
                                                 InstrumentType::kObservableCounter,
                                                 InstrumentValueType::kLong};
+  std::shared_ptr<ObservableRegistry> observable_registry(new ObservableRegistry());
   std::unique_ptr<AsyncWritableMetricStorage> metric_storage(new AsyncMultiMetricStorage());
-  ObservableInstrument observable_counter_long(instrument_descriptor, std::move(metric_storage));
+  ObservableInstrument observable_counter_long(instrument_descriptor, std::move(metric_storage),
+                                               observable_registry);
   observable_counter_long.AddCallback(asyc_generate_measurements, nullptr);
 }
 

--- a/sdk/test/metrics/meter_test.cc
+++ b/sdk/test/metrics/meter_test.cc
@@ -38,17 +38,6 @@ nostd::shared_ptr<metrics::Meter> InitMeter(MetricReader **metricReaderPtr)
   p->AddMetricReader(std::move(metric_reader));
   auto meter = provider->GetMeter("meter_name");
   return meter;
-  // auto sdk_meter = std::static_pointer_cast<opentelemetry::sdk::metrics::Meter>(meter);
-
-  /*
-    provider->
-    auto context = std::make_shared<opentelemetry::sdk::metrics::MeterContext>();
-    std::unique_ptr<MetricReader> metric_reader(new MockMetricReader());
-    *metricReaderPtr = metric_reader.get();
-    context->AddMetricReader(std::move(metric_reader));
-    std::shared_ptr<Meter> meter(new Meter(context));
-    return meter;
-    */
 }
 }  // namespace
 

--- a/sdk/test/metrics/meter_test.cc
+++ b/sdk/test/metrics/meter_test.cc
@@ -23,9 +23,9 @@ public:
   {
     return AggregationTemporality::kCumulative;
   }
-  virtual bool OnShutDown(std::chrono::microseconds timeout) noexcept override { return true; }
-  virtual bool OnForceFlush(std::chrono::microseconds timeout) noexcept override { return true; }
-  virtual void OnInitialized() noexcept override {}
+  bool OnShutDown(std::chrono::microseconds timeout) noexcept override { return true; }
+  bool OnForceFlush(std::chrono::microseconds timeout) noexcept override { return true; }
+  void OnInitialized() noexcept override {}
 };
 
 namespace

--- a/sdk/test/metrics/meter_test.cc
+++ b/sdk/test/metrics/meter_test.cc
@@ -1,0 +1,77 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef ENABLE_METRICS_PREVIEW
+#  include "opentelemetry/sdk/metrics/meter.h"
+#  include "opentelemetry/sdk/metrics/meter_context.h"
+#  include "opentelemetry/sdk/metrics/meter_provider.h"
+#  include "opentelemetry/sdk/metrics/metric_reader.h"
+
+#  include <gtest/gtest.h>
+
+using namespace opentelemetry;
+using namespace opentelemetry::sdk::instrumentationscope;
+using namespace opentelemetry::sdk::metrics;
+
+class MockMetricReader : public MetricReader
+{
+public:
+  MockMetricReader() = default;
+  AggregationTemporality GetAggregationTemporality(
+      InstrumentType instrument_type) const noexcept override
+  {
+    return AggregationTemporality::kCumulative;
+  }
+  virtual bool OnShutDown(std::chrono::microseconds timeout) noexcept override { return true; }
+  virtual bool OnForceFlush(std::chrono::microseconds timeout) noexcept override { return true; }
+  virtual void OnInitialized() noexcept override {}
+};
+
+namespace
+{
+nostd::shared_ptr<metrics::Meter> InitMeter(MetricReader **metricReaderPtr)
+{
+  static std::shared_ptr<metrics::MeterProvider> provider(new MeterProvider());
+  std::unique_ptr<MetricReader> metric_reader(new MockMetricReader());
+  *metricReaderPtr = metric_reader.get();
+  auto p           = std::static_pointer_cast<MeterProvider>(provider);
+  p->AddMetricReader(std::move(metric_reader));
+  auto meter = provider->GetMeter("meter_name");
+  return meter;
+  // auto sdk_meter = std::static_pointer_cast<opentelemetry::sdk::metrics::Meter>(meter);
+
+  /*
+    provider->
+    auto context = std::make_shared<opentelemetry::sdk::metrics::MeterContext>();
+    std::unique_ptr<MetricReader> metric_reader(new MockMetricReader());
+    *metricReaderPtr = metric_reader.get();
+    context->AddMetricReader(std::move(metric_reader));
+    std::shared_ptr<Meter> meter(new Meter(context));
+    return meter;
+    */
+}
+}  // namespace
+
+void asyc_generate_measurements(opentelemetry::metrics::ObserverResult observer, void *state)
+{
+  auto observer_long =
+      nostd::get<nostd::shared_ptr<opentelemetry::metrics::ObserverResultT<long>>>(observer);
+  observer_long->Observe(10l);
+}
+
+TEST(MeterTest, BasicAsyncTests)
+{
+  MetricReader *metricReaderPtr = nullptr;
+  auto meter                    = InitMeter(&metricReaderPtr);
+  auto observable_counter       = meter->CreateLongObservableCounter("observable_counter");
+  observable_counter->AddCallback(asyc_generate_measurements, nullptr);
+
+  size_t count = 0;
+  metricReaderPtr->Collect([&count](ResourceMetrics &metric_data) {
+    count += metric_data.scope_metric_data_.size();
+    EXPECT_EQ(count, 1);
+    return true;
+  });
+}
+
+#endif

--- a/sdk/test/metrics/meter_test.cc
+++ b/sdk/test/metrics/meter_test.cc
@@ -51,13 +51,13 @@ void asyc_generate_measurements(opentelemetry::metrics::ObserverResult observer,
 
 TEST(MeterTest, BasicAsyncTests)
 {
-  MetricReader *metricReaderPtr = nullptr;
-  auto meter                    = InitMeter(&metricReaderPtr);
-  auto observable_counter       = meter->CreateLongObservableCounter("observable_counter");
+  MetricReader *metric_reader_ptr = nullptr;
+  auto meter                      = InitMeter(&metric_reader_ptr);
+  auto observable_counter         = meter->CreateLongObservableCounter("observable_counter");
   observable_counter->AddCallback(asyc_generate_measurements, nullptr);
 
   size_t count = 0;
-  metricReaderPtr->Collect([&count](ResourceMetrics &metric_data) {
+  metric_reader_ptr->Collect([&count](ResourceMetrics &metric_data) {
     EXPECT_EQ(metric_data.scope_metric_data_.size(), 1);
     if (metric_data.scope_metric_data_.size())
     {

--- a/sdk/test/metrics/meter_test.cc
+++ b/sdk/test/metrics/meter_test.cc
@@ -3,6 +3,7 @@
 
 #ifndef ENABLE_METRICS_PREVIEW
 #  include "opentelemetry/sdk/metrics/meter.h"
+#  include "opentelemetry/sdk/metrics/data/point_data.h"
 #  include "opentelemetry/sdk/metrics/meter_context.h"
 #  include "opentelemetry/sdk/metrics/meter_provider.h"
 #  include "opentelemetry/sdk/metrics/metric_reader.h"
@@ -57,8 +58,16 @@ TEST(MeterTest, BasicAsyncTests)
 
   size_t count = 0;
   metricReaderPtr->Collect([&count](ResourceMetrics &metric_data) {
-    count += metric_data.scope_metric_data_.size();
-    EXPECT_EQ(count, 1);
+    EXPECT_EQ(metric_data.scope_metric_data_.size(), 1);
+    if (metric_data.scope_metric_data_.size())
+    {
+      EXPECT_EQ(metric_data.scope_metric_data_[0].metric_data_.size(), 1);
+      if (metric_data.scope_metric_data_.size())
+      {
+        count += metric_data.scope_metric_data_[0].metric_data_.size();
+        EXPECT_EQ(count, 1);
+      }
+    }
     return true;
   });
 }


### PR DESCRIPTION
Fixes #1550, #1556

## Changes

Please provide a brief description of the changes here.
1. Create ObservableRegistry during Meter creation.
2. Store the reference to ObservableRegistry while Instruments created from that Meter.
3. During the collection (in `Meter::Collect()`), call all the registered callbacks once.

For significant contributions please make sure you have completed the following items:

* [ ] `CHANGELOG.md` updated for non-trivial changes
* [x] Unit tests have been added
* [ ] Changes in public API reviewed