### PR TITLE
[Exporter] add fix for prometheus exporter build

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -229,6 +229,11 @@ load("@io_opentelemetry_cpp//bazel:repository.bzl", "opentelemetry_cpp_deps")
 
 opentelemetry_cpp_deps()
 
+# Load extra dependencies required for OpenTelemetry
+load("@io_opentelemetry_cpp//bazel:extra_deps.bzl", "opentelemetry_extra_deps")
+
+opentelemetry_extra_deps()
+
 # Load gRPC dependencies after load.
 load("@com_github_grpc_grpc//bazel:grpc_deps.bzl", "grpc_deps")
 

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -19,14 +19,9 @@ load("//bazel:repository.bzl", "opentelemetry_cpp_deps")
 
 opentelemetry_cpp_deps()
 
-# Load prometheus C++ dependencies.
-load("@com_github_jupp0r_prometheus_cpp//bazel:repositories.bzl", "prometheus_cpp_repositories")
+load("//bazel:extra_deps.bzl", "opentelemetry_extra_deps")
 
-prometheus_cpp_repositories()
-
-load("@bazel_skylib//:workspace.bzl", "bazel_skylib_workspace")
-
-bazel_skylib_workspace()
+opentelemetry_extra_deps()
 
 # Load gRPC dependencies after load.
 load("@com_github_grpc_grpc//bazel:grpc_deps.bzl", "grpc_deps")
@@ -37,12 +32,3 @@ grpc_deps()
 load("@com_github_grpc_grpc//bazel:grpc_extra_deps.bzl", "grpc_extra_deps")
 
 grpc_extra_deps()
-
-load("@com_github_grpc_grpc//bazel:cc_grpc_library.bzl", "cc_grpc_library")
-load("@upb//bazel:workspace_deps.bzl", "upb_deps")
-
-upb_deps()
-
-load("@rules_foreign_cc//foreign_cc:repositories.bzl", "rules_foreign_cc_dependencies")
-
-rules_foreign_cc_dependencies()

--- a/bazel/extra_deps.bzl
+++ b/bazel/extra_deps.bzl
@@ -1,0 +1,13 @@
+# Copyright The OpenTelemetry Authors
+# SPDX-License-Identifier: Apache-2.0
+
+# Load prometheus C++ dependencies.
+
+load("@com_github_jupp0r_prometheus_cpp//bazel:repositories.bzl", "prometheus_cpp_repositories")
+load("@bazel_skylib//:workspace.bzl", "bazel_skylib_workspace")
+load("@rules_foreign_cc//foreign_cc:repositories.bzl", "rules_foreign_cc_dependencies")
+
+def opentelemetry_extra_deps():
+    prometheus_cpp_repositories()
+    bazel_skylib_workspace()
+    rules_foreign_cc_dependencies()


### PR DESCRIPTION
Signed-off-by: Roshan Chaudhari rochaudhari@nvidia.com

Fixes https://github.com/open-telemetry/opentelemetry-cpp/issues/1728

For prometheus exporter, required dependencies are not loaded in repository.bzl. When Opentelemetry is imported in some other project, these dependencies are missing.