### PR TITLE
bump to gRPC v1.48.1 for bazel CIs

### DIFF
--- a/bazel/repository.bzl
+++ b/bazel/repository.bzl
@@ -50,6 +50,17 @@ def opentelemetry_cpp_deps():
         ],
     )
 
+    maybe(
+        http_archive,
+        name = "com_google_absl_latest11",
+        sha256 = "dcf71b9cba8dc0ca9940c4b316a0c796be8fab42b070bb6b7cab62b48f0e66c4",
+        strip_prefix = "abseil-cpp-20211102.0",
+        urls = [
+            "https://storage.googleapis.com/grpc-bazel-mirror/github.com/abseil/abseil-cpp/archive/20211102.0.tar.gz",
+            "https://github.com/abseil/abseil-cpp/archive/20211102.0.tar.gz",
+        ],
+    )
+
     # Load abseil dependency(optional)
     maybe(
         http_archive,
@@ -74,11 +85,21 @@ def opentelemetry_cpp_deps():
 
     maybe(
         http_archive,
-        name = "com_github_grpc_grpc",
-        sha256 = "b74ce7d26fe187970d1d8e2c06a5d3391122f7bc1fdce569aff5e435fb8fe780",
-        strip_prefix = "grpc-1.43.2",
+        name = "com_github_grpc_grpc_latest11",
+        sha256 = "e266aa0d9d9cddb876484a370b94f468248594a96ca0b6f87c21f969db2b8c5b",
+        strip_prefix = "grpc-1.46.4",
         urls = [
-            "https://github.com/grpc/grpc/archive/v1.43.2.tar.gz",
+            "https://github.com/grpc/grpc/archive/v1.46.4.tar.gz",
+        ],
+    )
+
+    maybe(
+        http_archive,
+        name = "com_github_grpc_grpc",
+        sha256 = "320366665d19027cda87b2368c03939006a37e0388bfd1091c8d2a96fbc93bd8",
+        strip_prefix = "grpc-1.48.1",
+        urls = [
+            "https://github.com/grpc/grpc/archive/v1.48.1.tar.gz",
         ],
     )
 

--- a/bazel/repository.bzl
+++ b/bazel/repository.bzl
@@ -50,17 +50,6 @@ def opentelemetry_cpp_deps():
         ],
     )
 
-    maybe(
-        http_archive,
-        name = "com_google_absl_latest11",
-        sha256 = "dcf71b9cba8dc0ca9940c4b316a0c796be8fab42b070bb6b7cab62b48f0e66c4",
-        strip_prefix = "abseil-cpp-20211102.0",
-        urls = [
-            "https://storage.googleapis.com/grpc-bazel-mirror/github.com/abseil/abseil-cpp/archive/20211102.0.tar.gz",
-            "https://github.com/abseil/abseil-cpp/archive/20211102.0.tar.gz",
-        ],
-    )
-
     # Load abseil dependency(optional)
     maybe(
         http_archive,

--- a/ci/do_ci.sh
+++ b/ci/do_ci.sh
@@ -25,7 +25,7 @@ function run_benchmarks
 
   [ -z "${BENCHMARK_DIR}" ] && export BENCHMARK_DIR=$HOME/benchmark
   mkdir -p $BENCHMARK_DIR
-  bazel $BAZEL_STARTUP_OPTIONS build $BAZEL_OPTIONS_ASYNC -c opt -- \
+  bazel $BAZEL_STARTUP_OPTIONS build --cxxopt=-std=c++14 $BAZEL_OPTIONS_ASYNC -c opt -- \
     $(bazel query 'attr("tags", "benchmark_result", ...)')
   echo ""
   echo "Benchmark results in $BENCHMARK_DIR:"
@@ -59,7 +59,8 @@ mkdir -p "${BUILD_DIR}"
 [ -z "${PLUGIN_DIR}" ] && export PLUGIN_DIR=$HOME/plugin
 mkdir -p "${PLUGIN_DIR}"
 
-BAZEL_OPTIONS="--copt=-DENABLE_LOGS_PREVIEW --copt=-DENABLE_TEST --copt=-DENABLE_METRICS_EXEMPLAR_PREVIEW"
+BAZEL_OPTIONS_DEFAULT="--copt=-DENABLE_LOGS_PREVIEW --copt=-DENABLE_TEST --copt=-DENABLE_METRICS_EXEMPLAR_PREVIEW"
+BAZEL_OPTIONS="--cxxopt=-std=c++14 $BAZEL_OPTIONS_DEFAULT"
 
 BAZEL_TEST_OPTIONS="$BAZEL_OPTIONS --test_output=errors"
 
@@ -298,9 +299,13 @@ elif [[ "$1" == "bazel.valgrind" ]]; then
   bazel $BAZEL_STARTUP_OPTIONS build $BAZEL_OPTIONS_ASYNC //...
   bazel $BAZEL_STARTUP_OPTIONS test --run_under="/usr/bin/valgrind --leak-check=full --error-exitcode=1 --suppressions=\"${SRC_DIR}/ci/valgrind-suppressions\"" $BAZEL_TEST_OPTIONS_ASYNC //...
   exit 0
+elif [[ "$1" == "bazel.e2e" ]]; then
+  cd examples/e2e
+  bazel $BAZEL_STARTUP_OPTIONS build $BAZEL_OPTIONS_DEFAULT //...
+  exit 0
 elif [[ "$1" == "benchmark" ]]; then
   [ -z "${BENCHMARK_DIR}" ] && export BENCHMARK_DIR=$HOME/benchmark
-  bazel $BAZEL_STARTUP_OPTIONS build $BAZEL_OPTIONS_ASYNC -c opt -- \
+  bazel $BAZEL_STARTUP_OPTIONS build --cxxopt=-std=c++14 $BAZEL_OPTIONS_ASYNC -c opt -- \
     $(bazel query 'attr("tags", "benchmark_result", ...)')
   echo ""
   echo "Benchmark results in $BENCHMARK_DIR:"

--- a/exporters/otlp/test/otlp_grpc_exporter_benchmark.cc
+++ b/exporters/otlp/test/otlp_grpc_exporter_benchmark.cc
@@ -187,6 +187,7 @@ BENCHMARK(BM_OtlpExporterDenseSpans);
 }  // namespace exporter
 OPENTELEMETRY_END_NAMESPACE
 
+#ifdef NDEBUG
 namespace
 {
 opentelemetry::exporter::otlp::OtlpGrpcExporterOptions opts;
@@ -212,5 +213,6 @@ void BM_otlp_grpc_with_collector(benchmark::State &state)
 }
 BENCHMARK(BM_otlp_grpc_with_collector);
 }  // namespace
+#endif
 
 BENCHMARK_MAIN();

--- a/exporters/otlp/test/otlp_grpc_exporter_benchmark.cc
+++ b/exporters/otlp/test/otlp_grpc_exporter_benchmark.cc
@@ -188,6 +188,9 @@ BENCHMARK(BM_OtlpExporterDenseSpans);
 OPENTELEMETRY_END_NAMESPACE
 
 #ifdef NDEBUG
+// disabled as valgrind reports a memroy leak at absl::lts_20220623::random_internal::(anonymous
+// namespace)::PoolAlignedAlloc()
+// see PR #1737
 namespace
 {
 opentelemetry::exporter::otlp::OtlpGrpcExporterOptions opts;

--- a/exporters/otlp/test/otlp_http_exporter_test.cc
+++ b/exporters/otlp/test/otlp_http_exporter_test.cc
@@ -21,6 +21,7 @@
 #  include "opentelemetry/sdk/trace/tracer_provider.h"
 #  include "opentelemetry/trace/provider.h"
 
+#  include <google/protobuf/message_lite.h>
 #  include <gtest/gtest.h>
 #  include "gmock/gmock.h"
 
@@ -466,6 +467,7 @@ TEST_F(OtlpHttpExporterTestPeer, ExportJsonIntegrationTestSync)
 TEST_F(OtlpHttpExporterTestPeer, ExportJsonIntegrationTestAsync)
 {
   ExportJsonIntegrationTestAsync();
+  google::protobuf::ShutdownProtobufLibrary();
 }
 #  endif
 

--- a/exporters/otlp/test/otlp_http_log_record_exporter_test.cc
+++ b/exporters/otlp/test/otlp_http_log_record_exporter_test.cc
@@ -26,6 +26,7 @@
 #    include "opentelemetry/sdk/logs/logger_provider.h"
 #    include "opentelemetry/sdk/resource/resource.h"
 
+#    include <google/protobuf/message_lite.h>
 #    include <gtest/gtest.h>
 #    include "gmock/gmock.h"
 
@@ -507,6 +508,7 @@ TEST_F(OtlpHttpLogRecordExporterTestPeer, ExportJsonIntegrationTestSync)
 TEST_F(OtlpHttpLogRecordExporterTestPeer, ExportJsonIntegrationTestAsync)
 {
   ExportJsonIntegrationTestAsync();
+  google::protobuf::ShutdownProtobufLibrary();
 }
 #    endif
 

--- a/exporters/otlp/test/otlp_http_metric_exporter_test.cc
+++ b/exporters/otlp/test/otlp_http_metric_exporter_test.cc
@@ -23,6 +23,7 @@
 #include "opentelemetry/sdk/metrics/instruments.h"
 #include "opentelemetry/sdk/resource/resource.h"
 
+#include <google/protobuf/message_lite.h>
 #include <gtest/gtest.h>
 #include "gmock/gmock.h"
 
@@ -845,6 +846,7 @@ TEST_F(OtlpHttpMetricExporterTestPeer, ConfigJsonBytesMappingTest)
   opts.json_bytes_mapping = JsonBytesMappingKind::kHex;
   std::unique_ptr<OtlpHttpMetricExporter> exporter(new OtlpHttpMetricExporter(opts));
   EXPECT_EQ(GetOptions(exporter).json_bytes_mapping, JsonBytesMappingKind::kHex);
+  google::protobuf::ShutdownProtobufLibrary();
 }
 
 #ifndef NO_GETENV


### PR DESCRIPTION
#1634 (issue) step 1/2

## Changes

This PR bumps gRPC to v1.48.1 for bazel CIs. It also adds the latest gRPC with C++11 support, so that in a separate PR we can hava e2e C++11 test: https://github.com/open-telemetry/opentelemetry-cpp/blob/21ced217aa96bee528d7c028b68213d26a2e3c70/examples/e2e/WORKSPACE#L15

For significant contributions please make sure you have completed the following items:

* [ ] `CHANGELOG.md` updated for non-trivial changes
* [ ] Unit tests have been added
* [ ] Changes in public API reviewed