### PR TITLE
Update copyright for the remaining repo

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -1,16 +1,5 @@
-# Copyright 2019, OpenTelemetry Authors
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# Copyright The OpenTelemetry Authors
+# SPDX-License-Identifier: Apache-2.0
 
 workspace(name = "io_opentelemetry_cpp")
 

--- a/api/BUILD
+++ b/api/BUILD
@@ -1,16 +1,5 @@
-# Copyright 2019, OpenTelemetry Authors
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# Copyright The OpenTelemetry Authors
+# SPDX-License-Identifier: Apache-2.0
 
 load("@bazel_skylib//rules:common_settings.bzl", "bool_flag")
 

--- a/api/CMakeLists.txt
+++ b/api/CMakeLists.txt
@@ -1,3 +1,6 @@
+# Copyright The OpenTelemetry Authors
+# SPDX-License-Identifier: Apache-2.0
+
 add_library(opentelemetry_api INTERFACE)
 target_include_directories(
   opentelemetry_api

--- a/api/include/opentelemetry/nostd/detail/all.h
+++ b/api/include/opentelemetry/nostd/detail/all.h
@@ -1,3 +1,6 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
 #pragma once
 
 #include <type_traits>

--- a/api/include/opentelemetry/nostd/detail/decay.h
+++ b/api/include/opentelemetry/nostd/detail/decay.h
@@ -1,3 +1,6 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
 #pragma once
 
 #include <type_traits>

--- a/api/include/opentelemetry/nostd/detail/dependent_type.h
+++ b/api/include/opentelemetry/nostd/detail/dependent_type.h
@@ -1,3 +1,6 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
 #pragma once
 
 #include <type_traits>

--- a/api/include/opentelemetry/nostd/detail/functional.h
+++ b/api/include/opentelemetry/nostd/detail/functional.h
@@ -1,3 +1,6 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
 #pragma once
 
 #include <utility>

--- a/api/include/opentelemetry/nostd/detail/invoke.h
+++ b/api/include/opentelemetry/nostd/detail/invoke.h
@@ -1,3 +1,6 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
 #pragma once
 
 #include <type_traits>

--- a/api/include/opentelemetry/nostd/detail/trait.h
+++ b/api/include/opentelemetry/nostd/detail/trait.h
@@ -1,3 +1,6 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
 #pragma once
 
 #include <type_traits>

--- a/api/include/opentelemetry/nostd/detail/type_pack_element.h
+++ b/api/include/opentelemetry/nostd/detail/type_pack_element.h
@@ -1,3 +1,6 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
 #pragma once
 
 #include <cstddef>

--- a/api/include/opentelemetry/nostd/detail/valueless.h
+++ b/api/include/opentelemetry/nostd/detail/valueless.h
@@ -1,3 +1,6 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
 #pragma once
 
 #include "opentelemetry/version.h"

--- a/api/include/opentelemetry/nostd/detail/variant_alternative.h
+++ b/api/include/opentelemetry/nostd/detail/variant_alternative.h
@@ -1,3 +1,6 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
 #pragma once
 
 #include <type_traits>

--- a/api/include/opentelemetry/nostd/detail/variant_fwd.h
+++ b/api/include/opentelemetry/nostd/detail/variant_fwd.h
@@ -1,3 +1,6 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
 #pragma once
 
 #include "opentelemetry/version.h"

--- a/api/include/opentelemetry/nostd/detail/variant_size.h
+++ b/api/include/opentelemetry/nostd/detail/variant_size.h
@@ -1,3 +1,6 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
 #pragma once
 
 #include <type_traits>

--- a/api/include/opentelemetry/nostd/detail/void.h
+++ b/api/include/opentelemetry/nostd/detail/void.h
@@ -1,3 +1,6 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
 #pragma once
 
 #include "opentelemetry/version.h"

--- a/api/include/opentelemetry/trace/span_id.h
+++ b/api/include/opentelemetry/trace/span_id.h
@@ -1,16 +1,5 @@
-// Copyright 2019, OpenTelemetry Authors
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
 
 #pragma once
 

--- a/api/test/CMakeLists.txt
+++ b/api/test/CMakeLists.txt
@@ -1,3 +1,6 @@
+# Copyright The OpenTelemetry Authors
+# SPDX-License-Identifier: Apache-2.0
+
 add_subdirectory(core)
 add_subdirectory(context)
 add_subdirectory(plugin)

--- a/api/test/baggage/BUILD
+++ b/api/test/baggage/BUILD
@@ -1,3 +1,6 @@
+# Copyright The OpenTelemetry Authors
+# SPDX-License-Identifier: Apache-2.0
+
 load("//bazel:otel_cc_benchmark.bzl", "otel_cc_benchmark")
 
 cc_test(

--- a/api/test/baggage/CMakeLists.txt
+++ b/api/test/baggage/CMakeLists.txt
@@ -1,3 +1,6 @@
+# Copyright The OpenTelemetry Authors
+# SPDX-License-Identifier: Apache-2.0
+
 include(GoogleTest)
 
 foreach(testname baggage_test)

--- a/api/test/baggage/propagation/BUILD
+++ b/api/test/baggage/propagation/BUILD
@@ -1,3 +1,6 @@
+# Copyright The OpenTelemetry Authors
+# SPDX-License-Identifier: Apache-2.0
+
 load("//bazel:otel_cc_benchmark.bzl", "otel_cc_benchmark")
 
 cc_test(

--- a/api/test/baggage/propagation/CMakeLists.txt
+++ b/api/test/baggage/propagation/CMakeLists.txt
@@ -1,3 +1,6 @@
+# Copyright The OpenTelemetry Authors
+# SPDX-License-Identifier: Apache-2.0
+
 foreach(testname baggage_propagator_test)
   add_executable(${testname} "${testname}.cc")
   target_link_libraries(${testname} ${GTEST_BOTH_LIBRARIES}

--- a/api/test/common/BUILD
+++ b/api/test/common/BUILD
@@ -1,3 +1,6 @@
+# Copyright The OpenTelemetry Authors
+# SPDX-License-Identifier: Apache-2.0
+
 load("//bazel:otel_cc_benchmark.bzl", "otel_cc_benchmark")
 
 otel_cc_benchmark(

--- a/api/test/common/CMakeLists.txt
+++ b/api/test/common/CMakeLists.txt
@@ -1,3 +1,6 @@
+# Copyright The OpenTelemetry Authors
+# SPDX-License-Identifier: Apache-2.0
+
 include(GoogleTest)
 
 foreach(testname kv_properties_test string_util_test)

--- a/api/test/context/BUILD
+++ b/api/test/context/BUILD
@@ -1,3 +1,6 @@
+# Copyright The OpenTelemetry Authors
+# SPDX-License-Identifier: Apache-2.0
+
 load("//bazel:otel_cc_benchmark.bzl", "otel_cc_benchmark")
 
 cc_test(

--- a/api/test/context/CMakeLists.txt
+++ b/api/test/context/CMakeLists.txt
@@ -1,3 +1,6 @@
+# Copyright The OpenTelemetry Authors
+# SPDX-License-Identifier: Apache-2.0
+
 add_subdirectory(propagation)
 
 include(GoogleTest)

--- a/api/test/context/propagation/BUILD
+++ b/api/test/context/propagation/BUILD
@@ -1,3 +1,6 @@
+# Copyright The OpenTelemetry Authors
+# SPDX-License-Identifier: Apache-2.0
+
 load("//bazel:otel_cc_benchmark.bzl", "otel_cc_benchmark")
 
 cc_test(

--- a/api/test/context/propagation/CMakeLists.txt
+++ b/api/test/context/propagation/CMakeLists.txt
@@ -1,3 +1,6 @@
+# Copyright The OpenTelemetry Authors
+# SPDX-License-Identifier: Apache-2.0
+
 foreach(testname composite_propagator_test)
   add_executable(${testname} "${testname}.cc")
   target_link_libraries(${testname} ${GTEST_BOTH_LIBRARIES}

--- a/api/test/core/BUILD
+++ b/api/test/core/BUILD
@@ -1,3 +1,6 @@
+# Copyright The OpenTelemetry Authors
+# SPDX-License-Identifier: Apache-2.0
+
 cc_test(
     name = "timestamp_test",
     srcs = [

--- a/api/test/core/CMakeLists.txt
+++ b/api/test/core/CMakeLists.txt
@@ -1,3 +1,6 @@
+# Copyright The OpenTelemetry Authors
+# SPDX-License-Identifier: Apache-2.0
+
 include(GoogleTest)
 
 add_executable(timestamp_test timestamp_test.cc)

--- a/api/test/logs/BUILD
+++ b/api/test/logs/BUILD
@@ -1,3 +1,6 @@
+# Copyright The OpenTelemetry Authors
+# SPDX-License-Identifier: Apache-2.0
+
 load("//bazel:otel_cc_benchmark.bzl", "otel_cc_benchmark")
 
 cc_test(

--- a/api/test/logs/CMakeLists.txt
+++ b/api/test/logs/CMakeLists.txt
@@ -1,3 +1,6 @@
+# Copyright The OpenTelemetry Authors
+# SPDX-License-Identifier: Apache-2.0
+
 foreach(testname provider_test logger_test)
   add_executable(logs_api_${testname} "${testname}.cc")
   target_link_libraries(logs_api_${testname} ${GTEST_BOTH_LIBRARIES}

--- a/api/test/metrics/BUILD
+++ b/api/test/metrics/BUILD
@@ -1,3 +1,6 @@
+# Copyright The OpenTelemetry Authors
+# SPDX-License-Identifier: Apache-2.0
+
 load("//bazel:otel_cc_benchmark.bzl", "otel_cc_benchmark")
 
 cc_test(

--- a/api/test/metrics/CMakeLists.txt
+++ b/api/test/metrics/CMakeLists.txt
@@ -1,3 +1,6 @@
+# Copyright The OpenTelemetry Authors
+# SPDX-License-Identifier: Apache-2.0
+
 foreach(testname meter_provider_test noop_sync_instrument_test)
   add_executable(${testname} "${testname}.cc")
   target_link_libraries(${testname} ${GTEST_BOTH_LIBRARIES}

--- a/api/test/nostd/BUILD
+++ b/api/test/nostd/BUILD
@@ -1,3 +1,6 @@
+# Copyright The OpenTelemetry Authors
+# SPDX-License-Identifier: Apache-2.0
+
 cc_test(
     name = "function_ref_test",
     srcs = [

--- a/api/test/nostd/CMakeLists.txt
+++ b/api/test/nostd/CMakeLists.txt
@@ -1,3 +1,6 @@
+# Copyright The OpenTelemetry Authors
+# SPDX-License-Identifier: Apache-2.0
+
 include(GoogleTest)
 
 foreach(

--- a/api/test/plugin/BUILD
+++ b/api/test/plugin/BUILD
@@ -1,3 +1,6 @@
+# Copyright The OpenTelemetry Authors
+# SPDX-License-Identifier: Apache-2.0
+
 cc_test(
     name = "dynamic_load_test",
     srcs = [

--- a/api/test/plugin/CMakeLists.txt
+++ b/api/test/plugin/CMakeLists.txt
@@ -1,3 +1,6 @@
+# Copyright The OpenTelemetry Authors
+# SPDX-License-Identifier: Apache-2.0
+
 include(GoogleTest)
 
 add_executable(dynamic_load_test dynamic_load_test.cc)

--- a/api/test/trace/BUILD
+++ b/api/test/trace/BUILD
@@ -1,3 +1,6 @@
+# Copyright The OpenTelemetry Authors
+# SPDX-License-Identifier: Apache-2.0
+
 load("//bazel:otel_cc_benchmark.bzl", "otel_cc_benchmark")
 
 cc_test(

--- a/api/test/trace/CMakeLists.txt
+++ b/api/test/trace/CMakeLists.txt
@@ -1,3 +1,6 @@
+# Copyright The OpenTelemetry Authors
+# SPDX-License-Identifier: Apache-2.0
+
 add_subdirectory(propagation)
 
 foreach(

--- a/api/test/trace/propagation/BUILD
+++ b/api/test/trace/propagation/BUILD
@@ -1,3 +1,6 @@
+# Copyright The OpenTelemetry Authors
+# SPDX-License-Identifier: Apache-2.0
+
 load("//bazel:otel_cc_benchmark.bzl", "otel_cc_benchmark")
 
 cc_test(

--- a/api/test/trace/propagation/CMakeLists.txt
+++ b/api/test/trace/propagation/CMakeLists.txt
@@ -1,3 +1,6 @@
+# Copyright The OpenTelemetry Authors
+# SPDX-License-Identifier: Apache-2.0
+
 foreach(testname http_text_format_test b3_propagation_test)
   add_executable(${testname} "${testname}.cc")
   target_link_libraries(${testname} ${GTEST_BOTH_LIBRARIES}

--- a/bazel/BUILD
+++ b/bazel/BUILD
@@ -1,3 +1,6 @@
+# Copyright The OpenTelemetry Authors
+# SPDX-License-Identifier: Apache-2.0
+
 package(default_visibility = ["//:__subpackages__"])
 
 config_setting(

--- a/bazel/curl.BUILD
+++ b/bazel/curl.BUILD
@@ -1,3 +1,6 @@
+# Copyright The OpenTelemetry Authors
+# SPDX-License-Identifier: Apache-2.0
+
 # Builds CURL from a distribution.
 
 load("@io_opentelemetry_cpp//bazel:curl.bzl", "CURL_COPTS")

--- a/bazel/curl.bzl
+++ b/bazel/curl.bzl
@@ -1,16 +1,5 @@
-# Copyright 2020, OpenTelemetry Authors
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# Copyright The OpenTelemetry Authors
+# SPDX-License-Identifier: Apache-2.0
 
 # Compiler options for building libcurl.
 

--- a/bazel/nlohmann_json.BUILD
+++ b/bazel/nlohmann_json.BUILD
@@ -1,3 +1,6 @@
+# Copyright The OpenTelemetry Authors
+# SPDX-License-Identifier: Apache-2.0
+
 licenses(["notice"])  # 3-Clause BSD
 
 exports_files(["LICENSE.MIT"])

--- a/bazel/opentelemetry_proto.BUILD
+++ b/bazel/opentelemetry_proto.BUILD
@@ -1,16 +1,5 @@
-# Copyright 2020, OpenTelemetry Authors
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# Copyright The OpenTelemetry Authors
+# SPDX-License-Identifier: Apache-2.0
 
 package(default_visibility = ["//visibility:public"])
 

--- a/bazel/otel_cc_benchmark.bzl
+++ b/bazel/otel_cc_benchmark.bzl
@@ -1,3 +1,6 @@
+# Copyright The OpenTelemetry Authors
+# SPDX-License-Identifier: Apache-2.0
+
 def otel_cc_benchmark(name, srcs, deps, tags = [""]):
     """
     Creates targets for the benchmark and related targets.

--- a/bazel/repository.bzl
+++ b/bazel/repository.bzl
@@ -1,3 +1,6 @@
+# Copyright The OpenTelemetry Authors
+# SPDX-License-Identifier: Apache-2.0
+
 load("@bazel_tools//tools/build_defs/repo:utils.bzl", "maybe")
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")

--- a/buildscripts/semantic-convention/generate.sh
+++ b/buildscripts/semantic-convention/generate.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+# Copyright The OpenTelemetry Authors
+# SPDX-License-Identifier: Apache-2.0
+
 #
 # Adapted from:
 # opentelemetry-java/buildscripts/semantic-convention/generate.sh

--- a/ci/Dockerfile
+++ b/ci/Dockerfile
@@ -1,3 +1,6 @@
+# Copyright The OpenTelemetry Authors
+# SPDX-License-Identifier: Apache-2.0
+
 FROM ubuntu:18.04
 
 WORKDIR /setup-ci

--- a/ci/do_ci.ps1
+++ b/ci/do_ci.ps1
@@ -1,3 +1,6 @@
+# Copyright The OpenTelemetry Authors
+# SPDX-License-Identifier: Apache-2.0
+
 $ErrorActionPreference = "Stop";
 trap { $host.SetShouldExit(1) }
 

--- a/ci/install_windows_bazelisk.ps1
+++ b/ci/install_windows_bazelisk.ps1
@@ -1,3 +1,6 @@
+# Copyright The OpenTelemetry Authors
+# SPDX-License-Identifier: Apache-2.0
+
 $ErrorActionPreference = "Stop"
 trap { $host.SetShouldExit(1) }
 

--- a/ci/install_windows_protobuf.ps1
+++ b/ci/install_windows_protobuf.ps1
@@ -1,3 +1,6 @@
+# Copyright The OpenTelemetry Authors
+# SPDX-License-Identifier: Apache-2.0
+
 $ErrorActionPreference = "Stop"
 trap { $host.SetShouldExit(1) }
 

--- a/ci/ports/benchmark/portfile.cmake
+++ b/ci/ports/benchmark/portfile.cmake
@@ -1,3 +1,6 @@
+# Copyright The OpenTelemetry Authors
+# SPDX-License-Identifier: Apache-2.0
+
 if(VCPKG_CMAKE_SYSTEM_NAME STREQUAL "WindowsStore")
     message(FATAL_ERROR "${PORT} does not currently support UWP")
 endif()

--- a/ci/ports/protobuf/portfile.cmake
+++ b/ci/ports/protobuf/portfile.cmake
@@ -1,3 +1,6 @@
+# Copyright The OpenTelemetry Authors
+# SPDX-License-Identifier: Apache-2.0
+
 vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO protocolbuffers/protobuf

--- a/ci/setup_thrift.ps1
+++ b/ci/setup_thrift.ps1
@@ -1,3 +1,6 @@
+# Copyright The OpenTelemetry Authors
+# SPDX-License-Identifier: Apache-2.0
+
 $ErrorActionPreference = "Stop"
 trap { $host.SetShouldExit(1) }
 

--- a/ci/setup_thrift.sh
+++ b/ci/setup_thrift.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+# Copyright The OpenTelemetry Authors
+# SPDX-License-Identifier: Apache-2.0
+
 set -e
 export DEBIAN_FRONTEND=noninteractive
 export THRIFT_VERSION=0.14.1

--- a/ci/setup_windows_ci_environment.ps1
+++ b/ci/setup_windows_ci_environment.ps1
@@ -1,3 +1,6 @@
+# Copyright The OpenTelemetry Authors
+# SPDX-License-Identifier: Apache-2.0
+
 $ErrorActionPreference = "Stop"
 trap { $host.SetShouldExit(1) }
 

--- a/ci/setup_windows_cmake.ps1
+++ b/ci/setup_windows_cmake.ps1
@@ -1,3 +1,6 @@
+# Copyright The OpenTelemetry Authors
+# SPDX-License-Identifier: Apache-2.0
+
 $ErrorActionPreference = "Stop"
 trap { $host.SetShouldExit(1) }
 

--- a/cmake/ParseOsRelease.cmake
+++ b/cmake/ParseOsRelease.cmake
@@ -1,3 +1,6 @@
+# Copyright The OpenTelemetry Authors
+# SPDX-License-Identifier: Apache-2.0
+
 # Parse /etc/os-release to determine Linux distro
 
 if(EXISTS /etc/os-release)

--- a/cmake/modules/FindThrift.cmake
+++ b/cmake/modules/FindThrift.cmake
@@ -1,3 +1,6 @@
+# Copyright The OpenTelemetry Authors
+# SPDX-License-Identifier: Apache-2.0
+
 # This module defines Thrift_LIBRARIES, libraries to link Thrift_INCLUDE_DIR,
 # Thrift_FOUND, If false, do not try to use it.
 

--- a/cmake/opentelemetry-cpp-config.cmake.in
+++ b/cmake/opentelemetry-cpp-config.cmake.in
@@ -49,10 +49,8 @@
 #
 
 # =============================================================================
-# Copyright 2020 opentelemetry.
-#
-# Distributed under the Apache License (the "License"); see accompanying file
-# LICENSE for details.
+# Copyright The OpenTelemetry Authors
+# SPDX-License-Identifier: Apache-2.0
 # =============================================================================
 
 set(OPENTELEMETRY_ABI_VERSION_NO

--- a/cmake/package.cmake
+++ b/cmake/package.cmake
@@ -1,3 +1,5 @@
+# Copyright The OpenTelemetry Authors
+# SPDX-License-Identifier: Apache-2.0
 
 set(CPACK_PACKAGE_DESCRIPTION "OpenTelemetry C++ for Linux")
 set(CPACK_PACKAGE_DESCRIPTION_SUMMARY "OpenTelemetry C++ for Linux - C++ Implementation of OpenTelemetry Specification")

--- a/cmake/proto-options-patch.cmake
+++ b/cmake/proto-options-patch.cmake
@@ -1,3 +1,6 @@
+# Copyright The OpenTelemetry Authors
+# SPDX-License-Identifier: Apache-2.0
+
 macro(check_append_cxx_compiler_flag OUTPUT_VAR)
   foreach(CHECK_FLAG ${ARGN})
     check_cxx_compiler_flag(${CHECK_FLAG}

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,3 +1,6 @@
+# Copyright The OpenTelemetry Authors
+# SPDX-License-Identifier: Apache-2.0
+
 ARG BASE_IMAGE=ubuntu:latest
 ARG GRPC_IMAGE=grpc-${BASE_IMAGE}
 ARG THRIFT_IMAGE=thrift-${BASE_IMAGE}

--- a/docker/grpc/CMakeLists.txt
+++ b/docker/grpc/CMakeLists.txt
@@ -1,3 +1,6 @@
+# Copyright The OpenTelemetry Authors
+# SPDX-License-Identifier: Apache-2.0
+
 cmake_minimum_required(VERSION 3.11 FATAL_ERROR)
 
 project(

--- a/docker/grpc/Dockerfile
+++ b/docker/grpc/Dockerfile
@@ -1,3 +1,6 @@
+# Copyright The OpenTelemetry Authors
+# SPDX-License-Identifier: Apache-2.0
+
 ARG BASE_IMAGE=ubuntu:latest
 FROM ${BASE_IMAGE} AS grpc
 

--- a/docker/thrift/CMakeLists.txt
+++ b/docker/thrift/CMakeLists.txt
@@ -1,3 +1,6 @@
+# Copyright The OpenTelemetry Authors
+# SPDX-License-Identifier: Apache-2.0
+
 cmake_minimum_required(VERSION 3.11 FATAL_ERROR)
 
 project(

--- a/docker/thrift/Dockerfile
+++ b/docker/thrift/Dockerfile
@@ -1,3 +1,6 @@
+# Copyright The OpenTelemetry Authors
+# SPDX-License-Identifier: Apache-2.0
+
 ARG BASE_IMAGE=ubuntu:latest
 FROM ${BASE_IMAGE} AS thrift
 

--- a/docker/ubuntuLatest/Dockerfile
+++ b/docker/ubuntuLatest/Dockerfile
@@ -1,3 +1,6 @@
+# Copyright The OpenTelemetry Authors
+# SPDX-License-Identifier: Apache-2.0
+
 FROM ubuntu:latest
 ENV DEBIAN_FRONTEND=noninteractive
 WORKDIR /work

--- a/docs/public/Makefile
+++ b/docs/public/Makefile
@@ -1,3 +1,6 @@
+# Copyright The OpenTelemetry Authors
+# SPDX-License-Identifier: Apache-2.0
+
 # Minimal makefile for Sphinx documentation
 #
 

--- a/docs/public/conf.py
+++ b/docs/public/conf.py
@@ -1,3 +1,6 @@
+# Copyright The OpenTelemetry Authors
+# SPDX-License-Identifier: Apache-2.0
+
 # Configuration file for the Sphinx documentation builder.
 #
 # This file only contains a selection of the most common options. For a full

--- a/examples/batch/BUILD
+++ b/examples/batch/BUILD
@@ -1,3 +1,6 @@
+# Copyright The OpenTelemetry Authors
+# SPDX-License-Identifier: Apache-2.0
+
 cc_binary(
     name = "example_simple",
     srcs = [

--- a/examples/batch/CMakeLists.txt
+++ b/examples/batch/CMakeLists.txt
@@ -1,3 +1,6 @@
+# Copyright The OpenTelemetry Authors
+# SPDX-License-Identifier: Apache-2.0
+
 include_directories(${CMAKE_SOURCE_DIR}/exporters/ostream/include)
 
 add_executable(batch_span_processor_example main.cc)

--- a/examples/common/CMakeLists.txt
+++ b/examples/common/CMakeLists.txt
@@ -1,3 +1,6 @@
+# Copyright The OpenTelemetry Authors
+# SPDX-License-Identifier: Apache-2.0
+
 add_subdirectory(foo_library)
 if(WITH_LOGS_PREVIEW)
   add_subdirectory(logs_foo_library)

--- a/examples/common/foo_library/BUILD
+++ b/examples/common/foo_library/BUILD
@@ -1,3 +1,6 @@
+# Copyright The OpenTelemetry Authors
+# SPDX-License-Identifier: Apache-2.0
+
 package(default_visibility = ["//visibility:public"])
 
 cc_library(

--- a/examples/common/foo_library/CMakeLists.txt
+++ b/examples/common/foo_library/CMakeLists.txt
@@ -1,3 +1,6 @@
+# Copyright The OpenTelemetry Authors
+# SPDX-License-Identifier: Apache-2.0
+
 add_library(common_foo_library foo_library.h foo_library.cc)
 target_link_libraries(common_foo_library PUBLIC ${CMAKE_THREAD_LIBS_INIT}
                                                 opentelemetry_api)

--- a/examples/common/logs_foo_library/BUILD
+++ b/examples/common/logs_foo_library/BUILD
@@ -1,3 +1,6 @@
+# Copyright The OpenTelemetry Authors
+# SPDX-License-Identifier: Apache-2.0
+
 package(default_visibility = ["//visibility:public"])
 
 cc_library(

--- a/examples/common/logs_foo_library/CMakeLists.txt
+++ b/examples/common/logs_foo_library/CMakeLists.txt
@@ -1,3 +1,6 @@
+# Copyright The OpenTelemetry Authors
+# SPDX-License-Identifier: Apache-2.0
+
 add_library(common_logs_foo_library foo_library.h foo_library.cc)
 target_link_libraries(common_logs_foo_library PUBLIC ${CMAKE_THREAD_LIBS_INIT}
                                                      opentelemetry_api)

--- a/examples/common/metrics_foo_library/BUILD
+++ b/examples/common/metrics_foo_library/BUILD
@@ -1,3 +1,6 @@
+# Copyright The OpenTelemetry Authors
+# SPDX-License-Identifier: Apache-2.0
+
 package(default_visibility = ["//visibility:public"])
 
 cc_library(

--- a/examples/common/metrics_foo_library/CMakeLists.txt
+++ b/examples/common/metrics_foo_library/CMakeLists.txt
@@ -1,2 +1,5 @@
+# Copyright The OpenTelemetry Authors
+# SPDX-License-Identifier: Apache-2.0
+
 add_library(common_metrics_foo_library foo_library.h foo_library.cc)
 target_link_libraries(common_metrics_foo_library PUBLIC opentelemetry_api)

--- a/examples/etw_threads/CMakeLists.txt
+++ b/examples/etw_threads/CMakeLists.txt
@@ -1,3 +1,6 @@
+# Copyright The OpenTelemetry Authors
+# SPDX-License-Identifier: Apache-2.0
+
 project(etw_threadpool)
 
 add_executable(etw_threadpool main.cc)

--- a/examples/grpc/BUILD
+++ b/examples/grpc/BUILD
@@ -1,3 +1,6 @@
+# Copyright The OpenTelemetry Authors
+# SPDX-License-Identifier: Apache-2.0
+
 package(default_visibility = ["//visibility:public"])
 
 load("@rules_proto//proto:defs.bzl", "proto_library")

--- a/examples/grpc/CMakeLists.txt
+++ b/examples/grpc/CMakeLists.txt
@@ -1,3 +1,6 @@
+# Copyright The OpenTelemetry Authors
+# SPDX-License-Identifier: Apache-2.0
+
 # Proto file
 get_filename_component(proto_file "./protos/messages.proto" ABSOLUTE)
 get_filename_component(proto_file_path "${proto_file}" PATH)

--- a/examples/grpc/client.cc
+++ b/examples/grpc/client.cc
@@ -1,3 +1,6 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
 // Make sure to include GRPC headers first because otherwise Abseil may create
 // ambiguity with `nostd::variant` if compiled with Visual Studio 2015. Other
 // modern compilers are unaffected.

--- a/examples/grpc/protos/messages.proto
+++ b/examples/grpc/protos/messages.proto
@@ -1,3 +1,6 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
 syntax = "proto3";
 
 package grpc_example;

--- a/examples/grpc/server.cc
+++ b/examples/grpc/server.cc
@@ -1,3 +1,6 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
 #ifdef BAZEL_BUILD
 #  include "examples/grpc/protos/messages.grpc.pb.h"
 #else

--- a/examples/http/BUILD
+++ b/examples/http/BUILD
@@ -1,3 +1,6 @@
+# Copyright The OpenTelemetry Authors
+# SPDX-License-Identifier: Apache-2.0
+
 cc_binary(
     name = "example_http_client",
     srcs = [

--- a/examples/jaeger/BUILD
+++ b/examples/jaeger/BUILD
@@ -1,3 +1,6 @@
+# Copyright The OpenTelemetry Authors
+# SPDX-License-Identifier: Apache-2.0
+
 cc_binary(
     name = "example_jaeger",
     srcs = [

--- a/examples/jaeger/CMakeLists.txt
+++ b/examples/jaeger/CMakeLists.txt
@@ -1,3 +1,6 @@
+# Copyright The OpenTelemetry Authors
+# SPDX-License-Identifier: Apache-2.0
+
 include_directories(${CMAKE_SOURCE_DIR}/exporters/jaeger/include)
 
 add_executable(example_jaeger main.cc)

--- a/examples/metrics_simple/BUILD
+++ b/examples/metrics_simple/BUILD
@@ -1,3 +1,6 @@
+# Copyright The OpenTelemetry Authors
+# SPDX-License-Identifier: Apache-2.0
+
 cc_binary(
     name = "metrics_ostream_example",
     srcs = [

--- a/examples/metrics_simple/CMakeLists.txt
+++ b/examples/metrics_simple/CMakeLists.txt
@@ -1,3 +1,6 @@
+# Copyright The OpenTelemetry Authors
+# SPDX-License-Identifier: Apache-2.0
+
 include_directories(${CMAKE_SOURCE_DIR}/exporters/ostream/include)
 add_executable(metrics_ostream_example metrics_ostream.cc)
 target_link_libraries(

--- a/examples/multi_processor/BUILD
+++ b/examples/multi_processor/BUILD
@@ -1,3 +1,6 @@
+# Copyright The OpenTelemetry Authors
+# SPDX-License-Identifier: Apache-2.0
+
 cc_binary(
     name = "example_multi_processor",
     srcs = [

--- a/examples/multi_processor/CMakeLists.txt
+++ b/examples/multi_processor/CMakeLists.txt
@@ -1,3 +1,6 @@
+# Copyright The OpenTelemetry Authors
+# SPDX-License-Identifier: Apache-2.0
+
 include_directories(${CMAKE_SOURCE_DIR}/exporters/ostream/include
                     ${CMAKE_SOURCE_DIR}/exporters/memory/include)
 

--- a/examples/multithreaded/BUILD
+++ b/examples/multithreaded/BUILD
@@ -1,3 +1,6 @@
+# Copyright The OpenTelemetry Authors
+# SPDX-License-Identifier: Apache-2.0
+
 cc_binary(
     name = "example_multithreaded",
     srcs = [

--- a/examples/multithreaded/CMakeLists.txt
+++ b/examples/multithreaded/CMakeLists.txt
@@ -1,3 +1,6 @@
+# Copyright The OpenTelemetry Authors
+# SPDX-License-Identifier: Apache-2.0
+
 include_directories(${CMAKE_SOURCE_DIR}/exporters/ostream/include)
 
 add_executable(example_multithreaded main.cc)

--- a/examples/otlp/BUILD
+++ b/examples/otlp/BUILD
@@ -1,3 +1,6 @@
+# Copyright The OpenTelemetry Authors
+# SPDX-License-Identifier: Apache-2.0
+
 cc_binary(
     name = "example_otlp_grpc",
     srcs = [

--- a/examples/plugin/CMakeLists.txt
+++ b/examples/plugin/CMakeLists.txt
@@ -1,2 +1,5 @@
+# Copyright The OpenTelemetry Authors
+# SPDX-License-Identifier: Apache-2.0
+
 add_subdirectory(load)
 add_subdirectory(plugin)

--- a/examples/plugin/load/BUILD
+++ b/examples/plugin/load/BUILD
@@ -1,3 +1,6 @@
+# Copyright The OpenTelemetry Authors
+# SPDX-License-Identifier: Apache-2.0
+
 cc_binary(
     name = "load_plugin",
     srcs = [

--- a/examples/plugin/load/CMakeLists.txt
+++ b/examples/plugin/load/CMakeLists.txt
@@ -1,2 +1,5 @@
+# Copyright The OpenTelemetry Authors
+# SPDX-License-Identifier: Apache-2.0
+
 add_executable(load_plugin_example main.cc)
 target_link_libraries(load_plugin_example opentelemetry_api ${CMAKE_DL_LIBS})

--- a/examples/plugin/plugin/BUILD
+++ b/examples/plugin/plugin/BUILD
@@ -1,3 +1,6 @@
+# Copyright The OpenTelemetry Authors
+# SPDX-License-Identifier: Apache-2.0
+
 cc_binary(
     name = "example_plugin.so",
     srcs = [

--- a/examples/plugin/plugin/CMakeLists.txt
+++ b/examples/plugin/plugin/CMakeLists.txt
@@ -1,2 +1,5 @@
+# Copyright The OpenTelemetry Authors
+# SPDX-License-Identifier: Apache-2.0
+
 add_library(example_plugin SHARED tracer.cc factory_impl.cc)
 target_link_libraries(example_plugin opentelemetry_api)

--- a/examples/prometheus/BUILD
+++ b/examples/prometheus/BUILD
@@ -1,3 +1,6 @@
+# Copyright The OpenTelemetry Authors
+# SPDX-License-Identifier: Apache-2.0
+
 cc_binary(
     name = "prometheus_example",
     srcs = [

--- a/examples/prometheus/CMakeLists.txt
+++ b/examples/prometheus/CMakeLists.txt
@@ -1,3 +1,6 @@
+# Copyright The OpenTelemetry Authors
+# SPDX-License-Identifier: Apache-2.0
+
 include_directories(${CMAKE_SOURCE_DIR}/exporters/prometheus/include)
 add_executable(prometheus_example main.cc)
 target_link_libraries(

--- a/examples/prometheus/run.sh
+++ b/examples/prometheus/run.sh
@@ -1,1 +1,4 @@
+# Copyright The OpenTelemetry Authors
+# SPDX-License-Identifier: Apache-2.0
+
 docker run -p 9090:9090 -v $(pwd):/etc/prometheus --network="host" prom/prometheus

--- a/examples/simple/BUILD
+++ b/examples/simple/BUILD
@@ -1,3 +1,6 @@
+# Copyright The OpenTelemetry Authors
+# SPDX-License-Identifier: Apache-2.0
+
 cc_binary(
     name = "example_simple",
     srcs = [

--- a/examples/simple/CMakeLists.txt
+++ b/examples/simple/CMakeLists.txt
@@ -1,3 +1,6 @@
+# Copyright The OpenTelemetry Authors
+# SPDX-License-Identifier: Apache-2.0
+
 include_directories(${CMAKE_SOURCE_DIR}/exporters/ostream/include)
 
 add_executable(example_simple main.cc)

--- a/examples/zpages/BUILD
+++ b/examples/zpages/BUILD
@@ -1,16 +1,5 @@
-# Copyright 2020, OpenTelemetry Authors
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# Copyright The OpenTelemetry Authors
+# SPDX-License-Identifier: Apache-2.0
 
 package(default_visibility = ["//visibility:public"])
 

--- a/exporters/CMakeLists.txt
+++ b/exporters/CMakeLists.txt
@@ -1,16 +1,5 @@
-# Copyright 2021, OpenTelemetry Authors
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# Copyright The OpenTelemetry Authors
+# SPDX-License-Identifier: Apache-2.0
 
 if(WITH_OTLP)
   add_subdirectory(otlp)

--- a/exporters/elasticsearch/BUILD
+++ b/exporters/elasticsearch/BUILD
@@ -1,3 +1,6 @@
+# Copyright The OpenTelemetry Authors
+# SPDX-License-Identifier: Apache-2.0
+
 package(default_visibility = ["//visibility:public"])
 
 cc_library(

--- a/exporters/elasticsearch/CMakeLists.txt
+++ b/exporters/elasticsearch/CMakeLists.txt
@@ -1,3 +1,6 @@
+# Copyright The OpenTelemetry Authors
+# SPDX-License-Identifier: Apache-2.0
+
 add_library(opentelemetry_exporter_elasticsearch_logs
             src/es_log_record_exporter.cc src/es_log_recordable.cc)
 

--- a/exporters/etw/BUILD
+++ b/exporters/etw/BUILD
@@ -1,3 +1,6 @@
+# Copyright The OpenTelemetry Authors
+# SPDX-License-Identifier: Apache-2.0
+
 package(default_visibility = ["//visibility:public"])
 
 cc_library(

--- a/exporters/etw/CMakeLists.txt
+++ b/exporters/etw/CMakeLists.txt
@@ -1,3 +1,6 @@
+# Copyright The OpenTelemetry Authors
+# SPDX-License-Identifier: Apache-2.0
+
 add_library(opentelemetry_exporter_etw INTERFACE)
 
 target_include_directories(

--- a/exporters/etw/include/opentelemetry/exporters/etw/etw_traceloggingdynamic.h
+++ b/exporters/etw/include/opentelemetry/exporters/etw/etw_traceloggingdynamic.h
@@ -1,3 +1,6 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
 #pragma once
 
 #ifdef __has_include

--- a/exporters/jaeger/BUILD
+++ b/exporters/jaeger/BUILD
@@ -1,3 +1,6 @@
+# Copyright The OpenTelemetry Authors
+# SPDX-License-Identifier: Apache-2.0
+
 package(default_visibility = ["//visibility:public"])
 
 load("@rules_foreign_cc//foreign_cc:defs.bzl", "cmake", "configure_make", "configure_make_variant")

--- a/exporters/jaeger/src/http_transport.h
+++ b/exporters/jaeger/src/http_transport.h
@@ -1,3 +1,6 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
 #pragma once
 
 #include "THttpTransport.h"

--- a/exporters/memory/BUILD
+++ b/exporters/memory/BUILD
@@ -1,3 +1,6 @@
+# Copyright The OpenTelemetry Authors
+# SPDX-License-Identifier: Apache-2.0
+
 package(default_visibility = ["//visibility:public"])
 
 cc_library(

--- a/exporters/memory/CMakeLists.txt
+++ b/exporters/memory/CMakeLists.txt
@@ -1,3 +1,6 @@
+# Copyright The OpenTelemetry Authors
+# SPDX-License-Identifier: Apache-2.0
+
 add_library(opentelemetry_exporter_in_memory
             src/in_memory_span_exporter_factory.cc)
 

--- a/exporters/ostream/BUILD
+++ b/exporters/ostream/BUILD
@@ -1,3 +1,6 @@
+# Copyright The OpenTelemetry Authors
+# SPDX-License-Identifier: Apache-2.0
+
 package(default_visibility = ["//visibility:public"])
 
 cc_library(

--- a/exporters/ostream/CMakeLists.txt
+++ b/exporters/ostream/CMakeLists.txt
@@ -1,3 +1,6 @@
+# Copyright The OpenTelemetry Authors
+# SPDX-License-Identifier: Apache-2.0
+
 add_library(opentelemetry_exporter_ostream_span src/span_exporter.cc
                                                 src/span_exporter_factory.cc)
 

--- a/exporters/otlp/BUILD
+++ b/exporters/otlp/BUILD
@@ -1,16 +1,5 @@
-# Copyright 2020, OpenTelemetry Authors
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# Copyright The OpenTelemetry Authors
+# SPDX-License-Identifier: Apache-2.0
 
 package(default_visibility = ["//visibility:public"])
 

--- a/exporters/prometheus/BUILD
+++ b/exporters/prometheus/BUILD
@@ -1,16 +1,5 @@
-# Copyright 2020, OpenTelemetry Authors
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# Copyright The OpenTelemetry Authors
+# SPDX-License-Identifier: Apache-2.0
 
 package(default_visibility = ["//visibility:public"])
 

--- a/exporters/prometheus/CMakeLists.txt
+++ b/exporters/prometheus/CMakeLists.txt
@@ -1,16 +1,5 @@
-# Copyright 2020, OpenTelemetry Authors
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# Copyright The OpenTelemetry Authors
+# SPDX-License-Identifier: Apache-2.0
 
 include_directories(include)
 if(NOT TARGET prometheus-cpp::core)

--- a/exporters/prometheus/test/CMakeLists.txt
+++ b/exporters/prometheus/test/CMakeLists.txt
@@ -1,3 +1,6 @@
+# Copyright The OpenTelemetry Authors
+# SPDX-License-Identifier: Apache-2.0
+
 foreach(testname exporter_test collector_test exporter_utils_test)
   add_executable(${testname} "${testname}.cc")
   target_link_libraries(

--- a/exporters/zipkin/BUILD
+++ b/exporters/zipkin/BUILD
@@ -1,3 +1,6 @@
+# Copyright The OpenTelemetry Authors
+# SPDX-License-Identifier: Apache-2.0
+
 package(default_visibility = ["//visibility:public"])
 
 cc_library(

--- a/ext/BUILD
+++ b/ext/BUILD
@@ -1,3 +1,6 @@
+# Copyright The OpenTelemetry Authors
+# SPDX-License-Identifier: Apache-2.0
+
 package(default_visibility = ["//visibility:public"])
 
 cc_library(

--- a/ext/CMakeLists.txt
+++ b/ext/CMakeLists.txt
@@ -1,3 +1,6 @@
+# Copyright The OpenTelemetry Authors
+# SPDX-License-Identifier: Apache-2.0
+
 add_library(opentelemetry_ext INTERFACE)
 target_include_directories(
   opentelemetry_ext

--- a/ext/src/http/client/curl/BUILD
+++ b/ext/src/http/client/curl/BUILD
@@ -1,3 +1,6 @@
+# Copyright The OpenTelemetry Authors
+# SPDX-License-Identifier: Apache-2.0
+
 package(default_visibility = ["//visibility:public"])
 
 cc_library(

--- a/ext/src/zpages/BUILD
+++ b/ext/src/zpages/BUILD
@@ -1,16 +1,5 @@
-# Copyright 2020, OpenTelemetry Authors
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# Copyright The OpenTelemetry Authors
+# SPDX-License-Identifier: Apache-2.0
 
 package(default_visibility = ["//visibility:public"])
 

--- a/ext/src/zpages/CMakeLists.txt
+++ b/ext/src/zpages/CMakeLists.txt
@@ -1,3 +1,6 @@
+# Copyright The OpenTelemetry Authors
+# SPDX-License-Identifier: Apache-2.0
+
 add_library(
   opentelemetry_zpages
   tracez_processor.cc

--- a/ext/test/CMakeLists.txt
+++ b/ext/test/CMakeLists.txt
@@ -1,3 +1,6 @@
+# Copyright The OpenTelemetry Authors
+# SPDX-License-Identifier: Apache-2.0
+
 if(WITH_ZPAGES)
   add_subdirectory(zpages)
 endif()

--- a/ext/test/http/BUILD
+++ b/ext/test/http/BUILD
@@ -1,3 +1,6 @@
+# Copyright The OpenTelemetry Authors
+# SPDX-License-Identifier: Apache-2.0
+
 cc_test(
     name = "curl_http_test",
     srcs = [

--- a/ext/test/w3c_tracecontext_test/BUILD
+++ b/ext/test/w3c_tracecontext_test/BUILD
@@ -1,3 +1,6 @@
+# Copyright The OpenTelemetry Authors
+# SPDX-License-Identifier: Apache-2.0
+
 cc_binary(
     name = "w3c_tracecontext_test",
     srcs = [

--- a/ext/test/w3c_tracecontext_test/Dockerfile
+++ b/ext/test/w3c_tracecontext_test/Dockerfile
@@ -1,3 +1,6 @@
+# Copyright The OpenTelemetry Authors
+# SPDX-License-Identifier: Apache-2.0
+
 FROM python
 
 RUN pip install aiohttp

--- a/ext/test/zpages/BUILD
+++ b/ext/test/zpages/BUILD
@@ -1,3 +1,6 @@
+# Copyright The OpenTelemetry Authors
+# SPDX-License-Identifier: Apache-2.0
+
 cc_test(
     name = "threadsafe_span_data_tests",
     srcs = [

--- a/ext/test/zpages/CMakeLists.txt
+++ b/ext/test/zpages/CMakeLists.txt
@@ -1,3 +1,6 @@
+# Copyright The OpenTelemetry Authors
+# SPDX-License-Identifier: Apache-2.0
+
 foreach(testname tracez_processor_test tracez_data_aggregator_test
                  threadsafe_span_data_test)
   add_executable(${testname} "${testname}.cc")

--- a/sdk/BUILD
+++ b/sdk/BUILD
@@ -1,3 +1,6 @@
+# Copyright The OpenTelemetry Authors
+# SPDX-License-Identifier: Apache-2.0
+
 package(default_visibility = ["//visibility:public"])
 
 cc_library(

--- a/sdk/CMakeLists.txt
+++ b/sdk/CMakeLists.txt
@@ -1,3 +1,6 @@
+# Copyright The OpenTelemetry Authors
+# SPDX-License-Identifier: Apache-2.0
+
 add_library(opentelemetry_sdk INTERFACE)
 target_include_directories(
   opentelemetry_sdk

--- a/sdk/src/CMakeLists.txt
+++ b/sdk/src/CMakeLists.txt
@@ -1,3 +1,6 @@
+# Copyright The OpenTelemetry Authors
+# SPDX-License-Identifier: Apache-2.0
+
 add_subdirectory(common)
 add_subdirectory(trace)
 add_subdirectory(metrics)

--- a/sdk/src/common/BUILD
+++ b/sdk/src/common/BUILD
@@ -1,16 +1,5 @@
-# Copyright 2020, OpenTelemetry Authors
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# Copyright The OpenTelemetry Authors
+# SPDX-License-Identifier: Apache-2.0
 
 package(default_visibility = ["//visibility:public"])
 

--- a/sdk/src/common/CMakeLists.txt
+++ b/sdk/src/common/CMakeLists.txt
@@ -1,3 +1,6 @@
+# Copyright The OpenTelemetry Authors
+# SPDX-License-Identifier: Apache-2.0
+
 set(COMMON_SRCS random.cc core.cc global_log_handler.cc)
 if(WIN32)
   list(APPEND COMMON_SRCS platform/fork_windows.cc)

--- a/sdk/src/common/platform/BUILD
+++ b/sdk/src/common/platform/BUILD
@@ -1,16 +1,5 @@
-# Copyright 2020, OpenTelemetry Authors
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# Copyright The OpenTelemetry Authors
+# SPDX-License-Identifier: Apache-2.0
 
 package(default_visibility = ["//visibility:public"])
 

--- a/sdk/src/logs/BUILD
+++ b/sdk/src/logs/BUILD
@@ -1,16 +1,5 @@
-# Copyright 2020, OpenTelemetry Authors
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# Copyright The OpenTelemetry Authors
+# SPDX-License-Identifier: Apache-2.0
 
 package(default_visibility = ["//visibility:public"])
 

--- a/sdk/src/logs/CMakeLists.txt
+++ b/sdk/src/logs/CMakeLists.txt
@@ -1,3 +1,6 @@
+# Copyright The OpenTelemetry Authors
+# SPDX-License-Identifier: Apache-2.0
+
 add_library(
   opentelemetry_logs
   logger_provider.cc

--- a/sdk/src/metrics/BUILD
+++ b/sdk/src/metrics/BUILD
@@ -1,16 +1,5 @@
-# Copyright 2020, OpenTelemetry Authors
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# Copyright The OpenTelemetry Authors
+# SPDX-License-Identifier: Apache-2.0
 
 package(default_visibility = ["//visibility:public"])
 

--- a/sdk/src/metrics/CMakeLists.txt
+++ b/sdk/src/metrics/CMakeLists.txt
@@ -1,3 +1,6 @@
+# Copyright The OpenTelemetry Authors
+# SPDX-License-Identifier: Apache-2.0
+
 add_library(
   opentelemetry_metrics
   async_instruments.cc

--- a/sdk/src/resource/BUILD
+++ b/sdk/src/resource/BUILD
@@ -1,16 +1,5 @@
-# Copyright 2020, OpenTelemetry Authors
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# Copyright The OpenTelemetry Authors
+# SPDX-License-Identifier: Apache-2.0
 
 package(default_visibility = ["//visibility:public"])
 

--- a/sdk/src/resource/CMakeLists.txt
+++ b/sdk/src/resource/CMakeLists.txt
@@ -1,3 +1,6 @@
+# Copyright The OpenTelemetry Authors
+# SPDX-License-Identifier: Apache-2.0
+
 add_library(opentelemetry_resources resource.cc resource_detector.cc)
 
 set_target_properties(opentelemetry_resources PROPERTIES EXPORT_NAME resources)

--- a/sdk/src/trace/BUILD
+++ b/sdk/src/trace/BUILD
@@ -1,16 +1,5 @@
-# Copyright 2020, OpenTelemetry Authors
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# Copyright The OpenTelemetry Authors
+# SPDX-License-Identifier: Apache-2.0
 
 package(default_visibility = ["//visibility:public"])
 

--- a/sdk/src/trace/CMakeLists.txt
+++ b/sdk/src/trace/CMakeLists.txt
@@ -1,3 +1,6 @@
+# Copyright The OpenTelemetry Authors
+# SPDX-License-Identifier: Apache-2.0
+
 add_library(
   opentelemetry_trace
   tracer_context.cc

--- a/sdk/src/version/CMakeLists.txt
+++ b/sdk/src/version/CMakeLists.txt
@@ -1,3 +1,6 @@
+# Copyright The OpenTelemetry Authors
+# SPDX-License-Identifier: Apache-2.0
+
 add_library(opentelemetry_version version.cc)
 
 set_target_properties(opentelemetry_version PROPERTIES EXPORT_NAME version)

--- a/sdk/test/CMakeLists.txt
+++ b/sdk/test/CMakeLists.txt
@@ -1,3 +1,6 @@
+# Copyright The OpenTelemetry Authors
+# SPDX-License-Identifier: Apache-2.0
+
 add_subdirectory(common)
 add_subdirectory(trace)
 add_subdirectory(metrics)

--- a/sdk/test/common/BUILD
+++ b/sdk/test/common/BUILD
@@ -1,3 +1,6 @@
+# Copyright The OpenTelemetry Authors
+# SPDX-License-Identifier: Apache-2.0
+
 load("//bazel:otel_cc_benchmark.bzl", "otel_cc_benchmark")
 
 cc_test(

--- a/sdk/test/common/CMakeLists.txt
+++ b/sdk/test/common/CMakeLists.txt
@@ -1,3 +1,6 @@
+# Copyright The OpenTelemetry Authors
+# SPDX-License-Identifier: Apache-2.0
+
 foreach(
   testname
   random_test

--- a/sdk/test/instrumentationscope/BUILD
+++ b/sdk/test/instrumentationscope/BUILD
@@ -1,3 +1,6 @@
+# Copyright The OpenTelemetry Authors
+# SPDX-License-Identifier: Apache-2.0
+
 cc_test(
     name = "instrumentationscope_test",
     srcs = [

--- a/sdk/test/instrumentationscope/CMakeLists.txt
+++ b/sdk/test/instrumentationscope/CMakeLists.txt
@@ -1,3 +1,6 @@
+# Copyright The OpenTelemetry Authors
+# SPDX-License-Identifier: Apache-2.0
+
 include(GoogleTest)
 
 foreach(testname instrumentationscope_test)

--- a/sdk/test/logs/BUILD
+++ b/sdk/test/logs/BUILD
@@ -1,3 +1,6 @@
+# Copyright The OpenTelemetry Authors
+# SPDX-License-Identifier: Apache-2.0
+
 cc_test(
     name = "logger_provider_sdk_test",
     srcs = [

--- a/sdk/test/logs/CMakeLists.txt
+++ b/sdk/test/logs/CMakeLists.txt
@@ -1,3 +1,6 @@
+# Copyright The OpenTelemetry Authors
+# SPDX-License-Identifier: Apache-2.0
+
 foreach(testname
         logger_provider_sdk_test logger_sdk_test log_record_test
         simple_log_record_processor_test batch_log_record_processor_test)

--- a/sdk/test/metrics/BUILD
+++ b/sdk/test/metrics/BUILD
@@ -1,3 +1,6 @@
+# Copyright The OpenTelemetry Authors
+# SPDX-License-Identifier: Apache-2.0
+
 load("//bazel:otel_cc_benchmark.bzl", "otel_cc_benchmark")
 
 cc_test(

--- a/sdk/test/metrics/CMakeLists.txt
+++ b/sdk/test/metrics/CMakeLists.txt
@@ -1,3 +1,6 @@
+# Copyright The OpenTelemetry Authors
+# SPDX-License-Identifier: Apache-2.0
+
 foreach(
   testname
   meter_provider_sdk_test

--- a/sdk/test/metrics/exemplar/BUILD
+++ b/sdk/test/metrics/exemplar/BUILD
@@ -1,3 +1,6 @@
+# Copyright The OpenTelemetry Authors
+# SPDX-License-Identifier: Apache-2.0
+
 cc_test(
     name = "no_exemplar_reservoir_test",
     srcs = [

--- a/sdk/test/metrics/exemplar/CMakeLists.txt
+++ b/sdk/test/metrics/exemplar/CMakeLists.txt
@@ -1,3 +1,6 @@
+# Copyright The OpenTelemetry Authors
+# SPDX-License-Identifier: Apache-2.0
+
 foreach(
   testname
   no_exemplar_reservoir_test never_sample_filter_test always_sample_filter_test

--- a/sdk/test/resource/BUILD
+++ b/sdk/test/resource/BUILD
@@ -1,3 +1,6 @@
+# Copyright The OpenTelemetry Authors
+# SPDX-License-Identifier: Apache-2.0
+
 cc_test(
     name = "resource_test",
     srcs = [

--- a/sdk/test/resource/CMakeLists.txt
+++ b/sdk/test/resource/CMakeLists.txt
@@ -1,3 +1,6 @@
+# Copyright The OpenTelemetry Authors
+# SPDX-License-Identifier: Apache-2.0
+
 foreach(testname resource_test)
   add_executable(${testname} "${testname}.cc")
   target_link_libraries(${testname} ${GTEST_BOTH_LIBRARIES}

--- a/sdk/test/trace/BUILD
+++ b/sdk/test/trace/BUILD
@@ -1,3 +1,6 @@
+# Copyright The OpenTelemetry Authors
+# SPDX-License-Identifier: Apache-2.0
+
 load("//bazel:otel_cc_benchmark.bzl", "otel_cc_benchmark")
 
 cc_test(

--- a/sdk/test/trace/CMakeLists.txt
+++ b/sdk/test/trace/CMakeLists.txt
@@ -1,3 +1,6 @@
+# Copyright The OpenTelemetry Authors
+# SPDX-License-Identifier: Apache-2.0
+
 foreach(
   testname
   tracer_provider_test

--- a/test_common/BUILD
+++ b/test_common/BUILD
@@ -1,3 +1,6 @@
+# Copyright The OpenTelemetry Authors
+# SPDX-License-Identifier: Apache-2.0
+
 package(default_visibility = ["//visibility:public"])
 
 cc_library(

--- a/test_common/CMakeLists.txt
+++ b/test_common/CMakeLists.txt
@@ -1,3 +1,6 @@
+# Copyright The OpenTelemetry Authors
+# SPDX-License-Identifier: Apache-2.0
+
 if(BUILD_TESTING)
   add_library(opentelemetry_test_common INTERFACE)
   target_include_directories(

--- a/test_common/src/CMakeLists.txt
+++ b/test_common/src/CMakeLists.txt
@@ -1,3 +1,6 @@
+# Copyright The OpenTelemetry Authors
+# SPDX-License-Identifier: Apache-2.0
+
 if(BUILD_TESTING)
   add_subdirectory(http/client/nosend)
 endif()

--- a/test_common/src/http/client/nosend/BUILD
+++ b/test_common/src/http/client/nosend/BUILD
@@ -1,3 +1,6 @@
+# Copyright The OpenTelemetry Authors
+# SPDX-License-Identifier: Apache-2.0
+
 package(default_visibility = ["//visibility:public"])
 
 cc_library(

--- a/test_common/src/http/client/nosend/CMakeLists.txt
+++ b/test_common/src/http/client/nosend/CMakeLists.txt
@@ -1,3 +1,6 @@
+# Copyright The OpenTelemetry Authors
+# SPDX-License-Identifier: Apache-2.0
+
 if(${BUILD_TESTING})
   add_library(opentelemetry_http_client_nosend http_client_factory_nosend.cc
                                                http_client_nosend.cc)

--- a/third_party/BUILD
+++ b/third_party/BUILD
@@ -1,3 +1,6 @@
+# Copyright The OpenTelemetry Authors
+# SPDX-License-Identifier: Apache-2.0
+
 licenses(["notice"])  # Apache 2.0
 
 package(default_visibility = ["//:__subpackages__"])

--- a/tools/WORKSPACE
+++ b/tools/WORKSPACE
@@ -1,3 +1,6 @@
+# Copyright The OpenTelemetry Authors
+# SPDX-License-Identifier: Apache-2.0
+
 local_repository(
   name = "vcpkg",
   path = "./vcpkg",

--- a/tools/build-benchmark.sh
+++ b/tools/build-benchmark.sh
@@ -1,5 +1,8 @@
 #!/usr/bin/env bash
 
+# Copyright The OpenTelemetry Authors
+# SPDX-License-Identifier: Apache-2.0
+
 # Switch to workspace root directory first
 DIR="$( cd "$(dirname "$0")" >/dev/null 2>&1 ; pwd -P )"
 WORKSPACE_ROOT=$DIR/..

--- a/tools/build-gtest.sh
+++ b/tools/build-gtest.sh
@@ -1,5 +1,8 @@
 #!/usr/bin/env bash
 
+# Copyright The OpenTelemetry Authors
+# SPDX-License-Identifier: Apache-2.0
+
 # Switch to workspace root directory first
 DIR="$( cd "$(dirname "$0")" >/dev/null 2>&1 ; pwd -P )"
 WORKSPACE_ROOT=$DIR/..

--- a/tools/build-nuget.ps1
+++ b/tools/build-nuget.ps1
@@ -1,3 +1,6 @@
+# Copyright The OpenTelemetry Authors
+# SPDX-License-Identifier: Apache-2.0
+
 # Function returns 4-part 'classic' version string from SemVer 2.0 string
 function GenVer4Part([String] $Version)
 {

--- a/tools/build-vcpkg.sh
+++ b/tools/build-vcpkg.sh
@@ -1,4 +1,8 @@
 #!/bin/bash
+
+# Copyright The OpenTelemetry Authors
+# SPDX-License-Identifier: Apache-2.0
+
 export PATH=/usr/local/bin:$PATH
 DIR="$(
   cd "$(dirname "$0")" >/dev/null 2>&1

--- a/tools/build.sh
+++ b/tools/build.sh
@@ -1,4 +1,8 @@
 #!/bin/bash
+
+# Copyright The OpenTelemetry Authors
+# SPDX-License-Identifier: Apache-2.0
+
 export PATH=/usr/local/bin:$PATH
 
 ##

--- a/tools/download.ps1
+++ b/tools/download.ps1
@@ -1,3 +1,6 @@
+# Copyright The OpenTelemetry Authors
+# SPDX-License-Identifier: Apache-2.0
+
 $url=$args[0]
 $arr=$args[0].Split("/")
 $fileName=$arr[$arr.Count-1]

--- a/tools/format.sh
+++ b/tools/format.sh
@@ -1,4 +1,8 @@
 #!/bin/bash
+
+# Copyright The OpenTelemetry Authors
+# SPDX-License-Identifier: Apache-2.0
+
 if [[ ! -e tools/format.sh ]]; then
   echo "This tool must be run from the topmost directory." >&2
   exit 1

--- a/tools/git-cl.sh
+++ b/tools/git-cl.sh
@@ -1,4 +1,8 @@
 #!/bin/sh
+
+# Copyright The OpenTelemetry Authors
+# SPDX-License-Identifier: Apache-2.0
+
 if [ "format" = "$1" ]; then
   if [ -z "$2" ]; then
     echo Please specify file name.

--- a/tools/install.sh
+++ b/tools/install.sh
@@ -1,4 +1,8 @@
 #!/bin/bash
+
+# Copyright The OpenTelemetry Authors
+# SPDX-License-Identifier: Apache-2.0
+
 DIR="$( cd "$(dirname "$0")" >/dev/null 2>&1 ; pwd -P )"
 WORKSPACE_ROOT=$DIR/..
 pushd $WORKSPACE_ROOT

--- a/tools/install_llvm-win32.ps1
+++ b/tools/install_llvm-win32.ps1
@@ -1,3 +1,6 @@
+# Copyright The OpenTelemetry Authors
+# SPDX-License-Identifier: Apache-2.0
+
 $llvmVersion = "10.0.0"
 Write-Host "Installing LLVM $llvmVersion ..." -ForegroundColor Cyan
 Write-Host "Downloading..."

--- a/tools/install_llvm-win64.ps1
+++ b/tools/install_llvm-win64.ps1
@@ -1,3 +1,6 @@
+# Copyright The OpenTelemetry Authors
+# SPDX-License-Identifier: Apache-2.0
+
 $llvmVersion = "10.0.0"
 Write-Host "Installing LLVM $llvmVersion ..." -ForegroundColor Cyan
 Write-Host "Downloading..."

--- a/tools/setup-buildtools-mac.sh
+++ b/tools/setup-buildtools-mac.sh
@@ -1,5 +1,9 @@
 #!/bin/sh
 
+# Copyright The OpenTelemetry Authors
+# SPDX-License-Identifier: Apache-2.0
+
+
 # TODO: it's not ideal experience, but we use have to use brew-provided deps.
 # Sometimes we might run into a situation where a different user takes over
 # control of the brew dirs. That causes the brew update to fail.

--- a/tools/setup-buildtools.sh
+++ b/tools/setup-buildtools.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+# Copyright The OpenTelemetry Authors
+# SPDX-License-Identifier: Apache-2.0
+
 # Switch to workspace root directory first
 DIR="$( cd "$(dirname "$0")" >/dev/null 2>&1 ; pwd -P )"
 

--- a/tools/setup-cmake.sh
+++ b/tools/setup-cmake.sh
@@ -1,4 +1,8 @@
 #!/bin/bash
+
+# Copyright The OpenTelemetry Authors
+# SPDX-License-Identifier: Apache-2.0
+
 #
 # This script installs latest CMake on Linux machine
 #

--- a/tools/setup-devenv.sh
+++ b/tools/setup-devenv.sh
@@ -1,5 +1,8 @@
 #!/bin/sh
 
+# Copyright The OpenTelemetry Authors
+# SPDX-License-Identifier: Apache-2.0
+
 # Try to autodetect the tools dir
 if [ "$BASH_SOURCE" != "" ]; then
 TOOLS_PATH=`dirname ${BASH_SOURCE[0]}`

--- a/tools/setup-ninja.sh
+++ b/tools/setup-ninja.sh
@@ -1,4 +1,8 @@
 #!/bin/bash
+
+# Copyright The OpenTelemetry Authors
+# SPDX-License-Identifier: Apache-2.0
+
 # TODO: add support for Ninja on Mac OS X
 wget -O /tmp/ninja.zip https://github.com/ninja-build/ninja/releases/download/v1.10.1/ninja-linux.zip
 sudo unzip /tmp/ninja.zip -d /usr/local/bin/

--- a/tools/setup-protobuf.sh
+++ b/tools/setup-protobuf.sh
@@ -1,4 +1,8 @@
 #!/bin/bash
+
+# Copyright The OpenTelemetry Authors
+# SPDX-License-Identifier: Apache-2.0
+
 pushd /tmp
 curl -OL https://github.com/protocolbuffers/protobuf/releases/download/v3.14.0/protoc-3.14.0-linux-x86_64.zip
 unzip -o protoc-3.14.0-linux-x86_64.zip -d /usr/local/


### PR DESCRIPTION
This added copyright header for all files based on below 3 PRs.

https://github.com/open-telemetry/opentelemetry-cpp/pull/1960
https://github.com/open-telemetry/opentelemetry-cpp/pull/1961
https://github.com/open-telemetry/opentelemetry-cpp/pull/1962

## Changes

Please provide a brief description of the changes here.

For significant contributions please make sure you have completed the following items:

* [ ] `CHANGELOG.md` updated for non-trivial changes
* [ ] Unit tests have been added
* [ ] Changes in public API reviewed