### PR TITLE
Add `ForceFlush` for all `LogRecordExporter`s and `SpanExporter`s.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@ Increment the:
   [#2060](https://github.com/open-telemetry/opentelemetry-cpp/pull/2060)
 * [BUILD] Restore detfault value of `OPENTELEMETRY_INSTALL` to `ON` when it's on
   top level.[#2062](https://github.com/open-telemetry/opentelemetry-cpp/pull/2062)
+* [EXPORTERS]Add `ForceFlush` for `LogRecordExporter` and `SpanExporter`
+  [#2000](https://github.com/open-telemetry/opentelemetry-cpp/pull/2000)
 
 Important changes:
 
@@ -95,6 +97,13 @@ Important changes:
   [#1982](https://github.com/open-telemetry/opentelemetry-cpp/pull/1982)
 * [EXPORTER] Opentracing shim
   [#1909](https://github.com/open-telemetry/opentelemetry-cpp/pull/1909)
+
+Important changes:
+
+* `LogRecordExporter` and `SpanExporter` add a new pure virtual function
+  `ForceFlush`, and if users implement any customized `LogRecordExporter` and
+  `SpanExporter`, they should also implement this function.There should be no
+  influence if users only use factory to create exporters.
 
 ## [1.8.2] 2023-01-31
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,12 @@ Important changes:
     * As a result, a behavior change for GRPC SSL is possible,
       because the endpoint scheme now takes precedence.
       Please verify configuration settings for the GRPC endpoint.
+* [EXPORTERS]Add `ForceFlush` for `LogRecordExporter` and `SpanExporter`
+  [#2000](https://github.com/open-telemetry/opentelemetry-cpp/pull/2000)
+  * `LogRecordExporter` and `SpanExporter` add a new virtual function
+    `ForceFlush`, and if users implement any customized `LogRecordExporter` and
+    `SpanExporter`, they should also implement this function.There should be no
+    influence if users only use factory to create exporters.
 
 ## [1.8.3] 2023-03-06
 
@@ -97,13 +103,6 @@ Important changes:
   [#1982](https://github.com/open-telemetry/opentelemetry-cpp/pull/1982)
 * [EXPORTER] Opentracing shim
   [#1909](https://github.com/open-telemetry/opentelemetry-cpp/pull/1909)
-
-Important changes:
-
-* `LogRecordExporter` and `SpanExporter` add a new pure virtual function
-  `ForceFlush`, and if users implement any customized `LogRecordExporter` and
-  `SpanExporter`, they should also implement this function.There should be no
-  influence if users only use factory to create exporters.
 
 ## [1.8.2] 2023-01-31
 

--- a/examples/otlp/grpc_log_main.cc
+++ b/examples/otlp/grpc_log_main.cc
@@ -11,6 +11,11 @@
 #  include "opentelemetry/sdk/trace/tracer_provider_factory.h"
 #  include "opentelemetry/trace/provider.h"
 
+// sdk::TracerProvider and sdk::LoggerProvider is just used to call ForceFlush and prevent to cancle
+// running exportings when destroy and shutdown exporters.It's optional to users.
+#  include "opentelemetry/sdk/logs/logger_provider.h"
+#  include "opentelemetry/sdk/trace/tracer_provider.h"
+
 #  include <string>
 
 #  ifdef BAZEL_BUILD
@@ -42,6 +47,14 @@ void InitTracer()
 
 void CleanupTracer()
 {
+  // We call ForceFlush to prevent to cancel running exportings, It's optional.
+  opentelemetry::nostd::shared_ptr<opentelemetry::trace::TracerProvider> provider =
+      trace::Provider::GetTracerProvider();
+  if (provider)
+  {
+    static_cast<trace_sdk::TracerProvider *>(provider.get())->ForceFlush();
+  }
+
   std::shared_ptr<opentelemetry::trace::TracerProvider> none;
   trace::Provider::SetTracerProvider(none);
 }
@@ -59,6 +72,14 @@ void InitLogger()
 
 void CleanupLogger()
 {
+  // We call ForceFlush to prevent to cancel running exportings, It's optional.
+  opentelemetry::nostd::shared_ptr<logs::LoggerProvider> provider =
+      logs::Provider::GetLoggerProvider();
+  if (provider)
+  {
+    static_cast<logs_sdk::LoggerProvider *>(provider.get())->ForceFlush();
+  }
+
   nostd::shared_ptr<logs::LoggerProvider> none;
   opentelemetry::logs::Provider::SetLoggerProvider(none);
 }

--- a/examples/otlp/grpc_log_main.cc
+++ b/examples/otlp/grpc_log_main.cc
@@ -11,7 +11,7 @@
 #  include "opentelemetry/sdk/trace/tracer_provider_factory.h"
 #  include "opentelemetry/trace/provider.h"
 
-// sdk::TracerProvider and sdk::LoggerProvider is just used to call ForceFlush and prevent to cancle
+// sdk::TracerProvider and sdk::LoggerProvider is just used to call ForceFlush and prevent to cancel
 // running exportings when destroy and shutdown exporters.It's optional to users.
 #  include "opentelemetry/sdk/logs/logger_provider.h"
 #  include "opentelemetry/sdk/trace/tracer_provider.h"

--- a/examples/otlp/grpc_main.cc
+++ b/examples/otlp/grpc_main.cc
@@ -6,7 +6,7 @@
 #include "opentelemetry/sdk/trace/tracer_provider_factory.h"
 #include "opentelemetry/trace/provider.h"
 
-// sdk::TracerProvider is just used to call ForceFlush and prevent to cancle running exportings when
+// sdk::TracerProvider is just used to call ForceFlush and prevent to cancel running exportings when
 // destroy and shutdown exporters.It's optional to users.
 #include "opentelemetry/sdk/trace/tracer_provider.h"
 

--- a/examples/otlp/grpc_main.cc
+++ b/examples/otlp/grpc_main.cc
@@ -6,6 +6,10 @@
 #include "opentelemetry/sdk/trace/tracer_provider_factory.h"
 #include "opentelemetry/trace/provider.h"
 
+// sdk::TracerProvider is just used to call ForceFlush and prevent to cancle running exportings when
+// destroy and shutdown exporters.It's optional to users.
+#include "opentelemetry/sdk/trace/tracer_provider.h"
+
 #ifdef BAZEL_BUILD
 #  include "examples/common/foo_library/foo_library.h"
 #else
@@ -32,6 +36,14 @@ void InitTracer()
 
 void CleanupTracer()
 {
+  // We call ForceFlush to prevent to cancel running exportings, It's optional.
+  opentelemetry::nostd::shared_ptr<opentelemetry::trace::TracerProvider> provider =
+      trace::Provider::GetTracerProvider();
+  if (provider)
+  {
+    static_cast<trace_sdk::TracerProvider *>(provider.get())->ForceFlush();
+  }
+
   std::shared_ptr<opentelemetry::trace::TracerProvider> none;
   trace::Provider::SetTracerProvider(none);
 }

--- a/examples/otlp/http_log_main.cc
+++ b/examples/otlp/http_log_main.cc
@@ -13,7 +13,7 @@
 #  include "opentelemetry/sdk/trace/tracer_provider_factory.h"
 #  include "opentelemetry/trace/provider.h"
 
-// sdk::TracerProvider and sdk::LoggerProvider is just used to call ForceFlush and prevent to cancle
+// sdk::TracerProvider and sdk::LoggerProvider is just used to call ForceFlush and prevent to cancel
 // running exportings when destroy and shutdown exporters.It's optional to users.
 #  include "opentelemetry/sdk/logs/logger_provider.h"
 #  include "opentelemetry/sdk/trace/tracer_provider.h"

--- a/examples/otlp/http_log_main.cc
+++ b/examples/otlp/http_log_main.cc
@@ -13,6 +13,12 @@
 #  include "opentelemetry/sdk/trace/tracer_provider_factory.h"
 #  include "opentelemetry/trace/provider.h"
 
+// sdk::TracerProvider and sdk::LoggerProvider is just used to call ForceFlush and prevent to cancle
+// running exportings when destroy and shutdown exporters.It's optional to users.
+#  include "opentelemetry/sdk/logs/logger_provider.h"
+#  include "opentelemetry/sdk/trace/tracer_provider.h"
+
+#  include <iostream>
 #  include <string>
 
 #  ifdef BAZEL_BUILD
@@ -32,11 +38,27 @@ namespace internal_log = opentelemetry::sdk::common::internal_log;
 namespace
 {
 
-opentelemetry::exporter::otlp::OtlpHttpExporterOptions opts;
+opentelemetry::exporter::otlp::OtlpHttpExporterOptions trace_opts;
 void InitTracer()
 {
+  if (trace_opts.url.size() > 9)
+  {
+    if (trace_opts.url.substr(trace_opts.url.size() - 8) == "/v1/logs")
+    {
+      trace_opts.url = trace_opts.url.substr(0, trace_opts.url.size() - 8) + "/v1/traces";
+    }
+    else if (trace_opts.url.substr(trace_opts.url.size() - 9) == "/v1/logs/")
+    {
+      trace_opts.url = trace_opts.url.substr(0, trace_opts.url.size() - 9) + "/v1/traces";
+    }
+    else
+    {
+      trace_opts.url = opentelemetry::exporter::otlp::GetOtlpDefaultHttpTracesEndpoint();
+    }
+  }
+  std::cout << "Using " << trace_opts.url << " to export trace spans." << std::endl;
   // Create OTLP exporter instance
-  auto exporter  = otlp::OtlpHttpExporterFactory::Create(opts);
+  auto exporter  = otlp::OtlpHttpExporterFactory::Create(trace_opts);
   auto processor = trace_sdk::SimpleSpanProcessorFactory::Create(std::move(exporter));
   std::shared_ptr<opentelemetry::trace::TracerProvider> provider =
       trace_sdk::TracerProviderFactory::Create(std::move(processor));
@@ -46,6 +68,14 @@ void InitTracer()
 
 void CleanupTracer()
 {
+  // We call ForceFlush to prevent to cancel running exportings, It's optional.
+  opentelemetry::nostd::shared_ptr<opentelemetry::trace::TracerProvider> provider =
+      trace::Provider::GetTracerProvider();
+  if (provider)
+  {
+    static_cast<trace_sdk::TracerProvider *>(provider.get())->ForceFlush();
+  }
+
   std::shared_ptr<opentelemetry::trace::TracerProvider> none;
   trace::Provider::SetTracerProvider(none);
 }
@@ -53,6 +83,7 @@ void CleanupTracer()
 opentelemetry::exporter::otlp::OtlpHttpLogRecordExporterOptions logger_opts;
 void InitLogger()
 {
+  std::cout << "Using " << logger_opts.url << " to export log records." << std::endl;
   logger_opts.console_debug = true;
   // Create OTLP exporter instance
   auto exporter  = otlp::OtlpHttpLogRecordExporterFactory::Create(logger_opts);
@@ -65,6 +96,14 @@ void InitLogger()
 
 void CleanupLogger()
 {
+  // We call ForceFlush to prevent to cancel running exportings, It's optional.
+  opentelemetry::nostd::shared_ptr<logs::LoggerProvider> provider =
+      logs::Provider::GetLoggerProvider();
+  if (provider)
+  {
+    static_cast<logs_sdk::LoggerProvider *>(provider.get())->ForceFlush();
+  }
+
   std::shared_ptr<logs::LoggerProvider> none;
   opentelemetry::logs::Provider::SetLoggerProvider(none);
 }
@@ -83,12 +122,12 @@ int main(int argc, char *argv[])
 {
   if (argc > 1)
   {
-    opts.url        = argv[1];
+    trace_opts.url  = argv[1];
     logger_opts.url = argv[1];
     if (argc > 2)
     {
-      std::string debug  = argv[2];
-      opts.console_debug = debug != "" && debug != "0" && debug != "no";
+      std::string debug        = argv[2];
+      trace_opts.console_debug = debug != "" && debug != "0" && debug != "no";
     }
 
     if (argc > 3)
@@ -96,13 +135,13 @@ int main(int argc, char *argv[])
       std::string binary_mode = argv[3];
       if (binary_mode.size() >= 3 && binary_mode.substr(0, 3) == "bin")
       {
-        opts.content_type        = opentelemetry::exporter::otlp::HttpRequestContentType::kBinary;
+        trace_opts.content_type  = opentelemetry::exporter::otlp::HttpRequestContentType::kBinary;
         logger_opts.content_type = opentelemetry::exporter::otlp::HttpRequestContentType::kBinary;
       }
     }
   }
 
-  if (opts.console_debug)
+  if (trace_opts.console_debug)
   {
     internal_log::GlobalLogHandler::SetLogLevel(internal_log::LogLevel::Debug);
   }

--- a/examples/otlp/http_main.cc
+++ b/examples/otlp/http_main.cc
@@ -8,6 +8,10 @@
 #include "opentelemetry/sdk/trace/tracer_provider_factory.h"
 #include "opentelemetry/trace/provider.h"
 
+// sdk::TracerProvider is just used to call ForceFlush and prevent to cancle running exportings when
+// destroy and shutdown exporters.It's optional to users.
+#include "opentelemetry/sdk/trace/tracer_provider.h"
+
 #include <string>
 
 #ifdef BAZEL_BUILD
@@ -38,6 +42,14 @@ void InitTracer()
 
 void CleanupTracer()
 {
+  // We call ForceFlush to prevent to cancel running exportings, It's optional.
+  opentelemetry::nostd::shared_ptr<opentelemetry::trace::TracerProvider> provider =
+      trace::Provider::GetTracerProvider();
+  if (provider)
+  {
+    static_cast<trace_sdk::TracerProvider *>(provider.get())->ForceFlush();
+  }
+
   std::shared_ptr<opentelemetry::trace::TracerProvider> none;
   trace::Provider::SetTracerProvider(none);
 }

--- a/examples/otlp/http_main.cc
+++ b/examples/otlp/http_main.cc
@@ -8,7 +8,7 @@
 #include "opentelemetry/sdk/trace/tracer_provider_factory.h"
 #include "opentelemetry/trace/provider.h"
 
-// sdk::TracerProvider is just used to call ForceFlush and prevent to cancle running exportings when
+// sdk::TracerProvider is just used to call ForceFlush and prevent to cancel running exportings when
 // destroy and shutdown exporters.It's optional to users.
 #include "opentelemetry/sdk/trace/tracer_provider.h"
 

--- a/exporters/elasticsearch/include/opentelemetry/exporters/elasticsearch/es_log_record_exporter.h
+++ b/exporters/elasticsearch/include/opentelemetry/exporters/elasticsearch/es_log_record_exporter.h
@@ -7,12 +7,17 @@
 #  include "nlohmann/json.hpp"
 #  include "opentelemetry/common/spin_lock_mutex.h"
 #  include "opentelemetry/ext/http/client/http_client_factory.h"
+#  include "opentelemetry/nostd/shared_ptr.h"
 #  include "opentelemetry/nostd/type_traits.h"
 #  include "opentelemetry/sdk/logs/exporter.h"
 #  include "opentelemetry/sdk/logs/recordable.h"
 
 #  include <time.h>
+#  include <atomic>
+#  include <condition_variable>
+#  include <cstddef>
 #  include <iostream>
+#  include <mutex>
 
 OPENTELEMETRY_BEGIN_NAMESPACE
 namespace exporter
@@ -91,6 +96,14 @@ public:
           &records) noexcept override;
 
   /**
+   * Force flush the exporter.
+   * @param timeout an option timeout, default to max.
+   * @return return true when all data are exported, and false when timeout
+   */
+  bool ForceFlush(
+      std::chrono::microseconds timeout = std::chrono::microseconds::max()) noexcept override;
+
+  /**
    * Shutdown this exporter.
    * @param timeout The maximum time to wait for the shutdown method to return
    */
@@ -108,6 +121,18 @@ private:
   std::shared_ptr<ext::http::client::HttpClient> http_client_;
   mutable opentelemetry::common::SpinLockMutex lock_;
   bool isShutdown() const noexcept;
+
+#  ifdef ENABLE_ASYNC_EXPORT
+  struct SynchronizationData
+  {
+    std::atomic<std::size_t> session_counter_;
+    std::atomic<std::size_t> finished_session_counter_;
+    std::condition_variable force_flush_cv;
+    std::mutex force_flush_cv_m;
+    std::recursive_mutex force_flush_m;
+  };
+  nostd::shared_ptr<SynchronizationData> synchronization_data_;
+#  endif
 };
 }  // namespace logs
 }  // namespace exporter

--- a/exporters/elasticsearch/src/es_log_record_exporter.cc
+++ b/exporters/elasticsearch/src/es_log_record_exporter.cc
@@ -290,9 +290,19 @@ private:
 #  endif
 
 ElasticsearchLogRecordExporter::ElasticsearchLogRecordExporter()
-    : options_{ElasticsearchExporterOptions()},
-      http_client_{ext::http::client::HttpClientFactory::Create()}
-{}
+    : options_{ElasticsearchExporterOptions()}, http_client_
+{
+  ext::http::client::HttpClientFactory::Create()
+}
+#  ifdef ENABLE_ASYNC_EXPORT
+, synchronization_data_(new SynchronizationData())
+#  endif
+{
+#  ifdef ENABLE_ASYNC_EXPORT
+  synchronization_data_->finished_session_counter_.store(0);
+  synchronization_data_->session_counter_.store(0);
+#  endif
+}
 
 ElasticsearchLogRecordExporter::ElasticsearchLogRecordExporter(
     const ElasticsearchExporterOptions &options)
@@ -343,10 +353,12 @@ sdk::common::ExportResult ElasticsearchLogRecordExporter::Export(
 
 #  ifdef ENABLE_ASYNC_EXPORT
   // Send the request
-  std::size_t span_count = records.size();
-  auto handler           = std::make_shared<AsyncResponseHandler>(
+  synchronization_data_->session_counter_.fetch_add(1, std::memory_order_release);
+  std::size_t span_count    = records.size();
+  auto synchronization_data = synchronization_data_;
+  auto handler              = std::make_shared<AsyncResponseHandler>(
       session,
-      [span_count](opentelemetry::sdk::common::ExportResult result) {
+      [span_count, synchronization_data](opentelemetry::sdk::common::ExportResult result) {
         if (result != opentelemetry::sdk::common::ExportResult::kSuccess)
         {
           OTEL_INTERNAL_LOG_ERROR("[ES Log Exporter] ERROR: Export "
@@ -358,6 +370,9 @@ sdk::common::ExportResult ElasticsearchLogRecordExporter::Export(
           OTEL_INTERNAL_LOG_DEBUG("[ES Log Exporter] Export " << span_count
                                                               << " trace span(s) success");
         }
+
+        synchronization_data->finished_session_counter_.fetch_add(1, std::memory_order_release);
+        synchronization_data->force_flush_cv.notify_all();
         return true;
       },
       options_.console_debug_);
@@ -398,6 +413,49 @@ sdk::common::ExportResult ElasticsearchLogRecordExporter::Export(
   }
 
   return sdk::common::ExportResult::kSuccess;
+#  endif
+}
+
+bool ElasticsearchLogRecordExporter::ForceFlush(std::chrono::microseconds timeout) noexcept
+{
+#  ifdef ENABLE_ASYNC_EXPORT
+  std::lock_guard<std::recursive_mutex> lock_guard{synchronization_data_->force_flush_m};
+  std::size_t running_counter =
+      synchronization_data_->session_counter_.load(std::memory_order_acquire);
+  // ASAN will report chrono: runtime error: signed integer overflow: A + B cannot be represented
+  //   in type 'long int' here. So we reset timeout to meet signed long int limit here.
+  timeout = opentelemetry::common::DurationUtil::AdjustWaitForTimeout(
+      timeout, std::chrono::microseconds::zero());
+
+  std::chrono::steady_clock::duration timeout_steady =
+      std::chrono::duration_cast<std::chrono::steady_clock::duration>(timeout);
+  if (timeout_steady <= std::chrono::steady_clock::duration::zero())
+  {
+    timeout_steady = std::chrono::steady_clock::duration::max();
+  }
+
+  std::unique_lock<std::mutex> lk_cv(synchronization_data_->force_flush_cv_m);
+  // Wait for all the sessions to finish
+  while (timeout_steady > std::chrono::steady_clock::duration::zero())
+  {
+    if (synchronization_data_->finished_session_counter_.load(std::memory_order_acquire) >=
+        running_counter)
+    {
+      break;
+    }
+
+    std::chrono::steady_clock::time_point start_timepoint = std::chrono::steady_clock::now();
+    if (std::cv_status::no_timeout != synchronization_data_->force_flush_cv.wait_for(
+                                          lk_cv, std::chrono::seconds{options_.response_timeout_}))
+    {
+      break;
+    }
+    timeout_steady -= std::chrono::steady_clock::now() - start_timepoint;
+  }
+
+  return timeout_steady > std::chrono::steady_clock::duration::zero();
+#  else
+  return true;
 #  endif
 }
 

--- a/exporters/etw/CMakeLists.txt
+++ b/exporters/etw/CMakeLists.txt
@@ -11,8 +11,12 @@ target_include_directories(
 set_target_properties(opentelemetry_exporter_etw PROPERTIES EXPORT_NAME
                                                             etw_exporter)
 
-target_link_libraries(opentelemetry_exporter_etw
-                      INTERFACE opentelemetry_api nlohmann_json::nlohmann_json)
+target_link_libraries(
+  opentelemetry_exporter_etw INTERFACE opentelemetry_api opentelemetry_trace
+                                       nlohmann_json::nlohmann_json)
+if(WITH_LOGS_PREVIEW)
+  target_link_libraries(opentelemetry_exporter_etw INTERFACE opentelemetry_logs)
+endif()
 if(nlohmann_json_clone)
   add_dependencies(opentelemetry_exporter_etw nlohmann_json::nlohmann_json)
 endif()

--- a/exporters/jaeger/BUILD
+++ b/exporters/jaeger/BUILD
@@ -189,6 +189,7 @@ cc_library(
     deps = [
         ":jaeger_exporter",
         "//sdk/src/common:global_log_handler",
+        "//sdk/src/trace",
     ],
 )
 

--- a/exporters/jaeger/CMakeLists.txt
+++ b/exporters/jaeger/CMakeLists.txt
@@ -43,7 +43,8 @@ target_include_directories(
 
 target_link_libraries(
   opentelemetry_exporter_jaeger_trace
-  PUBLIC opentelemetry_resources opentelemetry_http_client_curl
+  PUBLIC opentelemetry_resources opentelemetry_trace
+         opentelemetry_http_client_curl
   PRIVATE thrift::thrift)
 
 if(MSVC)

--- a/exporters/jaeger/include/opentelemetry/exporters/jaeger/jaeger_exporter.h
+++ b/exporters/jaeger/include/opentelemetry/exporters/jaeger/jaeger_exporter.h
@@ -48,6 +48,14 @@ public:
       override;
 
   /**
+   * Force flush the exporter.
+   * @param timeout an option timeout, default to max.
+   * @return return true when all data are exported, and false when timeout
+   */
+  bool ForceFlush(
+      std::chrono::microseconds timeout = std::chrono::microseconds::max()) noexcept override;
+
+  /**
    * Shutdown the exporter.
    * @param timeout an option timeout, default to max.
    */

--- a/exporters/jaeger/src/jaeger_exporter.cc
+++ b/exporters/jaeger/src/jaeger_exporter.cc
@@ -98,6 +98,11 @@ void JaegerExporter::InitializeEndpoint()
   assert(false);
 }
 
+bool JaegerExporter::ForceFlush(std::chrono::microseconds /* timeout */) noexcept
+{
+  return true;
+}
+
 bool JaegerExporter::Shutdown(std::chrono::microseconds /* timeout */) noexcept
 {
   const std::lock_guard<opentelemetry::common::SpinLockMutex> locked(lock_);

--- a/exporters/memory/include/opentelemetry/exporters/memory/in_memory_span_exporter.h
+++ b/exporters/memory/include/opentelemetry/exporters/memory/in_memory_span_exporter.h
@@ -66,13 +66,6 @@ public:
   }
 
   /**
-   * Force flush the exporter.
-   * @param timeout an option timeout, default to max.
-   * @return return true when all data are exported, and false when timeout
-   */
-  bool ForceFlush(std::chrono::microseconds /* timeout */) noexcept override { return true; }
-
-  /**
    * @param timeout an optional value containing the timeout of the exporter
    * note: passing custom timeout values is not currently supported for this exporter
    * @return Returns the status of the operation

--- a/exporters/memory/include/opentelemetry/exporters/memory/in_memory_span_exporter.h
+++ b/exporters/memory/include/opentelemetry/exporters/memory/in_memory_span_exporter.h
@@ -66,6 +66,13 @@ public:
   }
 
   /**
+   * Force flush the exporter.
+   * @param timeout an option timeout, default to max.
+   * @return return true when all data are exported, and false when timeout
+   */
+  bool ForceFlush(std::chrono::microseconds /* timeout */) noexcept override { return true; }
+
+  /**
    * @param timeout an optional value containing the timeout of the exporter
    * note: passing custom timeout values is not currently supported for this exporter
    * @return Returns the status of the operation

--- a/exporters/ostream/include/opentelemetry/exporters/ostream/log_record_exporter.h
+++ b/exporters/ostream/include/opentelemetry/exporters/ostream/log_record_exporter.h
@@ -40,6 +40,14 @@ public:
       override;
 
   /**
+   * Force flush the exporter.
+   * @param timeout an option timeout, default to max.
+   * @return return true when all data are exported, and false when timeout
+   */
+  bool ForceFlush(
+      std::chrono::microseconds timeout = std::chrono::microseconds::max()) noexcept override;
+
+  /**
    * Marks the OStream Log Exporter as shut down.
    */
   bool Shutdown(

--- a/exporters/ostream/include/opentelemetry/exporters/ostream/span_exporter.h
+++ b/exporters/ostream/include/opentelemetry/exporters/ostream/span_exporter.h
@@ -38,6 +38,14 @@ public:
       const opentelemetry::nostd::span<std::unique_ptr<opentelemetry::sdk::trace::Recordable>>
           &spans) noexcept override;
 
+  /**
+   * Force flush the exporter.
+   * @param timeout an option timeout, default to max.
+   * @return return true when all data are exported, and false when timeout
+   */
+  bool ForceFlush(
+      std::chrono::microseconds timeout = std::chrono::microseconds::max()) noexcept override;
+
   bool Shutdown(
       std::chrono::microseconds timeout = std::chrono::microseconds::max()) noexcept override;
 

--- a/exporters/ostream/src/log_record_exporter.cc
+++ b/exporters/ostream/src/log_record_exporter.cc
@@ -113,6 +113,12 @@ sdk::common::ExportResult OStreamLogRecordExporter::Export(
   return sdk::common::ExportResult::kSuccess;
 }
 
+bool OStreamLogRecordExporter::ForceFlush(std::chrono::microseconds /* timeout */) noexcept
+{
+  sout_.flush();
+  return true;
+}
+
 bool OStreamLogRecordExporter::Shutdown(std::chrono::microseconds) noexcept
 {
   const std::lock_guard<opentelemetry::common::SpinLockMutex> locked(lock_);

--- a/exporters/ostream/src/span_exporter.cc
+++ b/exporters/ostream/src/span_exporter.cc
@@ -98,6 +98,12 @@ sdk::common::ExportResult OStreamSpanExporter::Export(
   return sdk::common::ExportResult::kSuccess;
 }
 
+bool OStreamSpanExporter::ForceFlush(std::chrono::microseconds /* timeout */) noexcept
+{
+  sout_.flush();
+  return true;
+}
+
 bool OStreamSpanExporter::Shutdown(std::chrono::microseconds /* timeout */) noexcept
 {
   const std::lock_guard<opentelemetry::common::SpinLockMutex> locked(lock_);

--- a/exporters/otlp/include/opentelemetry/exporters/otlp/otlp_grpc_exporter.h
+++ b/exporters/otlp/include/opentelemetry/exporters/otlp/otlp_grpc_exporter.h
@@ -53,6 +53,14 @@ public:
       const nostd::span<std::unique_ptr<sdk::trace::Recordable>> &spans) noexcept override;
 
   /**
+   * Force flush the exporter.
+   * @param timeout an option timeout, default to max.
+   * @return return true when all data are exported, and false when timeout
+   */
+  bool ForceFlush(
+      std::chrono::microseconds timeout = std::chrono::microseconds::max()) noexcept override;
+
+  /**
    * Shut down the exporter.
    * @param timeout an optional timeout, the default timeout of 0 means that no
    * timeout is applied.

--- a/exporters/otlp/include/opentelemetry/exporters/otlp/otlp_grpc_log_record_exporter.h
+++ b/exporters/otlp/include/opentelemetry/exporters/otlp/otlp_grpc_log_record_exporter.h
@@ -56,6 +56,14 @@ public:
       override;
 
   /**
+   * Force flush the exporter.
+   * @param timeout an option timeout, default to max.
+   * @return return true when all data are exported, and false when timeout
+   */
+  bool ForceFlush(
+      std::chrono::microseconds timeout = std::chrono::microseconds::max()) noexcept override;
+
+  /**
    * Shutdown this exporter.
    * @param timeout The maximum time to wait for the shutdown method to return.
    */

--- a/exporters/otlp/include/opentelemetry/exporters/otlp/otlp_http_exporter.h
+++ b/exporters/otlp/include/opentelemetry/exporters/otlp/otlp_http_exporter.h
@@ -54,6 +54,14 @@ public:
       override;
 
   /**
+   * Force flush the exporter.
+   * @param timeout an option timeout, default to max.
+   * @return return true when all data are exported, and false when timeout
+   */
+  bool ForceFlush(
+      std::chrono::microseconds timeout = std::chrono::microseconds::max()) noexcept override;
+
+  /**
    * Shut down the exporter.
    * @param timeout an optional timeout, the default timeout of 0 means that no
    * timeout is applied.

--- a/exporters/otlp/include/opentelemetry/exporters/otlp/otlp_http_log_record_exporter.h
+++ b/exporters/otlp/include/opentelemetry/exporters/otlp/otlp_http_log_record_exporter.h
@@ -54,6 +54,14 @@ public:
       override;
 
   /**
+   * Force flush the exporter.
+   * @param timeout an option timeout, default to max.
+   * @return return true when all data are exported, and false when timeout
+   */
+  bool ForceFlush(
+      std::chrono::microseconds timeout = std::chrono::microseconds::max()) noexcept override;
+
+  /**
    * Shutdown this exporter.
    * @param timeout The maximum time to wait for the shutdown method to return
    */

--- a/exporters/otlp/src/otlp_grpc_exporter.cc
+++ b/exporters/otlp/src/otlp_grpc_exporter.cc
@@ -72,6 +72,13 @@ sdk::common::ExportResult OtlpGrpcExporter::Export(
   return sdk::common::ExportResult::kSuccess;
 }
 
+bool OtlpGrpcExporter::ForceFlush(std::chrono::microseconds /* timeout */) noexcept
+{
+  // TODO: When we implement async exporting in OTLP gRPC exporter in the future, we need wait the
+  //       running exporting finished here.
+  return true;
+}
+
 bool OtlpGrpcExporter::Shutdown(std::chrono::microseconds /* timeout */) noexcept
 {
   const std::lock_guard<opentelemetry::common::SpinLockMutex> locked(lock_);

--- a/exporters/otlp/src/otlp_grpc_log_record_exporter.cc
+++ b/exporters/otlp/src/otlp_grpc_log_record_exporter.cc
@@ -91,6 +91,13 @@ bool OtlpGrpcLogRecordExporter::Shutdown(std::chrono::microseconds /* timeout */
   return true;
 }
 
+bool OtlpGrpcLogRecordExporter::ForceFlush(std::chrono::microseconds /* timeout */) noexcept
+{
+  // TODO: When we implement async exporting in OTLP gRPC exporter in the future, we need wait the
+  //       running exporting finished here.
+  return true;
+}
+
 bool OtlpGrpcLogRecordExporter::isShutdown() const noexcept
 {
   const std::lock_guard<opentelemetry::common::SpinLockMutex> locked(lock_);

--- a/exporters/otlp/src/otlp_http_exporter.cc
+++ b/exporters/otlp/src/otlp_http_exporter.cc
@@ -115,6 +115,11 @@ opentelemetry::sdk::common::ExportResult OtlpHttpExporter::Export(
 #endif
 }
 
+bool OtlpHttpExporter::ForceFlush(std::chrono::microseconds timeout) noexcept
+{
+  return http_client_->ForceFlush(timeout);
+}
+
 bool OtlpHttpExporter::Shutdown(std::chrono::microseconds timeout) noexcept
 {
   return http_client_->Shutdown(timeout);

--- a/exporters/otlp/src/otlp_http_log_record_exporter.cc
+++ b/exporters/otlp/src/otlp_http_log_record_exporter.cc
@@ -118,6 +118,11 @@ opentelemetry::sdk::common::ExportResult OtlpHttpLogRecordExporter::Export(
 #  endif
 }
 
+bool OtlpHttpLogRecordExporter::ForceFlush(std::chrono::microseconds timeout) noexcept
+{
+  return http_client_->ForceFlush(timeout);
+}
+
 bool OtlpHttpLogRecordExporter::Shutdown(std::chrono::microseconds timeout) noexcept
 {
   return http_client_->Shutdown(timeout);

--- a/exporters/zipkin/include/opentelemetry/exporters/zipkin/zipkin_exporter.h
+++ b/exporters/zipkin/include/opentelemetry/exporters/zipkin/zipkin_exporter.h
@@ -50,6 +50,14 @@ public:
       override;
 
   /**
+   * Force flush the exporter.
+   * @param timeout an option timeout, default to max.
+   * @return return true when all data are exported, and false when timeout
+   */
+  bool ForceFlush(
+      std::chrono::microseconds timeout = std::chrono::microseconds::max()) noexcept override;
+
+  /**
    * Shut down the exporter.
    * @param timeout an optional timeout, default to max.
    */

--- a/exporters/zipkin/src/zipkin_exporter.cc
+++ b/exporters/zipkin/src/zipkin_exporter.cc
@@ -110,6 +110,11 @@ void ZipkinExporter::InitializeLocalEndpoint()
   local_end_point_["port"] = url_parser_.port_;
 }
 
+bool ZipkinExporter::ForceFlush(std::chrono::microseconds /* timeout */) noexcept
+{
+  return true;
+}
+
 bool ZipkinExporter::Shutdown(std::chrono::microseconds /* timeout */) noexcept
 {
   const std::lock_guard<opentelemetry::common::SpinLockMutex> locked(lock_);

--- a/sdk/include/opentelemetry/sdk/logs/batch_log_record_processor.h
+++ b/sdk/include/opentelemetry/sdk/logs/batch_log_record_processor.h
@@ -117,6 +117,7 @@ protected:
     std::atomic<bool> is_force_wakeup_background_worker;
     std::atomic<bool> is_force_flush_pending;
     std::atomic<bool> is_force_flush_notified;
+    std::atomic<std::chrono::microseconds::rep> force_flush_timeout_us;
     std::atomic<bool> is_shutdown;
   };
 
@@ -128,6 +129,7 @@ protected:
    * @param synchronization_data Synchronization data to be notified.
    */
   static void NotifyCompletion(bool notify_force_flush,
+                               const std::unique_ptr<LogRecordExporter> &exporter,
                                const std::shared_ptr<SynchronizationData> &synchronization_data);
 
   void GetWaitAdjustedTime(std::chrono::microseconds &timeout,

--- a/sdk/include/opentelemetry/sdk/logs/exporter.h
+++ b/sdk/include/opentelemetry/sdk/logs/exporter.h
@@ -48,6 +48,12 @@ public:
       const nostd::span<std::unique_ptr<Recordable>> &records) noexcept = 0;
 
   /**
+   * Force flush the log records pushed into this log exporter.
+   */
+  virtual bool ForceFlush(
+      std::chrono::microseconds timeout = (std::chrono::microseconds::max)()) noexcept = 0;
+
+  /**
    * Marks the exporter as ShutDown and cleans up any resources as required.
    * Shutdown should be called only once for each Exporter instance.
    * @param timeout minimum amount of microseconds to wait for shutdown before giving up and

--- a/sdk/include/opentelemetry/sdk/logs/exporter.h
+++ b/sdk/include/opentelemetry/sdk/logs/exporter.h
@@ -23,7 +23,8 @@ namespace logs
 class OPENTELEMETRY_EXPORT LogRecordExporter
 {
 public:
-  virtual ~LogRecordExporter() = default;
+  LogRecordExporter();
+  virtual ~LogRecordExporter();
 
   /**
    * Create a log recordable. This object will be used to record log data and

--- a/sdk/include/opentelemetry/sdk/logs/exporter.h
+++ b/sdk/include/opentelemetry/sdk/logs/exporter.h
@@ -20,7 +20,7 @@ namespace logs
 /**
  * LogRecordExporter defines the interface that log exporters must implement.
  */
-class LogRecordExporter
+class OPENTELEMETRY_EXPORT LogRecordExporter
 {
 public:
   virtual ~LogRecordExporter() = default;
@@ -51,7 +51,7 @@ public:
    * Force flush the log records pushed into this log exporter.
    */
   virtual bool ForceFlush(
-      std::chrono::microseconds timeout = (std::chrono::microseconds::max)()) noexcept = 0;
+      std::chrono::microseconds timeout = (std::chrono::microseconds::max)()) noexcept;
 
   /**
    * Marks the exporter as ShutDown and cleans up any resources as required.

--- a/sdk/include/opentelemetry/sdk/trace/batch_span_processor.h
+++ b/sdk/include/opentelemetry/sdk/trace/batch_span_processor.h
@@ -115,6 +115,7 @@ protected:
     std::atomic<bool> is_force_wakeup_background_worker;
     std::atomic<bool> is_force_flush_pending;
     std::atomic<bool> is_force_flush_notified;
+    std::atomic<std::chrono::microseconds::rep> force_flush_timeout_us;
     std::atomic<bool> is_shutdown;
   };
 
@@ -126,6 +127,7 @@ protected:
    * @param synchronization_data Synchronization data to be notified.
    */
   static void NotifyCompletion(bool notify_force_flush,
+                               const std::unique_ptr<SpanExporter> &exporter,
                                const std::shared_ptr<SynchronizationData> &synchronization_data);
 
   void GetWaitAdjustedTime(std::chrono::microseconds &timeout,

--- a/sdk/include/opentelemetry/sdk/trace/exporter.h
+++ b/sdk/include/opentelemetry/sdk/trace/exporter.h
@@ -49,7 +49,7 @@ public:
    * @return return true when all data are exported, and false when timeout
    */
   virtual bool ForceFlush(
-      std::chrono::microseconds timeout = (std::chrono::microseconds::max)()) noexcept = 0;
+      std::chrono::microseconds timeout = (std::chrono::microseconds::max)()) noexcept;
 
   /**
    * Shut down the exporter.

--- a/sdk/include/opentelemetry/sdk/trace/exporter.h
+++ b/sdk/include/opentelemetry/sdk/trace/exporter.h
@@ -43,6 +43,15 @@ public:
           &spans) noexcept = 0;
 
   /**
+   * Export all spans that have been exported.
+   * @param timeout an optional timeout, the default timeout of 0 means that no
+   * timeout is applied.
+   * @return return true when all data are exported, and false when timeout
+   */
+  virtual bool ForceFlush(
+      std::chrono::microseconds timeout = (std::chrono::microseconds::max)()) noexcept = 0;
+
+  /**
    * Shut down the exporter.
    * @param timeout an optional timeout.
    * @return return the status of the operation.

--- a/sdk/include/opentelemetry/sdk/trace/exporter.h
+++ b/sdk/include/opentelemetry/sdk/trace/exporter.h
@@ -20,7 +20,8 @@ namespace trace
 class OPENTELEMETRY_EXPORT SpanExporter
 {
 public:
-  virtual ~SpanExporter() = default;
+  SpanExporter();
+  virtual ~SpanExporter();
 
   /**
    * Create a span recordable. This object will be used to record span data and

--- a/sdk/include/opentelemetry/sdk/trace/simple_processor.h
+++ b/sdk/include/opentelemetry/sdk/trace/simple_processor.h
@@ -55,7 +55,16 @@ public:
     }
   }
 
-  bool ForceFlush(std::chrono::microseconds /* timeout */) noexcept override { return true; }
+  bool ForceFlush(
+      std::chrono::microseconds timeout = (std::chrono::microseconds::max)()) noexcept override
+  {
+    if (exporter_ != nullptr)
+    {
+      return exporter_->ForceFlush(timeout);
+    }
+
+    return true;
+  }
 
   bool Shutdown(
       std::chrono::microseconds timeout = (std::chrono::microseconds::max)()) noexcept override

--- a/sdk/include/opentelemetry/sdk/trace/tracer_context.h
+++ b/sdk/include/opentelemetry/sdk/trace/tracer_context.h
@@ -87,7 +87,7 @@ public:
   /**
    * Shutdown the span processor associated with this tracer provider.
    */
-  bool Shutdown() noexcept;
+  bool Shutdown(std::chrono::microseconds timeout = (std::chrono::microseconds::max)()) noexcept;
 
 private:
   //  order of declaration is important here - resource object should be destroyed after processor.

--- a/sdk/src/logs/CMakeLists.txt
+++ b/sdk/src/logs/CMakeLists.txt
@@ -6,6 +6,7 @@ add_library(
   logger_provider.cc
   logger_provider_factory.cc
   logger.cc
+  exporter.cc
   event_logger_provider.cc
   event_logger_provider_factory.cc
   event_logger.cc

--- a/sdk/src/logs/batch_log_record_processor.cc
+++ b/sdk/src/logs/batch_log_record_processor.cc
@@ -46,6 +46,7 @@ BatchLogRecordProcessor::BatchLogRecordProcessor(std::unique_ptr<LogRecordExport
   synchronization_data_->is_force_wakeup_background_worker.store(false);
   synchronization_data_->is_force_flush_pending.store(false);
   synchronization_data_->is_force_flush_notified.store(false);
+  synchronization_data_->force_flush_timeout_us.store(0);
   synchronization_data_->is_shutdown.store(false);
 }
 
@@ -88,6 +89,7 @@ bool BatchLogRecordProcessor::ForceFlush(std::chrono::microseconds timeout) noex
   std::unique_lock<std::mutex> lk_cv(synchronization_data_->force_flush_cv_m);
 
   synchronization_data_->is_force_flush_pending.store(true, std::memory_order_release);
+  synchronization_data_->force_flush_timeout_us.store(timeout.count(), std::memory_order_release);
   auto break_condition = [this]() {
     if (synchronization_data_->is_shutdown.load() == true)
     {
@@ -106,23 +108,24 @@ bool BatchLogRecordProcessor::ForceFlush(std::chrono::microseconds timeout) noex
   // Fix timeout to meet requirement of wait_for
   timeout = opentelemetry::common::DurationUtil::AdjustWaitForTimeout(
       timeout, std::chrono::microseconds::zero());
-  bool result;
-  if (timeout <= std::chrono::microseconds::zero())
+
+  std::chrono::steady_clock::duration timeout_steady =
+      std::chrono::duration_cast<std::chrono::steady_clock::duration>(timeout);
+  if (timeout_steady <= std::chrono::steady_clock::duration::zero())
   {
-    bool wait_result = false;
-    while (!wait_result)
-    {
-      // When is_force_flush_notified.store(true) and force_flush_cv.notify_all() is called
-      // between is_force_flush_pending.load() and force_flush_cv.wait(). We must not wait
-      // for ever
-      wait_result = synchronization_data_->force_flush_cv.wait_for(lk_cv, scheduled_delay_millis_,
-                                                                   break_condition);
-    }
-    result = true;
+    timeout_steady = std::chrono::steady_clock::duration::max();
   }
-  else
+
+  bool result = false;
+  while (!result && timeout_steady > std::chrono::steady_clock::duration::zero())
   {
-    result = synchronization_data_->force_flush_cv.wait_for(lk_cv, timeout, break_condition);
+    // When is_force_flush_notified.store(true) and force_flush_cv.notify_all() is called
+    // between is_force_flush_pending.load() and force_flush_cv.wait(). We must not wait
+    // for ever
+    std::chrono::steady_clock::time_point start_timepoint = std::chrono::steady_clock::now();
+    result = synchronization_data_->force_flush_cv.wait_for(lk_cv, scheduled_delay_millis_,
+                                                            break_condition);
+    timeout_steady -= std::chrono::steady_clock::now() - start_timepoint;
   }
 
   // If it's already signaled, we must wait util notified.
@@ -202,7 +205,7 @@ void BatchLogRecordProcessor::Export()
 
     if (num_records_to_export == 0)
     {
-      NotifyCompletion(notify_force_flush, synchronization_data_);
+      NotifyCompletion(notify_force_flush, exporter_, synchronization_data_);
       break;
     }
 
@@ -218,12 +221,13 @@ void BatchLogRecordProcessor::Export()
 
     exporter_->Export(
         nostd::span<std::unique_ptr<Recordable>>(records_arr.data(), records_arr.size()));
-    NotifyCompletion(notify_force_flush, synchronization_data_);
+    NotifyCompletion(notify_force_flush, exporter_, synchronization_data_);
   } while (true);
 }
 
 void BatchLogRecordProcessor::NotifyCompletion(
     bool notify_force_flush,
+    const std::unique_ptr<LogRecordExporter> &exporter,
     const std::shared_ptr<SynchronizationData> &synchronization_data)
 {
   if (!synchronization_data)
@@ -233,6 +237,14 @@ void BatchLogRecordProcessor::NotifyCompletion(
 
   if (notify_force_flush)
   {
+    if (exporter)
+    {
+      std::chrono::microseconds timeout = opentelemetry::common::DurationUtil::AdjustWaitForTimeout(
+          std::chrono::microseconds{
+              synchronization_data->force_flush_timeout_us.load(std::memory_order_acquire)},
+          std::chrono::microseconds::zero());
+      exporter->ForceFlush(timeout);
+    }
     synchronization_data->is_force_flush_notified.store(true, std::memory_order_release);
     synchronization_data->force_flush_cv.notify_one();
   }

--- a/sdk/src/logs/exporter.cc
+++ b/sdk/src/logs/exporter.cc
@@ -11,6 +11,10 @@ namespace sdk
 namespace logs
 {
 
+OPENTELEMETRY_EXPORT LogRecordExporter::LogRecordExporter() {}
+
+OPENTELEMETRY_EXPORT LogRecordExporter::~LogRecordExporter() {}
+
 OPENTELEMETRY_EXPORT bool LogRecordExporter::ForceFlush(
     std::chrono::microseconds /*timeout*/) noexcept
 {

--- a/sdk/src/logs/exporter.cc
+++ b/sdk/src/logs/exporter.cc
@@ -1,0 +1,23 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+#ifdef ENABLE_LOGS_PREVIEW
+
+#  include "opentelemetry/sdk/logs/exporter.h"
+
+OPENTELEMETRY_BEGIN_NAMESPACE
+namespace sdk
+{
+namespace logs
+{
+
+OPENTELEMETRY_EXPORT bool LogRecordExporter::ForceFlush(
+    std::chrono::microseconds /*timeout*/) noexcept
+{
+  return true;
+}
+
+}  // namespace logs
+}  // namespace sdk
+OPENTELEMETRY_END_NAMESPACE
+#endif

--- a/sdk/src/logs/simple_log_record_processor.cc
+++ b/sdk/src/logs/simple_log_record_processor.cc
@@ -43,8 +43,12 @@ void SimpleLogRecordProcessor::OnEmit(std::unique_ptr<Recordable> &&record) noex
 /**
  *  The simple processor does not have any log records to flush so this method is not used
  */
-bool SimpleLogRecordProcessor::ForceFlush(std::chrono::microseconds /* timeout */) noexcept
+bool SimpleLogRecordProcessor::ForceFlush(std::chrono::microseconds timeout) noexcept
 {
+  if (exporter_ != nullptr)
+  {
+    return exporter_->ForceFlush(timeout);
+  }
   return true;
 }
 

--- a/sdk/src/trace/CMakeLists.txt
+++ b/sdk/src/trace/CMakeLists.txt
@@ -9,6 +9,7 @@ add_library(
   tracer_provider_factory.cc
   tracer.cc
   span.cc
+  exporter.cc
   batch_span_processor.cc
   batch_span_processor_factory.cc
   simple_processor_factory.cc

--- a/sdk/src/trace/batch_span_processor.cc
+++ b/sdk/src/trace/batch_span_processor.cc
@@ -30,6 +30,7 @@ BatchSpanProcessor::BatchSpanProcessor(std::unique_ptr<SpanExporter> &&exporter,
   synchronization_data_->is_force_wakeup_background_worker.store(false);
   synchronization_data_->is_force_flush_pending.store(false);
   synchronization_data_->is_force_flush_notified.store(false);
+  synchronization_data_->force_flush_timeout_us.store(0);
   synchronization_data_->is_shutdown.store(false);
 }
 
@@ -77,6 +78,7 @@ bool BatchSpanProcessor::ForceFlush(std::chrono::microseconds timeout) noexcept
   std::unique_lock<std::mutex> lk_cv(synchronization_data_->force_flush_cv_m);
 
   synchronization_data_->is_force_flush_pending.store(true, std::memory_order_release);
+  synchronization_data_->force_flush_timeout_us.store(timeout.count(), std::memory_order_release);
   auto break_condition = [this]() {
     if (synchronization_data_->is_shutdown.load() == true)
     {
@@ -97,23 +99,23 @@ bool BatchSpanProcessor::ForceFlush(std::chrono::microseconds timeout) noexcept
   // Fix timeout to meet requirement of wait_for
   timeout = opentelemetry::common::DurationUtil::AdjustWaitForTimeout(
       timeout, std::chrono::microseconds::zero());
-  bool result;
-  if (timeout <= std::chrono::microseconds::zero())
+  std::chrono::steady_clock::duration timeout_steady =
+      std::chrono::duration_cast<std::chrono::steady_clock::duration>(timeout);
+  if (timeout_steady <= std::chrono::steady_clock::duration::zero())
   {
-    bool wait_result = false;
-    while (!wait_result)
-    {
-      // When is_force_flush_notified.store(true) and force_flush_cv.notify_all() is called
-      // between is_force_flush_pending.load() and force_flush_cv.wait(). We must not wait
-      // for ever
-      wait_result = synchronization_data_->force_flush_cv.wait_for(lk_cv, schedule_delay_millis_,
-                                                                   break_condition);
-    }
-    result = true;
+    timeout_steady = std::chrono::steady_clock::duration::max();
   }
-  else
+
+  bool result = false;
+  while (!result && timeout_steady > std::chrono::steady_clock::duration::zero())
   {
-    result = synchronization_data_->force_flush_cv.wait_for(lk_cv, timeout, break_condition);
+    // When is_force_flush_notified.store(true) and force_flush_cv.notify_all() is called
+    // between is_force_flush_pending.load() and force_flush_cv.wait(). We must not wait
+    // for ever
+    std::chrono::steady_clock::time_point start_timepoint = std::chrono::steady_clock::now();
+    result = synchronization_data_->force_flush_cv.wait_for(lk_cv, schedule_delay_millis_,
+                                                            break_condition);
+    timeout_steady -= std::chrono::steady_clock::now() - start_timepoint;
   }
 
   // If it will be already signaled, we must wait util notified.
@@ -192,7 +194,7 @@ void BatchSpanProcessor::Export()
 
     if (num_records_to_export == 0)
     {
-      NotifyCompletion(notify_force_flush, synchronization_data_);
+      NotifyCompletion(notify_force_flush, exporter_, synchronization_data_);
       break;
     }
     buffer_.Consume(num_records_to_export,
@@ -206,12 +208,13 @@ void BatchSpanProcessor::Export()
                     });
 
     exporter_->Export(nostd::span<std::unique_ptr<Recordable>>(spans_arr.data(), spans_arr.size()));
-    NotifyCompletion(notify_force_flush, synchronization_data_);
+    NotifyCompletion(notify_force_flush, exporter_, synchronization_data_);
   } while (true);
 }
 
 void BatchSpanProcessor::NotifyCompletion(
     bool notify_force_flush,
+    const std::unique_ptr<SpanExporter> &exporter,
     const std::shared_ptr<SynchronizationData> &synchronization_data)
 {
   if (!synchronization_data)
@@ -221,6 +224,15 @@ void BatchSpanProcessor::NotifyCompletion(
 
   if (notify_force_flush)
   {
+    if (exporter)
+    {
+      std::chrono::microseconds timeout = opentelemetry::common::DurationUtil::AdjustWaitForTimeout(
+          std::chrono::microseconds{
+              synchronization_data->force_flush_timeout_us.load(std::memory_order_acquire)},
+          std::chrono::microseconds::zero());
+      exporter->ForceFlush(timeout);
+    }
+
     synchronization_data->is_force_flush_notified.store(true, std::memory_order_release);
     synchronization_data->force_flush_cv.notify_one();
   }

--- a/sdk/src/trace/exporter.cc
+++ b/sdk/src/trace/exporter.cc
@@ -1,0 +1,19 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+#include "opentelemetry/sdk/trace/exporter.h"
+
+OPENTELEMETRY_BEGIN_NAMESPACE
+namespace sdk
+{
+namespace trace
+{
+
+OPENTELEMETRY_EXPORT bool SpanExporter::ForceFlush(std::chrono::microseconds /*timeout*/) noexcept
+{
+  return true;
+}
+
+}  // namespace trace
+}  // namespace sdk
+OPENTELEMETRY_END_NAMESPACE

--- a/sdk/src/trace/exporter.cc
+++ b/sdk/src/trace/exporter.cc
@@ -9,6 +9,10 @@ namespace sdk
 namespace trace
 {
 
+OPENTELEMETRY_EXPORT SpanExporter::SpanExporter() {}
+
+OPENTELEMETRY_EXPORT SpanExporter::~SpanExporter() {}
+
 OPENTELEMETRY_EXPORT bool SpanExporter::ForceFlush(std::chrono::microseconds /*timeout*/) noexcept
 {
   return true;

--- a/sdk/src/trace/tracer.cc
+++ b/sdk/src/trace/tracer.cc
@@ -104,12 +104,22 @@ nostd::shared_ptr<trace_api::Span> Tracer::StartSpan(
 
 void Tracer::ForceFlushWithMicroseconds(uint64_t timeout) noexcept
 {
-  (void)timeout;
+  if (context_)
+  {
+    context_->ForceFlush(
+        std::chrono::microseconds{static_cast<std::chrono::microseconds::rep>(timeout)});
+  }
 }
 
 void Tracer::CloseWithMicroseconds(uint64_t timeout) noexcept
 {
-  (void)timeout;
+  // Trace context is shared by many tracers.So we just call ForceFlush to flush all pending spans
+  // and do not  shutdown it.
+  if (context_)
+  {
+    context_->ForceFlush(
+        std::chrono::microseconds{static_cast<std::chrono::microseconds::rep>(timeout)});
+  }
 }
 }  // namespace trace
 }  // namespace sdk

--- a/sdk/src/trace/tracer_context.cc
+++ b/sdk/src/trace/tracer_context.cc
@@ -53,9 +53,9 @@ bool TracerContext::ForceFlush(std::chrono::microseconds timeout) noexcept
   return processor_->ForceFlush(timeout);
 }
 
-bool TracerContext::Shutdown() noexcept
+bool TracerContext::Shutdown(std::chrono::microseconds timeout) noexcept
 {
-  return processor_->Shutdown();
+  return processor_->Shutdown(timeout);
 }
 
 }  // namespace trace

--- a/sdk/test/trace/simple_processor_test.cc
+++ b/sdk/test/trace/simple_processor_test.cc
@@ -38,7 +38,9 @@ TEST(SimpleProcessor, ToInMemorySpanExporter)
 class RecordShutdownExporter final : public SpanExporter
 {
 public:
-  RecordShutdownExporter(int *shutdown_counter) : shutdown_counter_(shutdown_counter) {}
+  RecordShutdownExporter(int *force_flush_counter, int *shutdown_counter)
+      : force_flush_counter_(force_flush_counter), shutdown_counter_(shutdown_counter)
+  {}
 
   std::unique_ptr<Recordable> MakeRecordable() noexcept override
   {
@@ -51,6 +53,12 @@ public:
     return ExportResult::kSuccess;
   }
 
+  bool ForceFlush(std::chrono::microseconds /* timeout */) noexcept override
+  {
+    *force_flush_counter_ += 1;
+    return true;
+  }
+
   bool Shutdown(std::chrono::microseconds /* timeout */) noexcept override
   {
     *shutdown_counter_ += 1;
@@ -58,17 +66,70 @@ public:
   }
 
 private:
+  int *force_flush_counter_;
   int *shutdown_counter_;
 };
 
 TEST(SimpleSpanProcessor, ShutdownCalledOnce)
 {
+  int force_flush                  = 0;
   int shutdowns                    = 0;
-  RecordShutdownExporter *exporter = new RecordShutdownExporter(&shutdowns);
+  RecordShutdownExporter *exporter = new RecordShutdownExporter(&force_flush, &shutdowns);
   SimpleSpanProcessor processor(std::unique_ptr<SpanExporter>{exporter});
   EXPECT_EQ(0, shutdowns);
   processor.Shutdown();
   EXPECT_EQ(1, shutdowns);
   processor.Shutdown();
   EXPECT_EQ(1, shutdowns);
+
+  EXPECT_EQ(0, force_flush);
+}
+
+TEST(SimpleSpanProcessor, ForceFlush)
+{
+  int force_flush                  = 0;
+  int shutdowns                    = 0;
+  RecordShutdownExporter *exporter = new RecordShutdownExporter(&force_flush, &shutdowns);
+  SimpleSpanProcessor processor(std::unique_ptr<SpanExporter>{exporter});
+  processor.ForceFlush();
+  EXPECT_EQ(0, shutdowns);
+  EXPECT_EQ(1, force_flush);
+  processor.ForceFlush();
+  EXPECT_EQ(2, force_flush);
+}
+
+// An exporter that does nothing but record (and give back ) the # of times Shutdown was called.
+class FailShutDownForceFlushExporter final : public SpanExporter
+{
+public:
+  FailShutDownForceFlushExporter() {}
+
+  std::unique_ptr<Recordable> MakeRecordable() noexcept override
+  {
+    return std::unique_ptr<Recordable>(new SpanData());
+  }
+
+  ExportResult Export(const opentelemetry::nostd::span<std::unique_ptr<Recordable>>
+                          & /* recordables */) noexcept override
+  {
+    return ExportResult::kSuccess;
+  }
+
+  bool ForceFlush(std::chrono::microseconds /* timeout */) noexcept override { return false; }
+
+  bool Shutdown(std::chrono::microseconds /* timeout */) noexcept override { return false; }
+};
+
+TEST(SimpleSpanProcessor, ShutdownFail)
+{
+  SimpleSpanProcessor processor(
+      std::unique_ptr<SpanExporter>{new FailShutDownForceFlushExporter()});
+  EXPECT_EQ(false, processor.Shutdown());
+}
+
+TEST(SimpleSpanProcessor, ForceFlushFail)
+{
+  SimpleSpanProcessor processor(
+      std::unique_ptr<SpanExporter>{new FailShutDownForceFlushExporter()});
+  EXPECT_EQ(false, processor.ForceFlush());
 }


### PR DESCRIPTION
Fixes #1623
Fixes #1955 

## Changes

+ Add `ForceFlush` for all `LogRecordExporter`s and `SpanExporter`s.
+ Call `ForceFlush` to prevent cancel in OTLP examples.
+ Optimize `BatchSpanProcessor::ForceFlush` and `BatchLogRecordProcessor::ForceFlush`. We will finish force flush more quickly when pass a large timeout .
+ Optimize OTLP HTTP log example

For significant contributions please make sure you have completed the following items:

* [x] `CHANGELOG.md` updated for non-trivial changes
* [x] Unit tests have been added
* [ ] Changes in public API reviewed