### PR TITLE
Fix warning for misconfiguration of PeriodicExportingMetricReader

### DIFF
--- a/sdk/src/metrics/export/periodic_exporting_metric_reader.cc
+++ b/sdk/src/metrics/export/periodic_exporting_metric_reader.cc
@@ -30,7 +30,7 @@ PeriodicExportingMetricReader::PeriodicExportingMetricReader(
   {
     OTEL_INTERNAL_LOG_WARN(
         "[Periodic Exporting Metric Reader] Invalid configuration: "
-        "export_interval_millis_ should be less than export_timeout_millis_, using default values");
+        "export_timeout_millis_ should be less than export_interval_millis_, using default values");
     export_interval_millis_ = kExportIntervalMillis;
     export_timeout_millis_  = kExportTimeOutMillis;
   }


### PR DESCRIPTION
## Changes

The periodically exporting metric reader requires the timeout field to be strictly less than the interval field. However, the warning that is logged out gives the opposite requirement. The existing logic in the code is correct.