### PR TITLE
Fix opentelemetry-proto file exists check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ Increment the:
 
 ## [Unreleased]
 
+* [BUILD] Fix opentelemetry-proto file exists check [#1824](https://github.com/open-telemetry/opentelemetry-cpp/pull/1824)
+
 ## [1.8.0] 2022-11-27
 
 * [DOC] Update Metrics status in README.md [#1722](https://github.com/open-telemetry/opentelemetry-cpp/pull/1722)

--- a/cmake/opentelemetry-proto.cmake
+++ b/cmake/opentelemetry-proto.cmake
@@ -26,7 +26,7 @@
 #
 
 if(OTELCPP_PROTO_PATH)
-  if(NOT EXISTS(${OTELCPP_PROTO_PATH}/opentelemetry/proto/common/v1/common.proto))
+  if(NOT EXISTS "${OTELCPP_PROTO_PATH}/opentelemetry/proto/common/v1/common.proto")
     message(FATAL_ERROR "OTELCPP_PROTO_PATH does not point to a opentelemetry-proto repository")
   endif()
   message(STATUS "opentelemetry-proto dependency satisfied by: external path")


### PR DESCRIPTION
Fixes #1823

## Changes

Fix CMake `EXISTS` syntax

For significant contributions please make sure you have completed the following items:

* [x] `CHANGELOG.md` updated for non-trivial changes
* [ ] Unit tests have been added
* [ ] Changes in public API reviewed