### PR TITLE
[BUILD] Build break with old curl, macro CURL_VERSION_BITS unknown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,9 @@ Increment the:
 
 ## [Unreleased]
 
+* [BUILD] Build break with old curl, macro CURL_VERSION_BITS unknown
+  [#2102](https://github.com/open-telemetry/opentelemetry-cpp/pull/2102)
+
 Deprecations:
 
 * The Jaeger Exporter is deprecated, see [DEPRECATED](./DEPRECATED.md) for details.

--- a/ext/src/http/client/curl/http_operation_curl.cc
+++ b/ext/src/http/client/curl/http_operation_curl.cc
@@ -8,6 +8,11 @@
 #include "opentelemetry/ext/http/client/curl/http_client_curl.h"
 #include "opentelemetry/sdk/common/global_log_handler.h"
 
+// CURL_VERSION_BITS was added in CURL 7.43.0
+#ifndef CURL_VERSION_BITS
+#  define CURL_VERSION_BITS(x, y, z) ((x) << 16 | (y) << 8 | (z))
+#endif
+
 OPENTELEMETRY_BEGIN_NAMESPACE
 namespace ext
 {


### PR DESCRIPTION
Fixes #2101

## Changes

Provide macro `CURL_VERSION_BITS`, when building old (< 7.43.0) CURL versions.

For significant contributions please make sure you have completed the following items:

* [X] `CHANGELOG.md` updated for non-trivial changes
* [ ] Unit tests have been added
* [ ] Changes in public API reviewed