### PR TITLE
fix typo [affecting otlp exported histogram metrics  max<uint>]

### DIFF
--- a/exporters/otlp/src/otlp_metric_utils.cc
+++ b/exporters/otlp/src/otlp_metric_utils.cc
@@ -116,7 +116,7 @@ void OtlpMetricUtils::ConvertHistogramMetric(
       }
       if (nostd::holds_alternative<int64_t>(histogram_data.max_))
       {
-        proto_histogram_point_data->set_min(nostd::get<int64_t>(histogram_data.max_));
+        proto_histogram_point_data->set_max(nostd::get<int64_t>(histogram_data.max_));
       }
       else
       {


### PR DESCRIPTION
## Changes

Trivial obvious typo affecting uint historgam max in otlp exported metrics

For significant contributions please make sure you have completed the following items:

* [ ] `CHANGELOG.md` updated for non-trivial changes
* [ ] Unit tests have been added
* [ ] Changes in public API reviewed