### PR TITLE
[SEMANTIC CONVENTIONS] Upgrade to version 1.15.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,7 +57,7 @@ Breaking changes:
     to camel case, like `SemanticConventions::kServiceName`.
     This is necessary to avoid collisions with macros in general,
     which breaks the build on some platforms.
-  * Semantic conventions are still flagged as unstable,
+  * Semantic conventions are flagged as experimental,
     which is why this change is done in this release.
 
 ## [1.7.0] 2022-10-28

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@ Increment the:
 * [METRICS SDK] - Remove old metrics from Github CI
   [#1733](https://github.com/open-telemetry/opentelemetry-cpp/pull/1733)
 * [BUILD] Add CMake OTELCPP_PROTO_PATH [#1730](https://github.com/open-telemetry/opentelemetry-cpp/pull/1730)
+* [SEMANTIC CONVENTIONS] Upgrade to version 1.15.0
+  [#1761](https://github.com/open-telemetry/opentelemetry-cpp/pull/1761)
 
 Deprecation notes:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,18 @@ Deprecation notes:
     Note that function `opentelemetry::utils::hashCode`,
     declared in the ETW exporter, is not affected by this deprecation.
 
+Breaking changes:
+
+* [SEMANTIC CONVENTIONS] Upgrade to version 1.15.0
+  [#1761](https://github.com/open-telemetry/opentelemetry-cpp/pull/1761)
+  * Naming of semantic conventions has changed from uppercase constants,
+    like `SemanticConventions::SERVICE_NAME`,
+    to camel case, like `SemanticConventions::kServiceName`.
+    This is necessary to avoid collisions with macros in general,
+    which breaks the build on some platforms.
+  * Semantic conventions are still flagged as unstable,
+    which is why this change is done in this release.
+
 ## [1.7.0] 2022-10-28
 
 * [METRICS SDK] Validate Instrument meta data (name, unit, description) [#1713](https://github.com/open-telemetry/opentelemetry-cpp/pull/1713)

--- a/api/include/opentelemetry/trace/semantic_conventions.h
+++ b/api/include/opentelemetry/trace/semantic_conventions.h
@@ -23,6 +23,12 @@
 #    undef DELETE
 #  endif
 #endif
+#ifdef _WIN32
+#  ifdef ERROR
+#    pragma message(__FILE__ ": removing define on ERROR")
+#    undef ERROR
+#  endif
+#endif
 
 OPENTELEMETRY_BEGIN_NAMESPACE
 namespace trace

--- a/api/include/opentelemetry/trace/semantic_conventions.h
+++ b/api/include/opentelemetry/trace/semantic_conventions.h
@@ -11,24 +11,6 @@
 #pragma once
 
 #include "opentelemetry/version.h"
-/*
- * Special considerations for FaasDocumentOperationValues::DELETE.
- *
- * The winnt.h header file is known to define a DELETE symbol,
- * which collides with FaasDocumentOperationValues::DELETE.
- */
-#ifdef _WIN32
-#  ifdef DELETE
-#    pragma message(__FILE__ ": removing define on DELETE")
-#    undef DELETE
-#  endif
-#endif
-#ifdef _WIN32
-#  ifdef ERROR
-#    pragma message(__FILE__ ": removing define on ERROR")
-#    undef ERROR
-#  endif
-#endif
 
 OPENTELEMETRY_BEGIN_NAMESPACE
 namespace trace
@@ -39,29 +21,29 @@ namespace SemanticConventions
 /**
  * The URL of the OpenTelemetry schema for these keys and values.
  */
-static constexpr const char *SCHEMA_URL = "https://opentelemetry.io/schemas/1.15.0";
+static constexpr const char *kSchemaUrl = "https://opentelemetry.io/schemas/1.15.0";
 
 /**
  * The type of the exception (its fully-qualified class name, if applicable). The dynamic type of
  * the exception should be preferred over the static type in languages that support it.
  */
-static constexpr const char *EXCEPTION_TYPE = "exception.type";
+static constexpr const char *kExceptionType = "exception.type";
 
 /**
  * The exception message.
  */
-static constexpr const char *EXCEPTION_MESSAGE = "exception.message";
+static constexpr const char *kExceptionMessage = "exception.message";
 
 /**
  * A stacktrace as a string in the natural representation for the language runtime. The
  * representation is to be determined and documented by each language SIG.
  */
-static constexpr const char *EXCEPTION_STACKTRACE = "exception.stacktrace";
+static constexpr const char *kExceptionStacktrace = "exception.stacktrace";
 
 /**
  * The name identifies the event.
  */
-static constexpr const char *EVENT_NAME = "event.name";
+static constexpr const char *kEventName = "event.name";
 
 /**
  * The domain identifies the context in which an event happened. An event name is unique only within
@@ -72,7 +54,7 @@ a domain.
 {@code event.domain}, so this allows for two events in different domains to
 have same {@code event.name}, yet be unrelated events.</li> </ul>
  */
-static constexpr const char *EVENT_DOMAIN = "event.domain";
+static constexpr const char *kEventDomain = "event.domain";
 
 /**
  * The full invoked ARN as provided on the {@code Context} passed to the function ({@code
@@ -81,41 +63,41 @@ static constexpr const char *EVENT_DOMAIN = "event.domain";
  * <p>Notes:
   <ul> <li>This may be different from {@code faas.id} if an alias is involved.</li> </ul>
  */
-static constexpr const char *AWS_LAMBDA_INVOKED_ARN = "aws.lambda.invoked_arn";
+static constexpr const char *kAwsLambdaInvokedArn = "aws.lambda.invoked_arn";
 
 /**
  * The <a href="https://github.com/cloudevents/spec/blob/v1.0.2/cloudevents/spec.md#id">event_id</a>
  * uniquely identifies the event.
  */
-static constexpr const char *CLOUDEVENTS_EVENT_ID = "cloudevents.event_id";
+static constexpr const char *kCloudeventsEventId = "cloudevents.event_id";
 
 /**
  * The <a
  * href="https://github.com/cloudevents/spec/blob/v1.0.2/cloudevents/spec.md#source-1">source</a>
  * identifies the context in which an event happened.
  */
-static constexpr const char *CLOUDEVENTS_EVENT_SOURCE = "cloudevents.event_source";
+static constexpr const char *kCloudeventsEventSource = "cloudevents.event_source";
 
 /**
  * The <a
  * href="https://github.com/cloudevents/spec/blob/v1.0.2/cloudevents/spec.md#specversion">version of
  * the CloudEvents specification</a> which the event uses.
  */
-static constexpr const char *CLOUDEVENTS_EVENT_SPEC_VERSION = "cloudevents.event_spec_version";
+static constexpr const char *kCloudeventsEventSpecVersion = "cloudevents.event_spec_version";
 
 /**
  * The <a
  * href="https://github.com/cloudevents/spec/blob/v1.0.2/cloudevents/spec.md#type">event_type</a>
  * contains a value describing the type of event related to the originating occurrence.
  */
-static constexpr const char *CLOUDEVENTS_EVENT_TYPE = "cloudevents.event_type";
+static constexpr const char *kCloudeventsEventType = "cloudevents.event_type";
 
 /**
  * The <a
  * href="https://github.com/cloudevents/spec/blob/v1.0.2/cloudevents/spec.md#subject">subject</a> of
  * the event in the context of the event producer (identified by source).
  */
-static constexpr const char *CLOUDEVENTS_EVENT_SUBJECT = "cloudevents.event_subject";
+static constexpr const char *kCloudeventsEventSubject = "cloudevents.event_subject";
 
 /**
  * Parent-child Reference type
@@ -123,31 +105,31 @@ static constexpr const char *CLOUDEVENTS_EVENT_SUBJECT = "cloudevents.event_subj
  * <p>Notes:
   <ul> <li>The causal relationship between a child Span and a parent Span.</li> </ul>
  */
-static constexpr const char *OPENTRACING_REF_TYPE = "opentracing.ref_type";
+static constexpr const char *kOpentracingRefType = "opentracing.ref_type";
 
 /**
  * An identifier for the database management system (DBMS) product being used. See below for a list
  * of well-known identifiers.
  */
-static constexpr const char *DB_SYSTEM = "db.system";
+static constexpr const char *kDbSystem = "db.system";
 
 /**
  * The connection string used to connect to the database. It is recommended to remove embedded
  * credentials.
  */
-static constexpr const char *DB_CONNECTION_STRING = "db.connection_string";
+static constexpr const char *kDbConnectionString = "db.connection_string";
 
 /**
  * Username for accessing the database.
  */
-static constexpr const char *DB_USER = "db.user";
+static constexpr const char *kDbUser = "db.user";
 
 /**
  * The fully-qualified class name of the <a
  * href="https://docs.oracle.com/javase/8/docs/technotes/guides/jdbc/">Java Database Connectivity
  * (JDBC)</a> driver used to connect.
  */
-static constexpr const char *DB_JDBC_DRIVER_CLASSNAME = "db.jdbc.driver_classname";
+static constexpr const char *kDbJdbcDriverClassname = "db.jdbc.driver_classname";
 
 /**
  * This attribute is used to report the name of the database being accessed. For commands that
@@ -159,7 +141,7 @@ static constexpr const char *DB_JDBC_DRIVER_CLASSNAME = "db.jdbc.driver_classnam
  name and schema name), the database name to be used is the more specific layer (e.g. Oracle schema
  name).</li> </ul>
  */
-static constexpr const char *DB_NAME = "db.name";
+static constexpr const char *kDbName = "db.name";
 
 /**
  * The database statement being executed.
@@ -167,7 +149,7 @@ static constexpr const char *DB_NAME = "db.name";
  * <p>Notes:
   <ul> <li>The value may be sanitized to exclude sensitive information.</li> </ul>
  */
-static constexpr const char *DB_STATEMENT = "db.statement";
+static constexpr const char *kDbStatement = "db.statement";
 
 /**
  * The name of the operation being executed, e.g. the <a
@@ -180,7 +162,7 @@ static constexpr const char *DB_STATEMENT = "db.statement";
  name is provided by the library being instrumented. If the SQL statement has an ambiguous
  operation, or performs more than one operation, this value may be omitted.</li> </ul>
  */
-static constexpr const char *DB_OPERATION = "db.operation";
+static constexpr const char *kDbOperation = "db.operation";
 
 /**
  * The Microsoft SQL Server <a
@@ -191,18 +173,18 @@ static constexpr const char *DB_OPERATION = "db.operation";
   <ul> <li>If setting a {@code db.mssql.instance_name}, {@code net.peer.port} is no longer required
  (but still recommended if non-standard).</li> </ul>
  */
-static constexpr const char *DB_MSSQL_INSTANCE_NAME = "db.mssql.instance_name";
+static constexpr const char *kDbMssqlInstanceName = "db.mssql.instance_name";
 
 /**
  * The fetch size used for paging, i.e. how many rows will be returned at once.
  */
-static constexpr const char *DB_CASSANDRA_PAGE_SIZE = "db.cassandra.page_size";
+static constexpr const char *kDbCassandraPageSize = "db.cassandra.page_size";
 
 /**
  * The consistency level of the query. Based on consistency values from <a
  * href="https://docs.datastax.com/en/cassandra-oss/3.0/cassandra/dml/dmlConfigConsistency.html">CQL</a>.
  */
-static constexpr const char *DB_CASSANDRA_CONSISTENCY_LEVEL = "db.cassandra.consistency_level";
+static constexpr const char *kDbCassandraConsistencyLevel = "db.cassandra.consistency_level";
 
 /**
  * The name of the primary table that the operation is acting upon, including the keyspace name (if
@@ -215,41 +197,41 @@ static constexpr const char *DB_CASSANDRA_CONSISTENCY_LEVEL = "db.cassandra.cons
  operation is acting upon an anonymous table, or more than one table, this value MUST NOT be
  set.</li> </ul>
  */
-static constexpr const char *DB_CASSANDRA_TABLE = "db.cassandra.table";
+static constexpr const char *kDbCassandraTable = "db.cassandra.table";
 
 /**
  * Whether or not the query is idempotent.
  */
-static constexpr const char *DB_CASSANDRA_IDEMPOTENCE = "db.cassandra.idempotence";
+static constexpr const char *kDbCassandraIdempotence = "db.cassandra.idempotence";
 
 /**
  * The number of times a query was speculatively executed. Not set or {@code 0} if the query was not
  * executed speculatively.
  */
-static constexpr const char *DB_CASSANDRA_SPECULATIVE_EXECUTION_COUNT =
+static constexpr const char *kDbCassandraSpeculativeExecutionCount =
     "db.cassandra.speculative_execution_count";
 
 /**
  * The ID of the coordinating node for a query.
  */
-static constexpr const char *DB_CASSANDRA_COORDINATOR_ID = "db.cassandra.coordinator.id";
+static constexpr const char *kDbCassandraCoordinatorId = "db.cassandra.coordinator.id";
 
 /**
  * The data center of the coordinating node for a query.
  */
-static constexpr const char *DB_CASSANDRA_COORDINATOR_DC = "db.cassandra.coordinator.dc";
+static constexpr const char *kDbCassandraCoordinatorDc = "db.cassandra.coordinator.dc";
 
 /**
  * The index of the database being accessed as used in the <a
  * href="https://redis.io/commands/select">{@code SELECT} command</a>, provided as an integer. To be
  * used instead of the generic {@code db.name} attribute.
  */
-static constexpr const char *DB_REDIS_DATABASE_INDEX = "db.redis.database_index";
+static constexpr const char *kDbRedisDatabaseIndex = "db.redis.database_index";
 
 /**
  * The collection being accessed within the database stated in {@code db.name}.
  */
-static constexpr const char *DB_MONGODB_COLLECTION = "db.mongodb.collection";
+static constexpr const char *kDbMongodbCollection = "db.mongodb.collection";
 
 /**
  * The name of the primary table that the operation is acting upon, including the database name (if
@@ -261,18 +243,18 @@ static constexpr const char *DB_MONGODB_COLLECTION = "db.mongodb.collection";
  operation is acting upon an anonymous table, or more than one table, this value MUST NOT be
  set.</li> </ul>
  */
-static constexpr const char *DB_SQL_TABLE = "db.sql.table";
+static constexpr const char *kDbSqlTable = "db.sql.table";
 
 /**
  * Name of the code, either &quot;OK&quot; or &quot;ERROR&quot;. MUST NOT be set if the status code
  * is UNSET.
  */
-static constexpr const char *OTEL_STATUS_CODE = "otel.status_code";
+static constexpr const char *kOtelStatusCode = "otel.status_code";
 
 /**
  * Description of the Status if it has a value, otherwise not set.
  */
-static constexpr const char *OTEL_STATUS_DESCRIPTION = "otel.status_description";
+static constexpr const char *kOtelStatusDescription = "otel.status_description";
 
 /**
  * Type of the trigger which caused this function execution.
@@ -285,56 +267,56 @@ If clients set it, it should be the same as the trigger that corresponding incom
 (i.e., this has nothing to do with the underlying transport used to make the API call to invoke the
 lambda, which is often HTTP).</li> </ul>
  */
-static constexpr const char *FAAS_TRIGGER = "faas.trigger";
+static constexpr const char *kFaasTrigger = "faas.trigger";
 
 /**
  * The execution ID of the current function execution.
  */
-static constexpr const char *FAAS_EXECUTION = "faas.execution";
+static constexpr const char *kFaasExecution = "faas.execution";
 
 /**
  * The name of the source on which the triggering operation was performed. For example, in Cloud
  * Storage or S3 corresponds to the bucket name, and in Cosmos DB to the database name.
  */
-static constexpr const char *FAAS_DOCUMENT_COLLECTION = "faas.document.collection";
+static constexpr const char *kFaasDocumentCollection = "faas.document.collection";
 
 /**
  * Describes the type of the operation that was performed on the data.
  */
-static constexpr const char *FAAS_DOCUMENT_OPERATION = "faas.document.operation";
+static constexpr const char *kFaasDocumentOperation = "faas.document.operation";
 
 /**
  * A string containing the time when the data was accessed in the <a
  * href="https://www.iso.org/iso-8601-date-and-time-format.html">ISO 8601</a> format expressed in <a
  * href="https://www.w3.org/TR/NOTE-datetime">UTC</a>.
  */
-static constexpr const char *FAAS_DOCUMENT_TIME = "faas.document.time";
+static constexpr const char *kFaasDocumentTime = "faas.document.time";
 
 /**
  * The document name/table subjected to the operation. For example, in Cloud Storage or S3 is the
  * name of the file, and in Cosmos DB the table name.
  */
-static constexpr const char *FAAS_DOCUMENT_NAME = "faas.document.name";
+static constexpr const char *kFaasDocumentName = "faas.document.name";
 
 /**
  * A string containing the function invocation time in the <a
  * href="https://www.iso.org/iso-8601-date-and-time-format.html">ISO 8601</a> format expressed in <a
  * href="https://www.w3.org/TR/NOTE-datetime">UTC</a>.
  */
-static constexpr const char *FAAS_TIME = "faas.time";
+static constexpr const char *kFaasTime = "faas.time";
 
 /**
  * A string containing the schedule period as <a
  * href="https://docs.oracle.com/cd/E12058_01/doc/doc.1014/e12030/cron_expressions.htm">Cron
  * Expression</a>.
  */
-static constexpr const char *FAAS_CRON = "faas.cron";
+static constexpr const char *kFaasCron = "faas.cron";
 
 /**
  * A boolean that is true if the serverless function is executed for the first time (aka
  * cold-start).
  */
-static constexpr const char *FAAS_COLDSTART = "faas.coldstart";
+static constexpr const char *kFaasColdstart = "faas.coldstart";
 
 /**
  * The name of the invoked function.
@@ -343,7 +325,7 @@ static constexpr const char *FAAS_COLDSTART = "faas.coldstart";
   <ul> <li>SHOULD be equal to the {@code faas.name} resource attribute of the invoked function.</li>
  </ul>
  */
-static constexpr const char *FAAS_INVOKED_NAME = "faas.invoked_name";
+static constexpr const char *kFaasInvokedName = "faas.invoked_name";
 
 /**
  * The cloud provider of the invoked function.
@@ -352,7 +334,7 @@ static constexpr const char *FAAS_INVOKED_NAME = "faas.invoked_name";
   <ul> <li>SHOULD be equal to the {@code cloud.provider} resource attribute of the invoked
  function.</li> </ul>
  */
-static constexpr const char *FAAS_INVOKED_PROVIDER = "faas.invoked_provider";
+static constexpr const char *kFaasInvokedProvider = "faas.invoked_provider";
 
 /**
  * The cloud region of the invoked function.
@@ -361,17 +343,17 @@ static constexpr const char *FAAS_INVOKED_PROVIDER = "faas.invoked_provider";
   <ul> <li>SHOULD be equal to the {@code cloud.region} resource attribute of the invoked
  function.</li> </ul>
  */
-static constexpr const char *FAAS_INVOKED_REGION = "faas.invoked_region";
+static constexpr const char *kFaasInvokedRegion = "faas.invoked_region";
 
 /**
  * Transport protocol used. See note below.
  */
-static constexpr const char *NET_TRANSPORT = "net.transport";
+static constexpr const char *kNetTransport = "net.transport";
 
 /**
  * Application layer protocol used. The value SHOULD be normalized to lowercase.
  */
-static constexpr const char *NET_APP_PROTOCOL_NAME = "net.app.protocol.name";
+static constexpr const char *kNetAppProtocolName = "net.app.protocol.name";
 
 /**
  * Version of the application layer protocol used. See note below.
@@ -382,29 +364,29 @@ static constexpr const char *NET_APP_PROTOCOL_NAME = "net.app.protocol.name";
  0.27.2}, but sends HTTP version {@code 1.1}, this attribute should be set to {@code 1.1}.</li>
  </ul>
  */
-static constexpr const char *NET_APP_PROTOCOL_VERSION = "net.app.protocol.version";
+static constexpr const char *kNetAppProtocolVersion = "net.app.protocol.version";
 
 /**
  * Remote socket peer name.
  */
-static constexpr const char *NET_SOCK_PEER_NAME = "net.sock.peer.name";
+static constexpr const char *kNetSockPeerName = "net.sock.peer.name";
 
 /**
  * Remote socket peer address: IPv4 or IPv6 for internet protocols, path for local communication, <a
  * href="https://man7.org/linux/man-pages/man7/address_families.7.html">etc</a>.
  */
-static constexpr const char *NET_SOCK_PEER_ADDR = "net.sock.peer.addr";
+static constexpr const char *kNetSockPeerAddr = "net.sock.peer.addr";
 
 /**
  * Remote socket peer port.
  */
-static constexpr const char *NET_SOCK_PEER_PORT = "net.sock.peer.port";
+static constexpr const char *kNetSockPeerPort = "net.sock.peer.port";
 
 /**
  * Protocol <a href="https://man7.org/linux/man-pages/man7/address_families.7.html">address
  * family</a> which is used for communication.
  */
-static constexpr const char *NET_SOCK_FAMILY = "net.sock.family";
+static constexpr const char *kNetSockFamily = "net.sock.family";
 
 /**
  * Logical remote hostname, see note below.
@@ -413,83 +395,83 @@ static constexpr const char *NET_SOCK_FAMILY = "net.sock.family";
   <ul> <li>{@code net.peer.name} SHOULD NOT be set if capturing it would require an extra DNS
  lookup.</li> </ul>
  */
-static constexpr const char *NET_PEER_NAME = "net.peer.name";
+static constexpr const char *kNetPeerName = "net.peer.name";
 
 /**
  * Logical remote port number
  */
-static constexpr const char *NET_PEER_PORT = "net.peer.port";
+static constexpr const char *kNetPeerPort = "net.peer.port";
 
 /**
  * Logical local hostname or similar, see note below.
  */
-static constexpr const char *NET_HOST_NAME = "net.host.name";
+static constexpr const char *kNetHostName = "net.host.name";
 
 /**
  * Logical local port number, preferably the one that the peer used to connect
  */
-static constexpr const char *NET_HOST_PORT = "net.host.port";
+static constexpr const char *kNetHostPort = "net.host.port";
 
 /**
  * Local socket address. Useful in case of a multi-IP host.
  */
-static constexpr const char *NET_SOCK_HOST_ADDR = "net.sock.host.addr";
+static constexpr const char *kNetSockHostAddr = "net.sock.host.addr";
 
 /**
  * Local socket port number.
  */
-static constexpr const char *NET_SOCK_HOST_PORT = "net.sock.host.port";
+static constexpr const char *kNetSockHostPort = "net.sock.host.port";
 
 /**
  * The internet connection type currently being used by the host.
  */
-static constexpr const char *NET_HOST_CONNECTION_TYPE = "net.host.connection.type";
+static constexpr const char *kNetHostConnectionType = "net.host.connection.type";
 
 /**
  * This describes more details regarding the connection.type. It may be the type of cell technology
  * connection, but it could be used for describing details about a wifi connection.
  */
-static constexpr const char *NET_HOST_CONNECTION_SUBTYPE = "net.host.connection.subtype";
+static constexpr const char *kNetHostConnectionSubtype = "net.host.connection.subtype";
 
 /**
  * The name of the mobile carrier.
  */
-static constexpr const char *NET_HOST_CARRIER_NAME = "net.host.carrier.name";
+static constexpr const char *kNetHostCarrierName = "net.host.carrier.name";
 
 /**
  * The mobile carrier country code.
  */
-static constexpr const char *NET_HOST_CARRIER_MCC = "net.host.carrier.mcc";
+static constexpr const char *kNetHostCarrierMcc = "net.host.carrier.mcc";
 
 /**
  * The mobile carrier network code.
  */
-static constexpr const char *NET_HOST_CARRIER_MNC = "net.host.carrier.mnc";
+static constexpr const char *kNetHostCarrierMnc = "net.host.carrier.mnc";
 
 /**
  * The ISO 3166-1 alpha-2 2-character country code associated with the mobile carrier network.
  */
-static constexpr const char *NET_HOST_CARRIER_ICC = "net.host.carrier.icc";
+static constexpr const char *kNetHostCarrierIcc = "net.host.carrier.icc";
 
 /**
  * The <a href="../../resource/semantic_conventions/README.md#service">{@code service.name}</a> of
  * the remote service. SHOULD be equal to the actual {@code service.name} resource attribute of the
  * remote service if any.
  */
-static constexpr const char *PEER_SERVICE = "peer.service";
+static constexpr const char *kPeerService = "peer.service";
 
 /**
  * Username or client_id extracted from the access token or <a
  * href="https://tools.ietf.org/html/rfc7235#section-4.2">Authorization</a> header in the inbound
  * request from outside the system.
  */
-static constexpr const char *ENDUSER_ID = "enduser.id";
+static constexpr const char *kEnduserId = "enduser.id";
 
 /**
  * Actual/assumed role the client is making the request under extracted from token or application
  * security context.
  */
-static constexpr const char *ENDUSER_ROLE = "enduser.role";
+static constexpr const char *kEnduserRole = "enduser.role";
 
 /**
  * Scopes or granted authorities the client currently possesses extracted from token or application
@@ -499,51 +481,51 @@ static constexpr const char *ENDUSER_ROLE = "enduser.role";
  * href="http://docs.oasis-open.org/security/saml/Post2.0/sstc-saml-tech-overview-2.0.html">SAML 2.0
  * Assertion</a>.
  */
-static constexpr const char *ENDUSER_SCOPE = "enduser.scope";
+static constexpr const char *kEnduserScope = "enduser.scope";
 
 /**
  * Current &quot;managed&quot; thread ID (as opposed to OS thread ID).
  */
-static constexpr const char *THREAD_ID = "thread.id";
+static constexpr const char *kThreadId = "thread.id";
 
 /**
  * Current thread name.
  */
-static constexpr const char *THREAD_NAME = "thread.name";
+static constexpr const char *kThreadName = "thread.name";
 
 /**
  * The method or function name, or equivalent (usually rightmost part of the code unit's name).
  */
-static constexpr const char *CODE_FUNCTION = "code.function";
+static constexpr const char *kCodeFunction = "code.function";
 
 /**
  * The &quot;namespace&quot; within which {@code code.function} is defined. Usually the qualified
  * class or module name, such that {@code code.namespace} + some separator + {@code code.function}
  * form a unique identifier for the code unit.
  */
-static constexpr const char *CODE_NAMESPACE = "code.namespace";
+static constexpr const char *kCodeNamespace = "code.namespace";
 
 /**
  * The source code file name that identifies the code unit as uniquely as possible (preferably an
  * absolute file path).
  */
-static constexpr const char *CODE_FILEPATH = "code.filepath";
+static constexpr const char *kCodeFilepath = "code.filepath";
 
 /**
  * The line number in {@code code.filepath} best representing the operation. It SHOULD point within
  * the code unit named in {@code code.function}.
  */
-static constexpr const char *CODE_LINENO = "code.lineno";
+static constexpr const char *kCodeLineno = "code.lineno";
 
 /**
  * HTTP request method.
  */
-static constexpr const char *HTTP_METHOD = "http.method";
+static constexpr const char *kHttpMethod = "http.method";
 
 /**
  * <a href="https://tools.ietf.org/html/rfc7231#section-6">HTTP response status code</a>.
  */
-static constexpr const char *HTTP_STATUS_CODE = "http.status_code";
+static constexpr const char *kHttpStatusCode = "http.status_code";
 
 /**
  * Kind of HTTP protocol used.
@@ -552,13 +534,13 @@ static constexpr const char *HTTP_STATUS_CODE = "http.status_code";
   <ul> <li>If {@code net.transport} is not specified, it can be assumed to be {@code IP.TCP} except
  if {@code http.flavor} is {@code QUIC}, in which case {@code IP.UDP} is assumed.</li> </ul>
  */
-static constexpr const char *HTTP_FLAVOR = "http.flavor";
+static constexpr const char *kHttpFlavor = "http.flavor";
 
 /**
  * Value of the <a href="https://www.rfc-editor.org/rfc/rfc9110.html#field.user-agent">HTTP
  * User-Agent</a> header sent by the client.
  */
-static constexpr const char *HTTP_USER_AGENT = "http.user_agent";
+static constexpr const char *kHttpUserAgent = "http.user_agent";
 
 /**
  * The size of the request payload body in bytes. This is the number of bytes transferred excluding
@@ -566,7 +548,7 @@ static constexpr const char *HTTP_USER_AGENT = "http.user_agent";
  * href="https://www.rfc-editor.org/rfc/rfc9110.html#field.content-length">Content-Length</a>
  * header. For requests using transport encoding, this should be the compressed size.
  */
-static constexpr const char *HTTP_REQUEST_CONTENT_LENGTH = "http.request_content_length";
+static constexpr const char *kHttpRequestContentLength = "http.request_content_length";
 
 /**
  * The size of the response payload body in bytes. This is the number of bytes transferred excluding
@@ -574,7 +556,7 @@ static constexpr const char *HTTP_REQUEST_CONTENT_LENGTH = "http.request_content
  * href="https://www.rfc-editor.org/rfc/rfc9110.html#field.content-length">Content-Length</a>
  * header. For requests using transport encoding, this should be the compressed size.
  */
-static constexpr const char *HTTP_RESPONSE_CONTENT_LENGTH = "http.response_content_length";
+static constexpr const char *kHttpResponseContentLength = "http.response_content_length";
 
 /**
  * Full HTTP request URL in the form {@code scheme://host[:port]/path?query[#fragment]}. Usually the
@@ -585,7 +567,7 @@ static constexpr const char *HTTP_RESPONSE_CONTENT_LENGTH = "http.response_conte
  https://username:password@www.example.com/}. In such case the attribute's value should be {@code
  https://www.example.com/}.</li> </ul>
  */
-static constexpr const char *HTTP_URL = "http.url";
+static constexpr const char *kHttpUrl = "http.url";
 
 /**
  * The ordinal number of request resending attempt (for any reason, including redirects).
@@ -595,17 +577,17 @@ static constexpr const char *HTTP_URL = "http.url";
  regardless of what was the cause of the resending (e.g. redirection, authorization failure, 503
  Server Unavailable, network issues, or any other).</li> </ul>
  */
-static constexpr const char *HTTP_RESEND_COUNT = "http.resend_count";
+static constexpr const char *kHttpResendCount = "http.resend_count";
 
 /**
  * The URI scheme identifying the used protocol.
  */
-static constexpr const char *HTTP_SCHEME = "http.scheme";
+static constexpr const char *kHttpScheme = "http.scheme";
 
 /**
  * The full request target as passed in a HTTP request line or equivalent.
  */
-static constexpr const char *HTTP_TARGET = "http.target";
+static constexpr const char *kHttpTarget = "http.target";
 
 /**
  * The matched route (path template in the format used by the respective server framework). See note
@@ -616,7 +598,7 @@ static constexpr const char *HTTP_TARGET = "http.target";
  framework as the route attribute should have low-cardinality and the URI path can NOT substitute
  it.</li> </ul>
  */
-static constexpr const char *HTTP_ROUTE = "http.route";
+static constexpr const char *kHttpRoute = "http.route";
 
 /**
  * The IP address of the original client behind all proxies, if known (e.g. from <a
@@ -633,136 +615,135 @@ the actual client. Setting
 one is at least somewhat confident that the address is not that of
 the closest proxy.</li> </ul>
  */
-static constexpr const char *HTTP_CLIENT_IP = "http.client_ip";
+static constexpr const char *kHttpClientIp = "http.client_ip";
 
 /**
  * The keys in the {@code RequestItems} object field.
  */
-static constexpr const char *AWS_DYNAMODB_TABLE_NAMES = "aws.dynamodb.table_names";
+static constexpr const char *kAwsDynamodbTableNames = "aws.dynamodb.table_names";
 
 /**
  * The JSON-serialized value of each item in the {@code ConsumedCapacity} response field.
  */
-static constexpr const char *AWS_DYNAMODB_CONSUMED_CAPACITY = "aws.dynamodb.consumed_capacity";
+static constexpr const char *kAwsDynamodbConsumedCapacity = "aws.dynamodb.consumed_capacity";
 
 /**
  * The JSON-serialized value of the {@code ItemCollectionMetrics} response field.
  */
-static constexpr const char *AWS_DYNAMODB_ITEM_COLLECTION_METRICS =
+static constexpr const char *kAwsDynamodbItemCollectionMetrics =
     "aws.dynamodb.item_collection_metrics";
 
 /**
  * The value of the {@code ProvisionedThroughput.ReadCapacityUnits} request parameter.
  */
-static constexpr const char *AWS_DYNAMODB_PROVISIONED_READ_CAPACITY =
+static constexpr const char *kAwsDynamodbProvisionedReadCapacity =
     "aws.dynamodb.provisioned_read_capacity";
 
 /**
  * The value of the {@code ProvisionedThroughput.WriteCapacityUnits} request parameter.
  */
-static constexpr const char *AWS_DYNAMODB_PROVISIONED_WRITE_CAPACITY =
+static constexpr const char *kAwsDynamodbProvisionedWriteCapacity =
     "aws.dynamodb.provisioned_write_capacity";
 
 /**
  * The value of the {@code ConsistentRead} request parameter.
  */
-static constexpr const char *AWS_DYNAMODB_CONSISTENT_READ = "aws.dynamodb.consistent_read";
+static constexpr const char *kAwsDynamodbConsistentRead = "aws.dynamodb.consistent_read";
 
 /**
  * The value of the {@code ProjectionExpression} request parameter.
  */
-static constexpr const char *AWS_DYNAMODB_PROJECTION = "aws.dynamodb.projection";
+static constexpr const char *kAwsDynamodbProjection = "aws.dynamodb.projection";
 
 /**
  * The value of the {@code Limit} request parameter.
  */
-static constexpr const char *AWS_DYNAMODB_LIMIT = "aws.dynamodb.limit";
+static constexpr const char *kAwsDynamodbLimit = "aws.dynamodb.limit";
 
 /**
  * The value of the {@code AttributesToGet} request parameter.
  */
-static constexpr const char *AWS_DYNAMODB_ATTRIBUTES_TO_GET = "aws.dynamodb.attributes_to_get";
+static constexpr const char *kAwsDynamodbAttributesToGet = "aws.dynamodb.attributes_to_get";
 
 /**
  * The value of the {@code IndexName} request parameter.
  */
-static constexpr const char *AWS_DYNAMODB_INDEX_NAME = "aws.dynamodb.index_name";
+static constexpr const char *kAwsDynamodbIndexName = "aws.dynamodb.index_name";
 
 /**
  * The value of the {@code Select} request parameter.
  */
-static constexpr const char *AWS_DYNAMODB_SELECT = "aws.dynamodb.select";
+static constexpr const char *kAwsDynamodbSelect = "aws.dynamodb.select";
 
 /**
  * The JSON-serialized value of each item of the {@code GlobalSecondaryIndexes} request field
  */
-static constexpr const char *AWS_DYNAMODB_GLOBAL_SECONDARY_INDEXES =
+static constexpr const char *kAwsDynamodbGlobalSecondaryIndexes =
     "aws.dynamodb.global_secondary_indexes";
 
 /**
  * The JSON-serialized value of each item of the {@code LocalSecondaryIndexes} request field.
  */
-static constexpr const char *AWS_DYNAMODB_LOCAL_SECONDARY_INDEXES =
+static constexpr const char *kAwsDynamodbLocalSecondaryIndexes =
     "aws.dynamodb.local_secondary_indexes";
 
 /**
  * The value of the {@code ExclusiveStartTableName} request parameter.
  */
-static constexpr const char *AWS_DYNAMODB_EXCLUSIVE_START_TABLE =
-    "aws.dynamodb.exclusive_start_table";
+static constexpr const char *kAwsDynamodbExclusiveStartTable = "aws.dynamodb.exclusive_start_table";
 
 /**
  * The the number of items in the {@code TableNames} response parameter.
  */
-static constexpr const char *AWS_DYNAMODB_TABLE_COUNT = "aws.dynamodb.table_count";
+static constexpr const char *kAwsDynamodbTableCount = "aws.dynamodb.table_count";
 
 /**
  * The value of the {@code ScanIndexForward} request parameter.
  */
-static constexpr const char *AWS_DYNAMODB_SCAN_FORWARD = "aws.dynamodb.scan_forward";
+static constexpr const char *kAwsDynamodbScanForward = "aws.dynamodb.scan_forward";
 
 /**
  * The value of the {@code Segment} request parameter.
  */
-static constexpr const char *AWS_DYNAMODB_SEGMENT = "aws.dynamodb.segment";
+static constexpr const char *kAwsDynamodbSegment = "aws.dynamodb.segment";
 
 /**
  * The value of the {@code TotalSegments} request parameter.
  */
-static constexpr const char *AWS_DYNAMODB_TOTAL_SEGMENTS = "aws.dynamodb.total_segments";
+static constexpr const char *kAwsDynamodbTotalSegments = "aws.dynamodb.total_segments";
 
 /**
  * The value of the {@code Count} response parameter.
  */
-static constexpr const char *AWS_DYNAMODB_COUNT = "aws.dynamodb.count";
+static constexpr const char *kAwsDynamodbCount = "aws.dynamodb.count";
 
 /**
  * The value of the {@code ScannedCount} response parameter.
  */
-static constexpr const char *AWS_DYNAMODB_SCANNED_COUNT = "aws.dynamodb.scanned_count";
+static constexpr const char *kAwsDynamodbScannedCount = "aws.dynamodb.scanned_count";
 
 /**
  * The JSON-serialized value of each item in the {@code AttributeDefinitions} request field.
  */
-static constexpr const char *AWS_DYNAMODB_ATTRIBUTE_DEFINITIONS =
+static constexpr const char *kAwsDynamodbAttributeDefinitions =
     "aws.dynamodb.attribute_definitions";
 
 /**
  * The JSON-serialized value of each item in the the {@code GlobalSecondaryIndexUpdates} request
  * field.
  */
-static constexpr const char *AWS_DYNAMODB_GLOBAL_SECONDARY_INDEX_UPDATES =
+static constexpr const char *kAwsDynamodbGlobalSecondaryIndexUpdates =
     "aws.dynamodb.global_secondary_index_updates";
 
 /**
  * The name of the operation being executed.
  */
-static constexpr const char *GRAPHQL_OPERATION_NAME = "graphql.operation.name";
+static constexpr const char *kGraphqlOperationName = "graphql.operation.name";
 
 /**
  * The type of the operation being executed.
  */
-static constexpr const char *GRAPHQL_OPERATION_TYPE = "graphql.operation.type";
+static constexpr const char *kGraphqlOperationType = "graphql.operation.type";
 
 /**
  * The GraphQL document being executed.
@@ -770,65 +751,65 @@ static constexpr const char *GRAPHQL_OPERATION_TYPE = "graphql.operation.type";
  * <p>Notes:
   <ul> <li>The value may be sanitized to exclude sensitive information.</li> </ul>
  */
-static constexpr const char *GRAPHQL_DOCUMENT = "graphql.document";
+static constexpr const char *kGraphqlDocument = "graphql.document";
 
 /**
  * A string identifying the messaging system.
  */
-static constexpr const char *MESSAGING_SYSTEM = "messaging.system";
+static constexpr const char *kMessagingSystem = "messaging.system";
 
 /**
  * The message destination name. This might be equal to the span name but is required nevertheless.
  */
-static constexpr const char *MESSAGING_DESTINATION = "messaging.destination";
+static constexpr const char *kMessagingDestination = "messaging.destination";
 
 /**
  * The kind of message destination
  */
-static constexpr const char *MESSAGING_DESTINATION_KIND = "messaging.destination_kind";
+static constexpr const char *kMessagingDestinationKind = "messaging.destination_kind";
 
 /**
  * A boolean that is true if the message destination is temporary.
  */
-static constexpr const char *MESSAGING_TEMP_DESTINATION = "messaging.temp_destination";
+static constexpr const char *kMessagingTempDestination = "messaging.temp_destination";
 
 /**
  * The name of the transport protocol.
  */
-static constexpr const char *MESSAGING_PROTOCOL = "messaging.protocol";
+static constexpr const char *kMessagingProtocol = "messaging.protocol";
 
 /**
  * The version of the transport protocol.
  */
-static constexpr const char *MESSAGING_PROTOCOL_VERSION = "messaging.protocol_version";
+static constexpr const char *kMessagingProtocolVersion = "messaging.protocol_version";
 
 /**
  * Connection string.
  */
-static constexpr const char *MESSAGING_URL = "messaging.url";
+static constexpr const char *kMessagingUrl = "messaging.url";
 
 /**
  * A value used by the messaging system as an identifier for the message, represented as a string.
  */
-static constexpr const char *MESSAGING_MESSAGE_ID = "messaging.message_id";
+static constexpr const char *kMessagingMessageId = "messaging.message_id";
 
 /**
  * The <a href="#conversations">conversation ID</a> identifying the conversation to which the
  * message belongs, represented as a string. Sometimes called &quot;Correlation ID&quot;.
  */
-static constexpr const char *MESSAGING_CONVERSATION_ID = "messaging.conversation_id";
+static constexpr const char *kMessagingConversationId = "messaging.conversation_id";
 
 /**
  * The (uncompressed) size of the message payload in bytes. Also use this attribute if it is unknown
  * whether the compressed or uncompressed payload size is reported.
  */
-static constexpr const char *MESSAGING_MESSAGE_PAYLOAD_SIZE_BYTES =
+static constexpr const char *kMessagingMessagePayloadSizeBytes =
     "messaging.message_payload_size_bytes";
 
 /**
  * The compressed size of the message payload in bytes.
  */
-static constexpr const char *MESSAGING_MESSAGE_PAYLOAD_COMPRESSED_SIZE_BYTES =
+static constexpr const char *kMessagingMessagePayloadCompressedSizeBytes =
     "messaging.message_payload_compressed_size_bytes";
 
 /**
@@ -837,7 +818,7 @@ static constexpr const char *MESSAGING_MESSAGE_PAYLOAD_COMPRESSED_SIZE_BYTES =
  * this attribute MUST NOT be set, since the operation can be inferred from the span kind in that
  * case.
  */
-static constexpr const char *MESSAGING_OPERATION = "messaging.operation";
+static constexpr const char *kMessagingOperation = "messaging.operation";
 
 /**
  * The identifier for the consumer receiving a message. For Kafka, set it to {@code
@@ -845,12 +826,12 @@ static constexpr const char *MESSAGING_OPERATION = "messaging.operation";
  * {@code messaging.kafka.consumer_group}. For brokers, such as RabbitMQ and Artemis, set it to the
  * {@code client_id} of the client consuming the message.
  */
-static constexpr const char *MESSAGING_CONSUMER_ID = "messaging.consumer_id";
+static constexpr const char *kMessagingConsumerId = "messaging.consumer_id";
 
 /**
  * RabbitMQ message routing key.
  */
-static constexpr const char *MESSAGING_RABBITMQ_ROUTING_KEY = "messaging.rabbitmq.routing_key";
+static constexpr const char *kMessagingRabbitmqRoutingKey = "messaging.rabbitmq.routing_key";
 
 /**
  * Message keys in Kafka are used for grouping alike messages to ensure they're processed on the
@@ -862,88 +843,88 @@ static constexpr const char *MESSAGING_RABBITMQ_ROUTING_KEY = "messaging.rabbitm
  attribute. If the key has no unambiguous, canonical string form, don't include its value.</li>
  </ul>
  */
-static constexpr const char *MESSAGING_KAFKA_MESSAGE_KEY = "messaging.kafka.message_key";
+static constexpr const char *kMessagingKafkaMessageKey = "messaging.kafka.message_key";
 
 /**
  * Name of the Kafka Consumer Group that is handling the message. Only applies to consumers, not
  * producers.
  */
-static constexpr const char *MESSAGING_KAFKA_CONSUMER_GROUP = "messaging.kafka.consumer_group";
+static constexpr const char *kMessagingKafkaConsumerGroup = "messaging.kafka.consumer_group";
 
 /**
  * Client Id for the Consumer or Producer that is handling the message.
  */
-static constexpr const char *MESSAGING_KAFKA_CLIENT_ID = "messaging.kafka.client_id";
+static constexpr const char *kMessagingKafkaClientId = "messaging.kafka.client_id";
 
 /**
  * Partition the message is sent to.
  */
-static constexpr const char *MESSAGING_KAFKA_PARTITION = "messaging.kafka.partition";
+static constexpr const char *kMessagingKafkaPartition = "messaging.kafka.partition";
 
 /**
  * A boolean that is true if the message is a tombstone.
  */
-static constexpr const char *MESSAGING_KAFKA_TOMBSTONE = "messaging.kafka.tombstone";
+static constexpr const char *kMessagingKafkaTombstone = "messaging.kafka.tombstone";
 
 /**
  * Namespace of RocketMQ resources, resources in different namespaces are individual.
  */
-static constexpr const char *MESSAGING_ROCKETMQ_NAMESPACE = "messaging.rocketmq.namespace";
+static constexpr const char *kMessagingRocketmqNamespace = "messaging.rocketmq.namespace";
 
 /**
  * Name of the RocketMQ producer/consumer group that is handling the message. The client type is
  * identified by the SpanKind.
  */
-static constexpr const char *MESSAGING_ROCKETMQ_CLIENT_GROUP = "messaging.rocketmq.client_group";
+static constexpr const char *kMessagingRocketmqClientGroup = "messaging.rocketmq.client_group";
 
 /**
  * The unique identifier for each client.
  */
-static constexpr const char *MESSAGING_ROCKETMQ_CLIENT_ID = "messaging.rocketmq.client_id";
+static constexpr const char *kMessagingRocketmqClientId = "messaging.rocketmq.client_id";
 
 /**
  * The timestamp in milliseconds that the delay message is expected to be delivered to consumer.
  */
-static constexpr const char *MESSAGING_ROCKETMQ_DELIVERY_TIMESTAMP =
+static constexpr const char *kMessagingRocketmqDeliveryTimestamp =
     "messaging.rocketmq.delivery_timestamp";
 
 /**
  * The delay time level for delay message, which determines the message delay time.
  */
-static constexpr const char *MESSAGING_ROCKETMQ_DELAY_TIME_LEVEL =
+static constexpr const char *kMessagingRocketmqDelayTimeLevel =
     "messaging.rocketmq.delay_time_level";
 
 /**
  * It is essential for FIFO message. Messages that belong to the same message group are always
  * processed one by one within the same consumer group.
  */
-static constexpr const char *MESSAGING_ROCKETMQ_MESSAGE_GROUP = "messaging.rocketmq.message_group";
+static constexpr const char *kMessagingRocketmqMessageGroup = "messaging.rocketmq.message_group";
 
 /**
  * Type of message.
  */
-static constexpr const char *MESSAGING_ROCKETMQ_MESSAGE_TYPE = "messaging.rocketmq.message_type";
+static constexpr const char *kMessagingRocketmqMessageType = "messaging.rocketmq.message_type";
 
 /**
  * The secondary classifier of message besides topic.
  */
-static constexpr const char *MESSAGING_ROCKETMQ_MESSAGE_TAG = "messaging.rocketmq.message_tag";
+static constexpr const char *kMessagingRocketmqMessageTag = "messaging.rocketmq.message_tag";
 
 /**
  * Key(s) of message, another way to mark message besides message id.
  */
-static constexpr const char *MESSAGING_ROCKETMQ_MESSAGE_KEYS = "messaging.rocketmq.message_keys";
+static constexpr const char *kMessagingRocketmqMessageKeys = "messaging.rocketmq.message_keys";
 
 /**
  * Model of message consumption. This only applies to consumer spans.
  */
-static constexpr const char *MESSAGING_ROCKETMQ_CONSUMPTION_MODEL =
+static constexpr const char *kMessagingRocketmqConsumptionModel =
     "messaging.rocketmq.consumption_model";
 
 /**
  * A string identifying the remoting system. See below for a list of well-known identifiers.
  */
-static constexpr const char *RPC_SYSTEM = "rpc.system";
+static constexpr const char *kRpcSystem = "rpc.system";
 
 /**
  * The full (logical) name of the service being called, including its package name, if applicable.
@@ -955,7 +936,7 @@ static constexpr const char *RPC_SYSTEM = "rpc.system";
  method actually executing the call on the server side, RPC client stub class on the client
  side).</li> </ul>
  */
-static constexpr const char *RPC_SERVICE = "rpc.service";
+static constexpr const char *kRpcService = "rpc.service";
 
 /**
  * The name of the (logical) method being called, must be equal to the $method part in the span
@@ -967,423 +948,423 @@ static constexpr const char *RPC_SERVICE = "rpc.service";
  may be used to store the latter (e.g., method actually executing the call on the server side, RPC
  client stub method on the client side).</li> </ul>
  */
-static constexpr const char *RPC_METHOD = "rpc.method";
+static constexpr const char *kRpcMethod = "rpc.method";
 
 /**
  * The <a href="https://github.com/grpc/grpc/blob/v1.33.2/doc/statuscodes.md">numeric status
  * code</a> of the gRPC request.
  */
-static constexpr const char *RPC_GRPC_STATUS_CODE = "rpc.grpc.status_code";
+static constexpr const char *kRpcGrpcStatusCode = "rpc.grpc.status_code";
 
 /**
  * Protocol version as in {@code jsonrpc} property of request/response. Since JSON-RPC 1.0 does not
  * specify this, the value can be omitted.
  */
-static constexpr const char *RPC_JSONRPC_VERSION = "rpc.jsonrpc.version";
+static constexpr const char *kRpcJsonrpcVersion = "rpc.jsonrpc.version";
 
 /**
  * {@code id} property of request or response. Since protocol allows id to be int, string, {@code
  * null} or missing (for notifications), value is expected to be cast to string for simplicity. Use
  * empty string in case of {@code null} value. Omit entirely if this is a notification.
  */
-static constexpr const char *RPC_JSONRPC_REQUEST_ID = "rpc.jsonrpc.request_id";
+static constexpr const char *kRpcJsonrpcRequestId = "rpc.jsonrpc.request_id";
 
 /**
  * {@code error.code} property of response if it is an error response.
  */
-static constexpr const char *RPC_JSONRPC_ERROR_CODE = "rpc.jsonrpc.error_code";
+static constexpr const char *kRpcJsonrpcErrorCode = "rpc.jsonrpc.error_code";
 
 /**
  * {@code error.message} property of response if it is an error response.
  */
-static constexpr const char *RPC_JSONRPC_ERROR_MESSAGE = "rpc.jsonrpc.error_message";
+static constexpr const char *kRpcJsonrpcErrorMessage = "rpc.jsonrpc.error_message";
 
 // Enum definitions
 namespace EventDomainValues
 {
 /** Events from browser apps. */
-static constexpr const char *BROWSER = "browser";
+static constexpr const char *kBrowser = "browser";
 /** Events from mobile apps. */
-static constexpr const char *DEVICE = "device";
+static constexpr const char *kDevice = "device";
 /** Events from Kubernetes. */
-static constexpr const char *K8S = "k8s";
+static constexpr const char *kK8s = "k8s";
 }  // namespace EventDomainValues
 
 namespace OpentracingRefTypeValues
 {
 /** The parent Span depends on the child Span in some capacity. */
-static constexpr const char *CHILD_OF = "child_of";
+static constexpr const char *kChildOf = "child_of";
 /** The parent Span does not depend in any way on the result of the child Span. */
-static constexpr const char *FOLLOWS_FROM = "follows_from";
+static constexpr const char *kFollowsFrom = "follows_from";
 }  // namespace OpentracingRefTypeValues
 
 namespace DbSystemValues
 {
 /** Some other SQL database. Fallback only. See notes. */
-static constexpr const char *OTHER_SQL = "other_sql";
+static constexpr const char *kOtherSql = "other_sql";
 /** Microsoft SQL Server. */
-static constexpr const char *MSSQL = "mssql";
+static constexpr const char *kMssql = "mssql";
 /** MySQL. */
-static constexpr const char *MYSQL = "mysql";
+static constexpr const char *kMysql = "mysql";
 /** Oracle Database. */
-static constexpr const char *ORACLE = "oracle";
+static constexpr const char *kOracle = "oracle";
 /** IBM Db2. */
-static constexpr const char *DB2 = "db2";
+static constexpr const char *kDb2 = "db2";
 /** PostgreSQL. */
-static constexpr const char *POSTGRESQL = "postgresql";
+static constexpr const char *kPostgresql = "postgresql";
 /** Amazon Redshift. */
-static constexpr const char *REDSHIFT = "redshift";
+static constexpr const char *kRedshift = "redshift";
 /** Apache Hive. */
-static constexpr const char *HIVE = "hive";
+static constexpr const char *kHive = "hive";
 /** Cloudscape. */
-static constexpr const char *CLOUDSCAPE = "cloudscape";
+static constexpr const char *kCloudscape = "cloudscape";
 /** HyperSQL DataBase. */
-static constexpr const char *HSQLDB = "hsqldb";
+static constexpr const char *kHsqldb = "hsqldb";
 /** Progress Database. */
-static constexpr const char *PROGRESS = "progress";
+static constexpr const char *kProgress = "progress";
 /** SAP MaxDB. */
-static constexpr const char *MAXDB = "maxdb";
+static constexpr const char *kMaxdb = "maxdb";
 /** SAP HANA. */
-static constexpr const char *HANADB = "hanadb";
+static constexpr const char *kHanadb = "hanadb";
 /** Ingres. */
-static constexpr const char *INGRES = "ingres";
+static constexpr const char *kIngres = "ingres";
 /** FirstSQL. */
-static constexpr const char *FIRSTSQL = "firstsql";
+static constexpr const char *kFirstsql = "firstsql";
 /** EnterpriseDB. */
-static constexpr const char *EDB = "edb";
+static constexpr const char *kEdb = "edb";
 /** InterSystems Caché. */
-static constexpr const char *CACHE = "cache";
+static constexpr const char *kCache = "cache";
 /** Adabas (Adaptable Database System). */
-static constexpr const char *ADABAS = "adabas";
+static constexpr const char *kAdabas = "adabas";
 /** Firebird. */
-static constexpr const char *FIREBIRD = "firebird";
+static constexpr const char *kFirebird = "firebird";
 /** Apache Derby. */
-static constexpr const char *DERBY = "derby";
+static constexpr const char *kDerby = "derby";
 /** FileMaker. */
-static constexpr const char *FILEMAKER = "filemaker";
+static constexpr const char *kFilemaker = "filemaker";
 /** Informix. */
-static constexpr const char *INFORMIX = "informix";
+static constexpr const char *kInformix = "informix";
 /** InstantDB. */
-static constexpr const char *INSTANTDB = "instantdb";
+static constexpr const char *kInstantdb = "instantdb";
 /** InterBase. */
-static constexpr const char *INTERBASE = "interbase";
+static constexpr const char *kInterbase = "interbase";
 /** MariaDB. */
-static constexpr const char *MARIADB = "mariadb";
+static constexpr const char *kMariadb = "mariadb";
 /** Netezza. */
-static constexpr const char *NETEZZA = "netezza";
+static constexpr const char *kNetezza = "netezza";
 /** Pervasive PSQL. */
-static constexpr const char *PERVASIVE = "pervasive";
+static constexpr const char *kPervasive = "pervasive";
 /** PointBase. */
-static constexpr const char *POINTBASE = "pointbase";
+static constexpr const char *kPointbase = "pointbase";
 /** SQLite. */
-static constexpr const char *SQLITE = "sqlite";
+static constexpr const char *kSqlite = "sqlite";
 /** Sybase. */
-static constexpr const char *SYBASE = "sybase";
+static constexpr const char *kSybase = "sybase";
 /** Teradata. */
-static constexpr const char *TERADATA = "teradata";
+static constexpr const char *kTeradata = "teradata";
 /** Vertica. */
-static constexpr const char *VERTICA = "vertica";
+static constexpr const char *kVertica = "vertica";
 /** H2. */
-static constexpr const char *H2 = "h2";
+static constexpr const char *kH2 = "h2";
 /** ColdFusion IMQ. */
-static constexpr const char *COLDFUSION = "coldfusion";
+static constexpr const char *kColdfusion = "coldfusion";
 /** Apache Cassandra. */
-static constexpr const char *CASSANDRA = "cassandra";
+static constexpr const char *kCassandra = "cassandra";
 /** Apache HBase. */
-static constexpr const char *HBASE = "hbase";
+static constexpr const char *kHbase = "hbase";
 /** MongoDB. */
-static constexpr const char *MONGODB = "mongodb";
+static constexpr const char *kMongodb = "mongodb";
 /** Redis. */
-static constexpr const char *REDIS = "redis";
+static constexpr const char *kRedis = "redis";
 /** Couchbase. */
-static constexpr const char *COUCHBASE = "couchbase";
+static constexpr const char *kCouchbase = "couchbase";
 /** CouchDB. */
-static constexpr const char *COUCHDB = "couchdb";
+static constexpr const char *kCouchdb = "couchdb";
 /** Microsoft Azure Cosmos DB. */
-static constexpr const char *COSMOSDB = "cosmosdb";
+static constexpr const char *kCosmosdb = "cosmosdb";
 /** Amazon DynamoDB. */
-static constexpr const char *DYNAMODB = "dynamodb";
+static constexpr const char *kDynamodb = "dynamodb";
 /** Neo4j. */
-static constexpr const char *NEO4J = "neo4j";
+static constexpr const char *kNeo4j = "neo4j";
 /** Apache Geode. */
-static constexpr const char *GEODE = "geode";
+static constexpr const char *kGeode = "geode";
 /** Elasticsearch. */
-static constexpr const char *ELASTICSEARCH = "elasticsearch";
+static constexpr const char *kElasticsearch = "elasticsearch";
 /** Memcached. */
-static constexpr const char *MEMCACHED = "memcached";
+static constexpr const char *kMemcached = "memcached";
 /** CockroachDB. */
-static constexpr const char *COCKROACHDB = "cockroachdb";
+static constexpr const char *kCockroachdb = "cockroachdb";
 /** OpenSearch. */
-static constexpr const char *OPENSEARCH = "opensearch";
+static constexpr const char *kOpensearch = "opensearch";
 }  // namespace DbSystemValues
 
 namespace DbCassandraConsistencyLevelValues
 {
 /** all. */
-static constexpr const char *ALL = "all";
+static constexpr const char *kAll = "all";
 /** each_quorum. */
-static constexpr const char *EACH_QUORUM = "each_quorum";
+static constexpr const char *kEachQuorum = "each_quorum";
 /** quorum. */
-static constexpr const char *QUORUM = "quorum";
+static constexpr const char *kQuorum = "quorum";
 /** local_quorum. */
-static constexpr const char *LOCAL_QUORUM = "local_quorum";
+static constexpr const char *kLocalQuorum = "local_quorum";
 /** one. */
-static constexpr const char *ONE = "one";
+static constexpr const char *kOne = "one";
 /** two. */
-static constexpr const char *TWO = "two";
+static constexpr const char *kTwo = "two";
 /** three. */
-static constexpr const char *THREE = "three";
+static constexpr const char *kThree = "three";
 /** local_one. */
-static constexpr const char *LOCAL_ONE = "local_one";
+static constexpr const char *kLocalOne = "local_one";
 /** any. */
-static constexpr const char *ANY = "any";
+static constexpr const char *kAny = "any";
 /** serial. */
-static constexpr const char *SERIAL = "serial";
+static constexpr const char *kSerial = "serial";
 /** local_serial. */
-static constexpr const char *LOCAL_SERIAL = "local_serial";
+static constexpr const char *kLocalSerial = "local_serial";
 }  // namespace DbCassandraConsistencyLevelValues
 
 namespace OtelStatusCodeValues
 {
 /** The operation has been validated by an Application developer or Operator to have completed
  * successfully. */
-static constexpr const char *OK = "OK";
+static constexpr const char *kOk = "OK";
 /** The operation contains an error. */
-static constexpr const char *ERROR = "ERROR";
+static constexpr const char *kError = "ERROR";
 }  // namespace OtelStatusCodeValues
 
 namespace FaasTriggerValues
 {
 /** A response to some data source operation such as a database or filesystem read/write. */
-static constexpr const char *DATASOURCE = "datasource";
+static constexpr const char *kDatasource = "datasource";
 /** To provide an answer to an inbound HTTP request. */
-static constexpr const char *HTTP = "http";
+static constexpr const char *kHttp = "http";
 /** A function is set to be executed when messages are sent to a messaging system. */
-static constexpr const char *PUBSUB = "pubsub";
+static constexpr const char *kPubsub = "pubsub";
 /** A function is scheduled to be executed regularly. */
-static constexpr const char *TIMER = "timer";
+static constexpr const char *kTimer = "timer";
 /** If none of the others apply. */
-static constexpr const char *OTHER = "other";
+static constexpr const char *kOther = "other";
 }  // namespace FaasTriggerValues
 
 namespace FaasDocumentOperationValues
 {
 /** When a new object is created. */
-static constexpr const char *INSERT = "insert";
+static constexpr const char *kInsert = "insert";
 /** When an object is modified. */
-static constexpr const char *EDIT = "edit";
+static constexpr const char *kEdit = "edit";
 /** When an object is deleted. */
-static constexpr const char *DELETE = "delete";
+static constexpr const char *kDelete = "delete";
 }  // namespace FaasDocumentOperationValues
 
 namespace FaasInvokedProviderValues
 {
 /** Alibaba Cloud. */
-static constexpr const char *ALIBABA_CLOUD = "alibaba_cloud";
+static constexpr const char *kAlibabaCloud = "alibaba_cloud";
 /** Amazon Web Services. */
-static constexpr const char *AWS = "aws";
+static constexpr const char *kAws = "aws";
 /** Microsoft Azure. */
-static constexpr const char *AZURE = "azure";
+static constexpr const char *kAzure = "azure";
 /** Google Cloud Platform. */
-static constexpr const char *GCP = "gcp";
+static constexpr const char *kGcp = "gcp";
 /** Tencent Cloud. */
-static constexpr const char *TENCENT_CLOUD = "tencent_cloud";
+static constexpr const char *kTencentCloud = "tencent_cloud";
 }  // namespace FaasInvokedProviderValues
 
 namespace NetTransportValues
 {
 /** ip_tcp. */
-static constexpr const char *IP_TCP = "ip_tcp";
+static constexpr const char *kIpTcp = "ip_tcp";
 /** ip_udp. */
-static constexpr const char *IP_UDP = "ip_udp";
+static constexpr const char *kIpUdp = "ip_udp";
 /** Named or anonymous pipe. See note below. */
-static constexpr const char *PIPE = "pipe";
+static constexpr const char *kPipe = "pipe";
 /** In-process communication. */
-static constexpr const char *INPROC = "inproc";
+static constexpr const char *kInproc = "inproc";
 /** Something else (non IP-based). */
-static constexpr const char *OTHER = "other";
+static constexpr const char *kOther = "other";
 }  // namespace NetTransportValues
 
 namespace NetSockFamilyValues
 {
 /** IPv4 address. */
-static constexpr const char *INET = "inet";
+static constexpr const char *kInet = "inet";
 /** IPv6 address. */
-static constexpr const char *INET6 = "inet6";
+static constexpr const char *kInet6 = "inet6";
 /** Unix domain socket path. */
-static constexpr const char *UNIX = "unix";
+static constexpr const char *kUnix = "unix";
 }  // namespace NetSockFamilyValues
 
 namespace NetHostConnectionTypeValues
 {
 /** wifi. */
-static constexpr const char *WIFI = "wifi";
+static constexpr const char *kWifi = "wifi";
 /** wired. */
-static constexpr const char *WIRED = "wired";
+static constexpr const char *kWired = "wired";
 /** cell. */
-static constexpr const char *CELL = "cell";
+static constexpr const char *kCell = "cell";
 /** unavailable. */
-static constexpr const char *UNAVAILABLE = "unavailable";
+static constexpr const char *kUnavailable = "unavailable";
 /** unknown. */
-static constexpr const char *UNKNOWN = "unknown";
+static constexpr const char *kUnknown = "unknown";
 }  // namespace NetHostConnectionTypeValues
 
 namespace NetHostConnectionSubtypeValues
 {
 /** GPRS. */
-static constexpr const char *GPRS = "gprs";
+static constexpr const char *kGprs = "gprs";
 /** EDGE. */
-static constexpr const char *EDGE = "edge";
+static constexpr const char *kEdge = "edge";
 /** UMTS. */
-static constexpr const char *UMTS = "umts";
+static constexpr const char *kUmts = "umts";
 /** CDMA. */
-static constexpr const char *CDMA = "cdma";
+static constexpr const char *kCdma = "cdma";
 /** EVDO Rel. 0. */
-static constexpr const char *EVDO_0 = "evdo_0";
+static constexpr const char *kEvdo0 = "evdo_0";
 /** EVDO Rev. A. */
-static constexpr const char *EVDO_A = "evdo_a";
+static constexpr const char *kEvdoA = "evdo_a";
 /** CDMA2000 1XRTT. */
-static constexpr const char *CDMA2000_1XRTT = "cdma2000_1xrtt";
+static constexpr const char *kCdma20001xrtt = "cdma2000_1xrtt";
 /** HSDPA. */
-static constexpr const char *HSDPA = "hsdpa";
+static constexpr const char *kHsdpa = "hsdpa";
 /** HSUPA. */
-static constexpr const char *HSUPA = "hsupa";
+static constexpr const char *kHsupa = "hsupa";
 /** HSPA. */
-static constexpr const char *HSPA = "hspa";
+static constexpr const char *kHspa = "hspa";
 /** IDEN. */
-static constexpr const char *IDEN = "iden";
+static constexpr const char *kIden = "iden";
 /** EVDO Rev. B. */
-static constexpr const char *EVDO_B = "evdo_b";
+static constexpr const char *kEvdoB = "evdo_b";
 /** LTE. */
-static constexpr const char *LTE = "lte";
+static constexpr const char *kLte = "lte";
 /** EHRPD. */
-static constexpr const char *EHRPD = "ehrpd";
+static constexpr const char *kEhrpd = "ehrpd";
 /** HSPAP. */
-static constexpr const char *HSPAP = "hspap";
+static constexpr const char *kHspap = "hspap";
 /** GSM. */
-static constexpr const char *GSM = "gsm";
+static constexpr const char *kGsm = "gsm";
 /** TD-SCDMA. */
-static constexpr const char *TD_SCDMA = "td_scdma";
+static constexpr const char *kTdScdma = "td_scdma";
 /** IWLAN. */
-static constexpr const char *IWLAN = "iwlan";
+static constexpr const char *kIwlan = "iwlan";
 /** 5G NR (New Radio). */
-static constexpr const char *NR = "nr";
+static constexpr const char *kNr = "nr";
 /** 5G NRNSA (New Radio Non-Standalone). */
-static constexpr const char *NRNSA = "nrnsa";
+static constexpr const char *kNrnsa = "nrnsa";
 /** LTE CA. */
-static constexpr const char *LTE_CA = "lte_ca";
+static constexpr const char *kLteCa = "lte_ca";
 }  // namespace NetHostConnectionSubtypeValues
 
 namespace HttpFlavorValues
 {
 /** HTTP/1.0. */
-static constexpr const char *HTTP_1_0 = "1.0";
+static constexpr const char *kHttp10 = "1.0";
 /** HTTP/1.1. */
-static constexpr const char *HTTP_1_1 = "1.1";
+static constexpr const char *kHttp11 = "1.1";
 /** HTTP/2. */
-static constexpr const char *HTTP_2_0 = "2.0";
+static constexpr const char *kHttp20 = "2.0";
 /** HTTP/3. */
-static constexpr const char *HTTP_3_0 = "3.0";
+static constexpr const char *kHttp30 = "3.0";
 /** SPDY protocol. */
-static constexpr const char *SPDY = "SPDY";
+static constexpr const char *kSpdy = "SPDY";
 /** QUIC protocol. */
-static constexpr const char *QUIC = "QUIC";
+static constexpr const char *kQuic = "QUIC";
 }  // namespace HttpFlavorValues
 
 namespace GraphqlOperationTypeValues
 {
 /** GraphQL query. */
-static constexpr const char *QUERY = "query";
+static constexpr const char *kQuery = "query";
 /** GraphQL mutation. */
-static constexpr const char *MUTATION = "mutation";
+static constexpr const char *kMutation = "mutation";
 /** GraphQL subscription. */
-static constexpr const char *SUBSCRIPTION = "subscription";
+static constexpr const char *kSubscription = "subscription";
 }  // namespace GraphqlOperationTypeValues
 
 namespace MessagingDestinationKindValues
 {
 /** A message sent to a queue. */
-static constexpr const char *QUEUE = "queue";
+static constexpr const char *kQueue = "queue";
 /** A message sent to a topic. */
-static constexpr const char *TOPIC = "topic";
+static constexpr const char *kTopic = "topic";
 }  // namespace MessagingDestinationKindValues
 
 namespace MessagingOperationValues
 {
 /** receive. */
-static constexpr const char *RECEIVE = "receive";
+static constexpr const char *kReceive = "receive";
 /** process. */
-static constexpr const char *PROCESS = "process";
+static constexpr const char *kProcess = "process";
 }  // namespace MessagingOperationValues
 
 namespace MessagingRocketmqMessageTypeValues
 {
 /** Normal message. */
-static constexpr const char *NORMAL = "normal";
+static constexpr const char *kNormal = "normal";
 /** FIFO message. */
-static constexpr const char *FIFO = "fifo";
+static constexpr const char *kFifo = "fifo";
 /** Delay message. */
-static constexpr const char *DELAY = "delay";
+static constexpr const char *kDelay = "delay";
 /** Transaction message. */
-static constexpr const char *TRANSACTION = "transaction";
+static constexpr const char *kTransaction = "transaction";
 }  // namespace MessagingRocketmqMessageTypeValues
 
 namespace MessagingRocketmqConsumptionModelValues
 {
 /** Clustering consumption model. */
-static constexpr const char *CLUSTERING = "clustering";
+static constexpr const char *kClustering = "clustering";
 /** Broadcasting consumption model. */
-static constexpr const char *BROADCASTING = "broadcasting";
+static constexpr const char *kBroadcasting = "broadcasting";
 }  // namespace MessagingRocketmqConsumptionModelValues
 
 namespace RpcSystemValues
 {
 /** gRPC. */
-static constexpr const char *GRPC = "grpc";
+static constexpr const char *kGrpc = "grpc";
 /** Java RMI. */
-static constexpr const char *JAVA_RMI = "java_rmi";
+static constexpr const char *kJavaRmi = "java_rmi";
 /** .NET WCF. */
-static constexpr const char *DOTNET_WCF = "dotnet_wcf";
+static constexpr const char *kDotnetWcf = "dotnet_wcf";
 /** Apache Dubbo. */
-static constexpr const char *APACHE_DUBBO = "apache_dubbo";
+static constexpr const char *kApacheDubbo = "apache_dubbo";
 }  // namespace RpcSystemValues
 
 namespace RpcGrpcStatusCodeValues
 {
 /** OK. */
-static constexpr const int OK = 0;
+static constexpr const int kOk = 0;
 /** CANCELLED. */
-static constexpr const int CANCELLED = 1;
+static constexpr const int kCancelled = 1;
 /** UNKNOWN. */
-static constexpr const int UNKNOWN = 2;
+static constexpr const int kUnknown = 2;
 /** INVALID_ARGUMENT. */
-static constexpr const int INVALID_ARGUMENT = 3;
+static constexpr const int kInvalidArgument = 3;
 /** DEADLINE_EXCEEDED. */
-static constexpr const int DEADLINE_EXCEEDED = 4;
+static constexpr const int kDeadlineExceeded = 4;
 /** NOT_FOUND. */
-static constexpr const int NOT_FOUND = 5;
+static constexpr const int kNotFound = 5;
 /** ALREADY_EXISTS. */
-static constexpr const int ALREADY_EXISTS = 6;
+static constexpr const int kAlreadyExists = 6;
 /** PERMISSION_DENIED. */
-static constexpr const int PERMISSION_DENIED = 7;
+static constexpr const int kPermissionDenied = 7;
 /** RESOURCE_EXHAUSTED. */
-static constexpr const int RESOURCE_EXHAUSTED = 8;
+static constexpr const int kResourceExhausted = 8;
 /** FAILED_PRECONDITION. */
-static constexpr const int FAILED_PRECONDITION = 9;
+static constexpr const int kFailedPrecondition = 9;
 /** ABORTED. */
-static constexpr const int ABORTED = 10;
+static constexpr const int kAborted = 10;
 /** OUT_OF_RANGE. */
-static constexpr const int OUT_OF_RANGE = 11;
+static constexpr const int kOutOfRange = 11;
 /** UNIMPLEMENTED. */
-static constexpr const int UNIMPLEMENTED = 12;
+static constexpr const int kUnimplemented = 12;
 /** INTERNAL. */
-static constexpr const int INTERNAL = 13;
+static constexpr const int kInternal = 13;
 /** UNAVAILABLE. */
-static constexpr const int UNAVAILABLE = 14;
+static constexpr const int kUnavailable = 14;
 /** DATA_LOSS. */
-static constexpr const int DATA_LOSS = 15;
+static constexpr const int kDataLoss = 15;
 /** UNAUTHENTICATED. */
-static constexpr const int UNAUTHENTICATED = 16;
+static constexpr const int kUnauthenticated = 16;
 }  // namespace RpcGrpcStatusCodeValues
 
 }  // namespace SemanticConventions

--- a/api/include/opentelemetry/trace/semantic_conventions.h
+++ b/api/include/opentelemetry/trace/semantic_conventions.h
@@ -33,7 +33,7 @@ namespace SemanticConventions
 /**
  * The URL of the OpenTelemetry schema for these keys and values.
  */
-static constexpr const char *SCHEMA_URL = "https://opentelemetry.io/schemas/1.14.0";
+static constexpr const char *SCHEMA_URL = "https://opentelemetry.io/schemas/1.15.0";
 
 /**
  * The type of the exception (its fully-qualified class name, if applicable). The dynamic type of
@@ -256,6 +256,17 @@ static constexpr const char *DB_MONGODB_COLLECTION = "db.mongodb.collection";
  set.</li> </ul>
  */
 static constexpr const char *DB_SQL_TABLE = "db.sql.table";
+
+/**
+ * Name of the code, either &quot;OK&quot; or &quot;ERROR&quot;. MUST NOT be set if the status code
+ * is UNSET.
+ */
+static constexpr const char *OTEL_STATUS_CODE = "otel.status_code";
+
+/**
+ * Description of the Status if it has a value, otherwise not set.
+ */
+static constexpr const char *OTEL_STATUS_DESCRIPTION = "otel.status_description";
 
 /**
  * Type of the trigger which caused this function execution.
@@ -571,9 +582,14 @@ static constexpr const char *HTTP_RESPONSE_CONTENT_LENGTH = "http.response_conte
 static constexpr const char *HTTP_URL = "http.url";
 
 /**
- * The ordinal number of request re-sending attempt.
+ * The ordinal number of request resending attempt (for any reason, including redirects).
+ *
+ * <p>Notes:
+  <ul> <li>The resend count SHOULD be updated each time an HTTP request gets resent by the client,
+ regardless of what was the cause of the resending (e.g. redirection, authorization failure, 503
+ Server Unavailable, network issues, or any other).</li> </ul>
  */
-static constexpr const char *HTTP_RETRY_COUNT = "http.retry_count";
+static constexpr const char *HTTP_RESEND_COUNT = "http.resend_count";
 
 /**
  * The URI scheme identifying the used protocol.
@@ -880,6 +896,24 @@ static constexpr const char *MESSAGING_ROCKETMQ_CLIENT_GROUP = "messaging.rocket
 static constexpr const char *MESSAGING_ROCKETMQ_CLIENT_ID = "messaging.rocketmq.client_id";
 
 /**
+ * The timestamp in milliseconds that the delay message is expected to be delivered to consumer.
+ */
+static constexpr const char *MESSAGING_ROCKETMQ_DELIVERY_TIMESTAMP =
+    "messaging.rocketmq.delivery_timestamp";
+
+/**
+ * The delay time level for delay message, which determines the message delay time.
+ */
+static constexpr const char *MESSAGING_ROCKETMQ_DELAY_TIME_LEVEL =
+    "messaging.rocketmq.delay_time_level";
+
+/**
+ * It is essential for FIFO message. Messages that belong to the same message group are always
+ * processed one by one within the same consumer group.
+ */
+static constexpr const char *MESSAGING_ROCKETMQ_MESSAGE_GROUP = "messaging.rocketmq.message_group";
+
+/**
  * Type of message.
  */
 static constexpr const char *MESSAGING_ROCKETMQ_MESSAGE_TYPE = "messaging.rocketmq.message_type";
@@ -1102,6 +1136,15 @@ static constexpr const char *SERIAL = "serial";
 /** local_serial. */
 static constexpr const char *LOCAL_SERIAL = "local_serial";
 }  // namespace DbCassandraConsistencyLevelValues
+
+namespace OtelStatusCodeValues
+{
+/** The operation has been validated by an Application developer or Operator to have completed
+ * successfully. */
+static constexpr const char *OK = "OK";
+/** The operation contains an error. */
+static constexpr const char *ERROR = "ERROR";
+}  // namespace OtelStatusCodeValues
 
 namespace FaasTriggerValues
 {

--- a/buildscripts/semantic-convention/generate.sh
+++ b/buildscripts/semantic-convention/generate.sh
@@ -10,7 +10,7 @@ SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 ROOT_DIR="${SCRIPT_DIR}/../../"
 
 # freeze the spec & generator tools versions to make SemanticAttributes generation reproducible
-SEMCONV_VERSION=1.14.0
+SEMCONV_VERSION=1.15.0
 SPEC_VERSION=v$SEMCONV_VERSION
 SCHEMA_URL=https://opentelemetry.io/schemas/$SEMCONV_VERSION
 GENERATOR_VERSION=0.14.0

--- a/buildscripts/semantic-convention/templates/SemanticAttributes.h.j2
+++ b/buildscripts/semantic-convention/templates/SemanticAttributes.h.j2
@@ -54,6 +54,12 @@
 #    undef DELETE
 #  endif
 #endif
+#ifdef _WIN32
+#  ifdef ERROR
+#    pragma message(__FILE__ ": removing define on ERROR")
+#    undef ERROR
+#  endif
+#endif
 {% endif %}
 
 OPENTELEMETRY_BEGIN_NAMESPACE

--- a/buildscripts/semantic-convention/templates/SemanticAttributes.h.j2
+++ b/buildscripts/semantic-convention/templates/SemanticAttributes.h.j2
@@ -41,27 +41,6 @@
 
 #include "opentelemetry/version.h"
 
-{%- if semconv == "trace" %}
-/*
- * Special considerations for FaasDocumentOperationValues::DELETE.
- *
- * The winnt.h header file is known to define a DELETE symbol,
- * which collides with FaasDocumentOperationValues::DELETE.
- */
-#ifdef _WIN32
-#  ifdef DELETE
-#    pragma message(__FILE__ ": removing define on DELETE")
-#    undef DELETE
-#  endif
-#endif
-#ifdef _WIN32
-#  ifdef ERROR
-#    pragma message(__FILE__ ": removing define on ERROR")
-#    undef ERROR
-#  endif
-#endif
-{% endif %}
-
 OPENTELEMETRY_BEGIN_NAMESPACE
 {{namespace_open}}
 
@@ -70,7 +49,7 @@ namespace {{class}}
 /**
  * The URL of the OpenTelemetry schema for these keys and values.
  */
-static constexpr const char *SCHEMA_URL = "{{schemaUrl}}";
+static constexpr const char *kSchemaUrl = "{{schemaUrl}}";
   {%- for attribute in attributes if attribute.is_local and not attribute.ref %}
 
 /**
@@ -88,7 +67,7 @@ static constexpr const char *SCHEMA_URL = "{{schemaUrl}}";
   {%- if attribute.deprecated %}
 @Deprecated
   {%- endif %}
-static constexpr const char *{{attribute.fqn | to_const_name}} = "{{attribute.fqn}}";
+static constexpr const char *k{{attribute.fqn | to_camelcase(True)}} = "{{attribute.fqn}}";
 {%- endfor %}
 
 // Enum definitions
@@ -100,7 +79,7 @@ namespace {{enum_name}}
 {
   {%- for member in attribute.attr_type.members %}
   /** {% filter escape %}{{member.brief | to_doc_brief}}.{% endfilter %} */
-  static constexpr const {{ type }} {{ member.member_id | to_const_name }} = {{ print_value(type, member.value) }};
+  static constexpr const {{ type }} k{{ member.member_id | to_camelcase(True) }} = {{ print_value(type, member.value) }};
   {%- endfor %}
 }
 {% endif %}

--- a/examples/grpc/client.cc
+++ b/examples/grpc/client.cc
@@ -47,11 +47,11 @@ public:
     std::string span_name = "GreeterClient/Greet";
     auto span             = get_tracer("grpc")->StartSpan(
         span_name,
-        {{SemanticConventions::RPC_SYSTEM, "grpc"},
-         {SemanticConventions::RPC_SERVICE, "grpc-example.GreetService"},
-         {SemanticConventions::RPC_METHOD, "Greet"},
-         {SemanticConventions::NET_SOCK_PEER_ADDR, ip},
-         {SemanticConventions::NET_PEER_PORT, port}},
+        {{SemanticConventions::kRpcSystem, "grpc"},
+         {SemanticConventions::kRpcService, "grpc-example.GreetService"},
+         {SemanticConventions::kRpcMethod, "Greet"},
+         {SemanticConventions::kNetSockPeerAddr, ip},
+         {SemanticConventions::kNetPeerPort, port}},
         options);
 
     auto scope = get_tracer("grpc-client")->WithActiveSpan(span);
@@ -67,7 +67,7 @@ public:
     if (status.ok())
     {
       span->SetStatus(StatusCode::kOk);
-      span->SetAttribute(SemanticConventions::RPC_GRPC_STATUS_CODE, status.error_code());
+      span->SetAttribute(SemanticConventions::kRpcGrpcStatusCode, status.error_code());
       // Make sure to end your spans!
       span->End();
       return response.response();
@@ -76,7 +76,7 @@ public:
     {
       std::cout << status.error_code() << ": " << status.error_message() << std::endl;
       span->SetStatus(StatusCode::kError);
-      span->SetAttribute(SemanticConventions::RPC_GRPC_STATUS_CODE, status.error_code());
+      span->SetAttribute(SemanticConventions::kRpcGrpcStatusCode, status.error_code());
       // Make sure to end your spans!
       span->End();
       return "RPC failed";

--- a/examples/grpc/server.cc
+++ b/examples/grpc/server.cc
@@ -65,10 +65,10 @@ public:
 
     std::string span_name = "GreeterService/Greet";
     auto span             = get_tracer("grpc")->StartSpan(span_name,
-                                              {{SemanticConventions::RPC_SYSTEM, "grpc"},
-                                               {SemanticConventions::RPC_SERVICE, "GreeterService"},
-                                               {SemanticConventions::RPC_METHOD, "Greet"},
-                                               {SemanticConventions::RPC_GRPC_STATUS_CODE, 0}},
+                                              {{SemanticConventions::kRpcSystem, "grpc"},
+                                               {SemanticConventions::kRpcService, "GreeterService"},
+                                               {SemanticConventions::kRpcMethod, "Greet"},
+                                               {SemanticConventions::kRpcGrpcStatusCode, 0}},
                                               options);
     auto scope            = get_tracer("grpc")->WithActiveSpan(span);
 

--- a/examples/http/client.cc
+++ b/examples/http/client.cc
@@ -26,9 +26,9 @@ void sendRequest(const std::string &url)
   std::string span_name = url_parser.path_;
   auto span             = get_tracer("http-client")
                   ->StartSpan(span_name,
-                              {{SemanticConventions::HTTP_URL, url_parser.url_},
-                               {SemanticConventions::HTTP_SCHEME, url_parser.scheme_},
-                               {SemanticConventions::HTTP_METHOD, "GET"}},
+                              {{SemanticConventions::kHttpUrl, url_parser.url_},
+                               {SemanticConventions::kHttpScheme, url_parser.scheme_},
+                               {SemanticConventions::kHttpMethod, "GET"}},
                               options);
   auto scope = get_tracer("http-client")->WithActiveSpan(span);
 
@@ -44,7 +44,7 @@ void sendRequest(const std::string &url)
   {
     // set span attributes
     auto status_code = result.GetResponse().GetStatusCode();
-    span->SetAttribute(SemanticConventions::HTTP_STATUS_CODE, status_code);
+    span->SetAttribute(SemanticConventions::kHttpStatusCode, status_code);
     result.GetResponse().ForEachHeader(
         [&span](nostd::string_view header_name, nostd::string_view header_value) {
           span->SetAttribute("http.header." + std::string(header_name.data()), header_value);

--- a/examples/http/server.cc
+++ b/examples/http/server.cc
@@ -40,13 +40,13 @@ public:
     // start span with parent context extracted from http header
     auto span = get_tracer("http-server")
                     ->StartSpan(span_name,
-                                {{SemanticConventions::NET_HOST_NAME, server_name},
-                                 {SemanticConventions::NET_HOST_PORT, server_port},
-                                 {SemanticConventions::HTTP_METHOD, request.method},
-                                 {SemanticConventions::HTTP_SCHEME, "http"},
-                                 {SemanticConventions::HTTP_REQUEST_CONTENT_LENGTH,
+                                {{SemanticConventions::kNetHostName, server_name},
+                                 {SemanticConventions::kNetHostPort, server_port},
+                                 {SemanticConventions::kHttpMethod, request.method},
+                                 {SemanticConventions::kHttpScheme, "http"},
+                                 {SemanticConventions::kHttpRequestContentLength,
                                   static_cast<uint64_t>(request.content.length())},
-                                 {SemanticConventions::HTTP_CLIENT_IP, request.client}},
+                                 {SemanticConventions::kHttpClientIp, request.client}},
                                 options);
 
     auto scope = get_tracer("http_server")->WithActiveSpan(span);

--- a/exporters/otlp/test/otlp_log_recordable_test.cc
+++ b/exporters/otlp/test/otlp_log_recordable_test.cc
@@ -104,17 +104,17 @@ TEST(OtlpLogRecordable, DefaultResource)
   for (int i = 0; i < proto_resource.attributes_size(); i++)
   {
     auto attr = proto_resource.attributes(static_cast<int>(i));
-    if (attr.key() == resource::SemanticConventions::TELEMETRY_SDK_LANGUAGE)
+    if (attr.key() == resource::SemanticConventions::kTelemetrySdkLanguage)
     {
       EXPECT_EQ(attr.value().string_value(), "cpp");
       ++found_resource_count;
     }
-    else if (attr.key() == resource::SemanticConventions::TELEMETRY_SDK_NAME)
+    else if (attr.key() == resource::SemanticConventions::kTelemetrySdkName)
     {
       EXPECT_EQ(attr.value().string_value(), "opentelemetry");
       ++found_resource_count;
     }
-    else if (attr.key() == resource::SemanticConventions::TELEMETRY_SDK_VERSION)
+    else if (attr.key() == resource::SemanticConventions::kTelemetrySdkVersion)
     {
       EXPECT_EQ(attr.value().string_value(), OPENTELEMETRY_SDK_VERSION);
       ++found_resource_count;

--- a/exporters/zipkin/src/recordable.cc
+++ b/exporters/zipkin/src/recordable.cc
@@ -216,9 +216,9 @@ void Recordable::SetResource(const sdk::resource::Resource &resource) noexcept
 {
   // only service.name attribute is supported by specs as of now.
   auto attributes = resource.GetAttributes();
-  if (attributes.find(SemanticConventions::SERVICE_NAME) != attributes.end())
+  if (attributes.find(SemanticConventions::kServiceName) != attributes.end())
   {
-    service_name_ = nostd::get<std::string>(attributes[SemanticConventions::SERVICE_NAME]);
+    service_name_ = nostd::get<std::string>(attributes[SemanticConventions::kServiceName]);
   }
 }
 

--- a/sdk/include/opentelemetry/sdk/resource/semantic_conventions.h
+++ b/sdk/include/opentelemetry/sdk/resource/semantic_conventions.h
@@ -23,7 +23,7 @@ namespace SemanticConventions
 /**
  * The URL of the OpenTelemetry schema for these keys and values.
  */
-static constexpr const char *SCHEMA_URL = "https://opentelemetry.io/schemas/1.14.0";
+static constexpr const char *SCHEMA_URL = "https://opentelemetry.io/schemas/1.15.0";
 
 /**
  * Array of brand name and version separated by a space
@@ -669,6 +669,26 @@ static constexpr const char *WEBENGINE_VERSION = "webengine.version";
  * Additional description of the web engine (e.g. detailed version and edition information).
  */
 static constexpr const char *WEBENGINE_DESCRIPTION = "webengine.description";
+
+/**
+ * The name of the instrumentation scope - ({@code InstrumentationScope.Name} in OTLP).
+ */
+static constexpr const char *OTEL_SCOPE_NAME = "otel.scope.name";
+
+/**
+ * The version of the instrumentation scope - ({@code InstrumentationScope.Version} in OTLP).
+ */
+static constexpr const char *OTEL_SCOPE_VERSION = "otel.scope.version";
+
+/**
+ * Deprecated, use the {@code otel.scope.name} attribute.
+ */
+static constexpr const char *OTEL_LIBRARY_NAME = "otel.library.name";
+
+/**
+ * Deprecated, use the {@code otel.scope.version} attribute.
+ */
+static constexpr const char *OTEL_LIBRARY_VERSION = "otel.library.version";
 
 // Enum definitions
 namespace CloudProviderValues

--- a/sdk/include/opentelemetry/sdk/resource/semantic_conventions.h
+++ b/sdk/include/opentelemetry/sdk/resource/semantic_conventions.h
@@ -23,7 +23,7 @@ namespace SemanticConventions
 /**
  * The URL of the OpenTelemetry schema for these keys and values.
  */
-static constexpr const char *SCHEMA_URL = "https://opentelemetry.io/schemas/1.15.0";
+static constexpr const char *kSchemaUrl = "https://opentelemetry.io/schemas/1.15.0";
 
 /**
  * Array of brand name and version separated by a space
@@ -33,7 +33,7 @@ static constexpr const char *SCHEMA_URL = "https://opentelemetry.io/schemas/1.15
  href="https://wicg.github.io/ua-client-hints/#interface">UA client hints API</a> ({@code
  navigator.userAgentData.brands}).</li> </ul>
  */
-static constexpr const char *BROWSER_BRANDS = "browser.brands";
+static constexpr const char *kBrowserBrands = "browser.brands";
 
 /**
  * The platform on which the browser is running
@@ -50,7 +50,7 @@ href="./os.md">{@code os.type} and {@code os.name} attributes</a>. However, for 
 values in the {@code browser.platform} attribute should capture the exact value that the user agent
 provides.</li> </ul>
  */
-static constexpr const char *BROWSER_PLATFORM = "browser.platform";
+static constexpr const char *kBrowserPlatform = "browser.platform";
 
 /**
  * A boolean that is true if the browser is running on a mobile device
@@ -60,7 +60,7 @@ static constexpr const char *BROWSER_PLATFORM = "browser.platform";
  href="https://wicg.github.io/ua-client-hints/#interface">UA client hints API</a> ({@code
  navigator.userAgentData.mobile}). If unavailable, this attribute SHOULD be left unset.</li> </ul>
  */
-static constexpr const char *BROWSER_MOBILE = "browser.mobile";
+static constexpr const char *kBrowserMobile = "browser.mobile";
 
 /**
  * Full user-agent string provided by the browser
@@ -70,7 +70,7 @@ static constexpr const char *BROWSER_MOBILE = "browser.mobile";
  to retrieve brands and platform individually from the User-Agent Client Hints API. To retrieve the
  value, the legacy {@code navigator.userAgent} API can be used.</li> </ul>
  */
-static constexpr const char *BROWSER_USER_AGENT = "browser.user_agent";
+static constexpr const char *kBrowserUserAgent = "browser.user_agent";
 
 /**
  * Preferred language of the user using the browser
@@ -79,17 +79,17 @@ static constexpr const char *BROWSER_USER_AGENT = "browser.user_agent";
   <ul> <li>This value is intended to be taken from the Navigator API {@code
  navigator.language}.</li> </ul>
  */
-static constexpr const char *BROWSER_LANGUAGE = "browser.language";
+static constexpr const char *kBrowserLanguage = "browser.language";
 
 /**
  * Name of the cloud provider.
  */
-static constexpr const char *CLOUD_PROVIDER = "cloud.provider";
+static constexpr const char *kCloudProvider = "cloud.provider";
 
 /**
  * The cloud account ID the resource is assigned to.
  */
-static constexpr const char *CLOUD_ACCOUNT_ID = "cloud.account.id";
+static constexpr const char *kCloudAccountId = "cloud.account.id";
 
 /**
  * The geographical region the resource is running.
@@ -103,7 +103,7 @@ static constexpr const char *CLOUD_ACCOUNT_ID = "cloud.account.id";
  href="https://intl.cloud.tencent.com/document/product/213/6091">Tencent Cloud regions</a>.</li>
  </ul>
  */
-static constexpr const char *CLOUD_REGION = "cloud.region";
+static constexpr const char *kCloudRegion = "cloud.region";
 
 /**
  * Cloud regions often have multiple, isolated locations known as zones to increase availability.
@@ -113,7 +113,7 @@ static constexpr const char *CLOUD_REGION = "cloud.region";
   <ul> <li>Availability zones are called &quot;zones&quot; on Alibaba Cloud and Google Cloud.</li>
  </ul>
  */
-static constexpr const char *CLOUD_AVAILABILITY_ZONE = "cloud.availability_zone";
+static constexpr const char *kCloudAvailabilityZone = "cloud.availability_zone";
 
 /**
  * The cloud platform in use.
@@ -122,49 +122,49 @@ static constexpr const char *CLOUD_AVAILABILITY_ZONE = "cloud.availability_zone"
   <ul> <li>The prefix of the service SHOULD match the one specified in {@code cloud.provider}.</li>
  </ul>
  */
-static constexpr const char *CLOUD_PLATFORM = "cloud.platform";
+static constexpr const char *kCloudPlatform = "cloud.platform";
 
 /**
  * The Amazon Resource Name (ARN) of an <a
  * href="https://docs.aws.amazon.com/AmazonECS/latest/developerguide/ECS_instances.html">ECS
  * container instance</a>.
  */
-static constexpr const char *AWS_ECS_CONTAINER_ARN = "aws.ecs.container.arn";
+static constexpr const char *kAwsEcsContainerArn = "aws.ecs.container.arn";
 
 /**
  * The ARN of an <a
  * href="https://docs.aws.amazon.com/AmazonECS/latest/developerguide/clusters.html">ECS cluster</a>.
  */
-static constexpr const char *AWS_ECS_CLUSTER_ARN = "aws.ecs.cluster.arn";
+static constexpr const char *kAwsEcsClusterArn = "aws.ecs.cluster.arn";
 
 /**
  * The <a
  * href="https://docs.aws.amazon.com/AmazonECS/latest/developerguide/launch_types.html">launch
  * type</a> for an ECS task.
  */
-static constexpr const char *AWS_ECS_LAUNCHTYPE = "aws.ecs.launchtype";
+static constexpr const char *kAwsEcsLaunchtype = "aws.ecs.launchtype";
 
 /**
  * The ARN of an <a
  * href="https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task_definitions.html">ECS task
  * definition</a>.
  */
-static constexpr const char *AWS_ECS_TASK_ARN = "aws.ecs.task.arn";
+static constexpr const char *kAwsEcsTaskArn = "aws.ecs.task.arn";
 
 /**
  * The task definition family this task definition is a member of.
  */
-static constexpr const char *AWS_ECS_TASK_FAMILY = "aws.ecs.task.family";
+static constexpr const char *kAwsEcsTaskFamily = "aws.ecs.task.family";
 
 /**
  * The revision for this task definition.
  */
-static constexpr const char *AWS_ECS_TASK_REVISION = "aws.ecs.task.revision";
+static constexpr const char *kAwsEcsTaskRevision = "aws.ecs.task.revision";
 
 /**
  * The ARN of an EKS cluster.
  */
-static constexpr const char *AWS_EKS_CLUSTER_ARN = "aws.eks.cluster.arn";
+static constexpr const char *kAwsEksClusterArn = "aws.eks.cluster.arn";
 
 /**
  * The name(s) of the AWS log group(s) an application is writing to.
@@ -173,7 +173,7 @@ static constexpr const char *AWS_EKS_CLUSTER_ARN = "aws.eks.cluster.arn";
   <ul> <li>Multiple log groups must be supported for cases like multi-container applications, where
  a single application has sidecar containers, and each write to their own log group.</li> </ul>
  */
-static constexpr const char *AWS_LOG_GROUP_NAMES = "aws.log.group.names";
+static constexpr const char *kAwsLogGroupNames = "aws.log.group.names";
 
 /**
  * The Amazon Resource Name(s) (ARN) of the AWS log group(s).
@@ -183,12 +183,12 @@ static constexpr const char *AWS_LOG_GROUP_NAMES = "aws.log.group.names";
  href="https://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/iam-access-control-overview-cwl.html#CWL_ARN_Format">log
  group ARN format documentation</a>.</li> </ul>
  */
-static constexpr const char *AWS_LOG_GROUP_ARNS = "aws.log.group.arns";
+static constexpr const char *kAwsLogGroupArns = "aws.log.group.arns";
 
 /**
  * The name(s) of the AWS log stream(s) an application is writing to.
  */
-static constexpr const char *AWS_LOG_STREAM_NAMES = "aws.log.stream.names";
+static constexpr const char *kAwsLogStreamNames = "aws.log.stream.names";
 
 /**
  * The ARN(s) of the AWS log stream(s).
@@ -199,40 +199,40 @@ static constexpr const char *AWS_LOG_STREAM_NAMES = "aws.log.stream.names";
  stream ARN format documentation</a>. One log group can contain several log streams, so these ARNs
  necessarily identify both a log group and a log stream.</li> </ul>
  */
-static constexpr const char *AWS_LOG_STREAM_ARNS = "aws.log.stream.arns";
+static constexpr const char *kAwsLogStreamArns = "aws.log.stream.arns";
 
 /**
  * Container name used by container runtime.
  */
-static constexpr const char *CONTAINER_NAME = "container.name";
+static constexpr const char *kContainerName = "container.name";
 
 /**
  * Container ID. Usually a UUID, as for example used to <a
  * href="https://docs.docker.com/engine/reference/run/#container-identification">identify Docker
  * containers</a>. The UUID might be abbreviated.
  */
-static constexpr const char *CONTAINER_ID = "container.id";
+static constexpr const char *kContainerId = "container.id";
 
 /**
  * The container runtime managing this container.
  */
-static constexpr const char *CONTAINER_RUNTIME = "container.runtime";
+static constexpr const char *kContainerRuntime = "container.runtime";
 
 /**
  * Name of the image the container was built on.
  */
-static constexpr const char *CONTAINER_IMAGE_NAME = "container.image.name";
+static constexpr const char *kContainerImageName = "container.image.name";
 
 /**
  * Container image tag.
  */
-static constexpr const char *CONTAINER_IMAGE_TAG = "container.image.tag";
+static constexpr const char *kContainerImageTag = "container.image.tag";
 
 /**
  * Name of the <a href="https://en.wikipedia.org/wiki/Deployment_environment">deployment
  * environment</a> (aka deployment tier).
  */
-static constexpr const char *DEPLOYMENT_ENVIRONMENT = "deployment.environment";
+static constexpr const char *kDeploymentEnvironment = "deployment.environment";
 
 /**
  * A unique identifier representing the device
@@ -250,7 +250,7 @@ static constexpr const char *DEPLOYMENT_ENVIRONMENT = "deployment.environment";
  can identify a user. GDPR and data protection laws may apply, ensure you do your own due
  diligence.</li> </ul>
  */
-static constexpr const char *DEVICE_ID = "device.id";
+static constexpr const char *kDeviceId = "device.id";
 
 /**
  * The model identifier for the device
@@ -259,7 +259,7 @@ static constexpr const char *DEVICE_ID = "device.id";
   <ul> <li>It's recommended this value represents a machine readable version of the model identifier
  rather than the market or consumer-friendly name of the device.</li> </ul>
  */
-static constexpr const char *DEVICE_MODEL_IDENTIFIER = "device.model.identifier";
+static constexpr const char *kDeviceModelIdentifier = "device.model.identifier";
 
 /**
  * The marketing name for the device model
@@ -268,7 +268,7 @@ static constexpr const char *DEVICE_MODEL_IDENTIFIER = "device.model.identifier"
   <ul> <li>It's recommended this value represents a human readable version of the device model
  rather than a machine readable alternative.</li> </ul>
  */
-static constexpr const char *DEVICE_MODEL_NAME = "device.model.name";
+static constexpr const char *kDeviceModelName = "device.model.name";
 
 /**
  * The name of the device manufacturer
@@ -278,7 +278,7 @@ static constexpr const char *DEVICE_MODEL_NAME = "device.model.name";
  href="https://developer.android.com/reference/android/os/Build#MANUFACTURER">Build</a>. iOS apps
  SHOULD hardcode the value {@code Apple}.</li> </ul>
  */
-static constexpr const char *DEVICE_MANUFACTURER = "device.manufacturer";
+static constexpr const char *kDeviceManufacturer = "device.manufacturer";
 
 /**
  * The name of the single function that this runtime instance executes.
@@ -298,7 +298,7 @@ Azure function app can host multiple functions that would usually share a Tracer
 the {@code faas.id} attribute).</li>
  </ul>
  */
-static constexpr const char *FAAS_NAME = "faas.name";
+static constexpr const char *kFaasName = "faas.name";
 
 /**
  * The unique ID of the single function that this runtime instance executes.
@@ -322,7 +322,7 @@ This means that a span attribute MUST be used, as an Azure function app can host
 that would usually share a TracerProvider.</li>
  </ul>
  */
-static constexpr const char *FAAS_ID = "faas.id";
+static constexpr const char *kFaasId = "faas.id";
 
 /**
  * The immutable version of the function being executed.
@@ -339,7 +339,7 @@ K_REVISION} environment variable</a>.</li> <li><strong>Azure Functions:</strong>
 not set this attribute.</li>
  </ul>
  */
-static constexpr const char *FAAS_VERSION = "faas.version";
+static constexpr const char *kFaasVersion = "faas.version";
 
 /**
  * The execution environment ID as a string, that will be potentially reused for other invocations
@@ -349,7 +349,7 @@ static constexpr const char *FAAS_VERSION = "faas.version";
   <ul> <li><strong>AWS Lambda:</strong> Use the (full) log stream name.</li>
  </ul>
  */
-static constexpr const char *FAAS_INSTANCE = "faas.instance";
+static constexpr const char *kFaasInstance = "faas.instance";
 
 /**
  * The amount of memory available to the serverless function in MiB.
@@ -359,205 +359,205 @@ static constexpr const char *FAAS_INSTANCE = "faas.instance";
  Java AWS Lambda function from working correctly. On AWS Lambda, the environment variable {@code
  AWS_LAMBDA_FUNCTION_MEMORY_SIZE} provides this information.</li> </ul>
  */
-static constexpr const char *FAAS_MAX_MEMORY = "faas.max_memory";
+static constexpr const char *kFaasMaxMemory = "faas.max_memory";
 
 /**
  * Unique host ID. For Cloud, this must be the instance_id assigned by the cloud provider.
  */
-static constexpr const char *HOST_ID = "host.id";
+static constexpr const char *kHostId = "host.id";
 
 /**
  * Name of the host. On Unix systems, it may contain what the hostname command returns, or the fully
  * qualified hostname, or another name specified by the user.
  */
-static constexpr const char *HOST_NAME = "host.name";
+static constexpr const char *kHostName = "host.name";
 
 /**
  * Type of host. For Cloud, this must be the machine type.
  */
-static constexpr const char *HOST_TYPE = "host.type";
+static constexpr const char *kHostType = "host.type";
 
 /**
  * The CPU architecture the host system is running on.
  */
-static constexpr const char *HOST_ARCH = "host.arch";
+static constexpr const char *kHostArch = "host.arch";
 
 /**
  * Name of the VM image or OS install the host was instantiated from.
  */
-static constexpr const char *HOST_IMAGE_NAME = "host.image.name";
+static constexpr const char *kHostImageName = "host.image.name";
 
 /**
  * VM image ID. For Cloud, this value is from the provider.
  */
-static constexpr const char *HOST_IMAGE_ID = "host.image.id";
+static constexpr const char *kHostImageId = "host.image.id";
 
 /**
  * The version string of the VM image as defined in <a href="README.md#version-attributes">Version
  * Attributes</a>.
  */
-static constexpr const char *HOST_IMAGE_VERSION = "host.image.version";
+static constexpr const char *kHostImageVersion = "host.image.version";
 
 /**
  * The name of the cluster.
  */
-static constexpr const char *K8S_CLUSTER_NAME = "k8s.cluster.name";
+static constexpr const char *kK8sClusterName = "k8s.cluster.name";
 
 /**
  * The name of the Node.
  */
-static constexpr const char *K8S_NODE_NAME = "k8s.node.name";
+static constexpr const char *kK8sNodeName = "k8s.node.name";
 
 /**
  * The UID of the Node.
  */
-static constexpr const char *K8S_NODE_UID = "k8s.node.uid";
+static constexpr const char *kK8sNodeUid = "k8s.node.uid";
 
 /**
  * The name of the namespace that the pod is running in.
  */
-static constexpr const char *K8S_NAMESPACE_NAME = "k8s.namespace.name";
+static constexpr const char *kK8sNamespaceName = "k8s.namespace.name";
 
 /**
  * The UID of the Pod.
  */
-static constexpr const char *K8S_POD_UID = "k8s.pod.uid";
+static constexpr const char *kK8sPodUid = "k8s.pod.uid";
 
 /**
  * The name of the Pod.
  */
-static constexpr const char *K8S_POD_NAME = "k8s.pod.name";
+static constexpr const char *kK8sPodName = "k8s.pod.name";
 
 /**
  * The name of the Container from Pod specification, must be unique within a Pod. Container runtime
  * usually uses different globally unique name ({@code container.name}).
  */
-static constexpr const char *K8S_CONTAINER_NAME = "k8s.container.name";
+static constexpr const char *kK8sContainerName = "k8s.container.name";
 
 /**
  * Number of times the container was restarted. This attribute can be used to identify a particular
  * container (running or stopped) within a container spec.
  */
-static constexpr const char *K8S_CONTAINER_RESTART_COUNT = "k8s.container.restart_count";
+static constexpr const char *kK8sContainerRestartCount = "k8s.container.restart_count";
 
 /**
  * The UID of the ReplicaSet.
  */
-static constexpr const char *K8S_REPLICASET_UID = "k8s.replicaset.uid";
+static constexpr const char *kK8sReplicasetUid = "k8s.replicaset.uid";
 
 /**
  * The name of the ReplicaSet.
  */
-static constexpr const char *K8S_REPLICASET_NAME = "k8s.replicaset.name";
+static constexpr const char *kK8sReplicasetName = "k8s.replicaset.name";
 
 /**
  * The UID of the Deployment.
  */
-static constexpr const char *K8S_DEPLOYMENT_UID = "k8s.deployment.uid";
+static constexpr const char *kK8sDeploymentUid = "k8s.deployment.uid";
 
 /**
  * The name of the Deployment.
  */
-static constexpr const char *K8S_DEPLOYMENT_NAME = "k8s.deployment.name";
+static constexpr const char *kK8sDeploymentName = "k8s.deployment.name";
 
 /**
  * The UID of the StatefulSet.
  */
-static constexpr const char *K8S_STATEFULSET_UID = "k8s.statefulset.uid";
+static constexpr const char *kK8sStatefulsetUid = "k8s.statefulset.uid";
 
 /**
  * The name of the StatefulSet.
  */
-static constexpr const char *K8S_STATEFULSET_NAME = "k8s.statefulset.name";
+static constexpr const char *kK8sStatefulsetName = "k8s.statefulset.name";
 
 /**
  * The UID of the DaemonSet.
  */
-static constexpr const char *K8S_DAEMONSET_UID = "k8s.daemonset.uid";
+static constexpr const char *kK8sDaemonsetUid = "k8s.daemonset.uid";
 
 /**
  * The name of the DaemonSet.
  */
-static constexpr const char *K8S_DAEMONSET_NAME = "k8s.daemonset.name";
+static constexpr const char *kK8sDaemonsetName = "k8s.daemonset.name";
 
 /**
  * The UID of the Job.
  */
-static constexpr const char *K8S_JOB_UID = "k8s.job.uid";
+static constexpr const char *kK8sJobUid = "k8s.job.uid";
 
 /**
  * The name of the Job.
  */
-static constexpr const char *K8S_JOB_NAME = "k8s.job.name";
+static constexpr const char *kK8sJobName = "k8s.job.name";
 
 /**
  * The UID of the CronJob.
  */
-static constexpr const char *K8S_CRONJOB_UID = "k8s.cronjob.uid";
+static constexpr const char *kK8sCronjobUid = "k8s.cronjob.uid";
 
 /**
  * The name of the CronJob.
  */
-static constexpr const char *K8S_CRONJOB_NAME = "k8s.cronjob.name";
+static constexpr const char *kK8sCronjobName = "k8s.cronjob.name";
 
 /**
  * The operating system type.
  */
-static constexpr const char *OS_TYPE = "os.type";
+static constexpr const char *kOsType = "os.type";
 
 /**
  * Human readable (not intended to be parsed) OS version information, like e.g. reported by {@code
  * ver} or {@code lsb_release -a} commands.
  */
-static constexpr const char *OS_DESCRIPTION = "os.description";
+static constexpr const char *kOsDescription = "os.description";
 
 /**
  * Human readable operating system name.
  */
-static constexpr const char *OS_NAME = "os.name";
+static constexpr const char *kOsName = "os.name";
 
 /**
  * The version string of the operating system as defined in <a
  * href="../../resource/semantic_conventions/README.md#version-attributes">Version Attributes</a>.
  */
-static constexpr const char *OS_VERSION = "os.version";
+static constexpr const char *kOsVersion = "os.version";
 
 /**
  * Process identifier (PID).
  */
-static constexpr const char *PROCESS_PID = "process.pid";
+static constexpr const char *kProcessPid = "process.pid";
 
 /**
  * Parent Process identifier (PID).
  */
-static constexpr const char *PROCESS_PARENT_PID = "process.parent_pid";
+static constexpr const char *kProcessParentPid = "process.parent_pid";
 
 /**
  * The name of the process executable. On Linux based systems, can be set to the {@code Name} in
  * {@code proc/[pid]/status}. On Windows, can be set to the base name of {@code
  * GetProcessImageFileNameW}.
  */
-static constexpr const char *PROCESS_EXECUTABLE_NAME = "process.executable.name";
+static constexpr const char *kProcessExecutableName = "process.executable.name";
 
 /**
  * The full path to the process executable. On Linux based systems, can be set to the target of
  * {@code proc/[pid]/exe}. On Windows, can be set to the result of {@code GetProcessImageFileNameW}.
  */
-static constexpr const char *PROCESS_EXECUTABLE_PATH = "process.executable.path";
+static constexpr const char *kProcessExecutablePath = "process.executable.path";
 
 /**
  * The command used to launch the process (i.e. the command name). On Linux based systems, can be
  * set to the zeroth string in {@code proc/[pid]/cmdline}. On Windows, can be set to the first
  * parameter extracted from {@code GetCommandLineW}.
  */
-static constexpr const char *PROCESS_COMMAND = "process.command";
+static constexpr const char *kProcessCommand = "process.command";
 
 /**
  * The full command used to launch the process as a single string representing the full command. On
  * Windows, can be set to the result of {@code GetCommandLineW}. Do not set this if you have to
  * assemble it just for monitoring; use {@code process.command_args} instead.
  */
-static constexpr const char *PROCESS_COMMAND_LINE = "process.command_line";
+static constexpr const char *kProcessCommandLine = "process.command_line";
 
 /**
  * All the command arguments (including the command/executable itself) as received by the process.
@@ -565,29 +565,29 @@ static constexpr const char *PROCESS_COMMAND_LINE = "process.command_line";
  * to the list of null-delimited strings extracted from {@code proc/[pid]/cmdline}. For libc-based
  * executables, this would be the full argv vector passed to {@code main}.
  */
-static constexpr const char *PROCESS_COMMAND_ARGS = "process.command_args";
+static constexpr const char *kProcessCommandArgs = "process.command_args";
 
 /**
  * The username of the user that owns the process.
  */
-static constexpr const char *PROCESS_OWNER = "process.owner";
+static constexpr const char *kProcessOwner = "process.owner";
 
 /**
  * The name of the runtime of this process. For compiled native binaries, this SHOULD be the name of
  * the compiler.
  */
-static constexpr const char *PROCESS_RUNTIME_NAME = "process.runtime.name";
+static constexpr const char *kProcessRuntimeName = "process.runtime.name";
 
 /**
  * The version of the runtime of this process, as returned by the runtime without modification.
  */
-static constexpr const char *PROCESS_RUNTIME_VERSION = "process.runtime.version";
+static constexpr const char *kProcessRuntimeVersion = "process.runtime.version";
 
 /**
  * An additional description about the runtime of the process, for example a specific vendor
  * customization of the runtime environment.
  */
-static constexpr const char *PROCESS_RUNTIME_DESCRIPTION = "process.runtime.description";
+static constexpr const char *kProcessRuntimeDescription = "process.runtime.description";
 
 /**
  * Logical name of the service.
@@ -599,7 +599,7 @@ static constexpr const char *PROCESS_RUNTIME_DESCRIPTION = "process.runtime.desc
  If {@code process.executable.name} is not available, the value MUST be set to {@code
  unknown_service}.</li> </ul>
  */
-static constexpr const char *SERVICE_NAME = "service.name";
+static constexpr const char *kServiceName = "service.name";
 
 /**
  * A namespace for {@code service.name}.
@@ -612,7 +612,7 @@ static constexpr const char *SERVICE_NAME = "service.name";
  defined (so the empty/unspecified namespace is simply one more valid namespace). Zero-length
  namespace string is assumed equal to unspecified namespace.</li> </ul>
  */
-static constexpr const char *SERVICE_NAMESPACE = "service.namespace";
+static constexpr const char *kServiceNamespace = "service.namespace";
 
 /**
  * The string ID of the service instance.
@@ -628,207 +628,207 @@ static constexpr const char *SERVICE_NAMESPACE = "service.namespace";
  recommended to generate a random Version 1 or Version 4 RFC 4122 UUID (services aiming for
  reproducible UUIDs may also use Version 5, see RFC 4122 for more recommendations).</li> </ul>
  */
-static constexpr const char *SERVICE_INSTANCE_ID = "service.instance.id";
+static constexpr const char *kServiceInstanceId = "service.instance.id";
 
 /**
  * The version string of the service API or implementation.
  */
-static constexpr const char *SERVICE_VERSION = "service.version";
+static constexpr const char *kServiceVersion = "service.version";
 
 /**
  * The name of the telemetry SDK as defined above.
  */
-static constexpr const char *TELEMETRY_SDK_NAME = "telemetry.sdk.name";
+static constexpr const char *kTelemetrySdkName = "telemetry.sdk.name";
 
 /**
  * The language of the telemetry SDK.
  */
-static constexpr const char *TELEMETRY_SDK_LANGUAGE = "telemetry.sdk.language";
+static constexpr const char *kTelemetrySdkLanguage = "telemetry.sdk.language";
 
 /**
  * The version string of the telemetry SDK.
  */
-static constexpr const char *TELEMETRY_SDK_VERSION = "telemetry.sdk.version";
+static constexpr const char *kTelemetrySdkVersion = "telemetry.sdk.version";
 
 /**
  * The version string of the auto instrumentation agent, if used.
  */
-static constexpr const char *TELEMETRY_AUTO_VERSION = "telemetry.auto.version";
+static constexpr const char *kTelemetryAutoVersion = "telemetry.auto.version";
 
 /**
  * The name of the web engine.
  */
-static constexpr const char *WEBENGINE_NAME = "webengine.name";
+static constexpr const char *kWebengineName = "webengine.name";
 
 /**
  * The version of the web engine.
  */
-static constexpr const char *WEBENGINE_VERSION = "webengine.version";
+static constexpr const char *kWebengineVersion = "webengine.version";
 
 /**
  * Additional description of the web engine (e.g. detailed version and edition information).
  */
-static constexpr const char *WEBENGINE_DESCRIPTION = "webengine.description";
+static constexpr const char *kWebengineDescription = "webengine.description";
 
 /**
  * The name of the instrumentation scope - ({@code InstrumentationScope.Name} in OTLP).
  */
-static constexpr const char *OTEL_SCOPE_NAME = "otel.scope.name";
+static constexpr const char *kOtelScopeName = "otel.scope.name";
 
 /**
  * The version of the instrumentation scope - ({@code InstrumentationScope.Version} in OTLP).
  */
-static constexpr const char *OTEL_SCOPE_VERSION = "otel.scope.version";
+static constexpr const char *kOtelScopeVersion = "otel.scope.version";
 
 /**
  * Deprecated, use the {@code otel.scope.name} attribute.
  */
-static constexpr const char *OTEL_LIBRARY_NAME = "otel.library.name";
+static constexpr const char *kOtelLibraryName = "otel.library.name";
 
 /**
  * Deprecated, use the {@code otel.scope.version} attribute.
  */
-static constexpr const char *OTEL_LIBRARY_VERSION = "otel.library.version";
+static constexpr const char *kOtelLibraryVersion = "otel.library.version";
 
 // Enum definitions
 namespace CloudProviderValues
 {
 /** Alibaba Cloud. */
-static constexpr const char *ALIBABA_CLOUD = "alibaba_cloud";
+static constexpr const char *kAlibabaCloud = "alibaba_cloud";
 /** Amazon Web Services. */
-static constexpr const char *AWS = "aws";
+static constexpr const char *kAws = "aws";
 /** Microsoft Azure. */
-static constexpr const char *AZURE = "azure";
+static constexpr const char *kAzure = "azure";
 /** Google Cloud Platform. */
-static constexpr const char *GCP = "gcp";
+static constexpr const char *kGcp = "gcp";
 /** Tencent Cloud. */
-static constexpr const char *TENCENT_CLOUD = "tencent_cloud";
+static constexpr const char *kTencentCloud = "tencent_cloud";
 }  // namespace CloudProviderValues
 
 namespace CloudPlatformValues
 {
 /** Alibaba Cloud Elastic Compute Service. */
-static constexpr const char *ALIBABA_CLOUD_ECS = "alibaba_cloud_ecs";
+static constexpr const char *kAlibabaCloudEcs = "alibaba_cloud_ecs";
 /** Alibaba Cloud Function Compute. */
-static constexpr const char *ALIBABA_CLOUD_FC = "alibaba_cloud_fc";
+static constexpr const char *kAlibabaCloudFc = "alibaba_cloud_fc";
 /** AWS Elastic Compute Cloud. */
-static constexpr const char *AWS_EC2 = "aws_ec2";
+static constexpr const char *kAwsEc2 = "aws_ec2";
 /** AWS Elastic Container Service. */
-static constexpr const char *AWS_ECS = "aws_ecs";
+static constexpr const char *kAwsEcs = "aws_ecs";
 /** AWS Elastic Kubernetes Service. */
-static constexpr const char *AWS_EKS = "aws_eks";
+static constexpr const char *kAwsEks = "aws_eks";
 /** AWS Lambda. */
-static constexpr const char *AWS_LAMBDA = "aws_lambda";
+static constexpr const char *kAwsLambda = "aws_lambda";
 /** AWS Elastic Beanstalk. */
-static constexpr const char *AWS_ELASTIC_BEANSTALK = "aws_elastic_beanstalk";
+static constexpr const char *kAwsElasticBeanstalk = "aws_elastic_beanstalk";
 /** AWS App Runner. */
-static constexpr const char *AWS_APP_RUNNER = "aws_app_runner";
+static constexpr const char *kAwsAppRunner = "aws_app_runner";
 /** Azure Virtual Machines. */
-static constexpr const char *AZURE_VM = "azure_vm";
+static constexpr const char *kAzureVm = "azure_vm";
 /** Azure Container Instances. */
-static constexpr const char *AZURE_CONTAINER_INSTANCES = "azure_container_instances";
+static constexpr const char *kAzureContainerInstances = "azure_container_instances";
 /** Azure Kubernetes Service. */
-static constexpr const char *AZURE_AKS = "azure_aks";
+static constexpr const char *kAzureAks = "azure_aks";
 /** Azure Functions. */
-static constexpr const char *AZURE_FUNCTIONS = "azure_functions";
+static constexpr const char *kAzureFunctions = "azure_functions";
 /** Azure App Service. */
-static constexpr const char *AZURE_APP_SERVICE = "azure_app_service";
+static constexpr const char *kAzureAppService = "azure_app_service";
 /** Google Cloud Compute Engine (GCE). */
-static constexpr const char *GCP_COMPUTE_ENGINE = "gcp_compute_engine";
+static constexpr const char *kGcpComputeEngine = "gcp_compute_engine";
 /** Google Cloud Run. */
-static constexpr const char *GCP_CLOUD_RUN = "gcp_cloud_run";
+static constexpr const char *kGcpCloudRun = "gcp_cloud_run";
 /** Google Cloud Kubernetes Engine (GKE). */
-static constexpr const char *GCP_KUBERNETES_ENGINE = "gcp_kubernetes_engine";
+static constexpr const char *kGcpKubernetesEngine = "gcp_kubernetes_engine";
 /** Google Cloud Functions (GCF). */
-static constexpr const char *GCP_CLOUD_FUNCTIONS = "gcp_cloud_functions";
+static constexpr const char *kGcpCloudFunctions = "gcp_cloud_functions";
 /** Google Cloud App Engine (GAE). */
-static constexpr const char *GCP_APP_ENGINE = "gcp_app_engine";
+static constexpr const char *kGcpAppEngine = "gcp_app_engine";
 /** Tencent Cloud Cloud Virtual Machine (CVM). */
-static constexpr const char *TENCENT_CLOUD_CVM = "tencent_cloud_cvm";
+static constexpr const char *kTencentCloudCvm = "tencent_cloud_cvm";
 /** Tencent Cloud Elastic Kubernetes Service (EKS). */
-static constexpr const char *TENCENT_CLOUD_EKS = "tencent_cloud_eks";
+static constexpr const char *kTencentCloudEks = "tencent_cloud_eks";
 /** Tencent Cloud Serverless Cloud Function (SCF). */
-static constexpr const char *TENCENT_CLOUD_SCF = "tencent_cloud_scf";
+static constexpr const char *kTencentCloudScf = "tencent_cloud_scf";
 }  // namespace CloudPlatformValues
 
 namespace AwsEcsLaunchtypeValues
 {
 /** ec2. */
-static constexpr const char *EC2 = "ec2";
+static constexpr const char *kEc2 = "ec2";
 /** fargate. */
-static constexpr const char *FARGATE = "fargate";
+static constexpr const char *kFargate = "fargate";
 }  // namespace AwsEcsLaunchtypeValues
 
 namespace HostArchValues
 {
 /** AMD64. */
-static constexpr const char *AMD64 = "amd64";
+static constexpr const char *kAmd64 = "amd64";
 /** ARM32. */
-static constexpr const char *ARM32 = "arm32";
+static constexpr const char *kArm32 = "arm32";
 /** ARM64. */
-static constexpr const char *ARM64 = "arm64";
+static constexpr const char *kArm64 = "arm64";
 /** Itanium. */
-static constexpr const char *IA64 = "ia64";
+static constexpr const char *kIa64 = "ia64";
 /** 32-bit PowerPC. */
-static constexpr const char *PPC32 = "ppc32";
+static constexpr const char *kPpc32 = "ppc32";
 /** 64-bit PowerPC. */
-static constexpr const char *PPC64 = "ppc64";
+static constexpr const char *kPpc64 = "ppc64";
 /** IBM z/Architecture. */
-static constexpr const char *S390X = "s390x";
+static constexpr const char *kS390x = "s390x";
 /** 32-bit x86. */
-static constexpr const char *X86 = "x86";
+static constexpr const char *kX86 = "x86";
 }  // namespace HostArchValues
 
 namespace OsTypeValues
 {
 /** Microsoft Windows. */
-static constexpr const char *WINDOWS = "windows";
+static constexpr const char *kWindows = "windows";
 /** Linux. */
-static constexpr const char *LINUX = "linux";
+static constexpr const char *kLinux = "linux";
 /** Apple Darwin. */
-static constexpr const char *DARWIN = "darwin";
+static constexpr const char *kDarwin = "darwin";
 /** FreeBSD. */
-static constexpr const char *FREEBSD = "freebsd";
+static constexpr const char *kFreebsd = "freebsd";
 /** NetBSD. */
-static constexpr const char *NETBSD = "netbsd";
+static constexpr const char *kNetbsd = "netbsd";
 /** OpenBSD. */
-static constexpr const char *OPENBSD = "openbsd";
+static constexpr const char *kOpenbsd = "openbsd";
 /** DragonFly BSD. */
-static constexpr const char *DRAGONFLYBSD = "dragonflybsd";
+static constexpr const char *kDragonflybsd = "dragonflybsd";
 /** HP-UX (Hewlett Packard Unix). */
-static constexpr const char *HPUX = "hpux";
+static constexpr const char *kHpux = "hpux";
 /** AIX (Advanced Interactive eXecutive). */
-static constexpr const char *AIX = "aix";
+static constexpr const char *kAix = "aix";
 /** SunOS, Oracle Solaris. */
-static constexpr const char *SOLARIS = "solaris";
+static constexpr const char *kSolaris = "solaris";
 /** IBM z/OS. */
-static constexpr const char *Z_OS = "z_os";
+static constexpr const char *kZOs = "z_os";
 }  // namespace OsTypeValues
 
 namespace TelemetrySdkLanguageValues
 {
 /** cpp. */
-static constexpr const char *CPP = "cpp";
+static constexpr const char *kCpp = "cpp";
 /** dotnet. */
-static constexpr const char *DOTNET = "dotnet";
+static constexpr const char *kDotnet = "dotnet";
 /** erlang. */
-static constexpr const char *ERLANG = "erlang";
+static constexpr const char *kErlang = "erlang";
 /** go. */
-static constexpr const char *GO = "go";
+static constexpr const char *kGo = "go";
 /** java. */
-static constexpr const char *JAVA = "java";
+static constexpr const char *kJava = "java";
 /** nodejs. */
-static constexpr const char *NODEJS = "nodejs";
+static constexpr const char *kNodejs = "nodejs";
 /** php. */
-static constexpr const char *PHP = "php";
+static constexpr const char *kPhp = "php";
 /** python. */
-static constexpr const char *PYTHON = "python";
+static constexpr const char *kPython = "python";
 /** ruby. */
-static constexpr const char *RUBY = "ruby";
+static constexpr const char *kRuby = "ruby";
 /** webjs. */
-static constexpr const char *WEBJS = "webjs";
+static constexpr const char *kWebjs = "webjs";
 /** swift. */
-static constexpr const char *SWIFT = "swift";
+static constexpr const char *kSwift = "swift";
 }  // namespace TelemetrySdkLanguageValues
 
 }  // namespace SemanticConventions

--- a/sdk/src/resource/resource.cc
+++ b/sdk/src/resource/resource.cc
@@ -30,16 +30,16 @@ Resource Resource::Create(const ResourceAttributes &attributes, const std::strin
   auto resource =
       Resource::GetDefault().Merge(otel_resource).Merge(Resource{attributes, schema_url});
 
-  if (resource.attributes_.find(SemanticConventions::SERVICE_NAME) == resource.attributes_.end())
+  if (resource.attributes_.find(SemanticConventions::kServiceName) == resource.attributes_.end())
   {
     std::string default_service_name = "unknown_service";
     auto it_process_executable_name =
-        resource.attributes_.find(SemanticConventions::PROCESS_EXECUTABLE_NAME);
+        resource.attributes_.find(SemanticConventions::kProcessExecutableName);
     if (it_process_executable_name != resource.attributes_.end())
     {
       default_service_name += ":" + nostd::get<std::string>(it_process_executable_name->second);
     }
-    resource.attributes_[SemanticConventions::SERVICE_NAME] = default_service_name;
+    resource.attributes_[SemanticConventions::kServiceName] = default_service_name;
   }
   return resource;
 }
@@ -53,9 +53,9 @@ Resource &Resource::GetEmpty()
 Resource &Resource::GetDefault()
 {
   static Resource default_resource(
-      {{SemanticConventions::TELEMETRY_SDK_LANGUAGE, "cpp"},
-       {SemanticConventions::TELEMETRY_SDK_NAME, "opentelemetry"},
-       {SemanticConventions::TELEMETRY_SDK_VERSION, OPENTELEMETRY_SDK_VERSION}},
+      {{SemanticConventions::kTelemetrySdkLanguage, "cpp"},
+       {SemanticConventions::kTelemetrySdkName, "opentelemetry"},
+       {SemanticConventions::kTelemetrySdkVersion, OPENTELEMETRY_SDK_VERSION}},
       std::string{});
   return default_resource;
 }

--- a/sdk/test/resource/resource_test.cc
+++ b/sdk/test/resource/resource_test.cc
@@ -35,10 +35,10 @@ TEST(ResourceTest, create_without_servicename)
       {"service", "backend"},
       {"version", (uint32_t)1},
       {"cost", 234.23},
-      {SemanticConventions::TELEMETRY_SDK_LANGUAGE, "cpp"},
-      {SemanticConventions::TELEMETRY_SDK_NAME, "opentelemetry"},
-      {SemanticConventions::TELEMETRY_SDK_VERSION, OPENTELEMETRY_SDK_VERSION},
-      {SemanticConventions::SERVICE_NAME, "unknown_service"}};
+      {SemanticConventions::kTelemetrySdkLanguage, "cpp"},
+      {SemanticConventions::kTelemetrySdkName, "opentelemetry"},
+      {SemanticConventions::kTelemetrySdkVersion, OPENTELEMETRY_SDK_VERSION},
+      {SemanticConventions::kServiceName, "unknown_service"}};
 
   ResourceAttributes attributes = {
       {"service", "backend"}, {"version", (uint32_t)1}, {"cost", 234.23}};
@@ -68,10 +68,10 @@ TEST(ResourceTest, create_with_servicename)
   ResourceAttributes expected_attributes = {
       {"version", (uint32_t)1},
       {"cost", 234.23},
-      {SemanticConventions::TELEMETRY_SDK_LANGUAGE, "cpp"},
-      {SemanticConventions::TELEMETRY_SDK_NAME, "opentelemetry"},
-      {SemanticConventions::TELEMETRY_SDK_VERSION, OPENTELEMETRY_SDK_VERSION},
-      {SemanticConventions::SERVICE_NAME, "backend"},
+      {SemanticConventions::kTelemetrySdkLanguage, "cpp"},
+      {SemanticConventions::kTelemetrySdkName, "opentelemetry"},
+      {SemanticConventions::kTelemetrySdkVersion, OPENTELEMETRY_SDK_VERSION},
+      {SemanticConventions::kServiceName, "backend"},
   };
   ResourceAttributes attributes = {
       {"service.name", "backend"}, {"version", (uint32_t)1}, {"cost", 234.23}};
@@ -99,10 +99,10 @@ TEST(ResourceTest, create_with_servicename)
 TEST(ResourceTest, create_with_emptyatrributes)
 {
   ResourceAttributes expected_attributes = {
-      {SemanticConventions::TELEMETRY_SDK_LANGUAGE, "cpp"},
-      {SemanticConventions::TELEMETRY_SDK_NAME, "opentelemetry"},
-      {SemanticConventions::TELEMETRY_SDK_VERSION, OPENTELEMETRY_SDK_VERSION},
-      {SemanticConventions::SERVICE_NAME, "unknown_service"},
+      {SemanticConventions::kTelemetrySdkLanguage, "cpp"},
+      {SemanticConventions::kTelemetrySdkName, "opentelemetry"},
+      {SemanticConventions::kTelemetrySdkVersion, OPENTELEMETRY_SDK_VERSION},
+      {SemanticConventions::kServiceName, "unknown_service"},
   };
   ResourceAttributes attributes = {};
   auto resource                 = Resource::Create(attributes);


### PR DESCRIPTION
Fixes #1758

## Changes

Upgrade semantic conventions to opentelemetry-specification 1.15.0
Change naming to use camel case, to avoid collisions with macros.

* [X] `CHANGELOG.md` updated for non-trivial changes
* [ ] Unit tests have been added
* [X] Changes in public API reviewed