### PR TITLE
Remove unused 'alerting' section from prometheus.yml in examples

### DIFF
--- a/examples/prometheus/README.md
+++ b/examples/prometheus/README.md
@@ -81,14 +81,6 @@ global:
   scrape_interval: 5s
   scrape_timeout: 2s
   evaluation_interval: 5s
-alerting:
-  alertmanagers:
-  - follow_redirects: true
-    scheme: http
-    timeout: 5s
-    api_version: v2
-    static_configs:
-    - targets: [localhost:9464]
 scrape_configs:
   - job_name: otel
     static_configs:

--- a/examples/prometheus/prometheus.yml
+++ b/examples/prometheus/prometheus.yml
@@ -5,14 +5,6 @@ global:
   scrape_interval: 5s
   scrape_timeout: 2s
   evaluation_interval: 5s
-alerting:
-  alertmanagers:
-    - follow_redirects: true
-      scheme: http
-      timeout: 5s
-      api_version: v2
-      static_configs:
-        - targets: [localhost:9464]
 scrape_configs:
   - job_name: otel
     static_configs:


### PR DESCRIPTION
Alerting is not used in this example and port 9464 can't be reused for this purpose