### PR TITLE
bump vcpk to 2022.08.15

### DIFF
--- a/third_party_release
+++ b/third_party_release
@@ -20,4 +20,4 @@ ms-gsl=v3.1.0-67-g6f45293
 nlohmann-json=v3.10.5
 opentelemetry-proto=v0.19.0
 prometheus-cpp=v1.0.0
-vcpkg=2022.04.12
+vcpkg=2022.08.15


### PR DESCRIPTION
Fixes # (issue)

## Changes

| library                  | version                                  |
|--------------------------|------------------------------------------|
| google-benchmark         | v1.5.0                                   |
| google-googletest        | release-1.12.1                           |
| nlohmann-json            | v3.11.2                                  |
| protocolbuffers-protobuf | 31ebe2ac71400344a5db91ffc13c4ddfb7589f92 |

For significant contributions please make sure you have completed the following items:

* [ ] `CHANGELOG.md` updated for non-trivial changes
* [ ] Unit tests have been added
* [ ] Changes in public API reviewed