### PR TITLE
Change Wednesday meeting time to 9:00 PT

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ along with build files for CMake and Bazel.
 See [CONTRIBUTING.md](CONTRIBUTING.md)
 
 We meet weekly, and the time of the meeting alternates between Monday at 13:00
-PT and Wednesday at 10:00 PT. The meeting is subject to change depending on
+PT and Wednesday at 9:00 PT. The meeting is subject to change depending on
 contributors' availability. Check the [OpenTelemetry community
 calendar](https://calendar.google.com/calendar/embed?src=google.com_b79e3e90j7bbsa2n2p5an5lf60%40group.calendar.google.com)
 for specific dates and Zoom meeting links.


### PR DESCRIPTION
## Changes

As discussed and agreed in the last SIG meeting - https://docs.google.com/document/d/1i1E4-_y4uJ083lCutKGDhkpi3n4_e774SBLi9hPLocw/edit?usp=sharing

PR to change in otel-community repo  - https://github.com/open-telemetry/community/pull/1199. 

Google calendar would be updated today.

For significant contributions please make sure you have completed the following items:

* [ ] `CHANGELOG.md` updated for non-trivial changes
* [ ] Unit tests have been added
* [ ] Changes in public API reviewed