### PR TITLE
upgrade prometheus-cpp to v1.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ Increment the:
 
 ## [Unreleased]
 
+* Convert Prometheus Exporter to Pull MetricReader [#1953](https://github.com/open-telemetry/opentelemetry-cpp/pull/1953)
+
 ## [1.8.2] 2023-01-31
 
 * Remove redundant macro check in nostd::shared_ptr [#1939](https://github.com/open-telemetry/opentelemetry-cpp/pull/1939)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ Increment the:
 
 ## [Unreleased]
 
-* Convert Prometheus Exporter to Pull MetricReader [#1953](https://github.com/open-telemetry/opentelemetry-cpp/pull/1953)
+* Upgrade prometheus-cpp to v1.1.0 [#1954](https://github.com/open-telemetry/opentelemetry-cpp/pull/1954)
 
 ## [1.8.2] 2023-01-31
 

--- a/bazel/repository.bzl
+++ b/bazel/repository.bzl
@@ -119,10 +119,10 @@ def opentelemetry_cpp_deps():
     maybe(
         http_archive,
         name = "com_github_jupp0r_prometheus_cpp",
-        sha256 = "07018db604ea3e61f5078583e87c80932ea10c300d979061490ee1b7dc8e3a41",
-        strip_prefix = "prometheus-cpp-1.0.0",
+            sha256 = "397544fe91e183029120b4eebcfab24ed9ec833d15850aae78fd5db19062d13a",
+        strip_prefix = "prometheus-cpp-1.1.0",
         urls = [
-            "https://github.com/jupp0r/prometheus-cpp/archive/refs/tags/v1.0.0.tar.gz",
+            "https://github.com/jupp0r/prometheus-cpp/archive/refs/tags/v1.1.0.tar.gz",
         ],
     )
 

--- a/bazel/repository.bzl
+++ b/bazel/repository.bzl
@@ -119,7 +119,7 @@ def opentelemetry_cpp_deps():
     maybe(
         http_archive,
         name = "com_github_jupp0r_prometheus_cpp",
-            sha256 = "397544fe91e183029120b4eebcfab24ed9ec833d15850aae78fd5db19062d13a",
+        sha256 = "397544fe91e183029120b4eebcfab24ed9ec833d15850aae78fd5db19062d13a",
         strip_prefix = "prometheus-cpp-1.1.0",
         urls = [
             "https://github.com/jupp0r/prometheus-cpp/archive/refs/tags/v1.1.0.tar.gz",

--- a/exporters/prometheus/test/exporter_utils_test.cc
+++ b/exporters/prometheus/test/exporter_utils_test.cc
@@ -48,10 +48,12 @@ void assert_basic(prometheus_client::MetricFamily &metric,
     }
     break;
     case prometheus_client::MetricType::Summary:
-      // Summary type not supported
+      // Summary and Info type not supported
       ASSERT_TRUE(false);
       break;
     case prometheus::MetricType::Untyped:
+      break;
+    default:
       break;
   }
 }

--- a/third_party_release
+++ b/third_party_release
@@ -19,5 +19,5 @@ googletest=release-1.12.1
 ms-gsl=v3.1.0-67-g6f45293
 nlohmann-json=v3.10.5
 opentelemetry-proto=v0.19.0
-prometheus-cpp=v1.0.0
+prometheus-cpp=v1.1.0
 vcpkg=2022.08.15


### PR DESCRIPTION
Fixes # (issue)

## Changes

The earlier version v1.0.0 was released on Nov 2021.

For significant contributions please make sure you have completed the following items:

* [ ] `CHANGELOG.md` updated for non-trivial changes
* [ ] Unit tests have been added
* [ ] Changes in public API reviewed