### PR TITLE
Fix thread-safety when shutdown.

### DIFF
--- a/ext/src/http/client/curl/http_client_curl.cc
+++ b/ext/src/http/client/curl/http_client_curl.cc
@@ -253,7 +253,9 @@ void HttpClient::CleanupSession(uint64_t session_id)
       }
       else if (session->IsSessionActive() && session->GetOperation())
       {
-        session->FinishOperation();
+        // If this session is alread waiting to be removed, just wakeup background thread to call
+        // doRemoveSessions()
+        wakeupBackgroundThread();
       }
     }
   }


### PR DESCRIPTION
Signed-off-by: owent <admin@owent.net>

Fixes #1976 

## Changes

Please provide a brief description of the changes here.

+ Do not reset curl handle and just wake background thread to finish the removing.

For significant contributions please make sure you have completed the following items:

* [ ] `CHANGELOG.md` updated for non-trivial changes
* [ ] Unit tests have been added
* [ ] Changes in public API reviewed