### PR TITLE
Update Metrics status in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,11 +10,11 @@ The C++ [OpenTelemetry](https://opentelemetry.io/) client.
 
 ## Project Status
 
-| Signal  | Status                  |
-| ------- | ----------------------- |
-| Traces  | Public Release          |
-| Metrics | Public Release [1]      |
-| Logs    | Experimental [2]        |
+| Signal  | Status                  | Project                                                                  |
+| ------- | ----------------------- | ------------------------------------------------------------------------ |
+| Traces  | Public Release          | N/A                                                                      |
+| Metrics | Public Release [1]      | N/A                                                                      |
+| Logs    | Experimental [2]        | [Release Milestone](https://github.com/open-telemetry/opentelemetry-cpp/milestone/18)|
 
 * [1]: The older metrics implementation (based on old
       specification) is now deprecated, and would be removed soon.

--- a/README.md
+++ b/README.md
@@ -10,35 +10,21 @@ The C++ [OpenTelemetry](https://opentelemetry.io/) client.
 
 ## Project Status
 
-| Signal  | Status                  | Project                                                                  |
-| ------- | ----------------------- | ------------------------------------------------------------------------ |
-| Traces  | Public Release          | N/A                                                                      |
-| Metrics | Release Candidate [1,2] | N/A                                                                      |
-| Logs    | Experimental [3]        | N/A                                                                      |
+| Signal  | Status                  |
+| ------- | ----------------------- |
+| Traces  | Public Release          |
+| Metrics | Public Release [1]      |
+| Logs    | Experimental [2]        |
 
-* [1]: The metric implementation is in release candidate phase. There would be
-      few iterations of new feature additions, and bug fixes before it is
-      publically available. Few breaking changes in API and SDK are expected.
-* [2]: The earlier implementation (based on old
-      specification) is now deprecated, and would be removed once new implementation
-      is declared stable. The older implementation can be included in build by setting
+* [1]: The older metrics implementation (based on old
+      specification) is now deprecated, and would be removed soon.
+      This can be included in build by setting
       `ENABLE_METRICS_PREVIEW` preprocessor macro, and is included under
       `*/_metrics/*` directory.
-* [3]: The current Log Signal Implementation is Experimental, and will change as
+* [2]: The current Log Signal Implementation is Experimental, and will change as
       the current OpenTelemetry Log specification matures. The current
       implementation can be included in build by setting `ENABLE_LOGS_PREVIEW`
       preprocessor macro.
-
-## OpenTelemetry Specification Compatibility Matrix
-
-| API Version | Core Version | Contrib Version [1]     |
-| ----------- |--------------|-------------------------|
-| 1.0.0       | 1.0.0-rc4    | N/A                     |
-| 1.0.0       | 1.0.0        | N/A                     |
-| 1.9.0       | 1.6.0        | N/A                     |
-
-* [1]: We don't have releases for opentelemetry-cpp contrib repo. This may
-      change in future.
 
 ## Supported C++ Versions
 


### PR DESCRIPTION
## Changes

- Tag Metrics as stable in README.md
- Remove section "OpenTelemetry Specification Compatibility Matrix". This was supposed to map the compatibility between specs version and otel-cpp version, but not much use is coming out of it.


For significant contributions please make sure you have completed the following items:

* [ ] `CHANGELOG.md` updated for non-trivial changes
* [ ] Unit tests have been added
* [ ] Changes in public API reviewed