### PR TITLE
Fix view names in Prometheus example

### DIFF
--- a/examples/prometheus/README.md
+++ b/examples/prometheus/README.md
@@ -59,7 +59,7 @@ Start the application and keep it running. Now we should be able to see the
 metrics at [http://localhost:9464/metrics](http://localhost:9464/metrics) from a
 web browser:
 
-![Browser UI](https://user-images.githubusercontent.com/71217171/168492500-12bd1c99-33ab-4515-a294-17bc349b5d13.png)
+![Browser UI](https://user-images.githubusercontent.com/9139451/224979531-beaa4d6e-98ec-4798-9934-ed25c6b196db.png)
 
 Now, we understand how we can configure `PrometheusExporter` to export metrics.
 Next, we are going to learn about how to use Prometheus to collect the metrics.
@@ -114,12 +114,12 @@ docker run -p 9090:9090 -v $(pwd):/etc/prometheus --network="host" prom/promethe
 
 To use the graphical interface for viewing our metrics with Prometheus, navigate
 to [http://localhost:9090/graph](http://localhost:9090/graph),
-and type `prometheus_metric_example_bucket` in the expression bar of the UI;
-finally, click the execute button.
+and type `prometheus_metric_example_histogram_bucket` in the expression bar of
+the UI; finally, click the execute button.
 
 We should be able to see the following chart from the browser:
 
-![Prometheus UI](https://user-images.githubusercontent.com/71217171/168492437-f9769db1-6f9e-49c6-8ef0-85f5e1188ba0.png)
+![Prometheus UI](https://user-images.githubusercontent.com/9139451/224979224-e7d3865a-f56e-4bb9-8aab-e3f81de40d6e.png)
 
 From the legend, we can see that the `instance` name and the `job` name are the
 values we have set in `prometheus.yml`.
@@ -164,7 +164,7 @@ Feel free to find some handy PromQL
 [here](https://promlabs.com/promql-cheat-sheet/).
 
 ![Grafana
-UI](https://user-images.githubusercontent.com/71217171/168492482-047a4429-4854-4b3c-a2dd-4d75362090d5.png)
+UI](https://user-images.githubusercontent.com/9139451/224979197-4f11abeb-7856-42b2-9b52-af5fd262c75c.png)
 
 ```mermaid
 graph TD

--- a/examples/prometheus/README.md
+++ b/examples/prometheus/README.md
@@ -164,7 +164,7 @@ Feel free to find some handy PromQL
 [here](https://promlabs.com/promql-cheat-sheet/).
 
 ![Grafana
-UI](https://user-images.githubusercontent.com/9139451/224979197-4f11abeb-7856-42b2-9b52-af5fd262c75c.png)
+UI](https://user-images.githubusercontent.com/9139451/224983906-52e061b8-b561-4414-87e9-68823bbc3ad6.png)
 
 ```mermaid
 graph TD

--- a/examples/prometheus/main.cc
+++ b/examples/prometheus/main.cc
@@ -52,7 +52,7 @@ void InitMetrics(const std::string &name, const std::string &addr)
   std::unique_ptr<metrics_sdk::MeterSelector> meter_selector{
       new metrics_sdk::MeterSelector(name, version, schema)};
   std::unique_ptr<metrics_sdk::View> sum_view{
-      new metrics_sdk::View{name, "description", metrics_sdk::AggregationType::kSum}};
+      new metrics_sdk::View{counter_name, "description", metrics_sdk::AggregationType::kSum}};
   p->AddView(std::move(instrument_selector), std::move(meter_selector), std::move(sum_view));
 
   // histogram view
@@ -62,7 +62,7 @@ void InitMetrics(const std::string &name, const std::string &addr)
   std::unique_ptr<metrics_sdk::MeterSelector> histogram_meter_selector{
       new metrics_sdk::MeterSelector(name, version, schema)};
   std::unique_ptr<metrics_sdk::View> histogram_view{
-      new metrics_sdk::View{name, "description", metrics_sdk::AggregationType::kHistogram}};
+      new metrics_sdk::View{histogram_name, "description", metrics_sdk::AggregationType::kHistogram}};
   p->AddView(std::move(histogram_instrument_selector), std::move(histogram_meter_selector),
              std::move(histogram_view));
   metrics_api::Provider::SetMeterProvider(provider);

--- a/examples/prometheus/main.cc
+++ b/examples/prometheus/main.cc
@@ -61,8 +61,8 @@ void InitMetrics(const std::string &name, const std::string &addr)
       new metrics_sdk::InstrumentSelector(metrics_sdk::InstrumentType::kHistogram, histogram_name)};
   std::unique_ptr<metrics_sdk::MeterSelector> histogram_meter_selector{
       new metrics_sdk::MeterSelector(name, version, schema)};
-  std::unique_ptr<metrics_sdk::View> histogram_view{
-      new metrics_sdk::View{histogram_name, "description", metrics_sdk::AggregationType::kHistogram}};
+  std::unique_ptr<metrics_sdk::View> histogram_view{new metrics_sdk::View{
+      histogram_name, "description", metrics_sdk::AggregationType::kHistogram}};
   p->AddView(std::move(histogram_instrument_selector), std::move(histogram_meter_selector),
              std::move(histogram_view));
   metrics_api::Provider::SetMeterProvider(provider);


### PR DESCRIPTION
As far as I can see View should have the same name as Instrument

> The name of the View (optional). If not provided, the **Instrument name** MUST be used by default. This will be used as the name of the [metrics stream](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/metrics/data-model.md#events--data-stream--timeseries).

https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/metrics/sdk.md#view