### PR TITLE
[ETW Exporter]  - Associate trace_id with the transaction, NOT the Tracer.

### DIFF
--- a/docs/dependencies.md
+++ b/docs/dependencies.md
@@ -31,7 +31,7 @@ Both these dependencies are listed here:
       License`
   - Uses Abseil C++ Library for `absl::variant` as default `nostd::variant` if
     `WITH_ABSEIL` cmake option or
-    `--@io_opentelemetry_cpp/api:with_abseil=true` (aka
+    `--@io_opentelemetry_cpp//api:with_abseil=true` (aka
     `--//api:with_abseil=true`) bazel option is enabled. License: `Apache
     License 2.0`
 

--- a/exporters/etw/include/opentelemetry/exporters/etw/etw_tracer.h
+++ b/exporters/etw/include/opentelemetry/exporters/etw/etw_tracer.h
@@ -182,8 +182,6 @@ class Tracer : public opentelemetry::trace::Tracer,
    */
   ETWProvider::Handle &provHandle;
 
-  opentelemetry::trace::TraceId traceId_;
-
   std::atomic<bool> isClosed_{true};
 
   /**
@@ -328,8 +326,6 @@ class Tracer : public opentelemetry::trace::Tracer,
     }
   }
 
-  const opentelemetry::trace::TraceId &trace_id() { return traceId_; }
-
   friend class Span;
 
   /**
@@ -357,9 +353,7 @@ public:
         provId(providerId.data(), providerId.size()),
         encoding(encoding),
         provHandle(initProvHandle())
-  {
-    traceId_ = GetIdGenerator(tracerProvider_).GenerateTraceId();
-  }
+  {}
 
   /**
    * @brief Start Span
@@ -416,7 +410,8 @@ public:
         parentContext = spanContext;
       }
     }
-    auto traceId = parentContext.IsValid() ? parentContext.trace_id() : traceId_;
+    auto traceId = parentContext.IsValid() ? parentContext.trace_id()
+                                           : GetIdGenerator(tracerProvider_).GenerateTraceId();
 
     // Sampling based on attributes is not supported for now, so passing empty below.
     std::map<std::string, int> emptyAttributes = {{}};

--- a/exporters/etw/test/etw_tracer_test.cc
+++ b/exporters/etw/test/etw_tracer_test.cc
@@ -506,7 +506,7 @@ TEST(ETWTracer, CustomSampler)
       EXPECT_EQ(child_span->GetContext().trace_id(), span->GetContext().trace_id());
     }
     auto another_span = tracer->StartSpan("span_test");
-    EXPECT_NE(span->GetContext().tracer_id(), another_span->GetContext().trace_id());
+    EXPECT_NE(span->GetContext().trace_id(), another_span->GetContext().trace_id());
 
   }
 }

--- a/exporters/etw/test/etw_tracer_test.cc
+++ b/exporters/etw/test/etw_tracer_test.cc
@@ -497,14 +497,17 @@ TEST(ETWTracer, CustomSampler)
     auto span = tracer->StartSpan("span_off");
     EXPECT_EQ(span->GetContext().IsValid(), true);
     EXPECT_EQ(span->GetContext().IsSampled(), true);
-    auto scope = tracer->WithActiveSpan(span);
-    auto trace_id = span->GetContext().trace_id();
     {
+      auto scope = tracer->WithActiveSpan(span);
+      auto trace_id = span->GetContext().trace_id();
       auto child_span = tracer->StartSpan("span on");
       EXPECT_EQ(child_span->GetContext().IsValid(), true);
       EXPECT_EQ(child_span->GetContext().IsSampled(), true);
-      EXPECT_EQ(child_span->GetContext().trace_id(), trace_id);
+      EXPECT_EQ(child_span->GetContext().trace_id(), span->GetContext().trace_id());
     }
+    auto another_span = tracer->StartSpan("span_test");
+    EXPECT_NE(span->GetContext().tracer_id(), another_span->GetContext().trace_id());
+
   }
 }
 


### PR DESCRIPTION
Fixes # (issue)

## Changes

As of now, In ETW exporter, trace_id is bound to a `Tracer`. And all the spans created through that tracer get the same trace_id, even if they belong to a different transaction. This is incorrect, as trace_id should be associated with the transaction and not the Tracer.

Fixed the issue by 
 - removing traceid_ member variable from Tracer class, 
 - and generate trace_id for a span if the parent context is invalid.

TraceIdRatioBasedSampling is not working correctly because of this issue.

For significant contributions please make sure you have completed the following items:

* [ ] `CHANGELOG.md` updated for non-trivial changes
* [x] Unit tests have been added
* [ ] Changes in public API reviewed