### PR TITLE
[BUILD] OTLP HTTP Exporter has build warnings in maintainer mode

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,9 +41,11 @@ jobs:
         CC: /usr/bin/gcc-12
         CXX: /usr/bin/g++-12
         GOOGLETEST_VERSION: 1.12.1
+        PROTOBUF_VERSION: 21.12
       run: |
         sudo -E ./ci/setup_cmake.sh
         sudo -E ./ci/setup_ci_environment.sh
+        sudo -E ./ci/install_protobuf.sh
     - name: run cmake gcc (maintainer mode)
       env:
         CC: /usr/bin/gcc-12
@@ -64,9 +66,11 @@ jobs:
         CC: /usr/bin/clang-14
         CXX: /usr/bin/clang++-14
         GOOGLETEST_VERSION: 1.12.1
+        PROTOBUF_VERSION: 21.12
       run: |
         sudo -E ./ci/setup_cmake.sh
         sudo -E ./ci/setup_ci_environment.sh
+        sudo -E ./ci/install_protobuf.sh
     - name: run cmake clang (maintainer mode)
       env:
         CC: /usr/bin/clang-14

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,8 @@ Increment the:
   [#1916](https://github.com/open-telemetry/opentelemetry-cpp/pull/1916)
 * [SEMANTIC CONVENTIONS] Upgrade to version 1.17.0
   [#1927](https://github.com/open-telemetry/opentelemetry-cpp/pull/1927)
+* [BUILD] OTLP HTTP Exporter has build warnings in maintainer mode
+  [#1943](https://github.com/open-telemetry/opentelemetry-cpp/pull/1943)
 
 Important changes:
 

--- a/ci/do_ci.sh
+++ b/ci/do_ci.sh
@@ -94,6 +94,8 @@ elif [[ "$1" == "cmake.maintainer.test" ]]; then
   cd "${BUILD_DIR}"
   rm -rf *
   cmake -DCMAKE_BUILD_TYPE=Debug  \
+        -DWITH_OTLP=ON \
+        -DWITH_OTLP_HTTP=ON \
         -DWITH_PROMETHEUS=ON \
         -DWITH_EXAMPLES=ON \
         -DWITH_EXAMPLES_HTTP=ON \

--- a/ci/install_protobuf.sh
+++ b/ci/install_protobuf.sh
@@ -38,5 +38,5 @@ wget https://github.com/google/protobuf/releases/download/v${PROTOBUF_VERSION}/p
 tar zxf protobuf-cpp-${CPP_PROTOBUF_VERSION}.tar.gz --no-same-owner
 cd protobuf-${CPP_PROTOBUF_VERSION}
 ./configure
-make && make install
+make -j $(nproc) && make install
 ldconfig

--- a/ci/install_protobuf.sh
+++ b/ci/install_protobuf.sh
@@ -5,12 +5,39 @@
 
 set -e
 
-[ -z "${PROTOBUF_VERSION}" ] && export PROTOBUF_VERSION="3.11.4"
+[ -z "${PROTOBUF_VERSION}" ] && export PROTOBUF_VERSION="21.12"
+
+#
+# Note
+#
+# protobuf uses two release number schemes,
+# for example 3.21.12 and 21.12,
+# and both tags corresponds to the same commit:
+#
+#   commit f0dc78d7e6e331b8c6bb2d5283e06aa26883ca7c (HEAD -> release-3.21.12, tag: v3.21.12, tag: v21.12)
+#   Author: Protobuf Team Bot <protobuf-team-bot@google.com>
+#   Date:   Mon Dec 12 16:03:12 2022 -0800
+#
+#       Updating version.json and repo version numbers to: 21.12
+#
+# tag v21.12 corresponds to the 'protoc version', or repo version
+# tag v3.21.12 corresponds to the 'cpp version'
+#
+# protobuf-cpp-3.21.12.tar.gz:
+# - is provided under releases/download/v21.12
+# - is no longer provided under releases/download/v3.21.12,
+#
+# Use the "repo version number" (PROTOBUF_VERSION=21.12)
+# when calling this script
+#
+
+export CPP_PROTOBUF_VERSION="3.${PROTOBUF_VERSION}"
 
 cd /
-wget https://github.com/google/protobuf/releases/download/v${PROTOBUF_VERSION}/protobuf-cpp-${PROTOBUF_VERSION}.tar.gz
-tar zxf protobuf-cpp-${PROTOBUF_VERSION}.tar.gz --no-same-owner
-cd protobuf-${PROTOBUF_VERSION}
+wget
+https://github.com/google/protobuf/releases/download/v${PROTOBUF_VERSION}/protobuf-cpp-${CPP_PROTOBUF_VERSION}.tar.gz
+tar zxf protobuf-cpp-${CPP_PROTOBUF_VERSION}.tar.gz --no-same-owner
+cd protobuf-${CPP_PROTOBUF_VERSION}
 ./configure
-make && make install
+make -j (nproc) && make install
 ldconfig

--- a/ci/install_protobuf.sh
+++ b/ci/install_protobuf.sh
@@ -38,5 +38,5 @@ wget https://github.com/google/protobuf/releases/download/v${PROTOBUF_VERSION}/p
 tar zxf protobuf-cpp-${CPP_PROTOBUF_VERSION}.tar.gz --no-same-owner
 cd protobuf-${CPP_PROTOBUF_VERSION}
 ./configure
-make -j ${nproc} && make install
+make && make install
 ldconfig

--- a/ci/install_protobuf.sh
+++ b/ci/install_protobuf.sh
@@ -34,8 +34,7 @@ set -e
 export CPP_PROTOBUF_VERSION="3.${PROTOBUF_VERSION}"
 
 cd /
-wget
-https://github.com/google/protobuf/releases/download/v${PROTOBUF_VERSION}/protobuf-cpp-${CPP_PROTOBUF_VERSION}.tar.gz
+wget https://github.com/google/protobuf/releases/download/v${PROTOBUF_VERSION}/protobuf-cpp-${CPP_PROTOBUF_VERSION}.tar.gz
 tar zxf protobuf-cpp-${CPP_PROTOBUF_VERSION}.tar.gz --no-same-owner
 cd protobuf-${CPP_PROTOBUF_VERSION}
 ./configure

--- a/ci/install_protobuf.sh
+++ b/ci/install_protobuf.sh
@@ -38,5 +38,5 @@ wget https://github.com/google/protobuf/releases/download/v${PROTOBUF_VERSION}/p
 tar zxf protobuf-cpp-${CPP_PROTOBUF_VERSION}.tar.gz --no-same-owner
 cd protobuf-${CPP_PROTOBUF_VERSION}
 ./configure
-make -j $(nproc) && make install
+make -j ${nproc} && make install
 ldconfig

--- a/ci/install_protobuf.sh
+++ b/ci/install_protobuf.sh
@@ -38,5 +38,5 @@ wget https://github.com/google/protobuf/releases/download/v${PROTOBUF_VERSION}/p
 tar zxf protobuf-cpp-${CPP_PROTOBUF_VERSION}.tar.gz --no-same-owner
 cd protobuf-${CPP_PROTOBUF_VERSION}
 ./configure
-make -j (nproc) && make install
+make -j $(nproc) && make install
 ldconfig

--- a/exporters/otlp/src/otlp_metric_utils.cc
+++ b/exporters/otlp/src/otlp_metric_utils.cc
@@ -266,7 +266,7 @@ sdk::metrics::AggregationTemporality OtlpMetricUtils::DeltaTemporalitySelector(
 }
 
 sdk::metrics::AggregationTemporality OtlpMetricUtils::CumulativeTemporalitySelector(
-    sdk::metrics::InstrumentType instrument_type) noexcept
+    sdk::metrics::InstrumentType /* instrument_type */) noexcept
 {
   return sdk::metrics::AggregationTemporality::kCumulative;
 }

--- a/sdk/include/opentelemetry/sdk/metrics/state/sync_metric_storage.h
+++ b/sdk/include/opentelemetry/sdk/metrics/state/sync_metric_storage.h
@@ -30,7 +30,8 @@ public:
   SyncMetricStorage(InstrumentDescriptor instrument_descriptor,
                     const AggregationType aggregation_type,
                     const AttributesProcessor *attributes_processor,
-                    nostd::shared_ptr<ExemplarReservoir> &&exemplar_reservoir,
+                    nostd::shared_ptr<ExemplarReservoir> &&exemplar_reservoir
+                        OPENTELEMETRY_MAYBE_UNUSED,
                     const AggregationConfig *aggregation_config)
       : instrument_descriptor_(instrument_descriptor),
         attributes_hashmap_(new AttributesHashMap()),
@@ -48,7 +49,9 @@ public:
     };
   }
 
-  void RecordLong(int64_t value, const opentelemetry::context::Context &context) noexcept override
+  void RecordLong(int64_t value,
+                  const opentelemetry::context::Context &context
+                      OPENTELEMETRY_MAYBE_UNUSED) noexcept override
   {
     if (instrument_descriptor_.value_type_ != InstrumentValueType::kLong)
     {
@@ -63,7 +66,8 @@ public:
 
   void RecordLong(int64_t value,
                   const opentelemetry::common::KeyValueIterable &attributes,
-                  const opentelemetry::context::Context &context) noexcept override
+                  const opentelemetry::context::Context &context
+                      OPENTELEMETRY_MAYBE_UNUSED) noexcept override
   {
     if (instrument_descriptor_.value_type_ != InstrumentValueType::kLong)
     {
@@ -78,7 +82,9 @@ public:
     attributes_hashmap_->GetOrSetDefault(attr, create_default_aggregation_)->Aggregate(value);
   }
 
-  void RecordDouble(double value, const opentelemetry::context::Context &context) noexcept override
+  void RecordDouble(double value,
+                    const opentelemetry::context::Context &context
+                        OPENTELEMETRY_MAYBE_UNUSED) noexcept override
   {
     if (instrument_descriptor_.value_type_ != InstrumentValueType::kDouble)
     {
@@ -93,7 +99,8 @@ public:
 
   void RecordDouble(double value,
                     const opentelemetry::common::KeyValueIterable &attributes,
-                    const opentelemetry::context::Context &context) noexcept override
+                    const opentelemetry::context::Context &context
+                        OPENTELEMETRY_MAYBE_UNUSED) noexcept override
   {
 #ifdef ENABLE_METRICS_EXEMPLAR_PREVIEW
     exemplar_reservoir_->OfferMeasurement(value, attributes, context,


### PR DESCRIPTION
Fixes #1942

## Changes

Fixed build warnings in the OTLP HTTP exporter.
Added OTLP HTTP to the `MAINTAINER_MODE` CI.

For significant contributions please make sure you have completed the following items:

* [X] `CHANGELOG.md` updated for non-trivial changes
* [ ] Unit tests have been added
* [ ] Changes in public API reviewed