### PR TITLE
Fix typo in package name in documentation.

### DIFF
--- a/docs/dependencies.md
+++ b/docs/dependencies.md
@@ -31,7 +31,7 @@ Both these dependencies are listed here:
       License`
   - Uses Abseil C++ Library for `absl::variant` as default `nostd::variant` if
     `WITH_ABSEIL` cmake option or
-    `--@io_opentelemetry_cpp/api:with_abseil=true` (aka
+    `--@io_opentelemetry_cpp//api:with_abseil=true` (aka
     `--//api:with_abseil=true`) bazel option is enabled. License: `Apache
     License 2.0`
 


### PR DESCRIPTION
This is a minor fix of a typo in the dependencies documentation.`@io_opentelemetry_cpp/api:with_abseil` is not a valid Bazel target name, I believe that it should instead be @io_opentelemetry_cpp//api:with_abseil.