### PR TITLE
[BUILD] Fix default bazel build

### DIFF
--- a/test_common/src/http/client/nosend/http_client_factory_nosend.cc
+++ b/test_common/src/http/client/nosend/http_client_factory_nosend.cc
@@ -1,9 +1,10 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-#include "opentelemetry/ext/http/client/http_client.h"
-#include "opentelemetry/ext/http/client/http_client_factory.h"
-#include "opentelemetry/test_common/ext/http/client/nosend/http_client_nosend.h"
+#ifdef ENABLE_TEST
+#  include "opentelemetry/ext/http/client/http_client.h"
+#  include "opentelemetry/ext/http/client/http_client_factory.h"
+#  include "opentelemetry/test_common/ext/http/client/nosend/http_client_nosend.h"
 
 namespace http_client = opentelemetry::ext::http::client;
 
@@ -11,3 +12,4 @@ std::shared_ptr<http_client::HttpClient> http_client::HttpClientFactory::CreateN
 {
   return std::make_shared<http_client::nosend::HttpClient>();
 }
+#endif


### PR DESCRIPTION
Fixes #1802 (issue)

can be tested with (no test target):
` bazel query '//... except kind(.*test, //...)' | xargs bazel build --cxxopt=-std=c++14`

## Changes

moves `HttpClientFactory::CreateNoSend()` under `ENABLE_TEST` flag.

For significant contributions please make sure you have completed the following items:

* [ ] `CHANGELOG.md` updated for non-trivial changes
* [ ] Unit tests have been added
* [ ] Changes in public API reviewed