### PR TITLE
Integrate CPack for binary package

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ Increment the:
 ## [Unreleased]
 
 * [BUILD] Fix opentelemetry-proto file exists check [#1824](https://github.com/open-telemetry/opentelemetry-cpp/pull/1824)
+* [BUILD] Generate binary package with CPack [#1834](https://github.com/open-telemetry/opentelemetry-cpp/pull/1834)
 
 ## [1.8.0] 2022-11-27
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,7 +10,14 @@ if(${CMAKE_VERSION} VERSION_GREATER_EQUAL "3.12")
   cmake_policy(SET CMP0074 NEW)
 endif()
 
-project(opentelemetry-cpp)
+project(opentelemetry-cpp VERSION 1.8.0)
+
+set(CPACK_PACKAGE_VENDOR "OpenTelemetry")
+set(CPACK_PACKAGE_DESCRIPTION "The C++ OpenTelemetry client.")
+set(CPACK_PACKAGE_HOMEPAGE_URL "https://opentelemetry.io/")
+set(CPACK_RPM_PACKAGE_LICENSE "Apache-2.0")
+
+include(CPack)
 
 # Mark variables as used so cmake doesn't complain about them
 mark_as_advanced(CMAKE_TOOLCHAIN_FILE)


### PR DESCRIPTION
Fixes #1834

## Changes

Please provide a brief description of the changes here.

- Integrate `CPack` in the CMake build system
- Generate binary package with `make package` or `ninja package`

For significant contributions please make sure you have completed the following items:

* [x] `CHANGELOG.md` updated for non-trivial changes
* [ ] Unit tests have been added
* [ ] Changes in public API reviewed