### PR TITLE
[MINOR]: Fix ObservableInstrument::RemoveCallback

### DIFF
--- a/sdk/src/metrics/async_instruments.cc
+++ b/sdk/src/metrics/async_instruments.cc
@@ -32,7 +32,7 @@ void ObservableInstrument::AddCallback(opentelemetry::metrics::ObservableCallbac
 void ObservableInstrument::RemoveCallback(opentelemetry::metrics::ObservableCallbackPtr callback,
                                           void *state) noexcept
 {
-  observable_registry_->AddCallback(callback, state, this);
+  observable_registry_->RemoveCallback(callback, state, this);
 }
 
 const InstrumentDescriptor &ObservableInstrument::GetInstrumentDescriptor()


### PR DESCRIPTION
## Changes

This PR fixes the issue of not being able to de-register async instrument callbacks.