### PR TITLE
Rename `OnReceive` to `OnEmit`

### DIFF
--- a/sdk/include/opentelemetry/sdk/logs/batch_log_processor.h
+++ b/sdk/include/opentelemetry/sdk/logs/batch_log_processor.h
@@ -64,7 +64,7 @@ public:
    * @param record the log record
    */
 
-  void OnReceive(std::unique_ptr<Recordable> &&record) noexcept override;
+  void OnEmit(std::unique_ptr<Recordable> &&record) noexcept override;
 
   /**
    * Export all log records that have not been exported yet.

--- a/sdk/include/opentelemetry/sdk/logs/multi_log_processor.h
+++ b/sdk/include/opentelemetry/sdk/logs/multi_log_processor.h
@@ -36,10 +36,10 @@ public:
   std::unique_ptr<Recordable> MakeRecordable() noexcept override;
 
   /**
-   * OnReceive is called by the SDK once a log record has been successfully created.
+   * OnEmit is called by the SDK once a log record has been successfully created.
    * @param record the log record
    */
-  void OnReceive(std::unique_ptr<Recordable> &&record) noexcept override;
+  void OnEmit(std::unique_ptr<Recordable> &&record) noexcept override;
 
   /**
    * Exports all log records that have not yet been exported to the configured Exporter.

--- a/sdk/include/opentelemetry/sdk/logs/processor.h
+++ b/sdk/include/opentelemetry/sdk/logs/processor.h
@@ -32,10 +32,10 @@ public:
   virtual std::unique_ptr<Recordable> MakeRecordable() noexcept = 0;
 
   /**
-   * OnReceive is called by the SDK once a log record has been successfully created.
+   * OnEmit is called by the SDK once a log record has been successfully created.
    * @param record the log record
    */
-  virtual void OnReceive(std::unique_ptr<Recordable> &&record) noexcept = 0;
+  virtual void OnEmit(std::unique_ptr<Recordable> &&record) noexcept = 0;
 
   /**
    * Exports all log records that have not yet been exported to the configured Exporter.

--- a/sdk/include/opentelemetry/sdk/logs/simple_log_processor.h
+++ b/sdk/include/opentelemetry/sdk/logs/simple_log_processor.h
@@ -33,7 +33,7 @@ public:
 
   std::unique_ptr<Recordable> MakeRecordable() noexcept override;
 
-  void OnReceive(std::unique_ptr<Recordable> &&record) noexcept override;
+  void OnEmit(std::unique_ptr<Recordable> &&record) noexcept override;
 
   bool ForceFlush(
       std::chrono::microseconds timeout = std::chrono::microseconds::max()) noexcept override;

--- a/sdk/src/logs/batch_log_processor.cc
+++ b/sdk/src/logs/batch_log_processor.cc
@@ -53,7 +53,7 @@ std::unique_ptr<Recordable> BatchLogProcessor::MakeRecordable() noexcept
   return exporter_->MakeRecordable();
 }
 
-void BatchLogProcessor::OnReceive(std::unique_ptr<Recordable> &&record) noexcept
+void BatchLogProcessor::OnEmit(std::unique_ptr<Recordable> &&record) noexcept
 {
   if (synchronization_data_->is_shutdown.load() == true)
   {

--- a/sdk/src/logs/logger.cc
+++ b/sdk/src/logs/logger.cc
@@ -111,7 +111,7 @@ void Logger::Log(opentelemetry::logs::Severity severity,
   }
 
   // Send the log record to the processor
-  processor.OnReceive(std::move(recordable));
+  processor.OnEmit(std::move(recordable));
 }
 
 const opentelemetry::sdk::instrumentationscope::InstrumentationScope &

--- a/sdk/src/logs/multi_log_processor.cc
+++ b/sdk/src/logs/multi_log_processor.cc
@@ -48,7 +48,7 @@ std::unique_ptr<Recordable> MultiLogProcessor::MakeRecordable() noexcept
   return recordable;
 }
 
-void MultiLogProcessor::OnReceive(std::unique_ptr<Recordable> &&record) noexcept
+void MultiLogProcessor::OnEmit(std::unique_ptr<Recordable> &&record) noexcept
 {
   if (!record)
   {
@@ -61,7 +61,7 @@ void MultiLogProcessor::OnReceive(std::unique_ptr<Recordable> &&record) noexcept
     auto recordable = multi_recordable->ReleaseRecordable(*processor);
     if (recordable)
     {
-      processor->OnReceive(std::move(recordable));
+      processor->OnEmit(std::move(recordable));
     }
   }
 }

--- a/sdk/src/logs/simple_log_processor.cc
+++ b/sdk/src/logs/simple_log_processor.cc
@@ -29,7 +29,7 @@ std::unique_ptr<Recordable> SimpleLogProcessor::MakeRecordable() noexcept
  * Batches the log record it receives in a batch of 1 and immediately sends it
  * to the configured exporter
  */
-void SimpleLogProcessor::OnReceive(std::unique_ptr<Recordable> &&record) noexcept
+void SimpleLogProcessor::OnEmit(std::unique_ptr<Recordable> &&record) noexcept
 {
   nostd::span<std::unique_ptr<Recordable>> batch(&record, 1);
   // Get lock to ensure Export() is never called concurrently

--- a/sdk/test/logs/batch_log_processor_test.cc
+++ b/sdk/test/logs/batch_log_processor_test.cc
@@ -111,7 +111,7 @@ TEST_F(BatchLogProcessorTest, TestShutdown)
   {
     auto log = batch_processor->MakeRecordable();
     log->SetBody("Log" + std::to_string(i));
-    batch_processor->OnReceive(std::move(log));
+    batch_processor->OnEmit(std::move(log));
   }
 
   // Test that shutting down the processor will first wait for the
@@ -146,7 +146,7 @@ TEST_F(BatchLogProcessorTest, TestForceFlush)
   {
     auto log = batch_processor->MakeRecordable();
     log->SetBody("Log" + std::to_string(i));
-    batch_processor->OnReceive(std::move(log));
+    batch_processor->OnEmit(std::move(log));
   }
 
   EXPECT_TRUE(batch_processor->ForceFlush());
@@ -162,7 +162,7 @@ TEST_F(BatchLogProcessorTest, TestForceFlush)
   {
     auto log = batch_processor->MakeRecordable();
     log->SetBody("Log" + std::to_string(i));
-    batch_processor->OnReceive(std::move(log));
+    batch_processor->OnEmit(std::move(log));
   }
 
   EXPECT_TRUE(batch_processor->ForceFlush());
@@ -191,7 +191,7 @@ TEST_F(BatchLogProcessorTest, TestManyLogsLoss)
   {
     auto log = batch_processor->MakeRecordable();
     log->SetBody("Log" + std::to_string(i));
-    batch_processor->OnReceive(std::move(log));
+    batch_processor->OnEmit(std::move(log));
   }
 
   EXPECT_TRUE(batch_processor->ForceFlush());
@@ -215,7 +215,7 @@ TEST_F(BatchLogProcessorTest, TestManyLogsLossLess)
   {
     auto log = batch_processor->MakeRecordable();
     log->SetBody("Log" + std::to_string(i));
-    batch_processor->OnReceive(std::move(log));
+    batch_processor->OnEmit(std::move(log));
   }
 
   EXPECT_TRUE(batch_processor->ForceFlush());
@@ -248,7 +248,7 @@ TEST_F(BatchLogProcessorTest, TestScheduledDelayMillis)
   {
     auto log = batch_processor->MakeRecordable();
     log->SetBody("Log" + std::to_string(i));
-    batch_processor->OnReceive(std::move(log));
+    batch_processor->OnEmit(std::move(log));
   }
   // Sleep for scheduled_delay_millis milliseconds
   std::this_thread::sleep_for(scheduled_delay_millis);

--- a/sdk/test/logs/logger_provider_sdk_test.cc
+++ b/sdk/test/logs/logger_provider_sdk_test.cc
@@ -86,7 +86,7 @@ class DummyProcessor : public LogProcessor
     return std::unique_ptr<Recordable>(new LogRecord);
   }
 
-  void OnReceive(std::unique_ptr<Recordable> && /* record */) noexcept override {}
+  void OnEmit(std::unique_ptr<Recordable> && /* record */) noexcept override {}
   bool ForceFlush(std::chrono::microseconds /* timeout */) noexcept override { return true; }
   bool Shutdown(std::chrono::microseconds /* timeout */) noexcept override { return true; }
 };

--- a/sdk/test/logs/logger_sdk_test.cc
+++ b/sdk/test/logs/logger_sdk_test.cc
@@ -15,7 +15,7 @@ TEST(LoggerSDK, LogToNullProcessor)
 {
   // Confirm Logger::Log() does not have undefined behavior
   // even when there is no processor set
-  // since it calls Processor::OnReceive()
+  // since it calls Processor::OnEmit()
 
   auto lp = std::shared_ptr<logs_api::LoggerProvider>(new LoggerProvider());
   const std::string schema_url{"https://opentelemetry.io/schemas/1.11.0"};
@@ -44,9 +44,10 @@ public:
   {
     return std::unique_ptr<Recordable>(new LogRecord);
   }
-  // OnReceive stores the record it receives into the shared_ptr recordable passed into its
+
+  // OnEmit stores the record it receives into the shared_ptr recordable passed into its
   // constructor
-  void OnReceive(std::unique_ptr<Recordable> &&record) noexcept override
+  void OnEmit(std::unique_ptr<Recordable> &&record) noexcept override
   {
     // Cast the recordable received into a concrete LogRecord type
     auto copy = std::shared_ptr<LogRecord>(static_cast<LogRecord *>(record.release()));

--- a/sdk/test/logs/simple_log_processor_test.cc
+++ b/sdk/test/logs/simple_log_processor_test.cc
@@ -86,7 +86,7 @@ TEST(SimpleLogProcessorTest, SendReceivedLogsToExporter)
   {
     auto recordable = processor.MakeRecordable();
     recordable->SetBody("Log Body");
-    processor.OnReceive(std::move(recordable));
+    processor.OnEmit(std::move(recordable));
 
     // Verify that the batch of 1 log record sent by processor matches what exporter received
     EXPECT_EQ(1, batch_size_received);


### PR DESCRIPTION
Signed-off-by: owent <admin@owent.net>

Fixes #1291 

There are a lot changes of logs specification since #1291 . I think we can change `OnReceive` to `OnEmit` and close #1291 first. And we may need more discussion about the changes of logs API and SDK before the rest changes. #1653 

## Changes

+ Rename `OnReceive` to `OnEmit`

For significant contributions please make sure you have completed the following items:

* [x] `CHANGELOG.md` updated for non-trivial changes
* [x] Unit tests have been added
* [x] Changes in public API reviewed