### PR TITLE
[Build] Multiple CURL packages leads to invalid build (#1738)

### DIFF
--- a/ext/include/opentelemetry/ext/http/client/curl/http_operation_curl.h
+++ b/ext/include/opentelemetry/ext/http/client/curl/http_operation_curl.h
@@ -20,7 +20,7 @@
 #  include <poll.h>
 #  include <unistd.h>
 #endif
-#include <curl/curl.h>
+#include "curl/curl.h"
 
 OPENTELEMETRY_BEGIN_NAMESPACE
 namespace ext


### PR DESCRIPTION
Fixes #1738 

## Changes

Use include "curl/curl.h" instead of <curl/curl.h>,
to build with the proper CURL package.

* [ ] `CHANGELOG.md` updated for non-trivial changes
* [ ] Unit tests have been added
* [ ] Changes in public API reviewed