### PR TITLE
Fix metrics asan and tsan CI

### DIFF
--- a/sdk/test/metrics/async_metric_storage_test.cc
+++ b/sdk/test/metrics/async_metric_storage_test.cc
@@ -14,6 +14,7 @@
 #  include "opentelemetry/sdk/metrics/state/observable_registry.h"
 
 #  include <gtest/gtest.h>
+#  include <memory>
 #  include <vector>
 
 using namespace opentelemetry::sdk::metrics;
@@ -99,8 +100,10 @@ TEST_P(WritableMetricStorageTestFixture, TestAggregation)
   collectors.push_back(collector);
   size_t count_attributes = 0;
 
+  std::unique_ptr<AttributesProcessor> default_attributes_processor{
+      new DefaultAttributesProcessor{}};
   opentelemetry::sdk::metrics::AsyncMetricStorage storage(
-      instr_desc, AggregationType::kSum, new DefaultAttributesProcessor(),
+      instr_desc, AggregationType::kSum, default_attributes_processor.get(),
       std::shared_ptr<opentelemetry::sdk::metrics::AggregationConfig>{});
   long get_count                                                                  = 20l;
   long put_count                                                                  = 10l;


### PR DESCRIPTION
Fixes metrics asan and tsan CI

## Changes

We have false positive on attributes_hashmap_benchmark.cc, this can be removed if we store the lambda in a variable and construct threads with it.

also a raw pointer was used in test, changed to smart pointer.

For significant contributions please make sure you have completed the following items:

* [ ] `CHANGELOG.md` updated for non-trivial changes
* [ ] Unit tests have been added
* [ ] Changes in public API reviewed