### PR TITLE
Fix default value of `OtlpHttpMetricExporterOptions::aggregation_temporality`.

### DIFF
--- a/exporters/otlp/include/opentelemetry/exporters/otlp/otlp_http_metric_exporter.h
+++ b/exporters/otlp/include/opentelemetry/exporters/otlp/otlp_http_metric_exporter.h
@@ -55,7 +55,7 @@ struct OtlpHttpMetricExporterOptions
 
   // Preferred Aggregation Temporality
   sdk::metrics::AggregationTemporality aggregation_temporality =
-      sdk::metrics::AggregationTemporality::kCumulative;
+      sdk::metrics::AggregationTemporality::kDelta;
 
 #  ifdef ENABLE_ASYNC_EXPORT
   // Concurrent requests


### PR DESCRIPTION
Signed-off-by: owent <admin@owent.net>

Fixes #1600

## Changes

Fix default value of `OtlpHttpMetricExporterOptions::aggregation_temporality`.

For significant contributions please make sure you have completed the following items:

* [ ] `CHANGELOG.md` updated for non-trivial changes
* [ ] Unit tests have been added
* [x] Changes in public API reviewed