### PR TITLE
resource sdk: Update Resource::Merge function docs

### DIFF
--- a/sdk/include/opentelemetry/sdk/resource/resource.h
+++ b/sdk/include/opentelemetry/sdk/resource/resource.h
@@ -33,7 +33,7 @@ public:
 
   /**
    * Returns a new, merged {@link Resource} by merging the current Resource
-   * with the other Resource. In case of a collision, current Resource takes
+   * with the other Resource. In case of a collision, the other Resource takes
    * precedence.
    *
    * @param other the Resource that will be merged with this.


### PR DESCRIPTION
The documented behaviour of Resource::Merge is the opposite of what it actually does.

As per https://cplusplus.com/reference/unordered_map/unordered_map/insert/, when calling `insert` on an unordered_map, each element is inserted only if its key is not equivalent to the key of any other element already in the container.