### PR TITLE
[DOC] Document that clang-format version 10.0 is used.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -87,6 +87,12 @@ git submodule init
 git submodule update
 ```
 
+The source code is automatically formatted using clang-format.
+
+The output can vary between versions, so make sure to install `clang-format`
+version `10.0`, and have `clang-format-10` in your execution path,
+so that the helper script `tools/format.sh` can find it.
+
 Check out a new branch, make modifications and push the branch to your fork:
 
 ```sh

--- a/tools/format.sh
+++ b/tools/format.sh
@@ -22,7 +22,7 @@ fi
 # No trailing spaces.
 "${SED[@]}" 's/ \+$//' $($FIND -type f -print)
 
-# If not overridden, try to use clang-format-8 or clang-format.
+# If not overridden, try to use clang-format-10 or clang-format.
 if [[ -z "$CLANG_FORMAT" ]]; then
   CLANG_FORMAT=clang-format
   if which clang-format-10 >/dev/null; then


### PR DESCRIPTION
Fixes #1781 

## Changes

In CONTRIBUTING.md,
clarify that clang-format version 10.0 is used.

* [ ] `CHANGELOG.md` updated for non-trivial changes
* [ ] Unit tests have been added
* [ ] Changes in public API reviewed