### PR TITLE
[SEMANTIC CONVENTIONS] Upgrade to version 1.16.0 (#1853)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,9 @@ Increment the:
 
 ## [Unreleased]
 
+* [SEMANTIC CONVENTIONS] Upgrade to version 1.16.0
+  [#1854](https://github.com/open-telemetry/opentelemetry-cpp/pull/1854)
+
 ## [1.8.1] 2022-12-04
 
 * [ETW Exporter] Tail based sampling support [#1780](https://github.com/open-telemetry/opentelemetry-cpp/pull/1780)

--- a/api/include/opentelemetry/trace/semantic_conventions.h
+++ b/api/include/opentelemetry/trace/semantic_conventions.h
@@ -21,7 +21,7 @@ namespace SemanticConventions
 /**
  * The URL of the OpenTelemetry schema for these keys and values.
  */
-static constexpr const char *kSchemaUrl = "https://opentelemetry.io/schemas/1.15.0";
+static constexpr const char *kSchemaUrl = "https://opentelemetry.io/schemas/1.16.0";
 
 /**
  * The type of the exception (its fully-qualified class name, if applicable). The dynamic type of
@@ -46,13 +46,11 @@ static constexpr const char *kExceptionStacktrace = "exception.stacktrace";
 static constexpr const char *kEventName = "event.name";
 
 /**
- * The domain identifies the context in which an event happened. An event name is unique only within
-a domain.
+ * The domain identifies the business context for the events.
  *
  * <p>Notes:
-  <ul> <li>An {@code event.name} is supposed to be unique only in the context of an
-{@code event.domain}, so this allows for two events in different domains to
-have same {@code event.name}, yet be unrelated events.</li> </ul>
+  <ul> <li>Events across different domains may have same {@code event.name}, yet be
+unrelated events.</li> </ul>
  */
 static constexpr const char *kEventDomain = "event.domain";
 
@@ -860,6 +858,11 @@ static constexpr const char *kMessagingKafkaClientId = "messaging.kafka.client_i
  * Partition the message is sent to.
  */
 static constexpr const char *kMessagingKafkaPartition = "messaging.kafka.partition";
+
+/**
+ * The offset of a record in the corresponding Kafka partition.
+ */
+static constexpr const char *kMessagingKafkaMessageOffset = "messaging.kafka.message.offset";
 
 /**
  * A boolean that is true if the message is a tombstone.

--- a/buildscripts/semantic-convention/generate.sh
+++ b/buildscripts/semantic-convention/generate.sh
@@ -10,7 +10,7 @@ SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 ROOT_DIR="${SCRIPT_DIR}/../../"
 
 # freeze the spec & generator tools versions to make SemanticAttributes generation reproducible
-SEMCONV_VERSION=1.15.0
+SEMCONV_VERSION=1.16.0
 SPEC_VERSION=v$SEMCONV_VERSION
 SCHEMA_URL=https://opentelemetry.io/schemas/$SEMCONV_VERSION
 GENERATOR_VERSION=0.14.0

--- a/sdk/include/opentelemetry/sdk/resource/semantic_conventions.h
+++ b/sdk/include/opentelemetry/sdk/resource/semantic_conventions.h
@@ -23,7 +23,7 @@ namespace SemanticConventions
 /**
  * The URL of the OpenTelemetry schema for these keys and values.
  */
-static constexpr const char *kSchemaUrl = "https://opentelemetry.io/schemas/1.15.0";
+static constexpr const char *kSchemaUrl = "https://opentelemetry.io/schemas/1.16.0";
 
 /**
  * Array of brand name and version separated by a space
@@ -362,7 +362,9 @@ static constexpr const char *kFaasInstance = "faas.instance";
 static constexpr const char *kFaasMaxMemory = "faas.max_memory";
 
 /**
- * Unique host ID. For Cloud, this must be the instance_id assigned by the cloud provider.
+ * Unique host ID. For Cloud, this must be the instance_id assigned by the cloud provider. For
+ * non-containerized Linux systems, the {@code machine-id} located in {@code /etc/machine-id} or
+ * {@code /var/lib/dbus/machine-id} may be used.
  */
 static constexpr const char *kHostId = "host.id";
 
@@ -701,6 +703,8 @@ static constexpr const char *kAws = "aws";
 static constexpr const char *kAzure = "azure";
 /** Google Cloud Platform. */
 static constexpr const char *kGcp = "gcp";
+/** IBM Cloud. */
+static constexpr const char *kIbmCloud = "ibm_cloud";
 /** Tencent Cloud. */
 static constexpr const char *kTencentCloud = "tencent_cloud";
 }  // namespace CloudProviderValues
@@ -711,6 +715,8 @@ namespace CloudPlatformValues
 static constexpr const char *kAlibabaCloudEcs = "alibaba_cloud_ecs";
 /** Alibaba Cloud Function Compute. */
 static constexpr const char *kAlibabaCloudFc = "alibaba_cloud_fc";
+/** Red Hat OpenShift on Alibaba Cloud. */
+static constexpr const char *kAlibabaCloudOpenshift = "alibaba_cloud_openshift";
 /** AWS Elastic Compute Cloud. */
 static constexpr const char *kAwsEc2 = "aws_ec2";
 /** AWS Elastic Container Service. */
@@ -723,6 +729,8 @@ static constexpr const char *kAwsLambda = "aws_lambda";
 static constexpr const char *kAwsElasticBeanstalk = "aws_elastic_beanstalk";
 /** AWS App Runner. */
 static constexpr const char *kAwsAppRunner = "aws_app_runner";
+/** Red Hat OpenShift on AWS (ROSA). */
+static constexpr const char *kAwsOpenshift = "aws_openshift";
 /** Azure Virtual Machines. */
 static constexpr const char *kAzureVm = "azure_vm";
 /** Azure Container Instances. */
@@ -733,6 +741,8 @@ static constexpr const char *kAzureAks = "azure_aks";
 static constexpr const char *kAzureFunctions = "azure_functions";
 /** Azure App Service. */
 static constexpr const char *kAzureAppService = "azure_app_service";
+/** Azure Red Hat OpenShift. */
+static constexpr const char *kAzureOpenshift = "azure_openshift";
 /** Google Cloud Compute Engine (GCE). */
 static constexpr const char *kGcpComputeEngine = "gcp_compute_engine";
 /** Google Cloud Run. */
@@ -743,6 +753,10 @@ static constexpr const char *kGcpKubernetesEngine = "gcp_kubernetes_engine";
 static constexpr const char *kGcpCloudFunctions = "gcp_cloud_functions";
 /** Google Cloud App Engine (GAE). */
 static constexpr const char *kGcpAppEngine = "gcp_app_engine";
+/** Red Hat OpenShift on Google Cloud. */
+static constexpr const char *kGoogleCloudOpenshift = "google_cloud_openshift";
+/** Red Hat OpenShift on IBM Cloud. */
+static constexpr const char *kIbmCloudOpenshift = "ibm_cloud_openshift";
 /** Tencent Cloud Cloud Virtual Machine (CVM). */
 static constexpr const char *kTencentCloudCvm = "tencent_cloud_cvm";
 /** Tencent Cloud Elastic Kubernetes Service (EKS). */


### PR DESCRIPTION
Fixes #1853 

## Changes

Upgrade semantic conventions to opentelemetry-specification 1.16.0

* [X] `CHANGELOG.md` updated for non-trivial changes
* [ ] Unit tests have been added
* [X] Changes in public API reviewed