### PR TITLE
Add MeterContext::ForEachMeter() method to process callbacks on Meter in thread-safe manner

### DIFF
--- a/sdk/include/opentelemetry/sdk/metrics/meter_context.h
+++ b/sdk/include/opentelemetry/sdk/metrics/meter_context.h
@@ -59,12 +59,12 @@ public:
    * NOTE - INTERNAL method, can change in future.
    * Process callback for each meter in thread-safe manner
    */
- bool ForEachMeter(nostd::function_ref<bool(std::shared_ptr<Meter> &meter)> callback) noexcept;
+  bool ForEachMeter(nostd::function_ref<bool(std::shared_ptr<Meter> &meter)> callback) noexcept;
 
-  /** 
+  /**
    * NOTE - INTERNAL method, can change in future.
-   * Obtain the  configured meters. 
-   * This method is NOT thread-safe.
+   * Get the configured meters.
+   * This method is NOT thread safe, and only called through MeterProvider
    *
    */
   nostd::span<std::shared_ptr<Meter>> GetMeters() noexcept;
@@ -104,8 +104,8 @@ public:
                std::unique_ptr<View> view) noexcept;
 
   /**
-   * Adds a meter to the list of configured meters.
-   * Note: This method is INTERNAL to sdk not thread safe.
+   * NOTE - INTERNAL method, can change in future.
+   * Adds a meter to the list of configured meters in thread safe manner.
    *
    * @param meter
    */

--- a/sdk/include/opentelemetry/sdk/metrics/meter_context.h
+++ b/sdk/include/opentelemetry/sdk/metrics/meter_context.h
@@ -56,7 +56,15 @@ public:
   ViewRegistry *GetViewRegistry() const noexcept;
 
   /**
-   * Obtain the  configured meters.
+   * NOTE - INTERNAL method, can change in future.
+   * Process callback for each meter in thread-safe manner
+   */
+ bool ForEachMeter(nostd::function_ref<bool(std::shared_ptr<Meter> &meter)> callback) noexcept;
+
+  /** 
+   * NOTE - INTERNAL method, can change in future.
+   * Obtain the  configured meters. 
+   * This method is NOT thread-safe.
    *
    */
   nostd::span<std::shared_ptr<Meter>> GetMeters() noexcept;
@@ -124,7 +132,7 @@ private:
 
   std::atomic_flag shutdown_latch_ = ATOMIC_FLAG_INIT;
   opentelemetry::common::SpinLockMutex forceflush_lock_;
-  opentelemetry::common::SpinLockMutex storage_lock_;
+  opentelemetry::common::SpinLockMutex meter_lock_;
 };
 
 }  // namespace metrics

--- a/sdk/src/metrics/meter_context.cc
+++ b/sdk/src/metrics/meter_context.cc
@@ -28,17 +28,18 @@ ViewRegistry *MeterContext::GetViewRegistry() const noexcept
   return views_.get();
 }
 
-bool MeterContext::ForEachMeter(nostd::function_ref<bool(std::shared_ptr<Meter> &meter)> callback) noexcept
+bool MeterContext::ForEachMeter(
+    nostd::function_ref<bool(std::shared_ptr<Meter> &meter)> callback) noexcept
 {
   std::lock_guard<opentelemetry::common::SpinLockMutex> guard(meter_lock_);
-    for (auto &meter: meters_)
+  for (auto &meter : meters_)
+  {
+    if (!callback(meter))
     {
-      if (!callback(meter))
-      {
-        return false;
-      }
+      return false;
     }
-    return true;
+  }
+  return true;
 }
 
 nostd::span<std::shared_ptr<Meter>> MeterContext::GetMeters() noexcept

--- a/sdk/src/metrics/meter_context.cc
+++ b/sdk/src/metrics/meter_context.cc
@@ -28,9 +28,22 @@ ViewRegistry *MeterContext::GetViewRegistry() const noexcept
   return views_.get();
 }
 
+bool MeterContext::ForEachMeter(nostd::function_ref<bool(std::shared_ptr<Meter> &meter)> callback) noexcept
+{
+  std::lock_guard<opentelemetry::common::SpinLockMutex> guard(meter_lock_);
+    for (auto &meter: meters_)
+    {
+      if (!callback(meter))
+      {
+        return false;
+      }
+    }
+    return true;
+}
+
 nostd::span<std::shared_ptr<Meter>> MeterContext::GetMeters() noexcept
 {
-  std::lock_guard<opentelemetry::common::SpinLockMutex> guard(storage_lock_);
+  // no lock required, as this is called by MeterProvider in thread-safe manner.
   return nostd::span<std::shared_ptr<Meter>>{meters_};
 }
 
@@ -59,7 +72,7 @@ void MeterContext::AddView(std::unique_ptr<InstrumentSelector> instrument_select
 
 void MeterContext::AddMeter(std::shared_ptr<Meter> meter)
 {
-  std::lock_guard<opentelemetry::common::SpinLockMutex> guard(storage_lock_);
+  std::lock_guard<opentelemetry::common::SpinLockMutex> guard(meter_lock_);
   meters_.push_back(meter);
 }
 

--- a/sdk/src/metrics/state/metric_collector.cc
+++ b/sdk/src/metrics/state/metric_collector.cc
@@ -38,13 +38,12 @@ bool MetricCollector::Collect(
     return false;
   }
   ResourceMetrics resource_metrics;
-  meter_context_->ForEachMeter([&](std::shared_ptr<Meter> meter) noexcept 
-  {
+  meter_context_->ForEachMeter([&](std::shared_ptr<Meter> meter) noexcept {
     auto collection_ts = std::chrono::system_clock::now();
     ScopeMetrics scope_metrics;
     scope_metrics.metric_data_ = meter->Collect(this, collection_ts);
     scope_metrics.scope_       = meter->GetInstrumentationScope();
-    resource_metrics.scope_metric_data_.push_back(scope_metrics);  
+    resource_metrics.scope_metric_data_.push_back(scope_metrics);
     return true;
   });
   resource_metrics.resource_ = &meter_context_->GetResource();

--- a/sdk/src/metrics/state/metric_collector.cc
+++ b/sdk/src/metrics/state/metric_collector.cc
@@ -38,14 +38,15 @@ bool MetricCollector::Collect(
     return false;
   }
   ResourceMetrics resource_metrics;
-  for (auto &meter : meter_context_->GetMeters())
+  meter_context_->ForEachMeter([&](std::shared_ptr<Meter> meter) noexcept 
   {
     auto collection_ts = std::chrono::system_clock::now();
     ScopeMetrics scope_metrics;
     scope_metrics.metric_data_ = meter->Collect(this, collection_ts);
     scope_metrics.scope_       = meter->GetInstrumentationScope();
-    resource_metrics.scope_metric_data_.push_back(scope_metrics);
-  }
+    resource_metrics.scope_metric_data_.push_back(scope_metrics);  
+    return true;
+  });
   resource_metrics.resource_ = &meter_context_->GetResource();
   callback(resource_metrics);
   return true;


### PR DESCRIPTION
Fixes #1720 

## Changes

Another approach to fix #1720 (refer #1777 for first approach) by adding `MeterContext::ForEachMeter`, which invokes callback to process each meter in thread-safe manner. This will ensure that metric collection doesn't crash for existing meters while new meter is being added.

For significant contributions please make sure you have completed the following items:

* [ ] `CHANGELOG.md` updated for non-trivial changes
* [ ] Unit tests have been added
* [ ] Changes in public API reviewed