### PR TITLE
[gRPC]: Fix oob access of string_view in example

### DIFF
--- a/examples/grpc/tracer_common.h
+++ b/examples/grpc/tracer_common.h
@@ -38,7 +38,7 @@ public:
                    opentelemetry::nostd::string_view value) noexcept override
   {
     std::cout << " Client ::: Adding " << key << " " << value << "\n";
-    context_->AddMetadata(key.data(), value.data());
+    context_->AddMetadata(std::string(key), std::string(value));
   }
 
   ClientContext *context_;
@@ -52,7 +52,7 @@ public:
   virtual opentelemetry::nostd::string_view Get(
       opentelemetry::nostd::string_view key) const noexcept override
   {
-    auto it = context_->client_metadata().find(key.data());
+    auto it = context_->client_metadata().find({key.data(), key.size()});
     if (it != context_->client_metadata().end())
     {
       return it->second.data();


### PR DESCRIPTION
The GrpcClient/ServerCarrier in the gRPC examples assume that the provided string_views are null-terminated, 
which is not necessarily the case, e.g. when they are provided by the HttpTraceContext:

https://github.com/open-telemetry/opentelemetry-cpp/blob/82a81157a98c7120ab90e06295df0ff5ff328e56/api/include/opentelemetry/trace/propagation/http_trace_context.h#L89-L102