### PR TITLE
Remove running CI on async-changes branch on PR

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches: [ main ]
   pull_request:
-    branches: [ main, async-changes ]
+    branches: [ main ]
 
 jobs:
   cmake_test:


### PR DESCRIPTION
## Changes

Remove running CI on async-changes on PR because all async-changes commits had already been merged to main.

For significant contributions please make sure you have completed the following items:

* [ ] `CHANGELOG.md` updated for non-trivial changes
* [ ] Unit tests have been added
* [ ] Changes in public API reviewed