### PR TITLE
Fix more build warnings (#1616)

### DIFF
--- a/api/include/opentelemetry/context/runtime_context.h
+++ b/api/include/opentelemetry/context/runtime_context.h
@@ -18,7 +18,7 @@ class Token
 public:
   bool operator==(const Context &other) const noexcept { return context_ == other; }
 
-  ~Token();
+  ~Token() noexcept;
 
 private:
   friend class RuntimeContextStorage;

--- a/api/include/opentelemetry/logs/noop.h
+++ b/api/include/opentelemetry/logs/noop.h
@@ -49,6 +49,16 @@ public:
            trace::TraceFlags /* trace_flags */,
            common::SystemTimestamp /* timestamp */) noexcept override
   {}
+
+  void Log(Severity /* severity */,
+           nostd::string_view /* name */,
+           nostd::string_view /* body */,
+           const common::KeyValueIterable & /* attributes */,
+           trace::TraceId /* trace_id */,
+           trace::SpanId /* span_id */,
+           trace::TraceFlags /* trace_flags */,
+           common::SystemTimestamp /* timestamp */) noexcept override
+  {}
 };
 
 /**

--- a/api/include/opentelemetry/metrics/async_instruments.h
+++ b/api/include/opentelemetry/metrics/async_instruments.h
@@ -15,8 +15,8 @@ using ObservableCallbackPtr = void (*)(ObserverResult, void *);
 class ObservableInstrument
 {
 public:
-  ObservableInstrument() {}
-  virtual ~ObservableInstrument() {}
+  ObservableInstrument()          = default;
+  virtual ~ObservableInstrument() = default;
 
   /**
    * Sets up a function that will be called whenever a metric collection is initiated.

--- a/api/include/opentelemetry/metrics/async_instruments.h
+++ b/api/include/opentelemetry/metrics/async_instruments.h
@@ -15,6 +15,9 @@ using ObservableCallbackPtr = void (*)(ObserverResult, void *);
 class ObservableInstrument
 {
 public:
+  ObservableInstrument() {}
+  virtual ~ObservableInstrument() {}
+
   /**
    * Sets up a function that will be called whenever a metric collection is initiated.
    */

--- a/api/include/opentelemetry/metrics/noop.h
+++ b/api/include/opentelemetry/metrics/noop.h
@@ -58,7 +58,7 @@ public:
                     nostd::string_view /* description */,
                     nostd::string_view /* unit */) noexcept
   {}
-  ~NoopUpDownCounter() {}
+  ~NoopUpDownCounter() = default;
   void Add(T /* value */) noexcept override {}
   void Add(T /* value */, const opentelemetry::context::Context & /* context */) noexcept override
   {}

--- a/api/include/opentelemetry/metrics/noop.h
+++ b/api/include/opentelemetry/metrics/noop.h
@@ -58,6 +58,7 @@ public:
                     nostd::string_view /* description */,
                     nostd::string_view /* unit */) noexcept
   {}
+  ~NoopUpDownCounter() {}
   void Add(T /* value */) noexcept override {}
   void Add(T /* value */, const opentelemetry::context::Context & /* context */) noexcept override
   {}

--- a/api/include/opentelemetry/metrics/observer_result.h
+++ b/api/include/opentelemetry/metrics/observer_result.h
@@ -24,7 +24,7 @@ class ObserverResultT
 {
 
 public:
-  virtual ~ObserverResultT() {}
+  virtual ~ObserverResultT() = default;
 
   virtual void Observe(T value) noexcept = 0;
 

--- a/api/include/opentelemetry/metrics/observer_result.h
+++ b/api/include/opentelemetry/metrics/observer_result.h
@@ -24,6 +24,8 @@ class ObserverResultT
 {
 
 public:
+  virtual ~ObserverResultT() {}
+
   virtual void Observe(T value) noexcept = 0;
 
   virtual void Observe(T value, const common::KeyValueIterable &attributes) noexcept = 0;

--- a/api/include/opentelemetry/metrics/sync_instruments.h
+++ b/api/include/opentelemetry/metrics/sync_instruments.h
@@ -18,7 +18,7 @@ namespace metrics
 class SynchronousInstrument
 {
 public:
-  SynchronousInstrument(){}
+  SynchronousInstrument() {}
   virtual ~SynchronousInstrument() {}
 };
 

--- a/api/include/opentelemetry/metrics/sync_instruments.h
+++ b/api/include/opentelemetry/metrics/sync_instruments.h
@@ -18,8 +18,8 @@ namespace metrics
 class SynchronousInstrument
 {
 public:
-  SynchronousInstrument() {}
-  virtual ~SynchronousInstrument() {}
+  SynchronousInstrument()          = default;
+  virtual ~SynchronousInstrument() = default;
 };
 
 template <class T>

--- a/api/include/opentelemetry/metrics/sync_instruments.h
+++ b/api/include/opentelemetry/metrics/sync_instruments.h
@@ -16,7 +16,11 @@ namespace metrics
 {
 
 class SynchronousInstrument
-{};
+{
+public:
+  SynchronousInstrument(){}
+  virtual ~SynchronousInstrument() {}
+};
 
 template <class T>
 class Counter : public SynchronousInstrument

--- a/api/include/opentelemetry/nostd/detail/invoke.h
+++ b/api/include/opentelemetry/nostd/detail/invoke.h
@@ -95,24 +95,25 @@ inline constexpr auto invoke_impl(R T::*f, Arg &&arg, Args &&... args)
 #endif
 }  // namespace detail
 
+/* clang-format off */
 template <typename F, typename... Args>
 inline constexpr auto invoke(F &&f, Args &&... args)
     OPENTELEMETRY_RETURN(detail::invoke_impl(std::forward<F>(f), std::forward<Args>(args)...))
 
 namespace detail
+/* clang-format on */
 {
 
-template <typename Void, typename, typename...>
-struct invoke_result
-{};
+  template <typename Void, typename, typename...>
+  struct invoke_result
+  {};
 
-template <typename F, typename... Args>
-struct invoke_result<void_t<decltype(nostd::invoke(std::declval<F>(), std::declval<Args>()...))>,
-                     F,
-                     Args...>
-{
-  using type = decltype(nostd::invoke(std::declval<F>(), std::declval<Args>()...));
-};
+  template <typename F, typename... Args>
+  struct invoke_result<void_t<decltype(nostd::invoke(std::declval<F>(), std::declval<Args>()...))>,
+                       F, Args...>
+  {
+    using type = decltype(nostd::invoke(std::declval<F>(), std::declval<Args>()...));
+  };
 
 }  // namespace detail
 

--- a/api/include/opentelemetry/nostd/detail/invoke.h
+++ b/api/include/opentelemetry/nostd/detail/invoke.h
@@ -97,7 +97,7 @@ inline constexpr auto invoke_impl(R T::*f, Arg &&arg, Args &&... args)
 
 template <typename F, typename... Args>
 inline constexpr auto invoke(F &&f, Args &&... args)
-    OPENTELEMETRY_RETURN(detail::invoke_impl(std::forward<F>(f), std::forward<Args>(args)...));
+    OPENTELEMETRY_RETURN(detail::invoke_impl(std::forward<F>(f), std::forward<Args>(args)...))
 
 namespace detail
 {

--- a/api/include/opentelemetry/plugin/tracer.h
+++ b/api/include/opentelemetry/plugin/tracer.h
@@ -35,6 +35,12 @@ public:
   }
 
   void AddEvent(nostd::string_view name,
+                const common::KeyValueIterable &attributes) noexcept override
+  {
+    span_->AddEvent(name, attributes);
+  }
+
+  void AddEvent(nostd::string_view name,
                 common::SystemTimestamp timestamp,
                 const common::KeyValueIterable &attributes) noexcept override
   {

--- a/api/include/opentelemetry/trace/default_span.h
+++ b/api/include/opentelemetry/trace/default_span.h
@@ -22,33 +22,34 @@ public:
   // Returns an invalid span.
   static DefaultSpan GetInvalid() { return DefaultSpan(SpanContext::GetInvalid()); }
 
-  trace::SpanContext GetContext() const noexcept { return span_context_; }
+  trace::SpanContext GetContext() const noexcept override { return span_context_; }
 
-  bool IsRecording() const noexcept { return false; }
+  bool IsRecording() const noexcept override { return false; }
 
   void SetAttribute(nostd::string_view /* key */,
-                    const common::AttributeValue & /* value */) noexcept
+                    const common::AttributeValue & /* value */) noexcept override
   {}
 
-  void AddEvent(nostd::string_view /* name */) noexcept {}
+  void AddEvent(nostd::string_view /* name */) noexcept override {}
 
-  void AddEvent(nostd::string_view /* name */, common::SystemTimestamp /* timestamp */) noexcept {}
+  void AddEvent(nostd::string_view /* name */,
+                common::SystemTimestamp /* timestamp */) noexcept override
+  {}
+
+  void AddEvent(nostd::string_view /* name */,
+                const common::KeyValueIterable & /* attributes */) noexcept override
+  {}
 
   void AddEvent(nostd::string_view /* name */,
                 common::SystemTimestamp /* timestamp */,
-                const common::KeyValueIterable & /* attributes */) noexcept
+                const common::KeyValueIterable & /* attributes */) noexcept override
   {}
 
-  void AddEvent(nostd::string_view name, const common::KeyValueIterable &attributes) noexcept
-  {
-    this->AddEvent(name, std::chrono::system_clock::now(), attributes);
-  }
+  void SetStatus(StatusCode /* status */, nostd::string_view /* description */) noexcept override {}
 
-  void SetStatus(StatusCode /* status */, nostd::string_view /* description */) noexcept {}
+  void UpdateName(nostd::string_view /* name */) noexcept override {}
 
-  void UpdateName(nostd::string_view /* name */) noexcept {}
-
-  void End(const EndSpanOptions & /* options */ = {}) noexcept {}
+  void End(const EndSpanOptions & /* options */) noexcept override {}
 
   nostd::string_view ToString() const noexcept { return "DefaultSpan"; }
 

--- a/api/include/opentelemetry/trace/noop.h
+++ b/api/include/opentelemetry/trace/noop.h
@@ -49,6 +49,10 @@ public:
                 common::SystemTimestamp /*timestamp*/) noexcept override
   {}
 
+  void AddEvent(nostd::string_view /* name */,
+                const common::KeyValueIterable & /* attributes */) noexcept override
+  {}
+
   void AddEvent(nostd::string_view /*name*/,
                 common::SystemTimestamp /*timestamp*/,
                 const common::KeyValueIterable & /*attributes*/) noexcept override

--- a/api/test/logs/logger_test.cc
+++ b/api/test/logs/logger_test.cc
@@ -125,6 +125,16 @@ class TestLogger : public Logger
            trace::TraceFlags /* trace_flags */,
            common::SystemTimestamp /* timestamp */) noexcept override
   {}
+
+  void Log(Severity /* severity */,
+           nostd::string_view /* name */,
+           nostd::string_view /* body */,
+           const common::KeyValueIterable & /* attributes */,
+           trace::TraceId /* trace_id */,
+           trace::SpanId /* span_id */,
+           trace::TraceFlags /* trace_flags */,
+           common::SystemTimestamp /* timestamp */) noexcept override
+  {}
 };
 
 // Define a basic LoggerProvider class that returns an instance of the logger class defined above

--- a/exporters/memory/include/opentelemetry/exporters/memory/in_memory_span_exporter.h
+++ b/exporters/memory/include/opentelemetry/exporters/memory/in_memory_span_exporter.h
@@ -86,7 +86,7 @@ private:
   std::shared_ptr<InMemorySpanData> data_;
   bool is_shutdown_ = false;
   mutable opentelemetry::common::SpinLockMutex lock_;
-  const bool isShutdown() const noexcept
+  bool isShutdown() const noexcept
   {
     const std::lock_guard<opentelemetry::common::SpinLockMutex> locked(lock_);
     return is_shutdown_;

--- a/ext/test/http/curl_http_test.cc
+++ b/ext/test/http/curl_http_test.cc
@@ -43,7 +43,7 @@ public:
         break;
     }
   }
-  virtual void OnConnecting(const http_client::SSLCertificate &) noexcept {}
+  virtual void OnConnecting(const http_client::SSLCertificate &) noexcept override {}
   virtual ~CustomEventHandler() = default;
   bool is_called_               = false;
   bool got_response_            = false;

--- a/ext/test/http/url_parser_test.cc
+++ b/ext/test/http/url_parser_test.cc
@@ -7,7 +7,7 @@
 
 namespace http_common = opentelemetry::ext::http::common;
 
-inline const char *const BoolToString(bool b)
+inline const char *BoolToString(bool b)
 {
   return b ? "true" : "false";
 }

--- a/sdk/include/opentelemetry/sdk/logs/log_record.h
+++ b/sdk/include/opentelemetry/sdk/logs/log_record.h
@@ -177,7 +177,7 @@ public:
    * @param instrumentation_scope the instrumentation scope to set
    */
   void SetInstrumentationScope(const opentelemetry::sdk::instrumentationscope::InstrumentationScope
-                                   &instrumentation_scope) noexcept
+                                   &instrumentation_scope) noexcept override
   {
     instrumentation_scope_ = &instrumentation_scope;
   }

--- a/sdk/include/opentelemetry/sdk/logs/logger.h
+++ b/sdk/include/opentelemetry/sdk/logs/logger.h
@@ -58,6 +58,19 @@ public:
            opentelemetry::trace::TraceFlags trace_flags,
            opentelemetry::common::SystemTimestamp timestamp) noexcept override;
 
+  // Deprecated
+  void Log(opentelemetry::logs::Severity severity,
+           nostd::string_view /* name */,
+           nostd::string_view body,
+           const opentelemetry::common::KeyValueIterable &attributes,
+           opentelemetry::trace::TraceId trace_id,
+           opentelemetry::trace::SpanId span_id,
+           opentelemetry::trace::TraceFlags trace_flags,
+           opentelemetry::common::SystemTimestamp timestamp) noexcept override
+  {
+    Log(severity, body, attributes, trace_id, span_id, trace_flags, timestamp);
+  }
+
   /** Returns the associated instrumentation scope */
   const opentelemetry::sdk::instrumentationscope::InstrumentationScope &GetInstrumentationScope()
       const noexcept;

--- a/sdk/include/opentelemetry/sdk/metrics/aggregation/default_aggregation.h
+++ b/sdk/include/opentelemetry/sdk/metrics/aggregation/default_aggregation.h
@@ -56,7 +56,7 @@ public:
                    : std::move(std::unique_ptr<Aggregation>(new DoubleLastValueAggregation()));
         break;
       default:
-        return std::move(std::unique_ptr<Aggregation>(new DropAggregation()));
+        return std::unique_ptr<Aggregation>(new DropAggregation());
     };
   }
 

--- a/sdk/include/opentelemetry/sdk/metrics/observer_result.h
+++ b/sdk/include/opentelemetry/sdk/metrics/observer_result.h
@@ -23,6 +23,8 @@ public:
       : attributes_processor_(attributes_processor)
   {}
 
+  virtual ~ObserverResultT() {}
+
   void Observe(T value) noexcept override { data_.insert({{}, value}); }
 
   void Observe(T value, const opentelemetry::common::KeyValueIterable &attributes) noexcept override

--- a/sdk/include/opentelemetry/sdk/metrics/observer_result.h
+++ b/sdk/include/opentelemetry/sdk/metrics/observer_result.h
@@ -23,7 +23,7 @@ public:
       : attributes_processor_(attributes_processor)
   {}
 
-  virtual ~ObserverResultT() {}
+  virtual ~ObserverResultT() = default;
 
   void Observe(T value) noexcept override { data_.insert({{}, value}); }
 

--- a/sdk/include/opentelemetry/sdk/metrics/state/async_metric_storage.h
+++ b/sdk/include/opentelemetry/sdk/metrics/state/async_metric_storage.h
@@ -27,7 +27,7 @@ class AsyncMetricStorage : public MetricStorage, public AsyncWritableMetricStora
 public:
   AsyncMetricStorage(InstrumentDescriptor instrument_descriptor,
                      const AggregationType aggregation_type,
-                     const AttributesProcessor * attributes_processor,
+                     const AttributesProcessor *attributes_processor,
                      nostd::shared_ptr<AggregationConfig> aggregation_config,
                      void *state = nullptr)
       : instrument_descriptor_(instrument_descriptor),

--- a/sdk/include/opentelemetry/sdk/metrics/state/async_metric_storage.h
+++ b/sdk/include/opentelemetry/sdk/metrics/state/async_metric_storage.h
@@ -27,7 +27,7 @@ class AsyncMetricStorage : public MetricStorage, public AsyncWritableMetricStora
 public:
   AsyncMetricStorage(InstrumentDescriptor instrument_descriptor,
                      const AggregationType aggregation_type,
-                     const AttributesProcessor *attributes_processor,
+                     const AttributesProcessor * attributes_processor,
                      nostd::shared_ptr<AggregationConfig> aggregation_config,
                      void *state = nullptr)
       : instrument_descriptor_(instrument_descriptor),

--- a/sdk/include/opentelemetry/sdk/metrics/state/attributes_hashmap.h
+++ b/sdk/include/opentelemetry/sdk/metrics/state/attributes_hashmap.h
@@ -72,7 +72,7 @@ public:
       return it->second.get();
     }
 
-    hash_map_[attributes] = std::move(aggregation_callback());
+    hash_map_[attributes] = aggregation_callback();
     return hash_map_[attributes].get();
   }
 

--- a/sdk/include/opentelemetry/sdk/metrics/state/metric_collector.h
+++ b/sdk/include/opentelemetry/sdk/metrics/state/metric_collector.h
@@ -33,7 +33,7 @@ class MetricCollector : public MetricProducer, public CollectorHandle
 public:
   MetricCollector(MeterContext *context, std::unique_ptr<MetricReader> metric_reader);
 
-  virtual ~MetricCollector() {}
+  virtual ~MetricCollector() = default;
 
   AggregationTemporality GetAggregationTemporality(
       InstrumentType instrument_type) noexcept override;

--- a/sdk/include/opentelemetry/sdk/metrics/state/metric_collector.h
+++ b/sdk/include/opentelemetry/sdk/metrics/state/metric_collector.h
@@ -33,6 +33,8 @@ class MetricCollector : public MetricProducer, public CollectorHandle
 public:
   MetricCollector(MeterContext *context, std::unique_ptr<MetricReader> metric_reader);
 
+  virtual ~MetricCollector() {}
+
   AggregationTemporality GetAggregationTemporality(
       InstrumentType instrument_type) noexcept override;
 

--- a/sdk/include/opentelemetry/sdk/metrics/state/metric_storage.h
+++ b/sdk/include/opentelemetry/sdk/metrics/state/metric_storage.h
@@ -54,6 +54,9 @@ public:
 class AsyncWritableMetricStorage
 {
 public:
+  AsyncWritableMetricStorage() {}
+  virtual ~AsyncWritableMetricStorage() {}
+
   /* Records a batch of measurements */
   virtual void RecordLong(
       const std::unordered_map<MetricAttributes, long, AttributeHashGenerator> &measurements,
@@ -81,7 +84,7 @@ public:
 class NoopWritableMetricStorage : public SyncWritableMetricStorage
 {
 public:
-  void RecordLong(long value, const opentelemetry::context::Context &context) noexcept = 0;
+  void RecordLong(long value, const opentelemetry::context::Context &context) noexcept override = 0;
 
   void RecordLong(long /* value */,
                   const opentelemetry::common::KeyValueIterable & /* attributes */,

--- a/sdk/include/opentelemetry/sdk/metrics/state/metric_storage.h
+++ b/sdk/include/opentelemetry/sdk/metrics/state/metric_storage.h
@@ -54,8 +54,8 @@ public:
 class AsyncWritableMetricStorage
 {
 public:
-  AsyncWritableMetricStorage() {}
-  virtual ~AsyncWritableMetricStorage() {}
+  AsyncWritableMetricStorage()          = default;
+  virtual ~AsyncWritableMetricStorage() = default;
 
   /* Records a batch of measurements */
   virtual void RecordLong(

--- a/sdk/include/opentelemetry/sdk/metrics/state/sync_metric_storage.h
+++ b/sdk/include/opentelemetry/sdk/metrics/state/sync_metric_storage.h
@@ -41,8 +41,7 @@ public:
 
   {
     create_default_aggregation_ = [&]() -> std::unique_ptr<Aggregation> {
-      return std::move(
-          DefaultAggregation::CreateAggregation(aggregation_type_, instrument_descriptor_));
+      return DefaultAggregation::CreateAggregation(aggregation_type_, instrument_descriptor_);
     };
   }
 

--- a/sdk/include/opentelemetry/sdk/metrics/view/instrument_selector.h
+++ b/sdk/include/opentelemetry/sdk/metrics/view/instrument_selector.h
@@ -16,12 +16,12 @@ class InstrumentSelector
 public:
   InstrumentSelector(opentelemetry::sdk::metrics::InstrumentType instrument_type,
                      opentelemetry::nostd::string_view name)
-      : name_filter_{std::move(PredicateFactory::GetPredicate(name, PredicateType::kPattern))},
+      : name_filter_{PredicateFactory::GetPredicate(name, PredicateType::kPattern)},
         instrument_type_{instrument_type}
   {}
 
   // Returns name filter predicate. This shouldn't be deleted
-  const opentelemetry::sdk::metrics::Predicate *const GetNameFilter() { return name_filter_.get(); }
+  const opentelemetry::sdk::metrics::Predicate *GetNameFilter() const { return name_filter_.get(); }
 
   // Returns instrument filter.
   InstrumentType GetInstrumentType() { return instrument_type_; }

--- a/sdk/include/opentelemetry/sdk/metrics/view/meter_selector.h
+++ b/sdk/include/opentelemetry/sdk/metrics/view/meter_selector.h
@@ -16,22 +16,22 @@ public:
   MeterSelector(opentelemetry::nostd::string_view name,
                 opentelemetry::nostd::string_view version,
                 opentelemetry::nostd::string_view schema)
-      : name_filter_{std::move(PredicateFactory::GetPredicate(name, PredicateType::kExact))},
-        version_filter_{std::move(PredicateFactory::GetPredicate(version, PredicateType::kExact))},
-        schema_filter_{std::move(PredicateFactory::GetPredicate(schema, PredicateType::kExact))}
+      : name_filter_{PredicateFactory::GetPredicate(name, PredicateType::kExact)},
+        version_filter_{PredicateFactory::GetPredicate(version, PredicateType::kExact)},
+        schema_filter_{PredicateFactory::GetPredicate(schema, PredicateType::kExact)}
   {}
 
   // Returns name filter predicate. This shouldn't be deleted
-  const opentelemetry::sdk::metrics::Predicate *const GetNameFilter() { return name_filter_.get(); }
+  const opentelemetry::sdk::metrics::Predicate *GetNameFilter() const { return name_filter_.get(); }
 
   // Returns version filter predicate. This shouldn't be deleted
-  const opentelemetry::sdk::metrics::Predicate *const GetVersionFilter()
+  const opentelemetry::sdk::metrics::Predicate *GetVersionFilter() const
   {
     return version_filter_.get();
   }
 
   // Returns schema filter predicate. This shouldn't be deleted
-  const opentelemetry::sdk::metrics::Predicate *const GetSchemaFilter()
+  const opentelemetry::sdk::metrics::Predicate *GetSchemaFilter() const
   {
     return schema_filter_.get();
   }

--- a/sdk/include/opentelemetry/sdk/metrics/view/predicate_factory.h
+++ b/sdk/include/opentelemetry/sdk/metrics/view/predicate_factory.h
@@ -26,17 +26,17 @@ public:
     if ((type == PredicateType::kPattern && pattern == "*") ||
         (type == PredicateType::kExact && pattern == ""))
     {
-      return std::move(std::unique_ptr<Predicate>(new MatchEverythingPattern()));
+      return std::unique_ptr<Predicate>(new MatchEverythingPattern());
     }
     if (type == PredicateType::kPattern)
     {
-      return std::move(std::unique_ptr<Predicate>(new PatternPredicate(pattern)));
+      return std::unique_ptr<Predicate>(new PatternPredicate(pattern));
     }
     if (type == PredicateType::kExact)
     {
-      return std::move(std::unique_ptr<Predicate>(new ExactPredicate(pattern)));
+      return std::unique_ptr<Predicate>(new ExactPredicate(pattern));
     }
-    return std::move(std::unique_ptr<Predicate>(new MatchNothingPattern()));
+    return std::unique_ptr<Predicate>(new MatchNothingPattern());
   }
 };
 }  // namespace metrics

--- a/sdk/include/opentelemetry/sdk/metrics/view/view.h
+++ b/sdk/include/opentelemetry/sdk/metrics/view/view.h
@@ -37,6 +37,8 @@ public:
         attributes_processor_{std::move(attributes_processor)}
   {}
 
+  virtual ~View() {}
+
   virtual std::string GetName() const noexcept { return name_; }
 
   virtual std::string GetDescription() const noexcept { return description_; }

--- a/sdk/include/opentelemetry/sdk/metrics/view/view.h
+++ b/sdk/include/opentelemetry/sdk/metrics/view/view.h
@@ -37,7 +37,7 @@ public:
         attributes_processor_{std::move(attributes_processor)}
   {}
 
-  virtual ~View() {}
+  virtual ~View() = default;
 
   virtual std::string GetName() const noexcept { return name_; }
 

--- a/sdk/include/opentelemetry/sdk/trace/recordable.h
+++ b/sdk/include/opentelemetry/sdk/trace/recordable.h
@@ -87,6 +87,18 @@ public:
   }
 
   /**
+   * Add an event to a span.
+   * @param name the name of the event
+   * @param attributes the attributes associated with the event
+   */
+  void AddEvent(nostd::string_view name,
+                const opentelemetry::common::KeyValueIterable &attributes) noexcept
+  {
+    AddEvent(name, opentelemetry::common::SystemTimestamp(std::chrono::system_clock::now()),
+             attributes);
+  }
+
+  /**
    * Add a link to a span.
    * @param span_context the span context of the linked span
    * @param attributes the attributes associated with the link

--- a/sdk/src/trace/samplers/trace_id_ratio.cc
+++ b/sdk/src/trace/samplers/trace_id_ratio.cc
@@ -62,7 +62,7 @@ uint64_t CalculateThresholdFromBuffer(const trace_api::TraceId &trace_id) noexce
   uint64_t res = 0;
   std::memcpy(&res, &trace_id, 8);
 
-  double ratio = (double)res / UINT64_MAX;
+  double ratio = (double)res / (double)UINT64_MAX;
 
   return CalculateThreshold(ratio);
 }

--- a/sdk/src/trace/span.cc
+++ b/sdk/src/trace/span.cc
@@ -123,6 +123,17 @@ void Span::AddEvent(nostd::string_view name, SystemTimestamp timestamp) noexcept
 }
 
 void Span::AddEvent(nostd::string_view name,
+                    const common::KeyValueIterable &attributes) noexcept
+{
+  std::lock_guard<std::mutex> lock_guard{mu_};
+  if (recordable_ == nullptr)
+  {
+    return;
+  }
+  recordable_->AddEvent(name, attributes);
+}
+
+void Span::AddEvent(nostd::string_view name,
                     SystemTimestamp timestamp,
                     const common::KeyValueIterable &attributes) noexcept
 {

--- a/sdk/src/trace/span.cc
+++ b/sdk/src/trace/span.cc
@@ -122,8 +122,7 @@ void Span::AddEvent(nostd::string_view name, SystemTimestamp timestamp) noexcept
   recordable_->AddEvent(name, timestamp);
 }
 
-void Span::AddEvent(nostd::string_view name,
-                    const common::KeyValueIterable &attributes) noexcept
+void Span::AddEvent(nostd::string_view name, const common::KeyValueIterable &attributes) noexcept
 {
   std::lock_guard<std::mutex> lock_guard{mu_};
   if (recordable_ == nullptr)

--- a/sdk/src/trace/span.h
+++ b/sdk/src/trace/span.h
@@ -36,6 +36,9 @@ public:
                 opentelemetry::common::SystemTimestamp timestamp) noexcept override;
 
   void AddEvent(nostd::string_view name,
+                const opentelemetry::common::KeyValueIterable &attributes) noexcept override;
+
+  void AddEvent(nostd::string_view name,
                 opentelemetry::common::SystemTimestamp timestamp,
                 const opentelemetry::common::KeyValueIterable &attributes) noexcept override;
 

--- a/sdk/test/logs/batch_log_processor_test.cc
+++ b/sdk/test/logs/batch_log_processor_test.cc
@@ -32,7 +32,7 @@ public:
         export_delay_(export_delay)
   {}
 
-  std::unique_ptr<Recordable> MakeRecordable() noexcept
+  std::unique_ptr<Recordable> MakeRecordable() noexcept override
   {
     return std::unique_ptr<Recordable>(new LogRecord());
   }

--- a/sdk/test/logs/logger_provider_sdk_test.cc
+++ b/sdk/test/logs/logger_provider_sdk_test.cc
@@ -81,14 +81,14 @@ TEST(LoggerProviderSDK, LoggerProviderLoggerArguments)
 
 class DummyProcessor : public LogProcessor
 {
-  std::unique_ptr<Recordable> MakeRecordable() noexcept
+  std::unique_ptr<Recordable> MakeRecordable() noexcept override
   {
     return std::unique_ptr<Recordable>(new LogRecord);
   }
 
-  void OnReceive(std::unique_ptr<Recordable> && /* record */) noexcept {}
-  bool ForceFlush(std::chrono::microseconds /* timeout */) noexcept { return true; }
-  bool Shutdown(std::chrono::microseconds /* timeout */) noexcept { return true; }
+  void OnReceive(std::unique_ptr<Recordable> && /* record */) noexcept override {}
+  bool ForceFlush(std::chrono::microseconds /* timeout */) noexcept override { return true; }
+  bool Shutdown(std::chrono::microseconds /* timeout */) noexcept override { return true; }
 };
 
 TEST(LoggerProviderSDK, GetResource)

--- a/sdk/test/logs/logger_sdk_test.cc
+++ b/sdk/test/logs/logger_sdk_test.cc
@@ -40,13 +40,13 @@ public:
       : record_received_(record_received)
   {}
 
-  std::unique_ptr<Recordable> MakeRecordable() noexcept
+  std::unique_ptr<Recordable> MakeRecordable() noexcept override
   {
     return std::unique_ptr<Recordable>(new LogRecord);
   }
   // OnReceive stores the record it receives into the shared_ptr recordable passed into its
   // constructor
-  void OnReceive(std::unique_ptr<Recordable> &&record) noexcept
+  void OnReceive(std::unique_ptr<Recordable> &&record) noexcept override
   {
     // Cast the recordable received into a concrete LogRecord type
     auto copy = std::shared_ptr<LogRecord>(static_cast<LogRecord *>(record.release()));
@@ -56,8 +56,8 @@ public:
     record_received_->SetSeverity(copy->GetSeverity());
     record_received_->SetBody(copy->GetBody());
   }
-  bool ForceFlush(std::chrono::microseconds /* timeout */) noexcept { return true; }
-  bool Shutdown(std::chrono::microseconds /* timeout */) noexcept { return true; }
+  bool ForceFlush(std::chrono::microseconds /* timeout */) noexcept override { return true; }
+  bool Shutdown(std::chrono::microseconds /* timeout */) noexcept override { return true; }
 };
 
 TEST(LoggerSDK, LogToAProcessor)

--- a/sdk/test/metrics/async_metric_storage_test.cc
+++ b/sdk/test/metrics/async_metric_storage_test.cc
@@ -31,6 +31,8 @@ class MockCollectorHandle : public CollectorHandle
 public:
   MockCollectorHandle(AggregationTemporality temp) : temporality(temp) {}
 
+  virtual ~MockCollectorHandle() {}
+
   AggregationTemporality GetAggregationTemporality(
       InstrumentType /* instrument_type */) noexcept override
   {

--- a/sdk/test/metrics/async_metric_storage_test.cc
+++ b/sdk/test/metrics/async_metric_storage_test.cc
@@ -31,7 +31,7 @@ class MockCollectorHandle : public CollectorHandle
 public:
   MockCollectorHandle(AggregationTemporality temp) : temporality(temp) {}
 
-  virtual ~MockCollectorHandle() {}
+  virtual ~MockCollectorHandle() = default;
 
   AggregationTemporality GetAggregationTemporality(
       InstrumentType /* instrument_type */) noexcept override

--- a/sdk/test/metrics/sync_metric_storage_counter_test.cc
+++ b/sdk/test/metrics/sync_metric_storage_counter_test.cc
@@ -23,6 +23,8 @@ class MockCollectorHandle : public CollectorHandle
 public:
   MockCollectorHandle(AggregationTemporality temp) : temporality(temp) {}
 
+  virtual ~MockCollectorHandle() {}
+
   AggregationTemporality GetAggregationTemporality(
       InstrumentType /* instrument_type */) noexcept override
   {

--- a/sdk/test/metrics/sync_metric_storage_counter_test.cc
+++ b/sdk/test/metrics/sync_metric_storage_counter_test.cc
@@ -23,7 +23,7 @@ class MockCollectorHandle : public CollectorHandle
 public:
   MockCollectorHandle(AggregationTemporality temp) : temporality(temp) {}
 
-  virtual ~MockCollectorHandle() {}
+  virtual ~MockCollectorHandle() = default;
 
   AggregationTemporality GetAggregationTemporality(
       InstrumentType /* instrument_type */) noexcept override

--- a/sdk/test/metrics/sync_metric_storage_histogram_test.cc
+++ b/sdk/test/metrics/sync_metric_storage_histogram_test.cc
@@ -23,6 +23,8 @@ class MockCollectorHandle : public CollectorHandle
 public:
   MockCollectorHandle(AggregationTemporality temp) : temporality(temp) {}
 
+  virtual ~MockCollectorHandle() {}
+
   AggregationTemporality GetAggregationTemporality(
       InstrumentType /* instrument_type */) noexcept override
   {

--- a/sdk/test/metrics/sync_metric_storage_histogram_test.cc
+++ b/sdk/test/metrics/sync_metric_storage_histogram_test.cc
@@ -23,7 +23,7 @@ class MockCollectorHandle : public CollectorHandle
 public:
   MockCollectorHandle(AggregationTemporality temp) : temporality(temp) {}
 
-  virtual ~MockCollectorHandle() {}
+  virtual ~MockCollectorHandle() = default;
 
   AggregationTemporality GetAggregationTemporality(
       InstrumentType /* instrument_type */) noexcept override

--- a/sdk/test/trace/sampler_benchmark.cc
+++ b/sdk/test/trace/sampler_benchmark.cc
@@ -142,14 +142,14 @@ void BenchmarkSpanCreation(std::shared_ptr<Sampler> /* TODO: fix issue #1612 sam
 // Test to measure performance for span creation
 void BM_SpanCreation(benchmark::State &state)
 {
-  BenchmarkSpanCreation(std::move(std::make_shared<AlwaysOnSampler>()), state);
+  BenchmarkSpanCreation(std::make_shared<AlwaysOnSampler>(), state);
 }
 BENCHMARK(BM_SpanCreation);
 
 // Test to measure performance overhead for no-op span creation
 void BM_NoopSpanCreation(benchmark::State &state)
 {
-  BenchmarkSpanCreation(std::move(std::make_shared<AlwaysOffSampler>()), state);
+  BenchmarkSpanCreation(std::make_shared<AlwaysOffSampler>(), state);
 }
 BENCHMARK(BM_NoopSpanCreation);
 


### PR DESCRIPTION
Fixes #1616 

## Changes

Fixed the following warnings reported by gcc:

-Wall
-Werror
-Wextra-semi
-Werror=unused-parameter
-Werror=undef
-Werror=overloaded-virtual
-Werror=ignored-qualifiers

In particular, gcc gets confused by the trace::Span::AddEvent() methods,
and reports an error with -Werror=overloaded-virtual.

Likewise for logs::Logger::Log()

Fixed the following warnings reported by clang:

[-Werror,-Wimplicit-exception-spec-mismatch]

[-Werror,-Winconsistent-missing-override]

[-Werror,-Wpessimizing-move]

[-Werror,-Wimplicit-const-int-float-conversion]

[-Werror,-Wdelete-non-abstract-non-virtual-dtor]


* [ ] `CHANGELOG.md` updated for non-trivial changes
* [ ] Unit tests have been added
* [X] Changes in public API reviewed