### PR TITLE
Fix some docs typo

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -45,7 +45,7 @@ You can link OpenTelemetry C++ SDK with libraries provided in
 
 ### Building as standalone CMake Project
 
-1. Getting the opentelementry-cpp source with its submodules:
+1. Getting the opentelemetry-cpp source with its submodules:
 
    ```console
    # Change to the directory where you want to create the code repository
@@ -136,7 +136,7 @@ To use the library from a CMake project, you can locate it directly with
  `find_package` and use the imported targets from generated package
  configurations. As of now, this will import targets for both API and SDK. In
  future, there may be separate packages for API and SDK which can be installed
- and imported separtely according to need.
+ and imported separately according to need.
 
 ```cmake
 # CMakeLists.txt
@@ -171,7 +171,7 @@ Bazel](https://docs.bazel.build/versions/3.7.0/install.html) guide.
 
 ### Building as standalone Bazel Project
 
-1. Getting the opentelementry-cpp source:
+1. Getting the opentelemetry-cpp source:
 
    ```console
    # Change to the directory where you want to create the code repository
@@ -188,7 +188,7 @@ Bazel](https://docs.bazel.build/versions/3.7.0/install.html) guide.
    the source code:
 
    ```console
-   $ cd opentelemtry-cpp
+   $ cd opentelemetry-cpp
    $ bazel build //...
    bazel build -- //... -//exporters/otlp/... -//exporters/prometheus/...
    Extracting Bazel installation...
@@ -267,9 +267,9 @@ cc_library(
 Windows DLL build is supported under **preview**. Please check the
 [doc](./docs/build-as-dll.md) for more details.
 
-## Generatring binary packages
+## Generating binary packages
 
-OpenTelemetry C++ supports generating plateform specific binary packages from CMake
+OpenTelemetry C++ supports generating platform specific binary packages from CMake
 configuration. The packages generated through this mayn't be production ready,
 and user may have to customize it further before using it as distribution.
 

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ of the current project.
 | Windows Server 2022 (Visual Studio Enterprise 2022)                 | CMake         |
 
 [1]: Bazel build is disabled for GCC 4.8, as gRPC library 1.38 and above
-  (required by OTLP expoter) don't build with this compiler. See gRPC [official
+  (required by OTLP exporter) don't build with this compiler. See gRPC [official
   support](https://grpc.io/docs/#official-support) document. CMake build doesn't
   build OTLP exporter with GCC 4.8.
 

--- a/docs/dependencies.md
+++ b/docs/dependencies.md
@@ -46,7 +46,7 @@ Both these dependencies are listed here:
     - OTLP messages are constructed as protobuf payloads.
     - `protoc` compiler is used to generate C++ stubs for proto files provided
       by `opentelemetry-proto`.
-    - `libprotobuf` library is used for generating serialised trace/metrics/log
+    - `libprotobuf` library is used for generating serialized trace/metrics/log
       data to be sent to opentelemetry collector.
     - License: The library is licensed
       [here](https://github.com/protocolbuffers/protobuf/blob/master/LICENSE).
@@ -80,7 +80,7 @@ Both these dependencies are listed here:
   - [Thrift](https://github.com/apache/thrift) - Serialization and RPC
     framework.
     - `thrift` compiler to generate C++ stubs for IDL data model for Jaeger.
-    - `libthrift`  library to generate serialised trace/metrics/log data to be
+    - `libthrift`  library to generate serialized trace/metrics/log data to be
       sent to remote Jaeger service. Note: libthrift **0.12.0** doesn't work
       with this Jaeger exporter. See
       [#1680](https://github.com/open-telemetry/opentelemetry-cpp/issues/1680).

--- a/docs/library-distribution.md
+++ b/docs/library-distribution.md
@@ -118,7 +118,7 @@ Examples:
   NGINX's dynamic module capability, tracing can be supported as a plugin. For
   instance, the [nginx-opentracing
   module](https://github.com/opentracing-contrib/nginx-opentracing) provides
-  this type of extension and is used by projects such as Kubernete's [ingress
+  this type of extension and is used by projects such as Kubernetes [ingress
   controller](https://kubernetes.github.io/ingress-nginx/user-guide/third-party-addons/opentracing/).
 * The CPython binary also has no knowledge of OpenTelemetry, but C++ Python
   extension modules can be instrumented for OpenTelemetry.

--- a/docs/using-clang-format.md
+++ b/docs/using-clang-format.md
@@ -48,6 +48,6 @@ For further guidance on editor integration, see these specific pages:
 
 No. For the project as a whole, using clang-format is just one optional way to
 format your code. While it will produce style-guide conformant code, other
-formattings would also satisfy the style guide. For certain modules it may be
+formats would also satisfy the style guide. For certain modules it may be
 appropriate to use alternate coding style. In those scenarios a local directory
 *.clang-format* settings file takes precedence over the one at top-level.

--- a/examples/grpc/README.md
+++ b/examples/grpc/README.md
@@ -24,7 +24,7 @@ of tracing such as:
 
     ``find_package(gRPC)``
 
-2. Build and Deploy the opentelementry-cpp as described in
+2. Build and Deploy the opentelemetry-cpp as described in
    [INSTALL.md](../../INSTALL.md). Building the project will build all of the
    examples and create new folders containing their executables within the
    'build' directory NOT the 'examples' directory.

--- a/examples/http/README.md
+++ b/examples/http/README.md
@@ -21,7 +21,7 @@ to server. The example shows several aspects of tracing such as:
     * [HTTP
       Server](https://github.com/open-telemetry/opentelemetry-cpp/tree/main/ext/include/opentelemetry/ext/http/server)
 
-2. Build and Deploy the opentelementry-cpp as described in
+2. Build and Deploy the opentelemetry-cpp as described in
    [INSTALL.md](../../INSTALL.md)
 
 3. Start the server from the `examples/http` directory

--- a/examples/otlp/README.md
+++ b/examples/otlp/README.md
@@ -31,7 +31,7 @@ API](https://github.com/open-telemetry/opentelemetry-cpp/tree/main/api).
 To enable TLS authentication for OTLP grpc exporter, SslCredentials can be used
 by specifying the path to client certificate pem file, or the string containing
 this certificate via OtlpGrpcExporterOptions. The path to such a .pem file can be
-provided as a command-line argument alongwith the collector endpoint to the main
+provided as a command-line argument along with the collector endpoint to the main
 binary invocation above.
 
 ### Running OpenTelemetry Collector as docker container


### PR DESCRIPTION
Hi! I'm new for op-cpp and I found some typo when reading docs.
## Changes

Please provide a brief description of the changes here.

For significant contributions please make sure you have completed the following items:

* [ ] `CHANGELOG.md` updated for non-trivial changes
* [ ] Unit tests have been added
* [ ] Changes in public API reviewed