### PR TITLE
Fix build warnings

### DIFF
--- a/api/include/opentelemetry/baggage/baggage.h
+++ b/api/include/opentelemetry/baggage/baggage.h
@@ -28,7 +28,8 @@ public:
 
   Baggage() noexcept : kv_properties_(new opentelemetry::common::KeyValueProperties()) {}
   Baggage(size_t size) noexcept
-      : kv_properties_(new opentelemetry::common::KeyValueProperties(size)){};
+      : kv_properties_(new opentelemetry::common::KeyValueProperties(size))
+  {}
 
   template <class T>
   Baggage(const T &keys_and_values) noexcept

--- a/api/include/opentelemetry/context/propagation/noop_propagator.h
+++ b/api/include/opentelemetry/context/propagation/noop_propagator.h
@@ -26,9 +26,11 @@ public:
   }
 
   /** Noop inject function does nothing */
-  void Inject(TextMapCarrier & /*carrier*/, const context::Context &context) noexcept override {}
+  void Inject(TextMapCarrier & /*carrier*/,
+              const context::Context & /* context */) noexcept override
+  {}
 
-  bool Fields(nostd::function_ref<bool(nostd::string_view)> callback) const noexcept override
+  bool Fields(nostd::function_ref<bool(nostd::string_view)> /* callback */) const noexcept override
   {
     return true;
   }

--- a/api/include/opentelemetry/context/propagation/text_map_propagator.h
+++ b/api/include/opentelemetry/context/propagation/text_map_propagator.h
@@ -26,7 +26,7 @@ public:
 
   /* list of all the keys in the carrier.
    By default, it returns true without invoking callback */
-  virtual bool Keys(nostd::function_ref<bool(nostd::string_view)> callback) const noexcept
+  virtual bool Keys(nostd::function_ref<bool(nostd::string_view)> /* callback */) const noexcept
   {
     return true;
   }

--- a/api/include/opentelemetry/context/runtime_context.h
+++ b/api/include/opentelemetry/context/runtime_context.h
@@ -60,7 +60,7 @@ public:
    */
   virtual bool Detach(Token &token) noexcept = 0;
 
-  virtual ~RuntimeContextStorage(){};
+  virtual ~RuntimeContextStorage() {}
 
 protected:
   nostd::unique_ptr<Token> CreateToken(const Context &context) noexcept
@@ -232,7 +232,7 @@ private:
   {
     friend class ThreadLocalContextStorage;
 
-    Stack() noexcept : size_(0), capacity_(0), base_(nullptr){};
+    Stack() noexcept : size_(0), capacity_(0), base_(nullptr) {}
 
     // Pops the top Context off the stack.
     void Pop() noexcept

--- a/api/include/opentelemetry/logs/noop.h
+++ b/api/include/opentelemetry/logs/noop.h
@@ -41,13 +41,13 @@ class NoopLogger final : public Logger
 public:
   const nostd::string_view GetName() noexcept override { return "noop logger"; }
 
-  void Log(Severity severity,
-           nostd::string_view body,
-           const common::KeyValueIterable &attributes,
-           trace::TraceId trace_id,
-           trace::SpanId span_id,
-           trace::TraceFlags trace_flags,
-           common::SystemTimestamp timestamp) noexcept override
+  void Log(Severity /* severity */,
+           nostd::string_view /* body */,
+           const common::KeyValueIterable & /* attributes */,
+           trace::TraceId /* trace_id */,
+           trace::SpanId /* span_id */,
+           trace::TraceFlags /* trace_flags */,
+           common::SystemTimestamp /* timestamp */) noexcept override
   {}
 };
 
@@ -62,20 +62,20 @@ public:
             nostd::shared_ptr<opentelemetry::logs::NoopLogger>(new opentelemetry::logs::NoopLogger)}
   {}
 
-  nostd::shared_ptr<Logger> GetLogger(nostd::string_view logger_name,
-                                      nostd::string_view options,
-                                      nostd::string_view library_name,
-                                      nostd::string_view library_version = "",
-                                      nostd::string_view schema_url      = "") override
+  nostd::shared_ptr<Logger> GetLogger(nostd::string_view /* logger_name */,
+                                      nostd::string_view /* options */,
+                                      nostd::string_view /* library_name */,
+                                      nostd::string_view /* library_version */,
+                                      nostd::string_view /* schema_url */) override
   {
     return logger_;
   }
 
-  nostd::shared_ptr<Logger> GetLogger(nostd::string_view logger_name,
-                                      nostd::span<nostd::string_view> args,
-                                      nostd::string_view library_name,
-                                      nostd::string_view library_version = "",
-                                      nostd::string_view schema_url      = "") override
+  nostd::shared_ptr<Logger> GetLogger(nostd::string_view /* logger_name */,
+                                      nostd::span<nostd::string_view> /* args */,
+                                      nostd::string_view /* library_name */,
+                                      nostd::string_view /* library_version */,
+                                      nostd::string_view /* schema_url */) override
   {
     return logger_;
   }

--- a/api/include/opentelemetry/metrics/noop.h
+++ b/api/include/opentelemetry/metrics/noop.h
@@ -19,16 +19,17 @@ template <class T>
 class NoopCounter : public Counter<T>
 {
 public:
-  NoopCounter(nostd::string_view name,
-              nostd::string_view description,
-              nostd::string_view unit) noexcept
+  NoopCounter(nostd::string_view /* name */,
+              nostd::string_view /* description */,
+              nostd::string_view /* unit */) noexcept
   {}
-  void Add(T value) noexcept override {}
-  void Add(T value, const opentelemetry::context::Context &context) noexcept override {}
-  void Add(T value, const common::KeyValueIterable &attributes) noexcept override {}
-  void Add(T value,
-           const common::KeyValueIterable &attributes,
-           const opentelemetry::context::Context &context) noexcept override
+  void Add(T /* value */) noexcept override {}
+  void Add(T /* value */, const opentelemetry::context::Context & /* context */) noexcept override
+  {}
+  void Add(T /* value */, const common::KeyValueIterable & /* attributes */) noexcept override {}
+  void Add(T /* value */,
+           const common::KeyValueIterable & /* attributes */,
+           const opentelemetry::context::Context & /* context */) noexcept override
   {}
 };
 
@@ -36,14 +37,16 @@ template <class T>
 class NoopHistogram : public Histogram<T>
 {
 public:
-  NoopHistogram(nostd::string_view name,
-                nostd::string_view description,
-                nostd::string_view unit) noexcept
+  NoopHistogram(nostd::string_view /* name */,
+                nostd::string_view /* description */,
+                nostd::string_view /* unit */) noexcept
   {}
-  void Record(T value, const opentelemetry::context::Context &context) noexcept override {}
-  void Record(T value,
-              const common::KeyValueIterable &attributes,
-              const opentelemetry::context::Context &context) noexcept override
+  void Record(T /* value */,
+              const opentelemetry::context::Context & /* context */) noexcept override
+  {}
+  void Record(T /* value */,
+              const common::KeyValueIterable & /* attributes */,
+              const opentelemetry::context::Context & /* context */) noexcept override
   {}
 };
 
@@ -51,29 +54,30 @@ template <class T>
 class NoopUpDownCounter : public UpDownCounter<T>
 {
 public:
-  NoopUpDownCounter(nostd::string_view name,
-                    nostd::string_view description,
-                    nostd::string_view unit) noexcept
+  NoopUpDownCounter(nostd::string_view /* name */,
+                    nostd::string_view /* description */,
+                    nostd::string_view /* unit */) noexcept
   {}
-  void Add(T value) noexcept override {}
-  void Add(T value, const opentelemetry::context::Context &context) noexcept override {}
-  void Add(T value, const common::KeyValueIterable &attributes) noexcept override {}
-  void Add(T value,
-           const common::KeyValueIterable &attributes,
-           const opentelemetry::context::Context &context) noexcept override
+  void Add(T /* value */) noexcept override {}
+  void Add(T /* value */, const opentelemetry::context::Context & /* context */) noexcept override
+  {}
+  void Add(T /* value */, const common::KeyValueIterable & /* attributes */) noexcept override {}
+  void Add(T /* value */,
+           const common::KeyValueIterable & /* attributes */,
+           const opentelemetry::context::Context & /* context */) noexcept override
   {}
 };
 
 class NoopObservableInstrument : public ObservableInstrument
 {
 public:
-  NoopObservableInstrument(nostd::string_view name,
-                           nostd::string_view description,
-                           nostd::string_view unit) noexcept
+  NoopObservableInstrument(nostd::string_view /* name */,
+                           nostd::string_view /* description */,
+                           nostd::string_view /* unit */) noexcept
   {}
 
-  void AddCallback(ObservableCallbackPtr, void *state) noexcept override {}
-  void RemoveCallback(ObservableCallbackPtr, void *state) noexcept override {}
+  void AddCallback(ObservableCallbackPtr, void * /* state */) noexcept override {}
+  void RemoveCallback(ObservableCallbackPtr, void * /* state */) noexcept override {}
 };
 
 /**
@@ -194,9 +198,9 @@ class NoopMeterProvider final : public MeterProvider
 public:
   NoopMeterProvider() : meter_{nostd::shared_ptr<Meter>(new NoopMeter)} {}
 
-  nostd::shared_ptr<Meter> GetMeter(nostd::string_view library_name,
-                                    nostd::string_view library_version,
-                                    nostd::string_view schema_url) noexcept override
+  nostd::shared_ptr<Meter> GetMeter(nostd::string_view /* library_name */,
+                                    nostd::string_view /* library_version */,
+                                    nostd::string_view /* schema_url */) noexcept override
   {
     return meter_;
   }

--- a/api/include/opentelemetry/nostd/string_view.h
+++ b/api/include/opentelemetry/nostd/string_view.h
@@ -81,12 +81,12 @@ public:
     if (result == 0)
       result = size() == v.size() ? 0 : (size() < v.size() ? -1 : 1);
     return result;
-  };
+  }
 
   int compare(size_type pos1, size_type count1, string_view v) const
   {
     return substr(pos1, count1).compare(v);
-  };
+  }
 
   int compare(size_type pos1,
               size_type count1,
@@ -95,19 +95,19 @@ public:
               size_type count2) const
   {
     return substr(pos1, count1).compare(v.substr(pos2, count2));
-  };
+  }
 
-  int compare(const char *s) const { return compare(string_view(s)); };
+  int compare(const char *s) const { return compare(string_view(s)); }
 
   int compare(size_type pos1, size_type count1, const char *s) const
   {
     return substr(pos1, count1).compare(string_view(s));
-  };
+  }
 
   int compare(size_type pos1, size_type count1, const char *s, size_type count2) const
   {
     return substr(pos1, count1).compare(string_view(s, count2));
-  };
+  }
 
   size_type find(char ch, size_type pos = 0) const noexcept
   {
@@ -138,9 +138,13 @@ private:
 inline bool operator==(string_view lhs, string_view rhs) noexcept
 {
   return lhs.length() == rhs.length() &&
-#  if _MSC_VER == 1900
+#  if defined(_MSC_VER)
+#    if _MSC_VER == 1900
          // Avoid SCL error in Visual Studio 2015
          (std::memcmp(lhs.data(), rhs.data(), lhs.length()) == 0);
+#    else
+         std::equal(lhs.data(), lhs.data() + lhs.length(), rhs.data());
+#    endif
 #  else
          std::equal(lhs.data(), lhs.data() + lhs.length(), rhs.data());
 #  endif

--- a/api/include/opentelemetry/nostd/utility.h
+++ b/api/include/opentelemetry/nostd/utility.h
@@ -59,7 +59,7 @@ auto size(const C &c) noexcept(noexcept(c.size())) -> decltype(c.size())
 }
 
 template <class T, size_t N>
-size_t size(T (&array)[N]) noexcept
+size_t size(T (&/* array */)[N]) noexcept
 {
   return N;
 }

--- a/api/include/opentelemetry/trace/noop.h
+++ b/api/include/opentelemetry/trace/noop.h
@@ -106,9 +106,9 @@ public:
   {}
 
   nostd::shared_ptr<opentelemetry::trace::Tracer> GetTracer(
-      nostd::string_view library_name,
-      nostd::string_view library_version,
-      nostd::string_view schema_url) noexcept override
+      nostd::string_view /* library_name */,
+      nostd::string_view /* library_version */,
+      nostd::string_view /* schema_url */) noexcept override
   {
     return tracer_;
   }

--- a/api/include/opentelemetry/trace/span_context_kv_iterable.h
+++ b/api/include/opentelemetry/trace/span_context_kv_iterable.h
@@ -47,7 +47,7 @@ public:
     return true;
   }
 
-  size_t size() const noexcept override { return 0; };
+  size_t size() const noexcept override { return 0; }
 };
 
 }  // namespace trace

--- a/api/include/opentelemetry/trace/trace_state.h
+++ b/api/include/opentelemetry/trace/trace_state.h
@@ -233,8 +233,8 @@ public:
   }
 
 private:
-  TraceState() : kv_properties_(new opentelemetry::common::KeyValueProperties()){};
-  TraceState(size_t size) : kv_properties_(new opentelemetry::common::KeyValueProperties(size)){};
+  TraceState() : kv_properties_(new opentelemetry::common::KeyValueProperties()) {}
+  TraceState(size_t size) : kv_properties_(new opentelemetry::common::KeyValueProperties(size)) {}
 
   static nostd::string_view TrimString(nostd::string_view str, size_t left, size_t right)
   {

--- a/api/test/baggage/baggage_benchmark.cc
+++ b/api/test/baggage/baggage_benchmark.cc
@@ -46,7 +46,8 @@ void BM_ExtractBaggageHavingTenEntries(benchmark::State &state)
   auto baggage = Baggage::FromHeader(header_with_custom_entries(kNumEntries));
   while (state.KeepRunning())
   {
-    baggage->GetAllEntries([](nostd::string_view key, nostd::string_view value) { return true; });
+    baggage->GetAllEntries(
+        [](nostd::string_view /* key */, nostd::string_view /* value */) { return true; });
   }
 }
 BENCHMARK(BM_ExtractBaggageHavingTenEntries);
@@ -66,7 +67,8 @@ void BM_ExtractBaggageWith180Entries(benchmark::State &state)
   auto baggage = Baggage::FromHeader(header_with_custom_entries(Baggage::kMaxKeyValuePairs));
   while (state.KeepRunning())
   {
-    baggage->GetAllEntries([](nostd::string_view key, nostd::string_view value) { return true; });
+    baggage->GetAllEntries(
+        [](nostd::string_view /* key */, nostd::string_view /* value */) { return true; });
   }
 }
 BENCHMARK(BM_ExtractBaggageWith180Entries);

--- a/api/test/logs/logger_test.cc
+++ b/api/test/logs/logger_test.cc
@@ -117,33 +117,33 @@ class TestLogger : public Logger
 {
   const nostd::string_view GetName() noexcept override { return "test logger"; }
 
-  void Log(Severity severity,
-           string_view body,
-           const common::KeyValueIterable &attributes,
-           trace::TraceId trace_id,
-           trace::SpanId span_id,
-           trace::TraceFlags trace_flags,
-           common::SystemTimestamp timestamp) noexcept override
+  void Log(Severity /* severity */,
+           string_view /* body */,
+           const common::KeyValueIterable & /* attributes */,
+           trace::TraceId /* trace_id */,
+           trace::SpanId /* span_id */,
+           trace::TraceFlags /* trace_flags */,
+           common::SystemTimestamp /* timestamp */) noexcept override
   {}
 };
 
 // Define a basic LoggerProvider class that returns an instance of the logger class defined above
 class TestProvider : public LoggerProvider
 {
-  nostd::shared_ptr<Logger> GetLogger(nostd::string_view logger_name,
-                                      nostd::string_view options,
-                                      nostd::string_view library_name,
-                                      nostd::string_view library_version = "",
-                                      nostd::string_view schema_url      = "") override
+  nostd::shared_ptr<Logger> GetLogger(nostd::string_view /* logger_name */,
+                                      nostd::string_view /* options */,
+                                      nostd::string_view /* library_name */,
+                                      nostd::string_view /* library_version */,
+                                      nostd::string_view /* schema_url */) override
   {
     return shared_ptr<Logger>(new TestLogger());
   }
 
-  nostd::shared_ptr<Logger> GetLogger(nostd::string_view logger_name,
-                                      nostd::span<nostd::string_view> args,
-                                      nostd::string_view library_name,
-                                      nostd::string_view library_version = "",
-                                      nostd::string_view schema_url      = "") override
+  nostd::shared_ptr<Logger> GetLogger(nostd::string_view /* logger_name */,
+                                      nostd::span<nostd::string_view> /* args */,
+                                      nostd::string_view /* library_name */,
+                                      nostd::string_view /* library_version */,
+                                      nostd::string_view /* schema_url */) override
   {
     return shared_ptr<Logger>(new TestLogger());
   }

--- a/api/test/logs/provider_test.cc
+++ b/api/test/logs/provider_test.cc
@@ -17,20 +17,20 @@ namespace nostd = opentelemetry::nostd;
 
 class TestProvider : public LoggerProvider
 {
-  nostd::shared_ptr<Logger> GetLogger(nostd::string_view logger_name,
-                                      nostd::string_view options,
-                                      nostd::string_view library_name,
-                                      nostd::string_view library_version = "",
-                                      nostd::string_view schema_url      = "") override
+  nostd::shared_ptr<Logger> GetLogger(nostd::string_view /* logger_name */,
+                                      nostd::string_view /* options */,
+                                      nostd::string_view /* library_name */,
+                                      nostd::string_view /* library_version */,
+                                      nostd::string_view /* schema_url */) override
   {
     return shared_ptr<Logger>(nullptr);
   }
 
-  nostd::shared_ptr<Logger> GetLogger(nostd::string_view logger_name,
-                                      nostd::span<nostd::string_view> args,
-                                      nostd::string_view library_name,
-                                      nostd::string_view library_version = "",
-                                      nostd::string_view schema_url      = "") override
+  nostd::shared_ptr<Logger> GetLogger(nostd::string_view /* logger_name */,
+                                      nostd::span<nostd::string_view> /* args */,
+                                      nostd::string_view /* library_name */,
+                                      nostd::string_view /* library_version */,
+                                      nostd::string_view /* schema_url */) override
   {
     return shared_ptr<Logger>(nullptr);
   }

--- a/api/test/singleton/singleton_test.cc
+++ b/api/test/singleton/singleton_test.cc
@@ -78,10 +78,11 @@ void reset_counts()
 class MyTracer : public trace::Tracer
 {
 public:
-  nostd::shared_ptr<trace::Span> StartSpan(nostd::string_view name,
-                                           const common::KeyValueIterable &attributes,
-                                           const trace::SpanContextKeyValueIterable &links,
-                                           const trace::StartSpanOptions &options) noexcept override
+  nostd::shared_ptr<trace::Span> StartSpan(
+      nostd::string_view name,
+      const common::KeyValueIterable & /* attributes */,
+      const trace::SpanContextKeyValueIterable & /* links */,
+      const trace::StartSpanOptions & /* options */) noexcept override
   {
     nostd::shared_ptr<trace::Span> result(new trace::DefaultSpan(trace::SpanContext::GetInvalid()));
 
@@ -169,9 +170,9 @@ public:
     return result;
   }
 
-  void ForceFlushWithMicroseconds(uint64_t timeout) noexcept override {}
+  void ForceFlushWithMicroseconds(uint64_t /* timeout */) noexcept override {}
 
-  void CloseWithMicroseconds(uint64_t timeout) noexcept override {}
+  void CloseWithMicroseconds(uint64_t /* timeout */) noexcept override {}
 };
 
 class MyTracerProvider : public trace::TracerProvider
@@ -183,9 +184,9 @@ public:
     return result;
   }
 
-  nostd::shared_ptr<trace::Tracer> GetTracer(nostd::string_view library_name,
-                                             nostd::string_view library_version,
-                                             nostd::string_view schema_url) noexcept override
+  nostd::shared_ptr<trace::Tracer> GetTracer(nostd::string_view /* library_name */,
+                                             nostd::string_view /* library_version */,
+                                             nostd::string_view /* schema_url */) noexcept override
   {
     nostd::shared_ptr<trace::Tracer> result(new MyTracer());
     return result;

--- a/api/test/trace/key_value_iterable_view_test.cc
+++ b/api/test/trace/key_value_iterable_view_test.cc
@@ -13,10 +13,11 @@ static int TakeKeyValues(const common::KeyValueIterable &iterable)
 {
   std::map<std::string, common::AttributeValue> result;
   int count = 0;
-  iterable.ForEachKeyValue([&](nostd::string_view key, common::AttributeValue value) noexcept {
-    ++count;
-    return true;
-  });
+  iterable.ForEachKeyValue(
+      [&](nostd::string_view /* key */, common::AttributeValue /* value */) noexcept {
+        ++count;
+        return true;
+      });
   return count;
 }
 

--- a/api/test/trace/provider_test.cc
+++ b/api/test/trace/provider_test.cc
@@ -14,9 +14,9 @@ namespace nostd = opentelemetry::nostd;
 
 class TestProvider : public TracerProvider
 {
-  nostd::shared_ptr<Tracer> GetTracer(nostd::string_view library_name,
-                                      nostd::string_view library_version,
-                                      nostd::string_view schema_url) noexcept override
+  nostd::shared_ptr<Tracer> GetTracer(nostd::string_view /* library_name */,
+                                      nostd::string_view /* library_version */,
+                                      nostd::string_view /* schema_url */) noexcept override
   {
     return nostd::shared_ptr<Tracer>(nullptr);
   }

--- a/exporters/memory/include/opentelemetry/exporters/memory/in_memory_span_exporter.h
+++ b/exporters/memory/include/opentelemetry/exporters/memory/in_memory_span_exporter.h
@@ -70,13 +70,12 @@ public:
    * note: passing custom timeout values is not currently supported for this exporter
    * @return Returns the status of the operation
    */
-  bool Shutdown(
-      std::chrono::microseconds timeout = std::chrono::microseconds::max()) noexcept override
+  bool Shutdown(std::chrono::microseconds /* timeout */) noexcept override
   {
     const std::lock_guard<opentelemetry::common::SpinLockMutex> locked(lock_);
     is_shutdown_ = true;
     return true;
-  };
+  }
 
   /**
    * @return Returns a shared pointer to this exporters InMemorySpanData

--- a/exporters/ostream/src/metric_exporter.cc
+++ b/exporters/ostream/src/metric_exporter.cc
@@ -72,7 +72,7 @@ OStreamMetricExporter::OStreamMetricExporter(
 {}
 
 sdk::metrics::AggregationTemporality OStreamMetricExporter::GetAggregationTemporality(
-    sdk::metrics::InstrumentType instrument_type) const noexcept
+    sdk::metrics::InstrumentType /* instrument_type */) const noexcept
 {
   return aggregation_temporality_;
 }
@@ -249,13 +249,14 @@ void OStreamMetricExporter::printPointAttributes(
   }
 }
 
-bool OStreamMetricExporter::ForceFlush(std::chrono::microseconds timeout) noexcept
+bool OStreamMetricExporter::ForceFlush(std::chrono::microseconds /* timeout
+*/) noexcept
 {
   const std::lock_guard<opentelemetry::common::SpinLockMutex> locked(lock_);
   return true;
 }
 
-bool OStreamMetricExporter::Shutdown(std::chrono::microseconds timeout) noexcept
+bool OStreamMetricExporter::Shutdown(std::chrono::microseconds /* timeout */) noexcept
 {
   const std::lock_guard<opentelemetry::common::SpinLockMutex> locked(lock_);
   is_shutdown_ = true;

--- a/exporters/ostream/src/metric_exporter.cc
+++ b/exporters/ostream/src/metric_exporter.cc
@@ -249,8 +249,7 @@ void OStreamMetricExporter::printPointAttributes(
   }
 }
 
-bool OStreamMetricExporter::ForceFlush(std::chrono::microseconds /* timeout
-*/) noexcept
+bool OStreamMetricExporter::ForceFlush(std::chrono::microseconds /* timeout */) noexcept
 {
   const std::lock_guard<opentelemetry::common::SpinLockMutex> locked(lock_);
   return true;

--- a/exporters/ostream/src/span_exporter.cc
+++ b/exporters/ostream/src/span_exporter.cc
@@ -98,7 +98,7 @@ sdk::common::ExportResult OStreamSpanExporter::Export(
   return sdk::common::ExportResult::kSuccess;
 }
 
-bool OStreamSpanExporter::Shutdown(std::chrono::microseconds timeout) noexcept
+bool OStreamSpanExporter::Shutdown(std::chrono::microseconds /* timeout */) noexcept
 {
   const std::lock_guard<opentelemetry::common::SpinLockMutex> locked(lock_);
   is_shutdown_ = true;

--- a/exporters/otlp/src/otlp_grpc_exporter.cc
+++ b/exporters/otlp/src/otlp_grpc_exporter.cc
@@ -72,7 +72,7 @@ sdk::common::ExportResult OtlpGrpcExporter::Export(
   return sdk::common::ExportResult::kSuccess;
 }
 
-bool OtlpGrpcExporter::Shutdown(std::chrono::microseconds timeout) noexcept
+bool OtlpGrpcExporter::Shutdown(std::chrono::microseconds /* timeout */) noexcept
 {
   const std::lock_guard<opentelemetry::common::SpinLockMutex> locked(lock_);
   is_shutdown_ = true;

--- a/exporters/otlp/src/otlp_grpc_log_exporter.cc
+++ b/exporters/otlp/src/otlp_grpc_log_exporter.cc
@@ -82,7 +82,7 @@ opentelemetry::sdk::common::ExportResult OtlpGrpcLogExporter::Export(
   return sdk::common::ExportResult::kSuccess;
 }
 
-bool OtlpGrpcLogExporter::Shutdown(std::chrono::microseconds timeout) noexcept
+bool OtlpGrpcLogExporter::Shutdown(std::chrono::microseconds /* timeout */) noexcept
 {
   const std::lock_guard<opentelemetry::common::SpinLockMutex> locked(lock_);
   is_shutdown_ = true;

--- a/exporters/otlp/src/otlp_grpc_metric_exporter.cc
+++ b/exporters/otlp/src/otlp_grpc_metric_exporter.cc
@@ -80,13 +80,15 @@ opentelemetry::sdk::common::ExportResult OtlpGrpcMetricExporter::Export(
   return opentelemetry::sdk::common::ExportResult::kSuccess;
 }
 
-bool OtlpGrpcMetricExporter::ForceFlush(std::chrono::microseconds timeout) noexcept
+bool OtlpGrpcMetricExporter::ForceFlush(std::chrono::microseconds /* timeout
+*/) noexcept
 {
   // TODO: OTLP gRPC exporter does not support concurrency exporting now.
   return true;
 }
 
-bool OtlpGrpcMetricExporter::Shutdown(std::chrono::microseconds timeout) noexcept
+bool OtlpGrpcMetricExporter::Shutdown(std::chrono::microseconds /* timeout
+*/) noexcept
 {
   const std::lock_guard<opentelemetry::common::SpinLockMutex> locked(lock_);
   is_shutdown_ = true;

--- a/exporters/otlp/src/otlp_grpc_metric_exporter.cc
+++ b/exporters/otlp/src/otlp_grpc_metric_exporter.cc
@@ -80,15 +80,13 @@ opentelemetry::sdk::common::ExportResult OtlpGrpcMetricExporter::Export(
   return opentelemetry::sdk::common::ExportResult::kSuccess;
 }
 
-bool OtlpGrpcMetricExporter::ForceFlush(std::chrono::microseconds /* timeout
-*/) noexcept
+bool OtlpGrpcMetricExporter::ForceFlush(std::chrono::microseconds /* timeout */) noexcept
 {
   // TODO: OTLP gRPC exporter does not support concurrency exporting now.
   return true;
 }
 
-bool OtlpGrpcMetricExporter::Shutdown(std::chrono::microseconds /* timeout
-*/) noexcept
+bool OtlpGrpcMetricExporter::Shutdown(std::chrono::microseconds /* timeout */) noexcept
 {
   const std::lock_guard<opentelemetry::common::SpinLockMutex> locked(lock_);
   is_shutdown_ = true;

--- a/exporters/otlp/src/otlp_http_client.cc
+++ b/exporters/otlp/src/otlp_http_client.cc
@@ -346,7 +346,7 @@ public:
   {
     session_ = &session;
     owner_   = owner;
-  };
+  }
 
 private:
   // Define a mutex to keep thread safety

--- a/exporters/otlp/test/otlp_http_metric_exporter_test.cc
+++ b/exporters/otlp/test/otlp_http_metric_exporter_test.cc
@@ -196,16 +196,6 @@ public:
     auto client                = mock_otlp_client.second;
     auto exporter = GetExporter(std::unique_ptr<OtlpHttpClient>{mock_otlp_http_client});
 
-#  if 0
-    bool attribute_storage_bool_value[]          = {true, false, true};
-    int32_t attribute_storage_int32_value[]      = {1, 2};
-    uint32_t attribute_storage_uint32_value[]    = {3, 4};
-    int64_t attribute_storage_int64_value[]      = {5, 6};
-    uint64_t attribute_storage_uint64_value[]    = {7, 8};
-    double attribute_storage_double_value[]      = {3.2, 3.3};
-    std::string attribute_storage_string_value[] = {"vector", "string"};
-#  endif
-
     opentelemetry::sdk::metrics::SumPointData sum_point_data{};
     sum_point_data.value_ = 10.0;
     opentelemetry::sdk::metrics::SumPointData sum_point_data2{};
@@ -386,16 +376,6 @@ public:
     auto mock_otlp_http_client = mock_otlp_client.first;
     auto client                = mock_otlp_client.second;
     auto exporter = GetExporter(std::unique_ptr<OtlpHttpClient>{mock_otlp_http_client});
-
-#  if 0
-    bool attribute_storage_bool_value[]          = {true, false, true};
-    int32_t attribute_storage_int32_value[]      = {1, 2};
-    uint32_t attribute_storage_uint32_value[]    = {3, 4};
-    int64_t attribute_storage_int64_value[]      = {5, 6};
-    uint64_t attribute_storage_uint64_value[]    = {7, 8};
-    double attribute_storage_double_value[]      = {3.2, 3.3};
-    std::string attribute_storage_string_value[] = {"vector", "string"};
-#  endif
 
     opentelemetry::sdk::metrics::SumPointData sum_point_data{};
     sum_point_data.value_ = 10.0;
@@ -626,16 +606,6 @@ public:
     auto mock_otlp_http_client = mock_otlp_client.first;
     auto client                = mock_otlp_client.second;
     auto exporter = GetExporter(std::unique_ptr<OtlpHttpClient>{mock_otlp_http_client});
-
-#  if 0
-    bool attribute_storage_bool_value[]          = {true, false, true};
-    int32_t attribute_storage_int32_value[]      = {1, 2};
-    uint32_t attribute_storage_uint32_value[]    = {3, 4};
-    int64_t attribute_storage_int64_value[]      = {5, 6};
-    uint64_t attribute_storage_uint64_value[]    = {7, 8};
-    double attribute_storage_double_value[]      = {3.2, 3.3};
-    std::string attribute_storage_string_value[] = {"vector", "string"};
-#  endif
 
     opentelemetry::sdk::metrics::SumPointData sum_point_data{};
     sum_point_data.value_ = 10.0;

--- a/exporters/otlp/test/otlp_http_metric_exporter_test.cc
+++ b/exporters/otlp/test/otlp_http_metric_exporter_test.cc
@@ -196,6 +196,7 @@ public:
     auto client                = mock_otlp_client.second;
     auto exporter = GetExporter(std::unique_ptr<OtlpHttpClient>{mock_otlp_http_client});
 
+#  if 0
     bool attribute_storage_bool_value[]          = {true, false, true};
     int32_t attribute_storage_int32_value[]      = {1, 2};
     uint32_t attribute_storage_uint32_value[]    = {3, 4};
@@ -203,6 +204,7 @@ public:
     uint64_t attribute_storage_uint64_value[]    = {7, 8};
     double attribute_storage_double_value[]      = {3.2, 3.3};
     std::string attribute_storage_string_value[] = {"vector", "string"};
+#  endif
 
     opentelemetry::sdk::metrics::SumPointData sum_point_data{};
     sum_point_data.value_ = 10.0;
@@ -385,6 +387,7 @@ public:
     auto client                = mock_otlp_client.second;
     auto exporter = GetExporter(std::unique_ptr<OtlpHttpClient>{mock_otlp_http_client});
 
+#  if 0
     bool attribute_storage_bool_value[]          = {true, false, true};
     int32_t attribute_storage_int32_value[]      = {1, 2};
     uint32_t attribute_storage_uint32_value[]    = {3, 4};
@@ -392,6 +395,7 @@ public:
     uint64_t attribute_storage_uint64_value[]    = {7, 8};
     double attribute_storage_double_value[]      = {3.2, 3.3};
     std::string attribute_storage_string_value[] = {"vector", "string"};
+#  endif
 
     opentelemetry::sdk::metrics::SumPointData sum_point_data{};
     sum_point_data.value_ = 10.0;
@@ -623,6 +627,7 @@ public:
     auto client                = mock_otlp_client.second;
     auto exporter = GetExporter(std::unique_ptr<OtlpHttpClient>{mock_otlp_http_client});
 
+#  if 0
     bool attribute_storage_bool_value[]          = {true, false, true};
     int32_t attribute_storage_int32_value[]      = {1, 2};
     uint32_t attribute_storage_uint32_value[]    = {3, 4};
@@ -630,6 +635,7 @@ public:
     uint64_t attribute_storage_uint64_value[]    = {7, 8};
     double attribute_storage_double_value[]      = {3.2, 3.3};
     std::string attribute_storage_string_value[] = {"vector", "string"};
+#  endif
 
     opentelemetry::sdk::metrics::SumPointData sum_point_data{};
     sum_point_data.value_ = 10.0;

--- a/ext/include/opentelemetry/ext/http/client/http_client.h
+++ b/ext/include/opentelemetry/ext/http/client/http_client.h
@@ -156,14 +156,14 @@ public:
     return body;
   }
   bool ForEachHeader(nostd::function_ref<bool(nostd::string_view name, nostd::string_view value)>
-                         callable) const noexcept override
+                     /* callable */) const noexcept override
   {
     return true;
   }
 
-  bool ForEachHeader(const nostd::string_view &key,
+  bool ForEachHeader(const nostd::string_view & /* key */,
                      nostd::function_ref<bool(nostd::string_view name, nostd::string_view value)>
-                         callable) const noexcept override
+                     /* callable */) const noexcept override
   {
     return true;
   }

--- a/ext/include/opentelemetry/ext/http/server/http_server.h
+++ b/ext/include/opentelemetry/ext/http/server/http_server.h
@@ -53,15 +53,15 @@ protected:
   CallbackFunction callback = nullptr;
 
 public:
-  HttpRequestCallback(){};
+  HttpRequestCallback() {}
 
   HttpRequestCallback &operator=(HttpRequestCallback other)
   {
     callback = other.callback;
     return *this;
-  };
+  }
 
-  HttpRequestCallback(CallbackFunction func) : callback(func){};
+  HttpRequestCallback(CallbackFunction func) : callback(func) {}
 
   HttpRequestCallback &operator=(CallbackFunction func)
   {
@@ -76,7 +76,7 @@ public:
       return callback(request, response);
     }
     return 0;
-  };
+  }
 };
 
 // Simple HTTP server
@@ -123,32 +123,32 @@ protected:
     {
       first  = key;
       second = value;
-    };
+    }
 
     HttpRequestHandler() : std::pair<std::string, HttpRequestCallback *>()
     {
       first  = "";
       second = nullptr;
-    };
+    }
 
     HttpRequestHandler &operator=(std::pair<std::string, HttpRequestCallback *> other)
     {
       first  = other.first;
       second = other.second;
       return (*this);
-    };
+    }
 
     HttpRequestHandler &operator=(HttpRequestCallback &cb)
     {
       second = &cb;
       return (*this);
-    };
+    }
 
     HttpRequestHandler &operator=(HttpRequestCallback *cb)
     {
       second = cb;
       return (*this);
-    };
+    }
   };
 
   std::list<HttpRequestHandler> m_handlers;
@@ -164,7 +164,8 @@ public:
         allowKeepalive(true),
         m_reactor(*this),
         m_maxRequestHeadersSize(8192),
-        m_maxRequestContentSize(2 * 1024 * 1024){};
+        m_maxRequestContentSize(2 * 1024 * 1024)
+  {}
 
   HttpServer(std::string serverHost, int port = 30000) : HttpServer()
   {
@@ -172,7 +173,7 @@ public:
     os << serverHost << ":" << port;
     setServerName(os.str());
     addListeningPort(port);
-  };
+  }
 
   ~HttpServer()
   {
@@ -229,7 +230,7 @@ public:
     LOG_INFO("HttpServer: Added handler for %s", other.first.c_str());
     m_handlers.push_back(HttpRequestHandler(other.first, &other.second));
     return (*this);
-  };
+  }
 
   void start() { m_reactor.start(); }
 

--- a/ext/include/opentelemetry/ext/http/server/socket_tools.h
+++ b/ext/include/opentelemetry/ext/http/server/socket_tools.h
@@ -33,7 +33,7 @@
 #    include <sys/epoll.h>
 #  endif
 
-#  if __APPLE__
+#  ifdef __APPLE__
 #    include "TargetConditionals.h"
 // Use kqueue on mac
 #    include <sys/event.h>

--- a/ext/src/http/client/curl/http_operation_curl.cc
+++ b/ext/src/http/client/curl/http_operation_curl.cc
@@ -171,10 +171,10 @@ int HttpOperation::PreRequestCallback(void *clientp, char *, char *, int, int)
 
 #if LIBCURL_VERSION_NUM >= 0x072000
 int HttpOperation::OnProgressCallback(void *clientp,
-                                      curl_off_t dltotal,
-                                      curl_off_t dlnow,
-                                      curl_off_t ultotal,
-                                      curl_off_t ulnow)
+                                      curl_off_t /* dltotal */,
+                                      curl_off_t /* dlnow */,
+                                      curl_off_t /* ultotal */,
+                                      curl_off_t /* ulnow */)
 {
   HttpOperation *self = reinterpret_cast<HttpOperation *>(clientp);
   if (nullptr == self)
@@ -196,10 +196,10 @@ int HttpOperation::OnProgressCallback(void *clientp,
 }
 #else
 int HttpOperation::OnProgressCallback(void *clientp,
-                                      double dltotal,
-                                      double dlnow,
-                                      double ultotal,
-                                      double ulnow)
+                                      double /* dltotal */,
+                                      double /* dlnow */,
+                                      double /* ultotal */,
+                                      double /* ulnow */)
 {
   HttpOperation *self = reinterpret_cast<HttpOperation *>(clientp);
   if (nullptr == self)

--- a/ext/src/http/client/nosend/http_client_nosend.cc
+++ b/ext/src/http/client/nosend/http_client_nosend.cc
@@ -86,8 +86,7 @@ bool HttpClient::FinishAllSessions() noexcept
   return true;
 }
 
-void HttpClient::SetMaxSessionsPerConnection(std::size_t /*
-max_requests_per_connection */) noexcept
+void HttpClient::SetMaxSessionsPerConnection(std::size_t /* max_requests_per_connection */) noexcept
 {}
 
 void HttpClient::CleanupSession(uint64_t /* session_id */) {}

--- a/ext/src/http/client/nosend/http_client_nosend.cc
+++ b/ext/src/http/client/nosend/http_client_nosend.cc
@@ -86,9 +86,11 @@ bool HttpClient::FinishAllSessions() noexcept
   return true;
 }
 
-void HttpClient::SetMaxSessionsPerConnection(std::size_t max_requests_per_connection) noexcept {}
+void HttpClient::SetMaxSessionsPerConnection(std::size_t /*
+max_requests_per_connection */) noexcept
+{}
 
-void HttpClient::CleanupSession(uint64_t session_id) {}
+void HttpClient::CleanupSession(uint64_t /* session_id */) {}
 
 }  // namespace nosend
 }  // namespace client

--- a/ext/test/http/curl_http_test.cc
+++ b/ext/test/http/curl_http_test.cc
@@ -29,8 +29,8 @@ public:
   {
     got_response_ = true;
   }
-  virtual void OnEvent(http_client::SessionState state, nostd::string_view
-                       /* reason */) noexcept override
+  virtual void OnEvent(http_client::SessionState state,
+                       nostd::string_view /* reason */) noexcept override
   {
     switch (state)
     {

--- a/ext/test/http/curl_http_test.cc
+++ b/ext/test/http/curl_http_test.cc
@@ -25,11 +25,12 @@ namespace nostd       = opentelemetry::nostd;
 class CustomEventHandler : public http_client::EventHandler
 {
 public:
-  virtual void OnResponse(http_client::Response &response) noexcept override
+  virtual void OnResponse(http_client::Response & /* response */) noexcept override
   {
     got_response_ = true;
-  };
-  virtual void OnEvent(http_client::SessionState state, nostd::string_view reason) noexcept override
+  }
+  virtual void OnEvent(http_client::SessionState state, nostd::string_view
+                       /* reason */) noexcept override
   {
     switch (state)
     {
@@ -56,7 +57,7 @@ class GetEventHandler : public CustomEventHandler
     ASSERT_EQ(response.GetBody().size(), 0);
     is_called_    = true;
     got_response_ = true;
-  };
+  }
 };
 
 class PostEventHandler : public CustomEventHandler
@@ -107,7 +108,7 @@ protected:
   std::mutex cv_m;
 
 public:
-  BasicCurlHttpTests() : is_setup_(false), is_running_(false){};
+  BasicCurlHttpTests() : is_setup_(false), is_running_(false) {}
 
   virtual void SetUp() override
   {

--- a/sdk/include/opentelemetry/sdk/common/attribute_utils.h
+++ b/sdk/include/opentelemetry/sdk/common/attribute_utils.h
@@ -104,7 +104,7 @@ class AttributeMap : public std::unordered_map<std::string, OwnedAttributeValue>
 {
 public:
   // Contruct empty attribute map
-  AttributeMap() : std::unordered_map<std::string, OwnedAttributeValue>(){};
+  AttributeMap() : std::unordered_map<std::string, OwnedAttributeValue>() {}
 
   // Contruct attribute map and populate with attributes
   AttributeMap(const opentelemetry::common::KeyValueIterable &attributes) : AttributeMap()
@@ -152,7 +152,7 @@ class OrderedAttributeMap : public std::map<std::string, OwnedAttributeValue>
 {
 public:
   // Contruct empty attribute map
-  OrderedAttributeMap() : std::map<std::string, OwnedAttributeValue>(){};
+  OrderedAttributeMap() : std::map<std::string, OwnedAttributeValue>() {}
 
   // Contruct attribute map and populate with attributes
   OrderedAttributeMap(const opentelemetry::common::KeyValueIterable &attributes)

--- a/sdk/include/opentelemetry/sdk/metrics/aggregation/drop_aggregation.h
+++ b/sdk/include/opentelemetry/sdk/metrics/aggregation/drop_aggregation.h
@@ -25,9 +25,9 @@ public:
 
   DropAggregation(const DropPointData &) {}
 
-  void Aggregate(long value, const PointAttributes &attributes = {}) noexcept override {}
+  void Aggregate(long /* value */, const PointAttributes & /* attributes */) noexcept override {}
 
-  void Aggregate(double value, const PointAttributes &attributes = {}) noexcept override {}
+  void Aggregate(double /* value */, const PointAttributes & /* attributes */) noexcept override {}
 
   std::unique_ptr<Aggregation> Merge(const Aggregation &) const noexcept override
   {

--- a/sdk/include/opentelemetry/sdk/metrics/aggregation/histogram_aggregation.h
+++ b/sdk/include/opentelemetry/sdk/metrics/aggregation/histogram_aggregation.h
@@ -24,7 +24,7 @@ public:
 
   void Aggregate(long value, const PointAttributes &attributes = {}) noexcept override;
 
-  void Aggregate(double value, const PointAttributes &attributes = {}) noexcept override {}
+  void Aggregate(double /* value */, const PointAttributes & /* attributes */) noexcept override {}
 
   /* Returns the result of merge of the existing aggregation with delta aggregation with same
    * boundaries */
@@ -53,7 +53,7 @@ public:
   DoubleHistogramAggregation(HistogramPointData &&);
   DoubleHistogramAggregation(const HistogramPointData &);
 
-  void Aggregate(long value, const PointAttributes &attributes = {}) noexcept override {}
+  void Aggregate(long /* value */, const PointAttributes & /* attributes */) noexcept override {}
 
   void Aggregate(double value, const PointAttributes &attributes = {}) noexcept override;
 

--- a/sdk/include/opentelemetry/sdk/metrics/aggregation/lastvalue_aggregation.h
+++ b/sdk/include/opentelemetry/sdk/metrics/aggregation/lastvalue_aggregation.h
@@ -22,7 +22,7 @@ public:
 
   void Aggregate(long value, const PointAttributes &attributes = {}) noexcept override;
 
-  void Aggregate(double value, const PointAttributes &attributes = {}) noexcept override {}
+  void Aggregate(double /* value */, const PointAttributes & /* attributes */) noexcept override {}
 
   std::unique_ptr<Aggregation> Merge(const Aggregation &delta) const noexcept override;
 
@@ -42,7 +42,7 @@ public:
   DoubleLastValueAggregation(LastValuePointData &&);
   DoubleLastValueAggregation(const LastValuePointData &);
 
-  void Aggregate(long value, const PointAttributes &attributes = {}) noexcept override {}
+  void Aggregate(long /* value */, const PointAttributes & /* attributes */) noexcept override {}
 
   void Aggregate(double value, const PointAttributes &attributes = {}) noexcept override;
 

--- a/sdk/include/opentelemetry/sdk/metrics/aggregation/sum_aggregation.h
+++ b/sdk/include/opentelemetry/sdk/metrics/aggregation/sum_aggregation.h
@@ -23,7 +23,7 @@ public:
 
   void Aggregate(long value, const PointAttributes &attributes = {}) noexcept override;
 
-  void Aggregate(double value, const PointAttributes &attributes = {}) noexcept override {}
+  void Aggregate(double /* value */, const PointAttributes & /* attributes */) noexcept override {}
 
   std::unique_ptr<Aggregation> Merge(const Aggregation &delta) const noexcept override;
 
@@ -43,7 +43,7 @@ public:
   DoubleSumAggregation(SumPointData &&);
   DoubleSumAggregation(const SumPointData &);
 
-  void Aggregate(long value, const PointAttributes &attributes = {}) noexcept override {}
+  void Aggregate(long /* value */, const PointAttributes & /* attributes */) noexcept override {}
 
   void Aggregate(double value, const PointAttributes &attributes = {}) noexcept override;
 

--- a/sdk/include/opentelemetry/sdk/metrics/exemplar/always_sample_filter.h
+++ b/sdk/include/opentelemetry/sdk/metrics/exemplar/always_sample_filter.h
@@ -20,18 +20,18 @@ public:
     return alwaysSampleFilter;
   }
 
-  bool ShouldSampleMeasurement(long /* value */,
-                               const MetricAttributes & /* attributes */,
-                               const opentelemetry::context::Context & /*
-context */) noexcept override
+  bool ShouldSampleMeasurement(
+      long /* value */,
+      const MetricAttributes & /* attributes */,
+      const opentelemetry::context::Context & /* context */) noexcept override
   {
     return true;
   }
 
-  bool ShouldSampleMeasurement(double /* value */,
-                               const MetricAttributes & /* attributes */,
-                               const opentelemetry::context::Context & /*
-context */) noexcept override
+  bool ShouldSampleMeasurement(
+      double /* value */,
+      const MetricAttributes & /* attributes */,
+      const opentelemetry::context::Context & /* context */) noexcept override
   {
     return true;
   }

--- a/sdk/include/opentelemetry/sdk/metrics/exemplar/always_sample_filter.h
+++ b/sdk/include/opentelemetry/sdk/metrics/exemplar/always_sample_filter.h
@@ -20,16 +20,18 @@ public:
     return alwaysSampleFilter;
   }
 
-  bool ShouldSampleMeasurement(long value,
-                               const MetricAttributes &attributes,
-                               const opentelemetry::context::Context &context) noexcept override
+  bool ShouldSampleMeasurement(long /* value */,
+                               const MetricAttributes & /* attributes */,
+                               const opentelemetry::context::Context & /*
+context */) noexcept override
   {
     return true;
   }
 
-  bool ShouldSampleMeasurement(double value,
-                               const MetricAttributes &attributes,
-                               const opentelemetry::context::Context &context) noexcept override
+  bool ShouldSampleMeasurement(double /* value */,
+                               const MetricAttributes & /* attributes */,
+                               const opentelemetry::context::Context & /*
+context */) noexcept override
   {
     return true;
   }

--- a/sdk/include/opentelemetry/sdk/metrics/exemplar/never_sample_filter.h
+++ b/sdk/include/opentelemetry/sdk/metrics/exemplar/never_sample_filter.h
@@ -20,18 +20,18 @@ public:
     return neverSampleFilter;
   }
 
-  bool ShouldSampleMeasurement(long /* value */,
-                               const MetricAttributes & /* attributes */,
-                               const opentelemetry::context::Context & /*
-context */) noexcept override
+  bool ShouldSampleMeasurement(
+      long /* value */,
+      const MetricAttributes & /* attributes */,
+      const opentelemetry::context::Context & /* context */) noexcept override
   {
     return false;
   }
 
-  bool ShouldSampleMeasurement(double /* value */,
-                               const MetricAttributes & /* attributes */,
-                               const opentelemetry::context::Context & /*
-context */) noexcept override
+  bool ShouldSampleMeasurement(
+      double /* value */,
+      const MetricAttributes & /* attributes */,
+      const opentelemetry::context::Context & /* context */) noexcept override
   {
     return false;
   }

--- a/sdk/include/opentelemetry/sdk/metrics/exemplar/never_sample_filter.h
+++ b/sdk/include/opentelemetry/sdk/metrics/exemplar/never_sample_filter.h
@@ -20,16 +20,18 @@ public:
     return neverSampleFilter;
   }
 
-  bool ShouldSampleMeasurement(long value,
-                               const MetricAttributes &attributes,
-                               const opentelemetry::context::Context &context) noexcept override
+  bool ShouldSampleMeasurement(long /* value */,
+                               const MetricAttributes & /* attributes */,
+                               const opentelemetry::context::Context & /*
+context */) noexcept override
   {
     return false;
   }
 
-  bool ShouldSampleMeasurement(double value,
-                               const MetricAttributes &attributes,
-                               const opentelemetry::context::Context &context) noexcept override
+  bool ShouldSampleMeasurement(double /* value */,
+                               const MetricAttributes & /* attributes */,
+                               const opentelemetry::context::Context & /*
+context */) noexcept override
   {
     return false;
   }

--- a/sdk/include/opentelemetry/sdk/metrics/exemplar/no_exemplar_reservoir.h
+++ b/sdk/include/opentelemetry/sdk/metrics/exemplar/no_exemplar_reservoir.h
@@ -23,24 +23,26 @@ public:
     return nostd::shared_ptr<ExemplarReservoir>{new NoExemplarReservoir{}};
   }
 
-  void OfferMeasurement(long value,
-                        const MetricAttributes &attributes,
-                        const opentelemetry::context::Context &context,
-                        const opentelemetry::common::SystemTimestamp &timestamp) noexcept override
+  void OfferMeasurement(
+      long /* value */,
+      const MetricAttributes & /* attributes */,
+      const opentelemetry::context::Context & /* context */,
+      const opentelemetry::common::SystemTimestamp & /* timestamp */) noexcept override
   {
     // Stores nothing
   }
 
-  void OfferMeasurement(double value,
-                        const MetricAttributes &attributes,
-                        const opentelemetry::context::Context &context,
-                        const opentelemetry::common::SystemTimestamp &timestamp) noexcept override
+  void OfferMeasurement(
+      double /* value */,
+      const MetricAttributes & /* attributes */,
+      const opentelemetry::context::Context & /* context */,
+      const opentelemetry::common::SystemTimestamp & /* timestamp */) noexcept override
   {
     // Stores nothing.
   }
 
   std::vector<ExemplarData> CollectAndReset(
-      const MetricAttributes &pointAttributes) noexcept override
+      const MetricAttributes & /* pointAttributes */) noexcept override
   {
     return std::vector<ExemplarData>{};
   }

--- a/sdk/include/opentelemetry/sdk/metrics/state/async_metric_storage.h
+++ b/sdk/include/opentelemetry/sdk/metrics/state/async_metric_storage.h
@@ -41,7 +41,7 @@ public:
 
   template <class T>
   void Record(const std::unordered_map<MetricAttributes, T, AttributeHashGenerator> &measurements,
-              opentelemetry::common::SystemTimestamp observation_time) noexcept
+              opentelemetry::common::SystemTimestamp /* observation_time */) noexcept
   {
     // process the read measurements - aggregate and store in hashmap
     for (auto &measurement : measurements)

--- a/sdk/include/opentelemetry/sdk/metrics/state/metric_storage.h
+++ b/sdk/include/opentelemetry/sdk/metrics/state/metric_storage.h
@@ -88,8 +88,8 @@ public:
                   const opentelemetry::context::Context & /* context */) noexcept override
   {}
 
-  void RecordDouble(double /* value */, const opentelemetry::context::Context & /*
-context */) noexcept override
+  void RecordDouble(double /* value */,
+                    const opentelemetry::context::Context & /* context */) noexcept override
   {}
 
   void RecordDouble(double /* value */,

--- a/sdk/include/opentelemetry/sdk/metrics/state/metric_storage.h
+++ b/sdk/include/opentelemetry/sdk/metrics/state/metric_storage.h
@@ -67,10 +67,10 @@ public:
 class NoopMetricStorage : public MetricStorage
 {
 public:
-  bool Collect(CollectorHandle *collector,
-               nostd::span<std::shared_ptr<CollectorHandle>> collectors,
-               opentelemetry::common::SystemTimestamp sdk_start_ts,
-               opentelemetry::common::SystemTimestamp collection_ts,
+  bool Collect(CollectorHandle * /* collector */,
+               nostd::span<std::shared_ptr<CollectorHandle>> /* collectors */,
+               opentelemetry::common::SystemTimestamp /* sdk_start_ts */,
+               opentelemetry::common::SystemTimestamp /* collection_ts */,
                nostd::function_ref<bool(MetricData)> callback) noexcept override
   {
     MetricData metric_data;
@@ -83,17 +83,18 @@ class NoopWritableMetricStorage : public SyncWritableMetricStorage
 public:
   void RecordLong(long value, const opentelemetry::context::Context &context) noexcept = 0;
 
-  void RecordLong(long value,
-                  const opentelemetry::common::KeyValueIterable &attributes,
-                  const opentelemetry::context::Context &context) noexcept override
+  void RecordLong(long /* value */,
+                  const opentelemetry::common::KeyValueIterable & /* attributes */,
+                  const opentelemetry::context::Context & /* context */) noexcept override
   {}
 
-  void RecordDouble(double value, const opentelemetry::context::Context &context) noexcept override
+  void RecordDouble(double /* value */, const opentelemetry::context::Context & /*
+context */) noexcept override
   {}
 
-  void RecordDouble(double value,
-                    const opentelemetry::common::KeyValueIterable &attributes,
-                    const opentelemetry::context::Context &context) noexcept override
+  void RecordDouble(double /* value */,
+                    const opentelemetry::common::KeyValueIterable & /* attributes */,
+                    const opentelemetry::context::Context & /* context */) noexcept override
   {}
 };
 
@@ -101,13 +102,13 @@ class NoopAsyncWritableMetricStorage : public AsyncWritableMetricStorage
 {
 public:
   void RecordLong(
-      const std::unordered_map<MetricAttributes, long, AttributeHashGenerator> &measurements,
-      opentelemetry::common::SystemTimestamp observation_time) noexcept override
+      const std::unordered_map<MetricAttributes, long, AttributeHashGenerator> & /* measurements */,
+      opentelemetry::common::SystemTimestamp /* observation_time */) noexcept override
   {}
 
-  void RecordDouble(
-      const std::unordered_map<MetricAttributes, double, AttributeHashGenerator> &measurements,
-      opentelemetry::common::SystemTimestamp observation_time) noexcept override
+  void RecordDouble(const std::unordered_map<MetricAttributes, double, AttributeHashGenerator>
+                        & /* measurements */,
+                    opentelemetry::common::SystemTimestamp /* observation_time */) noexcept override
   {}
 };
 

--- a/sdk/include/opentelemetry/sdk/metrics/view/predicate.h
+++ b/sdk/include/opentelemetry/sdk/metrics/view/predicate.h
@@ -69,12 +69,12 @@ private:
 
 class MatchEverythingPattern : public Predicate
 {
-  bool Match(opentelemetry::nostd::string_view str) const noexcept override { return true; }
+  bool Match(opentelemetry::nostd::string_view /* str */) const noexcept override { return true; }
 };
 
 class MatchNothingPattern : public Predicate
 {
-  bool Match(opentelemetry::nostd::string_view str) const noexcept override { return false; }
+  bool Match(opentelemetry::nostd::string_view /* str */) const noexcept override { return false; }
 };
 }  // namespace metrics
 }  // namespace sdk

--- a/sdk/include/opentelemetry/sdk/trace/simple_processor.h
+++ b/sdk/include/opentelemetry/sdk/trace/simple_processor.h
@@ -40,8 +40,8 @@ public:
     return exporter_->MakeRecordable();
   }
 
-  void OnStart(Recordable &span,
-               const opentelemetry::trace::SpanContext &parent_context) noexcept override
+  void OnStart(Recordable & /* span */,
+               const opentelemetry::trace::SpanContext & /* parent_context */) noexcept override
   {}
 
   void OnEnd(std::unique_ptr<Recordable> &&span) noexcept override
@@ -55,11 +55,7 @@ public:
     }
   }
 
-  bool ForceFlush(
-      std::chrono::microseconds timeout = (std::chrono::microseconds::max)()) noexcept override
-  {
-    return true;
-  }
+  bool ForceFlush(std::chrono::microseconds /* timeout */) noexcept override { return true; }
 
   bool Shutdown(
       std::chrono::microseconds timeout = (std::chrono::microseconds::max)()) noexcept override

--- a/sdk/src/common/global_log_handler.cc
+++ b/sdk/src/common/global_log_handler.cc
@@ -20,7 +20,7 @@ void DefaultLogHandler::Handle(LogLevel level,
                                const char *file,
                                int line,
                                const char *msg,
-                               const sdk::common::AttributeMap &attributes) noexcept
+                               const sdk::common::AttributeMap & /* attributes */) noexcept
 {
   std::stringstream output_s;
   output_s << "[" << LevelToString(level) << "] ";

--- a/sdk/src/logs/batch_log_processor.cc
+++ b/sdk/src/logs/batch_log_processor.cc
@@ -183,8 +183,6 @@ void BatchLogProcessor::DoBackgroundWork()
 
 void BatchLogProcessor::Export()
 {
-  uint64_t current_pending;
-  uint64_t current_notified;
   do
   {
     std::vector<std::unique_ptr<Recordable>> records_arr;

--- a/sdk/src/logs/logger_provider.cc
+++ b/sdk/src/logs/logger_provider.cc
@@ -56,7 +56,7 @@ LoggerProvider::~LoggerProvider()
 
 nostd::shared_ptr<opentelemetry::logs::Logger> LoggerProvider::GetLogger(
     nostd::string_view logger_name,
-    nostd::string_view options,
+    nostd::string_view /* options */,
     nostd::string_view library_name,
     nostd::string_view library_version,
     nostd::string_view schema_url) noexcept
@@ -108,7 +108,7 @@ nostd::shared_ptr<opentelemetry::logs::Logger> LoggerProvider::GetLogger(
 
 nostd::shared_ptr<opentelemetry::logs::Logger> LoggerProvider::GetLogger(
     nostd::string_view logger_name,
-    nostd::span<nostd::string_view> args,
+    nostd::span<nostd::string_view> /* args */,
     nostd::string_view library_name,
     nostd::string_view library_version,
     nostd::string_view schema_url) noexcept

--- a/sdk/src/logs/simple_log_processor.cc
+++ b/sdk/src/logs/simple_log_processor.cc
@@ -43,7 +43,7 @@ void SimpleLogProcessor::OnReceive(std::unique_ptr<Recordable> &&record) noexcep
 /**
  *  The simple processor does not have any log records to flush so this method is not used
  */
-bool SimpleLogProcessor::ForceFlush(std::chrono::microseconds timeout) noexcept
+bool SimpleLogProcessor::ForceFlush(std::chrono::microseconds /* timeout */) noexcept
 {
   return true;
 }

--- a/sdk/src/metrics/aggregation/histogram_aggregation.cc
+++ b/sdk/src/metrics/aggregation/histogram_aggregation.cc
@@ -47,7 +47,8 @@ LongHistogramAggregation::LongHistogramAggregation(const HistogramPointData &dat
     : point_data_{data}, record_min_max_{point_data_.record_min_max_}
 {}
 
-void LongHistogramAggregation::Aggregate(long value, const PointAttributes &attributes) noexcept
+void LongHistogramAggregation::Aggregate(long value,
+                                         const PointAttributes & /* attributes */) noexcept
 {
   const std::lock_guard<opentelemetry::common::SpinLockMutex> locked(lock_);
   point_data_.count_ += 1;
@@ -130,7 +131,8 @@ DoubleHistogramAggregation::DoubleHistogramAggregation(const HistogramPointData 
     : point_data_{data}
 {}
 
-void DoubleHistogramAggregation::Aggregate(double value, const PointAttributes &attributes) noexcept
+void DoubleHistogramAggregation::Aggregate(double value,
+                                           const PointAttributes & /* attributes */) noexcept
 {
   const std::lock_guard<opentelemetry::common::SpinLockMutex> locked(lock_);
   point_data_.count_ += 1;

--- a/sdk/src/metrics/aggregation/lastvalue_aggregation.cc
+++ b/sdk/src/metrics/aggregation/lastvalue_aggregation.cc
@@ -28,7 +28,8 @@ LongLastValueAggregation::LongLastValueAggregation(const LastValuePointData &dat
     : point_data_{data}
 {}
 
-void LongLastValueAggregation::Aggregate(long value, const PointAttributes &attributes) noexcept
+void LongLastValueAggregation::Aggregate(long value,
+                                         const PointAttributes & /* attributes */) noexcept
 {
   const std::lock_guard<opentelemetry::common::SpinLockMutex> locked(lock_);
   point_data_.is_lastvalue_valid_ = true;
@@ -86,7 +87,8 @@ DoubleLastValueAggregation::DoubleLastValueAggregation(const LastValuePointData 
     : point_data_{data}
 {}
 
-void DoubleLastValueAggregation::Aggregate(double value, const PointAttributes &attributes) noexcept
+void DoubleLastValueAggregation::Aggregate(double value,
+                                           const PointAttributes & /* attributes */) noexcept
 {
   const std::lock_guard<opentelemetry::common::SpinLockMutex> locked(lock_);
   point_data_.is_lastvalue_valid_ = true;

--- a/sdk/src/metrics/aggregation/sum_aggregation.cc
+++ b/sdk/src/metrics/aggregation/sum_aggregation.cc
@@ -24,8 +24,7 @@ LongSumAggregation::LongSumAggregation(SumPointData &&data) : point_data_{std::m
 
 LongSumAggregation::LongSumAggregation(const SumPointData &data) : point_data_{data} {}
 
-void LongSumAggregation::Aggregate(long value, const PointAttributes & /*
-attributes */) noexcept
+void LongSumAggregation::Aggregate(long value, const PointAttributes & /* attributes */) noexcept
 {
   const std::lock_guard<opentelemetry::common::SpinLockMutex> locked(lock_);
   point_data_.value_ = nostd::get<long>(point_data_.value_) + value;
@@ -70,8 +69,8 @@ DoubleSumAggregation::DoubleSumAggregation(SumPointData &&data) : point_data_(st
 
 DoubleSumAggregation::DoubleSumAggregation(const SumPointData &data) : point_data_(data) {}
 
-void DoubleSumAggregation::Aggregate(double value, const PointAttributes &
-                                     /* attributes */) noexcept
+void DoubleSumAggregation::Aggregate(double value,
+                                     const PointAttributes & /* attributes */) noexcept
 {
   const std::lock_guard<opentelemetry::common::SpinLockMutex> locked(lock_);
   point_data_.value_ = nostd::get<double>(point_data_.value_) + value;

--- a/sdk/src/metrics/aggregation/sum_aggregation.cc
+++ b/sdk/src/metrics/aggregation/sum_aggregation.cc
@@ -24,7 +24,8 @@ LongSumAggregation::LongSumAggregation(SumPointData &&data) : point_data_{std::m
 
 LongSumAggregation::LongSumAggregation(const SumPointData &data) : point_data_{data} {}
 
-void LongSumAggregation::Aggregate(long value, const PointAttributes &attributes) noexcept
+void LongSumAggregation::Aggregate(long value, const PointAttributes & /*
+attributes */) noexcept
 {
   const std::lock_guard<opentelemetry::common::SpinLockMutex> locked(lock_);
   point_data_.value_ = nostd::get<long>(point_data_.value_) + value;
@@ -69,7 +70,8 @@ DoubleSumAggregation::DoubleSumAggregation(SumPointData &&data) : point_data_(st
 
 DoubleSumAggregation::DoubleSumAggregation(const SumPointData &data) : point_data_(data) {}
 
-void DoubleSumAggregation::Aggregate(double value, const PointAttributes &attributes) noexcept
+void DoubleSumAggregation::Aggregate(double value, const PointAttributes &
+                                     /* attributes */) noexcept
 {
   const std::lock_guard<opentelemetry::common::SpinLockMutex> locked(lock_);
   point_data_.value_ = nostd::get<double>(point_data_.value_) + value;

--- a/sdk/src/metrics/state/temporal_metric_storage.cc
+++ b/sdk/src/metrics/state/temporal_metric_storage.cc
@@ -69,7 +69,7 @@ bool TemporalMetricStorage::buildMetrics(CollectorHandle *collector,
                                                 instrument_descriptor_, aggregation_config_.get())
                                                 ->Merge(aggregation));
             merged_metrics->GetAllEnteries(
-                [](const MetricAttributes &attr, Aggregation &aggr) { return true; });
+                [](const MetricAttributes & /* attr */, Aggregation & /* aggr */) { return true; });
           }
           return true;
         });
@@ -112,7 +112,7 @@ bool TemporalMetricStorage::buildMetrics(CollectorHandle *collector,
   else
   {
     merged_metrics->GetAllEnteries(
-        [](const MetricAttributes &attr, Aggregation &aggr) { return true; });
+        [](const MetricAttributes & /* attr */, Aggregation & /* aggr */) { return true; });
     last_reported_metrics_.insert(
         std::make_pair(collector, LastReportedMetrics{std::move(merged_metrics), collection_ts}));
   }

--- a/sdk/src/metrics/state/temporal_metric_storage.cc
+++ b/sdk/src/metrics/state/temporal_metric_storage.cc
@@ -68,8 +68,6 @@ bool TemporalMetricStorage::buildMetrics(CollectorHandle *collector,
             merged_metrics->Set(attributes, DefaultAggregation::CreateAggregation(
                                                 instrument_descriptor_, aggregation_config_.get())
                                                 ->Merge(aggregation));
-            merged_metrics->GetAllEnteries(
-                [](const MetricAttributes & /* attr */, Aggregation & /* aggr */) { return true; });
           }
           return true;
         });
@@ -111,8 +109,6 @@ bool TemporalMetricStorage::buildMetrics(CollectorHandle *collector,
   }
   else
   {
-    merged_metrics->GetAllEnteries(
-        [](const MetricAttributes & /* attr */, Aggregation & /* aggr */) { return true; });
     last_reported_metrics_.insert(
         std::make_pair(collector, LastReportedMetrics{std::move(merged_metrics), collection_ts}));
   }

--- a/sdk/test/logs/batch_log_processor_test.cc
+++ b/sdk/test/logs/batch_log_processor_test.cc
@@ -57,8 +57,7 @@ public:
   }
 
   // toggles the boolean flag marking this exporter as shut down
-  bool Shutdown(
-      std::chrono::microseconds timeout = std::chrono::microseconds::max()) noexcept override
+  bool Shutdown(std::chrono::microseconds /* timeout */) noexcept override
   {
     *is_shutdown_ = true;
     return true;

--- a/sdk/test/logs/logger_provider_sdk_test.cc
+++ b/sdk/test/logs/logger_provider_sdk_test.cc
@@ -86,15 +86,9 @@ class DummyProcessor : public LogProcessor
     return std::unique_ptr<Recordable>(new LogRecord);
   }
 
-  void OnReceive(std::unique_ptr<Recordable> &&record) noexcept {}
-  bool ForceFlush(std::chrono::microseconds timeout = std::chrono::microseconds(0)) noexcept
-  {
-    return true;
-  }
-  bool Shutdown(std::chrono::microseconds timeout = std::chrono::microseconds(0)) noexcept
-  {
-    return true;
-  }
+  void OnReceive(std::unique_ptr<Recordable> && /* record */) noexcept {}
+  bool ForceFlush(std::chrono::microseconds /* timeout */) noexcept { return true; }
+  bool Shutdown(std::chrono::microseconds /* timeout */) noexcept { return true; }
 };
 
 TEST(LoggerProviderSDK, GetResource)

--- a/sdk/test/logs/logger_sdk_test.cc
+++ b/sdk/test/logs/logger_sdk_test.cc
@@ -56,14 +56,8 @@ public:
     record_received_->SetSeverity(copy->GetSeverity());
     record_received_->SetBody(copy->GetBody());
   }
-  bool ForceFlush(std::chrono::microseconds timeout = std::chrono::microseconds(0)) noexcept
-  {
-    return true;
-  }
-  bool Shutdown(std::chrono::microseconds timeout = std::chrono::microseconds(0)) noexcept
-  {
-    return true;
-  }
+  bool ForceFlush(std::chrono::microseconds /* timeout */) noexcept { return true; }
+  bool Shutdown(std::chrono::microseconds /* timeout */) noexcept { return true; }
 };
 
 TEST(LoggerSDK, LogToAProcessor)

--- a/sdk/test/logs/simple_log_processor_test.cc
+++ b/sdk/test/logs/simple_log_processor_test.cc
@@ -54,7 +54,7 @@ public:
   }
 
   // Increment the shutdown counter everytime this method is called
-  bool Shutdown(std::chrono::microseconds timeout) noexcept override
+  bool Shutdown(std::chrono::microseconds /* timeout */) noexcept override
   {
     *shutdown_counter_ += 1;
     return true;
@@ -132,12 +132,13 @@ public:
     return std::unique_ptr<Recordable>(new LogRecord());
   }
 
-  ExportResult Export(const nostd::span<std::unique_ptr<Recordable>> &records) noexcept override
+  ExportResult Export(const nostd::span<std::unique_ptr<Recordable>> & /*
+records */) noexcept override
   {
     return ExportResult::kSuccess;
   }
 
-  bool Shutdown(std::chrono::microseconds timeout) noexcept override { return false; }
+  bool Shutdown(std::chrono::microseconds /* timeout */) noexcept override { return false; }
 };
 
 // Tests for when when processor should fail to shutdown

--- a/sdk/test/logs/simple_log_processor_test.cc
+++ b/sdk/test/logs/simple_log_processor_test.cc
@@ -132,8 +132,8 @@ public:
     return std::unique_ptr<Recordable>(new LogRecord());
   }
 
-  ExportResult Export(const nostd::span<std::unique_ptr<Recordable>> & /*
-records */) noexcept override
+  ExportResult Export(
+      const nostd::span<std::unique_ptr<Recordable>> & /* records */) noexcept override
   {
     return ExportResult::kSuccess;
   }

--- a/sdk/test/metrics/async_instruments_test.cc
+++ b/sdk/test/metrics/async_instruments_test.cc
@@ -12,8 +12,8 @@ using namespace opentelemetry::sdk::metrics;
 
 using M = std::map<std::string, std::string>;
 
-void asyc_generate_measurements(opentelemetry::metrics::ObserverResult /*
-observer */, void * /* state */)
+void asyc_generate_measurements(opentelemetry::metrics::ObserverResult /* observer */,
+                                void * /* state */)
 {}
 
 TEST(AsyncInstruments, ObservableInstrument)

--- a/sdk/test/metrics/async_instruments_test.cc
+++ b/sdk/test/metrics/async_instruments_test.cc
@@ -12,7 +12,9 @@ using namespace opentelemetry::sdk::metrics;
 
 using M = std::map<std::string, std::string>;
 
-void asyc_generate_measurements(opentelemetry::metrics::ObserverResult observer, void *state) {}
+void asyc_generate_measurements(opentelemetry::metrics::ObserverResult /*
+observer */, void * /* state */)
+{}
 
 TEST(AsyncInstruments, ObservableInstrument)
 {

--- a/sdk/test/metrics/async_metric_storage_test.cc
+++ b/sdk/test/metrics/async_metric_storage_test.cc
@@ -31,7 +31,8 @@ class MockCollectorHandle : public CollectorHandle
 public:
   MockCollectorHandle(AggregationTemporality temp) : temporality(temp) {}
 
-  AggregationTemporality GetAggregationTemporality(InstrumentType instrument_type) noexcept override
+  AggregationTemporality GetAggregationTemporality(InstrumentType /*
+instrument_type */) noexcept override
   {
     return temporality;
   }

--- a/sdk/test/metrics/async_metric_storage_test.cc
+++ b/sdk/test/metrics/async_metric_storage_test.cc
@@ -31,8 +31,8 @@ class MockCollectorHandle : public CollectorHandle
 public:
   MockCollectorHandle(AggregationTemporality temp) : temporality(temp) {}
 
-  AggregationTemporality GetAggregationTemporality(InstrumentType /*
-instrument_type */) noexcept override
+  AggregationTemporality GetAggregationTemporality(
+      InstrumentType /* instrument_type */) noexcept override
   {
     return temporality;
   }

--- a/sdk/test/metrics/attributes_hashmap_test.cc
+++ b/sdk/test/metrics/attributes_hashmap_test.cc
@@ -61,13 +61,11 @@ TEST(AttributesHashMap, BasicTests)
 
   // GetAllEnteries
   size_t count = 0;
-  hash_map.GetAllEnteries([&count](const MetricAttributes & /* attributes
-                                                             */
-                                   ,
-                                   Aggregation & /* aggregation */) {
-    count++;
-    return true;
-  });
+  hash_map.GetAllEnteries(
+      [&count](const MetricAttributes & /* attributes */, Aggregation & /* aggregation */) {
+        count++;
+        return true;
+      });
   EXPECT_EQ(count, hash_map.Size());
 }
 

--- a/sdk/test/metrics/attributes_hashmap_test.cc
+++ b/sdk/test/metrics/attributes_hashmap_test.cc
@@ -61,7 +61,10 @@ TEST(AttributesHashMap, BasicTests)
 
   // GetAllEnteries
   size_t count = 0;
-  hash_map.GetAllEnteries([&count](const MetricAttributes &attributes, Aggregation &aggregation) {
+  hash_map.GetAllEnteries([&count](const MetricAttributes & /* attributes
+                                                             */
+                                   ,
+                                   Aggregation & /* aggregation */) {
     count++;
     return true;
   });

--- a/sdk/test/metrics/meter_provider_sdk_test.cc
+++ b/sdk/test/metrics/meter_provider_sdk_test.cc
@@ -18,27 +18,21 @@ class MockMetricExporter : public MetricExporter
 
 public:
   MockMetricExporter() = default;
-  opentelemetry::sdk::common::ExportResult Export(const ResourceMetrics &records) noexcept override
+  opentelemetry::sdk::common::ExportResult Export(
+      const ResourceMetrics & /* records */) noexcept override
   {
     return opentelemetry::sdk::common::ExportResult::kSuccess;
   }
 
   AggregationTemporality GetAggregationTemporality(
-      InstrumentType instrument_type) const noexcept override
+      InstrumentType /* instrument_type */) const noexcept override
   {
     return AggregationTemporality::kCumulative;
   }
 
-  bool ForceFlush(
-      std::chrono::microseconds timeout = (std::chrono::microseconds::max)()) noexcept override
-  {
-    return true;
-  }
+  bool ForceFlush(std::chrono::microseconds /* timeout */) noexcept override { return true; }
 
-  bool Shutdown(std::chrono::microseconds timeout = std::chrono::microseconds(0)) noexcept override
-  {
-    return true;
-  }
+  bool Shutdown(std::chrono::microseconds /* timeout */) noexcept override { return true; }
 };
 
 class MockMetricReader : public MetricReader
@@ -50,8 +44,14 @@ public:
   {
     return exporter_->GetAggregationTemporality(instrument_type);
   }
-  virtual bool OnForceFlush(std::chrono::microseconds timeout) noexcept override { return true; }
-  virtual bool OnShutDown(std::chrono::microseconds timeout) noexcept override { return true; }
+  virtual bool OnForceFlush(std::chrono::microseconds /* timeout */) noexcept override
+  {
+    return true;
+  }
+  virtual bool OnShutDown(std::chrono::microseconds /* timeout */) noexcept override
+  {
+    return true;
+  }
   virtual void OnInitialized() noexcept override {}
 
 private:

--- a/sdk/test/metrics/meter_test.cc
+++ b/sdk/test/metrics/meter_test.cc
@@ -19,12 +19,12 @@ class MockMetricReader : public MetricReader
 public:
   MockMetricReader() = default;
   AggregationTemporality GetAggregationTemporality(
-      InstrumentType instrument_type) const noexcept override
+      InstrumentType /* instrument_type */) const noexcept override
   {
     return AggregationTemporality::kCumulative;
   }
-  bool OnShutDown(std::chrono::microseconds timeout) noexcept override { return true; }
-  bool OnForceFlush(std::chrono::microseconds timeout) noexcept override { return true; }
+  bool OnShutDown(std::chrono::microseconds /* timeout */) noexcept override { return true; }
+  bool OnForceFlush(std::chrono::microseconds /* timeout */) noexcept override { return true; }
   void OnInitialized() noexcept override {}
 };
 
@@ -42,7 +42,7 @@ nostd::shared_ptr<metrics::Meter> InitMeter(MetricReader **metricReaderPtr)
 }
 }  // namespace
 
-void asyc_generate_measurements(opentelemetry::metrics::ObserverResult observer, void *state)
+void asyc_generate_measurements(opentelemetry::metrics::ObserverResult observer, void * /* state */)
 {
   auto observer_long =
       nostd::get<nostd::shared_ptr<opentelemetry::metrics::ObserverResultT<long>>>(observer);

--- a/sdk/test/metrics/metric_reader_test.cc
+++ b/sdk/test/metrics/metric_reader_test.cc
@@ -16,12 +16,18 @@ class MockMetricReader : public MetricReader
 public:
   MockMetricReader() = default;
   AggregationTemporality GetAggregationTemporality(
-      InstrumentType instrument_type) const noexcept override
+      InstrumentType /* instrument_type */) const noexcept override
   {
     return AggregationTemporality::kCumulative;
   }
-  virtual bool OnForceFlush(std::chrono::microseconds timeout) noexcept override { return true; }
-  virtual bool OnShutDown(std::chrono::microseconds timeout) noexcept override { return true; }
+  virtual bool OnForceFlush(std::chrono::microseconds /* timeout */) noexcept override
+  {
+    return true;
+  }
+  virtual bool OnShutDown(std::chrono::microseconds /* timeout */) noexcept override
+  {
+    return true;
+  }
   virtual void OnInitialized() noexcept override {}
 };
 
@@ -38,6 +44,6 @@ TEST(MetricReaderTest, BasicTests)
   std::shared_ptr<MeterContext> meter_context2(new MeterContext());
   std::shared_ptr<MetricProducer> metric_producer{
       new MetricCollector(meter_context2.get(), std::move(metric_reader2))};
-  metric_producer->Collect([](ResourceMetrics &metric_data) { return true; });
+  metric_producer->Collect([](ResourceMetrics & /* metric_data */) { return true; });
 }
 #endif

--- a/sdk/test/metrics/multi_metric_storage_test.cc
+++ b/sdk/test/metrics/multi_metric_storage_test.cc
@@ -16,26 +16,29 @@ using namespace opentelemetry::sdk::metrics;
 class TestMetricStorage : public SyncWritableMetricStorage
 {
 public:
-  void RecordLong(long value, const opentelemetry::context::Context &context) noexcept override
+  void RecordLong(long /* value */, const opentelemetry::context::Context &
+                  /* context */) noexcept override
   {
     num_calls_long++;
   }
 
-  void RecordLong(long value,
-                  const opentelemetry::common::KeyValueIterable &attributes,
-                  const opentelemetry::context::Context &context) noexcept override
+  void RecordLong(long /* value */,
+                  const opentelemetry::common::KeyValueIterable & /* attributes */,
+                  const opentelemetry::context::Context & /* context */) noexcept override
   {
     num_calls_long++;
   }
 
-  void RecordDouble(double value, const opentelemetry::context::Context &context) noexcept override
+  void RecordDouble(double /* value */, const opentelemetry::context::Context & /*
+context */) noexcept override
   {
     num_calls_double++;
   }
 
-  void RecordDouble(double value,
-                    const opentelemetry::common::KeyValueIterable &attributes,
-                    const opentelemetry::context::Context &context) noexcept override
+  void RecordDouble(double /* value */,
+                    const opentelemetry::common::KeyValueIterable & /*
+attributes */,
+                    const opentelemetry::context::Context & /* context */) noexcept override
   {
     num_calls_double++;
   }

--- a/sdk/test/metrics/multi_metric_storage_test.cc
+++ b/sdk/test/metrics/multi_metric_storage_test.cc
@@ -16,8 +16,8 @@ using namespace opentelemetry::sdk::metrics;
 class TestMetricStorage : public SyncWritableMetricStorage
 {
 public:
-  void RecordLong(long /* value */, const opentelemetry::context::Context &
-                  /* context */) noexcept override
+  void RecordLong(long /* value */,
+                  const opentelemetry::context::Context & /* context */) noexcept override
   {
     num_calls_long++;
   }
@@ -29,15 +29,14 @@ public:
     num_calls_long++;
   }
 
-  void RecordDouble(double /* value */, const opentelemetry::context::Context & /*
-context */) noexcept override
+  void RecordDouble(double /* value */,
+                    const opentelemetry::context::Context & /* context */) noexcept override
   {
     num_calls_double++;
   }
 
   void RecordDouble(double /* value */,
-                    const opentelemetry::common::KeyValueIterable & /*
-attributes */,
+                    const opentelemetry::common::KeyValueIterable & /* attributes */,
                     const opentelemetry::context::Context & /* context */) noexcept override
   {
     num_calls_double++;

--- a/sdk/test/metrics/periodic_exporting_metric_reader_test.cc
+++ b/sdk/test/metrics/periodic_exporting_metric_reader_test.cc
@@ -22,22 +22,15 @@ public:
     return opentelemetry::sdk::common::ExportResult::kSuccess;
   }
 
-  bool ForceFlush(
-      std::chrono::microseconds timeout = (std::chrono::microseconds::max)()) noexcept override
-  {
-    return false;
-  }
+  bool ForceFlush(std::chrono::microseconds /* timeout */) noexcept override { return false; }
 
   sdk::metrics::AggregationTemporality GetAggregationTemporality(
-      sdk::metrics::InstrumentType instrument_type) const noexcept override
+      sdk::metrics::InstrumentType /* instrument_type */) const noexcept override
   {
     return sdk::metrics::AggregationTemporality::kCumulative;
   }
 
-  bool Shutdown(std::chrono::microseconds timeout = std::chrono::microseconds(0)) noexcept override
-  {
-    return true;
-  }
+  bool Shutdown(std::chrono::microseconds /* timeout */) noexcept override { return true; }
 
   size_t GetDataCount() { return records_.size(); }
 

--- a/sdk/test/metrics/sync_metric_storage_counter_test.cc
+++ b/sdk/test/metrics/sync_metric_storage_counter_test.cc
@@ -23,8 +23,8 @@ class MockCollectorHandle : public CollectorHandle
 public:
   MockCollectorHandle(AggregationTemporality temp) : temporality(temp) {}
 
-  AggregationTemporality GetAggregationTemporality(InstrumentType /*
-instrument_type */) noexcept override
+  AggregationTemporality GetAggregationTemporality(
+      InstrumentType /* instrument_type */) noexcept override
   {
     return temporality;
   }

--- a/sdk/test/metrics/sync_metric_storage_counter_test.cc
+++ b/sdk/test/metrics/sync_metric_storage_counter_test.cc
@@ -23,7 +23,8 @@ class MockCollectorHandle : public CollectorHandle
 public:
   MockCollectorHandle(AggregationTemporality temp) : temporality(temp) {}
 
-  AggregationTemporality GetAggregationTemporality(InstrumentType instrument_type) noexcept override
+  AggregationTemporality GetAggregationTemporality(InstrumentType /*
+instrument_type */) noexcept override
   {
     return temporality;
   }

--- a/sdk/test/metrics/sync_metric_storage_histogram_test.cc
+++ b/sdk/test/metrics/sync_metric_storage_histogram_test.cc
@@ -23,8 +23,8 @@ class MockCollectorHandle : public CollectorHandle
 public:
   MockCollectorHandle(AggregationTemporality temp) : temporality(temp) {}
 
-  AggregationTemporality GetAggregationTemporality(InstrumentType /*
-instrument_type */) noexcept override
+  AggregationTemporality GetAggregationTemporality(
+      InstrumentType /* instrument_type */) noexcept override
   {
     return temporality;
   }

--- a/sdk/test/metrics/sync_metric_storage_histogram_test.cc
+++ b/sdk/test/metrics/sync_metric_storage_histogram_test.cc
@@ -23,7 +23,8 @@ class MockCollectorHandle : public CollectorHandle
 public:
   MockCollectorHandle(AggregationTemporality temp) : temporality(temp) {}
 
-  AggregationTemporality GetAggregationTemporality(InstrumentType instrument_type) noexcept override
+  AggregationTemporality GetAggregationTemporality(InstrumentType /*
+instrument_type */) noexcept override
   {
     return temporality;
   }

--- a/sdk/test/trace/batch_span_processor_test.cc
+++ b/sdk/test/trace/batch_span_processor_test.cc
@@ -58,8 +58,7 @@ public:
     return sdk::common::ExportResult::kSuccess;
   }
 
-  bool Shutdown(
-      std::chrono::microseconds timeout = std::chrono::microseconds::max()) noexcept override
+  bool Shutdown(std::chrono::microseconds /* timeout */) noexcept override
   {
     *is_shutdown_ = true;
     return true;

--- a/sdk/test/trace/sampler_benchmark.cc
+++ b/sdk/test/trace/sampler_benchmark.cc
@@ -118,7 +118,8 @@ void BM_TraceIdRatioBasedSamplerShouldSample(benchmark::State &state)
 BENCHMARK(BM_TraceIdRatioBasedSamplerShouldSample);
 
 // Sampler Helper Function
-void BenchmarkSpanCreation(std::shared_ptr<Sampler> sampler, benchmark::State &state)
+void BenchmarkSpanCreation(std::shared_ptr<Sampler> /* TODO: fix issue #1612 sampler */,
+                           benchmark::State &state)
 {
   std::unique_ptr<SpanExporter> exporter(new InMemorySpanExporter());
   std::unique_ptr<SpanProcessor> processor(new SimpleSpanProcessor(std::move(exporter)));

--- a/sdk/test/trace/simple_processor_test.cc
+++ b/sdk/test/trace/simple_processor_test.cc
@@ -45,14 +45,14 @@ public:
     return std::unique_ptr<Recordable>(new SpanData());
   }
 
-  ExportResult Export(
-      const opentelemetry::nostd::span<std::unique_ptr<Recordable>> &recordables) noexcept override
+  ExportResult Export(const opentelemetry::nostd::span<std::unique_ptr<Recordable>>
+                          & /*
+recordables */) noexcept override
   {
     return ExportResult::kSuccess;
   }
 
-  bool Shutdown(
-      std::chrono::microseconds timeout = std::chrono::microseconds::max()) noexcept override
+  bool Shutdown(std::chrono::microseconds /* timeout */) noexcept override
   {
     *shutdown_counter_ += 1;
     return true;

--- a/sdk/test/trace/simple_processor_test.cc
+++ b/sdk/test/trace/simple_processor_test.cc
@@ -46,8 +46,7 @@ public:
   }
 
   ExportResult Export(const opentelemetry::nostd::span<std::unique_ptr<Recordable>>
-                          & /*
-recordables */) noexcept override
+                          & /* recordables */) noexcept override
   {
     return ExportResult::kSuccess;
   }


### PR DESCRIPTION

Fixes #1611 

## Changes

Fix build warnings reported by gcc 10, with:
 -Wall -Werror
 -Wextra-semi
 -Werror=unused-parameter
 -Werror=undef

For significant contributions please make sure you have completed the following items:

* [ ] `CHANGELOG.md` updated for non-trivial changes
* [ ] Unit tests have been added
* [X] Changes in public API reviewed