### PR TITLE
[Metrics] Switch to explicit 64 bit integers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ Increment the:
 
 ## [Unreleased]
 
+* [Metrics] Switch to explicit 64 bit integers [#1686](https://github.com/open-telemetry/opentelemetry-cpp/pull/1686)
+  which includes breaking change in the Metrics api.
 * [BUILD] Add CMake OTELCPP_MAINTAINER_MODE [#1650](https://github.com/open-telemetry/opentelemetry-cpp/pull/1650)
 
 ## [1.6.1] 2022-09-22

--- a/api/include/opentelemetry/metrics/meter.h
+++ b/api/include/opentelemetry/metrics/meter.h
@@ -36,7 +36,7 @@ public:
    * @return a shared pointer to the created Counter.
    */
 
-  virtual nostd::shared_ptr<Counter<long>> CreateLongCounter(
+  virtual nostd::shared_ptr<Counter<int64_t>> CreateLongCounter(
       nostd::string_view name,
       nostd::string_view description = "",
       nostd::string_view unit        = "") noexcept = 0;
@@ -72,7 +72,7 @@ public:
    * @param unit the unit of metric values following https://unitsofmeasure.org/ucum.html.
    * @return a shared pointer to the created Histogram.
    */
-  virtual nostd::shared_ptr<Histogram<long>> CreateLongHistogram(
+  virtual nostd::shared_ptr<Histogram<int64_t>> CreateLongHistogram(
       nostd::string_view name,
       nostd::string_view description = "",
       nostd::string_view unit        = "") noexcept = 0;
@@ -109,7 +109,7 @@ public:
    * @param unit the unit of metric values following https://unitsofmeasure.org/ucum.html.
    * @return a shared pointer to the created UpDownCounter.
    */
-  virtual nostd::shared_ptr<UpDownCounter<long>> CreateLongUpDownCounter(
+  virtual nostd::shared_ptr<UpDownCounter<int64_t>> CreateLongUpDownCounter(
       nostd::string_view name,
       nostd::string_view description = "",
       nostd::string_view unit        = "") noexcept = 0;

--- a/api/include/opentelemetry/metrics/meter.h
+++ b/api/include/opentelemetry/metrics/meter.h
@@ -36,7 +36,7 @@ public:
    * @return a shared pointer to the created Counter.
    */
 
-  virtual nostd::shared_ptr<Counter<int64_t>> CreateInt64Counter(
+  virtual nostd::shared_ptr<Counter<uint64_t>> CreateUInt64Counter(
       nostd::string_view name,
       nostd::string_view description = "",
       nostd::string_view unit        = "") noexcept = 0;
@@ -54,7 +54,7 @@ public:
    * @param description a brief description of what the Observable Counter is used for.
    * @param unit the unit of metric values following https://unitsofmeasure.org/ucum.html.
    */
-  virtual nostd::shared_ptr<ObservableInstrument> CreateLongObservableCounter(
+  virtual nostd::shared_ptr<ObservableInstrument> CreateUInt64ObservableCounter(
       nostd::string_view name,
       nostd::string_view description = "",
       nostd::string_view unit        = "") noexcept = 0;
@@ -72,7 +72,7 @@ public:
    * @param unit the unit of metric values following https://unitsofmeasure.org/ucum.html.
    * @return a shared pointer to the created Histogram.
    */
-  virtual nostd::shared_ptr<Histogram<int64_t>> CreateLongHistogram(
+  virtual nostd::shared_ptr<Histogram<uint64_t>> CreateUInt64Histogram(
       nostd::string_view name,
       nostd::string_view description = "",
       nostd::string_view unit        = "") noexcept = 0;
@@ -90,7 +90,7 @@ public:
    * @param description a brief description of what the Observable Gauge is used for.
    * @param unit the unit of metric values following https://unitsofmeasure.org/ucum.html.
    */
-  virtual nostd::shared_ptr<ObservableInstrument> CreateLongObservableGauge(
+  virtual nostd::shared_ptr<ObservableInstrument> CreateUInt64ObservableGauge(
       nostd::string_view name,
       nostd::string_view description = "",
       nostd::string_view unit        = "") noexcept = 0;
@@ -109,7 +109,7 @@ public:
    * @param unit the unit of metric values following https://unitsofmeasure.org/ucum.html.
    * @return a shared pointer to the created UpDownCounter.
    */
-  virtual nostd::shared_ptr<UpDownCounter<int64_t>> CreateLongUpDownCounter(
+  virtual nostd::shared_ptr<UpDownCounter<int64_t>> CreateInt64UpDownCounter(
       nostd::string_view name,
       nostd::string_view description = "",
       nostd::string_view unit        = "") noexcept = 0;
@@ -127,7 +127,7 @@ public:
    * @param description a brief description of what the Observable UpDownCounter is used for.
    * @param unit the unit of metric values following https://unitsofmeasure.org/ucum.html.
    */
-  virtual nostd::shared_ptr<ObservableInstrument> CreateLongObservableUpDownCounter(
+  virtual nostd::shared_ptr<ObservableInstrument> CreateInt64ObservableUpDownCounter(
       nostd::string_view name,
       nostd::string_view description = "",
       nostd::string_view unit        = "") noexcept = 0;

--- a/api/include/opentelemetry/metrics/meter.h
+++ b/api/include/opentelemetry/metrics/meter.h
@@ -36,7 +36,7 @@ public:
    * @return a shared pointer to the created Counter.
    */
 
-  virtual nostd::shared_ptr<Counter<int64_t>> CreateLongCounter(
+  virtual nostd::shared_ptr<Counter<int64_t>> CreateInt64Counter(
       nostd::string_view name,
       nostd::string_view description = "",
       nostd::string_view unit        = "") noexcept = 0;

--- a/api/include/opentelemetry/metrics/meter.h
+++ b/api/include/opentelemetry/metrics/meter.h
@@ -90,7 +90,7 @@ public:
    * @param description a brief description of what the Observable Gauge is used for.
    * @param unit the unit of metric values following https://unitsofmeasure.org/ucum.html.
    */
-  virtual nostd::shared_ptr<ObservableInstrument> CreateUInt64ObservableGauge(
+  virtual nostd::shared_ptr<ObservableInstrument> CreateInt64ObservableGauge(
       nostd::string_view name,
       nostd::string_view description = "",
       nostd::string_view unit        = "") noexcept = 0;

--- a/api/include/opentelemetry/metrics/meter.h
+++ b/api/include/opentelemetry/metrics/meter.h
@@ -54,7 +54,7 @@ public:
    * @param description a brief description of what the Observable Counter is used for.
    * @param unit the unit of metric values following https://unitsofmeasure.org/ucum.html.
    */
-  virtual nostd::shared_ptr<ObservableInstrument> CreateUInt64ObservableCounter(
+  virtual nostd::shared_ptr<ObservableInstrument> CreateInt64ObservableCounter(
       nostd::string_view name,
       nostd::string_view description = "",
       nostd::string_view unit        = "") noexcept = 0;

--- a/api/include/opentelemetry/metrics/noop.h
+++ b/api/include/opentelemetry/metrics/noop.h
@@ -87,7 +87,7 @@ public:
 class NoopMeter final : public Meter
 {
 public:
-  nostd::shared_ptr<Counter<int64_t>> CreateLongCounter(
+  nostd::shared_ptr<Counter<int64_t>> CreateInt64Counter(
       nostd::string_view name,
       nostd::string_view description = "",
       nostd::string_view unit        = "") noexcept override

--- a/api/include/opentelemetry/metrics/noop.h
+++ b/api/include/opentelemetry/metrics/noop.h
@@ -138,7 +138,7 @@ public:
     return nostd::shared_ptr<Histogram<double>>{new NoopHistogram<double>(name, description, unit)};
   }
 
-  nostd::shared_ptr<ObservableInstrument> CreateUInt64ObservableGauge(
+  nostd::shared_ptr<ObservableInstrument> CreateInt64ObservableGauge(
       nostd::string_view name,
       nostd::string_view description = "",
       nostd::string_view unit        = "") noexcept override

--- a/api/include/opentelemetry/metrics/noop.h
+++ b/api/include/opentelemetry/metrics/noop.h
@@ -87,12 +87,12 @@ public:
 class NoopMeter final : public Meter
 {
 public:
-  nostd::shared_ptr<Counter<int64_t>> CreateInt64Counter(
+  nostd::shared_ptr<Counter<uint64_t>> CreateUInt64Counter(
       nostd::string_view name,
       nostd::string_view description = "",
       nostd::string_view unit        = "") noexcept override
   {
-    return nostd::shared_ptr<Counter<int64_t>>{new NoopCounter<int64_t>(name, description, unit)};
+    return nostd::shared_ptr<Counter<uint64_t>>{new NoopCounter<uint64_t>(name, description, unit)};
   }
 
   nostd::shared_ptr<Counter<double>> CreateDoubleCounter(
@@ -103,7 +103,7 @@ public:
     return nostd::shared_ptr<Counter<double>>{new NoopCounter<double>(name, description, unit)};
   }
 
-  nostd::shared_ptr<ObservableInstrument> CreateLongObservableCounter(
+  nostd::shared_ptr<ObservableInstrument> CreateUInt64ObservableCounter(
       nostd::string_view name,
       nostd::string_view description = "",
       nostd::string_view unit        = "") noexcept override
@@ -121,13 +121,13 @@ public:
         new NoopObservableInstrument(name, description, unit));
   }
 
-  nostd::shared_ptr<Histogram<int64_t>> CreateLongHistogram(
+  nostd::shared_ptr<Histogram<uint64_t>> CreateUInt64Histogram(
       nostd::string_view name,
       nostd::string_view description = "",
       nostd::string_view unit        = "") noexcept override
   {
-    return nostd::shared_ptr<Histogram<int64_t>>{
-        new NoopHistogram<int64_t>(name, description, unit)};
+    return nostd::shared_ptr<Histogram<uint64_t>>{
+        new NoopHistogram<uint64_t>(name, description, unit)};
   }
 
   nostd::shared_ptr<Histogram<double>> CreateDoubleHistogram(
@@ -138,7 +138,7 @@ public:
     return nostd::shared_ptr<Histogram<double>>{new NoopHistogram<double>(name, description, unit)};
   }
 
-  nostd::shared_ptr<ObservableInstrument> CreateLongObservableGauge(
+  nostd::shared_ptr<ObservableInstrument> CreateUInt64ObservableGauge(
       nostd::string_view name,
       nostd::string_view description = "",
       nostd::string_view unit        = "") noexcept override
@@ -156,7 +156,7 @@ public:
         new NoopObservableInstrument(name, description, unit));
   }
 
-  nostd::shared_ptr<UpDownCounter<int64_t>> CreateLongUpDownCounter(
+  nostd::shared_ptr<UpDownCounter<int64_t>> CreateInt64UpDownCounter(
       nostd::string_view name,
       nostd::string_view description = "",
       nostd::string_view unit        = "") noexcept override
@@ -174,7 +174,7 @@ public:
         new NoopUpDownCounter<double>(name, description, unit)};
   }
 
-  nostd::shared_ptr<ObservableInstrument> CreateLongObservableUpDownCounter(
+  nostd::shared_ptr<ObservableInstrument> CreateInt64ObservableUpDownCounter(
       nostd::string_view name,
       nostd::string_view description = "",
       nostd::string_view unit        = "") noexcept override

--- a/api/include/opentelemetry/metrics/noop.h
+++ b/api/include/opentelemetry/metrics/noop.h
@@ -103,7 +103,7 @@ public:
     return nostd::shared_ptr<Counter<double>>{new NoopCounter<double>(name, description, unit)};
   }
 
-  nostd::shared_ptr<ObservableInstrument> CreateUInt64ObservableCounter(
+  nostd::shared_ptr<ObservableInstrument> CreateInt64ObservableCounter(
       nostd::string_view name,
       nostd::string_view description = "",
       nostd::string_view unit        = "") noexcept override

--- a/api/include/opentelemetry/metrics/noop.h
+++ b/api/include/opentelemetry/metrics/noop.h
@@ -87,11 +87,12 @@ public:
 class NoopMeter final : public Meter
 {
 public:
-  nostd::shared_ptr<Counter<long>> CreateLongCounter(nostd::string_view name,
-                                                     nostd::string_view description = "",
-                                                     nostd::string_view unit = "") noexcept override
+  nostd::shared_ptr<Counter<int64_t>> CreateLongCounter(
+      nostd::string_view name,
+      nostd::string_view description = "",
+      nostd::string_view unit        = "") noexcept override
   {
-    return nostd::shared_ptr<Counter<long>>{new NoopCounter<long>(name, description, unit)};
+    return nostd::shared_ptr<Counter<int64_t>>{new NoopCounter<int64_t>(name, description, unit)};
   }
 
   nostd::shared_ptr<Counter<double>> CreateDoubleCounter(
@@ -120,12 +121,13 @@ public:
         new NoopObservableInstrument(name, description, unit));
   }
 
-  nostd::shared_ptr<Histogram<long>> CreateLongHistogram(
+  nostd::shared_ptr<Histogram<int64_t>> CreateLongHistogram(
       nostd::string_view name,
       nostd::string_view description = "",
       nostd::string_view unit        = "") noexcept override
   {
-    return nostd::shared_ptr<Histogram<long>>{new NoopHistogram<long>(name, description, unit)};
+    return nostd::shared_ptr<Histogram<int64_t>>{
+        new NoopHistogram<int64_t>(name, description, unit)};
   }
 
   nostd::shared_ptr<Histogram<double>> CreateDoubleHistogram(
@@ -154,13 +156,13 @@ public:
         new NoopObservableInstrument(name, description, unit));
   }
 
-  nostd::shared_ptr<UpDownCounter<long>> CreateLongUpDownCounter(
+  nostd::shared_ptr<UpDownCounter<int64_t>> CreateLongUpDownCounter(
       nostd::string_view name,
       nostd::string_view description = "",
       nostd::string_view unit        = "") noexcept override
   {
-    return nostd::shared_ptr<UpDownCounter<long>>{
-        new NoopUpDownCounter<long>(name, description, unit)};
+    return nostd::shared_ptr<UpDownCounter<int64_t>>{
+        new NoopUpDownCounter<int64_t>(name, description, unit)};
   }
 
   nostd::shared_ptr<UpDownCounter<double>> CreateDoubleUpDownCounter(

--- a/api/include/opentelemetry/metrics/observer_result.h
+++ b/api/include/opentelemetry/metrics/observer_result.h
@@ -46,7 +46,7 @@ public:
   }
 };
 
-using ObserverResult = nostd::variant<nostd::shared_ptr<ObserverResultT<long>>,
+using ObserverResult = nostd::variant<nostd::shared_ptr<ObserverResultT<int64_t>>,
                                       nostd::shared_ptr<ObserverResultT<double>>>;
 
 }  // namespace metrics

--- a/api/test/metrics/noop_sync_instrument_test.cc
+++ b/api/test/metrics/noop_sync_instrument_test.cc
@@ -10,7 +10,7 @@
 TEST(Counter, Add)
 {
   std::shared_ptr<opentelemetry::metrics::Counter<uint64_t>> counter{
-      new opentelemetry::metrics::NoopCounter<int64_t>("test", "none", "unitless")};
+      new opentelemetry::metrics::NoopCounter<uint64_t>("test", "none", "unitless")};
 
   std::map<std::string, std::string> labels = {{"k1", "v1"}};
   counter->Add(10, labels);

--- a/api/test/metrics/noop_sync_instrument_test.cc
+++ b/api/test/metrics/noop_sync_instrument_test.cc
@@ -9,7 +9,7 @@
 
 TEST(Counter, Add)
 {
-  std::shared_ptr<opentelemetry::metrics::Counter<int64_t>> counter{
+  std::shared_ptr<opentelemetry::metrics::Counter<uint64_t>> counter{
       new opentelemetry::metrics::NoopCounter<int64_t>("test", "none", "unitless")};
 
   std::map<std::string, std::string> labels = {{"k1", "v1"}};
@@ -23,14 +23,14 @@ TEST(Counter, Add)
 
 TEST(histogram, Record)
 {
-  std::shared_ptr<opentelemetry::metrics::Histogram<int64_t>> counter{
-      new opentelemetry::metrics::NoopHistogram<int64_t>("test", "none", "unitless")};
+  std::shared_ptr<opentelemetry::metrics::Histogram<uint64_t>> histogram{
+      new opentelemetry::metrics::NoopHistogram<uint64_t>("test", "none", "unitless")};
 
   std::map<std::string, std::string> labels = {{"k1", "v1"}};
-  counter->Record(10, labels, opentelemetry::context::Context{});
-  counter->Record(2, opentelemetry::context::Context{});
+  histogram->Record(10, labels, opentelemetry::context::Context{});
+  histogram->Record(2, opentelemetry::context::Context{});
 
-  counter->Record(10, {{"k1", "1"}, {"k2", 2}}, opentelemetry::context::Context{});
+  histogram->Record(10, {{"k1", "1"}, {"k2", 2}}, opentelemetry::context::Context{});
 }
 
 TEST(UpDownCountr, Record)

--- a/api/test/metrics/noop_sync_instrument_test.cc
+++ b/api/test/metrics/noop_sync_instrument_test.cc
@@ -13,12 +13,12 @@ TEST(Counter, Add)
       new opentelemetry::metrics::NoopCounter<int64_t>("test", "none", "unitless")};
 
   std::map<std::string, std::string> labels = {{"k1", "v1"}};
-  counter->Add((int64_t)10, labels);
-  counter->Add((int64_t)10, labels, opentelemetry::context::Context{});
-  counter->Add((int64_t)2);
-  counter->Add((int64_t)2, opentelemetry::context::Context{});
-  counter->Add((int64_t)10, {{"k1", "1"}, {"k2", 2}});
-  counter->Add((int64_t)10, {{"k1", "1"}, {"k2", 2}}, opentelemetry::context::Context{});
+  counter->Add(10, labels);
+  counter->Add(10, labels, opentelemetry::context::Context{});
+  counter->Add(2);
+  counter->Add(2, opentelemetry::context::Context{});
+  counter->Add(10, {{"k1", "1"}, {"k2", 2}});
+  counter->Add(10, {{"k1", "1"}, {"k2", 2}}, opentelemetry::context::Context{});
 }
 
 TEST(histogram, Record)
@@ -27,10 +27,10 @@ TEST(histogram, Record)
       new opentelemetry::metrics::NoopHistogram<int64_t>("test", "none", "unitless")};
 
   std::map<std::string, std::string> labels = {{"k1", "v1"}};
-  counter->Record((int64_t)10, labels, opentelemetry::context::Context{});
-  counter->Record((int64_t)2, opentelemetry::context::Context{});
+  counter->Record(10, labels, opentelemetry::context::Context{});
+  counter->Record(2, opentelemetry::context::Context{});
 
-  counter->Record((int64_t)10, {{"k1", "1"}, {"k2", 2}}, opentelemetry::context::Context{});
+  counter->Record(10, {{"k1", "1"}, {"k2", 2}}, opentelemetry::context::Context{});
 }
 
 TEST(UpDownCountr, Record)
@@ -39,12 +39,12 @@ TEST(UpDownCountr, Record)
       new opentelemetry::metrics::NoopUpDownCounter<int64_t>("test", "none", "unitless")};
 
   std::map<std::string, std::string> labels = {{"k1", "v1"}};
-  counter->Add((int64_t)10, labels);
-  counter->Add((int64_t)10, labels, opentelemetry::context::Context{});
-  counter->Add((int64_t)2);
-  counter->Add((int64_t)2, opentelemetry::context::Context{});
-  counter->Add((int64_t)10, {{"k1", "1"}, {"k2", 2}});
-  counter->Add((int64_t)10, {{"k1", "1"}, {"k2", 2}}, opentelemetry::context::Context{});
+  counter->Add(10, labels);
+  counter->Add(10, labels, opentelemetry::context::Context{});
+  counter->Add(2);
+  counter->Add(2, opentelemetry::context::Context{});
+  counter->Add(10, {{"k1", "1"}, {"k2", 2}});
+  counter->Add(10, {{"k1", "1"}, {"k2", 2}}, opentelemetry::context::Context{});
 }
 
 #endif

--- a/api/test/metrics/noop_sync_instrument_test.cc
+++ b/api/test/metrics/noop_sync_instrument_test.cc
@@ -13,12 +13,12 @@ TEST(Counter, Add)
       new opentelemetry::metrics::NoopCounter<int64_t>("test", "none", "unitless")};
 
   std::map<std::string, std::string> labels = {{"k1", "v1"}};
-  counter->Add(10l, labels);
-  counter->Add(10l, labels, opentelemetry::context::Context{});
-  counter->Add(2l);
-  counter->Add(2l, opentelemetry::context::Context{});
-  counter->Add(10l, {{"k1", "1"}, {"k2", 2}});
-  counter->Add(10l, {{"k1", "1"}, {"k2", 2}}, opentelemetry::context::Context{});
+  counter->Add((int64_t)10, labels);
+  counter->Add((int64_t)10, labels, opentelemetry::context::Context{});
+  counter->Add((int64_t)2);
+  counter->Add((int64_t)2, opentelemetry::context::Context{});
+  counter->Add((int64_t)10, {{"k1", "1"}, {"k2", 2}});
+  counter->Add((int64_t)10, {{"k1", "1"}, {"k2", 2}}, opentelemetry::context::Context{});
 }
 
 TEST(histogram, Record)
@@ -27,10 +27,10 @@ TEST(histogram, Record)
       new opentelemetry::metrics::NoopHistogram<int64_t>("test", "none", "unitless")};
 
   std::map<std::string, std::string> labels = {{"k1", "v1"}};
-  counter->Record(10l, labels, opentelemetry::context::Context{});
-  counter->Record(2l, opentelemetry::context::Context{});
+  counter->Record((int64_t)10, labels, opentelemetry::context::Context{});
+  counter->Record((int64_t)2, opentelemetry::context::Context{});
 
-  counter->Record(10l, {{"k1", "1"}, {"k2", 2}}, opentelemetry::context::Context{});
+  counter->Record((int64_t)10, {{"k1", "1"}, {"k2", 2}}, opentelemetry::context::Context{});
 }
 
 TEST(UpDownCountr, Record)
@@ -39,12 +39,12 @@ TEST(UpDownCountr, Record)
       new opentelemetry::metrics::NoopUpDownCounter<int64_t>("test", "none", "unitless")};
 
   std::map<std::string, std::string> labels = {{"k1", "v1"}};
-  counter->Add(10l, labels);
-  counter->Add(10l, labels, opentelemetry::context::Context{});
-  counter->Add(2l);
-  counter->Add(2l, opentelemetry::context::Context{});
-  counter->Add(10l, {{"k1", "1"}, {"k2", 2}});
-  counter->Add(10l, {{"k1", "1"}, {"k2", 2}}, opentelemetry::context::Context{});
+  counter->Add((int64_t)10, labels);
+  counter->Add((int64_t)10, labels, opentelemetry::context::Context{});
+  counter->Add((int64_t)2);
+  counter->Add((int64_t)2, opentelemetry::context::Context{});
+  counter->Add((int64_t)10, {{"k1", "1"}, {"k2", 2}});
+  counter->Add((int64_t)10, {{"k1", "1"}, {"k2", 2}}, opentelemetry::context::Context{});
 }
 
 #endif

--- a/api/test/metrics/noop_sync_instrument_test.cc
+++ b/api/test/metrics/noop_sync_instrument_test.cc
@@ -9,8 +9,8 @@
 
 TEST(Counter, Add)
 {
-  std::shared_ptr<opentelemetry::metrics::Counter<long>> counter{
-      new opentelemetry::metrics::NoopCounter<long>("test", "none", "unitless")};
+  std::shared_ptr<opentelemetry::metrics::Counter<int64_t>> counter{
+      new opentelemetry::metrics::NoopCounter<int64_t>("test", "none", "unitless")};
 
   std::map<std::string, std::string> labels = {{"k1", "v1"}};
   counter->Add(10l, labels);
@@ -23,8 +23,8 @@ TEST(Counter, Add)
 
 TEST(histogram, Record)
 {
-  std::shared_ptr<opentelemetry::metrics::Histogram<long>> counter{
-      new opentelemetry::metrics::NoopHistogram<long>("test", "none", "unitless")};
+  std::shared_ptr<opentelemetry::metrics::Histogram<int64_t>> counter{
+      new opentelemetry::metrics::NoopHistogram<int64_t>("test", "none", "unitless")};
 
   std::map<std::string, std::string> labels = {{"k1", "v1"}};
   counter->Record(10l, labels, opentelemetry::context::Context{});
@@ -35,8 +35,8 @@ TEST(histogram, Record)
 
 TEST(UpDownCountr, Record)
 {
-  std::shared_ptr<opentelemetry::metrics::UpDownCounter<long>> counter{
-      new opentelemetry::metrics::NoopUpDownCounter<long>("test", "none", "unitless")};
+  std::shared_ptr<opentelemetry::metrics::UpDownCounter<int64_t>> counter{
+      new opentelemetry::metrics::NoopUpDownCounter<int64_t>("test", "none", "unitless")};
 
   std::map<std::string, std::string> labels = {{"k1", "v1"}};
   counter->Add(10l, labels);

--- a/exporters/ostream/src/metric_exporter.cc
+++ b/exporters/ostream/src/metric_exporter.cc
@@ -164,9 +164,9 @@ void OStreamMetricExporter::printPointData(const opentelemetry::sdk::metrics::Po
     {
       sout_ << nostd::get<double>(sum_point_data.value_);
     }
-    else if (nostd::holds_alternative<long>(sum_point_data.value_))
+    else if (nostd::holds_alternative<int64_t>(sum_point_data.value_))
     {
-      sout_ << nostd::get<long>(sum_point_data.value_);
+      sout_ << nostd::get<int64_t>(sum_point_data.value_);
     }
   }
   else if (nostd::holds_alternative<sdk::metrics::HistogramPointData>(point_data))
@@ -179,24 +179,24 @@ void OStreamMetricExporter::printPointData(const opentelemetry::sdk::metrics::Po
     {
       sout_ << nostd::get<double>(histogram_point_data.sum_);
     }
-    else if (nostd::holds_alternative<long>(histogram_point_data.sum_))
+    else if (nostd::holds_alternative<int64_t>(histogram_point_data.sum_))
     {
-      sout_ << nostd::get<long>(histogram_point_data.sum_);
+      sout_ << nostd::get<int64_t>(histogram_point_data.sum_);
     }
 
     if (histogram_point_data.record_min_max_)
     {
-      if (nostd::holds_alternative<long>(histogram_point_data.min_))
+      if (nostd::holds_alternative<int64_t>(histogram_point_data.min_))
       {
-        sout_ << "\n  min     : " << nostd::get<long>(histogram_point_data.min_);
+        sout_ << "\n  min     : " << nostd::get<int64_t>(histogram_point_data.min_);
       }
       else if (nostd::holds_alternative<double>(histogram_point_data.min_))
       {
         sout_ << "\n  min     : " << nostd::get<double>(histogram_point_data.min_);
       }
-      if (nostd::holds_alternative<long>(histogram_point_data.max_))
+      if (nostd::holds_alternative<int64_t>(histogram_point_data.max_))
       {
-        sout_ << "\n  max     : " << nostd::get<long>(histogram_point_data.max_);
+        sout_ << "\n  max     : " << nostd::get<int64_t>(histogram_point_data.max_);
       }
       if (nostd::holds_alternative<double>(histogram_point_data.max_))
       {
@@ -222,9 +222,9 @@ void OStreamMetricExporter::printPointData(const opentelemetry::sdk::metrics::Po
     {
       sout_ << nostd::get<double>(last_point_data.value_);
     }
-    else if (nostd::holds_alternative<long>(last_point_data.value_))
+    else if (nostd::holds_alternative<int64_t>(last_point_data.value_))
     {
-      sout_ << nostd::get<long>(last_point_data.value_);
+      sout_ << nostd::get<int64_t>(last_point_data.value_);
     }
   }
 }

--- a/exporters/ostream/test/ostream_metric_test.cc
+++ b/exporters/ostream/test/ostream_metric_test.cc
@@ -108,7 +108,7 @@ TEST(OStreamMetricsExporter, ExportHistogramPointData)
   histogram_point_data2.boundaries_ = std::list<double>{10.0, 20.0, 30.0};
   histogram_point_data2.count_      = 3;
   histogram_point_data2.counts_     = {200, 300, 400, 500};
-  histogram_point_data2.sum_        = (int64_t)900;
+  histogram_point_data2.sum_        = 900;
   metric_sdk::ResourceMetrics data;
   auto resource = opentelemetry::sdk::resource::Resource::Create(
       opentelemetry::sdk::resource::ResourceAttributes{});
@@ -190,7 +190,7 @@ TEST(OStreamMetricsExporter, ExportLastValuePointData)
   last_value_point_data.is_lastvalue_valid_ = true;
   last_value_point_data.sample_ts_          = opentelemetry::common::SystemTimestamp{};
   metric_sdk::LastValuePointData last_value_point_data2{};
-  last_value_point_data2.value_              = (int64_t)20;
+  last_value_point_data2.value_              = 20;
   last_value_point_data2.is_lastvalue_valid_ = true;
   last_value_point_data2.sample_ts_          = opentelemetry::common::SystemTimestamp{};
   metric_sdk::MetricData metric_data{

--- a/exporters/ostream/test/ostream_metric_test.cc
+++ b/exporters/ostream/test/ostream_metric_test.cc
@@ -108,7 +108,7 @@ TEST(OStreamMetricsExporter, ExportHistogramPointData)
   histogram_point_data2.boundaries_ = std::list<double>{10.0, 20.0, 30.0};
   histogram_point_data2.count_      = 3;
   histogram_point_data2.counts_     = {200, 300, 400, 500};
-  histogram_point_data2.sum_        = 900l;
+  histogram_point_data2.sum_        = (int64_t)900;
   metric_sdk::ResourceMetrics data;
   auto resource = opentelemetry::sdk::resource::Resource::Create(
       opentelemetry::sdk::resource::ResourceAttributes{});
@@ -190,7 +190,7 @@ TEST(OStreamMetricsExporter, ExportLastValuePointData)
   last_value_point_data.is_lastvalue_valid_ = true;
   last_value_point_data.sample_ts_          = opentelemetry::common::SystemTimestamp{};
   metric_sdk::LastValuePointData last_value_point_data2{};
-  last_value_point_data2.value_              = 20l;
+  last_value_point_data2.value_              = (int64_t)20;
   last_value_point_data2.is_lastvalue_valid_ = true;
   last_value_point_data2.sample_ts_          = opentelemetry::common::SystemTimestamp{};
   metric_sdk::MetricData metric_data{

--- a/exporters/ostream/test/ostream_metric_test.cc
+++ b/exporters/ostream/test/ostream_metric_test.cc
@@ -108,7 +108,7 @@ TEST(OStreamMetricsExporter, ExportHistogramPointData)
   histogram_point_data2.boundaries_ = std::list<double>{10.0, 20.0, 30.0};
   histogram_point_data2.count_      = 3;
   histogram_point_data2.counts_     = {200, 300, 400, 500};
-  histogram_point_data2.sum_        = 900;
+  histogram_point_data2.sum_        = (int64_t)900;
   metric_sdk::ResourceMetrics data;
   auto resource = opentelemetry::sdk::resource::Resource::Create(
       opentelemetry::sdk::resource::ResourceAttributes{});
@@ -190,7 +190,7 @@ TEST(OStreamMetricsExporter, ExportLastValuePointData)
   last_value_point_data.is_lastvalue_valid_ = true;
   last_value_point_data.sample_ts_          = opentelemetry::common::SystemTimestamp{};
   metric_sdk::LastValuePointData last_value_point_data2{};
-  last_value_point_data2.value_              = 20;
+  last_value_point_data2.value_              = (int64_t)20;
   last_value_point_data2.is_lastvalue_valid_ = true;
   last_value_point_data2.sample_ts_          = opentelemetry::common::SystemTimestamp{};
   metric_sdk::MetricData metric_data{

--- a/exporters/otlp/src/otlp_metric_utils.cc
+++ b/exporters/otlp/src/otlp_metric_utils.cc
@@ -62,9 +62,9 @@ void OtlpMetricUtils::ConvertSumMetric(const metric_sdk::MetricData &metric_data
     proto_sum_point_data->set_time_unix_nano(ts);
     auto sum_data = nostd::get<sdk::metrics::SumPointData>(point_data_with_attributes.point_data);
 
-    if ((nostd::holds_alternative<long>(sum_data.value_)))
+    if ((nostd::holds_alternative<int64_t>(sum_data.value_)))
     {
-      proto_sum_point_data->set_as_int(nostd::get<long>(sum_data.value_));
+      proto_sum_point_data->set_as_int(nostd::get<int64_t>(sum_data.value_));
     }
     else
     {
@@ -96,9 +96,9 @@ void OtlpMetricUtils::ConvertHistogramMetric(
     auto histogram_data =
         nostd::get<sdk::metrics::HistogramPointData>(point_data_with_attributes.point_data);
     // sum
-    if ((nostd::holds_alternative<long>(histogram_data.sum_)))
+    if ((nostd::holds_alternative<int64_t>(histogram_data.sum_)))
     {
-      proto_histogram_point_data->set_sum(nostd::get<long>(histogram_data.sum_));
+      proto_histogram_point_data->set_sum(nostd::get<int64_t>(histogram_data.sum_));
     }
     else
     {
@@ -108,17 +108,17 @@ void OtlpMetricUtils::ConvertHistogramMetric(
     proto_histogram_point_data->set_count(histogram_data.count_);
     if (histogram_data.record_min_max_)
     {
-      if (nostd::holds_alternative<long>(histogram_data.min_))
+      if (nostd::holds_alternative<int64_t>(histogram_data.min_))
       {
-        proto_histogram_point_data->set_min(nostd::get<long>(histogram_data.min_));
+        proto_histogram_point_data->set_min(nostd::get<int64_t>(histogram_data.min_));
       }
       else
       {
         proto_histogram_point_data->set_min(nostd::get<double>(histogram_data.min_));
       }
-      if (nostd::holds_alternative<long>(histogram_data.max_))
+      if (nostd::holds_alternative<int64_t>(histogram_data.max_))
       {
-        proto_histogram_point_data->set_min(nostd::get<long>(histogram_data.max_));
+        proto_histogram_point_data->set_min(nostd::get<int64_t>(histogram_data.max_));
       }
       else
       {
@@ -158,9 +158,9 @@ void OtlpMetricUtils::ConvertGaugeMetric(const opentelemetry::sdk::metrics::Metr
     auto gauge_data =
         nostd::get<sdk::metrics::LastValuePointData>(point_data_with_attributes.point_data);
 
-    if ((nostd::holds_alternative<long>(gauge_data.value_)))
+    if ((nostd::holds_alternative<int64_t>(gauge_data.value_)))
     {
-      proto_gauge_point_data->set_as_int(nostd::get<long>(gauge_data.value_));
+      proto_gauge_point_data->set_as_int(nostd::get<int64_t>(gauge_data.value_));
     }
     else
     {

--- a/exporters/otlp/test/otlp_http_metric_exporter_test.cc
+++ b/exporters/otlp/test/otlp_http_metric_exporter_test.cc
@@ -296,7 +296,7 @@ public:
     last_value_point_data.is_lastvalue_valid_ = true;
     last_value_point_data.sample_ts_          = opentelemetry::common::SystemTimestamp{};
     opentelemetry::sdk::metrics::LastValuePointData last_value_point_data2{};
-    last_value_point_data2.value_              = 20;
+    last_value_point_data2.value_              = (int64_t)20;
     last_value_point_data2.is_lastvalue_valid_ = true;
     last_value_point_data2.sample_ts_          = opentelemetry::common::SystemTimestamp{};
     opentelemetry::sdk::metrics::MetricData metric_data{
@@ -392,7 +392,7 @@ public:
     last_value_point_data.is_lastvalue_valid_ = true;
     last_value_point_data.sample_ts_          = opentelemetry::common::SystemTimestamp{};
     opentelemetry::sdk::metrics::LastValuePointData last_value_point_data2{};
-    last_value_point_data2.value_              = 20;
+    last_value_point_data2.value_              = (int64_t)20;
     last_value_point_data2.is_lastvalue_valid_ = true;
     last_value_point_data2.sample_ts_          = opentelemetry::common::SystemTimestamp{};
     opentelemetry::sdk::metrics::MetricData metric_data{
@@ -492,7 +492,7 @@ public:
     histogram_point_data2.boundaries_ = {10.0, 20.0, 30.0};
     histogram_point_data2.count_      = 3;
     histogram_point_data2.counts_     = {200, 300, 400, 500};
-    histogram_point_data2.sum_        = 900;
+    histogram_point_data2.sum_        = (int64_t)900;
 
     opentelemetry::sdk::metrics::MetricData metric_data{
         opentelemetry::sdk::metrics::InstrumentDescriptor{
@@ -627,7 +627,7 @@ public:
     histogram_point_data2.boundaries_ = {10.0, 20.0, 30.0};
     histogram_point_data2.count_      = 3;
     histogram_point_data2.counts_     = {200, 300, 400, 500};
-    histogram_point_data2.sum_        = 900;
+    histogram_point_data2.sum_        = (int64_t)900;
 
     opentelemetry::sdk::metrics::MetricData metric_data{
         opentelemetry::sdk::metrics::InstrumentDescriptor{

--- a/exporters/otlp/test/otlp_http_metric_exporter_test.cc
+++ b/exporters/otlp/test/otlp_http_metric_exporter_test.cc
@@ -296,7 +296,7 @@ public:
     last_value_point_data.is_lastvalue_valid_ = true;
     last_value_point_data.sample_ts_          = opentelemetry::common::SystemTimestamp{};
     opentelemetry::sdk::metrics::LastValuePointData last_value_point_data2{};
-    last_value_point_data2.value_              = 20l;
+    last_value_point_data2.value_              = (int64_t)20;
     last_value_point_data2.is_lastvalue_valid_ = true;
     last_value_point_data2.sample_ts_          = opentelemetry::common::SystemTimestamp{};
     opentelemetry::sdk::metrics::MetricData metric_data{
@@ -392,7 +392,7 @@ public:
     last_value_point_data.is_lastvalue_valid_ = true;
     last_value_point_data.sample_ts_          = opentelemetry::common::SystemTimestamp{};
     opentelemetry::sdk::metrics::LastValuePointData last_value_point_data2{};
-    last_value_point_data2.value_              = 20l;
+    last_value_point_data2.value_              = (int64_t)20;
     last_value_point_data2.is_lastvalue_valid_ = true;
     last_value_point_data2.sample_ts_          = opentelemetry::common::SystemTimestamp{};
     opentelemetry::sdk::metrics::MetricData metric_data{
@@ -492,7 +492,7 @@ public:
     histogram_point_data2.boundaries_ = {10.0, 20.0, 30.0};
     histogram_point_data2.count_      = 3;
     histogram_point_data2.counts_     = {200, 300, 400, 500};
-    histogram_point_data2.sum_        = 900l;
+    histogram_point_data2.sum_        = (int64_t)900;
 
     opentelemetry::sdk::metrics::MetricData metric_data{
         opentelemetry::sdk::metrics::InstrumentDescriptor{
@@ -627,7 +627,7 @@ public:
     histogram_point_data2.boundaries_ = {10.0, 20.0, 30.0};
     histogram_point_data2.count_      = 3;
     histogram_point_data2.counts_     = {200, 300, 400, 500};
-    histogram_point_data2.sum_        = 900l;
+    histogram_point_data2.sum_        = (int64_t)900;
 
     opentelemetry::sdk::metrics::MetricData metric_data{
         opentelemetry::sdk::metrics::InstrumentDescriptor{

--- a/exporters/otlp/test/otlp_http_metric_exporter_test.cc
+++ b/exporters/otlp/test/otlp_http_metric_exporter_test.cc
@@ -296,7 +296,7 @@ public:
     last_value_point_data.is_lastvalue_valid_ = true;
     last_value_point_data.sample_ts_          = opentelemetry::common::SystemTimestamp{};
     opentelemetry::sdk::metrics::LastValuePointData last_value_point_data2{};
-    last_value_point_data2.value_              = (int64_t)20;
+    last_value_point_data2.value_              = 20;
     last_value_point_data2.is_lastvalue_valid_ = true;
     last_value_point_data2.sample_ts_          = opentelemetry::common::SystemTimestamp{};
     opentelemetry::sdk::metrics::MetricData metric_data{
@@ -392,7 +392,7 @@ public:
     last_value_point_data.is_lastvalue_valid_ = true;
     last_value_point_data.sample_ts_          = opentelemetry::common::SystemTimestamp{};
     opentelemetry::sdk::metrics::LastValuePointData last_value_point_data2{};
-    last_value_point_data2.value_              = (int64_t)20;
+    last_value_point_data2.value_              = 20;
     last_value_point_data2.is_lastvalue_valid_ = true;
     last_value_point_data2.sample_ts_          = opentelemetry::common::SystemTimestamp{};
     opentelemetry::sdk::metrics::MetricData metric_data{
@@ -492,7 +492,7 @@ public:
     histogram_point_data2.boundaries_ = {10.0, 20.0, 30.0};
     histogram_point_data2.count_      = 3;
     histogram_point_data2.counts_     = {200, 300, 400, 500};
-    histogram_point_data2.sum_        = (int64_t)900;
+    histogram_point_data2.sum_        = 900;
 
     opentelemetry::sdk::metrics::MetricData metric_data{
         opentelemetry::sdk::metrics::InstrumentDescriptor{
@@ -627,7 +627,7 @@ public:
     histogram_point_data2.boundaries_ = {10.0, 20.0, 30.0};
     histogram_point_data2.count_      = 3;
     histogram_point_data2.counts_     = {200, 300, 400, 500};
-    histogram_point_data2.sum_        = (int64_t)900;
+    histogram_point_data2.sum_        = 900;
 
     opentelemetry::sdk::metrics::MetricData metric_data{
         opentelemetry::sdk::metrics::InstrumentDescriptor{

--- a/exporters/otlp/test/otlp_metrics_serialization_test.cc
+++ b/exporters/otlp/test/otlp_metrics_serialization_test.cc
@@ -78,7 +78,7 @@ static metrics_sdk::MetricData CreateHistogramAggregationData()
   return data;
 }
 
-static metrics_sdk::MetricData CreateUInt64ObservableGaugeAggregationData()
+static metrics_sdk::MetricData CreateObservableGaugeAggregationData()
 {
   metrics_sdk::MetricData data;
   data.start_ts = opentelemetry::common::SystemTimestamp(std::chrono::system_clock::now());
@@ -140,7 +140,7 @@ TEST(OtlpMetricSerializationTest, Histogram)
 
 TEST(OtlpMetricSerializationTest, ObservableGauge)
 {
-  metrics_sdk::MetricData data = CreateUInt64ObservableGaugeAggregationData();
+  metrics_sdk::MetricData data = CreateObservableGaugeAggregationData();
   opentelemetry::proto::metrics::v1::Gauge gauge;
   otlp_exporter::OtlpMetricUtils::ConvertGaugeMetric(data, &gauge);
   for (size_t i = 0; i < 1; i++)

--- a/exporters/otlp/test/otlp_metrics_serialization_test.cc
+++ b/exporters/otlp/test/otlp_metrics_serialization_test.cc
@@ -78,7 +78,7 @@ static metrics_sdk::MetricData CreateHistogramAggregationData()
   return data;
 }
 
-static metrics_sdk::MetricData CreateObservableGaugeAggregationData()
+static metrics_sdk::MetricData CreateUInt64ObservableGaugeAggregationData()
 {
   metrics_sdk::MetricData data;
   data.start_ts = opentelemetry::common::SystemTimestamp(std::chrono::system_clock::now());
@@ -140,7 +140,7 @@ TEST(OtlpMetricSerializationTest, Histogram)
 
 TEST(OtlpMetricSerializationTest, ObservableGauge)
 {
-  metrics_sdk::MetricData data = CreateObservableGaugeAggregationData();
+  metrics_sdk::MetricData data = CreateUInt64ObservableGaugeAggregationData();
   opentelemetry::proto::metrics::v1::Gauge gauge;
   otlp_exporter::OtlpMetricUtils::ConvertGaugeMetric(data, &gauge);
   for (size_t i = 0; i < 1; i++)

--- a/exporters/prometheus/src/exporter_utils.cc
+++ b/exporters/prometheus/src/exporter_utils.cc
@@ -70,7 +70,7 @@ std::vector<prometheus_client::MetricFamily> PrometheusExporterUtils::TranslateT
             }
             else
             {
-              sum = nostd::get<long>(histogram_point_data.sum_);
+              sum = nostd::get<int64_t>(histogram_point_data.sum_);
             }
             SetData(std::vector<double>{sum, (double)histogram_point_data.count_}, boundaries,
                     counts, point_data_attr.attributes, time, &metric_family);
@@ -283,9 +283,9 @@ void PrometheusExporterUtils::SetValue(std::vector<T> values,
 {
   double value          = 0.0;
   const auto &value_var = values[0];
-  if (nostd::holds_alternative<long>(value_var))
+  if (nostd::holds_alternative<int64_t>(value_var))
   {
-    value = nostd::get<long>(value_var);
+    value = nostd::get<int64_t>(value_var);
   }
   else
   {

--- a/exporters/prometheus/test/prometheus_test_helper.h
+++ b/exporters/prometheus/test/prometheus_test_helper.h
@@ -54,7 +54,7 @@ inline metric_sdk::ResourceMetrics CreateHistogramPointData()
   histogram_point_data2.boundaries_ = {10.0, 20.0, 30.0};
   histogram_point_data2.count_      = 3;
   histogram_point_data2.counts_     = {200, 300, 400, 500};
-  histogram_point_data2.sum_        = 900l;
+  histogram_point_data2.sum_        = (int64_t)900;
   metric_sdk::ResourceMetrics data;
   auto resource = opentelemetry::sdk::resource::Resource::Create(
       opentelemetry::sdk::resource::ResourceAttributes{});
@@ -90,7 +90,7 @@ inline metric_sdk::ResourceMetrics CreateLastValuePointData()
   last_value_point_data.is_lastvalue_valid_ = true;
   last_value_point_data.sample_ts_          = opentelemetry::common::SystemTimestamp{};
   metric_sdk::LastValuePointData last_value_point_data2{};
-  last_value_point_data2.value_              = 20l;
+  last_value_point_data2.value_              = (int64_t)20;
   last_value_point_data2.is_lastvalue_valid_ = true;
   last_value_point_data2.sample_ts_          = opentelemetry::common::SystemTimestamp{};
   metric_sdk::MetricData metric_data{

--- a/exporters/prometheus/test/prometheus_test_helper.h
+++ b/exporters/prometheus/test/prometheus_test_helper.h
@@ -54,7 +54,7 @@ inline metric_sdk::ResourceMetrics CreateHistogramPointData()
   histogram_point_data2.boundaries_ = {10.0, 20.0, 30.0};
   histogram_point_data2.count_      = 3;
   histogram_point_data2.counts_     = {200, 300, 400, 500};
-  histogram_point_data2.sum_        = 900;
+  histogram_point_data2.sum_        = (int64_t)900;
   metric_sdk::ResourceMetrics data;
   auto resource = opentelemetry::sdk::resource::Resource::Create(
       opentelemetry::sdk::resource::ResourceAttributes{});

--- a/exporters/prometheus/test/prometheus_test_helper.h
+++ b/exporters/prometheus/test/prometheus_test_helper.h
@@ -54,7 +54,7 @@ inline metric_sdk::ResourceMetrics CreateHistogramPointData()
   histogram_point_data2.boundaries_ = {10.0, 20.0, 30.0};
   histogram_point_data2.count_      = 3;
   histogram_point_data2.counts_     = {200, 300, 400, 500};
-  histogram_point_data2.sum_        = (int64_t)900;
+  histogram_point_data2.sum_        = 900;
   metric_sdk::ResourceMetrics data;
   auto resource = opentelemetry::sdk::resource::Resource::Create(
       opentelemetry::sdk::resource::ResourceAttributes{});
@@ -90,7 +90,7 @@ inline metric_sdk::ResourceMetrics CreateLastValuePointData()
   last_value_point_data.is_lastvalue_valid_ = true;
   last_value_point_data.sample_ts_          = opentelemetry::common::SystemTimestamp{};
   metric_sdk::LastValuePointData last_value_point_data2{};
-  last_value_point_data2.value_              = (int64_t)20;
+  last_value_point_data2.value_              = 20;
   last_value_point_data2.is_lastvalue_valid_ = true;
   last_value_point_data2.sample_ts_          = opentelemetry::common::SystemTimestamp{};
   metric_sdk::MetricData metric_data{

--- a/exporters/prometheus/test/prometheus_test_helper.h
+++ b/exporters/prometheus/test/prometheus_test_helper.h
@@ -90,7 +90,7 @@ inline metric_sdk::ResourceMetrics CreateLastValuePointData()
   last_value_point_data.is_lastvalue_valid_ = true;
   last_value_point_data.sample_ts_          = opentelemetry::common::SystemTimestamp{};
   metric_sdk::LastValuePointData last_value_point_data2{};
-  last_value_point_data2.value_              = 20;
+  last_value_point_data2.value_              = (int64_t)20;
   last_value_point_data2.is_lastvalue_valid_ = true;
   last_value_point_data2.sample_ts_          = opentelemetry::common::SystemTimestamp{};
   metric_sdk::MetricData metric_data{

--- a/sdk/include/opentelemetry/sdk/metrics/aggregation/aggregation.h
+++ b/sdk/include/opentelemetry/sdk/metrics/aggregation/aggregation.h
@@ -14,7 +14,7 @@ namespace metrics
 class Aggregation
 {
 public:
-  virtual void Aggregate(long value, const PointAttributes &attributes = {}) noexcept = 0;
+  virtual void Aggregate(int64_t value, const PointAttributes &attributes = {}) noexcept = 0;
 
   virtual void Aggregate(double value, const PointAttributes &attributes = {}) noexcept = 0;
 

--- a/sdk/include/opentelemetry/sdk/metrics/aggregation/default_aggregation.h
+++ b/sdk/include/opentelemetry/sdk/metrics/aggregation/default_aggregation.h
@@ -42,9 +42,8 @@ public:
       case InstrumentType::kHistogram: {
         return (instrument_descriptor.value_type_ == InstrumentValueType::kLong)
                    ? std::move(std::unique_ptr<Aggregation>(new LongHistogramAggregation(
-                         static_cast<
-                             const opentelemetry::sdk::metrics::HistogramAggregationConfig<long> *>(
-                             aggregation_config))))
+                         static_cast<const opentelemetry::sdk::metrics::HistogramAggregationConfig<
+                             int64_t> *>(aggregation_config))))
                    : std::move(std::unique_ptr<Aggregation>(new DoubleHistogramAggregation(
                          static_cast<const opentelemetry::sdk::metrics::HistogramAggregationConfig<
                              double> *>(aggregation_config))));

--- a/sdk/include/opentelemetry/sdk/metrics/aggregation/drop_aggregation.h
+++ b/sdk/include/opentelemetry/sdk/metrics/aggregation/drop_aggregation.h
@@ -25,7 +25,7 @@ public:
 
   DropAggregation(const DropPointData &) {}
 
-  void Aggregate(long /* value */, const PointAttributes & /* attributes */) noexcept override {}
+  void Aggregate(int64_t /* value */, const PointAttributes & /* attributes */) noexcept override {}
 
   void Aggregate(double /* value */, const PointAttributes & /* attributes */) noexcept override {}
 

--- a/sdk/include/opentelemetry/sdk/metrics/aggregation/histogram_aggregation.h
+++ b/sdk/include/opentelemetry/sdk/metrics/aggregation/histogram_aggregation.h
@@ -18,11 +18,11 @@ namespace metrics
 class LongHistogramAggregation : public Aggregation
 {
 public:
-  LongHistogramAggregation(const HistogramAggregationConfig<long> *aggregation_config = nullptr);
+  LongHistogramAggregation(const HistogramAggregationConfig<int64_t> *aggregation_config = nullptr);
   LongHistogramAggregation(HistogramPointData &&);
   LongHistogramAggregation(const HistogramPointData &);
 
-  void Aggregate(long value, const PointAttributes &attributes = {}) noexcept override;
+  void Aggregate(int64_t value, const PointAttributes &attributes = {}) noexcept override;
 
   void Aggregate(double /* value */, const PointAttributes & /* attributes */) noexcept override {}
 
@@ -53,7 +53,7 @@ public:
   DoubleHistogramAggregation(HistogramPointData &&);
   DoubleHistogramAggregation(const HistogramPointData &);
 
-  void Aggregate(long /* value */, const PointAttributes & /* attributes */) noexcept override {}
+  void Aggregate(int64_t /* value */, const PointAttributes & /* attributes */) noexcept override {}
 
   void Aggregate(double value, const PointAttributes &attributes = {}) noexcept override;
 

--- a/sdk/include/opentelemetry/sdk/metrics/aggregation/lastvalue_aggregation.h
+++ b/sdk/include/opentelemetry/sdk/metrics/aggregation/lastvalue_aggregation.h
@@ -20,7 +20,7 @@ public:
   LongLastValueAggregation(LastValuePointData &&);
   LongLastValueAggregation(const LastValuePointData &);
 
-  void Aggregate(long value, const PointAttributes &attributes = {}) noexcept override;
+  void Aggregate(int64_t value, const PointAttributes &attributes = {}) noexcept override;
 
   void Aggregate(double /* value */, const PointAttributes & /* attributes */) noexcept override {}
 
@@ -42,7 +42,7 @@ public:
   DoubleLastValueAggregation(LastValuePointData &&);
   DoubleLastValueAggregation(const LastValuePointData &);
 
-  void Aggregate(long /* value */, const PointAttributes & /* attributes */) noexcept override {}
+  void Aggregate(int64_t /* value */, const PointAttributes & /* attributes */) noexcept override {}
 
   void Aggregate(double value, const PointAttributes &attributes = {}) noexcept override;
 

--- a/sdk/include/opentelemetry/sdk/metrics/aggregation/sum_aggregation.h
+++ b/sdk/include/opentelemetry/sdk/metrics/aggregation/sum_aggregation.h
@@ -21,7 +21,7 @@ public:
   LongSumAggregation(SumPointData &&);
   LongSumAggregation(const SumPointData &);
 
-  void Aggregate(long value, const PointAttributes &attributes = {}) noexcept override;
+  void Aggregate(int64_t value, const PointAttributes &attributes = {}) noexcept override;
 
   void Aggregate(double /* value */, const PointAttributes & /* attributes */) noexcept override {}
 
@@ -43,7 +43,7 @@ public:
   DoubleSumAggregation(SumPointData &&);
   DoubleSumAggregation(const SumPointData &);
 
-  void Aggregate(long /* value */, const PointAttributes & /* attributes */) noexcept override {}
+  void Aggregate(int64_t /* value */, const PointAttributes & /* attributes */) noexcept override {}
 
   void Aggregate(double value, const PointAttributes &attributes = {}) noexcept override;
 

--- a/sdk/include/opentelemetry/sdk/metrics/data/point_data.h
+++ b/sdk/include/opentelemetry/sdk/metrics/data/point_data.h
@@ -16,7 +16,7 @@ namespace sdk
 namespace metrics
 {
 
-using ValueType = nostd::variant<long, double>;
+using ValueType = nostd::variant<int64_t, double>;
 
 // TODO: remove ctors and initializers from below classes when GCC<5 stops shipping on Ubuntu
 

--- a/sdk/include/opentelemetry/sdk/metrics/exemplar/always_sample_filter.h
+++ b/sdk/include/opentelemetry/sdk/metrics/exemplar/always_sample_filter.h
@@ -15,7 +15,7 @@ class AlwaysSampleFilter final : public ExemplarFilter
 {
 public:
   bool ShouldSampleMeasurement(
-      long /* value */,
+      int64_t /* value */,
       const MetricAttributes & /* attributes */,
       const opentelemetry::context::Context & /* context */) noexcept override
   {

--- a/sdk/include/opentelemetry/sdk/metrics/exemplar/filter.h
+++ b/sdk/include/opentelemetry/sdk/metrics/exemplar/filter.h
@@ -21,7 +21,7 @@ class ExemplarFilter
 {
 public:
   // Returns whether or not a reservoir should attempt to filter a measurement.
-  virtual bool ShouldSampleMeasurement(long value,
+  virtual bool ShouldSampleMeasurement(int64_t value,
                                        const MetricAttributes &attributes,
                                        const opentelemetry::context::Context &context) noexcept = 0;
 

--- a/sdk/include/opentelemetry/sdk/metrics/exemplar/filtered_exemplar_reservoir.h
+++ b/sdk/include/opentelemetry/sdk/metrics/exemplar/filtered_exemplar_reservoir.h
@@ -25,7 +25,7 @@ public:
       : filter_(filter), reservoir_(reservoir)
   {}
 
-  void OfferMeasurement(long value,
+  void OfferMeasurement(int64_t value,
                         const MetricAttributes &attributes,
                         const opentelemetry::context::Context &context,
                         const opentelemetry::common::SystemTimestamp &timestamp) noexcept override

--- a/sdk/include/opentelemetry/sdk/metrics/exemplar/fixed_size_exemplar_reservoir.h
+++ b/sdk/include/opentelemetry/sdk/metrics/exemplar/fixed_size_exemplar_reservoir.h
@@ -46,7 +46,7 @@ public:
         reservoir_cell_selector_->ReservoirCellIndexFor(storage_, value, attributes, context);
     if (idx != -1)
     {
-      storage_[idx].RecordDoubleMeasurement(value, attributes, context);
+      storage_[idx].RecordLongMeasurement(value, attributes, context);
     }
   }
 

--- a/sdk/include/opentelemetry/sdk/metrics/exemplar/fixed_size_exemplar_reservoir.h
+++ b/sdk/include/opentelemetry/sdk/metrics/exemplar/fixed_size_exemplar_reservoir.h
@@ -33,7 +33,7 @@ public:
   {}
 
   void OfferMeasurement(
-      long value,
+      int64_t value,
       const MetricAttributes &attributes,
       const opentelemetry::context::Context &context,
       const opentelemetry::common::SystemTimestamp & /* timestamp */) noexcept override

--- a/sdk/include/opentelemetry/sdk/metrics/exemplar/histogram_exemplar_reservoir.h
+++ b/sdk/include/opentelemetry/sdk/metrics/exemplar/histogram_exemplar_reservoir.h
@@ -43,7 +43,7 @@ public:
     HistogramCellSelector(const std::vector<double> &boundaries) : boundaries_(boundaries) {}
 
     int ReservoirCellIndexFor(const std::vector<ReservoirCell> &cells,
-                              long value,
+                              int64_t value,
                               const MetricAttributes &attributes,
                               const opentelemetry::context::Context &context) override
     {

--- a/sdk/include/opentelemetry/sdk/metrics/exemplar/never_sample_filter.h
+++ b/sdk/include/opentelemetry/sdk/metrics/exemplar/never_sample_filter.h
@@ -15,7 +15,7 @@ class NeverSampleFilter final : public ExemplarFilter
 {
 public:
   bool ShouldSampleMeasurement(
-      long /* value */,
+      int64_t /* value */,
       const MetricAttributes & /* attributes */,
       const opentelemetry::context::Context & /* context */) noexcept override
   {

--- a/sdk/include/opentelemetry/sdk/metrics/exemplar/no_exemplar_reservoir.h
+++ b/sdk/include/opentelemetry/sdk/metrics/exemplar/no_exemplar_reservoir.h
@@ -19,7 +19,7 @@ class NoExemplarReservoir final : public ExemplarReservoir
 
 public:
   void OfferMeasurement(
-      long /* value */,
+      int64_t /* value */,
       const MetricAttributes & /* attributes */,
       const opentelemetry::context::Context & /* context */,
       const opentelemetry::common::SystemTimestamp & /* timestamp */) noexcept override

--- a/sdk/include/opentelemetry/sdk/metrics/exemplar/reservoir.h
+++ b/sdk/include/opentelemetry/sdk/metrics/exemplar/reservoir.h
@@ -25,7 +25,7 @@ public:
 
   /** Offers a long measurement to be sampled. */
   virtual void OfferMeasurement(
-      long value,
+      int64_t value,
       const MetricAttributes &attributes,
       const opentelemetry::context::Context &context,
       const opentelemetry::common::SystemTimestamp &timestamp) noexcept = 0;

--- a/sdk/include/opentelemetry/sdk/metrics/exemplar/reservoir_cell.h
+++ b/sdk/include/opentelemetry/sdk/metrics/exemplar/reservoir_cell.h
@@ -30,7 +30,7 @@ public:
   /**
    * Record the long measurement to the cell.
    */
-  void RecordLongMeasurement(long value,
+  void RecordLongMeasurement(int64_t value,
                              const MetricAttributes &attributes,
                              const opentelemetry::context::Context &context)
   {
@@ -63,7 +63,7 @@ public:
     auto attributes = attributes_;
     PointDataAttributes point_data_attributes;
     point_data_attributes.attributes = filtered(attributes, point_attributes);
-    if (nostd::holds_alternative<long>(value_))
+    if (nostd::holds_alternative<int64_t>(value_))
     {
       point_data_attributes.point_data = ExemplarData::CreateSumPointData(nostd::get<long>(value_));
     }
@@ -139,7 +139,7 @@ private:
 
   // Cell stores either long or double values, but must not store both
   std::shared_ptr<trace::SpanContext> context_;
-  nostd::variant<long, double> value_;
+  nostd::variant<int64_t, double> value_;
   opentelemetry::common::SystemTimestamp record_time_;
   MetricAttributes attributes_;
   // For testing

--- a/sdk/include/opentelemetry/sdk/metrics/exemplar/reservoir_cell.h
+++ b/sdk/include/opentelemetry/sdk/metrics/exemplar/reservoir_cell.h
@@ -52,7 +52,7 @@ public:
   /**
    * Retrieve the cell's {@link ExemplarData}.
    *
-   * <p>Must be used in tandem with {@link #recordLongMeasurement(long, Attributes, Context)}.
+   * <p>Must be used in tandem with {@link #recordLongMeasurement(int64_t, Attributes, Context)}.
    */
   std::shared_ptr<ExemplarData> GetAndResetLong(const MetricAttributes &point_attributes)
   {
@@ -65,7 +65,7 @@ public:
     point_data_attributes.attributes = filtered(attributes, point_attributes);
     if (nostd::holds_alternative<int64_t>(value_))
     {
-      point_data_attributes.point_data = ExemplarData::CreateSumPointData(nostd::get<long>(value_));
+      point_data_attributes.point_data = ExemplarData::CreateSumPointData(nostd::get<int64_t>(value_));
     }
     std::shared_ptr<ExemplarData> result{
         new ExemplarData{ExemplarData::Create(context_, record_time_, point_data_attributes)}};

--- a/sdk/include/opentelemetry/sdk/metrics/exemplar/reservoir_cell.h
+++ b/sdk/include/opentelemetry/sdk/metrics/exemplar/reservoir_cell.h
@@ -65,7 +65,8 @@ public:
     point_data_attributes.attributes = filtered(attributes, point_attributes);
     if (nostd::holds_alternative<int64_t>(value_))
     {
-      point_data_attributes.point_data = ExemplarData::CreateSumPointData(nostd::get<int64_t>(value_));
+      point_data_attributes.point_data =
+          ExemplarData::CreateSumPointData(nostd::get<int64_t>(value_));
     }
     std::shared_ptr<ExemplarData> result{
         new ExemplarData{ExemplarData::Create(context_, record_time_, point_data_attributes)}};

--- a/sdk/include/opentelemetry/sdk/metrics/exemplar/reservoir_cell_selector.h
+++ b/sdk/include/opentelemetry/sdk/metrics/exemplar/reservoir_cell_selector.h
@@ -24,7 +24,7 @@ public:
 
   /** Determine the index of the {@code cells} to record the measurement to. */
   virtual int ReservoirCellIndexFor(const std::vector<ReservoirCell> &cells,
-                                    long value,
+                                    int64_t value,
                                     const MetricAttributes &attributes,
                                     const opentelemetry::context::Context &context) = 0;
 

--- a/sdk/include/opentelemetry/sdk/metrics/exemplar/with_trace_sample_filter.h
+++ b/sdk/include/opentelemetry/sdk/metrics/exemplar/with_trace_sample_filter.h
@@ -15,7 +15,7 @@ namespace metrics
 class WithTraceSampleFilter final : public ExemplarFilter
 {
 public:
-  bool ShouldSampleMeasurement(long /* value */,
+  bool ShouldSampleMeasurement(int64_t /* value */,
                                const MetricAttributes & /* attributes */,
                                const opentelemetry::context::Context &context) noexcept override
   {

--- a/sdk/include/opentelemetry/sdk/metrics/meter.h
+++ b/sdk/include/opentelemetry/sdk/metrics/meter.h
@@ -35,7 +35,7 @@ public:
       std::unique_ptr<opentelemetry::sdk::instrumentationscope::InstrumentationScope> scope =
           opentelemetry::sdk::instrumentationscope::InstrumentationScope::Create("")) noexcept;
 
-  nostd::shared_ptr<opentelemetry::metrics::Counter<int64_t>> CreateInt64Counter(
+  nostd::shared_ptr<opentelemetry::metrics::Counter<uint64_t>> CreateUInt64Counter(
       nostd::string_view name,
       nostd::string_view description = "",
       nostd::string_view unit        = "") noexcept override;
@@ -45,7 +45,7 @@ public:
       nostd::string_view description = "",
       nostd::string_view unit        = "") noexcept override;
 
-  nostd::shared_ptr<opentelemetry::metrics::ObservableInstrument> CreateLongObservableCounter(
+  nostd::shared_ptr<opentelemetry::metrics::ObservableInstrument> CreateUInt64ObservableCounter(
       nostd::string_view name,
       nostd::string_view description = "",
       nostd::string_view unit        = "") noexcept override;
@@ -55,7 +55,7 @@ public:
       nostd::string_view description = "",
       nostd::string_view unit        = "") noexcept override;
 
-  nostd::shared_ptr<opentelemetry::metrics::Histogram<int64_t>> CreateLongHistogram(
+  nostd::shared_ptr<opentelemetry::metrics::Histogram<uint64_t>> CreateUInt64Histogram(
       nostd::string_view name,
       nostd::string_view description = "",
       nostd::string_view unit        = "") noexcept override;
@@ -65,7 +65,7 @@ public:
       nostd::string_view description = "",
       nostd::string_view unit        = "") noexcept override;
 
-  nostd::shared_ptr<opentelemetry::metrics::ObservableInstrument> CreateLongObservableGauge(
+  nostd::shared_ptr<opentelemetry::metrics::ObservableInstrument> CreateUInt64ObservableGauge(
       nostd::string_view name,
       nostd::string_view description = "",
       nostd::string_view unit        = "") noexcept override;
@@ -75,7 +75,7 @@ public:
       nostd::string_view description = "",
       nostd::string_view unit        = "") noexcept override;
 
-  nostd::shared_ptr<opentelemetry::metrics::UpDownCounter<int64_t>> CreateLongUpDownCounter(
+  nostd::shared_ptr<opentelemetry::metrics::UpDownCounter<int64_t>> CreateInt64UpDownCounter(
       nostd::string_view name,
       nostd::string_view description = "",
       nostd::string_view unit        = "") noexcept override;
@@ -85,10 +85,10 @@ public:
       nostd::string_view description = "",
       nostd::string_view unit        = "") noexcept override;
 
-  nostd::shared_ptr<opentelemetry::metrics::ObservableInstrument> CreateLongObservableUpDownCounter(
-      nostd::string_view name,
-      nostd::string_view description = "",
-      nostd::string_view unit        = "") noexcept override;
+  nostd::shared_ptr<opentelemetry::metrics::ObservableInstrument>
+  CreateInt64ObservableUpDownCounter(nostd::string_view name,
+                                     nostd::string_view description = "",
+                                     nostd::string_view unit        = "") noexcept override;
 
   nostd::shared_ptr<opentelemetry::metrics::ObservableInstrument>
   CreateDoubleObservableUpDownCounter(nostd::string_view name,

--- a/sdk/include/opentelemetry/sdk/metrics/meter.h
+++ b/sdk/include/opentelemetry/sdk/metrics/meter.h
@@ -65,7 +65,7 @@ public:
       nostd::string_view description = "",
       nostd::string_view unit        = "") noexcept override;
 
-  nostd::shared_ptr<opentelemetry::metrics::ObservableInstrument> CreateUInt64ObservableGauge(
+  nostd::shared_ptr<opentelemetry::metrics::ObservableInstrument> CreateInt64ObservableGauge(
       nostd::string_view name,
       nostd::string_view description = "",
       nostd::string_view unit        = "") noexcept override;

--- a/sdk/include/opentelemetry/sdk/metrics/meter.h
+++ b/sdk/include/opentelemetry/sdk/metrics/meter.h
@@ -35,7 +35,7 @@ public:
       std::unique_ptr<opentelemetry::sdk::instrumentationscope::InstrumentationScope> scope =
           opentelemetry::sdk::instrumentationscope::InstrumentationScope::Create("")) noexcept;
 
-  nostd::shared_ptr<opentelemetry::metrics::Counter<long>> CreateLongCounter(
+  nostd::shared_ptr<opentelemetry::metrics::Counter<int64_t>> CreateLongCounter(
       nostd::string_view name,
       nostd::string_view description = "",
       nostd::string_view unit        = "") noexcept override;
@@ -55,7 +55,7 @@ public:
       nostd::string_view description = "",
       nostd::string_view unit        = "") noexcept override;
 
-  nostd::shared_ptr<opentelemetry::metrics::Histogram<long>> CreateLongHistogram(
+  nostd::shared_ptr<opentelemetry::metrics::Histogram<int64_t>> CreateLongHistogram(
       nostd::string_view name,
       nostd::string_view description = "",
       nostd::string_view unit        = "") noexcept override;
@@ -75,7 +75,7 @@ public:
       nostd::string_view description = "",
       nostd::string_view unit        = "") noexcept override;
 
-  nostd::shared_ptr<opentelemetry::metrics::UpDownCounter<long>> CreateLongUpDownCounter(
+  nostd::shared_ptr<opentelemetry::metrics::UpDownCounter<int64_t>> CreateLongUpDownCounter(
       nostd::string_view name,
       nostd::string_view description = "",
       nostd::string_view unit        = "") noexcept override;

--- a/sdk/include/opentelemetry/sdk/metrics/meter.h
+++ b/sdk/include/opentelemetry/sdk/metrics/meter.h
@@ -45,7 +45,7 @@ public:
       nostd::string_view description = "",
       nostd::string_view unit        = "") noexcept override;
 
-  nostd::shared_ptr<opentelemetry::metrics::ObservableInstrument> CreateUInt64ObservableCounter(
+  nostd::shared_ptr<opentelemetry::metrics::ObservableInstrument> CreateInt64ObservableCounter(
       nostd::string_view name,
       nostd::string_view description = "",
       nostd::string_view unit        = "") noexcept override;

--- a/sdk/include/opentelemetry/sdk/metrics/meter.h
+++ b/sdk/include/opentelemetry/sdk/metrics/meter.h
@@ -35,7 +35,7 @@ public:
       std::unique_ptr<opentelemetry::sdk::instrumentationscope::InstrumentationScope> scope =
           opentelemetry::sdk::instrumentationscope::InstrumentationScope::Create("")) noexcept;
 
-  nostd::shared_ptr<opentelemetry::metrics::Counter<int64_t>> CreateLongCounter(
+  nostd::shared_ptr<opentelemetry::metrics::Counter<int64_t>> CreateInt64Counter(
       nostd::string_view name,
       nostd::string_view description = "",
       nostd::string_view unit        = "") noexcept override;

--- a/sdk/include/opentelemetry/sdk/metrics/state/async_metric_storage.h
+++ b/sdk/include/opentelemetry/sdk/metrics/state/async_metric_storage.h
@@ -72,14 +72,14 @@ public:
   }
 
   void RecordLong(
-      const std::unordered_map<MetricAttributes, long, AttributeHashGenerator> &measurements,
+      const std::unordered_map<MetricAttributes, int64_t, AttributeHashGenerator> &measurements,
       opentelemetry::common::SystemTimestamp observation_time) noexcept override
   {
     if (instrument_descriptor_.value_type_ != InstrumentValueType::kLong)
     {
       return;
     }
-    Record<long>(measurements, observation_time);
+    Record<int64_t>(measurements, observation_time);
   }
 
   void RecordDouble(

--- a/sdk/include/opentelemetry/sdk/metrics/state/metric_storage.h
+++ b/sdk/include/opentelemetry/sdk/metrics/state/metric_storage.h
@@ -37,9 +37,10 @@ public:
 class SyncWritableMetricStorage
 {
 public:
-  virtual void RecordLong(long value, const opentelemetry::context::Context &context) noexcept = 0;
+  virtual void RecordLong(int64_t value,
+                          const opentelemetry::context::Context &context) noexcept = 0;
 
-  virtual void RecordLong(long value,
+  virtual void RecordLong(int64_t value,
                           const opentelemetry::common::KeyValueIterable &attributes,
                           const opentelemetry::context::Context &context) noexcept = 0;
 
@@ -62,7 +63,7 @@ public:
 
   /* Records a batch of measurements */
   virtual void RecordLong(
-      const std::unordered_map<MetricAttributes, long, AttributeHashGenerator> &measurements,
+      const std::unordered_map<MetricAttributes, int64_t, AttributeHashGenerator> &measurements,
       opentelemetry::common::SystemTimestamp observation_time) noexcept = 0;
 
   virtual void RecordDouble(
@@ -87,9 +88,10 @@ public:
 class NoopWritableMetricStorage : public SyncWritableMetricStorage
 {
 public:
-  void RecordLong(long value, const opentelemetry::context::Context &context) noexcept override = 0;
+  void RecordLong(int64_t value,
+                  const opentelemetry::context::Context &context) noexcept override = 0;
 
-  void RecordLong(long /* value */,
+  void RecordLong(int64_t /* value */,
                   const opentelemetry::common::KeyValueIterable & /* attributes */,
                   const opentelemetry::context::Context & /* context */) noexcept override
   {}
@@ -107,9 +109,9 @@ public:
 class NoopAsyncWritableMetricStorage : public AsyncWritableMetricStorage
 {
 public:
-  void RecordLong(
-      const std::unordered_map<MetricAttributes, long, AttributeHashGenerator> & /* measurements */,
-      opentelemetry::common::SystemTimestamp /* observation_time */) noexcept override
+  void RecordLong(const std::unordered_map<MetricAttributes, int64_t, AttributeHashGenerator>
+                      & /* measurements */,
+                  opentelemetry::common::SystemTimestamp /* observation_time */) noexcept override
   {}
 
   void RecordDouble(const std::unordered_map<MetricAttributes, double, AttributeHashGenerator>

--- a/sdk/include/opentelemetry/sdk/metrics/state/multi_metric_storage.h
+++ b/sdk/include/opentelemetry/sdk/metrics/state/multi_metric_storage.h
@@ -23,7 +23,7 @@ public:
     storages_.push_back(storage);
   }
 
-  virtual void RecordLong(long value,
+  virtual void RecordLong(int64_t value,
                           const opentelemetry::context::Context &context) noexcept override
   {
     for (auto &s : storages_)
@@ -32,7 +32,7 @@ public:
     }
   }
 
-  virtual void RecordLong(long value,
+  virtual void RecordLong(int64_t value,
                           const opentelemetry::common::KeyValueIterable &attributes,
                           const opentelemetry::context::Context &context) noexcept override
   {
@@ -74,7 +74,7 @@ public:
   }
 
   void RecordLong(
-      const std::unordered_map<MetricAttributes, long, AttributeHashGenerator> &measurements,
+      const std::unordered_map<MetricAttributes, int64_t, AttributeHashGenerator> &measurements,
       opentelemetry::common::SystemTimestamp observation_time) noexcept override
   {
     for (auto &s : storages_)

--- a/sdk/include/opentelemetry/sdk/metrics/state/sync_metric_storage.h
+++ b/sdk/include/opentelemetry/sdk/metrics/state/sync_metric_storage.h
@@ -45,7 +45,7 @@ public:
     };
   }
 
-  void RecordLong(long value, const opentelemetry::context::Context &context) noexcept override
+  void RecordLong(int64_t value, const opentelemetry::context::Context &context) noexcept override
   {
     if (instrument_descriptor_.value_type_ != InstrumentValueType::kLong)
     {
@@ -56,7 +56,7 @@ public:
     attributes_hashmap_->GetOrSetDefault({}, create_default_aggregation_)->Aggregate(value);
   }
 
-  void RecordLong(long value,
+  void RecordLong(int64_t value,
                   const opentelemetry::common::KeyValueIterable &attributes,
                   const opentelemetry::context::Context &context) noexcept override
   {

--- a/sdk/include/opentelemetry/sdk/metrics/sync_instruments.h
+++ b/sdk/include/opentelemetry/sdk/metrics/sync_instruments.h
@@ -32,19 +32,20 @@ protected:
   std::unique_ptr<SyncWritableMetricStorage> storage_;
 };
 
-class LongCounter : public Synchronous, public opentelemetry::metrics::Counter<long>
+class LongCounter : public Synchronous, public opentelemetry::metrics::Counter<int64_t>
 {
 public:
   LongCounter(InstrumentDescriptor instrument_descriptor,
               std::unique_ptr<SyncWritableMetricStorage> storage);
 
-  void Add(long value, const opentelemetry::common::KeyValueIterable &attributes) noexcept override;
-  void Add(long value,
+  void Add(int64_t value,
+           const opentelemetry::common::KeyValueIterable &attributes) noexcept override;
+  void Add(int64_t value,
            const opentelemetry::common::KeyValueIterable &attributes,
            const opentelemetry::context::Context &context) noexcept override;
 
-  void Add(long value) noexcept override;
-  void Add(long value, const opentelemetry::context::Context &context) noexcept override;
+  void Add(int64_t value) noexcept override;
+  void Add(int64_t value, const opentelemetry::context::Context &context) noexcept override;
 };
 
 class DoubleCounter : public Synchronous, public opentelemetry::metrics::Counter<double>
@@ -64,19 +65,20 @@ public:
   void Add(double value, const opentelemetry::context::Context &context) noexcept override;
 };
 
-class LongUpDownCounter : public Synchronous, public opentelemetry::metrics::UpDownCounter<long>
+class LongUpDownCounter : public Synchronous, public opentelemetry::metrics::UpDownCounter<int64_t>
 {
 public:
   LongUpDownCounter(InstrumentDescriptor instrument_descriptor,
                     std::unique_ptr<SyncWritableMetricStorage> storage);
 
-  void Add(long value, const opentelemetry::common::KeyValueIterable &attributes) noexcept override;
-  void Add(long value,
+  void Add(int64_t value,
+           const opentelemetry::common::KeyValueIterable &attributes) noexcept override;
+  void Add(int64_t value,
            const opentelemetry::common::KeyValueIterable &attributes,
            const opentelemetry::context::Context &context) noexcept override;
 
-  void Add(long value) noexcept override;
-  void Add(long value, const opentelemetry::context::Context &context) noexcept override;
+  void Add(int64_t value) noexcept override;
+  void Add(int64_t value, const opentelemetry::context::Context &context) noexcept override;
 };
 
 class DoubleUpDownCounter : public Synchronous, public opentelemetry::metrics::UpDownCounter<double>
@@ -95,17 +97,17 @@ public:
   void Add(double value, const opentelemetry::context::Context &context) noexcept override;
 };
 
-class LongHistogram : public Synchronous, public opentelemetry::metrics::Histogram<long>
+class LongHistogram : public Synchronous, public opentelemetry::metrics::Histogram<int64_t>
 {
 public:
   LongHistogram(InstrumentDescriptor instrument_descriptor,
                 std::unique_ptr<SyncWritableMetricStorage> storage);
 
-  void Record(long value,
+  void Record(int64_t value,
               const opentelemetry::common::KeyValueIterable &attributes,
               const opentelemetry::context::Context &context) noexcept override;
 
-  void Record(long value, const opentelemetry::context::Context &context) noexcept override;
+  void Record(int64_t value, const opentelemetry::context::Context &context) noexcept override;
 };
 
 class DoubleHistogram : public Synchronous, public opentelemetry::metrics::Histogram<double>

--- a/sdk/include/opentelemetry/sdk/metrics/sync_instruments.h
+++ b/sdk/include/opentelemetry/sdk/metrics/sync_instruments.h
@@ -50,7 +50,7 @@ public:
     }
   }
 
-  void Add(T value, const opentelemetry::common::KeyValueIterable &attributes) noexcept
+  void Add(T value, const opentelemetry::common::KeyValueIterable &attributes) noexcept override
   {
     if (!storage_)
     {
@@ -62,7 +62,7 @@ public:
 
   void Add(T value,
            const opentelemetry::common::KeyValueIterable &attributes,
-           const opentelemetry::context::Context &context) noexcept
+           const opentelemetry::context::Context &context) noexcept override
   {
     if (!storage_)
     {
@@ -71,7 +71,7 @@ public:
     return storage_->RecordLong(value, attributes, context);
   }
 
-  void Add(T value) noexcept
+  void Add(T value) noexcept override
   {
     auto context = opentelemetry::context::Context{};
     if (!storage_)
@@ -81,7 +81,7 @@ public:
     return storage_->RecordLong(value, context);
   }
 
-  void Add(T value, const opentelemetry::context::Context &context) noexcept
+  void Add(T value, const opentelemetry::context::Context &context) noexcept override
   {
     if (!storage_)
     {
@@ -159,7 +159,7 @@ public:
 
   void Record(T value,
               const opentelemetry::common::KeyValueIterable &attributes,
-              const opentelemetry::context::Context &context) noexcept
+              const opentelemetry::context::Context &context) noexcept override
   {
     if (value < 0)
     {
@@ -171,7 +171,7 @@ public:
     return storage_->RecordLong(value, attributes, context);
   }
 
-  void Record(T value, const opentelemetry::context::Context &context) noexcept
+  void Record(T value, const opentelemetry::context::Context &context) noexcept override
   {
     if (value < 0)
     {

--- a/sdk/include/opentelemetry/sdk/metrics/sync_instruments.h
+++ b/sdk/include/opentelemetry/sdk/metrics/sync_instruments.h
@@ -7,6 +7,8 @@
 #  include "opentelemetry/metrics/sync_instruments.h"
 #  include "opentelemetry/nostd/string_view.h"
 #  include "opentelemetry/sdk/metrics/instruments.h"
+#  include "opentelemetry/sdk/metrics/state/metric_storage.h"
+#  include "opentelemetry/sdk_config.h"
 
 #  include "opentelemetry/sdk/instrumentationscope/instrumentation_scope.h"
 
@@ -32,20 +34,61 @@ protected:
   std::unique_ptr<SyncWritableMetricStorage> storage_;
 };
 
-class LongCounter : public Synchronous, public opentelemetry::metrics::Counter<int64_t>
+template <typename T>
+class LongCounter : public Synchronous, public opentelemetry::metrics::Counter<T>
 {
 public:
   LongCounter(InstrumentDescriptor instrument_descriptor,
-              std::unique_ptr<SyncWritableMetricStorage> storage);
+              std::unique_ptr<SyncWritableMetricStorage> storage)
+      : Synchronous(instrument_descriptor, std::move(storage))
+  {
+    if (!storage_)
+    {
+      OTEL_INTERNAL_LOG_ERROR("[LongCounter::LongCounter] - Error during constructing LongCounter."
+                              << "The metric storage is invalid"
+                              << "No value will be added");
+    }
+  }
 
-  void Add(int64_t value,
-           const opentelemetry::common::KeyValueIterable &attributes) noexcept override;
-  void Add(int64_t value,
+  void Add(T value, const opentelemetry::common::KeyValueIterable &attributes) noexcept
+  {
+    if (!storage_)
+    {
+      return;
+    }
+    auto context = opentelemetry::context::Context{};
+    return storage_->RecordLong(value, attributes, context);
+  }
+
+  void Add(T value,
            const opentelemetry::common::KeyValueIterable &attributes,
-           const opentelemetry::context::Context &context) noexcept override;
+           const opentelemetry::context::Context &context) noexcept
+  {
+    if (!storage_)
+    {
+      return;
+    }
+    return storage_->RecordLong(value, attributes, context);
+  }
 
-  void Add(int64_t value) noexcept override;
-  void Add(int64_t value, const opentelemetry::context::Context &context) noexcept override;
+  void Add(T value) noexcept
+  {
+    auto context = opentelemetry::context::Context{};
+    if (!storage_)
+    {
+      return;
+    }
+    return storage_->RecordLong(value, context);
+  }
+
+  void Add(T value, const opentelemetry::context::Context &context) noexcept
+  {
+    if (!storage_)
+    {
+      return;
+    }
+    return storage_->RecordLong(value, context);
+  }
 };
 
 class DoubleCounter : public Synchronous, public opentelemetry::metrics::Counter<double>
@@ -97,17 +140,48 @@ public:
   void Add(double value, const opentelemetry::context::Context &context) noexcept override;
 };
 
-class LongHistogram : public Synchronous, public opentelemetry::metrics::Histogram<int64_t>
+template <typename T>
+class LongHistogram : public Synchronous, public opentelemetry::metrics::Histogram<T>
 {
 public:
   LongHistogram(InstrumentDescriptor instrument_descriptor,
-                std::unique_ptr<SyncWritableMetricStorage> storage);
+                std::unique_ptr<SyncWritableMetricStorage> storage)
+      : Synchronous(instrument_descriptor, std::move(storage))
+  {
+    if (!storage_)
+    {
+      OTEL_INTERNAL_LOG_ERROR(
+          "[LongHistogram::LongHistogram] - Error during constructing LongHistogram."
+          << "The metric storage is invalid"
+          << "No value will be added");
+    }
+  }
 
-  void Record(int64_t value,
+  void Record(T value,
               const opentelemetry::common::KeyValueIterable &attributes,
-              const opentelemetry::context::Context &context) noexcept override;
+              const opentelemetry::context::Context &context) noexcept
+  {
+    if (value < 0)
+    {
+      OTEL_INTERNAL_LOG_WARN(
+          "[LongHistogram::Record(value, attributes)] negative value provided to histogram Name:"
+          << instrument_descriptor_.name_ << " Value:" << value);
+      return;
+    }
+    return storage_->RecordLong(value, attributes, context);
+  }
 
-  void Record(int64_t value, const opentelemetry::context::Context &context) noexcept override;
+  void Record(T value, const opentelemetry::context::Context &context) noexcept
+  {
+    if (value < 0)
+    {
+      OTEL_INTERNAL_LOG_WARN(
+          "[LongHistogram::Record(value)] negative value provided to histogram Name:"
+          << instrument_descriptor_.name_ << " Value:" << value);
+      return;
+    }
+    return storage_->RecordLong(value, context);
+  }
 };
 
 class DoubleHistogram : public Synchronous, public opentelemetry::metrics::Histogram<double>

--- a/sdk/src/metrics/aggregation/histogram_aggregation.cc
+++ b/sdk/src/metrics/aggregation/histogram_aggregation.cc
@@ -33,7 +33,7 @@ LongHistogramAggregation::LongHistogramAggregation(
     record_min_max_ = aggregation_config->record_min_max_;
   }
   point_data_.counts_         = std::vector<uint64_t>(point_data_.boundaries_.size() + 1, 0);
-  point_data_.sum_            = 0l;
+  point_data_.sum_            = (int64_t)0;
   point_data_.count_          = 0;
   point_data_.record_min_max_ = record_min_max_;
   point_data_.min_            = std::numeric_limits<int64_t>::max();

--- a/sdk/src/metrics/aggregation/histogram_aggregation.cc
+++ b/sdk/src/metrics/aggregation/histogram_aggregation.cc
@@ -16,7 +16,7 @@ namespace metrics
 {
 
 LongHistogramAggregation::LongHistogramAggregation(
-    const HistogramAggregationConfig<long> *aggregation_config)
+    const HistogramAggregationConfig<int64_t> *aggregation_config)
 {
   if (aggregation_config && aggregation_config->boundaries_.size())
   {
@@ -36,8 +36,8 @@ LongHistogramAggregation::LongHistogramAggregation(
   point_data_.sum_            = 0l;
   point_data_.count_          = 0;
   point_data_.record_min_max_ = record_min_max_;
-  point_data_.min_            = std::numeric_limits<long>::max();
-  point_data_.max_            = std::numeric_limits<long>::min();
+  point_data_.min_            = std::numeric_limits<int64_t>::max();
+  point_data_.max_            = std::numeric_limits<int64_t>::min();
 }
 
 LongHistogramAggregation::LongHistogramAggregation(HistogramPointData &&data)
@@ -48,16 +48,16 @@ LongHistogramAggregation::LongHistogramAggregation(const HistogramPointData &dat
     : point_data_{data}, record_min_max_{point_data_.record_min_max_}
 {}
 
-void LongHistogramAggregation::Aggregate(long value,
+void LongHistogramAggregation::Aggregate(int64_t value,
                                          const PointAttributes & /* attributes */) noexcept
 {
   const std::lock_guard<opentelemetry::common::SpinLockMutex> locked(lock_);
   point_data_.count_ += 1;
-  point_data_.sum_ = nostd::get<long>(point_data_.sum_) + value;
+  point_data_.sum_ = nostd::get<int64_t>(point_data_.sum_) + value;
   if (record_min_max_)
   {
-    point_data_.min_ = std::min(nostd::get<long>(point_data_.min_), value);
-    point_data_.max_ = std::max(nostd::get<long>(point_data_.max_), value);
+    point_data_.min_ = std::min(nostd::get<int64_t>(point_data_.min_), value);
+    point_data_.max_ = std::max(nostd::get<int64_t>(point_data_.max_), value);
   }
   size_t index = 0;
   for (auto it = point_data_.boundaries_.begin(); it != point_data_.boundaries_.end(); ++it)
@@ -78,7 +78,7 @@ std::unique_ptr<Aggregation> LongHistogramAggregation::Merge(
   auto delta_value = nostd::get<HistogramPointData>(
       (static_cast<const LongHistogramAggregation &>(delta).ToPoint()));
   LongHistogramAggregation *aggr = new LongHistogramAggregation();
-  HistogramMerge<long>(curr_value, delta_value, aggr->point_data_);
+  HistogramMerge<int64_t>(curr_value, delta_value, aggr->point_data_);
   return std::unique_ptr<Aggregation>(aggr);
 }
 
@@ -88,7 +88,7 @@ std::unique_ptr<Aggregation> LongHistogramAggregation::Diff(const Aggregation &n
   auto next_value = nostd::get<HistogramPointData>(
       (static_cast<const LongHistogramAggregation &>(next).ToPoint()));
   LongHistogramAggregation *aggr = new LongHistogramAggregation();
-  HistogramDiff<long>(curr_value, next_value, aggr->point_data_);
+  HistogramDiff<int64_t>(curr_value, next_value, aggr->point_data_);
   return std::unique_ptr<Aggregation>(aggr);
 }
 

--- a/sdk/src/metrics/aggregation/lastvalue_aggregation.cc
+++ b/sdk/src/metrics/aggregation/lastvalue_aggregation.cc
@@ -17,7 +17,7 @@ namespace metrics
 LongLastValueAggregation::LongLastValueAggregation()
 {
   point_data_.is_lastvalue_valid_ = false;
-  point_data_.value_              = 0l;
+  point_data_.value_              = (int64_t)0;
 }
 
 LongLastValueAggregation::LongLastValueAggregation(LastValuePointData &&data)

--- a/sdk/src/metrics/aggregation/lastvalue_aggregation.cc
+++ b/sdk/src/metrics/aggregation/lastvalue_aggregation.cc
@@ -28,7 +28,7 @@ LongLastValueAggregation::LongLastValueAggregation(const LastValuePointData &dat
     : point_data_{data}
 {}
 
-void LongLastValueAggregation::Aggregate(long value,
+void LongLastValueAggregation::Aggregate(int64_t value,
                                          const PointAttributes & /* attributes */) noexcept
 {
   const std::lock_guard<opentelemetry::common::SpinLockMutex> locked(lock_);

--- a/sdk/src/metrics/aggregation/sum_aggregation.cc
+++ b/sdk/src/metrics/aggregation/sum_aggregation.cc
@@ -17,7 +17,7 @@ namespace metrics
 
 LongSumAggregation::LongSumAggregation()
 {
-  point_data_.value_ = 0l;
+  point_data_.value_ = (int64_t)0;
 }
 
 LongSumAggregation::LongSumAggregation(SumPointData &&data) : point_data_{std::move(data)} {}

--- a/sdk/src/metrics/aggregation/sum_aggregation.cc
+++ b/sdk/src/metrics/aggregation/sum_aggregation.cc
@@ -24,19 +24,19 @@ LongSumAggregation::LongSumAggregation(SumPointData &&data) : point_data_{std::m
 
 LongSumAggregation::LongSumAggregation(const SumPointData &data) : point_data_{data} {}
 
-void LongSumAggregation::Aggregate(long value, const PointAttributes & /* attributes */) noexcept
+void LongSumAggregation::Aggregate(int64_t value, const PointAttributes & /* attributes */) noexcept
 {
   const std::lock_guard<opentelemetry::common::SpinLockMutex> locked(lock_);
-  point_data_.value_ = nostd::get<long>(point_data_.value_) + value;
+  point_data_.value_ = nostd::get<int64_t>(point_data_.value_) + value;
 }
 
 std::unique_ptr<Aggregation> LongSumAggregation::Merge(const Aggregation &delta) const noexcept
 {
-  long merge_value =
-      nostd::get<long>(
+  int64_t merge_value =
+      nostd::get<int64_t>(
           nostd::get<SumPointData>((static_cast<const LongSumAggregation &>(delta).ToPoint()))
               .value_) +
-      nostd::get<long>(nostd::get<SumPointData>(ToPoint()).value_);
+      nostd::get<int64_t>(nostd::get<SumPointData>(ToPoint()).value_);
   std::unique_ptr<Aggregation> aggr(new LongSumAggregation());
   static_cast<LongSumAggregation *>(aggr.get())->point_data_.value_ = merge_value;
   return aggr;
@@ -45,10 +45,11 @@ std::unique_ptr<Aggregation> LongSumAggregation::Merge(const Aggregation &delta)
 std::unique_ptr<Aggregation> LongSumAggregation::Diff(const Aggregation &next) const noexcept
 {
 
-  long diff_value = nostd::get<long>(nostd::get<SumPointData>(
-                                         (static_cast<const LongSumAggregation &>(next).ToPoint()))
-                                         .value_) -
-                    nostd::get<long>(nostd::get<SumPointData>(ToPoint()).value_);
+  int64_t diff_value =
+      nostd::get<int64_t>(
+          nostd::get<SumPointData>((static_cast<const LongSumAggregation &>(next).ToPoint()))
+              .value_) -
+      nostd::get<int64_t>(nostd::get<SumPointData>(ToPoint()).value_);
   std::unique_ptr<Aggregation> aggr(new LongSumAggregation());
   static_cast<LongSumAggregation *>(aggr.get())->point_data_.value_ = diff_value;
   return aggr;

--- a/sdk/src/metrics/meter.cc
+++ b/sdk/src/metrics/meter.cc
@@ -33,7 +33,7 @@ Meter::Meter(
       observable_registry_(new ObservableRegistry())
 {}
 
-nostd::shared_ptr<metrics::Counter<int64_t>> Meter::CreateLongCounter(
+nostd::shared_ptr<metrics::Counter<int64_t>> Meter::CreateInt64Counter(
     nostd::string_view name,
     nostd::string_view description,
     nostd::string_view unit) noexcept

--- a/sdk/src/metrics/meter.cc
+++ b/sdk/src/metrics/meter.cc
@@ -33,15 +33,16 @@ Meter::Meter(
       observable_registry_(new ObservableRegistry())
 {}
 
-nostd::shared_ptr<metrics::Counter<long>> Meter::CreateLongCounter(nostd::string_view name,
-                                                                   nostd::string_view description,
-                                                                   nostd::string_view unit) noexcept
+nostd::shared_ptr<metrics::Counter<int64_t>> Meter::CreateLongCounter(
+    nostd::string_view name,
+    nostd::string_view description,
+    nostd::string_view unit) noexcept
 {
   InstrumentDescriptor instrument_descriptor = {
       std::string{name.data(), name.size()}, std::string{description.data(), description.size()},
       std::string{unit.data(), unit.size()}, InstrumentType::kCounter, InstrumentValueType::kLong};
   auto storage = RegisterSyncMetricStorage(instrument_descriptor);
-  return nostd::shared_ptr<metrics::Counter<long>>(
+  return nostd::shared_ptr<metrics::Counter<int64_t>>(
       new LongCounter(instrument_descriptor, std::move(storage)));
 }
 
@@ -87,7 +88,7 @@ Meter::CreateDoubleObservableCounter(nostd::string_view name,
       new ObservableInstrument(instrument_descriptor, std::move(storage), observable_registry_)};
 }
 
-nostd::shared_ptr<metrics::Histogram<long>> Meter::CreateLongHistogram(
+nostd::shared_ptr<metrics::Histogram<int64_t>> Meter::CreateLongHistogram(
     nostd::string_view name,
     nostd::string_view description,
     nostd::string_view unit) noexcept
@@ -97,7 +98,7 @@ nostd::shared_ptr<metrics::Histogram<long>> Meter::CreateLongHistogram(
       std::string{unit.data(), unit.size()}, InstrumentType::kHistogram,
       InstrumentValueType::kLong};
   auto storage = RegisterSyncMetricStorage(instrument_descriptor);
-  return nostd::shared_ptr<metrics::Histogram<long>>{
+  return nostd::shared_ptr<metrics::Histogram<int64_t>>{
       new LongHistogram(instrument_descriptor, std::move(storage))};
 }
 
@@ -143,7 +144,7 @@ nostd::shared_ptr<opentelemetry::metrics::ObservableInstrument> Meter::CreateDou
       new ObservableInstrument(instrument_descriptor, std::move(storage), observable_registry_)};
 }
 
-nostd::shared_ptr<metrics::UpDownCounter<long>> Meter::CreateLongUpDownCounter(
+nostd::shared_ptr<metrics::UpDownCounter<int64_t>> Meter::CreateLongUpDownCounter(
     nostd::string_view name,
     nostd::string_view description,
     nostd::string_view unit) noexcept
@@ -153,7 +154,7 @@ nostd::shared_ptr<metrics::UpDownCounter<long>> Meter::CreateLongUpDownCounter(
       std::string{unit.data(), unit.size()}, InstrumentType::kUpDownCounter,
       InstrumentValueType::kLong};
   auto storage = RegisterSyncMetricStorage(instrument_descriptor);
-  return nostd::shared_ptr<metrics::UpDownCounter<long>>{
+  return nostd::shared_ptr<metrics::UpDownCounter<int64_t>>{
       new LongUpDownCounter(instrument_descriptor, std::move(storage))};
 }
 

--- a/sdk/src/metrics/meter.cc
+++ b/sdk/src/metrics/meter.cc
@@ -61,10 +61,10 @@ nostd::shared_ptr<metrics::Counter<double>> Meter::CreateDoubleCounter(
       new DoubleCounter(instrument_descriptor, std::move(storage))};
 }
 
-nostd::shared_ptr<opentelemetry::metrics::ObservableInstrument>
-Meter::CreateUInt64ObservableCounter(nostd::string_view name,
-                                     nostd::string_view description,
-                                     nostd::string_view unit) noexcept
+nostd::shared_ptr<opentelemetry::metrics::ObservableInstrument> Meter::CreateInt64ObservableCounter(
+    nostd::string_view name,
+    nostd::string_view description,
+    nostd::string_view unit) noexcept
 {
   InstrumentDescriptor instrument_descriptor = {
       std::string{name.data(), name.size()}, std::string{description.data(), description.size()},

--- a/sdk/src/metrics/meter.cc
+++ b/sdk/src/metrics/meter.cc
@@ -1,13 +1,13 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-#include <cstdint>
 #ifndef ENABLE_METRICS_PREVIEW
+#  include "opentelemetry/sdk/metrics/meter.h"
+#  include <cstdint>
 #  include "opentelemetry/metrics/noop.h"
 #  include "opentelemetry/nostd/shared_ptr.h"
 #  include "opentelemetry/sdk/metrics/async_instruments.h"
 #  include "opentelemetry/sdk/metrics/exemplar/histogram_exemplar_reservoir.h"
-#  include "opentelemetry/sdk/metrics/meter.h"
 #  include "opentelemetry/sdk/metrics/state/multi_metric_storage.h"
 #  include "opentelemetry/sdk/metrics/state/observable_registry.h"
 #  include "opentelemetry/sdk/metrics/state/sync_metric_storage.h"
@@ -117,7 +117,7 @@ nostd::shared_ptr<metrics::Histogram<double>> Meter::CreateDoubleHistogram(
       new DoubleHistogram(instrument_descriptor, std::move(storage))};
 }
 
-nostd::shared_ptr<opentelemetry::metrics::ObservableInstrument> Meter::CreateUInt64ObservableGauge(
+nostd::shared_ptr<opentelemetry::metrics::ObservableInstrument> Meter::CreateInt64ObservableGauge(
     nostd::string_view name,
     nostd::string_view description,
     nostd::string_view unit) noexcept

--- a/sdk/src/metrics/meter.cc
+++ b/sdk/src/metrics/meter.cc
@@ -1,12 +1,13 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
+#include <cstdint>
 #ifndef ENABLE_METRICS_PREVIEW
-#  include "opentelemetry/sdk/metrics/meter.h"
 #  include "opentelemetry/metrics/noop.h"
 #  include "opentelemetry/nostd/shared_ptr.h"
 #  include "opentelemetry/sdk/metrics/async_instruments.h"
 #  include "opentelemetry/sdk/metrics/exemplar/histogram_exemplar_reservoir.h"
+#  include "opentelemetry/sdk/metrics/meter.h"
 #  include "opentelemetry/sdk/metrics/state/multi_metric_storage.h"
 #  include "opentelemetry/sdk/metrics/state/observable_registry.h"
 #  include "opentelemetry/sdk/metrics/state/sync_metric_storage.h"
@@ -33,7 +34,7 @@ Meter::Meter(
       observable_registry_(new ObservableRegistry())
 {}
 
-nostd::shared_ptr<metrics::Counter<int64_t>> Meter::CreateInt64Counter(
+nostd::shared_ptr<metrics::Counter<uint64_t>> Meter::CreateUInt64Counter(
     nostd::string_view name,
     nostd::string_view description,
     nostd::string_view unit) noexcept
@@ -42,8 +43,8 @@ nostd::shared_ptr<metrics::Counter<int64_t>> Meter::CreateInt64Counter(
       std::string{name.data(), name.size()}, std::string{description.data(), description.size()},
       std::string{unit.data(), unit.size()}, InstrumentType::kCounter, InstrumentValueType::kLong};
   auto storage = RegisterSyncMetricStorage(instrument_descriptor);
-  return nostd::shared_ptr<metrics::Counter<int64_t>>(
-      new LongCounter(instrument_descriptor, std::move(storage)));
+  return nostd::shared_ptr<metrics::Counter<uint64_t>>(
+      new LongCounter<uint64_t>(instrument_descriptor, std::move(storage)));
 }
 
 nostd::shared_ptr<metrics::Counter<double>> Meter::CreateDoubleCounter(
@@ -60,10 +61,10 @@ nostd::shared_ptr<metrics::Counter<double>> Meter::CreateDoubleCounter(
       new DoubleCounter(instrument_descriptor, std::move(storage))};
 }
 
-nostd::shared_ptr<opentelemetry::metrics::ObservableInstrument> Meter::CreateLongObservableCounter(
-    nostd::string_view name,
-    nostd::string_view description,
-    nostd::string_view unit) noexcept
+nostd::shared_ptr<opentelemetry::metrics::ObservableInstrument>
+Meter::CreateUInt64ObservableCounter(nostd::string_view name,
+                                     nostd::string_view description,
+                                     nostd::string_view unit) noexcept
 {
   InstrumentDescriptor instrument_descriptor = {
       std::string{name.data(), name.size()}, std::string{description.data(), description.size()},
@@ -88,7 +89,7 @@ Meter::CreateDoubleObservableCounter(nostd::string_view name,
       new ObservableInstrument(instrument_descriptor, std::move(storage), observable_registry_)};
 }
 
-nostd::shared_ptr<metrics::Histogram<int64_t>> Meter::CreateLongHistogram(
+nostd::shared_ptr<metrics::Histogram<uint64_t>> Meter::CreateUInt64Histogram(
     nostd::string_view name,
     nostd::string_view description,
     nostd::string_view unit) noexcept
@@ -98,8 +99,8 @@ nostd::shared_ptr<metrics::Histogram<int64_t>> Meter::CreateLongHistogram(
       std::string{unit.data(), unit.size()}, InstrumentType::kHistogram,
       InstrumentValueType::kLong};
   auto storage = RegisterSyncMetricStorage(instrument_descriptor);
-  return nostd::shared_ptr<metrics::Histogram<int64_t>>{
-      new LongHistogram(instrument_descriptor, std::move(storage))};
+  return nostd::shared_ptr<metrics::Histogram<uint64_t>>{
+      new LongHistogram<uint64_t>(instrument_descriptor, std::move(storage))};
 }
 
 nostd::shared_ptr<metrics::Histogram<double>> Meter::CreateDoubleHistogram(
@@ -116,7 +117,7 @@ nostd::shared_ptr<metrics::Histogram<double>> Meter::CreateDoubleHistogram(
       new DoubleHistogram(instrument_descriptor, std::move(storage))};
 }
 
-nostd::shared_ptr<opentelemetry::metrics::ObservableInstrument> Meter::CreateLongObservableGauge(
+nostd::shared_ptr<opentelemetry::metrics::ObservableInstrument> Meter::CreateUInt64ObservableGauge(
     nostd::string_view name,
     nostd::string_view description,
     nostd::string_view unit) noexcept
@@ -144,7 +145,7 @@ nostd::shared_ptr<opentelemetry::metrics::ObservableInstrument> Meter::CreateDou
       new ObservableInstrument(instrument_descriptor, std::move(storage), observable_registry_)};
 }
 
-nostd::shared_ptr<metrics::UpDownCounter<int64_t>> Meter::CreateLongUpDownCounter(
+nostd::shared_ptr<metrics::UpDownCounter<int64_t>> Meter::CreateInt64UpDownCounter(
     nostd::string_view name,
     nostd::string_view description,
     nostd::string_view unit) noexcept
@@ -173,9 +174,9 @@ nostd::shared_ptr<metrics::UpDownCounter<double>> Meter::CreateDoubleUpDownCount
 }
 
 nostd::shared_ptr<opentelemetry::metrics::ObservableInstrument>
-Meter::CreateLongObservableUpDownCounter(nostd::string_view name,
-                                         nostd::string_view description,
-                                         nostd::string_view unit) noexcept
+Meter::CreateInt64ObservableUpDownCounter(nostd::string_view name,
+                                          nostd::string_view description,
+                                          nostd::string_view unit) noexcept
 {
   InstrumentDescriptor instrument_descriptor = {
       std::string{name.data(), name.size()}, std::string{description.data(), description.size()},

--- a/sdk/src/metrics/state/observable_registry.cc
+++ b/sdk/src/metrics/state/observable_registry.cc
@@ -70,11 +70,11 @@ void ObservableRegistry::Observe(opentelemetry::common::SystemTimestamp collecti
     }
     else
     {
-      nostd::shared_ptr<opentelemetry::metrics::ObserverResultT<long>> ob_res(
-          new opentelemetry::sdk::metrics::ObserverResultT<long>());
+      nostd::shared_ptr<opentelemetry::metrics::ObserverResultT<int64_t>> ob_res(
+          new opentelemetry::sdk::metrics::ObserverResultT<int64_t>());
       callback_wrap->callback(ob_res, callback_wrap->state);
       storage->RecordLong(
-          static_cast<opentelemetry::sdk::metrics::ObserverResultT<long> *>(ob_res.get())
+          static_cast<opentelemetry::sdk::metrics::ObserverResultT<int64_t> *>(ob_res.get())
               ->GetMeasurements(),
           collection_ts);
     }

--- a/sdk/src/metrics/sync_instruments.cc
+++ b/sdk/src/metrics/sync_instruments.cc
@@ -3,8 +3,6 @@
 
 #ifndef ENABLE_METRICS_PREVIEW
 #  include "opentelemetry/sdk/metrics/sync_instruments.h"
-#  include "opentelemetry/sdk/metrics/state/metric_storage.h"
-#  include "opentelemetry/sdk_config.h"
 
 #  include <cmath>
 
@@ -13,59 +11,6 @@ namespace sdk
 {
 namespace metrics
 {
-LongCounter::LongCounter(InstrumentDescriptor instrument_descriptor,
-                         std::unique_ptr<SyncWritableMetricStorage> storage)
-    : Synchronous(instrument_descriptor, std::move(storage))
-{
-  if (!storage_)
-  {
-    OTEL_INTERNAL_LOG_ERROR("[LongCounter::LongCounter] - Error during constructing LongCounter."
-                            << "The metric storage is invalid"
-                            << "No value will be added");
-  }
-}
-
-void LongCounter::Add(int64_t value,
-                      const opentelemetry::common::KeyValueIterable &attributes) noexcept
-{
-  if (!storage_)
-  {
-    return;
-  }
-  auto context = opentelemetry::context::Context{};
-  return storage_->RecordLong(value, attributes, context);
-}
-
-void LongCounter::Add(int64_t value,
-                      const opentelemetry::common::KeyValueIterable &attributes,
-                      const opentelemetry::context::Context &context) noexcept
-{
-  if (!storage_)
-  {
-    return;
-  }
-  return storage_->RecordLong(value, attributes, context);
-}
-
-void LongCounter::Add(int64_t value) noexcept
-{
-  auto context = opentelemetry::context::Context{};
-  if (!storage_)
-  {
-    return;
-  }
-  return storage_->RecordLong(value, context);
-}
-
-void LongCounter::Add(int64_t value, const opentelemetry::context::Context &context) noexcept
-{
-  if (!storage_)
-  {
-    return;
-  }
-  return storage_->RecordLong(value, context);
-}
-
 DoubleCounter::DoubleCounter(InstrumentDescriptor instrument_descriptor,
                              std::unique_ptr<SyncWritableMetricStorage> storage)
     : Synchronous(instrument_descriptor, std::move(storage))
@@ -223,45 +168,6 @@ void DoubleUpDownCounter::Add(double value, const opentelemetry::context::Contex
     return;
   }
   return storage_->RecordDouble(value, context);
-}
-
-LongHistogram::LongHistogram(InstrumentDescriptor instrument_descriptor,
-                             std::unique_ptr<SyncWritableMetricStorage> storage)
-    : Synchronous(instrument_descriptor, std::move(storage))
-{
-  if (!storage_)
-  {
-    OTEL_INTERNAL_LOG_ERROR(
-        "[LongHistogram::LongHistogram] - Error during constructing LongHistogram."
-        << "The metric storage is invalid"
-        << "No value will be added");
-  }
-}
-
-void LongHistogram::Record(int64_t value,
-                           const opentelemetry::common::KeyValueIterable &attributes,
-                           const opentelemetry::context::Context &context) noexcept
-{
-  if (value < 0)
-  {
-    OTEL_INTERNAL_LOG_WARN(
-        "[LongHistogram::Record(value, attributes)] negative value provided to histogram Name:"
-        << instrument_descriptor_.name_ << " Value:" << value);
-    return;
-  }
-  return storage_->RecordLong(value, attributes, context);
-}
-
-void LongHistogram::Record(int64_t value, const opentelemetry::context::Context &context) noexcept
-{
-  if (value < 0)
-  {
-    OTEL_INTERNAL_LOG_WARN(
-        "[LongHistogram::Record(value)] negative value provided to histogram Name:"
-        << instrument_descriptor_.name_ << " Value:" << value);
-    return;
-  }
-  return storage_->RecordLong(value, context);
 }
 
 DoubleHistogram::DoubleHistogram(InstrumentDescriptor instrument_descriptor,

--- a/sdk/src/metrics/sync_instruments.cc
+++ b/sdk/src/metrics/sync_instruments.cc
@@ -25,7 +25,7 @@ LongCounter::LongCounter(InstrumentDescriptor instrument_descriptor,
   }
 }
 
-void LongCounter::Add(long value,
+void LongCounter::Add(int64_t value,
                       const opentelemetry::common::KeyValueIterable &attributes) noexcept
 {
   if (!storage_)
@@ -36,7 +36,7 @@ void LongCounter::Add(long value,
   return storage_->RecordLong(value, attributes, context);
 }
 
-void LongCounter::Add(long value,
+void LongCounter::Add(int64_t value,
                       const opentelemetry::common::KeyValueIterable &attributes,
                       const opentelemetry::context::Context &context) noexcept
 {
@@ -47,7 +47,7 @@ void LongCounter::Add(long value,
   return storage_->RecordLong(value, attributes, context);
 }
 
-void LongCounter::Add(long value) noexcept
+void LongCounter::Add(int64_t value) noexcept
 {
   auto context = opentelemetry::context::Context{};
   if (!storage_)
@@ -57,7 +57,7 @@ void LongCounter::Add(long value) noexcept
   return storage_->RecordLong(value, context);
 }
 
-void LongCounter::Add(long value, const opentelemetry::context::Context &context) noexcept
+void LongCounter::Add(int64_t value, const opentelemetry::context::Context &context) noexcept
 {
   if (!storage_)
   {
@@ -133,7 +133,7 @@ LongUpDownCounter::LongUpDownCounter(InstrumentDescriptor instrument_descriptor,
   }
 }
 
-void LongUpDownCounter::Add(long value,
+void LongUpDownCounter::Add(int64_t value,
                             const opentelemetry::common::KeyValueIterable &attributes) noexcept
 {
   auto context = opentelemetry::context::Context{};
@@ -144,7 +144,7 @@ void LongUpDownCounter::Add(long value,
   return storage_->RecordLong(value, attributes, context);
 }
 
-void LongUpDownCounter::Add(long value,
+void LongUpDownCounter::Add(int64_t value,
                             const opentelemetry::common::KeyValueIterable &attributes,
                             const opentelemetry::context::Context &context) noexcept
 {
@@ -155,7 +155,7 @@ void LongUpDownCounter::Add(long value,
   return storage_->RecordLong(value, attributes, context);
 }
 
-void LongUpDownCounter::Add(long value) noexcept
+void LongUpDownCounter::Add(int64_t value) noexcept
 {
   auto context = opentelemetry::context::Context{};
   if (!storage_)
@@ -165,7 +165,7 @@ void LongUpDownCounter::Add(long value) noexcept
   return storage_->RecordLong(value, context);
 }
 
-void LongUpDownCounter::Add(long value, const opentelemetry::context::Context &context) noexcept
+void LongUpDownCounter::Add(int64_t value, const opentelemetry::context::Context &context) noexcept
 {
   if (!storage_)
   {
@@ -238,7 +238,7 @@ LongHistogram::LongHistogram(InstrumentDescriptor instrument_descriptor,
   }
 }
 
-void LongHistogram::Record(long value,
+void LongHistogram::Record(int64_t value,
                            const opentelemetry::common::KeyValueIterable &attributes,
                            const opentelemetry::context::Context &context) noexcept
 {
@@ -252,7 +252,7 @@ void LongHistogram::Record(long value,
   return storage_->RecordLong(value, attributes, context);
 }
 
-void LongHistogram::Record(long value, const opentelemetry::context::Context &context) noexcept
+void LongHistogram::Record(int64_t value, const opentelemetry::context::Context &context) noexcept
 {
   if (value < 0)
   {

--- a/sdk/test/_metrics/exact_aggregator_test.cc
+++ b/sdk/test/_metrics/exact_aggregator_test.cc
@@ -83,7 +83,7 @@ TEST(ExactAggregatorOrdered, Types)
   // This test verifies that we do not encounter any errors when
   // using various numeric types.
   ExactAggregator<int> agg_int(metrics_api::InstrumentKind::Counter);
-  ExactAggregator<long> agg_long(metrics_api::InstrumentKind::Counter);
+  ExactAggregator<int64_t> agg_long(metrics_api::InstrumentKind::Counter);
   ExactAggregator<float> agg_float(metrics_api::InstrumentKind::Counter);
   ExactAggregator<double> agg_double(metrics_api::InstrumentKind::Counter);
 
@@ -100,7 +100,7 @@ TEST(ExactAggregatorOrdered, Types)
   }
 
   std::vector<int> correct_int{1, 2, 3, 4, 5};
-  std::vector<long> correct_long{1, 2, 3, 4, 5};
+  std::vector<int64_t> correct_long{1, 2, 3, 4, 5};
   std::vector<float> correct_float{1.0, 2.0, 3.0, 4.0, 5.0};
   std::vector<double> correct_double{1.0, 2.0, 3.0, 4.0, 5.0};
 

--- a/sdk/test/_metrics/exact_aggregator_test.cc
+++ b/sdk/test/_metrics/exact_aggregator_test.cc
@@ -83,7 +83,7 @@ TEST(ExactAggregatorOrdered, Types)
   // This test verifies that we do not encounter any errors when
   // using various numeric types.
   ExactAggregator<int> agg_int(metrics_api::InstrumentKind::Counter);
-  ExactAggregator<int64_t> agg_long(metrics_api::InstrumentKind::Counter);
+  ExactAggregator<long> agg_long(metrics_api::InstrumentKind::Counter);
   ExactAggregator<float> agg_float(metrics_api::InstrumentKind::Counter);
   ExactAggregator<double> agg_double(metrics_api::InstrumentKind::Counter);
 
@@ -100,7 +100,7 @@ TEST(ExactAggregatorOrdered, Types)
   }
 
   std::vector<int> correct_int{1, 2, 3, 4, 5};
-  std::vector<int64_t> correct_long{1, 2, 3, 4, 5};
+  std::vector<long> correct_long{1, 2, 3, 4, 5};
   std::vector<float> correct_float{1.0, 2.0, 3.0, 4.0, 5.0};
   std::vector<double> correct_double{1.0, 2.0, 3.0, 4.0, 5.0};
 

--- a/sdk/test/_metrics/gauge_aggregator_test.cc
+++ b/sdk/test/_metrics/gauge_aggregator_test.cc
@@ -86,7 +86,7 @@ TEST(GaugeAggregator, Types)
   // This test verifies that we do not encounter any errors when
   // using various numeric types.
   GaugeAggregator<int> agg_int(metrics_api::InstrumentKind::Counter);
-  GaugeAggregator<int64_t> agg_long(metrics_api::InstrumentKind::Counter);
+  GaugeAggregator<long> agg_long(metrics_api::InstrumentKind::Counter);
   GaugeAggregator<float> agg_float(metrics_api::InstrumentKind::Counter);
   GaugeAggregator<double> agg_double(metrics_api::InstrumentKind::Counter);
 

--- a/sdk/test/_metrics/gauge_aggregator_test.cc
+++ b/sdk/test/_metrics/gauge_aggregator_test.cc
@@ -86,7 +86,7 @@ TEST(GaugeAggregator, Types)
   // This test verifies that we do not encounter any errors when
   // using various numeric types.
   GaugeAggregator<int> agg_int(metrics_api::InstrumentKind::Counter);
-  GaugeAggregator<long> agg_long(metrics_api::InstrumentKind::Counter);
+  GaugeAggregator<int64_t> agg_long(metrics_api::InstrumentKind::Counter);
   GaugeAggregator<float> agg_float(metrics_api::InstrumentKind::Counter);
   GaugeAggregator<double> agg_double(metrics_api::InstrumentKind::Counter);
 

--- a/sdk/test/_metrics/min_max_sum_count_aggregator_test.cc
+++ b/sdk/test/_metrics/min_max_sum_count_aggregator_test.cc
@@ -138,7 +138,7 @@ TEST(MinMaxSumCountAggregator, Types)
   // This test verifies that we do not encounter any errors when
   // using various numeric types.
   MinMaxSumCountAggregator<int> agg_int(metrics_api::InstrumentKind::Counter);
-  MinMaxSumCountAggregator<long> agg_long(metrics_api::InstrumentKind::Counter);
+  MinMaxSumCountAggregator<int64_t> agg_long(metrics_api::InstrumentKind::Counter);
   MinMaxSumCountAggregator<float> agg_float(metrics_api::InstrumentKind::Counter);
   MinMaxSumCountAggregator<double> agg_double(metrics_api::InstrumentKind::Counter);
 

--- a/sdk/test/_metrics/min_max_sum_count_aggregator_test.cc
+++ b/sdk/test/_metrics/min_max_sum_count_aggregator_test.cc
@@ -138,7 +138,7 @@ TEST(MinMaxSumCountAggregator, Types)
   // This test verifies that we do not encounter any errors when
   // using various numeric types.
   MinMaxSumCountAggregator<int> agg_int(metrics_api::InstrumentKind::Counter);
-  MinMaxSumCountAggregator<int64_t> agg_long(metrics_api::InstrumentKind::Counter);
+  MinMaxSumCountAggregator<long> agg_long(metrics_api::InstrumentKind::Counter);
   MinMaxSumCountAggregator<float> agg_float(metrics_api::InstrumentKind::Counter);
   MinMaxSumCountAggregator<double> agg_double(metrics_api::InstrumentKind::Counter);
 

--- a/sdk/test/metrics/aggregation_test.cc
+++ b/sdk/test/metrics/aggregation_test.cc
@@ -18,12 +18,12 @@ TEST(Aggregation, LongSumAggregation)
   auto data = aggr.ToPoint();
   ASSERT_TRUE(nostd::holds_alternative<SumPointData>(data));
   auto sum_data = nostd::get<SumPointData>(data);
-  ASSERT_TRUE(nostd::holds_alternative<long>(sum_data.value_));
-  EXPECT_EQ(nostd::get<long>(sum_data.value_), 0l);
+  ASSERT_TRUE(nostd::holds_alternative<int64_t>(sum_data.value_));
+  EXPECT_EQ(nostd::get<int64_t>(sum_data.value_), 0l);
   aggr.Aggregate(12l, {});
   aggr.Aggregate(0l, {});
   sum_data = nostd::get<SumPointData>(aggr.ToPoint());
-  EXPECT_EQ(nostd::get<long>(sum_data.value_), 12l);
+  EXPECT_EQ(nostd::get<int64_t>(sum_data.value_), 12l);
 }
 
 TEST(Aggregation, DoubleSumAggregation)
@@ -46,12 +46,12 @@ TEST(Aggregation, LongLastValueAggregation)
   auto data = aggr.ToPoint();
   ASSERT_TRUE(nostd::holds_alternative<LastValuePointData>(data));
   auto lastvalue_data = nostd::get<LastValuePointData>(data);
-  ASSERT_TRUE(nostd::holds_alternative<long>(lastvalue_data.value_));
+  ASSERT_TRUE(nostd::holds_alternative<int64_t>(lastvalue_data.value_));
   EXPECT_EQ(lastvalue_data.is_lastvalue_valid_, false);
   aggr.Aggregate(12l, {});
   aggr.Aggregate(1l, {});
   lastvalue_data = nostd::get<LastValuePointData>(aggr.ToPoint());
-  EXPECT_EQ(nostd::get<long>(lastvalue_data.value_), 1.0);
+  EXPECT_EQ(nostd::get<int64_t>(lastvalue_data.value_), 1.0);
 }
 
 TEST(Aggregation, DoubleLastValueAggregation)
@@ -74,15 +74,15 @@ TEST(Aggregation, LongHistogramAggregation)
   auto data = aggr.ToPoint();
   ASSERT_TRUE(nostd::holds_alternative<HistogramPointData>(data));
   auto histogram_data = nostd::get<HistogramPointData>(data);
-  ASSERT_TRUE(nostd::holds_alternative<long>(histogram_data.sum_));
-  EXPECT_EQ(nostd::get<long>(histogram_data.sum_), 0);
+  ASSERT_TRUE(nostd::holds_alternative<int64_t>(histogram_data.sum_));
+  EXPECT_EQ(nostd::get<int64_t>(histogram_data.sum_), 0);
   EXPECT_EQ(histogram_data.count_, 0);
   aggr.Aggregate(12l, {});   // lies in fourth bucket
   aggr.Aggregate(100l, {});  // lies in eight bucket
   histogram_data = nostd::get<HistogramPointData>(aggr.ToPoint());
-  EXPECT_EQ(nostd::get<long>(histogram_data.min_), 12);
-  EXPECT_EQ(nostd::get<long>(histogram_data.max_), 100);
-  EXPECT_EQ(nostd::get<long>(histogram_data.sum_), 112);
+  EXPECT_EQ(nostd::get<int64_t>(histogram_data.min_), 12);
+  EXPECT_EQ(nostd::get<int64_t>(histogram_data.max_), 100);
+  EXPECT_EQ(nostd::get<int64_t>(histogram_data.sum_), 112);
   EXPECT_EQ(histogram_data.count_, 2);
   EXPECT_EQ(histogram_data.counts_[3], 1);
   EXPECT_EQ(histogram_data.counts_[7], 1);
@@ -92,8 +92,8 @@ TEST(Aggregation, LongHistogramAggregation)
   EXPECT_EQ(histogram_data.count_, 4);
   EXPECT_EQ(histogram_data.counts_[3], 2);
   EXPECT_EQ(histogram_data.counts_[8], 1);
-  EXPECT_EQ(nostd::get<long>(histogram_data.min_), 12);
-  EXPECT_EQ(nostd::get<long>(histogram_data.max_), 252);
+  EXPECT_EQ(nostd::get<int64_t>(histogram_data.min_), 12);
+  EXPECT_EQ(nostd::get<int64_t>(histogram_data.max_), 252);
 
   // Merge
   LongHistogramAggregation aggr1;
@@ -116,8 +116,8 @@ TEST(Aggregation, LongHistogramAggregation)
   EXPECT_EQ(histogram_data.counts_[3], 2);  // 11, 13
   EXPECT_EQ(histogram_data.counts_[4], 2);  // 25, 28
   EXPECT_EQ(histogram_data.counts_[7], 1);  // 105
-  EXPECT_EQ(nostd::get<long>(histogram_data.min_), 1);
-  EXPECT_EQ(nostd::get<long>(histogram_data.max_), 105);
+  EXPECT_EQ(nostd::get<int64_t>(histogram_data.min_), 1);
+  EXPECT_EQ(nostd::get<int64_t>(histogram_data.max_), 105);
 
   // Diff
   auto aggr4     = aggr1.Diff(aggr2);
@@ -131,8 +131,8 @@ TEST(Aggregation, LongHistogramAggregation)
 
 TEST(Aggregation, LongHistogramAggregationBoundaries)
 {
-  nostd::shared_ptr<opentelemetry::sdk::metrics::HistogramAggregationConfig<long>>
-      aggregation_config{new opentelemetry::sdk::metrics::HistogramAggregationConfig<long>};
+  nostd::shared_ptr<opentelemetry::sdk::metrics::HistogramAggregationConfig<int64_t>>
+      aggregation_config{new opentelemetry::sdk::metrics::HistogramAggregationConfig<int64_t>};
   std::list<double> user_boundaries = {0.0,   50.0,   100.0,  250.0,  500.0,
                                        750.0, 1000.0, 2500.0, 5000.0, 10000.0};
   aggregation_config->boundaries_   = user_boundaries;

--- a/sdk/test/metrics/aggregation_test.cc
+++ b/sdk/test/metrics/aggregation_test.cc
@@ -19,11 +19,11 @@ TEST(Aggregation, LongSumAggregation)
   ASSERT_TRUE(nostd::holds_alternative<SumPointData>(data));
   auto sum_data = nostd::get<SumPointData>(data);
   ASSERT_TRUE(nostd::holds_alternative<int64_t>(sum_data.value_));
-  EXPECT_EQ(nostd::get<int64_t>(sum_data.value_), 0l);
-  aggr.Aggregate(12l, {});
-  aggr.Aggregate(0l, {});
+  EXPECT_EQ(nostd::get<int64_t>(sum_data.value_), (int64_t)0);
+  aggr.Aggregate((int64_t)12, {});
+  aggr.Aggregate((int64_t)0, {});
   sum_data = nostd::get<SumPointData>(aggr.ToPoint());
-  EXPECT_EQ(nostd::get<int64_t>(sum_data.value_), 12l);
+  EXPECT_EQ(nostd::get<int64_t>(sum_data.value_), (int64_t)12);
 }
 
 TEST(Aggregation, DoubleSumAggregation)
@@ -48,8 +48,8 @@ TEST(Aggregation, LongLastValueAggregation)
   auto lastvalue_data = nostd::get<LastValuePointData>(data);
   ASSERT_TRUE(nostd::holds_alternative<int64_t>(lastvalue_data.value_));
   EXPECT_EQ(lastvalue_data.is_lastvalue_valid_, false);
-  aggr.Aggregate(12l, {});
-  aggr.Aggregate(1l, {});
+  aggr.Aggregate((int64_t)12, {});
+  aggr.Aggregate((int64_t)1, {});
   lastvalue_data = nostd::get<LastValuePointData>(aggr.ToPoint());
   EXPECT_EQ(nostd::get<int64_t>(lastvalue_data.value_), 1.0);
 }
@@ -77,8 +77,8 @@ TEST(Aggregation, LongHistogramAggregation)
   ASSERT_TRUE(nostd::holds_alternative<int64_t>(histogram_data.sum_));
   EXPECT_EQ(nostd::get<int64_t>(histogram_data.sum_), 0);
   EXPECT_EQ(histogram_data.count_, 0);
-  aggr.Aggregate(12l, {});   // lies in fourth bucket
-  aggr.Aggregate(100l, {});  // lies in eight bucket
+  aggr.Aggregate((int64_t)12, {});   // lies in fourth bucket
+  aggr.Aggregate((int64_t)100, {});  // lies in eight bucket
   histogram_data = nostd::get<HistogramPointData>(aggr.ToPoint());
   EXPECT_EQ(nostd::get<int64_t>(histogram_data.min_), 12);
   EXPECT_EQ(nostd::get<int64_t>(histogram_data.max_), 100);
@@ -86,8 +86,8 @@ TEST(Aggregation, LongHistogramAggregation)
   EXPECT_EQ(histogram_data.count_, 2);
   EXPECT_EQ(histogram_data.counts_[3], 1);
   EXPECT_EQ(histogram_data.counts_[7], 1);
-  aggr.Aggregate(13l, {});   // lies in fourth bucket
-  aggr.Aggregate(252l, {});  // lies in ninth bucket
+  aggr.Aggregate((int64_t)13, {});   // lies in fourth bucket
+  aggr.Aggregate((int64_t)252, {});  // lies in ninth bucket
   histogram_data = nostd::get<HistogramPointData>(aggr.ToPoint());
   EXPECT_EQ(histogram_data.count_, 4);
   EXPECT_EQ(histogram_data.counts_[3], 2);
@@ -97,16 +97,16 @@ TEST(Aggregation, LongHistogramAggregation)
 
   // Merge
   LongHistogramAggregation aggr1;
-  aggr1.Aggregate(1l, {});
-  aggr1.Aggregate(11l, {});
-  aggr1.Aggregate(26l, {});
+  aggr1.Aggregate((int64_t)1, {});
+  aggr1.Aggregate((int64_t)11, {});
+  aggr1.Aggregate((int64_t)26, {});
 
   LongHistogramAggregation aggr2;
-  aggr2.Aggregate(2l, {});
-  aggr2.Aggregate(3l, {});
-  aggr2.Aggregate(13l, {});
-  aggr2.Aggregate(28l, {});
-  aggr2.Aggregate(105l, {});
+  aggr2.Aggregate((int64_t)2, {});
+  aggr2.Aggregate((int64_t)3, {});
+  aggr2.Aggregate((int64_t)13, {});
+  aggr2.Aggregate((int64_t)28, {});
+  aggr2.Aggregate((int64_t)105, {});
 
   auto aggr3     = aggr1.Merge(aggr2);
   histogram_data = nostd::get<HistogramPointData>(aggr3->ToPoint());

--- a/sdk/test/metrics/aggregation_test.cc
+++ b/sdk/test/metrics/aggregation_test.cc
@@ -19,11 +19,11 @@ TEST(Aggregation, LongSumAggregation)
   ASSERT_TRUE(nostd::holds_alternative<SumPointData>(data));
   auto sum_data = nostd::get<SumPointData>(data);
   ASSERT_TRUE(nostd::holds_alternative<int64_t>(sum_data.value_));
-  EXPECT_EQ(nostd::get<int64_t>(sum_data.value_), (int64_t)0);
+  EXPECT_EQ(nostd::get<int64_t>(sum_data.value_), 0);
   aggr.Aggregate((int64_t)12, {});
   aggr.Aggregate((int64_t)0, {});
   sum_data = nostd::get<SumPointData>(aggr.ToPoint());
-  EXPECT_EQ(nostd::get<int64_t>(sum_data.value_), (int64_t)12);
+  EXPECT_EQ(nostd::get<int64_t>(sum_data.value_), 12);
 }
 
 TEST(Aggregation, DoubleSumAggregation)

--- a/sdk/test/metrics/async_metric_storage_test.cc
+++ b/sdk/test/metrics/async_metric_storage_test.cc
@@ -70,8 +70,8 @@ TEST_P(WritableMetricStorageTestFixture, TestAggregation)
       new DefaultAttributesProcessor{}};
   opentelemetry::sdk::metrics::AsyncMetricStorage storage(
       instr_desc, AggregationType::kSum, default_attributes_processor.get(), nullptr);
-  int64_t get_count1                                                                  = (int64_t)20;
-  int64_t put_count1                                                                  = (int64_t)10;
+  int64_t get_count1                                                                  = 20;
+  int64_t put_count1                                                                  = 10;
   std::unordered_map<MetricAttributes, int64_t, AttributeHashGenerator> measurements1 = {
       {{{"RequestType", "GET"}}, get_count1}, {{{"RequestType", "PUT"}}, put_count1}};
   storage.RecordLong(measurements1,
@@ -97,8 +97,8 @@ TEST_P(WritableMetricStorageTestFixture, TestAggregation)
       });
   // subsequent recording after collection shouldn't fail
   // monotonic increasing values;
-  int64_t get_count2 = (int64_t)50;
-  int64_t put_count2 = (int64_t)70;
+  int64_t get_count2 = 50;
+  int64_t put_count2 = 70;
 
   std::unordered_map<MetricAttributes, int64_t, AttributeHashGenerator> measurements2 = {
       {{{"RequestType", "GET"}}, get_count2}, {{{"RequestType", "PUT"}}, put_count2}};
@@ -162,8 +162,8 @@ TEST_P(WritableMetricStorageTestObservableGaugeFixture, TestAggregation)
       new DefaultAttributesProcessor{}};
   opentelemetry::sdk::metrics::AsyncMetricStorage storage(
       instr_desc, AggregationType::kLastValue, default_attributes_processor.get(), nullptr);
-  int64_t freq_cpu0                                                                   = (int64_t)3;
-  int64_t freq_cpu1                                                                   = (int64_t)5;
+  int64_t freq_cpu0                                                                   = 3;
+  int64_t freq_cpu1                                                                   = 5;
   std::unordered_map<MetricAttributes, int64_t, AttributeHashGenerator> measurements1 = {
       {{{"CPU", "0"}}, freq_cpu0}, {{{"CPU", "1"}}, freq_cpu1}};
   storage.RecordLong(measurements1,
@@ -188,8 +188,8 @@ TEST_P(WritableMetricStorageTestObservableGaugeFixture, TestAggregation)
         return true;
       });
 
-  freq_cpu0 = (int64_t)6;
-  freq_cpu1 = (int64_t)8;
+  freq_cpu0 = 6;
+  freq_cpu1 = 8;
 
   std::unordered_map<MetricAttributes, int64_t, AttributeHashGenerator> measurements2 = {
       {{{"CPU", "0"}}, freq_cpu0}, {{{"CPU", "1"}}, freq_cpu1}};

--- a/sdk/test/metrics/async_metric_storage_test.cc
+++ b/sdk/test/metrics/async_metric_storage_test.cc
@@ -9,8 +9,8 @@
 #  include "opentelemetry/sdk/metrics/meter_context.h"
 #  include "opentelemetry/sdk/metrics/metric_reader.h"
 #  include "opentelemetry/sdk/metrics/observer_result.h"
-#  include "opentelemetry/sdk/metrics/state/async_metric_storage.h"
 #  include "opentelemetry/sdk/metrics/push_metric_exporter.h"
+#  include "opentelemetry/sdk/metrics/state/async_metric_storage.h"
 #  include "opentelemetry/sdk/metrics/state/metric_collector.h"
 #  include "opentelemetry/sdk/metrics/state/observable_registry.h"
 

--- a/sdk/test/metrics/async_metric_storage_test.cc
+++ b/sdk/test/metrics/async_metric_storage_test.cc
@@ -70,9 +70,9 @@ TEST_P(WritableMetricStorageTestFixture, TestAggregation)
   opentelemetry::sdk::metrics::AsyncMetricStorage storage(
       instr_desc, AggregationType::kSum, default_attributes_processor.get(),
       std::shared_ptr<opentelemetry::sdk::metrics::AggregationConfig>{});
-  long get_count1                                                                  = 20l;
-  long put_count1                                                                  = 10l;
-  std::unordered_map<MetricAttributes, long, AttributeHashGenerator> measurements1 = {
+  int64_t get_count1                                                                  = 20l;
+  int64_t put_count1                                                                  = 10l;
+  std::unordered_map<MetricAttributes, int64_t, AttributeHashGenerator> measurements1 = {
       {{{"RequestType", "GET"}}, get_count1}, {{{"RequestType", "PUT"}}, put_count1}};
   storage.RecordLong(measurements1,
                      opentelemetry::common::SystemTimestamp(std::chrono::system_clock::now()));
@@ -85,22 +85,22 @@ TEST_P(WritableMetricStorageTestFixture, TestAggregation)
           if (opentelemetry::nostd::get<std::string>(
                   data_attr.attributes.find("RequestType")->second) == "GET")
           {
-            EXPECT_EQ(opentelemetry::nostd::get<long>(data.value_), get_count1);
+            EXPECT_EQ(opentelemetry::nostd::get<int64_t>(data.value_), get_count1);
           }
           else if (opentelemetry::nostd::get<std::string>(
                        data_attr.attributes.find("RequestType")->second) == "PUT")
           {
-            EXPECT_EQ(opentelemetry::nostd::get<long>(data.value_), put_count1);
+            EXPECT_EQ(opentelemetry::nostd::get<int64_t>(data.value_), put_count1);
           }
         }
         return true;
       });
   // subsequent recording after collection shouldn't fail
   // monotonic increasing values;
-  long get_count2 = 50l;
-  long put_count2 = 70l;
+  int64_t get_count2 = 50l;
+  int64_t put_count2 = 70l;
 
-  std::unordered_map<MetricAttributes, long, AttributeHashGenerator> measurements2 = {
+  std::unordered_map<MetricAttributes, int64_t, AttributeHashGenerator> measurements2 = {
       {{{"RequestType", "GET"}}, get_count2}, {{{"RequestType", "PUT"}}, put_count2}};
   storage.RecordLong(measurements2,
                      opentelemetry::common::SystemTimestamp(std::chrono::system_clock::now()));
@@ -114,11 +114,11 @@ TEST_P(WritableMetricStorageTestFixture, TestAggregation)
           {
             if (temporality == AggregationTemporality::kCumulative)
             {
-              EXPECT_EQ(opentelemetry::nostd::get<long>(data.value_), get_count2);
+              EXPECT_EQ(opentelemetry::nostd::get<int64_t>(data.value_), get_count2);
             }
             else
             {
-              EXPECT_EQ(opentelemetry::nostd::get<long>(data.value_), get_count2 - get_count1);
+              EXPECT_EQ(opentelemetry::nostd::get<int64_t>(data.value_), get_count2 - get_count1);
             }
           }
           else if (opentelemetry::nostd::get<std::string>(
@@ -126,11 +126,11 @@ TEST_P(WritableMetricStorageTestFixture, TestAggregation)
           {
             if (temporality == AggregationTemporality::kCumulative)
             {
-              EXPECT_EQ(opentelemetry::nostd::get<long>(data.value_), put_count2);
+              EXPECT_EQ(opentelemetry::nostd::get<int64_t>(data.value_), put_count2);
             }
             else
             {
-              EXPECT_EQ(opentelemetry::nostd::get<long>(data.value_), put_count2 - put_count1);
+              EXPECT_EQ(opentelemetry::nostd::get<int64_t>(data.value_), put_count2 - put_count1);
             }
           }
         }
@@ -163,9 +163,9 @@ TEST_P(WritableMetricStorageTestObservableGaugeFixture, TestAggregation)
   opentelemetry::sdk::metrics::AsyncMetricStorage storage(
       instr_desc, AggregationType::kLastValue, default_attributes_processor.get(),
       std::shared_ptr<opentelemetry::sdk::metrics::AggregationConfig>{});
-  long freq_cpu0                                                                   = 3l;
-  long freq_cpu1                                                                   = 5l;
-  std::unordered_map<MetricAttributes, long, AttributeHashGenerator> measurements1 = {
+  int64_t freq_cpu0                                                                   = 3l;
+  int64_t freq_cpu1                                                                   = 5l;
+  std::unordered_map<MetricAttributes, int64_t, AttributeHashGenerator> measurements1 = {
       {{{"CPU", "0"}}, freq_cpu0}, {{{"CPU", "1"}}, freq_cpu1}};
   storage.RecordLong(measurements1,
                      opentelemetry::common::SystemTimestamp(std::chrono::system_clock::now()));
@@ -178,12 +178,12 @@ TEST_P(WritableMetricStorageTestObservableGaugeFixture, TestAggregation)
           if (opentelemetry::nostd::get<std::string>(data_attr.attributes.find("CPU")->second) ==
               "0")
           {
-            EXPECT_EQ(opentelemetry::nostd::get<long>(data.value_), freq_cpu0);
+            EXPECT_EQ(opentelemetry::nostd::get<int64_t>(data.value_), freq_cpu0);
           }
           else if (opentelemetry::nostd::get<std::string>(
                        data_attr.attributes.find("CPU")->second) == "1")
           {
-            EXPECT_EQ(opentelemetry::nostd::get<long>(data.value_), freq_cpu1);
+            EXPECT_EQ(opentelemetry::nostd::get<int64_t>(data.value_), freq_cpu1);
           }
         }
         return true;
@@ -192,7 +192,7 @@ TEST_P(WritableMetricStorageTestObservableGaugeFixture, TestAggregation)
   freq_cpu0 = 6l;
   freq_cpu1 = 8l;
 
-  std::unordered_map<MetricAttributes, long, AttributeHashGenerator> measurements2 = {
+  std::unordered_map<MetricAttributes, int64_t, AttributeHashGenerator> measurements2 = {
       {{{"CPU", "0"}}, freq_cpu0}, {{{"CPU", "1"}}, freq_cpu1}};
   storage.RecordLong(measurements2,
                      opentelemetry::common::SystemTimestamp(std::chrono::system_clock::now()));
@@ -204,12 +204,12 @@ TEST_P(WritableMetricStorageTestObservableGaugeFixture, TestAggregation)
           if (opentelemetry::nostd::get<std::string>(data_attr.attributes.find("CPU")->second) ==
               "0")
           {
-            EXPECT_EQ(opentelemetry::nostd::get<long>(data.value_), freq_cpu0);
+            EXPECT_EQ(opentelemetry::nostd::get<int64_t>(data.value_), freq_cpu0);
           }
           else if (opentelemetry::nostd::get<std::string>(
                        data_attr.attributes.find("CPU")->second) == "1")
           {
-            EXPECT_EQ(opentelemetry::nostd::get<long>(data.value_), freq_cpu1);
+            EXPECT_EQ(opentelemetry::nostd::get<int64_t>(data.value_), freq_cpu1);
           }
         }
         return true;

--- a/sdk/test/metrics/async_metric_storage_test.cc
+++ b/sdk/test/metrics/async_metric_storage_test.cc
@@ -70,8 +70,8 @@ TEST_P(WritableMetricStorageTestFixture, TestAggregation)
   opentelemetry::sdk::metrics::AsyncMetricStorage storage(
       instr_desc, AggregationType::kSum, default_attributes_processor.get(),
       std::shared_ptr<opentelemetry::sdk::metrics::AggregationConfig>{});
-  int64_t get_count1                                                                  = 20l;
-  int64_t put_count1                                                                  = 10l;
+  int64_t get_count1                                                                  = (int64_t)20;
+  int64_t put_count1                                                                  = (int64_t)10;
   std::unordered_map<MetricAttributes, int64_t, AttributeHashGenerator> measurements1 = {
       {{{"RequestType", "GET"}}, get_count1}, {{{"RequestType", "PUT"}}, put_count1}};
   storage.RecordLong(measurements1,
@@ -97,8 +97,8 @@ TEST_P(WritableMetricStorageTestFixture, TestAggregation)
       });
   // subsequent recording after collection shouldn't fail
   // monotonic increasing values;
-  int64_t get_count2 = 50l;
-  int64_t put_count2 = 70l;
+  int64_t get_count2 = (int64_t)50;
+  int64_t put_count2 = (int64_t)70;
 
   std::unordered_map<MetricAttributes, int64_t, AttributeHashGenerator> measurements2 = {
       {{{"RequestType", "GET"}}, get_count2}, {{{"RequestType", "PUT"}}, put_count2}};
@@ -163,8 +163,8 @@ TEST_P(WritableMetricStorageTestObservableGaugeFixture, TestAggregation)
   opentelemetry::sdk::metrics::AsyncMetricStorage storage(
       instr_desc, AggregationType::kLastValue, default_attributes_processor.get(),
       std::shared_ptr<opentelemetry::sdk::metrics::AggregationConfig>{});
-  int64_t freq_cpu0                                                                   = 3l;
-  int64_t freq_cpu1                                                                   = 5l;
+  int64_t freq_cpu0                                                                   = (int64_t)3;
+  int64_t freq_cpu1                                                                   = (int64_t)5;
   std::unordered_map<MetricAttributes, int64_t, AttributeHashGenerator> measurements1 = {
       {{{"CPU", "0"}}, freq_cpu0}, {{{"CPU", "1"}}, freq_cpu1}};
   storage.RecordLong(measurements1,
@@ -189,8 +189,8 @@ TEST_P(WritableMetricStorageTestObservableGaugeFixture, TestAggregation)
         return true;
       });
 
-  freq_cpu0 = 6l;
-  freq_cpu1 = 8l;
+  freq_cpu0 = (int64_t)6;
+  freq_cpu1 = (int64_t)8;
 
   std::unordered_map<MetricAttributes, int64_t, AttributeHashGenerator> measurements2 = {
       {{{"CPU", "0"}}, freq_cpu0}, {{{"CPU", "1"}}, freq_cpu1}};

--- a/sdk/test/metrics/async_metric_storage_test.cc
+++ b/sdk/test/metrics/async_metric_storage_test.cc
@@ -1,8 +1,8 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
+#include <cstdint>
 #ifndef ENABLE_METRICS_PREVIEW
-#  include "opentelemetry/sdk/metrics/state/async_metric_storage.h"
 #  include "opentelemetry/common/key_value_iterable_view.h"
 #  include "opentelemetry/sdk/metrics/async_instruments.h"
 #  include "opentelemetry/sdk/metrics/instruments.h"
@@ -10,6 +10,7 @@
 #  include "opentelemetry/sdk/metrics/metric_exporter.h"
 #  include "opentelemetry/sdk/metrics/metric_reader.h"
 #  include "opentelemetry/sdk/metrics/observer_result.h"
+#  include "opentelemetry/sdk/metrics/state/async_metric_storage.h"
 #  include "opentelemetry/sdk/metrics/state/metric_collector.h"
 #  include "opentelemetry/sdk/metrics/state/observable_registry.h"
 
@@ -161,9 +162,9 @@ TEST_P(WritableMetricStorageTestObservableGaugeFixture, TestAggregation)
       new DefaultAttributesProcessor{}};
   opentelemetry::sdk::metrics::AsyncMetricStorage storage(
       instr_desc, AggregationType::kLastValue, default_attributes_processor.get(), nullptr);
-  long freq_cpu0                                                                   = 3l;
-  long freq_cpu1                                                                   = 5l;
-  std::unordered_map<MetricAttributes, long, AttributeHashGenerator> measurements1 = {
+  int64_t freq_cpu0                                                                   = (int64_t)3;
+  int64_t freq_cpu1                                                                   = (int64_t)5;
+  std::unordered_map<MetricAttributes, int64_t, AttributeHashGenerator> measurements1 = {
       {{{"CPU", "0"}}, freq_cpu0}, {{{"CPU", "1"}}, freq_cpu1}};
   storage.RecordLong(measurements1,
                      opentelemetry::common::SystemTimestamp(std::chrono::system_clock::now()));

--- a/sdk/test/metrics/attributes_hashmap_benchmark.cc
+++ b/sdk/test/metrics/attributes_hashmap_benchmark.cc
@@ -33,7 +33,7 @@ void BM_AttributseHashMap(benchmark::State &state)
       return std::unique_ptr<Aggregation>(new DropAggregation);
     };
     m.lock();
-    hash_map.GetOrSetDefault(attributes[i % 2], create_default_aggregation)->Aggregate(1l);
+    hash_map.GetOrSetDefault(attributes[i % 2], create_default_aggregation)->Aggregate((int64_t)1);
     benchmark::DoNotOptimize(hash_map.Has(attributes[i % 2]));
     m.unlock();
   };

--- a/sdk/test/metrics/attributes_hashmap_test.cc
+++ b/sdk/test/metrics/attributes_hashmap_test.cc
@@ -26,14 +26,14 @@ TEST(AttributesHashMap, BasicTests)
   std::unique_ptr<Aggregation> aggregation1(
       new DropAggregation());  //  = std::unique_ptr<Aggregation>(new DropAggregation);
   hash_map.Set(m1, std::move(aggregation1));
-  EXPECT_NO_THROW(hash_map.Get(m1)->Aggregate(1l));
+  EXPECT_NO_THROW(hash_map.Get(m1)->Aggregate((int64_t)1));
   EXPECT_EQ(hash_map.Size(), 1);
   EXPECT_EQ(hash_map.Has(m1), true);
 
   // Set same key again
   auto aggregation2 = std::unique_ptr<Aggregation>(new DropAggregation());
   hash_map.Set(m1, std::move(aggregation2));
-  EXPECT_NO_THROW(hash_map.Get(m1)->Aggregate(1l));
+  EXPECT_NO_THROW(hash_map.Get(m1)->Aggregate((int64_t)1));
   EXPECT_EQ(hash_map.Size(), 1);
   EXPECT_EQ(hash_map.Has(m1), true);
 
@@ -43,7 +43,7 @@ TEST(AttributesHashMap, BasicTests)
   hash_map.Set(m3, std::move(aggregation3));
   EXPECT_EQ(hash_map.Has(m1), true);
   EXPECT_EQ(hash_map.Has(m3), true);
-  EXPECT_NO_THROW(hash_map.Get(m3)->Aggregate(1l));
+  EXPECT_NO_THROW(hash_map.Get(m3)->Aggregate((int64_t)1));
   EXPECT_EQ(hash_map.Size(), 2);
 
   // GetOrSetDefault
@@ -52,7 +52,7 @@ TEST(AttributesHashMap, BasicTests)
     return std::unique_ptr<Aggregation>(new DropAggregation);
   };
   MetricAttributes m4 = {{"k1", "v1"}, {"k2", "v2"}, {"k3", "v3"}};
-  EXPECT_NO_THROW(hash_map.GetOrSetDefault(m4, create_default_aggregation)->Aggregate(1l));
+  EXPECT_NO_THROW(hash_map.GetOrSetDefault(m4, create_default_aggregation)->Aggregate((int64_t)1));
   EXPECT_EQ(hash_map.Size(), 3);
 
   // Set attributes with different order - shouldn't create a new entry.

--- a/sdk/test/metrics/exemplar/always_sample_filter_test.cc
+++ b/sdk/test/metrics/exemplar/always_sample_filter_test.cc
@@ -12,8 +12,8 @@ TEST(AlwaysSampleFilter, SampleMeasurement)
   auto filter = opentelemetry::sdk::metrics::ExemplarFilter::GetAlwaysSampleFilter();
   ASSERT_TRUE(
       filter->ShouldSampleMeasurement(1.0, MetricAttributes{}, opentelemetry::context::Context{}));
-  ASSERT_TRUE(
-      filter->ShouldSampleMeasurement(1l, MetricAttributes{}, opentelemetry::context::Context{}));
+  ASSERT_TRUE(filter->ShouldSampleMeasurement((int64_t)1, MetricAttributes{},
+                                              opentelemetry::context::Context{}));
 }
 
 #endif

--- a/sdk/test/metrics/exemplar/histogram_exemplar_reservoir_test.cc
+++ b/sdk/test/metrics/exemplar/histogram_exemplar_reservoir_test.cc
@@ -23,8 +23,9 @@ TEST_F(HistogramExemplarReservoirTestPeer, OfferMeasurement)
       boundaries.size(), HistogramExemplarReservoir::GetHistogramCellSelector(boundaries), nullptr);
   histogram_exemplar_reservoir->OfferMeasurement(
       1.0, MetricAttributes{}, opentelemetry::context::Context{}, std::chrono::system_clock::now());
-  histogram_exemplar_reservoir->OfferMeasurement(
-      1l, MetricAttributes{}, opentelemetry::context::Context{}, std::chrono::system_clock::now());
+  histogram_exemplar_reservoir->OfferMeasurement((int64_t)1, MetricAttributes{},
+                                                 opentelemetry::context::Context{},
+                                                 std::chrono::system_clock::now());
   auto exemplar_data = histogram_exemplar_reservoir->CollectAndReset(MetricAttributes{});
   ASSERT_TRUE(exemplar_data.empty());
 }

--- a/sdk/test/metrics/exemplar/never_sample_filter_test.cc
+++ b/sdk/test/metrics/exemplar/never_sample_filter_test.cc
@@ -13,8 +13,8 @@ TEST(NeverSampleFilter, SampleMeasurement)
   auto filter = opentelemetry::sdk::metrics::ExemplarFilter::GetNeverSampleFilter();
   ASSERT_FALSE(
       filter->ShouldSampleMeasurement(1.0, MetricAttributes{}, opentelemetry::context::Context{}));
-  ASSERT_FALSE(
-      filter->ShouldSampleMeasurement(1l, MetricAttributes{}, opentelemetry::context::Context{}));
+  ASSERT_FALSE(filter->ShouldSampleMeasurement((int64_t)1, MetricAttributes{},
+                                               opentelemetry::context::Context{}));
 }
 
 #endif

--- a/sdk/test/metrics/exemplar/no_exemplar_reservoir_test.cc
+++ b/sdk/test/metrics/exemplar/no_exemplar_reservoir_test.cc
@@ -12,7 +12,7 @@ TEST(NoExemplarReservoir, OfferMeasurement)
   auto reservoir = opentelemetry::sdk::metrics::ExemplarReservoir::GetNoExemplarReservoir();
   reservoir->OfferMeasurement(1.0, MetricAttributes{}, opentelemetry::context::Context{},
                               std::chrono::system_clock::now());
-  reservoir->OfferMeasurement(1l, MetricAttributes{}, opentelemetry::context::Context{},
+  reservoir->OfferMeasurement((int64_t)1, MetricAttributes{}, opentelemetry::context::Context{},
                               std::chrono::system_clock::now());
   auto exemplar_data = reservoir->CollectAndReset(MetricAttributes{});
   ASSERT_TRUE(exemplar_data.empty());

--- a/sdk/test/metrics/exemplar/reservoir_cell_test.cc
+++ b/sdk/test/metrics/exemplar/reservoir_cell_test.cc
@@ -13,9 +13,9 @@ namespace metrics
 class ReservoirCellTestPeer : public ::testing::Test
 {
 public:
-  long GetLongVal(const opentelemetry::sdk::metrics::ReservoirCell &reservoir_cell)
+  int64_t GetLongVal(const opentelemetry::sdk::metrics::ReservoirCell &reservoir_cell)
   {
-    return nostd::get<long>(reservoir_cell.value_);
+    return nostd::get<int64_t>(reservoir_cell.value_);
   }
 
   double GetDoubleVal(const opentelemetry::sdk::metrics::ReservoirCell &reservoir_cell)

--- a/sdk/test/metrics/exemplar/reservoir_cell_test.cc
+++ b/sdk/test/metrics/exemplar/reservoir_cell_test.cc
@@ -42,7 +42,8 @@ public:
 TEST_F(ReservoirCellTestPeer, recordMeasurement)
 {
   opentelemetry::sdk::metrics::ReservoirCell reservoir_cell;
-  reservoir_cell.RecordLongMeasurement(1l, MetricAttributes{}, opentelemetry::context::Context{});
+  reservoir_cell.RecordLongMeasurement((int64_t)1, MetricAttributes{},
+                                       opentelemetry::context::Context{});
   ASSERT_TRUE(GetLongVal(reservoir_cell) == 1);
 
   reservoir_cell.RecordDoubleMeasurement(1.5, MetricAttributes{},

--- a/sdk/test/metrics/exemplar/with_trace_sample_filter_test.cc
+++ b/sdk/test/metrics/exemplar/with_trace_sample_filter_test.cc
@@ -13,8 +13,8 @@ TEST(WithTraceSampleFilter, SampleMeasurement)
   auto filter = opentelemetry::sdk::metrics::ExemplarFilter::GetWithTraceSampleFilter();
   ASSERT_FALSE(
       filter->ShouldSampleMeasurement(1.0, MetricAttributes{}, opentelemetry::context::Context{}));
-  ASSERT_FALSE(
-      filter->ShouldSampleMeasurement(1l, MetricAttributes{}, opentelemetry::context::Context{}));
+  ASSERT_FALSE(filter->ShouldSampleMeasurement((int64_t)1, MetricAttributes{},
+                                               opentelemetry::context::Context{}));
 }
 
 #endif

--- a/sdk/test/metrics/meter_test.cc
+++ b/sdk/test/metrics/meter_test.cc
@@ -47,7 +47,7 @@ void asyc_generate_measurements(opentelemetry::metrics::ObserverResult observer,
 {
   auto observer_long =
       nostd::get<nostd::shared_ptr<opentelemetry::metrics::ObserverResultT<int64_t>>>(observer);
-  observer_long->Observe(10l);
+  observer_long->Observe((int64_t)10);
 }
 
 TEST(MeterTest, BasicAsyncTests)

--- a/sdk/test/metrics/meter_test.cc
+++ b/sdk/test/metrics/meter_test.cc
@@ -54,7 +54,7 @@ TEST(MeterTest, BasicAsyncTests)
 {
   MetricReader *metric_reader_ptr = nullptr;
   auto meter                      = InitMeter(&metric_reader_ptr);
-  auto observable_counter         = meter->CreateLongObservableCounter("observable_counter");
+  auto observable_counter         = meter->CreateUInt64ObservableCounter("observable_counter");
   observable_counter->AddCallback(asyc_generate_measurements, nullptr);
 
   size_t count = 0;
@@ -99,15 +99,15 @@ TEST(MeterTest, StressMultiThread)
           if (do_sync_create.exchange(false))
           {
             std::string instrument_name = "test_couter_" + std::to_string(instrument_id);
-            meter->CreateInt64Counter(instrument_name, "", "");
+            meter->CreateUInt64Counter(instrument_name, "", "");
             do_async_create.store(true);
             instrument_id++;
           }
           if (do_async_create.exchange(false))
           {
             std::cout << "\n creating async thread " << std::to_string(numIterations);
-            auto observable_instrument =
-                meter->CreateLongObservableGauge("test_gauge_" + std::to_string(instrument_id));
+            auto observable_instrument = meter->CreateInt64ObservableUpDownCounter(
+                "test_gauge_" + std::to_string(instrument_id));
             observable_instrument->AddCallback(asyc_generate_measurements, nullptr);
             observable_instruments.push_back(std::move(observable_instrument));
             do_collect.store(true);

--- a/sdk/test/metrics/meter_test.cc
+++ b/sdk/test/metrics/meter_test.cc
@@ -99,7 +99,7 @@ TEST(MeterTest, StressMultiThread)
           if (do_sync_create.exchange(false))
           {
             std::string instrument_name = "test_couter_" + std::to_string(instrument_id);
-            meter->CreateLongCounter(instrument_name, "", "");
+            meter->CreateInt64Counter(instrument_name, "", "");
             do_async_create.store(true);
             instrument_id++;
           }

--- a/sdk/test/metrics/meter_test.cc
+++ b/sdk/test/metrics/meter_test.cc
@@ -47,7 +47,7 @@ void asyc_generate_measurements(opentelemetry::metrics::ObserverResult observer,
 {
   auto observer_long =
       nostd::get<nostd::shared_ptr<opentelemetry::metrics::ObserverResultT<int64_t>>>(observer);
-  observer_long->Observe((int64_t)10);
+  observer_long->Observe(10);
 }
 
 TEST(MeterTest, BasicAsyncTests)

--- a/sdk/test/metrics/meter_test.cc
+++ b/sdk/test/metrics/meter_test.cc
@@ -54,7 +54,7 @@ TEST(MeterTest, BasicAsyncTests)
 {
   MetricReader *metric_reader_ptr = nullptr;
   auto meter                      = InitMeter(&metric_reader_ptr);
-  auto observable_counter         = meter->CreateUInt64ObservableCounter("observable_counter");
+  auto observable_counter         = meter->CreateInt64ObservableCounter("observable_counter");
   observable_counter->AddCallback(asyc_generate_measurements, nullptr);
 
   size_t count = 0;

--- a/sdk/test/metrics/meter_test.cc
+++ b/sdk/test/metrics/meter_test.cc
@@ -46,7 +46,7 @@ nostd::shared_ptr<metrics::Meter> InitMeter(MetricReader **metricReaderPtr,
 void asyc_generate_measurements(opentelemetry::metrics::ObserverResult observer, void * /* state */)
 {
   auto observer_long =
-      nostd::get<nostd::shared_ptr<opentelemetry::metrics::ObserverResultT<long>>>(observer);
+      nostd::get<nostd::shared_ptr<opentelemetry::metrics::ObserverResultT<int64_t>>>(observer);
   observer_long->Observe(10l);
 }
 

--- a/sdk/test/metrics/multi_metric_storage_test.cc
+++ b/sdk/test/metrics/multi_metric_storage_test.cc
@@ -52,11 +52,11 @@ TEST(MultiMetricStorageTest, BasicTests)
       new TestMetricStorage());
   SyncMultiMetricStorage storages{};
   storages.AddStorage(storage);
-  storages.RecordLong(10l, opentelemetry::context::Context{});
-  storages.RecordLong(20l, opentelemetry::context::Context{});
+  storages.RecordLong((int64_t)10, opentelemetry::context::Context{});
+  storages.RecordLong((int64_t)20, opentelemetry::context::Context{});
 
   storages.RecordDouble(10.0, opentelemetry::context::Context{});
-  storages.RecordLong(30l, opentelemetry::context::Context{});
+  storages.RecordLong((int64_t)30, opentelemetry::context::Context{});
 
   EXPECT_EQ(static_cast<TestMetricStorage *>(storage.get())->num_calls_long, 3);
   EXPECT_EQ(static_cast<TestMetricStorage *>(storage.get())->num_calls_double, 1);

--- a/sdk/test/metrics/multi_metric_storage_test.cc
+++ b/sdk/test/metrics/multi_metric_storage_test.cc
@@ -52,11 +52,11 @@ TEST(MultiMetricStorageTest, BasicTests)
       new TestMetricStorage());
   SyncMultiMetricStorage storages{};
   storages.AddStorage(storage);
-  storages.RecordLong((int64_t)10, opentelemetry::context::Context{});
-  storages.RecordLong((int64_t)20, opentelemetry::context::Context{});
+  storages.RecordLong(10, opentelemetry::context::Context{});
+  storages.RecordLong(20, opentelemetry::context::Context{});
 
   storages.RecordDouble(10.0, opentelemetry::context::Context{});
-  storages.RecordLong((int64_t)30, opentelemetry::context::Context{});
+  storages.RecordLong(30, opentelemetry::context::Context{});
 
   EXPECT_EQ(static_cast<TestMetricStorage *>(storage.get())->num_calls_long, 3);
   EXPECT_EQ(static_cast<TestMetricStorage *>(storage.get())->num_calls_double, 1);

--- a/sdk/test/metrics/multi_metric_storage_test.cc
+++ b/sdk/test/metrics/multi_metric_storage_test.cc
@@ -16,13 +16,13 @@ using namespace opentelemetry::sdk::metrics;
 class TestMetricStorage : public SyncWritableMetricStorage
 {
 public:
-  void RecordLong(long /* value */,
+  void RecordLong(int64_t /* value */,
                   const opentelemetry::context::Context & /* context */) noexcept override
   {
     num_calls_long++;
   }
 
-  void RecordLong(long /* value */,
+  void RecordLong(int64_t /* value */,
                   const opentelemetry::common::KeyValueIterable & /* attributes */,
                   const opentelemetry::context::Context & /* context */) noexcept override
   {

--- a/sdk/test/metrics/observable_registry_test.cc
+++ b/sdk/test/metrics/observable_registry_test.cc
@@ -62,8 +62,8 @@ public:
   }
 
   static size_t fetch_count1, fetch_count2;
-  static long number_of_get1, number_of_get2;
-  static long number_of_put1, number_of_put2;
+  static int64_t number_of_get1, number_of_get2;
+  static int64_t number_of_put1, number_of_put2;
   static const size_t number_of_attributes = 2;  // GET , PUT
 };
 

--- a/sdk/test/metrics/observable_registry_test.cc
+++ b/sdk/test/metrics/observable_registry_test.cc
@@ -19,15 +19,15 @@ public:
     fetch_count1++;
     if (fetch_count1 == 1)
     {
-      std::get<observer_result.Observe(20l, {{"RequestType", "GET"}});
-      observer_result.Observe(10l, {{"RequestType", "PUT"}});
+      std::get<observer_result.Observe((int64_t)20, {{"RequestType", "GET"}});
+      observer_result.Observe((int64_t)10, {{"RequestType", "PUT"}});
       number_of_get1 += (int64_t)20;
       number_of_put1 += (int64_t)10;
     }
     else if (fetch_count1 == 2)
     {
-      observer_result.Observe(40l, {{"RequestType", "GET"}});
-      observer_result.Observe(20l, {{"RequestType", "PUT"}});
+      observer_result.Observe((int64_t)40, {{"RequestType", "GET"}});
+      observer_result.Observe((int64_t)20, {{"RequestType", "PUT"}});
       number_of_get1 += (int64_t)40;
       number_of_put1 += (int64_t)20;
     }
@@ -39,15 +39,15 @@ public:
     fetch_count2++;
     if (fetch_count2 == 1)
     {
-      observer_result.Observe(20l, {{"RequestType", "GET"}});
-      observer_result.Observe(10l, {{"RequestType", "PUT"}});
+      observer_result.Observe((int64_t)20, {{"RequestType", "GET"}});
+      observer_result.Observe((int64_t)10, {{"RequestType", "PUT"}});
       number_of_get2 += (int64_t)20;
       number_of_put2 += (int64_t)10;
     }
     else if (fetch_count2 == 2)
     {
-      observer_result.Observe(40l, {{"RequestType", "GET"}});
-      observer_result.Observe(20l, {{"RequestType", "PUT"}});
+      observer_result.Observe((int64_t)40, {{"RequestType", "GET"}});
+      observer_result.Observe((int64_t)20, {{"RequestType", "PUT"}});
       number_of_get2 += (int64_t)40;
       number_of_put2 += (int64_t)20;
     }

--- a/sdk/test/metrics/observable_registry_test.cc
+++ b/sdk/test/metrics/observable_registry_test.cc
@@ -21,15 +21,15 @@ public:
     {
       std::get<observer_result.Observe(20l, {{"RequestType", "GET"}});
       observer_result.Observe(10l, {{"RequestType", "PUT"}});
-      number_of_get1 += 20l;
-      number_of_put1 += 10l;
+      number_of_get1 += (int64_t)20;
+      number_of_put1 += (int64_t)10;
     }
     else if (fetch_count1 == 2)
     {
       observer_result.Observe(40l, {{"RequestType", "GET"}});
       observer_result.Observe(20l, {{"RequestType", "PUT"}});
-      number_of_get1 += 40l;
-      number_of_put1 += 20l;
+      number_of_get1 += (int64_t)40;
+      number_of_put1 += (int64_t)20;
     }
   }
 
@@ -41,15 +41,15 @@ public:
     {
       observer_result.Observe(20l, {{"RequestType", "GET"}});
       observer_result.Observe(10l, {{"RequestType", "PUT"}});
-      number_of_get2 += 20l;
-      number_of_put2 += 10l;
+      number_of_get2 += (int64_t)20;
+      number_of_put2 += (int64_t)10;
     }
     else if (fetch_count2 == 2)
     {
       observer_result.Observe(40l, {{"RequestType", "GET"}});
       observer_result.Observe(20l, {{"RequestType", "PUT"}});
-      number_of_get2 += 40l;
-      number_of_put2 += 20l;
+      number_of_get2 += (int64_t)40;
+      number_of_put2 += (int64_t)20;
     }
   }
 

--- a/sdk/test/metrics/observer_result_test.cc
+++ b/sdk/test/metrics/observer_result_test.cc
@@ -14,22 +14,22 @@ TEST(ObserverResult, BasicTests)
 
   ObserverResultT<int64_t> observer_result(attributes_processor);
 
-  observer_result.Observe(10l);
-  observer_result.Observe(20l);
+  observer_result.Observe((int64_t)10);
+  observer_result.Observe((int64_t)20);
   EXPECT_EQ(observer_result.GetMeasurements().size(), 1);
 
   std::map<std::string, int64_t> m1 = {{"k2", 12}};
   observer_result.Observe(
-      30l, opentelemetry::common::KeyValueIterableView<std::map<std::string, int64_t>>(m1));
+      (int64_t)30, opentelemetry::common::KeyValueIterableView<std::map<std::string, int64_t>>(m1));
   EXPECT_EQ(observer_result.GetMeasurements().size(), 2);
 
   observer_result.Observe(
-      40l, opentelemetry::common::KeyValueIterableView<std::map<std::string, int64_t>>(m1));
+      (int64_t)40, opentelemetry::common::KeyValueIterableView<std::map<std::string, int64_t>>(m1));
   EXPECT_EQ(observer_result.GetMeasurements().size(), 2);
 
   std::map<std::string, int64_t> m2 = {{"k2", 12}, {"k4", 12}};
   observer_result.Observe(
-      40l, opentelemetry::common::KeyValueIterableView<std::map<std::string, int64_t>>(m2));
+      (int64_t)40, opentelemetry::common::KeyValueIterableView<std::map<std::string, int64_t>>(m2));
   EXPECT_EQ(observer_result.GetMeasurements().size(), 3);
 
   delete attributes_processor;

--- a/sdk/test/metrics/observer_result_test.cc
+++ b/sdk/test/metrics/observer_result_test.cc
@@ -14,22 +14,22 @@ TEST(ObserverResult, BasicTests)
 
   ObserverResultT<int64_t> observer_result(attributes_processor);
 
-  observer_result.Observe((int64_t)10);
-  observer_result.Observe((int64_t)20);
+  observer_result.Observe(10);
+  observer_result.Observe(20);
   EXPECT_EQ(observer_result.GetMeasurements().size(), 1);
 
   std::map<std::string, int64_t> m1 = {{"k2", 12}};
   observer_result.Observe(
-      (int64_t)30, opentelemetry::common::KeyValueIterableView<std::map<std::string, int64_t>>(m1));
+      30, opentelemetry::common::KeyValueIterableView<std::map<std::string, int64_t>>(m1));
   EXPECT_EQ(observer_result.GetMeasurements().size(), 2);
 
   observer_result.Observe(
-      (int64_t)40, opentelemetry::common::KeyValueIterableView<std::map<std::string, int64_t>>(m1));
+      40, opentelemetry::common::KeyValueIterableView<std::map<std::string, int64_t>>(m1));
   EXPECT_EQ(observer_result.GetMeasurements().size(), 2);
 
   std::map<std::string, int64_t> m2 = {{"k2", 12}, {"k4", 12}};
   observer_result.Observe(
-      (int64_t)40, opentelemetry::common::KeyValueIterableView<std::map<std::string, int64_t>>(m2));
+      40, opentelemetry::common::KeyValueIterableView<std::map<std::string, int64_t>>(m2));
   EXPECT_EQ(observer_result.GetMeasurements().size(), 3);
 
   delete attributes_processor;

--- a/sdk/test/metrics/observer_result_test.cc
+++ b/sdk/test/metrics/observer_result_test.cc
@@ -12,7 +12,7 @@ TEST(ObserverResult, BasicTests)
 {
   const AttributesProcessor *attributes_processor = new DefaultAttributesProcessor();
 
-  ObserverResultT<long> observer_result(attributes_processor);
+  ObserverResultT<int64_t> observer_result(attributes_processor);
 
   observer_result.Observe(10l);
   observer_result.Observe(20l);

--- a/sdk/test/metrics/sync_instruments_test.cc
+++ b/sdk/test/metrics/sync_instruments_test.cc
@@ -25,7 +25,7 @@ TEST(SyncInstruments, LongCounter)
   InstrumentDescriptor instrument_descriptor = {
       "long_counter", "description", "1", InstrumentType::kCounter, InstrumentValueType::kLong};
   std::unique_ptr<SyncWritableMetricStorage> metric_storage(new SyncMultiMetricStorage());
-  LongCounter counter(instrument_descriptor, std::move(metric_storage));
+  LongCounter<int64_t> counter(instrument_descriptor, std::move(metric_storage));
   counter.Add((int64_t)10);
   counter.Add((int64_t)10, opentelemetry::context::Context{});
 
@@ -103,7 +103,7 @@ TEST(SyncInstruments, LongHistogram)
   InstrumentDescriptor instrument_descriptor = {
       "long_histogram", "description", "1", InstrumentType::kHistogram, InstrumentValueType::kLong};
   std::unique_ptr<SyncWritableMetricStorage> metric_storage(new SyncMultiMetricStorage());
-  LongHistogram counter(instrument_descriptor, std::move(metric_storage));
+  LongHistogram<int64_t> counter(instrument_descriptor, std::move(metric_storage));
   counter.Record((int64_t)10, opentelemetry::context::Context{});
   counter.Record((int64_t)-10, opentelemetry::context::Context{});  // This is ignored
 

--- a/sdk/test/metrics/sync_instruments_test.cc
+++ b/sdk/test/metrics/sync_instruments_test.cc
@@ -26,15 +26,16 @@ TEST(SyncInstruments, LongCounter)
       "long_counter", "description", "1", InstrumentType::kCounter, InstrumentValueType::kLong};
   std::unique_ptr<SyncWritableMetricStorage> metric_storage(new SyncMultiMetricStorage());
   LongCounter counter(instrument_descriptor, std::move(metric_storage));
-  counter.Add(10l);
-  counter.Add(10l, opentelemetry::context::Context{});
+  counter.Add((int64_t)10);
+  counter.Add((int64_t)10, opentelemetry::context::Context{});
 
-  counter.Add(10l,
+  counter.Add((int64_t)10,
               opentelemetry::common::KeyValueIterableView<M>({{"abc", "123"}, {"xyz", "456"}}));
-  counter.Add(10l, opentelemetry::common::KeyValueIterableView<M>({{"abc", "123"}, {"xyz", "456"}}),
+  counter.Add((int64_t)10,
+              opentelemetry::common::KeyValueIterableView<M>({{"abc", "123"}, {"xyz", "456"}}),
               opentelemetry::context::Context{});
-  counter.Add(10l, opentelemetry::common::KeyValueIterableView<M>({}));
-  counter.Add(10l, opentelemetry::common::KeyValueIterableView<M>({}),
+  counter.Add((int64_t)10, opentelemetry::common::KeyValueIterableView<M>({}));
+  counter.Add((int64_t)10, opentelemetry::common::KeyValueIterableView<M>({}),
               opentelemetry::context::Context{});
 }
 
@@ -64,15 +65,16 @@ TEST(SyncInstruments, LongUpDownCounter)
                                                 InstrumentValueType::kLong};
   std::unique_ptr<SyncWritableMetricStorage> metric_storage(new SyncMultiMetricStorage());
   LongUpDownCounter counter(instrument_descriptor, std::move(metric_storage));
-  counter.Add(10l);
-  counter.Add(10l, opentelemetry::context::Context{});
+  counter.Add((int64_t)10);
+  counter.Add((int64_t)10, opentelemetry::context::Context{});
 
-  counter.Add(10l,
+  counter.Add((int64_t)10,
               opentelemetry::common::KeyValueIterableView<M>({{"abc", "123"}, {"xyz", "456"}}));
-  counter.Add(10l, opentelemetry::common::KeyValueIterableView<M>({{"abc", "123"}, {"xyz", "456"}}),
+  counter.Add((int64_t)10,
+              opentelemetry::common::KeyValueIterableView<M>({{"abc", "123"}, {"xyz", "456"}}),
               opentelemetry::context::Context{});
-  counter.Add(10l, opentelemetry::common::KeyValueIterableView<M>({}));
-  counter.Add(10l, opentelemetry::common::KeyValueIterableView<M>({}),
+  counter.Add((int64_t)10, opentelemetry::common::KeyValueIterableView<M>({}));
+  counter.Add((int64_t)10, opentelemetry::common::KeyValueIterableView<M>({}),
               opentelemetry::context::Context{});
 }
 
@@ -102,13 +104,13 @@ TEST(SyncInstruments, LongHistogram)
       "long_histogram", "description", "1", InstrumentType::kHistogram, InstrumentValueType::kLong};
   std::unique_ptr<SyncWritableMetricStorage> metric_storage(new SyncMultiMetricStorage());
   LongHistogram counter(instrument_descriptor, std::move(metric_storage));
-  counter.Record(10l, opentelemetry::context::Context{});
-  counter.Record(-10l, opentelemetry::context::Context{});  // This is ignored
+  counter.Record((int64_t)10, opentelemetry::context::Context{});
+  counter.Record((int64_t)-10, opentelemetry::context::Context{});  // This is ignored
 
-  counter.Record(10l,
+  counter.Record((int64_t)10,
                  opentelemetry::common::KeyValueIterableView<M>({{"abc", "123"}, {"xyz", "456"}}),
                  opentelemetry::context::Context{});
-  counter.Record(10l, opentelemetry::common::KeyValueIterableView<M>({}),
+  counter.Record((int64_t)10, opentelemetry::common::KeyValueIterableView<M>({}),
                  opentelemetry::context::Context{});
 }
 

--- a/sdk/test/metrics/sync_instruments_test.cc
+++ b/sdk/test/metrics/sync_instruments_test.cc
@@ -26,16 +26,14 @@ TEST(SyncInstruments, LongCounter)
       "long_counter", "description", "1", InstrumentType::kCounter, InstrumentValueType::kLong};
   std::unique_ptr<SyncWritableMetricStorage> metric_storage(new SyncMultiMetricStorage());
   LongCounter<int64_t> counter(instrument_descriptor, std::move(metric_storage));
-  counter.Add((int64_t)10);
-  counter.Add((int64_t)10, opentelemetry::context::Context{});
+  counter.Add(10);
+  counter.Add(10, opentelemetry::context::Context{});
 
-  counter.Add((int64_t)10,
-              opentelemetry::common::KeyValueIterableView<M>({{"abc", "123"}, {"xyz", "456"}}));
-  counter.Add((int64_t)10,
-              opentelemetry::common::KeyValueIterableView<M>({{"abc", "123"}, {"xyz", "456"}}),
+  counter.Add(10, opentelemetry::common::KeyValueIterableView<M>({{"abc", "123"}, {"xyz", "456"}}));
+  counter.Add(10, opentelemetry::common::KeyValueIterableView<M>({{"abc", "123"}, {"xyz", "456"}}),
               opentelemetry::context::Context{});
-  counter.Add((int64_t)10, opentelemetry::common::KeyValueIterableView<M>({}));
-  counter.Add((int64_t)10, opentelemetry::common::KeyValueIterableView<M>({}),
+  counter.Add(10, opentelemetry::common::KeyValueIterableView<M>({}));
+  counter.Add(10, opentelemetry::common::KeyValueIterableView<M>({}),
               opentelemetry::context::Context{});
 }
 
@@ -65,16 +63,14 @@ TEST(SyncInstruments, LongUpDownCounter)
                                                 InstrumentValueType::kLong};
   std::unique_ptr<SyncWritableMetricStorage> metric_storage(new SyncMultiMetricStorage());
   LongUpDownCounter counter(instrument_descriptor, std::move(metric_storage));
-  counter.Add((int64_t)10);
-  counter.Add((int64_t)10, opentelemetry::context::Context{});
+  counter.Add(10);
+  counter.Add(10, opentelemetry::context::Context{});
 
-  counter.Add((int64_t)10,
-              opentelemetry::common::KeyValueIterableView<M>({{"abc", "123"}, {"xyz", "456"}}));
-  counter.Add((int64_t)10,
-              opentelemetry::common::KeyValueIterableView<M>({{"abc", "123"}, {"xyz", "456"}}),
+  counter.Add(10, opentelemetry::common::KeyValueIterableView<M>({{"abc", "123"}, {"xyz", "456"}}));
+  counter.Add(10, opentelemetry::common::KeyValueIterableView<M>({{"abc", "123"}, {"xyz", "456"}}),
               opentelemetry::context::Context{});
-  counter.Add((int64_t)10, opentelemetry::common::KeyValueIterableView<M>({}));
-  counter.Add((int64_t)10, opentelemetry::common::KeyValueIterableView<M>({}),
+  counter.Add(10, opentelemetry::common::KeyValueIterableView<M>({}));
+  counter.Add(10, opentelemetry::common::KeyValueIterableView<M>({}),
               opentelemetry::context::Context{});
 }
 
@@ -104,13 +100,13 @@ TEST(SyncInstruments, LongHistogram)
       "long_histogram", "description", "1", InstrumentType::kHistogram, InstrumentValueType::kLong};
   std::unique_ptr<SyncWritableMetricStorage> metric_storage(new SyncMultiMetricStorage());
   LongHistogram<int64_t> counter(instrument_descriptor, std::move(metric_storage));
-  counter.Record((int64_t)10, opentelemetry::context::Context{});
-  counter.Record((int64_t)-10, opentelemetry::context::Context{});  // This is ignored
+  counter.Record(10, opentelemetry::context::Context{});
+  counter.Record(-10, opentelemetry::context::Context{});  // This is ignored
 
-  counter.Record((int64_t)10,
+  counter.Record(10,
                  opentelemetry::common::KeyValueIterableView<M>({{"abc", "123"}, {"xyz", "456"}}),
                  opentelemetry::context::Context{});
-  counter.Record((int64_t)10, opentelemetry::common::KeyValueIterableView<M>({}),
+  counter.Record(10, opentelemetry::common::KeyValueIterableView<M>({}),
                  opentelemetry::context::Context{});
 }
 

--- a/sdk/test/metrics/sync_metric_storage_counter_test.cc
+++ b/sdk/test/metrics/sync_metric_storage_counter_test.cc
@@ -55,23 +55,19 @@ TEST_P(WritableMetricStorageTestFixture, LongSumAggregation)
       instr_desc, AggregationType::kSum, default_attributes_processor.get(),
       ExemplarReservoir::GetNoExemplarReservoir(), nullptr);
 
-  storage.RecordLong((int64_t)10,
-                     KeyValueIterableView<std::map<std::string, std::string>>(attributes_get),
+  storage.RecordLong(10, KeyValueIterableView<std::map<std::string, std::string>>(attributes_get),
                      opentelemetry::context::Context{});
   expected_total_get_requests += 10;
 
-  storage.RecordLong((int64_t)30,
-                     KeyValueIterableView<std::map<std::string, std::string>>(attributes_put),
+  storage.RecordLong(30, KeyValueIterableView<std::map<std::string, std::string>>(attributes_put),
                      opentelemetry::context::Context{});
   expected_total_put_requests += 30;
 
-  storage.RecordLong((int64_t)20,
-                     KeyValueIterableView<std::map<std::string, std::string>>(attributes_get),
+  storage.RecordLong(20, KeyValueIterableView<std::map<std::string, std::string>>(attributes_get),
                      opentelemetry::context::Context{});
   expected_total_get_requests += 20;
 
-  storage.RecordLong((int64_t)40,
-                     KeyValueIterableView<std::map<std::string, std::string>>(attributes_put),
+  storage.RecordLong(40, KeyValueIterableView<std::map<std::string, std::string>>(attributes_put),
                      opentelemetry::context::Context{});
   expected_total_put_requests += 40;
 
@@ -139,12 +135,10 @@ TEST_P(WritableMetricStorageTestFixture, LongSumAggregation)
     EXPECT_EQ(count_attributes, 2);  // GET AND PUT
   }
 
-  storage.RecordLong((int64_t)50,
-                     KeyValueIterableView<std::map<std::string, std::string>>(attributes_get),
+  storage.RecordLong(50, KeyValueIterableView<std::map<std::string, std::string>>(attributes_get),
                      opentelemetry::context::Context{});
   expected_total_get_requests += 50;
-  storage.RecordLong((int64_t)40,
-                     KeyValueIterableView<std::map<std::string, std::string>>(attributes_put),
+  storage.RecordLong(40, KeyValueIterableView<std::map<std::string, std::string>>(attributes_put),
                      opentelemetry::context::Context{});
   expected_total_put_requests += 40;
 

--- a/sdk/test/metrics/sync_metric_storage_counter_test.cc
+++ b/sdk/test/metrics/sync_metric_storage_counter_test.cc
@@ -40,11 +40,11 @@ class WritableMetricStorageTestFixture : public ::testing::TestWithParam<Aggrega
 
 TEST_P(WritableMetricStorageTestFixture, LongSumAggregation)
 {
-  AggregationTemporality temporality = GetParam();
-  auto sdk_start_ts                  = std::chrono::system_clock::now();
-  long expected_total_get_requests   = 0;
-  long expected_total_put_requests   = 0;
-  InstrumentDescriptor instr_desc    = {"name", "desc", "1unit", InstrumentType::kCounter,
+  AggregationTemporality temporality  = GetParam();
+  auto sdk_start_ts                   = std::chrono::system_clock::now();
+  int64_t expected_total_get_requests = 0;
+  int64_t expected_total_put_requests = 0;
+  InstrumentDescriptor instr_desc     = {"name", "desc", "1unit", InstrumentType::kCounter,
                                      InstrumentValueType::kLong};
   std::map<std::string, std::string> attributes_get = {{"RequestType", "GET"}};
   std::map<std::string, std::string> attributes_put = {{"RequestType", "PUT"}};
@@ -87,13 +87,13 @@ TEST_P(WritableMetricStorageTestFixture, LongSumAggregation)
           if (opentelemetry::nostd::get<std::string>(
                   data_attr.attributes.find("RequestType")->second) == "GET")
           {
-            EXPECT_EQ(opentelemetry::nostd::get<long>(data.value_), expected_total_get_requests);
+            EXPECT_EQ(opentelemetry::nostd::get<int64_t>(data.value_), expected_total_get_requests);
             count_attributes++;
           }
           else if (opentelemetry::nostd::get<std::string>(
                        data_attr.attributes.find("RequestType")->second) == "PUT")
           {
-            EXPECT_EQ(opentelemetry::nostd::get<long>(data.value_), expected_total_put_requests);
+            EXPECT_EQ(opentelemetry::nostd::get<int64_t>(data.value_), expected_total_put_requests);
             count_attributes++;
           }
         }
@@ -120,13 +120,13 @@ TEST_P(WritableMetricStorageTestFixture, LongSumAggregation)
                   data_attr.attributes.find("RequestType")->second) == "GET")
           {
             count_attributes++;
-            EXPECT_EQ(opentelemetry::nostd::get<long>(data.value_), expected_total_get_requests);
+            EXPECT_EQ(opentelemetry::nostd::get<int64_t>(data.value_), expected_total_get_requests);
           }
           else if (opentelemetry::nostd::get<std::string>(
                        data_attr.attributes.find("RequestType")->second) == "PUT")
           {
             count_attributes++;
-            EXPECT_EQ(opentelemetry::nostd::get<long>(data.value_), expected_total_put_requests);
+            EXPECT_EQ(opentelemetry::nostd::get<int64_t>(data.value_), expected_total_put_requests);
           }
         }
         return true;
@@ -153,13 +153,13 @@ TEST_P(WritableMetricStorageTestFixture, LongSumAggregation)
           if (opentelemetry::nostd::get<std::string>(
                   data_attr.attributes.find("RequestType")->second) == "GET")
           {
-            EXPECT_EQ(opentelemetry::nostd::get<long>(data.value_), expected_total_get_requests);
+            EXPECT_EQ(opentelemetry::nostd::get<int64_t>(data.value_), expected_total_get_requests);
             count_attributes++;
           }
           else if (opentelemetry::nostd::get<std::string>(
                        data_attr.attributes.find("RequestType")->second) == "PUT")
           {
-            EXPECT_EQ(opentelemetry::nostd::get<long>(data.value_), expected_total_put_requests);
+            EXPECT_EQ(opentelemetry::nostd::get<int64_t>(data.value_), expected_total_put_requests);
             count_attributes++;
           }
         }

--- a/sdk/test/metrics/sync_metric_storage_counter_test.cc
+++ b/sdk/test/metrics/sync_metric_storage_counter_test.cc
@@ -56,19 +56,23 @@ TEST_P(WritableMetricStorageTestFixture, LongSumAggregation)
       ExemplarReservoir::GetNoExemplarReservoir(),
       std::shared_ptr<opentelemetry::sdk::metrics::AggregationConfig>{});
 
-  storage.RecordLong(10l, KeyValueIterableView<std::map<std::string, std::string>>(attributes_get),
+  storage.RecordLong((int64_t)10,
+                     KeyValueIterableView<std::map<std::string, std::string>>(attributes_get),
                      opentelemetry::context::Context{});
   expected_total_get_requests += 10;
 
-  storage.RecordLong(30l, KeyValueIterableView<std::map<std::string, std::string>>(attributes_put),
+  storage.RecordLong((int64_t)30,
+                     KeyValueIterableView<std::map<std::string, std::string>>(attributes_put),
                      opentelemetry::context::Context{});
   expected_total_put_requests += 30;
 
-  storage.RecordLong(20l, KeyValueIterableView<std::map<std::string, std::string>>(attributes_get),
+  storage.RecordLong((int64_t)20,
+                     KeyValueIterableView<std::map<std::string, std::string>>(attributes_get),
                      opentelemetry::context::Context{});
   expected_total_get_requests += 20;
 
-  storage.RecordLong(40l, KeyValueIterableView<std::map<std::string, std::string>>(attributes_put),
+  storage.RecordLong((int64_t)40,
+                     KeyValueIterableView<std::map<std::string, std::string>>(attributes_put),
                      opentelemetry::context::Context{});
   expected_total_put_requests += 40;
 
@@ -136,10 +140,12 @@ TEST_P(WritableMetricStorageTestFixture, LongSumAggregation)
     EXPECT_EQ(count_attributes, 2);  // GET AND PUT
   }
 
-  storage.RecordLong(50l, KeyValueIterableView<std::map<std::string, std::string>>(attributes_get),
+  storage.RecordLong((int64_t)50,
+                     KeyValueIterableView<std::map<std::string, std::string>>(attributes_get),
                      opentelemetry::context::Context{});
   expected_total_get_requests += 50;
-  storage.RecordLong(40l, KeyValueIterableView<std::map<std::string, std::string>>(attributes_put),
+  storage.RecordLong((int64_t)40,
+                     KeyValueIterableView<std::map<std::string, std::string>>(attributes_put),
                      opentelemetry::context::Context{});
   expected_total_put_requests += 40;
 

--- a/sdk/test/metrics/sync_metric_storage_histogram_test.cc
+++ b/sdk/test/metrics/sync_metric_storage_histogram_test.cc
@@ -41,11 +41,11 @@ class WritableMetricStorageHistogramTestFixture
 
 TEST_P(WritableMetricStorageHistogramTestFixture, LongHistogram)
 {
-  AggregationTemporality temporality = GetParam();
-  auto sdk_start_ts                  = std::chrono::system_clock::now();
-  long expected_total_get_requests   = 0;
-  long expected_total_put_requests   = 0;
-  InstrumentDescriptor instr_desc    = {"name", "desc", "1unit", InstrumentType::kHistogram,
+  AggregationTemporality temporality  = GetParam();
+  auto sdk_start_ts                   = std::chrono::system_clock::now();
+  int64_t expected_total_get_requests = 0;
+  int64_t expected_total_put_requests = 0;
+  InstrumentDescriptor instr_desc     = {"name", "desc", "1unit", InstrumentType::kHistogram,
                                      InstrumentValueType::kLong};
   std::map<std::string, std::string> attributes_get = {{"RequestType", "GET"}};
   std::map<std::string, std::string> attributes_put = {{"RequestType", "PUT"}};
@@ -88,13 +88,13 @@ TEST_P(WritableMetricStorageHistogramTestFixture, LongHistogram)
           if (opentelemetry::nostd::get<std::string>(
                   data_attr.attributes.find("RequestType")->second) == "GET")
           {
-            EXPECT_EQ(opentelemetry::nostd::get<long>(data.sum_), expected_total_get_requests);
+            EXPECT_EQ(opentelemetry::nostd::get<int64_t>(data.sum_), expected_total_get_requests);
             count_attributes++;
           }
           else if (opentelemetry::nostd::get<std::string>(
                        data_attr.attributes.find("RequestType")->second) == "PUT")
           {
-            EXPECT_EQ(opentelemetry::nostd::get<long>(data.sum_), expected_total_put_requests);
+            EXPECT_EQ(opentelemetry::nostd::get<int64_t>(data.sum_), expected_total_put_requests);
             count_attributes++;
           }
         }
@@ -121,13 +121,13 @@ TEST_P(WritableMetricStorageHistogramTestFixture, LongHistogram)
                   data_attr.attributes.find("RequestType")->second) == "GET")
           {
             count_attributes++;
-            EXPECT_EQ(opentelemetry::nostd::get<long>(data.sum_), expected_total_get_requests);
+            EXPECT_EQ(opentelemetry::nostd::get<int64_t>(data.sum_), expected_total_get_requests);
           }
           else if (opentelemetry::nostd::get<std::string>(
                        data_attr.attributes.find("RequestType")->second) == "PUT")
           {
             count_attributes++;
-            EXPECT_EQ(opentelemetry::nostd::get<long>(data.sum_), expected_total_put_requests);
+            EXPECT_EQ(opentelemetry::nostd::get<int64_t>(data.sum_), expected_total_put_requests);
           }
         }
         return true;
@@ -154,13 +154,13 @@ TEST_P(WritableMetricStorageHistogramTestFixture, LongHistogram)
           if (opentelemetry::nostd::get<std::string>(
                   data_attr.attributes.find("RequestType")->second) == "GET")
           {
-            EXPECT_EQ(opentelemetry::nostd::get<long>(data.sum_), expected_total_get_requests);
+            EXPECT_EQ(opentelemetry::nostd::get<int64_t>(data.sum_), expected_total_get_requests);
             count_attributes++;
           }
           else if (opentelemetry::nostd::get<std::string>(
                        data_attr.attributes.find("RequestType")->second) == "PUT")
           {
-            EXPECT_EQ(opentelemetry::nostd::get<long>(data.sum_), expected_total_put_requests);
+            EXPECT_EQ(opentelemetry::nostd::get<int64_t>(data.sum_), expected_total_put_requests);
             count_attributes++;
           }
         }

--- a/sdk/test/metrics/sync_metric_storage_histogram_test.cc
+++ b/sdk/test/metrics/sync_metric_storage_histogram_test.cc
@@ -57,19 +57,23 @@ TEST_P(WritableMetricStorageHistogramTestFixture, LongHistogram)
       NoExemplarReservoir::GetNoExemplarReservoir(),
       std::shared_ptr<opentelemetry::sdk::metrics::AggregationConfig>{});
 
-  storage.RecordLong(10l, KeyValueIterableView<std::map<std::string, std::string>>(attributes_get),
+  storage.RecordLong((int64_t)10,
+                     KeyValueIterableView<std::map<std::string, std::string>>(attributes_get),
                      opentelemetry::context::Context{});
   expected_total_get_requests += 10;
 
-  storage.RecordLong(30l, KeyValueIterableView<std::map<std::string, std::string>>(attributes_put),
+  storage.RecordLong((int64_t)30,
+                     KeyValueIterableView<std::map<std::string, std::string>>(attributes_put),
                      opentelemetry::context::Context{});
   expected_total_put_requests += 30;
 
-  storage.RecordLong(20l, KeyValueIterableView<std::map<std::string, std::string>>(attributes_get),
+  storage.RecordLong((int64_t)20,
+                     KeyValueIterableView<std::map<std::string, std::string>>(attributes_get),
                      opentelemetry::context::Context{});
   expected_total_get_requests += 20;
 
-  storage.RecordLong(40l, KeyValueIterableView<std::map<std::string, std::string>>(attributes_put),
+  storage.RecordLong((int64_t)40,
+                     KeyValueIterableView<std::map<std::string, std::string>>(attributes_put),
                      opentelemetry::context::Context{});
   expected_total_put_requests += 40;
 
@@ -137,10 +141,12 @@ TEST_P(WritableMetricStorageHistogramTestFixture, LongHistogram)
     EXPECT_EQ(count_attributes, 2);  // GET AND PUT
   }
 
-  storage.RecordLong(50l, KeyValueIterableView<std::map<std::string, std::string>>(attributes_get),
+  storage.RecordLong((int64_t)50,
+                     KeyValueIterableView<std::map<std::string, std::string>>(attributes_get),
                      opentelemetry::context::Context{});
   expected_total_get_requests += 50;
-  storage.RecordLong(40l, KeyValueIterableView<std::map<std::string, std::string>>(attributes_put),
+  storage.RecordLong((int64_t)40,
+                     KeyValueIterableView<std::map<std::string, std::string>>(attributes_put),
                      opentelemetry::context::Context{});
   expected_total_put_requests += 40;
 

--- a/sdk/test/metrics/sync_metric_storage_histogram_test.cc
+++ b/sdk/test/metrics/sync_metric_storage_histogram_test.cc
@@ -56,23 +56,19 @@ TEST_P(WritableMetricStorageHistogramTestFixture, LongHistogram)
       instr_desc, AggregationType::kHistogram, default_attributes_processor.get(),
       NoExemplarReservoir::GetNoExemplarReservoir(), nullptr);
 
-  storage.RecordLong((int64_t)10,
-                     KeyValueIterableView<std::map<std::string, std::string>>(attributes_get),
+  storage.RecordLong(10, KeyValueIterableView<std::map<std::string, std::string>>(attributes_get),
                      opentelemetry::context::Context{});
   expected_total_get_requests += 10;
 
-  storage.RecordLong((int64_t)30,
-                     KeyValueIterableView<std::map<std::string, std::string>>(attributes_put),
+  storage.RecordLong(30, KeyValueIterableView<std::map<std::string, std::string>>(attributes_put),
                      opentelemetry::context::Context{});
   expected_total_put_requests += 30;
 
-  storage.RecordLong((int64_t)20,
-                     KeyValueIterableView<std::map<std::string, std::string>>(attributes_get),
+  storage.RecordLong(20, KeyValueIterableView<std::map<std::string, std::string>>(attributes_get),
                      opentelemetry::context::Context{});
   expected_total_get_requests += 20;
 
-  storage.RecordLong((int64_t)40,
-                     KeyValueIterableView<std::map<std::string, std::string>>(attributes_put),
+  storage.RecordLong(40, KeyValueIterableView<std::map<std::string, std::string>>(attributes_put),
                      opentelemetry::context::Context{});
   expected_total_put_requests += 40;
 
@@ -140,12 +136,10 @@ TEST_P(WritableMetricStorageHistogramTestFixture, LongHistogram)
     EXPECT_EQ(count_attributes, 2);  // GET AND PUT
   }
 
-  storage.RecordLong((int64_t)50,
-                     KeyValueIterableView<std::map<std::string, std::string>>(attributes_get),
+  storage.RecordLong(50, KeyValueIterableView<std::map<std::string, std::string>>(attributes_get),
                      opentelemetry::context::Context{});
   expected_total_get_requests += 50;
-  storage.RecordLong((int64_t)40,
-                     KeyValueIterableView<std::map<std::string, std::string>>(attributes_put),
+  storage.RecordLong(40, KeyValueIterableView<std::map<std::string, std::string>>(attributes_put),
                      opentelemetry::context::Context{});
   expected_total_put_requests += 40;
 


### PR DESCRIPTION
Fixes #1639 (issue)

## Changes

"Long" instruments changed to accept `int64_t` integer values, which are unambiguously 64 bit depth.

For significant contributions please make sure you have completed the following items:

* [x] `CHANGELOG.md` updated for non-trivial changes
* [ ] Unit tests have been added
* [x] Changes in public API reviewed