### PR TITLE
Fix 1585 - Multiple cumulative metric collections without measurement recording.

### DIFF
--- a/sdk/test/metrics/sync_metric_storage_test.cc
+++ b/sdk/test/metrics/sync_metric_storage_test.cc
@@ -96,7 +96,7 @@ TEST_P(WritableMetricStorageTestFixture, LongSumAggregation)
         }
         return true;
       });
-
+  EXPECT_EQ(count_attributes, 2);  // GET and PUT
   // In case of delta temporarily, subsequent collection would contain new data points, so resetting
   // the counts
   if (temporality == AggregationTemporality::kDelta)
@@ -116,18 +116,22 @@ TEST_P(WritableMetricStorageTestFixture, LongSumAggregation)
           if (opentelemetry::nostd::get<std::string>(
                   data_attr.attributes.find("RequestType")->second) == "GET")
           {
-            EXPECT_EQ(opentelemetry::nostd::get<long>(data.value_), expected_total_get_requests);
             count_attributes++;
+            EXPECT_EQ(opentelemetry::nostd::get<long>(data.value_), expected_total_get_requests);
           }
           else if (opentelemetry::nostd::get<std::string>(
                        data_attr.attributes.find("RequestType")->second) == "PUT")
           {
-            EXPECT_EQ(opentelemetry::nostd::get<long>(data.value_), expected_total_put_requests);
             count_attributes++;
+            EXPECT_EQ(opentelemetry::nostd::get<long>(data.value_), expected_total_put_requests);
           }
         }
         return true;
       });
+  if (temporality == AggregationTemporality::kCumulative)
+  {
+    EXPECT_EQ(count_attributes, 2);  // GET AND PUT
+  }
 
   storage.RecordLong(50l, KeyValueIterableView<std::map<std::string, std::string>>(attributes_get),
                      opentelemetry::context::Context{});
@@ -158,7 +162,9 @@ TEST_P(WritableMetricStorageTestFixture, LongSumAggregation)
         }
         return true;
       });
+  EXPECT_EQ(count_attributes, 2);  // GET and PUT
 }
+
 INSTANTIATE_TEST_SUITE_P(WritableMetricStorageTestLong,
                          WritableMetricStorageTestFixture,
                          ::testing::Values(AggregationTemporality::kCumulative,
@@ -229,6 +235,7 @@ TEST_P(WritableMetricStorageTestFixture, DoubleSumAggregation)
         }
         return true;
       });
+  EXPECT_EQ(count_attributes, 2);  // GET and PUT
 
   // In case of delta temporarily, subsequent collection would contain new data points, so resetting
   // the counts
@@ -249,18 +256,22 @@ TEST_P(WritableMetricStorageTestFixture, DoubleSumAggregation)
           if (opentelemetry::nostd::get<std::string>(
                   data_attr.attributes.find("RequestType")->second) == "GET")
           {
-            EXPECT_EQ(opentelemetry::nostd::get<double>(data.value_), expected_total_get_requests);
             count_attributes++;
+            EXPECT_EQ(opentelemetry::nostd::get<double>(data.value_), expected_total_get_requests);
           }
           else if (opentelemetry::nostd::get<std::string>(
                        data_attr.attributes.find("RequestType")->second) == "PUT")
           {
-            EXPECT_EQ(opentelemetry::nostd::get<double>(data.value_), expected_total_put_requests);
             count_attributes++;
+            EXPECT_EQ(opentelemetry::nostd::get<double>(data.value_), expected_total_put_requests);
           }
         }
         return true;
       });
+  if (temporality == AggregationTemporality::kCumulative)
+  {
+    EXPECT_EQ(count_attributes, 2);  // GET AND PUT
+  }
 
   storage.RecordDouble(50.0,
                        KeyValueIterableView<std::map<std::string, std::string>>(attributes_get),
@@ -293,6 +304,7 @@ TEST_P(WritableMetricStorageTestFixture, DoubleSumAggregation)
         }
         return true;
       });
+  EXPECT_EQ(count_attributes, 2);  // GET and PUT
 }
 INSTANTIATE_TEST_SUITE_P(WritableMetricStorageTestDouble,
                          WritableMetricStorageTestFixture,

--- a/sdk/test/metrics/sync_metric_storage_test.cc
+++ b/sdk/test/metrics/sync_metric_storage_test.cc
@@ -105,6 +105,30 @@ TEST_P(WritableMetricStorageTestFixture, LongSumAggregation)
     expected_total_put_requests = 0;
   }
 
+  // collect one more time.
+  collection_ts    = std::chrono::system_clock::now();
+  count_attributes = 0;
+  storage.Collect(
+      collector.get(), collectors, sdk_start_ts, collection_ts, [&](const MetricData data) {
+        for (auto data_attr : data.point_data_attr_)
+        {
+          auto data = opentelemetry::nostd::get<SumPointData>(data_attr.point_data);
+          if (opentelemetry::nostd::get<std::string>(
+                  data_attr.attributes.find("RequestType")->second) == "GET")
+          {
+            EXPECT_EQ(opentelemetry::nostd::get<long>(data.value_), expected_total_get_requests);
+            count_attributes++;
+          }
+          else if (opentelemetry::nostd::get<std::string>(
+                       data_attr.attributes.find("RequestType")->second) == "PUT")
+          {
+            EXPECT_EQ(opentelemetry::nostd::get<long>(data.value_), expected_total_put_requests);
+            count_attributes++;
+          }
+        }
+        return true;
+      });
+
   storage.RecordLong(50l, KeyValueIterableView<std::map<std::string, std::string>>(attributes_get),
                      opentelemetry::context::Context{});
   expected_total_get_requests += 50;
@@ -213,6 +237,30 @@ TEST_P(WritableMetricStorageTestFixture, DoubleSumAggregation)
     expected_total_get_requests = 0;
     expected_total_put_requests = 0;
   }
+
+  // collect one more time.
+  collection_ts    = std::chrono::system_clock::now();
+  count_attributes = 0;
+  storage.Collect(
+      collector.get(), collectors, sdk_start_ts, collection_ts, [&](const MetricData data) {
+        for (auto data_attr : data.point_data_attr_)
+        {
+          auto data = opentelemetry::nostd::get<SumPointData>(data_attr.point_data);
+          if (opentelemetry::nostd::get<std::string>(
+                  data_attr.attributes.find("RequestType")->second) == "GET")
+          {
+            EXPECT_EQ(opentelemetry::nostd::get<double>(data.value_), expected_total_get_requests);
+            count_attributes++;
+          }
+          else if (opentelemetry::nostd::get<std::string>(
+                       data_attr.attributes.find("RequestType")->second) == "PUT")
+          {
+            EXPECT_EQ(opentelemetry::nostd::get<double>(data.value_), expected_total_put_requests);
+            count_attributes++;
+          }
+        }
+        return true;
+      });
 
   storage.RecordDouble(50.0,
                        KeyValueIterableView<std::map<std::string, std::string>>(attributes_get),


### PR DESCRIPTION
Fixes #1585 

## Changes

In case cumulative metric collection is done without any measurement recorded in between, the same metrics should be returned. Merge was not happening properly if there is no unreported metrics. This is fixed now. Also added the tests to validate.


For significant contributions please make sure you have completed the following items:

* [ ] `CHANGELOG.md` updated for non-trivial changes
* [x] Unit tests have been added
* [ ] Changes in public API reviewed