### PR TITLE
Make some targets parallel in CI pipeline (UNIX)

### DIFF
--- a/ci/do_ci.sh
+++ b/ci/do_ci.sh
@@ -12,7 +12,7 @@ function install_prometheus_cpp_client
   [[ -d _build ]] && rm -rf ./_build
   mkdir _build && cd _build
   cmake .. -DBUILD_SHARED_LIBS=ON -DUSE_THIRDPARTY_LIBRARIES=ON
-  make -j 4
+  make -j $(nproc)
   sudo make install
   popd
 }
@@ -87,7 +87,7 @@ if [[ "$1" == "cmake.test" ]]; then
         -DWITH_LOGS_PREVIEW=ON \
         -DCMAKE_CXX_FLAGS="-Werror $CXXFLAGS" \
         "${SRC_DIR}"
-  make
+  make -j $(nproc)
   make test
   exit 0
 elif [[ "$1" == "cmake.maintainer.test" ]]; then
@@ -109,7 +109,7 @@ elif [[ "$1" == "cmake.maintainer.test" ]]; then
         -DOTELCPP_MAINTAINER_MODE=ON \
         -DWITH_NO_DEPRECATED_CODE=ON \
         "${SRC_DIR}"
-  make -k
+  make -k -j $(nproc)
   make test
   exit 0
 elif [[ "$1" == "cmake.with_async_export.test" ]]; then
@@ -125,7 +125,7 @@ elif [[ "$1" == "cmake.with_async_export.test" ]]; then
         -DCMAKE_CXX_FLAGS="-Werror $CXXFLAGS" \
         -DWITH_ASYNC_EXPORT_PREVIEW=ON \
         "${SRC_DIR}"
-  make
+  make -j $(nproc)
   make test
   exit 0
 elif [[ "$1" == "cmake.abseil.test" ]]; then
@@ -138,7 +138,7 @@ elif [[ "$1" == "cmake.abseil.test" ]]; then
         -DWITH_ASYNC_EXPORT_PREVIEW=ON \
         -DWITH_ABSEIL=ON \
         "${SRC_DIR}"
-  make
+  make -j $(nproc)
   make test
   exit 0
 elif [[ "$1" == "cmake.opentracing_shim.test" ]]; then
@@ -148,7 +148,7 @@ elif [[ "$1" == "cmake.opentracing_shim.test" ]]; then
         -DCMAKE_CXX_FLAGS="-Werror -Wno-error=redundant-move $CXXFLAGS" \
         -DWITH_OPENTRACING=ON \
         "${SRC_DIR}"
-  make
+  make -j $(nproc)
   make test
   exit 0
 elif [[ "$1" == "cmake.c++20.test" ]]; then
@@ -159,7 +159,7 @@ elif [[ "$1" == "cmake.c++20.test" ]]; then
         -DWITH_ASYNC_EXPORT_PREVIEW=ON \
         -DCMAKE_CXX_STANDARD=20 \
         "${SRC_DIR}"
-  make
+  make -j $(nproc)
   make test
   exit 0
 elif [[ "$1" == "cmake.c++20.stl.test" ]]; then
@@ -172,7 +172,7 @@ elif [[ "$1" == "cmake.c++20.stl.test" ]]; then
         -DWITH_ASYNC_EXPORT_PREVIEW=ON \
         -DWITH_STL=ON \
         "${SRC_DIR}"
-  make
+  make -j $(nproc)
   make test
   exit 0
 elif [[ "$1" == "cmake.legacy.test" ]]; then
@@ -184,7 +184,7 @@ elif [[ "$1" == "cmake.legacy.test" ]]; then
         -DCMAKE_CXX_FLAGS="-Werror $CXXFLAGS" \
         -DCMAKE_CXX_STANDARD=11 \
         "${SRC_DIR}"
-  make
+  make -j $(nproc)
   make test
   exit 0
 elif [[ "$1" == "cmake.legacy.exporter.otprotocol.test" ]]; then


### PR DESCRIPTION
Fixes #2074

## Changes

Some of targets does not contain parallel build mechanism which was supported by default.

For significant contributions please make sure you have completed the following items:

* [ ] `CHANGELOG.md` updated for non-trivial changes
* [ ] Unit tests have been added
* [ ] Changes in public API reviewed