### PR TITLE
Remove separate run of metrics ostream example

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,7 +35,7 @@ Increment the:
   [#1992](https://github.com/open-telemetry/opentelemetry-cpp/pull/1992)
 * [ETW Exporter] Support serialize span/log attributes into JSON
   [#1991](https://github.com/open-telemetry/opentelemetry-cpp/pull/1991)
-* ETW Exporter]Do not overwrite ParentId when setting attribute on Span
+* [ETW Exporter]Do not overwrite ParentId when setting attribute on Span
   [#1989](https://github.com/open-telemetry/opentelemetry-cpp/pull/1989)
 * Upgrade prometheus-cpp to v1.1.0
   [#1954](https://github.com/open-telemetry/opentelemetry-cpp/pull/1954)

--- a/ci/do_ci.sh
+++ b/ci/do_ci.sh
@@ -320,13 +320,11 @@ elif [[ "$1" == "bazel.nortti" ]]; then
   exit 0
 elif [[ "$1" == "bazel.asan" ]]; then
   bazel $BAZEL_STARTUP_OPTIONS test --config=asan $BAZEL_TEST_OPTIONS_ASYNC //...
-  bazel $BAZEL_STARTUP_OPTIONS run --config=asan $BAZEL_TEST_OPTIONS_ASYNC \
   exit 0
 elif [[ "$1" == "bazel.tsan" ]]; then
 # TODO - potential race condition in Civetweb server used by prometheus-cpp during shutdown
 # https://github.com/civetweb/civetweb/issues/861, so removing prometheus from the test
   bazel $BAZEL_STARTUP_OPTIONS test --config=tsan $BAZEL_TEST_OPTIONS_ASYNC  -- //... -//exporters/prometheus/...
-  bazel $BAZEL_STARTUP_OPTIONS run --config=tsan $BAZEL_TEST_OPTIONS_ASYNC \
   exit 0
 elif [[ "$1" == "bazel.valgrind" ]]; then
   bazel $BAZEL_STARTUP_OPTIONS build $BAZEL_OPTIONS_ASYNC //...

--- a/ci/do_ci.sh
+++ b/ci/do_ci.sh
@@ -321,14 +321,12 @@ elif [[ "$1" == "bazel.nortti" ]]; then
 elif [[ "$1" == "bazel.asan" ]]; then
   bazel $BAZEL_STARTUP_OPTIONS test --config=asan $BAZEL_TEST_OPTIONS_ASYNC //...
   bazel $BAZEL_STARTUP_OPTIONS run --config=asan $BAZEL_TEST_OPTIONS_ASYNC \
-  //examples/metrics_simple:metrics_ostream_example > /dev/null
   exit 0
 elif [[ "$1" == "bazel.tsan" ]]; then
 # TODO - potential race condition in Civetweb server used by prometheus-cpp during shutdown
 # https://github.com/civetweb/civetweb/issues/861, so removing prometheus from the test
   bazel $BAZEL_STARTUP_OPTIONS test --config=tsan $BAZEL_TEST_OPTIONS_ASYNC  -- //... -//exporters/prometheus/...
   bazel $BAZEL_STARTUP_OPTIONS run --config=tsan $BAZEL_TEST_OPTIONS_ASYNC \
-  //examples/metrics_simple:metrics_ostream_example > /dev/null
   exit 0
 elif [[ "$1" == "bazel.valgrind" ]]; then
   bazel $BAZEL_STARTUP_OPTIONS build $BAZEL_OPTIONS_ASYNC //...


### PR DESCRIPTION
Fixes #1952 

## Changes

It is no longer needed to run the metrics ostream example in CI.

For significant contributions please make sure you have completed the following items:

* [ ] `CHANGELOG.md` updated for non-trivial changes
* [ ] Unit tests have been added
* [ ] Changes in public API reviewed