### PR TITLE
minor metrics handling optimizations

### DIFF
--- a/sdk/src/metrics/state/metric_collector.cc
+++ b/sdk/src/metrics/state/metric_collector.cc
@@ -40,13 +40,13 @@ bool MetricCollector::Collect(
   ResourceMetrics resource_metrics;
   meter_context_->ForEachMeter([&](std::shared_ptr<Meter> meter) noexcept {
     auto collection_ts = std::chrono::system_clock::now();
-    auto metric_data = meter->Collect(this, collection_ts);
-    if (!metric_data.empty ())
+    auto metric_data   = meter->Collect(this, collection_ts);
+    if (!metric_data.empty())
     {
       ScopeMetrics scope_metrics;
-      scope_metrics.metric_data_ = std::move (metric_data);
+      scope_metrics.metric_data_ = std::move(metric_data);
       scope_metrics.scope_       = meter->GetInstrumentationScope();
-      resource_metrics.scope_metric_data_.emplace_back(std::move (scope_metrics));
+      resource_metrics.scope_metric_data_.emplace_back(std::move(scope_metrics));
     }
     return true;
   });

--- a/sdk/src/metrics/state/metric_collector.cc
+++ b/sdk/src/metrics/state/metric_collector.cc
@@ -40,10 +40,14 @@ bool MetricCollector::Collect(
   ResourceMetrics resource_metrics;
   meter_context_->ForEachMeter([&](std::shared_ptr<Meter> meter) noexcept {
     auto collection_ts = std::chrono::system_clock::now();
-    ScopeMetrics scope_metrics;
-    scope_metrics.metric_data_ = meter->Collect(this, collection_ts);
-    scope_metrics.scope_       = meter->GetInstrumentationScope();
-    resource_metrics.scope_metric_data_.push_back(scope_metrics);
+    auto metric_data = meter->Collect(this, collection_ts);
+    if (!metric_data.empty ())
+    {
+      ScopeMetrics scope_metrics;
+      scope_metrics.metric_data_ = std::move (metric_data);
+      scope_metrics.scope_       = meter->GetInstrumentationScope();
+      resource_metrics.scope_metric_data_.emplace_back(std::move (scope_metrics));
+    }
     return true;
   });
   resource_metrics.resource_ = &meter_context_->GetResource();

--- a/sdk/src/metrics/state/temporal_metric_storage.cc
+++ b/sdk/src/metrics/state/temporal_metric_storage.cc
@@ -126,7 +126,7 @@ bool TemporalMetricStorage::buildMetrics(CollectorHandle *collector,
         PointDataAttributes point_data_attr;
         point_data_attr.point_data = aggregation.ToPoint();
         point_data_attr.attributes = attributes;
-        metric_data.point_data_attr_.emplace_back(std::move (point_data_attr));
+        metric_data.point_data_attr_.emplace_back(std::move(point_data_attr));
         return true;
       });
   return callback(metric_data);

--- a/sdk/src/metrics/state/temporal_metric_storage.cc
+++ b/sdk/src/metrics/state/temporal_metric_storage.cc
@@ -126,7 +126,7 @@ bool TemporalMetricStorage::buildMetrics(CollectorHandle *collector,
         PointDataAttributes point_data_attr;
         point_data_attr.point_data = aggregation.ToPoint();
         point_data_attr.attributes = attributes;
-        metric_data.point_data_attr_.push_back(point_data_attr);
+        metric_data.point_data_attr_.emplace_back(std::move (point_data_attr));
         return true;
       });
   return callback(metric_data);


### PR DESCRIPTION
Minor metrics handling optimizations:
- avoid few unnecessary copies
- avoid empty exports with no data points