### PR TITLE
Fix typo GENENV -> GETENV

### DIFF
--- a/api/CMakeLists.txt
+++ b/api/CMakeLists.txt
@@ -81,7 +81,7 @@ if(WITH_LOGS_PREVIEW)
   target_compile_definitions(opentelemetry_api INTERFACE ENABLE_LOGS_PREVIEW)
 endif()
 
-if(WITH_NO_GENENV)
+if(WITH_NO_GETENV)
   target_compile_definitions(opentelemetry_api INTERFACE NO_GETENV)
 endif()
 


### PR DESCRIPTION
Noticed this while making some adjustments to the Conan recipe for opentelemetry-cpp.

## Changes

Fix a typo to align with the cmake `option` defined in the top level `CMakeLists.txt`.

For significant contributions please make sure you have completed the following items:

* [ ] `CHANGELOG.md` updated for non-trivial changes
* [ ] Unit tests have been added
* [ ] Changes in public API reviewed