### PR TITLE
Change BatchLogRecordProcessorFactory::Create to static method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ Increment the:
 
 ## [Unreleased]
 
+* [METRICS] Change BatchLogRecordProcessorFactory::Create to static method
 * [BUILD] Fix OTELCPP_MAINTAINER_MODE [#1844](https://github.com/open-telemetry/opentelemetry-cpp/pull/1844)
 * [BUILD] Fix compatibility when using clang and libc++, upgrade GTest and
   cmake when using C++20 [#1852](https://github.com/open-telemetry/opentelemetry-cpp/pull/1852)

--- a/sdk/include/opentelemetry/sdk/common/global_log_handler.h
+++ b/sdk/include/opentelemetry/sdk/common/global_log_handler.h
@@ -134,7 +134,7 @@ private:
 OPENTELEMETRY_END_NAMESPACE
 
 /**
- * GlobalLogHandler and TracerProvider/MeterProvider/LoggerProvider are lazy sigletons.
+ * GlobalLogHandler and TracerProvider/MeterProvider/LoggerProvider are lazy singletons.
  * To ensure that GlobalLogHandler is the first one to be initialized (and so last to be
  * destroyed), it is first used inside the constructors of TraceProvider, MeterProvider
  * and LoggerProvider for debug logging. */

--- a/sdk/include/opentelemetry/sdk/logs/batch_log_record_processor_factory.h
+++ b/sdk/include/opentelemetry/sdk/logs/batch_log_record_processor_factory.h
@@ -27,8 +27,8 @@ public:
   /**
    * Create a BatchLogRecordProcessor.
    */
-  std::unique_ptr<LogRecordProcessor> Create(std::unique_ptr<LogRecordExporter> &&exporter,
-                                             const BatchLogRecordProcessorOptions &options);
+  static std::unique_ptr<LogRecordProcessor> Create(std::unique_ptr<LogRecordExporter> &&exporter,
+                                                    const BatchLogRecordProcessorOptions &options);
 };
 
 }  // namespace logs


### PR DESCRIPTION
Change BatchLogRecordProcessorFactory::Create to static method.
Fixed a typo in a comment.

Fixes # (issue)

## Changes

* [METRICS] Change BatchLogRecordProcessorFactory::Create to static method

Please provide a brief description of the changes here.

For significant contributions please make sure you have completed the following items:

* [ ] `CHANGELOG.md` updated for non-trivial changes
* [ ] Unit tests have been added
* [ ] Changes in public API reviewed