### PR TITLE
OT shim page adjustments

### DIFF
--- a/opentracing-shim/README.md
+++ b/opentracing-shim/README.md
@@ -1,10 +1,10 @@
-# OpenTracing Shim
+# C++ OpenTracing Shim
 
 [![Apache License][license-image]][license-image]
 
-The OpenTracing shim is a bridge layer from OpenTelemetry to the OpenTracing API.
-It takes an OpenTelemetry Tracer and exposes it as an implementation compatible with
-that of an OpenTracing Tracer.
+An [OpenTracing shim][migrating] is a bridge layer from OpenTelemetry to the
+OpenTracing API. It takes an OpenTelemetry Tracer and exposes it as an
+implementation compatible with that of an OpenTracing Tracer.
 
 ## Usage
 
@@ -37,15 +37,17 @@ auto tracer_shim = TracerShim::createTracerShim(tracer, propagators);
 
 If propagators are not specified, OpenTelemetry's global propagator will be used.
 
+## More information and help
+
+- [Migrating from OpenTracing][migrating]
+- [OpenTelemetry](https://opentelemetry.io)
+- For help or feedback on this project, join us in [GitHub Discussions][discussions-url]
+
 ## License
 
 Apache 2.0 - See [LICENSE][license-url] for more information.
 
-## Useful links
-
-- For more information on OpenTelemetry, visit: <https://opentelemetry.io/>
-- For help or feedback on this project, join us in [GitHub Discussions][discussions-url]
-
 [discussions-url]: https://github.com/open-telemetry/opentelemetry-cpp/discussions
 [license-url]: https://github.com/open-telemetry/opentelemetry-cpp/blob/main/LICENSE
 [license-image]: https://img.shields.io/badge/license-Apache_2.0-green.svg?style=flat
+[migrating]: https://opentelemetry.io/docs/migration/opentracing/


### PR DESCRIPTION
- Followup to #1909
- Adds a direct link to the [Migrating from OpenTracing][migrating] page from the OTel website (that page contains a link to the corresponding specification page).
- Makes a few copyedits
- Related: https://github.com/open-telemetry/opentelemetry.io/pull/2466

**Preview**: https://github.com/open-telemetry/opentelemetry-cpp/blob/79ecce82bb29d2a71a66f8fd79c8d33c26b17ce9/opentracing-shim/README.md

/cc @chusitoo @lalitb @reyang 

[migrating]: https://opentelemetry.io/docs/migration/opentracing/
