### PR TITLE
fix Histogram crash

### DIFF
--- a/examples/metrics_simple/metrics_ostream.cc
+++ b/examples/metrics_simple/metrics_ostream.cc
@@ -75,9 +75,8 @@ void initMetrics(const std::string &name)
   std::shared_ptr<opentelemetry::sdk::metrics::AggregationConfig> aggregation_config{
       new opentelemetry::sdk::metrics::HistogramAggregationConfig};
   static_cast<opentelemetry::sdk::metrics::HistogramAggregationConfig *>(aggregation_config.get())
-      ->boundaries_ =
-      std::list<double>{0.0,    50.0,   100.0,  250.0,   500.0,  750.0,
-                        1000.0, 2500.0, 5000.0, 10000.0, 20000.0};
+      ->boundaries_ = std::list<double>{0.0,    50.0,   100.0,  250.0,   500.0,  750.0,
+                                        1000.0, 2500.0, 5000.0, 10000.0, 20000.0};
   std::unique_ptr<metric_sdk::View> histogram_view{new metric_sdk::View{
       name, "description", metric_sdk::AggregationType::kHistogram, aggregation_config}};
   p->AddView(std::move(histogram_instrument_selector), std::move(histogram_meter_selector),

--- a/examples/metrics_simple/metrics_ostream.cc
+++ b/examples/metrics_simple/metrics_ostream.cc
@@ -73,11 +73,11 @@ void initMetrics(const std::string &name)
   std::unique_ptr<metric_sdk::MeterSelector> histogram_meter_selector{
       new metric_sdk::MeterSelector(name, version, schema)};
   std::shared_ptr<opentelemetry::sdk::metrics::AggregationConfig> aggregation_config{
-      new opentelemetry::sdk::metrics::HistogramAggregationConfig<double>};
-  static_cast<opentelemetry::sdk::metrics::HistogramAggregationConfig<double> *>(
-      aggregation_config.get())
+      new opentelemetry::sdk::metrics::HistogramAggregationConfig};
+  static_cast<opentelemetry::sdk::metrics::HistogramAggregationConfig *>(aggregation_config.get())
       ->boundaries_ =
-      std::list<double>{0.0, 50.0, 100.0, 250.0, 500.0, 750.0, 1000.0, 2500.0, 5000.0, 10000.0};
+      std::list<double>{0.0,    50.0,   100.0,  250.0,   500.0,  750.0,
+                        1000.0, 2500.0, 5000.0, 10000.0, 20000.0};
   std::unique_ptr<metric_sdk::View> histogram_view{new metric_sdk::View{
       name, "description", metric_sdk::AggregationType::kHistogram, aggregation_config}};
   p->AddView(std::move(histogram_instrument_selector), std::move(histogram_meter_selector),

--- a/sdk/include/opentelemetry/sdk/metrics/aggregation/aggregation_config.h
+++ b/sdk/include/opentelemetry/sdk/metrics/aggregation/aggregation_config.h
@@ -16,7 +16,6 @@ public:
   virtual ~AggregationConfig() = default;
 };
 
-template <typename T>
 class HistogramAggregationConfig : public AggregationConfig
 {
 public:

--- a/sdk/include/opentelemetry/sdk/metrics/aggregation/default_aggregation.h
+++ b/sdk/include/opentelemetry/sdk/metrics/aggregation/default_aggregation.h
@@ -27,7 +27,7 @@ class DefaultAggregation
 public:
   static std::unique_ptr<Aggregation> CreateAggregation(
       const opentelemetry::sdk::metrics::InstrumentDescriptor &instrument_descriptor,
-      const std::shared_ptr<AggregationConfig> aggregation_config)
+      const AggregationConfig *aggregation_config)
   {
     switch (instrument_descriptor.type_)
     {
@@ -64,7 +64,7 @@ public:
   static std::unique_ptr<Aggregation> CreateAggregation(
       AggregationType aggregation_type,
       InstrumentDescriptor instrument_descriptor,
-      std::shared_ptr<AggregationConfig> aggregation_config = nullptr)
+      const AggregationConfig *aggregation_config = nullptr)
   {
     switch (aggregation_type)
     {

--- a/sdk/include/opentelemetry/sdk/metrics/aggregation/default_aggregation.h
+++ b/sdk/include/opentelemetry/sdk/metrics/aggregation/default_aggregation.h
@@ -42,13 +42,11 @@ public:
       case InstrumentType::kHistogram: {
         if (instrument_descriptor.value_type_ == InstrumentValueType::kLong)
         {
-          return (std::move(
-              std::unique_ptr<Aggregation>(new LongHistogramAggregation(aggregation_config))));
+          return (std::unique_ptr<Aggregation>(new LongHistogramAggregation(aggregation_config)));
         }
         else
         {
-          return (std::move(
-              std::unique_ptr<Aggregation>(new DoubleHistogramAggregation(aggregation_config))));
+          return (std::unique_ptr<Aggregation>(new DoubleHistogramAggregation(aggregation_config)));
         }
 
         break;

--- a/sdk/include/opentelemetry/sdk/metrics/aggregation/default_aggregation.h
+++ b/sdk/include/opentelemetry/sdk/metrics/aggregation/default_aggregation.h
@@ -27,7 +27,7 @@ class DefaultAggregation
 public:
   static std::unique_ptr<Aggregation> CreateAggregation(
       const opentelemetry::sdk::metrics::InstrumentDescriptor &instrument_descriptor,
-      const opentelemetry::sdk::metrics::AggregationConfig *aggregation_config)
+      const std::shared_ptr<AggregationConfig> aggregation_config)
   {
     switch (instrument_descriptor.type_)
     {
@@ -40,14 +40,17 @@ public:
                    : std::move(std::unique_ptr<Aggregation>(new DoubleSumAggregation()));
         break;
       case InstrumentType::kHistogram: {
-        return (instrument_descriptor.value_type_ == InstrumentValueType::kLong)
-                   ? std::move(std::unique_ptr<Aggregation>(new LongHistogramAggregation(
-                         static_cast<
-                             const opentelemetry::sdk::metrics::HistogramAggregationConfig<long> *>(
-                             aggregation_config))))
-                   : std::move(std::unique_ptr<Aggregation>(new DoubleHistogramAggregation(
-                         static_cast<const opentelemetry::sdk::metrics::HistogramAggregationConfig<
-                             double> *>(aggregation_config))));
+        if (instrument_descriptor.value_type_ == InstrumentValueType::kLong)
+        {
+          return (std::move(
+              std::unique_ptr<Aggregation>(new LongHistogramAggregation(aggregation_config))));
+        }
+        else
+        {
+          return (std::move(
+              std::unique_ptr<Aggregation>(new DoubleHistogramAggregation(aggregation_config))));
+        }
+
         break;
       }
       case InstrumentType::kObservableGauge:
@@ -60,8 +63,10 @@ public:
     };
   }
 
-  static std::unique_ptr<Aggregation> CreateAggregation(AggregationType aggregation_type,
-                                                        InstrumentDescriptor instrument_descriptor)
+  static std::unique_ptr<Aggregation> CreateAggregation(
+      AggregationType aggregation_type,
+      InstrumentDescriptor instrument_descriptor,
+      std::shared_ptr<AggregationConfig> aggregation_config = nullptr)
   {
     switch (aggregation_type)
     {
@@ -71,11 +76,11 @@ public:
       case AggregationType::kHistogram:
         if (instrument_descriptor.value_type_ == InstrumentValueType::kLong)
         {
-          return std::unique_ptr<Aggregation>(new LongHistogramAggregation());
+          return std::unique_ptr<Aggregation>(new LongHistogramAggregation(aggregation_config));
         }
         else
         {
-          return std::unique_ptr<Aggregation>(new DoubleHistogramAggregation());
+          return std::unique_ptr<Aggregation>(new DoubleHistogramAggregation(aggregation_config));
         }
         break;
       case AggregationType::kLastValue:
@@ -99,7 +104,7 @@ public:
         }
         break;
       default:
-        return DefaultAggregation::CreateAggregation(instrument_descriptor, nullptr);
+        return DefaultAggregation::CreateAggregation(instrument_descriptor, aggregation_config);
     }
   }
 

--- a/sdk/include/opentelemetry/sdk/metrics/aggregation/histogram_aggregation.h
+++ b/sdk/include/opentelemetry/sdk/metrics/aggregation/histogram_aggregation.h
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #pragma once
+#include <memory>
 #ifndef ENABLE_METRICS_PREVIEW
 #  include "opentelemetry/common/spin_lock_mutex.h"
 #  include "opentelemetry/sdk/metrics/aggregation/aggregation.h"
@@ -18,7 +19,7 @@ namespace metrics
 class LongHistogramAggregation : public Aggregation
 {
 public:
-  LongHistogramAggregation(const HistogramAggregationConfig<long> *aggregation_config = nullptr);
+  LongHistogramAggregation(std::shared_ptr<AggregationConfig> aggregation_config = nullptr);
   LongHistogramAggregation(HistogramPointData &&);
   LongHistogramAggregation(const HistogramPointData &);
 
@@ -48,8 +49,7 @@ private:
 class DoubleHistogramAggregation : public Aggregation
 {
 public:
-  DoubleHistogramAggregation(
-      const HistogramAggregationConfig<double> *aggregation_config = nullptr);
+  DoubleHistogramAggregation(std::shared_ptr<AggregationConfig> aggregation_config = nullptr);
   DoubleHistogramAggregation(HistogramPointData &&);
   DoubleHistogramAggregation(const HistogramPointData &);
 

--- a/sdk/include/opentelemetry/sdk/metrics/aggregation/histogram_aggregation.h
+++ b/sdk/include/opentelemetry/sdk/metrics/aggregation/histogram_aggregation.h
@@ -19,7 +19,7 @@ namespace metrics
 class LongHistogramAggregation : public Aggregation
 {
 public:
-  LongHistogramAggregation(std::shared_ptr<AggregationConfig> aggregation_config = nullptr);
+  LongHistogramAggregation(const AggregationConfig *aggregation_config = nullptr);
   LongHistogramAggregation(HistogramPointData &&);
   LongHistogramAggregation(const HistogramPointData &);
 
@@ -49,7 +49,7 @@ private:
 class DoubleHistogramAggregation : public Aggregation
 {
 public:
-  DoubleHistogramAggregation(std::shared_ptr<AggregationConfig> aggregation_config = nullptr);
+  DoubleHistogramAggregation(const AggregationConfig *aggregation_config = nullptr);
   DoubleHistogramAggregation(HistogramPointData &&);
   DoubleHistogramAggregation(const HistogramPointData &);
 

--- a/sdk/include/opentelemetry/sdk/metrics/state/async_metric_storage.h
+++ b/sdk/include/opentelemetry/sdk/metrics/state/async_metric_storage.h
@@ -28,7 +28,7 @@ public:
   AsyncMetricStorage(InstrumentDescriptor instrument_descriptor,
                      const AggregationType aggregation_type,
                      const AttributesProcessor *attributes_processor,
-                     nostd::shared_ptr<AggregationConfig> aggregation_config,
+                     std::shared_ptr<AggregationConfig> aggregation_config,
                      void *state = nullptr)
       : instrument_descriptor_(instrument_descriptor),
         aggregation_type_{aggregation_type},
@@ -49,7 +49,8 @@ public:
     std::lock_guard<opentelemetry::common::SpinLockMutex> guard(hashmap_lock_);
     for (auto &measurement : measurements)
     {
-      auto aggr = DefaultAggregation::CreateAggregation(aggregation_type_, instrument_descriptor_);
+      auto aggr = DefaultAggregation::CreateAggregation(
+          aggregation_type_, instrument_descriptor_);
       aggr->Aggregate(measurement.second);
       auto prev = cumulative_hash_map_->Get(measurement.first);
       if (prev)

--- a/sdk/include/opentelemetry/sdk/metrics/state/async_metric_storage.h
+++ b/sdk/include/opentelemetry/sdk/metrics/state/async_metric_storage.h
@@ -49,8 +49,7 @@ public:
     std::lock_guard<opentelemetry::common::SpinLockMutex> guard(hashmap_lock_);
     for (auto &measurement : measurements)
     {
-      auto aggr = DefaultAggregation::CreateAggregation(
-          aggregation_type_, instrument_descriptor_);
+      auto aggr = DefaultAggregation::CreateAggregation(aggregation_type_, instrument_descriptor_);
       aggr->Aggregate(measurement.second);
       auto prev = cumulative_hash_map_->Get(measurement.first);
       if (prev)

--- a/sdk/include/opentelemetry/sdk/metrics/state/async_metric_storage.h
+++ b/sdk/include/opentelemetry/sdk/metrics/state/async_metric_storage.h
@@ -28,7 +28,7 @@ public:
   AsyncMetricStorage(InstrumentDescriptor instrument_descriptor,
                      const AggregationType aggregation_type,
                      const AttributesProcessor *attributes_processor,
-                     std::shared_ptr<AggregationConfig> aggregation_config,
+                     const AggregationConfig *aggregation_config,
                      void *state = nullptr)
       : instrument_descriptor_(instrument_descriptor),
         aggregation_type_{aggregation_type},

--- a/sdk/include/opentelemetry/sdk/metrics/state/sync_metric_storage.h
+++ b/sdk/include/opentelemetry/sdk/metrics/state/sync_metric_storage.h
@@ -31,7 +31,7 @@ public:
                     const AggregationType aggregation_type,
                     const AttributesProcessor *attributes_processor,
                     nostd::shared_ptr<ExemplarReservoir> &&exemplar_reservoir,
-                    nostd::shared_ptr<AggregationConfig> aggregation_config)
+                    std::shared_ptr<AggregationConfig> aggregation_config)
       : instrument_descriptor_(instrument_descriptor),
         aggregation_type_{aggregation_type},
         attributes_hashmap_(new AttributesHashMap()),
@@ -40,8 +40,10 @@ public:
         temporal_metric_storage_(instrument_descriptor, aggregation_config)
 
   {
-    create_default_aggregation_ = [&]() -> std::unique_ptr<Aggregation> {
-      return DefaultAggregation::CreateAggregation(aggregation_type_, instrument_descriptor_);
+    create_default_aggregation_ = [aggregation_type, aggregation_config,
+                                   instrument_descriptor]() -> std::unique_ptr<Aggregation> {
+      return DefaultAggregation::CreateAggregation(aggregation_type, instrument_descriptor,
+                                                   aggregation_config);
     };
   }
 

--- a/sdk/include/opentelemetry/sdk/metrics/state/sync_metric_storage.h
+++ b/sdk/include/opentelemetry/sdk/metrics/state/sync_metric_storage.h
@@ -31,7 +31,7 @@ public:
                     const AggregationType aggregation_type,
                     const AttributesProcessor *attributes_processor,
                     nostd::shared_ptr<ExemplarReservoir> &&exemplar_reservoir,
-                    std::shared_ptr<AggregationConfig> aggregation_config)
+                    const AggregationConfig *aggregation_config)
       : instrument_descriptor_(instrument_descriptor),
         aggregation_type_{aggregation_type},
         attributes_hashmap_(new AttributesHashMap()),

--- a/sdk/include/opentelemetry/sdk/metrics/state/sync_metric_storage.h
+++ b/sdk/include/opentelemetry/sdk/metrics/state/sync_metric_storage.h
@@ -40,9 +40,8 @@ public:
         temporal_metric_storage_(instrument_descriptor, aggregation_config)
 
   {
-    create_default_aggregation_ = [aggregation_type, aggregation_config,
-                                   instrument_descriptor]() -> std::unique_ptr<Aggregation> {
-      return DefaultAggregation::CreateAggregation(aggregation_type, instrument_descriptor,
+    create_default_aggregation_ = [&, aggregation_config]() -> std::unique_ptr<Aggregation> {
+      return DefaultAggregation::CreateAggregation(aggregation_type_, instrument_descriptor_,
                                                    aggregation_config);
     };
   }

--- a/sdk/include/opentelemetry/sdk/metrics/state/temporal_metric_storage.h
+++ b/sdk/include/opentelemetry/sdk/metrics/state/temporal_metric_storage.h
@@ -26,7 +26,7 @@ class TemporalMetricStorage
 {
 public:
   TemporalMetricStorage(InstrumentDescriptor instrument_descriptor,
-                        nostd::shared_ptr<AggregationConfig> aggregation_config);
+                        std::shared_ptr<AggregationConfig> aggregation_config);
 
   bool buildMetrics(CollectorHandle *collector,
                     nostd::span<std::shared_ptr<CollectorHandle>> collectors,
@@ -46,7 +46,7 @@ private:
 
   // Lock while building metrics
   mutable opentelemetry::common::SpinLockMutex lock_;
-  const nostd::shared_ptr<AggregationConfig> aggregation_config_;
+  const std::shared_ptr<AggregationConfig> aggregation_config_;
 };
 }  // namespace metrics
 }  // namespace sdk

--- a/sdk/include/opentelemetry/sdk/metrics/state/temporal_metric_storage.h
+++ b/sdk/include/opentelemetry/sdk/metrics/state/temporal_metric_storage.h
@@ -26,7 +26,7 @@ class TemporalMetricStorage
 {
 public:
   TemporalMetricStorage(InstrumentDescriptor instrument_descriptor,
-                        std::shared_ptr<AggregationConfig> aggregation_config);
+                        const AggregationConfig *aggregation_config);
 
   bool buildMetrics(CollectorHandle *collector,
                     nostd::span<std::shared_ptr<CollectorHandle>> collectors,
@@ -46,7 +46,7 @@ private:
 
   // Lock while building metrics
   mutable opentelemetry::common::SpinLockMutex lock_;
-  const std::shared_ptr<AggregationConfig> aggregation_config_;
+  const AggregationConfig *aggregation_config_;
 };
 }  // namespace metrics
 }  // namespace sdk

--- a/sdk/include/opentelemetry/sdk/metrics/view/view.h
+++ b/sdk/include/opentelemetry/sdk/metrics/view/view.h
@@ -45,9 +45,9 @@ public:
 
   virtual AggregationType GetAggregationType() const noexcept { return aggregation_type_; }
 
-  virtual std::shared_ptr<AggregationConfig> GetAggregationConfig() const noexcept
+  virtual AggregationConfig *GetAggregationConfig() const noexcept
   {
-    return aggregation_config_;
+    return aggregation_config_.get();
   }
 
   virtual const opentelemetry::sdk::metrics::AttributesProcessor &GetAttributesProcessor()

--- a/sdk/include/opentelemetry/sdk/metrics/view/view.h
+++ b/sdk/include/opentelemetry/sdk/metrics/view/view.h
@@ -26,7 +26,7 @@ public:
   View(const std::string &name,
        const std::string &description                        = "",
        AggregationType aggregation_type                      = AggregationType::kDefault,
-       std::shared_ptr<AggregationConfig> aggregation_config = std::shared_ptr<AggregationConfig>{},
+       std::shared_ptr<AggregationConfig> aggregation_config = nullptr,
        std::unique_ptr<opentelemetry::sdk::metrics::AttributesProcessor> attributes_processor =
            std::unique_ptr<opentelemetry::sdk::metrics::AttributesProcessor>(
                new opentelemetry::sdk::metrics::DefaultAttributesProcessor()))
@@ -45,7 +45,7 @@ public:
 
   virtual AggregationType GetAggregationType() const noexcept { return aggregation_type_; }
 
-  virtual nostd::shared_ptr<AggregationConfig> GetAggregationConfig() const noexcept
+  virtual std::shared_ptr<AggregationConfig> GetAggregationConfig() const noexcept
   {
     return aggregation_config_;
   }
@@ -60,7 +60,7 @@ private:
   std::string name_;
   std::string description_;
   AggregationType aggregation_type_;
-  nostd::shared_ptr<AggregationConfig> aggregation_config_;
+  std::shared_ptr<AggregationConfig> aggregation_config_;
   std::unique_ptr<opentelemetry::sdk::metrics::AttributesProcessor> attributes_processor_;
 };
 }  // namespace metrics

--- a/sdk/src/metrics/aggregation/histogram_aggregation.cc
+++ b/sdk/src/metrics/aggregation/histogram_aggregation.cc
@@ -1,13 +1,12 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-#include <memory>
 #ifndef ENABLE_METRICS_PREVIEW
+#  include "opentelemetry/sdk/metrics/aggregation/histogram_aggregation.h"
 #  include <algorithm>
 #  include <iomanip>
-#  include <iostream>
 #  include <limits>
-#  include "opentelemetry/sdk/metrics/aggregation/histogram_aggregation.h"
+#  include <memory>
 #  include "opentelemetry/version.h"
 
 #  include <mutex>

--- a/sdk/src/metrics/aggregation/histogram_aggregation.cc
+++ b/sdk/src/metrics/aggregation/histogram_aggregation.cc
@@ -1,11 +1,13 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
+#include <memory>
 #ifndef ENABLE_METRICS_PREVIEW
-#  include "opentelemetry/sdk/metrics/aggregation/histogram_aggregation.h"
 #  include <algorithm>
 #  include <iomanip>
+#  include <iostream>
 #  include <limits>
+#  include "opentelemetry/sdk/metrics/aggregation/histogram_aggregation.h"
 #  include "opentelemetry/version.h"
 
 #  include <mutex>
@@ -16,11 +18,12 @@ namespace metrics
 {
 
 LongHistogramAggregation::LongHistogramAggregation(
-    const HistogramAggregationConfig<long> *aggregation_config)
+    std::shared_ptr<AggregationConfig> aggregation_config)
 {
-  if (aggregation_config && aggregation_config->boundaries_.size())
+  auto ac = std::dynamic_pointer_cast<HistogramAggregationConfig>(aggregation_config);
+  if (ac && ac->boundaries_.size())
   {
-    point_data_.boundaries_ = aggregation_config->boundaries_;
+    point_data_.boundaries_ = ac->boundaries_;
   }
   else
   {
@@ -28,9 +31,9 @@ LongHistogramAggregation::LongHistogramAggregation(
                                500.0, 750.0, 1000.0, 2500.0, 5000.0, 7500.0, 10000.0};
   }
 
-  if (aggregation_config)
+  if (ac)
   {
-    record_min_max_ = aggregation_config->record_min_max_;
+    record_min_max_ = ac->record_min_max_;
   }
   point_data_.counts_         = std::vector<uint64_t>(point_data_.boundaries_.size() + 1, 0);
   point_data_.sum_            = 0l;
@@ -99,20 +102,21 @@ PointType LongHistogramAggregation::ToPoint() const noexcept
 }
 
 DoubleHistogramAggregation::DoubleHistogramAggregation(
-    const HistogramAggregationConfig<double> *aggregation_config)
+    std::shared_ptr<AggregationConfig> aggregation_config)
 {
-  if (aggregation_config && aggregation_config->boundaries_.size())
+  auto ac = std::dynamic_pointer_cast<HistogramAggregationConfig>(aggregation_config);
+  if (ac && ac->boundaries_.size())
   {
-    point_data_.boundaries_ = aggregation_config->boundaries_;
+    point_data_.boundaries_ = ac->boundaries_;
   }
   else
   {
     point_data_.boundaries_ =
         std::list<double>{0.0, 5.0, 10.0, 25.0, 50.0, 75.0, 100.0, 250.0, 500.0, 1000.0};
   }
-  if (aggregation_config)
+  if (ac)
   {
-    record_min_max_ = aggregation_config->record_min_max_;
+    record_min_max_ = ac->record_min_max_;
   }
   point_data_.counts_         = std::vector<uint64_t>(point_data_.boundaries_.size() + 1, 0);
   point_data_.sum_            = 0.0;
@@ -159,7 +163,12 @@ std::unique_ptr<Aggregation> DoubleHistogramAggregation::Merge(
   auto curr_value  = nostd::get<HistogramPointData>(ToPoint());
   auto delta_value = nostd::get<HistogramPointData>(
       (static_cast<const DoubleHistogramAggregation &>(delta).ToPoint()));
-  DoubleHistogramAggregation *aggr = new DoubleHistogramAggregation();
+  std::shared_ptr<AggregationConfig> aggregation_config(new HistogramAggregationConfig);
+  static_cast<opentelemetry::sdk::metrics::HistogramAggregationConfig *>(aggregation_config.get())
+      ->boundaries_ = curr_value.boundaries_;
+  static_cast<opentelemetry::sdk::metrics::HistogramAggregationConfig *>(aggregation_config.get())
+      ->record_min_max_            = record_min_max_;
+  DoubleHistogramAggregation *aggr = new DoubleHistogramAggregation(aggregation_config);
   HistogramMerge<double>(curr_value, delta_value, aggr->point_data_);
   return std::unique_ptr<Aggregation>(aggr);
 }

--- a/sdk/src/metrics/aggregation/histogram_aggregation.cc
+++ b/sdk/src/metrics/aggregation/histogram_aggregation.cc
@@ -17,10 +17,9 @@ namespace sdk
 namespace metrics
 {
 
-LongHistogramAggregation::LongHistogramAggregation(
-    std::shared_ptr<AggregationConfig> aggregation_config)
+LongHistogramAggregation::LongHistogramAggregation(const AggregationConfig *aggregation_config)
 {
-  auto ac = std::dynamic_pointer_cast<HistogramAggregationConfig>(aggregation_config);
+  auto ac = static_cast<const HistogramAggregationConfig *>(aggregation_config);
   if (ac && ac->boundaries_.size())
   {
     point_data_.boundaries_ = ac->boundaries_;
@@ -101,10 +100,9 @@ PointType LongHistogramAggregation::ToPoint() const noexcept
   return point_data_;
 }
 
-DoubleHistogramAggregation::DoubleHistogramAggregation(
-    std::shared_ptr<AggregationConfig> aggregation_config)
+DoubleHistogramAggregation::DoubleHistogramAggregation(const AggregationConfig *aggregation_config)
 {
-  auto ac = std::dynamic_pointer_cast<HistogramAggregationConfig>(aggregation_config);
+  auto ac = static_cast<const HistogramAggregationConfig *>(aggregation_config);
   if (ac && ac->boundaries_.size())
   {
     point_data_.boundaries_ = ac->boundaries_;
@@ -168,7 +166,7 @@ std::unique_ptr<Aggregation> DoubleHistogramAggregation::Merge(
       ->boundaries_ = curr_value.boundaries_;
   static_cast<opentelemetry::sdk::metrics::HistogramAggregationConfig *>(aggregation_config.get())
       ->record_min_max_            = record_min_max_;
-  DoubleHistogramAggregation *aggr = new DoubleHistogramAggregation(aggregation_config);
+  DoubleHistogramAggregation *aggr = new DoubleHistogramAggregation(aggregation_config.get());
   HistogramMerge<double>(curr_value, delta_value, aggr->point_data_);
   return std::unique_ptr<Aggregation>(aggr);
 }

--- a/sdk/src/metrics/state/temporal_metric_storage.cc
+++ b/sdk/src/metrics/state/temporal_metric_storage.cc
@@ -18,7 +18,7 @@ namespace metrics
 {
 
 TemporalMetricStorage::TemporalMetricStorage(InstrumentDescriptor instrument_descriptor,
-                                             std::shared_ptr<AggregationConfig> aggregation_config)
+                                             const AggregationConfig *aggregation_config)
     : instrument_descriptor_(instrument_descriptor), aggregation_config_(aggregation_config)
 {}
 

--- a/sdk/test/metrics/aggregation_test.cc
+++ b/sdk/test/metrics/aggregation_test.cc
@@ -131,12 +131,12 @@ TEST(Aggregation, LongHistogramAggregation)
 
 TEST(Aggregation, LongHistogramAggregationBoundaries)
 {
-  nostd::shared_ptr<opentelemetry::sdk::metrics::HistogramAggregationConfig<long>>
-      aggregation_config{new opentelemetry::sdk::metrics::HistogramAggregationConfig<long>};
+  std::shared_ptr<opentelemetry::sdk::metrics::HistogramAggregationConfig> aggregation_config{
+      new opentelemetry::sdk::metrics::HistogramAggregationConfig};
   std::list<double> user_boundaries = {0.0,   50.0,   100.0,  250.0,  500.0,
                                        750.0, 1000.0, 2500.0, 5000.0, 10000.0};
   aggregation_config->boundaries_   = user_boundaries;
-  LongHistogramAggregation aggr{aggregation_config.get()};
+  LongHistogramAggregation aggr{aggregation_config};
   auto data = aggr.ToPoint();
   ASSERT_TRUE(nostd::holds_alternative<HistogramPointData>(data));
   auto histogram_data = nostd::get<HistogramPointData>(data);
@@ -145,12 +145,12 @@ TEST(Aggregation, LongHistogramAggregationBoundaries)
 
 TEST(Aggregation, DoubleHistogramAggregationBoundaries)
 {
-  nostd::shared_ptr<opentelemetry::sdk::metrics::HistogramAggregationConfig<double>>
-      aggregation_config{new opentelemetry::sdk::metrics::HistogramAggregationConfig<double>};
+  std::shared_ptr<opentelemetry::sdk::metrics::HistogramAggregationConfig> aggregation_config{
+      new opentelemetry::sdk::metrics::HistogramAggregationConfig};
   std::list<double> user_boundaries = {0.0,   50.0,   100.0,  250.0,  500.0,
                                        750.0, 1000.0, 2500.0, 5000.0, 10000.0};
   aggregation_config->boundaries_   = user_boundaries;
-  DoubleHistogramAggregation aggr{aggregation_config.get()};
+  DoubleHistogramAggregation aggr{aggregation_config};
   auto data = aggr.ToPoint();
   ASSERT_TRUE(nostd::holds_alternative<HistogramPointData>(data));
   auto histogram_data = nostd::get<HistogramPointData>(data);

--- a/sdk/test/metrics/aggregation_test.cc
+++ b/sdk/test/metrics/aggregation_test.cc
@@ -136,7 +136,7 @@ TEST(Aggregation, LongHistogramAggregationBoundaries)
   std::list<double> user_boundaries = {0.0,   50.0,   100.0,  250.0,  500.0,
                                        750.0, 1000.0, 2500.0, 5000.0, 10000.0};
   aggregation_config->boundaries_   = user_boundaries;
-  LongHistogramAggregation aggr{aggregation_config};
+  LongHistogramAggregation aggr{aggregation_config.get()};
   auto data = aggr.ToPoint();
   ASSERT_TRUE(nostd::holds_alternative<HistogramPointData>(data));
   auto histogram_data = nostd::get<HistogramPointData>(data);
@@ -150,7 +150,7 @@ TEST(Aggregation, DoubleHistogramAggregationBoundaries)
   std::list<double> user_boundaries = {0.0,   50.0,   100.0,  250.0,  500.0,
                                        750.0, 1000.0, 2500.0, 5000.0, 10000.0};
   aggregation_config->boundaries_   = user_boundaries;
-  DoubleHistogramAggregation aggr{aggregation_config};
+  DoubleHistogramAggregation aggr{aggregation_config.get()};
   auto data = aggr.ToPoint();
   ASSERT_TRUE(nostd::holds_alternative<HistogramPointData>(data));
   auto histogram_data = nostd::get<HistogramPointData>(data);

--- a/sdk/test/metrics/async_metric_storage_test.cc
+++ b/sdk/test/metrics/async_metric_storage_test.cc
@@ -68,8 +68,7 @@ TEST_P(WritableMetricStorageTestFixture, TestAggregation)
   std::unique_ptr<AttributesProcessor> default_attributes_processor{
       new DefaultAttributesProcessor{}};
   opentelemetry::sdk::metrics::AsyncMetricStorage storage(
-      instr_desc, AggregationType::kSum, default_attributes_processor.get(),
-      std::shared_ptr<opentelemetry::sdk::metrics::AggregationConfig>{});
+      instr_desc, AggregationType::kSum, default_attributes_processor.get(), nullptr);
   long get_count1                                                                  = 20l;
   long put_count1                                                                  = 10l;
   std::unordered_map<MetricAttributes, long, AttributeHashGenerator> measurements1 = {
@@ -161,8 +160,7 @@ TEST_P(WritableMetricStorageTestObservableGaugeFixture, TestAggregation)
   std::unique_ptr<AttributesProcessor> default_attributes_processor{
       new DefaultAttributesProcessor{}};
   opentelemetry::sdk::metrics::AsyncMetricStorage storage(
-      instr_desc, AggregationType::kLastValue, default_attributes_processor.get(),
-      std::shared_ptr<opentelemetry::sdk::metrics::AggregationConfig>{});
+      instr_desc, AggregationType::kLastValue, default_attributes_processor.get(), nullptr);
   long freq_cpu0                                                                   = 3l;
   long freq_cpu1                                                                   = 5l;
   std::unordered_map<MetricAttributes, long, AttributeHashGenerator> measurements1 = {

--- a/sdk/test/metrics/sync_metric_storage_counter_test.cc
+++ b/sdk/test/metrics/sync_metric_storage_counter_test.cc
@@ -53,8 +53,7 @@ TEST_P(WritableMetricStorageTestFixture, LongSumAggregation)
       new DefaultAttributesProcessor{}};
   opentelemetry::sdk::metrics::SyncMetricStorage storage(
       instr_desc, AggregationType::kSum, default_attributes_processor.get(),
-      ExemplarReservoir::GetNoExemplarReservoir(),
-      std::shared_ptr<opentelemetry::sdk::metrics::AggregationConfig>{});
+      ExemplarReservoir::GetNoExemplarReservoir(), nullptr);
 
   storage.RecordLong(10l, KeyValueIterableView<std::map<std::string, std::string>>(attributes_get),
                      opentelemetry::context::Context{});
@@ -188,8 +187,7 @@ TEST_P(WritableMetricStorageTestFixture, DoubleSumAggregation)
       new DefaultAttributesProcessor{}};
   opentelemetry::sdk::metrics::SyncMetricStorage storage(
       instr_desc, AggregationType::kSum, default_attributes_processor.get(),
-      ExemplarReservoir::GetNoExemplarReservoir(),
-      std::shared_ptr<opentelemetry::sdk::metrics::AggregationConfig>{});
+      ExemplarReservoir::GetNoExemplarReservoir(), nullptr);
 
   storage.RecordDouble(10.0,
                        KeyValueIterableView<std::map<std::string, std::string>>(attributes_get),

--- a/sdk/test/metrics/sync_metric_storage_histogram_test.cc
+++ b/sdk/test/metrics/sync_metric_storage_histogram_test.cc
@@ -54,8 +54,7 @@ TEST_P(WritableMetricStorageHistogramTestFixture, LongHistogram)
       new DefaultAttributesProcessor{}};
   opentelemetry::sdk::metrics::SyncMetricStorage storage(
       instr_desc, AggregationType::kHistogram, default_attributes_processor.get(),
-      NoExemplarReservoir::GetNoExemplarReservoir(),
-      std::shared_ptr<opentelemetry::sdk::metrics::AggregationConfig>{});
+      NoExemplarReservoir::GetNoExemplarReservoir(), nullptr);
 
   storage.RecordLong(10l, KeyValueIterableView<std::map<std::string, std::string>>(attributes_get),
                      opentelemetry::context::Context{});
@@ -189,8 +188,7 @@ TEST_P(WritableMetricStorageHistogramTestFixture, DoubleHistogram)
       new DefaultAttributesProcessor{}};
   opentelemetry::sdk::metrics::SyncMetricStorage storage(
       instr_desc, AggregationType::kHistogram, default_attributes_processor.get(),
-      NoExemplarReservoir::GetNoExemplarReservoir(),
-      std::shared_ptr<opentelemetry::sdk::metrics::AggregationConfig>{});
+      NoExemplarReservoir::GetNoExemplarReservoir(), nullptr);
 
   storage.RecordDouble(10.0,
                        KeyValueIterableView<std::map<std::string, std::string>>(attributes_get),


### PR DESCRIPTION
Fixes #1665 (issue)

## Changes

One of the `CreateAggregation` overloads was not passing the aggregation config to the histogram ctors. Also replaced nostd with `std::shared_ptr`.

For significant contributions please make sure you have completed the following items:

* [ ] `CHANGELOG.md` updated for non-trivial changes
* [ ] Unit tests have been added
* [ ] Changes in public API reviewed