### PR TITLE
[Semantic Conventions] Align on the specification 1.13.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ Increment the:
   [#1606](https://github.com/open-telemetry/opentelemetry-cpp/pull/1606)
 * [METRICS EXPORTER] Add `OtlpGrpcClient` [#1606](https://github.com/open-telemetry/opentelemetry-cpp/pull/1606)
 * [BUILD] Fix header only api singletons [#1604](https://github.com/open-telemetry/opentelemetry-cpp/pull/1604)
+* [SEMANTIC CONVENTIONS] Upgrade to version 1.13.0 [#1624](https://github.com/open-telemetry/opentelemetry-cpp/pull/1624)
 
 ## [1.6.0] 2022-08-15
 

--- a/buildscripts/semantic-convention/generate.sh
+++ b/buildscripts/semantic-convention/generate.sh
@@ -10,10 +10,10 @@ SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 ROOT_DIR="${SCRIPT_DIR}/../../"
 
 # freeze the spec & generator tools versions to make SemanticAttributes generation reproducible
-SEMCONV_VERSION=1.12.0
+SEMCONV_VERSION=1.13.0
 SPEC_VERSION=v$SEMCONV_VERSION
 SCHEMA_URL=https://opentelemetry.io/schemas/$SEMCONV_VERSION
-GENERATOR_VERSION=0.7.0
+GENERATOR_VERSION=0.14.0
 
 cd ${SCRIPT_DIR}
 

--- a/examples/grpc/client.cc
+++ b/examples/grpc/client.cc
@@ -50,7 +50,7 @@ public:
         {{SemanticConventions::RPC_SYSTEM, "grpc"},
          {SemanticConventions::RPC_SERVICE, "grpc-example.GreetService"},
          {SemanticConventions::RPC_METHOD, "Greet"},
-         {SemanticConventions::NET_PEER_IP, ip},
+         {SemanticConventions::NET_SOCK_PEER_ADDR, ip},
          {SemanticConventions::NET_PEER_PORT, port}},
         options);
 

--- a/examples/http/server.cc
+++ b/examples/http/server.cc
@@ -39,7 +39,7 @@ public:
     // start span with parent context extracted from http header
     auto span = get_tracer("http-server")
                     ->StartSpan(span_name,
-                                {{SemanticConventions::HTTP_SERVER_NAME, server_name},
+                                {{SemanticConventions::NET_HOST_NAME, server_name},
                                  {SemanticConventions::NET_HOST_PORT, server_port},
                                  {SemanticConventions::HTTP_METHOD, request.method},
                                  {SemanticConventions::HTTP_SCHEME, "http"},

--- a/sdk/include/opentelemetry/sdk/resource/semantic_conventions.h
+++ b/sdk/include/opentelemetry/sdk/resource/semantic_conventions.h
@@ -23,7 +23,7 @@ namespace SemanticConventions
 /**
  * The URL of the OpenTelemetry schema for these keys and values.
  */
-static constexpr const char *SCHEMA_URL = "https://opentelemetry.io/schemas/1.12.0";
+static constexpr const char *SCHEMA_URL = "https://opentelemetry.io/schemas/1.13.0";
 
 /**
  * Array of brand name and version separated by a space
@@ -507,6 +507,11 @@ static constexpr const char *OS_VERSION = "os.version";
  * Process identifier (PID).
  */
 static constexpr const char *PROCESS_PID = "process.pid";
+
+/**
+ * Parent Process identifier (PID).
+ */
+static constexpr const char *PROCESS_PARENT_PID = "process.parent_pid";
 
 /**
  * The name of the process executable. On Linux based systems, can be set to the {@code Name} in


### PR DESCRIPTION
Fixes #1624 

## Changes

Upgrade semantic conventions to opentelemetry-specification v1.13.0

BREAKING: rename `net.peer.ip` to `net.sock.peer.addr`, `net.host.ip` to `net.sock.host.addr`,
`net.peer.name` to `net.sock.peer.name` for socket-level instrumentation.

See the opentelemetry-specification v.1.13.0 release notes,
section Semantic Conventions, for full details.


* [X] `CHANGELOG.md` updated for non-trivial changes
* [ ] Unit tests have been added
* [ ] Changes in public API reviewed