### PR TITLE
Update Bazel build support for jaeger exporter with an explicit depen…

### DIFF
--- a/bazel/extra_deps.bzl
+++ b/bazel/extra_deps.bzl
@@ -6,8 +6,10 @@
 load("@com_github_jupp0r_prometheus_cpp//bazel:repositories.bzl", "prometheus_cpp_repositories")
 load("@bazel_skylib//:workspace.bzl", "bazel_skylib_workspace")
 load("@rules_foreign_cc//foreign_cc:repositories.bzl", "rules_foreign_cc_dependencies")
+load("@com_github_nelhage_rules_boost//:boost/boost.bzl", "boost_deps")
 
 def opentelemetry_extra_deps():
     prometheus_cpp_repositories()
     bazel_skylib_workspace()
     rules_foreign_cc_dependencies()
+    boost_deps()

--- a/bazel/repository.bzl
+++ b/bazel/repository.bzl
@@ -179,6 +179,14 @@ def opentelemetry_cpp_deps():
         ],
     )
 
+    # boost (optional)
+    maybe(
+        http_archive,
+        name = "com_github_nelhage_rules_boost",
+        url = "https://github.com/nelhage/rules_boost/archive/69d2b1331a7e659be76c646273ff140c75d71bab.tar.gz",
+        strip_prefix = "rules_boost-69d2b1331a7e659be76c646273ff140c75d71bab",
+    )
+
     # boost headers from vcpkg
     maybe(
         native.new_local_repository,

--- a/exporters/jaeger/BUILD
+++ b/exporters/jaeger/BUILD
@@ -1,6 +1,8 @@
 package(default_visibility = ["//visibility:public"])
 
+load("@bazel_skylib//rules:common_settings.bzl", "bool_flag")
 load("@rules_foreign_cc//foreign_cc:defs.bzl", "cmake", "configure_make", "configure_make_variant")
+
 
 constraint_setting(
     name = "incompatible_setting",
@@ -96,7 +98,13 @@ cmake(
     }),
     tags = ["jaeger"],
     visibility = ["//visibility:private"],
-    deps = [],
+    deps = select({
+        "@platforms//os:osx": [],
+        "@platforms//os:linux": [
+            "@boost//:locale",
+        ],
+        "@platforms//os:windows": [],
+    }),
 )
 
 THRIFT_GEN_DEPS = [


### PR DESCRIPTION
…dency on boost(Linux only).

## Changes

Previously boost libraries had to be installed on the build machine.  This  change allows Bazel to pull it in.