### PR TITLE
Fix GlobalLogHandler singleton creation order

### DIFF
--- a/sdk/include/opentelemetry/sdk/common/global_log_handler.h
+++ b/sdk/include/opentelemetry/sdk/common/global_log_handler.h
@@ -134,11 +134,10 @@ private:
 OPENTELEMETRY_END_NAMESPACE
 
 /**
- * We can not decide the destroying order of signaltons.
- * Which means, the destructors of other singletons (GlobalLogHandler,TracerProvider and etc.)
- * may be called after destroying of global LogHandler and use OTEL_INTERNAL_LOG_* in it.We can do
- * nothing but ignore the log in this situation.
- */
+ * GlobalLogHandler and TracerProvider/MeterProvider/LoggerProvider are lazy sigletons.
+ * To ensure that GlobalLogHandler is the first one to be initialized (and so last to be
+ * destroyed), it is first used inside the constructors of TraceProvider, MeterProvider
+ * and LoggerProvider for debug logging. */
 #define OTEL_INTERNAL_LOG_DISPATCH(level, message, attributes)                            \
   do                                                                                      \
   {                                                                                       \

--- a/sdk/src/logs/logger_provider.cc
+++ b/sdk/src/logs/logger_provider.cc
@@ -26,6 +26,7 @@ LoggerProvider::LoggerProvider(std::unique_ptr<LogRecordProcessor> &&processor,
   std::vector<std::unique_ptr<LogRecordProcessor>> processors;
   processors.emplace_back(std::move(processor));
   context_ = std::make_shared<sdk::logs::LoggerContext>(std::move(processors), std::move(resource));
+  OTEL_INTERNAL_LOG_DEBUG("[LoggerProvider] LoggerProvider created.");
 }
 
 LoggerProvider::LoggerProvider(std::vector<std::unique_ptr<LogRecordProcessor>> &&processors,

--- a/sdk/src/logs/logger_provider.cc
+++ b/sdk/src/logs/logger_provider.cc
@@ -4,6 +4,7 @@
 #ifdef ENABLE_LOGS_PREVIEW
 
 #  include "opentelemetry/sdk/logs/logger_provider.h"
+#  include "opentelemetry/sdk/common/global_log_handler.h"
 
 #  include <memory>
 #  include <mutex>

--- a/sdk/src/metrics/meter_provider.cc
+++ b/sdk/src/metrics/meter_provider.cc
@@ -24,7 +24,9 @@ MeterProvider::MeterProvider(std::shared_ptr<MeterContext> context) noexcept : c
 MeterProvider::MeterProvider(std::unique_ptr<ViewRegistry> views,
                              sdk::resource::Resource resource) noexcept
     : context_(std::make_shared<MeterContext>(std::move(views), resource))
-{}
+{
+  OTEL_INTERNAL_LOG_DEBUG("[MeterProvider] MeterProvider created.");
+}
 
 nostd::shared_ptr<metrics_api::Meter> MeterProvider::GetMeter(
     nostd::string_view name,

--- a/sdk/src/trace/tracer_provider.cc
+++ b/sdk/src/trace/tracer_provider.cc
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "opentelemetry/sdk/trace/tracer_provider.h"
+#include "opentelemetry/sdk/common/global_log_handler.h"
 #include "opentelemetry/sdk_config.h"
 
 OPENTELEMETRY_BEGIN_NAMESPACE

--- a/sdk/src/trace/tracer_provider.cc
+++ b/sdk/src/trace/tracer_provider.cc
@@ -14,7 +14,9 @@ namespace trace_api = opentelemetry::trace;
 
 TracerProvider::TracerProvider(std::shared_ptr<sdk::trace::TracerContext> context) noexcept
     : context_{context}
-{}
+{
+  OTEL_INTERNAL_LOG_DEBUG("[TracerProvider] TracerProvider created.");
+}
 
 TracerProvider::TracerProvider(std::unique_ptr<SpanProcessor> processor,
                                resource::Resource resource,


### PR DESCRIPTION
Fixes #1718 

## Changes
`GlobalLogHandler` and  `MeterProvider` are lazy singletons. As of now, `MeterProvider` singleton is first initialized, followed by `GlobalLogHandler` (when the first message is logged).  This order of initialization means `GlobalLogHandler` is destroyed before `MeterProvider`, which further results in segfault when trying to use the logger from MeterProvider destructor.

The easy solution would be to use `GlobalLogHandler` to log message from inside the `MeterProvider` constructor. This makes the complier to guarantee that the GlobalLogHandler is constructed before MeterProvider, and so destroyed after MeterProvider. Have tested the changes locally by reproducing the segfault, and then ensuring there is no segfault with the change.

To demonstrate the order of initialization, refer to the sample code here - https://godbolt.org/z/K8x1dcPW5

The order of initiation and destruction in sample is:
```cpp
Log::Log
MeterProvider
MeterProvider::ForceFlush
~MeterProvider
~Log::Log
```

And order of initialization and destruction after replacing line 32 with `std::cout << "MeterProvider\n"` in the sample code is:
```cpp
MeterProvider
Log::Log
MeterProvider::ForceFlush
~Log::Log
~MeterProvider
```

Please provide a brief description of the changes here.

For significant contributions please make sure you have completed the following items:

* [ ] `CHANGELOG.md` updated for non-trivial changes
* [ ] Unit tests have been added
* [ ] Changes in public API reviewed