### PR TITLE
 GetEnvironmentVariable(), mismatched delete / delete[] on windows

### DIFF
--- a/sdk/include/opentelemetry/sdk/common/env_variables.h
+++ b/sdk/include/opentelemetry/sdk/common/env_variables.h
@@ -33,10 +33,10 @@ inline const std::string GetEnvironmentVariable(const char *env_var_name)
   // avoid calling std::getenv which is deprecated in MSVC.
   size_t required_size = 0;
   getenv_s(&required_size, nullptr, 0, env_var_name);
-  std::unique_ptr<char> endpoint_buffer;
+  std::unique_ptr<char[]> endpoint_buffer;
   if (required_size > 0)
   {
-    endpoint_buffer = std::unique_ptr<char>{new char[required_size]};
+    endpoint_buffer = std::unique_ptr<char[]>{new char[required_size]};
     getenv_s(&required_size, endpoint_buffer.get(), required_size, env_var_name);
     endpoint_from_env = endpoint_buffer.get();
   }


### PR DESCRIPTION
Fixes #1970

## Changes

Fixed `unique_ptr<char>` to `unique_ptr<char[]>` in `GetEnvironmentVariable()`,
so that `delete[]` is used instead of `delete`, when freeing the `char[]` data.

* [ ] `CHANGELOG.md` updated for non-trivial changes
* [ ] Unit tests have been added
* [ ] Changes in public API reviewed