### PR TITLE
Fix default value of `OPENTELEMETRY_INSTALL_default`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ Increment the:
   [#2036](https://github.com/open-telemetry/opentelemetry-cpp/pull/2036)
 * [EXPORTER] GRPC endpoint scheme should take precedence over OTEL_EXPORTER_OTLP_TRACES_INSECURE
   [#2060](https://github.com/open-telemetry/opentelemetry-cpp/pull/2060)
+* [BUILD] Restore detfault value of `OPENTELEMETRY_INSTALL` to `ON` when it's on
+  top level.[#2062](https://github.com/open-telemetry/opentelemetry-cpp/pull/2062)
 
 Important changes:
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -118,9 +118,8 @@ option(WITH_GSL
 
 option(WITH_ABSEIL "Whether to use Abseil for C++latest features" OFF)
 
+set(OPENTELEMETRY_INSTALL_default ON)
 if(NOT CMAKE_SOURCE_DIR STREQUAL CMAKE_CURRENT_SOURCE_DIR)
-  set(OPENTELEMETRY_INSTALL_default ON)
-else()
   set(OPENTELEMETRY_INSTALL_default OFF)
 endif()
 option(OPENTELEMETRY_INSTALL "Whether to install opentelemetry targets"


### PR DESCRIPTION
Fixes #2061 

## Changes

The default value of `OPENTELEMETRY_INSTALL_default` should be `ON` when otel-cpp in on top level.

For significant contributions please make sure you have completed the following items:

* [x] `CHANGELOG.md` updated for non-trivial changes
* [ ] Unit tests have been added
* [x] Changes in public API reviewed