### PR TITLE
sdk::resource::Resource::Merge should be const

### DIFF
--- a/sdk/include/opentelemetry/sdk/resource/resource.h
+++ b/sdk/include/opentelemetry/sdk/resource/resource.h
@@ -40,7 +40,7 @@ public:
    * @returns the newly merged Resource.
    */
 
-  Resource Merge(const Resource &other) noexcept;
+  Resource Merge(const Resource &other) const noexcept;
 
   /**
    * Returns a newly created Resource with the specified attributes.

--- a/sdk/src/resource/resource.cc
+++ b/sdk/src/resource/resource.cc
@@ -17,7 +17,7 @@ Resource::Resource(const ResourceAttributes &attributes, const std::string &sche
     : attributes_(attributes), schema_url_(schema_url)
 {}
 
-Resource Resource::Merge(const Resource &other) noexcept
+Resource Resource::Merge(const Resource &other) const noexcept
 {
   ResourceAttributes merged_resource_attributes(other.attributes_);
   merged_resource_attributes.insert(attributes_.begin(), attributes_.end());


### PR DESCRIPTION
Fixes #1898 (issue)

## Changes
changes `sdk::resource::Resource::Merge` to const.
Please provide a brief description of the changes here.

For significant contributions please make sure you have completed the following items:

* [ ] `CHANGELOG.md` updated for non-trivial changes
* [ ] Unit tests have been added
* [ ] Changes in public API reviewed