### PR TITLE
Fix console debug logs for otlp exporters.

### DIFF
--- a/examples/otlp/http_log_main.cc
+++ b/examples/otlp/http_log_main.cc
@@ -6,6 +6,7 @@
 #  include "opentelemetry/exporters/otlp/otlp_http_log_record_exporter_factory.h"
 #  include "opentelemetry/exporters/otlp/otlp_http_log_record_exporter_options.h"
 #  include "opentelemetry/logs/provider.h"
+#  include "opentelemetry/sdk/common/global_log_handler.h"
 #  include "opentelemetry/sdk/logs/logger_provider_factory.h"
 #  include "opentelemetry/sdk/logs/simple_log_record_processor_factory.h"
 #  include "opentelemetry/sdk/trace/simple_processor_factory.h"
@@ -26,6 +27,8 @@ namespace otlp      = opentelemetry::exporter::otlp;
 namespace logs_sdk  = opentelemetry::sdk::logs;
 namespace logs      = opentelemetry::logs;
 namespace trace_sdk = opentelemetry::sdk::trace;
+
+namespace internal_log = opentelemetry::sdk::common::internal_log;
 
 namespace
 {
@@ -56,6 +59,15 @@ void InitLogger()
 }
 }  // namespace
 
+/*
+  Usage:
+  - example_otlp_http_log
+  - example_otlp_http_log <URL>
+  - example_otlp_http_log <URL> <DEBUG>
+  - example_otlp_http_log <URL> <DEBUG> <BIN>
+  <DEBUG> = yes|no, to turn console debug on or off
+  <BIN> = bin, to export in binary format
+*/
 int main(int argc, char *argv[])
 {
   if (argc > 1)
@@ -78,6 +90,12 @@ int main(int argc, char *argv[])
       }
     }
   }
+
+  if (opts.console_debug)
+  {
+    internal_log::GlobalLogHandler::SetLogLevel(internal_log::LogLevel::Debug);
+  }
+
   InitLogger();
   InitTracer();
   foo_library();

--- a/examples/otlp/http_main.cc
+++ b/examples/otlp/http_main.cc
@@ -3,6 +3,7 @@
 
 #include "opentelemetry/exporters/otlp/otlp_http_exporter_factory.h"
 #include "opentelemetry/exporters/otlp/otlp_http_exporter_options.h"
+#include "opentelemetry/sdk/common/global_log_handler.h"
 #include "opentelemetry/sdk/trace/simple_processor_factory.h"
 #include "opentelemetry/sdk/trace/tracer_provider_factory.h"
 #include "opentelemetry/trace/provider.h"
@@ -20,6 +21,8 @@ namespace nostd     = opentelemetry::nostd;
 namespace trace_sdk = opentelemetry::sdk::trace;
 namespace otlp      = opentelemetry::exporter::otlp;
 
+namespace internal_log = opentelemetry::sdk::common::internal_log;
+
 namespace
 {
 opentelemetry::exporter::otlp::OtlpHttpExporterOptions opts;
@@ -35,6 +38,15 @@ void InitTracer()
 }
 }  // namespace
 
+/*
+  Usage:
+  - example_otlp_http
+  - example_otlp_http <URL>
+  - example_otlp_http <URL> <DEBUG>
+  - example_otlp_http <URL> <DEBUG> <BIN>
+  <DEBUG> = yes|no, to turn console debug on or off
+  <BIN> = bin, to export in binary format
+*/
 int main(int argc, char *argv[])
 {
   if (argc > 1)
@@ -55,6 +67,12 @@ int main(int argc, char *argv[])
       }
     }
   }
+
+  if (opts.console_debug)
+  {
+    internal_log::GlobalLogHandler::SetLogLevel(internal_log::LogLevel::Debug);
+  }
+
   // Removing this line will leave the default noop TracerProvider in place.
   InitTracer();
 

--- a/exporters/elasticsearch/src/es_log_record_exporter.cc
+++ b/exporters/elasticsearch/src/es_log_record_exporter.cc
@@ -355,8 +355,8 @@ sdk::common::ExportResult ElasticsearchLogRecordExporter::Export(
         }
         else
         {
-          OTEL_INTERNAL_LOG_DEBUG("[ES Log Exporter] DEBUG: Export " << span_count
-                                                                     << " trace span(s) success");
+          OTEL_INTERNAL_LOG_DEBUG("[ES Log Exporter] Export " << span_count
+                                                              << " trace span(s) success");
         }
         return true;
       },

--- a/exporters/otlp/src/otlp_http_client.cc
+++ b/exporters/otlp/src/otlp_http_client.cc
@@ -113,7 +113,7 @@ public:
       {
         log_message = BuildResponseLogMessage(response, body_);
 
-        OTEL_INTERNAL_LOG_ERROR("OTLP HTTP Client] Export failed, " << log_message);
+        OTEL_INTERNAL_LOG_ERROR("[OTLP HTTP Client] Export failed, " << log_message);
         result = sdk::common::ExportResult::kFailure;
       }
       else if (console_debug_)
@@ -289,7 +289,7 @@ public:
       case http_client::SessionState::WriteError:
         if (console_debug_)
         {
-          OTEL_INTERNAL_LOG_DEBUG("[OTLP HTTP Client] DEBUG:Session state: error writing request");
+          OTEL_INTERNAL_LOG_DEBUG("[OTLP HTTP Client] Session state: error writing request");
         }
         break;
 
@@ -760,7 +760,7 @@ sdk::common::ExportResult OtlpHttpClient::Export(
   if (options_.console_debug)
   {
     OTEL_INTERNAL_LOG_DEBUG(
-        "[OTLP HTTP Client] DEBUG: Waiting for response from "
+        "[OTLP HTTP Client] Waiting for response from "
         << options_.url << " (timeout = "
         << std::chrono::duration_cast<std::chrono::milliseconds>(options_.timeout).count()
         << " milliseconds)");

--- a/exporters/otlp/src/otlp_http_exporter.cc
+++ b/exporters/otlp/src/otlp_http_exporter.cc
@@ -94,8 +94,8 @@ opentelemetry::sdk::common::ExportResult OtlpHttpExporter::Export(
         }
         else
         {
-          OTEL_INTERNAL_LOG_DEBUG("[OTLP HTTP Client] DEBUG: Export " << span_count
-                                                                      << " trace span(s) success");
+          OTEL_INTERNAL_LOG_DEBUG("[OTLP HTTP Client] Export " << span_count
+                                                               << " trace span(s) success");
         }
         return true;
       });
@@ -109,8 +109,7 @@ opentelemetry::sdk::common::ExportResult OtlpHttpExporter::Export(
   }
   else
   {
-    OTEL_INTERNAL_LOG_DEBUG("[OTLP HTTP Client] DEBUG: Export " << span_count
-                                                                << " trace span(s) success");
+    OTEL_INTERNAL_LOG_DEBUG("[OTLP HTTP Client] Export " << span_count << " trace span(s) success");
   }
   return opentelemetry::sdk::common::ExportResult::kSuccess;
 #endif

--- a/exporters/otlp/src/otlp_http_log_record_exporter.cc
+++ b/exporters/otlp/src/otlp_http_log_record_exporter.cc
@@ -99,8 +99,7 @@ opentelemetry::sdk::common::ExportResult OtlpHttpLogRecordExporter::Export(
         }
         else
         {
-          OTEL_INTERNAL_LOG_DEBUG("[OTLP HTTP Client] DEBUG: Export " << log_count
-                                                                      << " log(s) success");
+          OTEL_INTERNAL_LOG_DEBUG("[OTLP HTTP Client] Export " << log_count << " log(s) success");
         }
         return true;
       });
@@ -114,7 +113,7 @@ opentelemetry::sdk::common::ExportResult OtlpHttpLogRecordExporter::Export(
   }
   else
   {
-    OTEL_INTERNAL_LOG_DEBUG("[OTLP HTTP Client] DEBUG: Export " << log_count << " log(s) success");
+    OTEL_INTERNAL_LOG_DEBUG("[OTLP HTTP Client] Export " << log_count << " log(s) success");
   }
   return opentelemetry::sdk::common::ExportResult::kSuccess;
 #  endif

--- a/exporters/otlp/src/otlp_http_metric_exporter.cc
+++ b/exporters/otlp/src/otlp_http_metric_exporter.cc
@@ -99,8 +99,7 @@ opentelemetry::sdk::common::ExportResult OtlpHttpMetricExporter::Export(
     }
     else
     {
-      OTEL_INTERNAL_LOG_DEBUG("[OTLP HTTP Client] DEBUG: Export " << metric_count
-                                                                  << " metric(s) success");
+      OTEL_INTERNAL_LOG_DEBUG("[OTLP HTTP Client] Export " << metric_count << " metric(s) success");
     }
     return true;
   });
@@ -114,8 +113,7 @@ opentelemetry::sdk::common::ExportResult OtlpHttpMetricExporter::Export(
   }
   else
   {
-    OTEL_INTERNAL_LOG_DEBUG("[OTLP HTTP Client] DEBUG: Export " << metric_count
-                                                                << " metric(s) success");
+    OTEL_INTERNAL_LOG_DEBUG("[OTLP HTTP Client] Export " << metric_count << " metric(s) success");
   }
   return opentelemetry::sdk::common::ExportResult::kSuccess;
 #endif

--- a/sdk/src/common/global_log_handler.cc
+++ b/sdk/src/common/global_log_handler.cc
@@ -26,7 +26,7 @@ void DefaultLogHandler::Handle(LogLevel level,
   output_s << "[" << LevelToString(level) << "] ";
   if (file != nullptr)
   {
-    output_s << "File: " << file << ":" << line;
+    output_s << "File: " << file << ":" << line << " ";
   }
   if (msg != nullptr)
   {


### PR DESCRIPTION

Fixes #1847 

## Changes

Fixed console debug logs for otlp exporters.

- Removed `DEBUG:` text from logs, redundant with `OTEL_INTERNAL_LOG_DEBUG`
- Fixed a broken `OTLP HTTP Client]` tag
- Added a space after `FILE:LINE` to separate from the log message
- Added usage comments in examples
- Set `GlobalLogHandler::SetLogLevel(LogLevel::Debug)` in examples when `console_log` is enabled

* [ ] `CHANGELOG.md` updated for non-trivial changes
* [ ] Unit tests have been added
* [ ] Changes in public API reviewed