### PR TITLE
Remove extra character from CMakeLists.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -164,7 +164,7 @@ option(WITH_NO_GETENV "Whether the platform supports environment variables" OFF)
 
 option(BUILD_TESTING "Whether to enable tests" ON)
 
-option(WITH_BENCHMARK "Whether to build benchmark program" ON)
+option(WITH_BENCHMARK "Whether to build benchmark program" ON)
 
 option(BUILD_W3CTRACECONTEXT_TEST "Whether to build w3c trace context" OFF)
 


### PR DESCRIPTION
Fixes #1804 

## Changes

Remove an extra character from CMakeLists.txt


* [ ] `CHANGELOG.md` updated for non-trivial changes
* [ ] Unit tests have been added
* [ ] Changes in public API reviewed