### PR TITLE
[Old Metrics Cleanup] Remove old metric from GitHub CI 

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,22 +69,6 @@ jobs:
     - name: run tests
       run: ./ci/do_ci.ps1 cmake.maintainer.test
 
-  cmake_deprecated_metrics_test:
-    name: CMake test (without otlp-exporter and with deprecated metrics)
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v3
-      with:
-        submodules: 'recursive'
-    - name: setup
-      run: |
-        sudo ./ci/setup_cmake.sh
-        sudo ./ci/setup_ci_environment.sh
-    - name: run cmake tests (without otlp-exporter)
-      run: |
-        sudo ./ci/setup_thrift.sh
-        ./ci/do_ci.sh cmake.deprecated_metrics.test
-
   cmake_with_async_export_test:
     name: CMake test (without otlp-exporter and with async export)
     runs-on: ubuntu-latest
@@ -227,28 +211,6 @@ jobs:
         sudo ./ci/install_bazelisk.sh
     - name: run tests
       run: ./ci/do_ci.sh bazel.test
-
-  bazel_deprecated_metrics_test:
-    name: Bazel deprecated metrics
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v3
-      with:
-        submodules: 'recursive'
-    - name: Mount Bazel Cache
-      uses: actions/cache@v3
-      env:
-        cache-name: bazel_cache
-      with:
-        path: /home/runner/.cache/bazel
-        key: bazel_test
-    - name: setup
-      run: |
-        sudo ./ci/setup_thrift.sh dependencies_only
-        sudo ./ci/setup_ci_environment.sh
-        sudo ./ci/install_bazelisk.sh
-    - name: run tests
-      run: ./ci/do_ci.sh bazel.deprecated_metrics.test
 
   bazel_test_async:
     name: Bazel with async export

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ Increment the:
 
 * [LOGS SDK] Rename LogProcessor and LogExporter to LogRecordProcessor and LogRecordExporter
   [#1727](https://github.com/open-telemetry/opentelemetry-cpp/pull/1727)
+* [METRICS SDK] - Remove old metrics from Github CI
+  [#1733](https://github.com/open-telemetry/opentelemetry-cpp/pull/1733)
 
 ## [1.7.0] 2022-10-28
 

--- a/ci/do_ci.ps1
+++ b/ci/do_ci.ps1
@@ -5,7 +5,7 @@ $action = $args[0]
 
 $SRC_DIR = (Get-Item -Path ".\").FullName
 
-$BAZEL_OPTIONS = "--copt=-DENABLE_METRICS_PREVIEW --copt=-DENABLE_LOGS_PREVIEW --copt=-DENABLE_ASYNC_EXPORT"
+$BAZEL_OPTIONS = "--copt=-DENABLE_LOGS_PREVIEW --copt=-DENABLE_ASYNC_EXPORT"
 $BAZEL_TEST_OPTIONS = "$BAZEL_OPTIONS --test_output=errors"
 
 if (!(test-path build)) {

--- a/ci/do_ci.sh
+++ b/ci/do_ci.sh
@@ -124,22 +124,6 @@ elif [[ "$1" == "cmake.with_async_export.test" ]]; then
   make
   make test
   exit 0
-elif [[ "$1" == "cmake.deprecated_metrics.test" ]]; then
-  cd "${BUILD_DIR}"
-  rm -rf *
-  cmake -DCMAKE_BUILD_TYPE=Debug  \
-        -DWITH_PROMETHEUS=ON \
-        -DWITH_ZIPKIN=OFF \
-        -DWITH_JAEGER=OFF \
-        -DWITH_ELASTICSEARCH=OFF \
-        -DWITH_METRICS_PREVIEW=ON \
-        -DWITH_LOGS_PREVIEW=OFF \
-        -DCMAKE_CXX_FLAGS="-Werror" \
-        -DWITH_ASYNC_EXPORT_PREVIEW=ON \
-        "${SRC_DIR}"
-  make
-  make test
-  exit 0
 elif [[ "$1" == "cmake.abseil.test" ]]; then
   cd "${BUILD_DIR}"
   rm -rf *
@@ -275,10 +259,6 @@ EOF
 elif [[ "$1" == "bazel.test" ]]; then
   bazel $BAZEL_STARTUP_OPTIONS build $BAZEL_OPTIONS //...
   bazel $BAZEL_STARTUP_OPTIONS test $BAZEL_TEST_OPTIONS //...
-  exit 0
-elif [[ "$1" == "bazel.deprecated_metrics.test" ]]; then
-  bazel $BAZEL_STARTUP_OPTIONS build $BAZEL_OPTIONS --copt=-DENABLE_METRICS_PREVIEW //...
-  bazel $BAZEL_STARTUP_OPTIONS test $BAZEL_TEST_OPTIONS --copt=-DENABLE_METRICS_PREVIEW //...
   exit 0
 elif [[ "$1" == "bazel.with_async_export.test" ]]; then
   bazel $BAZEL_STARTUP_OPTIONS build $BAZEL_OPTIONS_ASYNC //...


### PR DESCRIPTION
## Changes

This does cleanup of first part of #1573 - Removing old metrics build/tests from GitHub CI

For significant contributions please make sure you have completed the following items:

* [x] `CHANGELOG.md` updated for non-trivial changes
* [ ] Unit tests have been added
* [ ] Changes in public API reviewed