### PR TITLE
Metrics warnings

### DIFF
--- a/sdk/include/opentelemetry/sdk/metrics/instruments.h
+++ b/sdk/include/opentelemetry/sdk/metrics/instruments.h
@@ -4,6 +4,7 @@
 #pragma once
 #ifndef ENABLE_METRICS_PREVIEW
 #  include <functional>
+#  include "opentelemetry/common/macros.h"
 #  include "opentelemetry/sdk/common/attribute_utils.h"
 OPENTELEMETRY_BEGIN_NAMESPACE
 namespace sdk
@@ -61,7 +62,7 @@ struct InstrumentDescriptor
 
 using MetricAttributes               = opentelemetry::sdk::common::OrderedAttributeMap;
 using AggregationTemporalitySelector = std::function<AggregationTemporality(InstrumentType)>;
-static InstrumentClass GetInstrumentClass(InstrumentType type)
+OPENTELEMETRY_MAYBE_UNUSED static InstrumentClass GetInstrumentClass(InstrumentType type)
 {
   if (type == InstrumentType::kCounter || type == InstrumentType::kHistogram ||
       type == InstrumentType::kUpDownCounter)

--- a/sdk/test/metrics/async_metric_storage_test.cc
+++ b/sdk/test/metrics/async_metric_storage_test.cc
@@ -97,7 +97,6 @@ TEST_P(WritableMetricStorageTestFixture, TestAggregation)
   std::shared_ptr<CollectorHandle> collector(new MockCollectorHandle(temporality));
   std::vector<std::shared_ptr<CollectorHandle>> collectors;
   collectors.push_back(collector);
-  size_t count_attributes = 0;
 
   opentelemetry::sdk::metrics::AsyncMetricStorage storage(
       instr_desc, AggregationType::kSum, new DefaultAttributesProcessor(),

--- a/sdk/test/metrics/metric_reader_test.cc
+++ b/sdk/test/metrics/metric_reader_test.cc
@@ -27,7 +27,6 @@ public:
 
 TEST(MetricReaderTest, BasicTests)
 {
-  AggregationTemporality aggr_temporality = AggregationTemporality::kDelta;
   std::unique_ptr<MetricReader> metric_reader1(new MockMetricReader());
   EXPECT_EQ(metric_reader1->GetAggregationTemporality(InstrumentType::kCounter),
             AggregationTemporality::kCumulative);


### PR DESCRIPTION
Fixes Metrics warnings

## Changes

removes unused variables.

For significant contributions please make sure you have completed the following items:

* [ ] `CHANGELOG.md` updated for non-trivial changes
* [ ] Unit tests have been added
* [ ] Changes in public API reviewed