### PR TITLE
[BUILD] Bump abseil-cpp for cmake CI

### DIFF
--- a/ci/do_ci.sh
+++ b/ci/do_ci.sh
@@ -340,9 +340,9 @@ elif [[ "$1" == "code.coverage" ]]; then
   cp tmp_coverage.info coverage.info
   exit 0
 elif [[ "$1" == "third_party.tags" ]]; then
-  echo "gRPC=v1.43.2" > third_party_release
+  echo "gRPC=v1.48.1" > third_party_release
   echo "thrift=0.14.1" >> third_party_release
-  echo "abseil=20210324.0" >> third_party_release
+  echo "abseil=20220623.1" >> third_party_release
   git submodule foreach --quiet 'echo "$name=$(git describe --tags HEAD)"' | sed 's:.*/::' >> third_party_release
   exit 0
 fi

--- a/ci/install_abseil.sh
+++ b/ci/install_abseil.sh
@@ -8,7 +8,7 @@ export DEBIAN_FRONTEND=noninteractive
 
 BUILD_DIR=/tmp/
 INSTALL_DIR=/usr/local/
-TAG=20210324.0
+TAG=20220623.1
 pushd $BUILD_DIR
 git clone --depth=1 -b ${TAG} https://github.com/abseil/abseil-cpp.git
 cd abseil-cpp

--- a/third_party_release
+++ b/third_party_release
@@ -11,9 +11,9 @@
 #   git submodule status
 #
 
-gRPC=v1.43.2
+gRPC=v1.48.1
 thrift=0.14.1
-abseil=20210324.0
+abseil=20220623.1
 benchmark=v1.5.3
 googletest=release-1.10.0-459-ga6dfd3ac
 ms-gsl=v3.1.0-67-g6f45293


### PR DESCRIPTION
Bump `abseil-cpp` for cmake CI

## Changes

from `20210324.0` to `20220623.1`
also fixes `gRPC` version in `third_party_release`

For significant contributions please make sure you have completed the following items:

* [ ] `CHANGELOG.md` updated for non-trivial changes
* [ ] Unit tests have been added
* [ ] Changes in public API reviewed