### PR TITLE
fix data race on MeterContext::meters_

### DIFF
--- a/sdk/include/opentelemetry/sdk/metrics/meter_context.h
+++ b/sdk/include/opentelemetry/sdk/metrics/meter_context.h
@@ -125,6 +125,7 @@ private:
 
   std::atomic_flag shutdown_latch_ = ATOMIC_FLAG_INIT;
   opentelemetry::common::SpinLockMutex forceflush_lock_;
+  opentelemetry::common::SpinLockMutex storage_lock_;
 };
 
 }  // namespace metrics

--- a/sdk/src/metrics/meter_context.cc
+++ b/sdk/src/metrics/meter_context.cc
@@ -31,6 +31,7 @@ ViewRegistry *MeterContext::GetViewRegistry() const noexcept
 
 nostd::span<std::shared_ptr<Meter>> MeterContext::GetMeters() noexcept
 {
+  std::lock_guard<opentelemetry::common::SpinLockMutex> guard(storage_lock_);
   return nostd::span<std::shared_ptr<Meter>>{meters_};
 }
 
@@ -59,6 +60,7 @@ void MeterContext::AddView(std::unique_ptr<InstrumentSelector> instrument_select
 
 void MeterContext::AddMeter(std::shared_ptr<Meter> meter)
 {
+  std::lock_guard<opentelemetry::common::SpinLockMutex> guard(storage_lock_);
   meters_.push_back(meter);
 }
 


### PR DESCRIPTION
Fixes #1667 (issue)

## Changes

adds a lock for reads and writes of `MeterContext::meters_`.

For significant contributions please make sure you have completed the following items:

* [ ] `CHANGELOG.md` updated for non-trivial changes
* [ ] Unit tests have been added
* [ ] Changes in public API reviewed