### PR TITLE
Have MeterContext::GetMeters return a copy instead of a span

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,13 +13,21 @@ Increment the:
 * MINOR version when you add functionality in a backwards compatible manner, and
 * PATCH version when you make backwards compatible bug fixes.
 
-## [Unreleased]
-
+## [Unreleased] 
+* [METRICS SDK] Change return type of MeterContext::GetMeters from span to
+  vector to prevent segfaults during MetricsCollector::Collect
+  [#1777](https://github.com/open-telemetry/opentelemetry-cpp/pull/1777)
 * [LOGS SDK] Rename LogProcessor and LogExporter to LogRecordProcessor and LogRecordExporter
   [#1727](https://github.com/open-telemetry/opentelemetry-cpp/pull/1727)
 * [METRICS SDK] - Remove old metrics from Github CI
   [#1733](https://github.com/open-telemetry/opentelemetry-cpp/pull/1733)
 * [BUILD] Add CMake OTELCPP_PROTO_PATH [#1730](https://github.com/open-telemetry/opentelemetry-cpp/pull/1730)
+
+Notes:
+
+Metrics SDK changes include PR
+[#1777](https://github.com/open-telemetry/opentelemetry-cpp/pull/1777)
+introducing a breaking change.
 
 Deprecation notes:
 

--- a/sdk/include/opentelemetry/sdk/metrics/meter_context.h
+++ b/sdk/include/opentelemetry/sdk/metrics/meter_context.h
@@ -59,7 +59,7 @@ public:
    * Obtain the  configured meters.
    *
    */
-  nostd::span<std::shared_ptr<Meter>> GetMeters() noexcept;
+  std::vector<std::shared_ptr<Meter>> GetMeters() noexcept;
 
   /**
    * Obtain the configured collectors.

--- a/sdk/src/metrics/meter_context.cc
+++ b/sdk/src/metrics/meter_context.cc
@@ -28,10 +28,10 @@ ViewRegistry *MeterContext::GetViewRegistry() const noexcept
   return views_.get();
 }
 
-nostd::span<std::shared_ptr<Meter>> MeterContext::GetMeters() noexcept
+std::vector<std::shared_ptr<Meter>> MeterContext::GetMeters() noexcept
 {
   std::lock_guard<opentelemetry::common::SpinLockMutex> guard(storage_lock_);
-  return nostd::span<std::shared_ptr<Meter>>{meters_};
+  return meters_;
 }
 
 nostd::span<std::shared_ptr<CollectorHandle>> MeterContext::GetCollectors() noexcept


### PR DESCRIPTION
Fixes #1720

## Changes

`MeterContext::GetMeters` returns a span viewing into the `meters_` vector used to manage meter storage. While the span is constructed, the storage is locked, but when the span returns and the lock is released, another thread may modify the vector while the caller of `MeterContext::GetMeters` continues to work with the span.

This PR changes `MeterContext::GetMeters` to simply return a copy of the metrics storage vector while it is being locked.

* [x] `CHANGELOG.md` updated for non-trivial changes
* [ ] Unit tests have been added
* [ ] Changes in public API reviewed