### PR TITLE
Document libthrift 0.12.0 doesn't work with Jaeger exporter

### DIFF
--- a/docs/dependencies.md
+++ b/docs/dependencies.md
@@ -77,7 +77,9 @@ Both these dependencies are listed here:
     framework.
     - `thrift` compiler to generate C++ stubs for IDL data model for Jaeger.
     - `libthrift`  library to generate serialised trace/metrics/log data to be
-      sent to remote Jaeger service.
+      sent to remote Jaeger service. Note: libthrift **0.12.0** doesn't work
+      with this Jaeger exporter. See
+      [#1680](https://github.com/open-telemetry/opentelemetry-cpp/issues/1680).
     - License: `Apache License 2.0`
 
 - [ETW](/exporters/etw)


### PR DESCRIPTION
Fixes #1680 

## Changes

Please provide a brief description of the changes here.

For significant contributions please make sure you have completed the following items:

* [ ] `CHANGELOG.md` updated for non-trivial changes
* [ ] Unit tests have been added
* [ ] Changes in public API reviewed