### PR TITLE
Bump googletest to 1.12.1

### DIFF
--- a/ci/setup_cmake.sh
+++ b/ci/setup_cmake.sh
@@ -9,7 +9,7 @@ export DEBIAN_FRONTEND=noninteractive
 apt-get update
 
 export CMAKE_VERSION=3.15.2
-export GOOGLETEST_VERSION=1.10.0
+export GOOGLETEST_VERSION=1.12.1
 
 cmake_install() {
     tmp_dir=$(mktemp -d)


### PR DESCRIPTION
Bump googletest to 1.12.1

## Changes

This fix a build break on ubuntu-latest (now ubuntu-22.04) with googletest 1.10.0

* [ ] `CHANGELOG.md` updated for non-trivial changes
* [ ] Unit tests have been added
* [ ] Changes in public API reviewed