### PR TITLE
Migrate from @bazel_tools//platforms to https://github.com/bazelbuild/platforms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@ Increment the:
   cmake when using C++20 [#1852](https://github.com/open-telemetry/opentelemetry-cpp/pull/1852)
 * [SEMANTIC CONVENTIONS] Upgrade to version 1.16.0
   [#1854](https://github.com/open-telemetry/opentelemetry-cpp/pull/1854)
+* [BUILD] Migrate from @bazel_tools//platforms to [Bazel Platforms](https://github.com/bazelbuild/platforms)
+  to enable Bazel 6.0.0 compatibility [#1873](https://github.com/open-telemetry/opentelemetry-cpp/pull/1873)
 
 ## [1.8.1] 2022-12-04
 

--- a/bazel/BUILD
+++ b/bazel/BUILD
@@ -2,5 +2,5 @@ package(default_visibility = ["//:__subpackages__"])
 
 config_setting(
     name = "windows",
-    constraint_values = ["@bazel_tools//platforms:windows"],
+    constraint_values = ["@platforms//os:windows"],
 )

--- a/bazel/curl.BUILD
+++ b/bazel/curl.BUILD
@@ -7,7 +7,7 @@ package(features = ["no_copts_tokenization"])
 config_setting(
     name = "windows",
     constraint_values = [
-        "@bazel_tools//platforms:windows",
+        "@platforms//os:windows",
     ],
     visibility = ["//visibility:private"],
 )
@@ -15,7 +15,7 @@ config_setting(
 config_setting(
     name = "osx",
     constraint_values = [
-        "@bazel_tools//platforms:osx",
+        "@platforms//os:osx",
     ],
     visibility = ["//visibility:private"],
 )

--- a/bazel/repository.bzl
+++ b/bazel/repository.bzl
@@ -43,10 +43,10 @@ def opentelemetry_cpp_deps():
     maybe(
         http_archive,
         name = "com_google_googletest",
-        sha256 = "a03a7b24b3a0766dc823c9008dd32c56a1183889c04f084653266af22289ab0c",
-        strip_prefix = "googletest-a6dfd3aca7f2f91f95fc7ab650c95a48420d513d",
+        sha256 = "81964fe578e9bd7c94dfdb09c8e4d6e6759e19967e397dbea48d1c10e45d0df2",
+        strip_prefix = "googletest-release-1.12.1",
         urls = [
-            "https://github.com/google/googletest/archive/a6dfd3aca7f2f91f95fc7ab650c95a48420d513d.tar.gz",
+            "https://github.com/google/googletest/archive/release-1.12.1.tar.gz",
         ],
     )
 
@@ -85,10 +85,10 @@ def opentelemetry_cpp_deps():
     maybe(
         http_archive,
         name = "com_github_grpc_grpc",
-        sha256 = "320366665d19027cda87b2368c03939006a37e0388bfd1091c8d2a96fbc93bd8",
-        strip_prefix = "grpc-1.48.1",
+        sha256 = "cdeb805385fba23242bf87073e68d590c446751e09089f26e5e0b3f655b0f089",
+        strip_prefix = "grpc-1.49.2",
         urls = [
-            "https://github.com/grpc/grpc/archive/v1.48.1.tar.gz",
+            "https://github.com/grpc/grpc/archive/v1.49.2.tar.gz",
         ],
     )
 

--- a/bazel/repository.bzl
+++ b/bazel/repository.bzl
@@ -126,6 +126,17 @@ def opentelemetry_cpp_deps():
         ],
     )
 
+    # bazel platforms
+    maybe(
+        http_archive,
+        name = "platforms",
+        sha256 = "5308fc1d8865406a49427ba24a9ab53087f17f5266a7aabbfc28823f3916e1ca",
+        urls = [
+            "https://mirror.bazel.build/github.com/bazelbuild/platforms/releases/download/0.0.6/platforms-0.0.6.tar.gz",
+            "https://github.com/bazelbuild/platforms/releases/download/0.0.6/platforms-0.0.6.tar.gz",
+        ],
+    )
+
     # libcurl (optional)
     maybe(
         http_archive,

--- a/ci/do_ci.sh
+++ b/ci/do_ci.sh
@@ -304,7 +304,7 @@ elif [[ "$1" == "bazel.e2e" ]]; then
   exit 0
 elif [[ "$1" == "benchmark" ]]; then
   [ -z "${BENCHMARK_DIR}" ] && export BENCHMARK_DIR=$HOME/benchmark
-  bazel $BAZEL_STARTUP_OPTIONS build --cxxopt=-std=c++14 $BAZEL_OPTIONS_ASYNC -c opt -- \
+  bazel $BAZEL_STARTUP_OPTIONS build --host_cxxopt=-std=c++14 --cxxopt=-std=c++14 $BAZEL_OPTIONS_ASYNC -c opt -- \
     $(bazel query 'attr("tags", "benchmark_result", ...)')
   echo ""
   echo "Benchmark results in $BENCHMARK_DIR:"
@@ -339,7 +339,7 @@ elif [[ "$1" == "code.coverage" ]]; then
   cp tmp_coverage.info coverage.info
   exit 0
 elif [[ "$1" == "third_party.tags" ]]; then
-  echo "gRPC=v1.48.1" > third_party_release
+  echo "gRPC=v1.49.2" > third_party_release
   echo "thrift=0.14.1" >> third_party_release
   echo "abseil=20220623.1" >> third_party_release
   git submodule foreach --quiet 'echo "$name=$(git describe --tags HEAD)"' | sed 's:.*/::' >> third_party_release

--- a/ci/setup_grpc.sh
+++ b/ci/setup_grpc.sh
@@ -6,7 +6,7 @@
 set -e
 export DEBIAN_FRONTEND=noninteractive
 old_grpc_version='v1.33.2'
-new_grpc_version='v1.48.1'
+new_grpc_version='v1.49.2'
 gcc_version_for_new_grpc='5.1'
 std_version='14'
 install_grpc_version=${new_grpc_version}

--- a/exporters/jaeger/BUILD
+++ b/exporters/jaeger/BUILD
@@ -14,7 +14,7 @@ constraint_value(
 config_setting(
     name = "windows",
     constraint_values = [
-        "@bazel_tools//platforms:windows",
+        "@platforms//os:windows",
     ],
     tags = ["jaeger"],
     visibility = ["//visibility:private"],
@@ -59,38 +59,38 @@ THRIFT_CACHE_ENTRIES_WIN = {
 cmake(
     name = "thrift",
     cache_entries = select({
-        "@bazel_tools//platforms:osx": THRIFT_CACHE_ENTRIES,
-        "@bazel_tools//platforms:linux": THRIFT_CACHE_ENTRIES,
-        "@bazel_tools//platforms:windows": THRIFT_CACHE_ENTRIES_WIN,
+        "@platforms//os:osx": THRIFT_CACHE_ENTRIES,
+        "@platforms//os:linux": THRIFT_CACHE_ENTRIES,
+        "@platforms//os:windows": THRIFT_CACHE_ENTRIES_WIN,
     }),
     copts = [
         "-Ilibs/exporters/jaeger/openssl/include",
         "-fexceptions",
     ],
     generate_args = select({
-        "@bazel_tools//platforms:osx": [],
-        "@bazel_tools//platforms:linux": [],
-        "@bazel_tools//platforms:windows": [
+        "@platforms//os:osx": [],
+        "@platforms//os:linux": [],
+        "@platforms//os:windows": [
             "-G \"NMake Makefiles\"",
         ],
     }),
     install = True,
     lib_source = "@com_github_thrift//:all_srcs",
     out_lib_dir = select({
-        "@bazel_tools//platforms:osx": "lib",
-        "@bazel_tools//platforms:linux": "lib",
-        "@bazel_tools//platforms:windows": "bin",
+        "@platforms//os:osx": "lib",
+        "@platforms//os:linux": "lib",
+        "@platforms//os:windows": "bin",
     }),
     out_static_libs = select({
-        "@bazel_tools//platforms:osx": [
+        "@platforms//os:osx": [
             "libthrift.a",
             "libthriftz.a",
         ],
-        "@bazel_tools//platforms:linux": [
+        "@platforms//os:linux": [
             "libthrift.a",
             "libthriftz.a",
         ],
-        "@bazel_tools//platforms:windows": [
+        "@platforms//os:windows": [
             "thriftmd.lib",
         ],
     }),
@@ -133,9 +133,9 @@ cc_library(
     strip_include_prefix = "thrift-gen",
     tags = ["jaeger"],
     deps = select({
-        "@bazel_tools//platforms:osx": THRIFT_GEN_DEPS,
-        "@bazel_tools//platforms:linux": THRIFT_GEN_DEPS,
-        "@bazel_tools//platforms:windows": THRIFT_GEN_DEPS_WIN,
+        "@platforms//os:osx": THRIFT_GEN_DEPS,
+        "@platforms//os:linux": THRIFT_GEN_DEPS,
+        "@platforms//os:windows": THRIFT_GEN_DEPS_WIN,
     }),
 )
 

--- a/third_party_release
+++ b/third_party_release
@@ -11,7 +11,7 @@
 #   git submodule status
 #
 
-gRPC=v1.48.1
+gRPC=v1.49.2
 thrift=0.14.1
 abseil=20220623.1
 benchmark=v1.5.3


### PR DESCRIPTION
## Changes

This MR migrates [platforms](https://bazel.build/extending/platforms) constraints from the deprecated `@bazel_tools//platforms` target to instead depend on the `https://github.com/bazelbuild/platforms` repository, per https://github.com/bazelbuild/bazel/issues/8622

This enables compatibility with the newly released [Bazel 6.0.0](https://github.com/bazelbuild/bazel/releases).