### PR TITLE
Enforce copyright check in CI

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -1,3 +1,6 @@
+# Copyright The OpenTelemetry Authors
+# SPDX-License-Identifier: Apache-2.0
+
 # bazel configurations for running tests under sanitizers.
 # Based on https://github.com/bazelment/trunk/blob/master/tools/bazel.rc
 

--- a/.clang-format
+++ b/.clang-format
@@ -1,3 +1,6 @@
+# Copyright The OpenTelemetry Authors
+# SPDX-License-Identifier: Apache-2.0
+
 # See Clang docs: http://clang.llvm.org/docs/ClangFormatStyleOptions.html
 BasedOnStyle: Chromium
 

--- a/.cmake-format.py
+++ b/.cmake-format.py
@@ -1,3 +1,6 @@
+# Copyright The OpenTelemetry Authors
+# SPDX-License-Identifier: Apache-2.0
+
 # If comment markup is enabled, don't reflow the first comment block in
 # eachlistfile. Use this to preserve formatting of your
 # copyright/licensestatements.

--- a/.copyright-ignore
+++ b/.copyright-ignore
@@ -1,18 +1,22 @@
 # Copyright 2023, The OpenTelemetry Authors
 # SPDX-License-Identifier: Apache-2.0
 
-## Ignore the following directories
+# Ignore the following directories
 
 ./.git/*
 ./.github/*
 ./third_party/*
 ./tools/vcpkg/*
+./tools/ports/*
 
 # Third party code
+
 ./api/include/opentelemetry/nostd/internal/absl/*
 ./exporters/jaeger/thrift-gen/*
+./exporters/etw/include/opentelemetry/exporters/etw/TraceLoggingDynamic.h
 
 # Doc
+
 ./docs/*
 
 ## Ignore the following files patterns
@@ -23,9 +27,13 @@
 *.log
 *.patch
 *.json
+*.nuspec
 
-## Ignore the following files
+# Ignore the following files
 
+./.bazelignore
+./.bazelversion
 ./LICENSE
 ./exporters/etw/include/opentelemetry/exporters/etw/LICENSE
+./docker/.gitignore
 

--- a/.copyright-ignore
+++ b/.copyright-ignore
@@ -1,0 +1,34 @@
+# Copyright 2023, The OpenTelemetry Authors
+# SPDX-License-Identifier: Apache-2.0
+
+## Ignore the following directories
+
+./.git/*
+
+./third_party/*
+
+./tools/vcpkg/*
+
+./api/include/opentelemetry/nostd/internal/absl/*
+
+./exporters/jaeger/thrift-gen/*
+
+## Ignore the following files patterns
+
+# Markdown (unsure how to add comments in markdown)
+
+*.md
+
+# Images
+
+*.png
+
+# Log files
+
+*.log
+
+## Ignore the following files
+
+./LICENSE
+./exporters/etw/include/opentelemetry/exporters/etw/LICENSE
+

--- a/.copyright-ignore
+++ b/.copyright-ignore
@@ -1,4 +1,4 @@
-# Copyright 2023, The OpenTelemetry Authors
+# Copyright The OpenTelemetry Authors
 # SPDX-License-Identifier: Apache-2.0
 
 # Ignore the following directories

--- a/.copyright-ignore
+++ b/.copyright-ignore
@@ -4,28 +4,25 @@
 ## Ignore the following directories
 
 ./.git/*
-
+./.github/*
 ./third_party/*
-
 ./tools/vcpkg/*
 
+# Third party code
 ./api/include/opentelemetry/nostd/internal/absl/*
-
 ./exporters/jaeger/thrift-gen/*
+
+# Doc
+./docs/*
 
 ## Ignore the following files patterns
 
-# Markdown (unsure how to add comments in markdown)
-
 *.md
-
-# Images
-
+*.rst
 *.png
-
-# Log files
-
 *.log
+*.patch
+*.json
 
 ## Ignore the following files
 

--- a/.copyright-ignore
+++ b/.copyright-ignore
@@ -5,7 +5,13 @@
 
 ./.git/*
 ./.github/*
-./third_party/*
+./third_party/benchmark/*
+./third_party/boost/*
+./third_party/googletest/*
+./third_party/ms-gsl/*
+./third_party/nlohmann-json/*
+./third_party/opentelemetry-proto/*
+./third_party/prometheus-cpp/*
 ./tools/vcpkg/*
 ./tools/ports/*
 

--- a/.copyright-ignore
+++ b/.copyright-ignore
@@ -29,11 +29,17 @@
 *.json
 *.nuspec
 
-# Ignore the following files
+# Packaging
+*/CONTROL
+
+# LICENSE files
+*/LICENSE
+
+# Ignore the following misc files
 
 ./.bazelignore
 ./.bazelversion
-./LICENSE
-./exporters/etw/include/opentelemetry/exporters/etw/LICENSE
 ./docker/.gitignore
-
+.markdownlintignore
+./ci/toc.yml
+./ci/valgrind-suppressions

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -493,6 +493,13 @@ jobs:
     - name: run tests
       run: ./ci/do_ci.sh format
 
+  copyright:
+    name: Copyright
+    runs-on: ubuntu-20.04
+    steps:
+    - uses: actions/checkout@v3
+    - name: check copyright
+      run: ./tools/check_copyright.sh
 
   windows:
     name: CMake -> exporter proto

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# Copyright The OpenTelemetry Authors
+# SPDX-License-Identifier: Apache-2.0
+
 # Ref. https://github.com/github/gitignore/blob/master/C%2B%2B.gitignore
 # Prerequisites
 *.d
@@ -51,3 +54,6 @@
 
 tags
 .cache/clangd/*
+
+# Temporary dir used when generating semconv
+./buildscripts/semantic-convention/opentelemetry-specification

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ Increment the:
 
 * Convert Prometheus Exporter to Pull MetricReader [#1953](https://github.com/open-telemetry/opentelemetry-cpp/pull/1953)
 * Upgrade prometheus-cpp to v1.1.0 [#1954](https://github.com/open-telemetry/opentelemetry-cpp/pull/1954)
+* [CI] Enforce copyright check in CI [#1965](https://github.com/open-telemetry/opentelemetry-cpp/pull/1965)
 
 ## [1.8.2] 2023-01-31
 

--- a/buildscripts/semantic-convention/.gitignore
+++ b/buildscripts/semantic-convention/.gitignore
@@ -1,1 +1,0 @@
-opentelemetry-specification/

--- a/ci/docfx.cmd
+++ b/ci/docfx.cmd
@@ -1,3 +1,6 @@
+REM Copyright The OpenTelemetry Authors
+REM SPDX-License-Identifier: Apache-2.0
+
 SETLOCAL ENABLEEXTENSIONS
 
 type ci\docfx.json > docfx.json

--- a/cmake/opentelemetry-cpp-config.cmake.in
+++ b/cmake/opentelemetry-cpp-config.cmake.in
@@ -1,4 +1,4 @@
-# Copyright 2023, The OpenTelemetry Authors
+# Copyright The OpenTelemetry Authors
 # SPDX-License-Identifier: Apache-2.0
 
 #.rst:

--- a/cmake/opentelemetry-cpp-config.cmake.in
+++ b/cmake/opentelemetry-cpp-config.cmake.in
@@ -1,3 +1,6 @@
+# Copyright 2023, The OpenTelemetry Authors
+# SPDX-License-Identifier: Apache-2.0
+
 #.rst:
 # opentelemetry-cpp-config.cmake
 # --------

--- a/docker/Dockerfile.alpine.base
+++ b/docker/Dockerfile.alpine.base
@@ -1,3 +1,6 @@
+# Copyright 2023, The OpenTelemetry Authors
+# SPDX-License-Identifier: Apache-2.0
+
 ARG BASE_IMAGE=alpine:latest
 ARG CORES=${nproc}
 

--- a/docker/Dockerfile.alpine.base
+++ b/docker/Dockerfile.alpine.base
@@ -1,4 +1,4 @@
-# Copyright 2023, The OpenTelemetry Authors
+# Copyright The OpenTelemetry Authors
 # SPDX-License-Identifier: Apache-2.0
 
 ARG BASE_IMAGE=alpine:latest

--- a/docker/Dockerfile.centos
+++ b/docker/Dockerfile.centos
@@ -1,3 +1,6 @@
+# Copyright 2023, The OpenTelemetry Authors
+# SPDX-License-Identifier: Apache-2.0
+
 FROM centos:7
 
 ARG TOOLSET_VER=11

--- a/docker/Dockerfile.centos
+++ b/docker/Dockerfile.centos
@@ -1,4 +1,4 @@
-# Copyright 2023, The OpenTelemetry Authors
+# Copyright The OpenTelemetry Authors
 # SPDX-License-Identifier: Apache-2.0
 
 FROM centos:7

--- a/docker/Dockerfile.debian.deps
+++ b/docker/Dockerfile.debian.deps
@@ -1,3 +1,6 @@
+# Copyright 2023, The OpenTelemetry Authors
+# SPDX-License-Identifier: Apache-2.0
+
 ARG BASE_IMAGE=ubuntu:latest
 ARG CORES=${nproc}
 

--- a/docker/Dockerfile.debian.deps
+++ b/docker/Dockerfile.debian.deps
@@ -1,4 +1,4 @@
-# Copyright 2023, The OpenTelemetry Authors
+# Copyright The OpenTelemetry Authors
 # SPDX-License-Identifier: Apache-2.0
 
 ARG BASE_IMAGE=ubuntu:latest

--- a/sdk/src/trace/samplers/trace_id_ratio.cc
+++ b/sdk/src/trace/samplers/trace_id_ratio.cc
@@ -1,17 +1,6 @@
-// Copyright 2020, Open Telemetry Authors
+// Copyright 2020, 2023, The OpenTelemetry Authors
 // Copyright 2017, OpenCensus Authors
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// SPDX-License-Identifier: Apache-2.0
 
 #include "opentelemetry/sdk/trace/samplers/trace_id_ratio.h"
 

--- a/sdk/src/trace/samplers/trace_id_ratio.cc
+++ b/sdk/src/trace/samplers/trace_id_ratio.cc
@@ -1,4 +1,4 @@
-// Copyright 2020, 2023, The OpenTelemetry Authors
+// Copyright The OpenTelemetry Authors
 // Copyright 2017, OpenCensus Authors
 // SPDX-License-Identifier: Apache-2.0
 

--- a/third_party_release
+++ b/third_party_release
@@ -1,3 +1,5 @@
+# Copyright The OpenTelemetry Authors
+# SPDX-License-Identifier: Apache-2.0
 #
 # MAINTAINER
 #

--- a/tools/build-bazel.cmd
+++ b/tools/build-bazel.cmd
@@ -1,3 +1,6 @@
+REM Copyright The OpenTelemetry Authors
+REM SPDX-License-Identifier: Apache-2.0
+
 pushd "%~dp0"
 set "PATH=%CD%;%PATH%"
 cd ..

--- a/tools/build-benchmark.cmd
+++ b/tools/build-benchmark.cmd
@@ -1,3 +1,6 @@
+REM Copyright The OpenTelemetry Authors
+REM SPDX-License-Identifier: Apache-2.0
+
 @echo off
 set BUILDTOOLS_VERSION=vs2019
 set CMAKE_GEN="Visual Studio 16 2019"

--- a/tools/build-clang-12.cmd
+++ b/tools/build-clang-12.cmd
@@ -1,3 +1,6 @@
+REM Copyright The OpenTelemetry Authors
+REM SPDX-License-Identifier: Apache-2.0
+
 @echo off
 pushd %~dp0
 set "PATH=%ProgramFiles%\LLVM-12\bin;%PATH%"

--- a/tools/build-clang.cmd
+++ b/tools/build-clang.cmd
@@ -1,3 +1,6 @@
+REM Copyright The OpenTelemetry Authors
+REM SPDX-License-Identifier: Apache-2.0
+
 @echo off
 pushd %~dp0
 set "PATH=%ProgramFiles%\LLVM\bin;%PATH%"

--- a/tools/build-docker.cmd
+++ b/tools/build-docker.cmd
@@ -1,3 +1,6 @@
+REM Copyright The OpenTelemetry Authors
+REM SPDX-License-Identifier: Apache-2.0
+
 @echo off
 pushd %~dp0
 REM Default arguments

--- a/tools/build-nuget.cmd
+++ b/tools/build-nuget.cmd
@@ -1,3 +1,6 @@
+REM Copyright The OpenTelemetry Authors
+REM SPDX-License-Identifier: Apache-2.0
+
 @echo off
 pushd "%~dp0"
 set "PATH=%CD%;%PATH%"

--- a/tools/build-vs2015.cmd
+++ b/tools/build-vs2015.cmd
@@ -1,3 +1,6 @@
+REM Copyright The OpenTelemetry Authors
+REM SPDX-License-Identifier: Apache-2.0
+
 REM Build with Visual Studio 2015
 set "PATH=%ProgramFiles(x86)%\MSBuild\14.0\Bin;%ProgramFiles(x86)%\Microsoft Visual Studio 14.0\VC\bin;%PATH%"
 

--- a/tools/build-vs2017.cmd
+++ b/tools/build-vs2017.cmd
@@ -1,3 +1,6 @@
+REM Copyright The OpenTelemetry Authors
+REM SPDX-License-Identifier: Apache-2.0
+
 REM Build with Visual Studio 2017
 set "BUILDTOOLS_VERSION=vs2017"
 set ARCH=x64

--- a/tools/build-vs2019.cmd
+++ b/tools/build-vs2019.cmd
@@ -1,3 +1,6 @@
+REM Copyright The OpenTelemetry Authors
+REM SPDX-License-Identifier: Apache-2.0
+
 REM Build with Visual Studio 2019
 set "BUILDTOOLS_VERSION=vs2019"
 set ARCH=x64

--- a/tools/build-vs2022.cmd
+++ b/tools/build-vs2022.cmd
@@ -1,3 +1,6 @@
+REM Copyright The OpenTelemetry Authors
+REM SPDX-License-Identifier: Apache-2.0
+
 REM Build with Visual Studio 2022
 set "BUILDTOOLS_VERSION=vs2022"
 set ARCH=x64

--- a/tools/build.cmd
+++ b/tools/build.cmd
@@ -1,3 +1,6 @@
+REM Copyright The OpenTelemetry Authors
+REM SPDX-License-Identifier: Apache-2.0
+
 @echo off
 REM ##########################################################################################
 REM # Build SDK with (msvc or clang) + CMake + (MSBuild or Ninja).                           #

--- a/tools/check_copyright.sh
+++ b/tools/check_copyright.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# Copyright 2023, The OpenTelemetry Authors
+# Copyright The OpenTelemetry Authors
 # SPDX-License-Identifier: Apache-2.0
 
 if [[ ! -e tools/check_copyright.sh ]]; then
@@ -51,8 +51,6 @@ done < /tmp/all_ignored
 #
 # Valid copyright strings are:
 # - Copyright The OpenTelemetry Authors
-# - Copyright YEAR, The OpenTelemetry Authors
-# - Copyright YEAR, YEAR, The OpenTelemetry Authors
 #
 # Valid license strings are:
 # - SPDX-License-Identifier: Apache-2.0
@@ -64,7 +62,7 @@ touch /tmp/all_missing
 for FILE in `cat /tmp/all_checked`
 do
   echo "Checking ${FILE}"
-  export COPYRIGHT=`head -10 ${FILE} | egrep -c "Copyright (20[0-9][0-9], ){0,2}The OpenTelemetry Authors"`
+  export COPYRIGHT=`head -10 ${FILE} | grep -c "Copyright The OpenTelemetry Authors"`
   export LICENSE=`head -10 ${FILE} | grep -c "SPDX-License-Identifier: Apache-2.0"`
   if [ "$COPYRIGHT" == "0" ]; then
     echo "Missing copyright in ${FILE}" >> /tmp/all_missing

--- a/tools/check_copyright.sh
+++ b/tools/check_copyright.sh
@@ -1,0 +1,102 @@
+#!/bin/bash
+
+# Copyright 2023, The OpenTelemetry Authors
+# SPDX-License-Identifier: Apache-2.0
+
+if [[ ! -e tools/check_copyright.sh ]]; then
+  echo "This tool must be run from the topmost directory." >&2
+  exit 1
+fi
+
+set -e
+
+#
+# Process input file .copyright-ignore,
+# - remove comments
+# - remove blank lines
+# to create file /tmp/all_ignored
+#
+
+grep -v "^#" < .copyright-ignore | \
+grep -v "^[[:space:]]*$" > /tmp/all_ignored
+
+#
+# Find all files from the repository
+# - ignore ./.git
+# - ignore git submodules in ./third_party
+# - ignore git submodules in ./tools/vcpkg
+# to create file /tmp/all_checked
+#
+
+find . -type f -print | sort -u > /tmp/all_checked
+
+#
+# Filter out /tmp/all_checked,
+# remove all ignored patterns from /tmp/all_ignored
+# When the pattern is *.md,
+# make sure to filter *\.md to avoid hiding *.cmd
+# Then, *\.md needs to be escaped to *\\.md,
+# to be given to egrep, hence the sed.
+# 
+
+while IFS= read -r PATTERN; do
+  SAFE_PATTERN=`echo "${PATTERN}" | sed "s!\.!\\\\\.!g"`
+  echo "Filtering out ${SAFE_PATTERN}"
+  egrep -v "${SAFE_PATTERN}" < /tmp/all_checked > /tmp/all_checked-tmp
+  mv /tmp/all_checked-tmp /tmp/all_checked
+done < /tmp/all_ignored
+
+#
+# For all files in /tmp/all_checked
+# - verify there is copyright
+# - verify there is a license
+# and append to /tmp/all_missing
+#
+# Valid copyright strings are:
+# - Copyright The OpenTelemetry Authors
+# - Copyright YEAR, The OpenTelemetry Authors
+# - Copyright YEAR, YEAR, The OpenTelemetry Authors
+#
+# Valid license strings are:
+# - SPDX-License-Identifier: Apache-2.0
+#
+
+rm -rf /tmp/all_missing
+touch /tmp/all_missing
+
+for FILE in `cat /tmp/all_checked`
+do
+  echo "Checking ${FILE}"
+  export COPYRIGHT=`head -10 ${FILE} | egrep -c "Copyright (20[0-9][0-9], ){0,2}The OpenTelemetry Authors"`
+  export LICENSE=`head -10 ${FILE} | grep -c "SPDX-License-Identifier: Apache-2.0"`
+  if [ "$COPYRIGHT" == "0" ]; then
+    echo "Missing copyright in ${FILE}" >> /tmp/all_missing
+  fi;
+  if [ "${LICENSE}" == "0" ]; then
+    echo "Missing license in ${FILE}" >> /tmp/all_missing
+  fi;
+done
+
+#
+# Final report
+#
+
+FAIL_COUNT=`wc -l < /tmp/all_missing`
+
+if [ ${FAIL_COUNT} != "0" ]; then
+  #
+  # CI FAILED
+  #
+
+  cat /tmp/all_missing
+
+  echo "Total number of failed checks: ${FAIL_COUNT}"
+  exit 1
+fi;
+
+#
+# CI PASSED
+#
+
+exit 0
+

--- a/tools/check_copyright.sh
+++ b/tools/check_copyright.sh
@@ -22,9 +22,6 @@ grep -v "^[[:space:]]*$" > /tmp/all_ignored
 
 #
 # Find all files from the repository
-# - ignore ./.git
-# - ignore git submodules in ./third_party
-# - ignore git submodules in ./tools/vcpkg
 # to create file /tmp/all_checked
 #
 

--- a/tools/download.cmd
+++ b/tools/download.cmd
@@ -1,3 +1,6 @@
+REM Copyright The OpenTelemetry Authors
+REM SPDX-License-Identifier: Apache-2.0
+
 @REM This script allows to download a file to local machine. First argument is URL
 set "PATH=%SystemRoot%;%SystemRoot%\System32;%SystemRoot%\System32\WindowsPowerShell\v1.0\;%ProgramFiles%\Git\bin"
 @powershell -File Download.ps1 %1

--- a/tools/git-cl.cmd
+++ b/tools/git-cl.cmd
@@ -1,3 +1,6 @@
+REM Copyright The OpenTelemetry Authors
+REM SPDX-License-Identifier: Apache-2.0
+
 @echo off
 setlocal enabledelayedexpansion
 if "%1" == "format" (

--- a/tools/install-vs-addons.cmd
+++ b/tools/install-vs-addons.cmd
@@ -1,3 +1,6 @@
+REM Copyright The OpenTelemetry Authors
+REM SPDX-License-Identifier: Apache-2.0
+
 set "PATH=%SystemRoot%;%SystemRoot%\System32;%SystemRoot%\System32\WindowsPowerShell\v1.0\;%ProgramFiles%\Git\bin"
 cd %~dp0
 call powershell -File .\install_llvm-win64.ps1

--- a/tools/setup-buildtools.cmd
+++ b/tools/setup-buildtools.cmd
@@ -1,3 +1,6 @@
+REM Copyright The OpenTelemetry Authors
+REM SPDX-License-Identifier: Apache-2.0
+
 @echo off
 setlocal enableextensions
 setlocal enabledelayedexpansion

--- a/tools/setup-devenv.cmd
+++ b/tools/setup-devenv.cmd
@@ -1,3 +1,6 @@
+REM Copyright The OpenTelemetry Authors
+REM SPDX-License-Identifier: Apache-2.0
+
 endlocal
 set "PATH=%~dp0;%PATH%"
 set "TOOLS_PATH=%~dp0"

--- a/tools/vcvars.cmd
+++ b/tools/vcvars.cmd
@@ -1,3 +1,6 @@
+REM Copyright The OpenTelemetry Authors
+REM SPDX-License-Identifier: Apache-2.0
+
 @echo off
 REM +-------------------------------------------------------------------+
 REM | Autodetect and set up the build environment.                      |


### PR DESCRIPTION
Enforce copyright check in CI.

## Changes

Added:

* a Copyright check in CI,
* a `tools/check_copyright.sh` script,
* file `.copyright-ignored` to allow for copyright exceptions.

Checklist:

* [X] `CHANGELOG.md` updated for non-trivial changes
* [ ] Unit tests have been added
* [X] Changes in public API reviewed (no changes)