### PR TITLE
Ignore more warning of generated protobuf files than not included in `-Wall` and `-Wextra`

### DIFF
--- a/exporters/otlp/include/opentelemetry/exporters/otlp/protobuf_include_prefix.h
+++ b/exporters/otlp/include/opentelemetry/exporters/otlp/protobuf_include_prefix.h
@@ -54,11 +54,13 @@
 #  pragma clang diagnostic ignored "-Wshadow"
 #  pragma clang diagnostic ignored "-Wuninitialized"
 #  pragma clang diagnostic ignored "-Wconversion"
-#  if !(((__clang_major__ * 100) + __clang_minor__) >= 305)
-#    pragma clang diagnostic ignored "-Wsuggest-override"
+#  if ((__clang_major__ * 100) + __clang_minor__) >= 305
+#    pragma clang diagnostic ignored "-Wfloat-conversion"
+#  endif
+#  if ((__clang_major__ * 100) + __clang_minor__) >= 306
 #    pragma clang diagnostic ignored "-Winconsistent-missing-override"
 #  endif
-#  if !(((__clang_major__ * 100) + __clang_minor__) >= 309)
-#    pragma clang diagnostic ignored "-Wfloat-conversion"
+#  if ((__clang_major__ * 100) + __clang_minor__) >= 1100
+#    pragma clang diagnostic ignored "-Wsuggest-override"
 #  endif
 #endif

--- a/exporters/otlp/include/opentelemetry/exporters/otlp/protobuf_include_prefix.h
+++ b/exporters/otlp/include/opentelemetry/exporters/otlp/protobuf_include_prefix.h
@@ -55,10 +55,10 @@
 #  pragma clang diagnostic ignored "-Wuninitialized"
 #  pragma clang diagnostic ignored "-Wconversion"
 #  if !(((__clang_major__ * 100) + __clang_minor__) >= 305)
-#    pragma GCC diagnostic ignored "-Wsuggest-override"
-#    pragma GCC diagnostic ignored "-Winconsistent-missing-override"
+#    pragma clang diagnostic ignored "-Wsuggest-override"
+#    pragma clang diagnostic ignored "-Winconsistent-missing-override"
 #  endif
 #  if !(((__clang_major__ * 100) + __clang_minor__) >= 309)
-#    pragma GCC diagnostic ignored "-Wfloat-conversion"
+#    pragma clang diagnostic ignored "-Wfloat-conversion"
 #  endif
 #endif

--- a/exporters/otlp/include/opentelemetry/exporters/otlp/protobuf_include_prefix.h
+++ b/exporters/otlp/include/opentelemetry/exporters/otlp/protobuf_include_prefix.h
@@ -22,6 +22,9 @@
 #  pragma warning(disable : 4267)
 #  pragma warning(disable : 4668)
 #  pragma warning(disable : 4946)
+#  pragma warning(disable : 6001)
+#  pragma warning(disable : 6244)
+#  pragma warning(disable : 6246)
 #endif
 
 #if defined(__GNUC__) && !defined(__clang__) && !defined(__apple_build_version__)
@@ -30,9 +33,32 @@
 #  endif
 #  pragma GCC diagnostic ignored "-Wunused-parameter"
 #  pragma GCC diagnostic ignored "-Wtype-limits"
+#  pragma GCC diagnostic ignored "-Wsign-compare"
+#  pragma GCC diagnostic ignored "-Wsign-conversion"
+#  pragma GCC diagnostic ignored "-Wshadow"
+#  pragma GCC diagnostic ignored "-Wuninitialized"
+#  pragma GCC diagnostic ignored "-Wconversion"
+#  if (__GNUC__ * 100 + __GNUC_MINOR__) >= 409
+#    pragma GCC diagnostic ignored "-Wfloat-conversion"
+#  endif
+#  if (__GNUC__ * 100 + __GNUC_MINOR__) >= 501
+#    pragma GCC diagnostic ignored "-Wsuggest-override"
+#  endif
 #elif defined(__clang__) || defined(__apple_build_version__)
 #  pragma clang diagnostic push
 #  pragma clang diagnostic ignored "-Wunused-parameter"
 #  pragma clang diagnostic ignored "-Wtype-limits"
 #  pragma clang diagnostic ignored "-Wshadow-field"
+#  pragma clang diagnostic ignored "-Wsign-compare"
+#  pragma clang diagnostic ignored "-Wsign-conversion"
+#  pragma clang diagnostic ignored "-Wshadow"
+#  pragma clang diagnostic ignored "-Wuninitialized"
+#  pragma clang diagnostic ignored "-Wconversion"
+#  if !(((__clang_major__ * 100) + __clang_minor__) >= 305)
+#    pragma GCC diagnostic ignored "-Wsuggest-override"
+#    pragma GCC diagnostic ignored "-Winconsistent-missing-override"
+#  endif
+#  if !(((__clang_major__ * 100) + __clang_minor__) >= 309)
+#    pragma GCC diagnostic ignored "-Wfloat-conversion"
+#  endif
 #endif


### PR DESCRIPTION

Fixes #2065 

## Changes

Ignore more warning of generated protobuf files than not included in `-Wall` and `-Wextra`.
