### PR TITLE
[ETW Exporter]Do not overwrite ParentId when setting attribute on Span

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ Increment the:
 
 ## [Unreleased]
 
+* ETW Exporter]Do not overwrite ParentId when setting attribute on Span
+  [#1989](https://github.com/open-telemetry/opentelemetry-cpp/pull/1989)
 * Convert Prometheus Exporter to Pull MetricReader [#1953](https://github.com/open-telemetry/opentelemetry-cpp/pull/1953)
 * Upgrade prometheus-cpp to v1.1.0 [#1954](https://github.com/open-telemetry/opentelemetry-cpp/pull/1954)
 * [BUILD] Build OpenTelemetry SDK and exporters into DLL

--- a/exporters/etw/include/opentelemetry/exporters/etw/etw_tracer.h
+++ b/exporters/etw/include/opentelemetry/exporters/etw/etw_tracer.h
@@ -870,7 +870,8 @@ public:
   void SetAttribute(nostd::string_view key, const common::AttributeValue &value) noexcept override
   {
     // don't override fields propagated from span data.
-    if (key == ETW_FIELD_NAME || key == ETW_FIELD_SPAN_ID || key == ETW_FIELD_TRACE_ID)
+    if (key == ETW_FIELD_NAME || key == ETW_FIELD_SPAN_ID || key == ETW_FIELD_TRACE_ID ||
+        key == ETW_FILE_SPAN_PARENTID)
     {
       return;
     }

--- a/exporters/etw/include/opentelemetry/exporters/etw/etw_tracer.h
+++ b/exporters/etw/include/opentelemetry/exporters/etw/etw_tracer.h
@@ -871,7 +871,7 @@ public:
   {
     // don't override fields propagated from span data.
     if (key == ETW_FIELD_NAME || key == ETW_FIELD_SPAN_ID || key == ETW_FIELD_TRACE_ID ||
-        key == ETW_FILE_SPAN_PARENTID)
+        key == ETW_FIELD_SPAN_PARENTID)
     {
       return;
     }


### PR DESCRIPTION
Check attribute name is "ParentId“， and bypass set attribute if so.

For significant contributions please make sure you have completed the following items:

* [ ] `CHANGELOG.md` updated for non-trivial changes
* [ ] Unit tests have been added
* [ ] Changes in public API reviewed