### PR TITLE
Fix CI benchmark

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -11,7 +11,7 @@ permissions:
 jobs:
   benchmark:
     name: Run OpenTelemetry-cpp benchmarks
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v3
         with:
@@ -45,7 +45,7 @@ jobs:
       matrix:
         components: ["api", "sdk", "exporters"]
     name: Store benchmark result
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v3
       - uses: actions/download-artifact@master


### PR DESCRIPTION
Fixes #1800

## Changes

Fix `OpenTelemetry-cpp benchmarks / Run OpenTelemetry-cpp benchmarks` in CI

The ubuntu-latest upgrade from 20.04 to 22.04 broke benchmarks.
Restoring ubuntu-20.04

* [ ] `CHANGELOG.md` updated for non-trivial changes
* [ ] Unit tests have been added
* [ ] Changes in public API reviewed