### PR TITLE
Fix debug log of OTLP HTTP exporter and ES log exporter

### DIFF
--- a/exporters/elasticsearch/src/es_log_exporter.cc
+++ b/exporters/elasticsearch/src/es_log_exporter.cc
@@ -35,10 +35,10 @@ public:
                                       const std::string &body) noexcept
   {
     std::stringstream ss;
-    ss << "Status:" << response.GetStatusCode() << "Header:";
+    ss << "Status:" << response.GetStatusCode() << ", Header:";
     response.ForEachHeader([&ss](opentelemetry::nostd::string_view header_name,
                                  opentelemetry::nostd::string_view header_value) {
-      ss << "\t" << header_name.data() << " : " << header_value.data() << ",";
+      ss << "\t" << header_name.data() << ": " << header_value.data() << ",";
       return true;
     });
     ss << "Body:" << body;

--- a/exporters/otlp/src/otlp_http_client.cc
+++ b/exporters/otlp/src/otlp_http_client.cc
@@ -83,10 +83,10 @@ public:
                                       const std::string &body) noexcept
   {
     std::stringstream ss;
-    ss << "Status:" << response.GetStatusCode() << "Header:";
+    ss << "Status:" << response.GetStatusCode() << ", Header:";
     response.ForEachHeader([&ss](opentelemetry::nostd::string_view header_name,
                                  opentelemetry::nostd::string_view header_value) {
-      ss << "\t" << header_name.data() << " : " << header_value.data() << ",";
+      ss << "\t" << header_name.data() << ": " << header_value.data() << ",";
       return true;
     });
     ss << "Body:" << body;
@@ -116,8 +116,7 @@ public:
         OTEL_INTERNAL_LOG_ERROR("OTLP HTTP Client] Export failed, " << log_message);
         result = sdk::common::ExportResult::kFailure;
       }
-
-      if (console_debug_)
+      else if (console_debug_)
       {
         if (log_message.empty())
         {


### PR DESCRIPTION
Signed-off-by: owent <admin@owent.net>

Fixes #1702 

## Changes

+ Fix debug log of OTLP HTTP exporter and ES log exporter

For significant contributions please make sure you have completed the following items:

* [ ] `CHANGELOG.md` updated for non-trivial changes
* [ ] Unit tests have been added
* [x] Changes in public API reviewed