### PR TITLE
Fix #1867 Orderly shutdown in examples

### DIFF
--- a/examples/batch/main.cc
+++ b/examples/batch/main.cc
@@ -19,7 +19,7 @@ namespace nostd          = opentelemetry::nostd;
 namespace
 {
 
-void initTracer()
+void InitTracer()
 {
   auto exporter = trace_exporter::OStreamSpanExporterFactory::Create();
 
@@ -46,6 +46,12 @@ void initTracer()
   trace_api::Provider::SetTracerProvider(provider);
 }
 
+void CleanupTracer()
+{
+  std::shared_ptr<opentelemetry::trace::TracerProvider> none;
+  trace_api::Provider::SetTracerProvider(none);
+}
+
 nostd::shared_ptr<trace_api::Tracer> get_tracer()
 {
   auto provider = trace_api::Provider::GetTracerProvider();
@@ -65,7 +71,7 @@ void StartAndEndSpans()
 int main()
 {
   // Removing this line will leave the default noop TracerProvider in place.
-  initTracer();
+  InitTracer();
 
   std::cout << "Creating first batch of " << kNumSpans << " spans and waiting 3 seconds ...\n";
   StartAndEndSpans();
@@ -83,7 +89,9 @@ int main()
   StartAndEndSpans();
   printf("Shutting down and draining queue.... \n");
   std::this_thread::sleep_for(std::chrono::milliseconds(2000));
-  // We immediately let the program terminate which invokes the processor destructor
+
+  // We invoke the processor destructor
   // which in turn invokes the processor Shutdown(), which finally drains the queue of ALL
   // its spans.
+  CleanupTracer();
 }

--- a/examples/grpc/client.cc
+++ b/examples/grpc/client.cc
@@ -98,7 +98,7 @@ void RunClient(uint16_t port)
 
 int main(int argc, char **argv)
 {
-  initTracer();
+  InitTracer();
   // set global propagator
   context::propagation::GlobalTextMapPropagator::SetGlobalPropagator(
       opentelemetry::nostd::shared_ptr<context::propagation::TextMapPropagator>(
@@ -114,5 +114,6 @@ int main(int argc, char **argv)
     port = default_port;
   }
   RunClient(port);
+  CleanupTracer();
   return 0;
 }

--- a/examples/grpc/server.cc
+++ b/examples/grpc/server.cc
@@ -107,7 +107,7 @@ void RunServer(uint16_t port)
 
 int main(int argc, char **argv)
 {
-  initTracer();
+  InitTracer();
   constexpr uint16_t default_port = 8800;
   uint16_t port;
   if (argc > 1)
@@ -120,5 +120,6 @@ int main(int argc, char **argv)
   }
 
   RunServer(port);
+  CleanupTracer();
   return 0;
 }

--- a/examples/grpc/tracer_common.h
+++ b/examples/grpc/tracer_common.h
@@ -69,7 +69,7 @@ public:
   ServerContext *context_;
 };
 
-void initTracer()
+void InitTracer()
 {
   auto exporter = opentelemetry::exporter::trace::OStreamSpanExporterFactory::Create();
   auto processor =
@@ -88,6 +88,12 @@ void initTracer()
   opentelemetry::context::propagation::GlobalTextMapPropagator::SetGlobalPropagator(
       opentelemetry::nostd::shared_ptr<opentelemetry::context::propagation::TextMapPropagator>(
           new opentelemetry::trace::propagation::HttpTraceContext()));
+}
+
+void CleanupTracer()
+{
+  std::shared_ptr<opentelemetry::trace::TracerProvider> none;
+  opentelemetry::trace::Provider::SetTracerProvider(none);
 }
 
 opentelemetry::nostd::shared_ptr<opentelemetry::trace::Tracer> get_tracer(std::string tracer_name)

--- a/examples/http/client.cc
+++ b/examples/http/client.cc
@@ -73,7 +73,7 @@ void sendRequest(const std::string &url)
 
 int main(int argc, char *argv[])
 {
-  initTracer();
+  InitTracer();
   constexpr char default_host[]   = "localhost";
   constexpr char default_path[]   = "/helloworld";
   constexpr uint16_t default_port = 8800;
@@ -92,4 +92,5 @@ int main(int argc, char *argv[])
   std::string url = "http://" + std::string(default_host) + ":" + std::to_string(port) +
                     std::string(default_path);
   sendRequest(url);
+  CleanupTracer();
 }

--- a/examples/http/server.cc
+++ b/examples/http/server.cc
@@ -70,7 +70,7 @@ public:
 
 int main(int argc, char *argv[])
 {
-  initTracer();
+  InitTracer();
 
   // The port the validation service listens to can be specified via the command line.
   if (argc > 1)
@@ -91,5 +91,6 @@ int main(int argc, char *argv[])
   }
   http_server.Stop();
   root_span->End();
+  CleanupTracer();
   return 0;
 }

--- a/examples/http/tracer_common.h
+++ b/examples/http/tracer_common.h
@@ -59,7 +59,7 @@ public:
   T headers_;
 };
 
-void initTracer()
+void InitTracer()
 {
   auto exporter = opentelemetry::exporter::trace::OStreamSpanExporterFactory::Create();
   auto processor =
@@ -78,6 +78,12 @@ void initTracer()
   opentelemetry::context::propagation::GlobalTextMapPropagator::SetGlobalPropagator(
       opentelemetry::nostd::shared_ptr<opentelemetry::context::propagation::TextMapPropagator>(
           new opentelemetry::trace::propagation::HttpTraceContext()));
+}
+
+void CleanupTracer()
+{
+  std::shared_ptr<opentelemetry::trace::TracerProvider> none;
+  opentelemetry::trace::Provider::SetTracerProvider(none);
 }
 
 opentelemetry::nostd::shared_ptr<opentelemetry::trace::Tracer> get_tracer(std::string tracer_name)

--- a/examples/jaeger/main.cc
+++ b/examples/jaeger/main.cc
@@ -30,6 +30,12 @@ void InitTracer()
   // Set the global trace provider
   trace::Provider::SetTracerProvider(provider);
 }
+
+void CleanupTracer()
+{
+  std::shared_ptr<opentelemetry::trace::TracerProvider> none;
+  trace::Provider::SetTracerProvider(none);
+}
 }  // namespace
 
 int main(int argc, char *argv[])
@@ -42,4 +48,6 @@ int main(int argc, char *argv[])
   InitTracer();
 
   foo_library();
+
+  CleanupTracer();
 }

--- a/examples/metrics_simple/metrics_ostream.cc
+++ b/examples/metrics_simple/metrics_ostream.cc
@@ -26,7 +26,7 @@ namespace metrics_api     = opentelemetry::metrics;
 namespace
 {
 
-void initMetrics(const std::string &name)
+void InitMetrics(const std::string &name)
 {
   std::unique_ptr<metric_sdk::PushMetricExporter> exporter{
       new exportermetrics::OStreamMetricExporter};
@@ -83,6 +83,12 @@ void initMetrics(const std::string &name)
              std::move(histogram_view));
   metrics_api::Provider::SetMeterProvider(provider);
 }
+
+void CleanupMetrics()
+{
+  std::shared_ptr<metrics_api::MeterProvider> none;
+  metrics_api::Provider::SetMeterProvider(none);
+}
 }  // namespace
 
 int main(int argc, char **argv)
@@ -94,7 +100,7 @@ int main(int argc, char **argv)
   }
 
   std::string name{"ostream_metric_example"};
-  initMetrics(name);
+  InitMetrics(name);
 
   if (example_type == "counter")
   {
@@ -118,4 +124,6 @@ int main(int argc, char **argv)
     observable_counter_example.join();
     histogram_example.join();
   }
+
+  CleanupMetrics();
 }

--- a/examples/multi_processor/main.cc
+++ b/examples/multi_processor/main.cc
@@ -22,7 +22,7 @@ namespace nostd     = opentelemetry::nostd;
 
 namespace
 {
-std::shared_ptr<InMemorySpanData> initTracer()
+std::shared_ptr<InMemorySpanData> InitTracer()
 {
   std::shared_ptr<InMemorySpanData> data;
 
@@ -42,6 +42,12 @@ std::shared_ptr<InMemorySpanData> initTracer()
   trace_api::Provider::SetTracerProvider(std::move(provider));
 
   return data;
+}
+
+void CleanupTracer()
+{
+  std::shared_ptr<opentelemetry::trace::TracerProvider> none;
+  trace_api::Provider::SetTracerProvider(none);
 }
 
 void dumpSpans(std::vector<std::unique_ptr<trace_sdk::SpanData>> &spans)
@@ -79,9 +85,11 @@ void dumpSpans(std::vector<std::unique_ptr<trace_sdk::SpanData>> &spans)
 int main()
 {
   // Removing this line will leave the default noop TracerProvider in place.
-  std::shared_ptr<InMemorySpanData> data = initTracer();
+  std::shared_ptr<InMemorySpanData> data = InitTracer();
 
   foo_library();
   auto memory_spans = data->GetSpans();
   dumpSpans(memory_spans);
+
+  CleanupTracer();
 }

--- a/examples/multithreaded/main.cc
+++ b/examples/multithreaded/main.cc
@@ -17,7 +17,7 @@ namespace nostd     = opentelemetry::nostd;
 
 namespace
 {
-void initTracer()
+void InitTracer()
 {
   auto exporter  = opentelemetry::exporter::trace::OStreamSpanExporterFactory::Create();
   auto processor = trace_sdk::SimpleSpanProcessorFactory::Create(std::move(exporter));
@@ -26,6 +26,12 @@ void initTracer()
                                                opentelemetry::sdk::resource::Resource::Create({}));
   // Set the global trace provider
   trace_api::Provider::SetTracerProvider(provider);
+}
+
+void CleanupTracer()
+{
+  std::shared_ptr<opentelemetry::trace::TracerProvider> none;
+  trace_api::Provider::SetTracerProvider(none);
 }
 
 nostd::shared_ptr<trace_api::Tracer> get_tracer()
@@ -56,10 +62,14 @@ void run_threads()
 
 int main()
 {
-  initTracer();
+  InitTracer();
 
-  auto root_span = get_tracer()->StartSpan(__func__);
-  trace_api::Scope scope(root_span);
+  {
+    auto root_span = get_tracer()->StartSpan(__func__);
+    trace_api::Scope scope(root_span);
 
-  run_threads();
+    run_threads();
+  }
+
+  CleanupTracer();
 }

--- a/examples/otlp/grpc_log_main.cc
+++ b/examples/otlp/grpc_log_main.cc
@@ -40,6 +40,12 @@ void InitTracer()
   trace::Provider::SetTracerProvider(provider);
 }
 
+void CleanupTracer()
+{
+  std::shared_ptr<opentelemetry::trace::TracerProvider> none;
+  trace::Provider::SetTracerProvider(none);
+}
+
 void InitLogger()
 {
   // Create OTLP exporter instance
@@ -49,6 +55,12 @@ void InitLogger()
       logs_sdk::LoggerProviderFactory::Create(std::move(processor)));
 
   opentelemetry::logs::Provider::SetLoggerProvider(provider);
+}
+
+void CleanupLogger()
+{
+  nostd::shared_ptr<logs::LoggerProvider> none;
+  opentelemetry::logs::Provider::SetLoggerProvider(none);
 }
 }  // namespace
 
@@ -66,6 +78,8 @@ int main(int argc, char *argv[])
   InitLogger();
   InitTracer();
   foo_library();
+  CleanupTracer();
+  CleanupLogger();
 }
 #else
 int main()

--- a/examples/otlp/grpc_main.cc
+++ b/examples/otlp/grpc_main.cc
@@ -30,6 +30,12 @@ void InitTracer()
   // Set the global trace provider
   trace::Provider::SetTracerProvider(provider);
 }
+
+void CleanupTracer()
+{
+  std::shared_ptr<opentelemetry::trace::TracerProvider> none;
+  trace::Provider::SetTracerProvider(none);
+}
 }  // namespace
 
 int main(int argc, char *argv[])
@@ -47,4 +53,6 @@ int main(int argc, char *argv[])
   InitTracer();
 
   foo_library();
+
+  CleanupTracer();
 }

--- a/examples/otlp/grpc_metric_main.cc
+++ b/examples/otlp/grpc_metric_main.cc
@@ -28,7 +28,7 @@ namespace
 
 otlp_exporter::OtlpGrpcMetricExporterOptions options;
 
-void initMetrics()
+void InitMetrics()
 {
   auto exporter = otlp_exporter::OtlpGrpcMetricExporterFactory::Create(options);
 
@@ -46,6 +46,12 @@ void initMetrics()
   p->AddMetricReader(std::move(reader));
 
   metrics_api::Provider::SetMeterProvider(provider);
+}
+
+void CleanupMetrics()
+{
+  std::shared_ptr<metrics_api::MeterProvider> none;
+  metrics_api::Provider::SetMeterProvider(none);
 }
 }  // namespace
 
@@ -66,7 +72,7 @@ int main(int argc, char *argv[])
     }
   }
   // Removing this line will leave the default noop MetricProvider in place.
-  initMetrics();
+  InitMetrics();
   std::string name{"otlp_grpc_metric_example"};
 
   if (example_type == "counter")
@@ -91,4 +97,6 @@ int main(int argc, char *argv[])
     observable_counter_example.join();
     histogram_example.join();
   }
+
+  CleanupMetrics();
 }

--- a/examples/otlp/http_log_main.cc
+++ b/examples/otlp/http_log_main.cc
@@ -45,6 +45,12 @@ void InitTracer()
   trace::Provider::SetTracerProvider(provider);
 }
 
+void CleanupTracer()
+{
+  std::shared_ptr<opentelemetry::trace::TracerProvider> none;
+  trace::Provider::SetTracerProvider(none);
+}
+
 opentelemetry::exporter::otlp::OtlpHttpLogRecordExporterOptions logger_opts;
 void InitLogger()
 {
@@ -56,6 +62,12 @@ void InitLogger()
       logs_sdk::LoggerProviderFactory::Create(std::move(processor));
 
   opentelemetry::logs::Provider::SetLoggerProvider(provider);
+}
+
+void CleanupLogger()
+{
+  std::shared_ptr<logs::LoggerProvider> none;
+  opentelemetry::logs::Provider::SetLoggerProvider(none);
 }
 }  // namespace
 
@@ -99,6 +111,8 @@ int main(int argc, char *argv[])
   InitLogger();
   InitTracer();
   foo_library();
+  CleanupTracer();
+  CleanupLogger();
 }
 #else
 int main()

--- a/examples/otlp/http_main.cc
+++ b/examples/otlp/http_main.cc
@@ -36,6 +36,12 @@ void InitTracer()
   // Set the global trace provider
   trace::Provider::SetTracerProvider(provider);
 }
+
+void CleanupTracer()
+{
+  std::shared_ptr<opentelemetry::trace::TracerProvider> none;
+  trace::Provider::SetTracerProvider(none);
+}
 }  // namespace
 
 /*
@@ -77,4 +83,6 @@ int main(int argc, char *argv[])
   InitTracer();
 
   foo_library();
+
+  CleanupTracer();
 }

--- a/examples/prometheus/main.cc
+++ b/examples/prometheus/main.cc
@@ -26,7 +26,7 @@ namespace metrics_api      = opentelemetry::metrics;
 namespace
 {
 
-void initMetrics(const std::string &name, const std::string &addr)
+void InitMetrics(const std::string &name, const std::string &addr)
 {
   metrics_exporter::PrometheusExporterOptions opts;
   if (!addr.empty())
@@ -73,6 +73,12 @@ void initMetrics(const std::string &name, const std::string &addr)
              std::move(histogram_view));
   metrics_api::Provider::SetMeterProvider(provider);
 }
+
+void CleanupMetrics()
+{
+  std::shared_ptr<metrics_api::MeterProvider> none;
+  metrics_api::Provider::SetMeterProvider(none);
+}
 }  // namespace
 
 int main(int argc, char **argv)
@@ -94,7 +100,7 @@ int main(int argc, char **argv)
   }
 
   std::string name{"prometheus_metric_example"};
-  initMetrics(name, addr);
+  InitMetrics(name, addr);
 
   if (example_type == "counter")
   {
@@ -111,4 +117,6 @@ int main(int argc, char **argv)
     counter_example.join();
     histogram_example.join();
   }
+
+  CleanupMetrics();
 }

--- a/examples/simple/main.cc
+++ b/examples/simple/main.cc
@@ -18,7 +18,7 @@ namespace trace_exporter = opentelemetry::exporter::trace;
 
 namespace
 {
-void initTracer()
+void InitTracer()
 {
   auto exporter  = trace_exporter::OStreamSpanExporterFactory::Create();
   auto processor = trace_sdk::SimpleSpanProcessorFactory::Create(std::move(exporter));
@@ -28,12 +28,20 @@ void initTracer()
   // Set the global trace provider
   trace_api::Provider::SetTracerProvider(provider);
 }
+
+void CleanupTracer()
+{
+  std::shared_ptr<opentelemetry::trace::TracerProvider> none;
+  trace_api::Provider::SetTracerProvider(none);
+}
 }  // namespace
 
 int main()
 {
   // Removing this line will leave the default noop TracerProvider in place.
-  initTracer();
+  InitTracer();
 
   foo_library();
+
+  CleanupTracer();
 }

--- a/examples/zipkin/main.cc
+++ b/examples/zipkin/main.cc
@@ -33,6 +33,12 @@ void InitTracer()
   // Set the global trace provider
   trace::Provider::SetTracerProvider(provider);
 }
+
+void CleanupTracer()
+{
+  std::shared_ptr<opentelemetry::trace::TracerProvider> none;
+  trace::Provider::SetTracerProvider(none);
+}
 }  // namespace
 
 int main(int argc, char *argv[])
@@ -45,4 +51,6 @@ int main(int argc, char *argv[])
   InitTracer();
 
   foo_library();
+
+  CleanupTracer();
 }


### PR DESCRIPTION
Fixes #1867

## Changes

Implemented explicit cleanup for:

- The global Tracer provider
- The global Meter provider
- The global Logger provider

in examples.

This is needed to shutdown opentelemetry-cpp in a controlled way.

* [ ] `CHANGELOG.md` updated for non-trivial changes
* [ ] Unit tests have been added
* [ ] Changes in public API reviewed