### PR TITLE
Make macros.h available for all source files via version.h

### DIFF
--- a/api/include/opentelemetry/common/macros.h
+++ b/api/include/opentelemetry/common/macros.h
@@ -3,8 +3,6 @@
 
 #pragma once
 
-#include <cstdint>
-
 #if !defined(OPENTELEMETRY_LIKELY_IF) && defined(__cplusplus)
 // GCC 9 has likely attribute but do not support declare it at the beginning of statement
 #  if defined(__has_cpp_attribute) && (defined(__clang__) || !defined(__GNUC__) || __GNUC__ > 9)
@@ -90,10 +88,9 @@
 
 // Regex support
 #if (__GNUC__ == 4 && (__GNUC_MINOR__ == 8 || __GNUC_MINOR__ == 9))
-#  define HAVE_WORKING_REGEX 0
+#  define OPENTELEMETRY_HAVE_WORKING_REGEX 0
 #else
-#  include <regex>
-#  define HAVE_WORKING_REGEX 1
+#  define OPENTELEMETRY_HAVE_WORKING_REGEX 1
 #endif
 
 /* clang-format off */

--- a/api/include/opentelemetry/common/macros.h
+++ b/api/include/opentelemetry/common/macros.h
@@ -5,8 +5,6 @@
 
 #include <cstdint>
 
-#include "opentelemetry/version.h"
-
 #if !defined(OPENTELEMETRY_LIKELY_IF) && defined(__cplusplus)
 // GCC 9 has likely attribute but do not support declare it at the beginning of statement
 #  if defined(__has_cpp_attribute) && (defined(__clang__) || !defined(__GNUC__) || __GNUC__ > 9)

--- a/api/include/opentelemetry/trace/trace_state.h
+++ b/api/include/opentelemetry/trace/trace_state.h
@@ -7,19 +7,15 @@
 #include <cstring>
 #include <string>
 
-#include <regex>
-#if (__GNUC__ == 4 && (__GNUC_MINOR__ == 8 || __GNUC_MINOR__ == 9))
-#  define HAVE_WORKING_REGEX 0
-#else
-#  define HAVE_WORKING_REGEX 1
-#endif
-
 #include "opentelemetry/common/kv_properties.h"
-#include "opentelemetry/common/macros.h"
 #include "opentelemetry/nostd/shared_ptr.h"
 #include "opentelemetry/nostd/span.h"
 #include "opentelemetry/nostd/string_view.h"
 #include "opentelemetry/nostd/unique_ptr.h"
+
+#if defined(OPENTELEMETRY_HAVE_WORKING_REGEX)
+#  include <regex>
+#endif
 
 OPENTELEMETRY_BEGIN_NAMESPACE
 namespace trace
@@ -212,7 +208,7 @@ public:
    */
   static bool IsValidKey(nostd::string_view key)
   {
-#if HAVE_WORKING_REGEX
+#if OPENTELEMETRY_HAVE_WORKING_REGEX
     return IsValidKeyRegEx(key);
 #else
     return IsValidKeyNonRegEx(key);
@@ -225,7 +221,7 @@ public:
    */
   static bool IsValidValue(nostd::string_view value)
   {
-#if HAVE_WORKING_REGEX
+#if OPENTELEMETRY_HAVE_WORKING_REGEX
     return IsValidValueRegEx(value);
 #else
     return IsValidValueNonRegEx(value);

--- a/api/include/opentelemetry/version.h
+++ b/api/include/opentelemetry/version.h
@@ -3,6 +3,7 @@
 
 #pragma once
 
+#include "opentelemetry/common/macros.h"
 #include "opentelemetry/detail/preprocessor.h"
 
 #define OPENTELEMETRY_ABI_VERSION_NO 1

--- a/sdk/include/opentelemetry/sdk/metrics/instrument_metadata_validator.h
+++ b/sdk/include/opentelemetry/sdk/metrics/instrument_metadata_validator.h
@@ -8,7 +8,7 @@
 #include "opentelemetry/nostd/string_view.h"
 #include "opentelemetry/version.h"
 
-#if HAVE_WORKING_REGEX
+#if OPENTELEMETRY_HAVE_WORKING_REGEX
 #  include <regex>
 #endif
 
@@ -26,7 +26,7 @@ public:
   bool ValidateDescription(nostd::string_view description) const;
 
 private:
-#if HAVE_WORKING_REGEX
+#if OPENTELEMETRY_HAVE_WORKING_REGEX
   const std::regex name_reg_key_;
   const std::regex unit_reg_key_;
 #endif

--- a/sdk/include/opentelemetry/sdk/metrics/view/predicate.h
+++ b/sdk/include/opentelemetry/sdk/metrics/view/predicate.h
@@ -8,6 +8,10 @@
 #include "opentelemetry/nostd/string_view.h"
 #include "opentelemetry/sdk/common/global_log_handler.h"
 
+#if defined(OPENTELEMETRY_HAVE_WORKING_REGEX)
+#  include <regex>
+#endif
+
 OPENTELEMETRY_BEGIN_NAMESPACE
 namespace sdk
 {
@@ -26,7 +30,7 @@ public:
   PatternPredicate(opentelemetry::nostd::string_view pattern) : reg_key_{pattern.data()} {}
   bool Match(opentelemetry::nostd::string_view str) const noexcept override
   {
-#if HAVE_WORKING_REGEX
+#if OPENTELEMETRY_HAVE_WORKING_REGEX
     return std::regex_match(str.data(), reg_key_);
 #else
     // TBD - Support regex match for GCC4.8
@@ -37,7 +41,7 @@ public:
   }
 
 private:
-#if HAVE_WORKING_REGEX
+#if OPENTELEMETRY_HAVE_WORKING_REGEX
   std::regex reg_key_;
 #else
   std::string reg_key_;

--- a/sdk/src/metrics/instrument_metadata_validator.cc
+++ b/sdk/src/metrics/instrument_metadata_validator.cc
@@ -8,6 +8,10 @@
 #include <algorithm>
 #include <iostream>
 
+#if defined(OPENTELEMETRY_HAVE_WORKING_REGEX)
+#  include <regex>
+#endif
+
 OPENTELEMETRY_BEGIN_NAMESPACE
 namespace sdk
 {
@@ -20,7 +24,7 @@ const std::string kInstrumentUnitPattern = "[\x01-\x7F]{0,63}";
 // instrument-unit = It can have a maximum length of 63 ASCII chars
 
 InstrumentMetaDataValidator::InstrumentMetaDataValidator()
-#if HAVE_WORKING_REGEX
+#if OPENTELEMETRY_HAVE_WORKING_REGEX
     // clang-format off
     : name_reg_key_{kInstrumentNamePattern},
       unit_reg_key_{kInstrumentUnitPattern}
@@ -31,7 +35,7 @@ InstrumentMetaDataValidator::InstrumentMetaDataValidator()
 bool InstrumentMetaDataValidator::ValidateName(nostd::string_view name) const
 {
 
-#if HAVE_WORKING_REGEX
+#if OPENTELEMETRY_HAVE_WORKING_REGEX
   return std::regex_match(name.data(), name_reg_key_);
 #else
   const size_t kMaxSize = 63;
@@ -53,7 +57,7 @@ bool InstrumentMetaDataValidator::ValidateName(nostd::string_view name) const
 
 bool InstrumentMetaDataValidator::ValidateUnit(nostd::string_view unit) const
 {
-#if HAVE_WORKING_REGEX
+#if OPENTELEMETRY_HAVE_WORKING_REGEX
   return std::regex_match(unit.data(), unit_reg_key_);
 #else
   const size_t kMaxSize = 63;

--- a/sdk/test/metrics/histogram_test.cc
+++ b/sdk/test/metrics/histogram_test.cc
@@ -11,6 +11,10 @@
 
 #include <gtest/gtest.h>
 
+#if defined(OPENTELEMETRY_HAVE_WORKING_REGEX)
+#  include <regex>
+#endif
+
 using namespace opentelemetry;
 using namespace opentelemetry::sdk::instrumentationscope;
 using namespace opentelemetry::sdk::metrics;
@@ -111,7 +115,7 @@ TEST(Histogram, Double)
             actual.counts_);
 }
 
-#if (HAVE_WORKING_REGEX)
+#if (OPENTELEMETRY_HAVE_WORKING_REGEX)
 // FIXME - View Preficate search is only supported through regex
 TEST(Histogram, DoubleCustomBuckets)
 {
@@ -223,7 +227,7 @@ TEST(Histogram, UInt64)
             actual.counts_);
 }
 
-#if (HAVE_WORKING_REGEX)
+#if (OPENTELEMETRY_HAVE_WORKING_REGEX)
 // FIXME - View Preficate search is only supported through regex
 TEST(Histogram, UInt64CustomBuckets)
 {

--- a/sdk/test/metrics/view_registry_test.cc
+++ b/sdk/test/metrics/view_registry_test.cc
@@ -8,6 +8,10 @@
 
 #include <gtest/gtest.h>
 
+#if defined(OPENTELEMETRY_HAVE_WORKING_REGEX)
+#  include <regex>
+#endif
+
 using namespace opentelemetry::sdk::metrics;
 using namespace opentelemetry::sdk::instrumentationscope;
 
@@ -28,14 +32,14 @@ TEST(ViewRegistry, FindViewsEmptyRegistry)
       registry.FindViews(default_instrument_descriptor, *default_instrumentation_scope.get(),
                          [&count](const View &view) {
                            count++;
-#if HAVE_WORKING_REGEX
+#if OPENTELEMETRY_HAVE_WORKING_REGEX
                            EXPECT_EQ(view.GetName(), "");
                            EXPECT_EQ(view.GetDescription(), "");
 #endif
                            EXPECT_EQ(view.GetAggregationType(), AggregationType::kDefault);
                            return true;
                          });
-#if HAVE_WORKING_REGEX
+#if OPENTELEMETRY_HAVE_WORKING_REGEX
   EXPECT_EQ(count, 1);
   EXPECT_EQ(status, true);
 #endif
@@ -73,13 +77,13 @@ TEST(ViewRegistry, FindNonExistingView)
       registry.FindViews(default_instrument_descriptor, *default_instrumentation_scope.get(),
                          [&count, &view_name, &view_description](const View &view) {
                            count++;
-#if HAVE_WORKING_REGEX
+#if OPENTELEMETRY_HAVE_WORKING_REGEX
                            EXPECT_EQ(view.GetName(), view_name);
                            EXPECT_EQ(view.GetDescription(), view_description);
 #endif
                            return true;
                          });
-#if HAVE_WORKING_REGEX
+#if OPENTELEMETRY_HAVE_WORKING_REGEX
   EXPECT_EQ(count, 1);
   EXPECT_EQ(status, true);
 #endif


### PR DESCRIPTION
## Changes

As the macros defined in `macros.h` is general for all sources, including it in `version.h` to make it available for all sources (no need for separate `#include "opentelemetry/common/macros.h"` statement.

For significant contributions please make sure you have completed the following items:

* [ ] `CHANGELOG.md` updated for non-trivial changes
* [ ] Unit tests have been added
* [ ] Changes in public API reviewed