### PR TITLE
Log a warning when the BatchSpanProcessor queue is full.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@ Increment the:
   cmake when using C++20 [#1852](https://github.com/open-telemetry/opentelemetry-cpp/pull/1852)
 * [SEMANTIC CONVENTIONS] Upgrade to version 1.16.0
   [#1854](https://github.com/open-telemetry/opentelemetry-cpp/pull/1854)
+* [SDK] BatchSpanProcessor now logs a warning when dropping a span because the queue is full 
+  [1871](https://github.com/open-telemetry/opentelemetry-cpp/pull/1871)
 
 ## [1.8.1] 2022-12-04
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,9 +20,10 @@ Increment the:
   cmake when using C++20 [#1852](https://github.com/open-telemetry/opentelemetry-cpp/pull/1852)
 * [SEMANTIC CONVENTIONS] Upgrade to version 1.16.0
   [#1854](https://github.com/open-telemetry/opentelemetry-cpp/pull/1854)
-* [SDK] BatchSpanProcessor now logs a warning when dropping a span because the queue is full
+* [SDK] BatchSpanProcessor now logs a warning when dropping a span because the
+  queue is full
   [1871](https://github.com/open-telemetry/opentelemetry-cpp/pull/1871)
-
+  
 ## [1.8.1] 2022-12-04
 
 * [ETW Exporter] Tail based sampling support [#1780](https://github.com/open-telemetry/opentelemetry-cpp/pull/1780)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@ Increment the:
   cmake when using C++20 [#1852](https://github.com/open-telemetry/opentelemetry-cpp/pull/1852)
 * [SEMANTIC CONVENTIONS] Upgrade to version 1.16.0
   [#1854](https://github.com/open-telemetry/opentelemetry-cpp/pull/1854)
-* [SDK] BatchSpanProcessor now logs a warning when dropping a span because the queue is full 
+* [SDK] BatchSpanProcessor now logs a warning when dropping a span because the queue is full
   [1871](https://github.com/open-telemetry/opentelemetry-cpp/pull/1871)
 
 ## [1.8.1] 2022-12-04

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,7 @@ Increment the:
 * [SDK] BatchSpanProcessor now logs a warning when dropping a span because the
   queue is full
   [1871](https://github.com/open-telemetry/opentelemetry-cpp/pull/1871)
-  
+
 ## [1.8.1] 2022-12-04
 
 * [ETW Exporter] Tail based sampling support [#1780](https://github.com/open-telemetry/opentelemetry-cpp/pull/1780)

--- a/sdk/src/trace/batch_span_processor.cc
+++ b/sdk/src/trace/batch_span_processor.cc
@@ -3,6 +3,7 @@
 
 #include "opentelemetry/sdk/trace/batch_span_processor.h"
 #include "opentelemetry/common/spin_lock_mutex.h"
+#include "opentelemetry/sdk/common/global_log_handler.h"
 
 #include <vector>
 using opentelemetry::sdk::common::AtomicUniquePtr;
@@ -51,6 +52,7 @@ void BatchSpanProcessor::OnEnd(std::unique_ptr<Recordable> &&span) noexcept
 
   if (buffer_.Add(span) == false)
   {
+    OTEL_INTERNAL_LOG_WARN("BatchSpanProcessor queue is full - dropping span.");
     return;
   }
 

--- a/sdk/test/trace/batch_span_processor_test.cc
+++ b/sdk/test/trace/batch_span_processor_test.cc
@@ -190,10 +190,10 @@ struct MockLogHandler : public sdk::common::internal_log::LogHandler
   using Message = std::pair<sdk::common::internal_log::LogLevel, std::string>;
 
   void Handle(sdk::common::internal_log::LogLevel level,
-              const char *file,
-              int line,
+              const char * /*file*/,
+              int /*line*/,
               const char *msg,
-              const sdk::common::AttributeMap &attributes) noexcept
+              const sdk::common::AttributeMap & /*attributes*/) noexcept
   {
     messages.emplace_back(level, msg);
   }

--- a/sdk/test/trace/batch_span_processor_test.cc
+++ b/sdk/test/trace/batch_span_processor_test.cc
@@ -193,7 +193,7 @@ struct MockLogHandler : public sdk::common::internal_log::LogHandler
               const char * /*file*/,
               int /*line*/,
               const char *msg,
-              const sdk::common::AttributeMap & /*attributes*/) noexcept
+              const sdk::common::AttributeMap & /*attributes*/) noexcept override
   {
     messages.emplace_back(level, msg);
   }

--- a/sdk/test/trace/batch_span_processor_test.cc
+++ b/sdk/test/trace/batch_span_processor_test.cc
@@ -236,12 +236,14 @@ TEST_F(BatchSpanProcessorTestPeer, TestManySpansLoss)
   EXPECT_GE(max_queue_size, spans_received->size());
 
   // At least one log message warning about the dropped span should have been emitted by now.
-  auto &vec = dynamic_cast<MockLogHandler *>(log_handler.get())->messages;
-  EXPECT_TRUE(std::find(vec.begin(), vec.end(),
-                        MockLogHandler::Message(
-                            sdk::common::internal_log::LogLevel::Warning,
-                            "BatchSpanProcessor queue is full - dropping span.")) != vec.end());
-
+#if OTEL_INTERNAL_LOG_LEVEL >= OTEL_INTERNAL_LOG_LEVEL_WARN
+  auto &messages = static_cast<MockLogHandler *>(log_handler.get())->messages;
+  EXPECT_TRUE(
+      std::find(messages.begin(), messages.end(),
+                MockLogHandler::Message(sdk::common::internal_log::LogLevel::Warning,
+                                        "BatchSpanProcessor queue is full - dropping span.")) !=
+      messages.end());
+#endif
   // Reinstate the default log handler.
   sdk::common::internal_log::GlobalLogHandler::SetLogHandler(
       nostd::shared_ptr<sdk::common::internal_log::LogHandler>(

--- a/sdk/test/trace/batch_span_processor_test.cc
+++ b/sdk/test/trace/batch_span_processor_test.cc
@@ -215,10 +215,13 @@ TEST_F(BatchSpanProcessorTestPeer, TestManySpansLoss)
 
   const int max_queue_size = 4096;
 
+  sdk::trace::BatchSpanProcessorOptions bsp_options;
+  bsp_options.max_export_batch_size = 16;
+
   auto batch_processor =
       std::shared_ptr<sdk::trace::BatchSpanProcessor>(new sdk::trace::BatchSpanProcessor(
           std::unique_ptr<MockSpanExporter>(new MockSpanExporter(spans_received, is_shutdown)),
-          sdk::trace::BatchSpanProcessorOptions()));
+          bsp_options));
 
   auto test_spans = GetTestSpans(batch_processor, max_queue_size);
 
@@ -226,9 +229,6 @@ TEST_F(BatchSpanProcessorTestPeer, TestManySpansLoss)
   {
     batch_processor->OnEnd(std::move(test_spans->at(i)));
   }
-
-  // Give some time to export the spans
-  std::this_thread::sleep_for(std::chrono::milliseconds(700));
 
   EXPECT_TRUE(batch_processor->ForceFlush());
 

--- a/sdk/test/trace/batch_span_processor_test.cc
+++ b/sdk/test/trace/batch_span_processor_test.cc
@@ -241,6 +241,11 @@ TEST_F(BatchSpanProcessorTestPeer, TestManySpansLoss)
                         MockLogHandler::Message(
                             sdk::common::internal_log::LogLevel::Warning,
                             "BatchSpanProcessor queue is full - dropping span.")) != vec.end());
+
+  // Reinstate the default log handler.
+  sdk::common::internal_log::GlobalLogHandler::SetLogHandler(
+      nostd::shared_ptr<sdk::common::internal_log::LogHandler>(
+          new sdk::common::internal_log::DefaultLogHandler()));
 }
 
 TEST_F(BatchSpanProcessorTestPeer, TestManySpansLossLess)

--- a/sdk/test/trace/batch_span_processor_test.cc
+++ b/sdk/test/trace/batch_span_processor_test.cc
@@ -215,13 +215,10 @@ TEST_F(BatchSpanProcessorTestPeer, TestManySpansLoss)
 
   const int max_queue_size = 4096;
 
-  sdk::trace::BatchSpanProcessorOptions bsp_options;
-  bsp_options.max_export_batch_size = 16;
-
   auto batch_processor =
       std::shared_ptr<sdk::trace::BatchSpanProcessor>(new sdk::trace::BatchSpanProcessor(
           std::unique_ptr<MockSpanExporter>(new MockSpanExporter(spans_received, is_shutdown)),
-          bsp_options));
+          sdk::trace::BatchSpanProcessorOptions()));
 
   auto test_spans = GetTestSpans(batch_processor, max_queue_size);
 
@@ -229,6 +226,9 @@ TEST_F(BatchSpanProcessorTestPeer, TestManySpansLoss)
   {
     batch_processor->OnEnd(std::move(test_spans->at(i)));
   }
+
+  // Give some time to export the spans
+  std::this_thread::sleep_for(std::chrono::milliseconds(700));
 
   EXPECT_TRUE(batch_processor->ForceFlush());
 


### PR DESCRIPTION
Fixes #1870 

## Changes

Adds a warning when a span is dropped in case the `BatchSpanProcessor` queue is full.

* [x] `CHANGELOG.md` updated for non-trivial changes
* [x] Unit tests have been added
* [n/a] Changes in public API reviewed