### PR TITLE
Add Marc Alff in cpp-approvers

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,9 +121,9 @@ For edit access, get in touch on
 ([@open-telemetry/cpp-approvers](https://github.com/orgs/open-telemetry/teams/cpp-approvers)):
 
 * [Josh Suereth](https://github.com/jsuereth), Google
+* [Marc Alff](https://github.com/marcalff), Oracle
 * [Reiley Yang](https://github.com/reyang), Microsoft
 * [WenTao Ou](https://github.com/owent), Tencent
-* [Marc Alff](https://github.com/marcalff), Oracle
 
 [Emeritus
 Maintainer/Approver/Triager](https://github.com/open-telemetry/community/blob/main/community-membership.md#emeritus-maintainerapprovertriager):

--- a/README.md
+++ b/README.md
@@ -123,6 +123,7 @@ For edit access, get in touch on
 * [Josh Suereth](https://github.com/jsuereth), Google
 * [Reiley Yang](https://github.com/reyang), Microsoft
 * [WenTao Ou](https://github.com/owent), Tencent
+* [Marc Alff](https://github.com/marcalff), Oracle
 
 [Emeritus
 Maintainer/Approver/Triager](https://github.com/open-telemetry/community/blob/main/community-membership.md#emeritus-maintainerapprovertriager):


### PR DESCRIPTION
Add Marc Alff in cpp-approvers

Per discussion in C++ SIG Meeting, 2022-09-26.
