### PR TITLE
Fix Prometheus target name

### DIFF
--- a/exporters/prometheus/CMakeLists.txt
+++ b/exporters/prometheus/CMakeLists.txt
@@ -19,6 +19,9 @@ endif()
 
 add_library(opentelemetry_exporter_prometheus src/exporter.cc src/collector.cc
                                               src/exporter_utils.cc)
+
+set_target_properties(opentelemetry_exporter_prometheus
+                      PROPERTIES EXPORT_NAME exporter_prometheus)
 target_include_directories(
   opentelemetry_exporter_prometheus
   PUBLIC "$<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}/include>"

--- a/exporters/prometheus/CMakeLists.txt
+++ b/exporters/prometheus/CMakeLists.txt
@@ -21,7 +21,7 @@ add_library(opentelemetry_exporter_prometheus src/exporter.cc src/collector.cc
                                               src/exporter_utils.cc)
 
 set_target_properties(opentelemetry_exporter_prometheus
-                      PROPERTIES EXPORT_NAME exporter_prometheus)
+                      PROPERTIES EXPORT_NAME prometheus_exporter)
 target_include_directories(
   opentelemetry_exporter_prometheus
   PUBLIC "$<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}/include>"


### PR DESCRIPTION
Fixes #1819

## Changes

Revert back the target name for Prometheus in otel-cpp cmake config.

This is incorrect in the latest release, probably we have to plan next release bit sooner, let's discuss in community meeting. 

For significant contributions please make sure you have completed the following items:

* [ ] `CHANGELOG.md` updated for non-trivial changes
* [ ] Unit tests have been added
* [ ] Changes in public API reviewed