### PR TITLE
Pick old schema url when updating schema url is empty according to specification in Resource::Merge

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ Increment the:
 * PATCH version when you make backwards compatible bug fixes.
 
 ## [Unreleased]
+* [RESOURCE SDK] Fix schema URL precedence bug in `Resource::Merge`.
+  [#2036](https://github.com/open-telemetry/opentelemetry-cpp/pull/2036)
 
 ## [1.8.3] 2023-03-06
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ Increment the:
 * PATCH version when you make backwards compatible bug fixes.
 
 ## [Unreleased]
+
 * [RESOURCE SDK] Fix schema URL precedence bug in `Resource::Merge`.
   [#2036](https://github.com/open-telemetry/opentelemetry-cpp/pull/2036)
 

--- a/sdk/include/opentelemetry/sdk/resource/resource.h
+++ b/sdk/include/opentelemetry/sdk/resource/resource.h
@@ -36,6 +36,10 @@ public:
    * with the other Resource. In case of a collision, the other Resource takes
    * precedence.
    *
+   * The specification notes that if schema urls collide, the resulting
+   * schema url is implementation-defined. In the C++ implementation, the
+   * schema url of @param other is picked.
+   *
    * @param other the Resource that will be merged with this.
    * @returns the newly merged Resource.
    */

--- a/sdk/src/resource/resource.cc
+++ b/sdk/src/resource/resource.cc
@@ -21,7 +21,8 @@ Resource Resource::Merge(const Resource &other) const noexcept
 {
   ResourceAttributes merged_resource_attributes(other.attributes_);
   merged_resource_attributes.insert(attributes_.begin(), attributes_.end());
-  return Resource(merged_resource_attributes, other.schema_url_);
+  return Resource(merged_resource_attributes,
+                  other.schema_url_.empty() ? schema_url_ : other.schema_url_);
 }
 
 Resource Resource::Create(const ResourceAttributes &attributes, const std::string &schema_url)


### PR DESCRIPTION
Fixes #2035 

## Changes

In `Resource::Merge` this PR will cause the old schema url to be used if the updating schema url is empty. This is in accord with [the specification](https://opentelemetry.io/docs/reference/specification/resource/sdk/#merge).

For significant contributions please make sure you have completed the following items:

* [x] `CHANGELOG.md` updated for non-trivial changes
* [x] Unit tests have been added
* [ ] Changes in public API reviewed