### PR TITLE
Moved otlp_grpc_utils.cc to opentelemetry_exporter_otlp_grpc_client.

### DIFF
--- a/exporters/otlp/BUILD
+++ b/exporters/otlp/BUILD
@@ -96,7 +96,6 @@ cc_library(
     deps = [
         ":otlp_recordable",
         ":otlp_grpc_client",
-        ":otlp_grpc_utils",
         "//ext:headers",
         "//sdk/src/trace",
 

--- a/exporters/otlp/BUILD
+++ b/exporters/otlp/BUILD
@@ -47,31 +47,16 @@ cc_library(
 )
 
 cc_library(
-    name = "otlp_grpc_utils",
-    srcs = [
-        "src/otlp_grpc_utils.cc",
-    ],
-    hdrs = [
-        "include/opentelemetry/exporters/otlp/otlp_grpc_utils.h",
-    ],
-    strip_include_prefix = "include",
-    tags = ["otlp"],
-    deps = [
-        "//api",
-        "//sdk:headers",
-        "@com_github_grpc_grpc//:grpc++",
-    ],
-)
-
-cc_library(
     name = "otlp_grpc_client",
     srcs = [
         "src/otlp_grpc_client.cc",
+        "src/otlp_grpc_utils.cc",
     ],
     hdrs = [
         "include/opentelemetry/exporters/otlp/otlp_environment.h",
         "include/opentelemetry/exporters/otlp/otlp_grpc_client.h",
         "include/opentelemetry/exporters/otlp/otlp_grpc_exporter_options.h",
+        "include/opentelemetry/exporters/otlp/otlp_grpc_utils.h",
         "include/opentelemetry/exporters/otlp/protobuf_include_prefix.h",
         "include/opentelemetry/exporters/otlp/protobuf_include_suffix.h",
     ],

--- a/exporters/otlp/CMakeLists.txt
+++ b/exporters/otlp/CMakeLists.txt
@@ -2,7 +2,7 @@ add_library(
   opentelemetry_otlp_recordable
   src/otlp_log_recordable.cc src/otlp_recordable.cc
   src/otlp_populate_attribute_utils.cc src/otlp_recordable_utils.cc
-  src/otlp_metric_utils.cc src/otlp_grpc_utils.cc)
+  src/otlp_metric_utils.cc)
 set_target_properties(opentelemetry_otlp_recordable PROPERTIES EXPORT_NAME
                                                                otlp_recordable)
 
@@ -24,7 +24,8 @@ target_link_libraries(opentelemetry_otlp_recordable
 
 if(WITH_OTLP_GRPC)
   find_package(gRPC REQUIRED)
-  add_library(opentelemetry_exporter_otlp_grpc_client src/otlp_grpc_client.cc)
+  add_library(opentelemetry_exporter_otlp_grpc_client src/otlp_grpc_client.cc
+                                                      src/otlp_grpc_utils.cc)
   set_target_properties(opentelemetry_exporter_otlp_grpc_client
                         PROPERTIES EXPORT_NAME otlp_grpc_client)
   target_link_libraries(

--- a/exporters/otlp/CMakeLists.txt
+++ b/exporters/otlp/CMakeLists.txt
@@ -49,6 +49,10 @@ if(WITH_OTLP_GRPC)
   list(APPEND OPENTELEMETRY_OTLP_TARGETS
        opentelemetry_exporter_otlp_grpc_client)
 
+  add_library(opentelemetry_exporter_otlp_grpc_utils src/otlp_grpc_utils.cc)
+  set_target_properties(opentelemetry_exporter_otlp_grpc_utils
+                        PROPERTIES EXPORT_NAME otlp_grpc_utils)
+
   add_library(opentelemetry_exporter_otlp_grpc
               src/otlp_grpc_exporter.cc src/otlp_grpc_exporter_factory.cc)
 

--- a/exporters/otlp/CMakeLists.txt
+++ b/exporters/otlp/CMakeLists.txt
@@ -49,10 +49,6 @@ if(WITH_OTLP_GRPC)
   list(APPEND OPENTELEMETRY_OTLP_TARGETS
        opentelemetry_exporter_otlp_grpc_client)
 
-  add_library(opentelemetry_exporter_otlp_grpc_utils src/otlp_grpc_utils.cc)
-  set_target_properties(opentelemetry_exporter_otlp_grpc_utils
-                        PROPERTIES EXPORT_NAME otlp_grpc_utils)
-
   add_library(opentelemetry_exporter_otlp_grpc
               src/otlp_grpc_exporter.cc src/otlp_grpc_exporter_factory.cc)
 


### PR DESCRIPTION
Fixes #1826

## Changes

Moved otlp_grpc_utils.cc to opentelemetry_exporter_otlp_grpc_client.

For significant contributions please make sure you have completed the following items:

* [ ] `CHANGELOG.md` updated for non-trivial changes
* [ ] Unit tests have been added
* [ ] Changes in public API reviewed