### PR TITLE
Change default temporality as "Cumulative" for OTLP metrics exporters

### DIFF
--- a/exporters/otlp/include/opentelemetry/exporters/otlp/otlp_grpc_metric_exporter_options.h
+++ b/exporters/otlp/include/opentelemetry/exporters/otlp/otlp_grpc_metric_exporter_options.h
@@ -22,7 +22,7 @@ struct OtlpGrpcMetricExporterOptions : public OtlpGrpcExporterOptions
 
   // Preferred Aggregation Temporality
   sdk::metrics::AggregationTemporality aggregation_temporality =
-      sdk::metrics::AggregationTemporality::kDelta;
+      sdk::metrics::AggregationTemporality::kCumulative;
 };
 
 }  // namespace otlp

--- a/exporters/otlp/include/opentelemetry/exporters/otlp/otlp_http_metric_exporter_options.h
+++ b/exporters/otlp/include/opentelemetry/exporters/otlp/otlp_http_metric_exporter_options.h
@@ -51,7 +51,7 @@ struct OtlpHttpMetricExporterOptions
 
   // Preferred Aggregation Temporality
   sdk::metrics::AggregationTemporality aggregation_temporality =
-      sdk::metrics::AggregationTemporality::kDelta;
+      sdk::metrics::AggregationTemporality::kCumulative;
 
 #ifdef ENABLE_ASYNC_EXPORT
   // Concurrent requests

--- a/exporters/otlp/test/otlp_http_metric_exporter_test.cc
+++ b/exporters/otlp/test/otlp_http_metric_exporter_test.cc
@@ -936,7 +936,7 @@ TEST_F(OtlpHttpMetricExporterTestPeer, DefaultEndpoint)
   EXPECT_EQ("http://localhost:4318/v1/metrics", GetOtlpDefaultMetricsEndpoint());
 }
 
-TEST_F(OtlpHttpMetricExporterTestPeer, CheckDefultTemporality)
+TEST_F(OtlpHttpMetricExporterTestPeer, CheckDefaultTemporality)
 {
   std::unique_ptr<OtlpHttpMetricExporter> exporter(new OtlpHttpMetricExporter());
   EXPECT_EQ(

--- a/exporters/otlp/test/otlp_http_metric_exporter_test.cc
+++ b/exporters/otlp/test/otlp_http_metric_exporter_test.cc
@@ -936,6 +936,28 @@ TEST_F(OtlpHttpMetricExporterTestPeer, DefaultEndpoint)
   EXPECT_EQ("http://localhost:4318/v1/metrics", GetOtlpDefaultMetricsEndpoint());
 }
 
+TEST_F(OtlpHttpMetricExporterTestPeer, CheckDefultTemporality)
+{
+  std::unique_ptr<OtlpHttpMetricExporter> exporter(new OtlpHttpMetricExporter());
+  EXPECT_EQ(
+      opentelemetry::sdk::metrics::AggregationTemporality::kCumulative,
+      exporter->GetAggregationTemporality(opentelemetry::sdk::metrics::InstrumentType::kCounter));
+  EXPECT_EQ(
+      opentelemetry::sdk::metrics::AggregationTemporality::kCumulative,
+      exporter->GetAggregationTemporality(opentelemetry::sdk::metrics::InstrumentType::kHistogram));
+  EXPECT_EQ(opentelemetry::sdk::metrics::AggregationTemporality::kCumulative,
+            exporter->GetAggregationTemporality(
+                opentelemetry::sdk::metrics::InstrumentType::kUpDownCounter));
+  EXPECT_EQ(opentelemetry::sdk::metrics::AggregationTemporality::kCumulative,
+            exporter->GetAggregationTemporality(
+                opentelemetry::sdk::metrics::InstrumentType::kObservableCounter));
+  EXPECT_EQ(opentelemetry::sdk::metrics::AggregationTemporality::kCumulative,
+            exporter->GetAggregationTemporality(
+                opentelemetry::sdk::metrics::InstrumentType::kObservableGauge));
+  EXPECT_EQ(opentelemetry::sdk::metrics::AggregationTemporality::kCumulative,
+            exporter->GetAggregationTemporality(
+                opentelemetry::sdk::metrics::InstrumentType::kObservableUpDownCounter));
+}
 #endif
 
 }  // namespace otlp


### PR DESCRIPTION
Fixes #1821 

## Changes
Add default temporality as "Cumulative" for OTLP exporter - https://github.com/open-telemetry/opentelemetry-specification/blob/v1.15.0/specification/metrics/sdk_exporters/otlp.md#additional-configuration

For significant contributions please make sure you have completed the following items:

* [ ] `CHANGELOG.md` updated for non-trivial changes
* [x] Unit tests have been added
* [ ] Changes in public API reviewed