### PR TITLE
[Metrics SDK] Move Metrics Exemplar processing behind feature flag

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -192,6 +192,7 @@ option(WITH_EXAMPLES "Whether to build examples" ON)
 option(WITH_METRICS_PREVIEW "Whether to build metrics preview" OFF)
 option(WITH_LOGS_PREVIEW "Whether to build logs preview" OFF)
 option(WITH_ASYNC_EXPORT_PREVIEW "Whether enable async export" OFF)
+# Exemplar specs status is experimental, so behind feature flag by default
 option(WITH_METRICS_EXEMPLAR_PREVIEW
        "Whethere to enable exemplar within metrics" OFF)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -192,6 +192,8 @@ option(WITH_EXAMPLES "Whether to build examples" ON)
 option(WITH_METRICS_PREVIEW "Whether to build metrics preview" OFF)
 option(WITH_LOGS_PREVIEW "Whether to build logs preview" OFF)
 option(WITH_ASYNC_EXPORT_PREVIEW "Whether enable async export" OFF)
+option(WITH_METRICS_EXEMPLAR_PREVIEW
+       "Whethere to enable exemplar within metrics" OFF)
 
 find_package(Threads)
 

--- a/api/CMakeLists.txt
+++ b/api/CMakeLists.txt
@@ -96,3 +96,8 @@ endif()
 if(WITH_ASYNC_EXPORT_PREVIEW)
   target_compile_definitions(opentelemetry_api INTERFACE ENABLE_ASYNC_EXPORT)
 endif()
+
+if(WITH_METRICS_EXEMPLAR_PREVIEW)
+  target_compile_definitions(opentelemetry_api
+                             INTERFACE ENABLE_METRICS_EXEMPLAR_PREVIEW)
+endif()

--- a/ci/do_ci.sh
+++ b/ci/do_ci.sh
@@ -59,7 +59,7 @@ mkdir -p "${BUILD_DIR}"
 [ -z "${PLUGIN_DIR}" ] && export PLUGIN_DIR=$HOME/plugin
 mkdir -p "${PLUGIN_DIR}"
 
-BAZEL_OPTIONS="--copt=-DENABLE_LOGS_PREVIEW --copt=-DENABLE_TEST"
+BAZEL_OPTIONS="--copt=-DENABLE_LOGS_PREVIEW --copt=-DENABLE_TEST --copt=-DENABLE_METRICS_EXEMPLAR_PREVIEW"
 
 BAZEL_TEST_OPTIONS="$BAZEL_OPTIONS --test_output=errors"
 
@@ -82,7 +82,8 @@ if [[ "$1" == "cmake.test" ]]; then
         -DWITH_ZIPKIN=ON \
         -DWITH_JAEGER=ON \
         -DWITH_ELASTICSEARCH=ON \
-        -DWITH_METRICS_PREVIEW=ON \
+        -DWITH_METRICS_PREVIEW=OFF \
+        -DWITH_METRICS_EXEMPLAR_PREVIEW=ON \
         -DWITH_LOGS_PREVIEW=ON \
         -DCMAKE_CXX_FLAGS="-Werror" \
         "${SRC_DIR}"
@@ -99,6 +100,7 @@ elif [[ "$1" == "cmake.maintainer.test" ]]; then
         -DWITH_ELASTICSEARCH=ON \
         -DWITH_LOGS_PREVIEW=ON \
         -DWITH_METRICS_PREVIEW=OFF \
+        -DWITH_METRICS_EXEMPLAR_PREVIEW=ON \
         -DWITH_ASYNC_EXPORT_PREVIEW=ON \
         -DOTELCPP_MAINTAINER_MODE=ON \
         "${SRC_DIR}"
@@ -114,6 +116,7 @@ elif [[ "$1" == "cmake.with_async_export.test" ]]; then
         -DWITH_JAEGER=ON \
         -DWITH_ELASTICSEARCH=ON \
         -DWITH_METRICS_PREVIEW=OFF \
+        -DWITH_METRICS_EXEMPLAR_PREVIEW=ON \
         -DWITH_LOGS_PREVIEW=ON \
         -DCMAKE_CXX_FLAGS="-Werror" \
         -DWITH_ASYNC_EXPORT_PREVIEW=ON \
@@ -142,6 +145,7 @@ elif [[ "$1" == "cmake.abseil.test" ]]; then
   rm -rf *
   cmake -DCMAKE_BUILD_TYPE=Debug  \
         -DWITH_METRICS_PREVIEW=OFF \
+        -DWITH_METRICS_EXEMPLAR_PREVIEW=ON \
         -DWITH_LOGS_PREVIEW=ON \
         -DCMAKE_CXX_FLAGS="-Werror" \
         -DWITH_ASYNC_EXPORT_PREVIEW=ON \
@@ -166,6 +170,7 @@ elif [[ "$1" == "cmake.c++20.stl.test" ]]; then
   rm -rf *
   cmake -DCMAKE_BUILD_TYPE=Debug  \
         -DWITH_METRICS_PREVIEW=OFF \
+        -DWITH_METRICS_EXEMPLAR_PREVIEW=ON \
         -DWITH_LOGS_PREVIEW=ON \
         -DCMAKE_CXX_FLAGS="-Werror" \
         -DWITH_ASYNC_EXPORT_PREVIEW=ON \


### PR DESCRIPTION
Exemplar are still experimental, so exemplar processing is moved behind feature flag macro - `ENABLE_METRICS_EXEMPLAR_PREVIEW`. The exemplar would be processed in hot path only if the flag is enabled. The flag needs to be explicitly enabled in build script to use exemplars.

This allows us 
 - to give a message to users that this functionality could change in future.
 - and achieve (slight) performance gain during measurement recording, even while using the non-sampling exemplar.

The CI tests still continue to test the full metrics functionality with feature flag enabled for both cmake and bazel.