### PR TITLE
Remove ubuntu 18.04 runner image from CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -182,7 +182,8 @@ jobs:
     - name: Add Ubuntu Xenial package sources
       run: |
           sudo apt-add-repository 'deb http://archive.ubuntu.com/ubuntu/ xenial main'
-          sudo apt-add-repository 'deb http://archive.ubuntu.com/ubuntu/ xenial universe'    - name: setup
+          sudo apt-add-repository 'deb http://archive.ubuntu.com/ubuntu/ xenial universe'
+    - name: setup
       run: |
         sudo ./ci/setup_ci_environment.sh
         sudo ./ci/install_gcc48.sh

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -147,11 +147,15 @@ jobs:
 
   cmake_gcc_48_test:
     name: CMake gcc 4.8 (without otlp exporter)
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
     - uses: actions/checkout@v3
       with:
         submodules: 'recursive'
+    - name: Add Ubuntu Xenial package sources
+      run: |
+          sudo apt-add-repository 'deb http://archive.ubuntu.com/ubuntu/ xenial main'
+          sudo apt-add-repository 'deb http://archive.ubuntu.com/ubuntu/ xenial universe'
     - name: setup
       run: |
         sudo ./ci/setup_ci_environment.sh
@@ -170,12 +174,15 @@ jobs:
 
   cmake_gcc_48_otlp_exporter_test:
     name: CMake gcc 4.8 (with otlp exporter)
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
     - uses: actions/checkout@v3
       with:
         submodules: 'recursive'
-    - name: setup
+    - name: Add Ubuntu Xenial package sources
+      run: |
+          sudo apt-add-repository 'deb http://archive.ubuntu.com/ubuntu/ xenial main'
+          sudo apt-add-repository 'deb http://archive.ubuntu.com/ubuntu/ xenial universe'    - name: setup
       run: |
         sudo ./ci/setup_ci_environment.sh
         sudo ./ci/install_gcc48.sh

--- a/README.md
+++ b/README.md
@@ -43,11 +43,13 @@ of the current project.
 
 | Platform                                                            |   Build type  |
 |---------------------------------------------------------------------|---------------|
-| ubuntu-20.04 (Default GCC Compiler - 9.3.0)                         | CMake, Bazel  |
-| ubuntu-18.04 (GCC 4.8 with -std=c++11 flag)                         | CMake [1]     |
-| ubuntu-20.04 (Default GCC Compiler - 9.3.0 with -std=c++20 flags)   | CMake, Bazel  |
-| macOS 10.15 (Xcode 12.2)                                            | Bazel         |
+| ubuntu-22.04 (GCC - 10, 12)                                         | CMake, Bazel  |
+| ubuntu-20.04 (GCC 4.8 with -std=c++11 flag)                         | CMake [1]     |
+| ubuntu-20.04 (GCC 9.4.0)                                            | CMake, Bazel  |
+| ubuntu-20.04 (Default GCC Compiler - 9.4.0 with -std=c++20 flags)   | CMake, Bazel  |
+| macOS 12.0 (Xcode 14.2)                                             | Bazel         |
 | Windows Server 2019 (Visual Studio Enterprise 2019)                 | CMake, Bazel  |
+| Windows Server 2022 (Visual Studio Enterprise 2022)                 | CMake         |
 
 [1]: Bazel build is disabled for GCC 4.8, as gRPC library 1.38 and above
   (required by OTLP expoter) don't build with this compiler. See gRPC [official


### PR DESCRIPTION
Fixes #2019 

## Changes

- Use ubuntu-20.04 instead of ubuntu-18.04
- Add Xenial package repo to download GCC 4.8 
- Update Supported Development Platforms (based on CI pipeline) in README.md

For significant contributions please make sure you have completed the following items:

* [ ] `CHANGELOG.md` updated for non-trivial changes
* [ ] Unit tests have been added
* [ ] Changes in public API reviewed