### PR TITLE
Updated clone command in INSTALL.md

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -45,12 +45,12 @@ You can link OpenTelemetry C++ SDK with libraries provided in
 
 ### Building as standalone CMake Project
 
-1. Getting the opentelementry-cpp source:
+1. Getting the opentelementry-cpp source with its submodules:
 
    ```console
    # Change to the directory where you want to create the code repository
    $ cd ~
-   $ mkdir source && cd source && git clone --recursive https://github.com/open-telemetry/opentelemetry-cpp
+   $ mkdir source && cd source && git clone --recurse-submodules https://github.com/open-telemetry/opentelemetry-cpp
    Cloning into 'opentelemetry-cpp'...
    ...
    Resolving deltas: 100% (3225/3225), done.


### PR DESCRIPTION
Fixes # (issue)

## Changes

Since version 2.13 of git, the `--recursive` flag has been replaced by `--recurse-submodules`. So I updated the `INSTALL.md` file to reflect that change.

See [this issue](https://stackoverflow.com/questions/3796927/how-do-i-git-clone-a-repo-including-its-submodules) for details.

For significant contributions please make sure you have completed the following items:

* [ ] `CHANGELOG.md` updated for non-trivial changes
* [ ] Unit tests have been added
* [ ] Changes in public API reviewed

I don't consider this contribution to be significant enough to add into `CHANGELOG.md`.