### PR TITLE
Fix clang-format in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -413,7 +413,7 @@ jobs:
 
   format:
     name: Format
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
     - uses: actions/checkout@v3
     - name: setup


### PR DESCRIPTION
Fix clang-format in CI

## Changes

ubuntu-20.04 contains:
Clang-format 10.0.0, 11.0.0, 12.0.0

ubuntu-22.04 contains:
Clang-format 12.0.1, 13.0.1, 14.0.0

Opentelemetry-cpp CI uses Clang-format 10 on ubuntu-latest.

This now breaks because ubuntu-latest was upgraded from 20.04 to 22.04.

Change the format workflow to use ubuntu 20.04 explicitly, to restore a working CI.

* [ ] `CHANGELOG.md` updated for non-trivial changes
* [ ] Unit tests have been added
* [ ] Changes in public API reviewed