### PR TITLE
Small fix in INSTALL.md for enabling building package.

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -285,7 +285,7 @@ configuration
 
    ```console
    $ cd opentelemetry-cpp
-   $ mkdir build && cd build && cmake -DBUILD_PACKAGE ..
+   $ mkdir build && cd build && cmake -DBUILD_PACKAGE=ON ..
 
    -- Package name: opentelemetry-cpp-1.8.1-ubuntu-20.04-x86_64.deb
    -- Configuring done


### PR DESCRIPTION
## Changes

Please provide a brief description of the changes here.
Fix documentation to use `cmake -DBUILD_PACKAGE=ON ..` to configure building package.
For significant contributions please make sure you have completed the following items:

* [ ] `CHANGELOG.md` updated for non-trivial changes
* [ ] Unit tests have been added
* [ ] Changes in public API reviewed