### PR TITLE
Rename the global SDK version variables to avoid naming clash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ Increment the:
 
 ## [Unreleased]
 
+* [SDK] Rename the global SDK version variables to avoid naming clash
+  [#2011](https://github.com/open-telemetry/opentelemetry-cpp/pull/2011)
 * [SDK]Add attributes for InstrumentationScope
   [#2004](https://github.com/open-telemetry/opentelemetry-cpp/pull/2004)
 * [ETW Exporter]Support serialize span/log attributes into JSON

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -211,7 +211,7 @@ option(
   OFF)
 
 option(WITH_LOGS_PREVIEW "Whether to build logs preview" OFF)
-option(WITH_ASYNC_EXPORT_PREVIEW "Whether enable async export" OFF)
+option(WITH_ASYNC_EXPORT_PREVIEW "Whether to enable async export" OFF)
 # Exemplar specs status is experimental, so behind feature flag by default
 option(WITH_METRICS_EXEMPLAR_PREVIEW
        "Whethere to enable exemplar within metrics" OFF)

--- a/buildscripts/pre-commit
+++ b/buildscripts/pre-commit
@@ -61,18 +61,18 @@ namespace sdk
 {
 namespace version
 {
-const int MAJOR_VERSION = ${major};
-const int MINOR_VERSION = ${minor};
-const int PATCH_VERSION = ${patch};
-const char* PRE_RELEASE = "${pre_release}";
-const char* BUILD_METADATA = "${build_metadata}";
-const int COUNT_NEW_COMMITS = ${count_new_commits};
-const char* BRANCH = "${branch}";
-const char* COMMIT_HASH = "${latest_commit_hash}";
-const char* SHORT_VERSION = "${short_version}";
-const char* FULL_VERSION =
+const int OPENTELEMETRY_SDK_MAJOR_VERSION = ${major};
+const int OPENTELEMETRY_SDK_MINOR_VERSION = ${minor};
+const int OPENTELEMETRY_SDK_PATCH_VERSION = ${patch};
+const char* OPENTELEMETRY_SDK_PRE_RELEASE = "${pre_release}";
+const char* OPENTELEMETRY_SDK_BUILD_METADATA = "${build_metadata}";
+const int OPENTELEMETRY_SDK_COUNT_NEW_COMMITS = ${count_new_commits};
+const char* OPENTELEMETRY_SDK_BRANCH = "${branch}";
+const char* OPENTELEMETRY_SDK_COMMIT_HASH = "${latest_commit_hash}";
+const char* OPENTELEMETRY_SDK_SHORT_VERSION = "${short_version}";
+const char* OPENTELEMETRY_SDK_FULL_VERSION =
     "${full_version}";
-const char* BUILD_DATE = "$(date -u)";
+const char* OPENTELEMETRY_SDK_BUILD_DATE = "$(date -u)";
 }  // namespace version
 }  // namespace sdk
 OPENTELEMETRY_END_NAMESPACE

--- a/sdk/include/opentelemetry/sdk/version/version.h
+++ b/sdk/include/opentelemetry/sdk/version/version.h
@@ -22,9 +22,8 @@ extern const char *OPENTELEMETRY_SDK_BUILD_METADATA;
 extern const int OPENTELEMETRY_SDK_COUNT_NEW_COMMITS;
 extern const char *OPENTELEMETRY_SDK_BRANCH;
 extern const char *OPENTELEMETRY_SDK_COMMIT_HASH;
-extern const char *OPENTELEMETRY_SDK_SHORT_VERSION
+extern const char *OPENTELEMETRY_SDK_SHORT_VERSION;
 extern const char *OPENTELEMETRY_SDK_FULL_VERSION;
-// extern const char *FULL_VERSION_WITH_BRANCH_COMMITHASH;
 extern const char *OPENTELEMETRY_SDK_BUILD_DATE;
 }  // namespace version
 }  // namespace sdk

--- a/sdk/include/opentelemetry/sdk/version/version.h
+++ b/sdk/include/opentelemetry/sdk/version/version.h
@@ -14,17 +14,18 @@ namespace sdk
 {
 namespace version
 {
-extern const int MAJOR_VERSION;
-extern const int MINOR_VERSION;
-extern const int PATCH_VERSION;
-extern const char *PRE_RELEASE;
-extern const char *BUILD_METADATA;
-extern const int COUNT_NEW_COMMITS;
-extern const char *BRANCH;
-extern const char *COMMIT_HASH;
-extern const char *FULL_VERSION;
-extern const char *FULL_VERSION_WITH_BRANCH_COMMITHASH;
-extern const char *BUILD_DATE;
+extern const int OPENTELEMETRY_SDK_MAJOR_VERSION;
+extern const int OPENTELEMETRY_SDK_MINOR_VERSION;
+extern const int OPENTELEMETRY_SDK_PATCH_VERSION;
+extern const char *OPENTELEMETRY_SDK_PRE_RELEASE;
+extern const char *OPENTELEMETRY_SDK_BUILD_METADATA;
+extern const int OPENTELEMETRY_SDK_COUNT_NEW_COMMITS;
+extern const char *OPENTELEMETRY_SDK_BRANCH;
+extern const char *OPENTELEMETRY_SDK_COMMIT_HASH;
+extern const char *OPENTELEMETRY_SDK_SHORT_VERSION
+extern const char *OPENTELEMETRY_SDK_FULL_VERSION;
+// extern const char *FULL_VERSION_WITH_BRANCH_COMMITHASH;
+extern const char *OPENTELEMETRY_SDK_BUILD_DATE;
 }  // namespace version
 }  // namespace sdk
 OPENTELEMETRY_END_NAMESPACE

--- a/sdk/src/version/version.cc
+++ b/sdk/src/version/version.cc
@@ -11,18 +11,18 @@ namespace sdk
 {
 namespace version
 {
-const int MAJOR_VERSION     = 1;
-const int MINOR_VERSION     = 8;
-const int PATCH_VERSION     = 2;
-const char *PRE_RELEASE     = "NONE";
-const char *BUILD_METADATA  = "NONE";
-const int COUNT_NEW_COMMITS = 37;
-const char *BRANCH          = "pre_release_1.8.2";
-const char *COMMIT_HASH     = "435ce60f233b6718aaa04bb7068dd641b536299b";
-const char *SHORT_VERSION   = "1.8.2";
-const char *FULL_VERSION =
+const int OPENTELEMETRY_SDK_MAJOR_VERSION     = 1;
+const int OPENTELEMETRY_SDK_MINOR_VERSION     = 8;
+const int OPENTELEMETRY_SDK_PATCH_VERSION     = 2;
+const char *OPENTELEMETRY_SDK_PRE_RELEASE     = "NONE";
+const char *OPENTELEMETRY_SDK_BUILD_METADATA  = "NONE";
+const int OPENTELEMETRY_SDK_COUNT_NEW_COMMITS = 37;
+const char *OPENTELEMETRY_SDK_BRANCH          = "pre_release_1.8.2";
+const char *OPENTELEMETRY_SDK_COMMIT_HASH     = "435ce60f233b6718aaa04bb7068dd641b536299b";
+const char *OPENTELEMETRY_SDK_SHORT_VERSION   = "1.8.2";
+const char *OPENTELEMETRY_SDK_FULL_VERSION =
     "1.8.2-NONE-NONE-37-pre_release_1.8.2-435ce60f233b6718aaa04bb7068dd641b536299b";
-const char *BUILD_DATE = "Tue 31 Jan 2023 04:01:10 PM UTC";
+const char *OPENTELEMETRY_SDK_BUILD_DATE = "Tue 31 Jan 2023 04:01:10 PM UTC";
 }  // namespace version
 }  // namespace sdk
 OPENTELEMETRY_END_NAMESPACE


### PR DESCRIPTION
## Changes

Avoid using the general macro like name as `MAJOR_VERSION`. It could clash with the macro definition form other header files even it is under namespace. Add the prefix `OPENTELEMETRY_SDK_` to make the name more specific.

For significant contributions please make sure you have completed the following items:

* [ ] `CHANGELOG.md` updated for non-trivial changes
* [ ] Unit tests have been added
* [ ] Changes in public API reviewed