### PR TITLE
Fix: #2100 Building shared libraries with version suffix, along with the symbolic link

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -274,7 +274,7 @@ function(set_target_version target_name)
   if(OTELCPP_VERSIONED_LIBS)
     set_target_properties(
       ${target_name} PROPERTIES VERSION ${OPENTELEMETRY_VERSION}
-                                SOVERSION ${OPENTELEMETRY_VERSION})
+                                SOVERSION ${OPENTELEMETRY_ABI_VERSION_NO})
   endif()
 endfunction()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -191,6 +191,10 @@ option(WITH_OPENTRACING "Whether to include the Opentracing shim" OFF)
 option(OTELCPP_VERSIONED_LIBS "Whether to generate the versioned shared libs"
        OFF)
 
+if(OTELCPP_VERSIONED_LIBS AND NOT BUILD_SHARED_LIBS)
+  message(FATAL_ERROR "OTELCPP_VERSIONED_LIBS=ON requires BUILD_SHARED_LIBS=ON")
+endif()
+
 set(OTELCPP_PROTO_PATH
     ""
     CACHE PATH "Path to opentelemetry-proto")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -188,6 +188,9 @@ option(OTELCPP_MAINTAINER_MODE "Build in maintainer mode (-Wall -Werror)" OFF)
 
 option(WITH_OPENTRACING "Whether to include the Opentracing shim" OFF)
 
+option(OTELCPP_VERSIONED_LIBS "Whether to generate the versioned shared libs"
+       OFF)
+
 set(OTELCPP_PROTO_PATH
     ""
     CACHE PATH "Path to opentelemetry-proto")
@@ -265,6 +268,14 @@ function(install_windows_deps)
   set(CMAKE_TOOLCHAIN_FILE
       ${CMAKE_CURRENT_SOURCE_DIR}/tools/vcpkg/scripts/buildsystems/vcpkg.cmake
       PARENT_SCOPE)
+endfunction()
+
+function(set_target_version target_name)
+  if(OTELCPP_VERSIONED_LIBS)
+    set_target_properties(
+      ${target_name} PROPERTIES VERSION ${OPENTELEMETRY_VERSION}
+                                SOVERSION ${OPENTELEMETRY_VERSION})
+  endif()
 endfunction()
 
 if(WITH_JAEGER)

--- a/examples/common/foo_library/CMakeLists.txt
+++ b/examples/common/foo_library/CMakeLists.txt
@@ -6,5 +6,7 @@ if(DEFINED OPENTELEMETRY_BUILD_DLL)
 endif()
 
 add_library(common_foo_library foo_library.h foo_library.cc)
+set_target_version(common_foo_library)
+
 target_link_libraries(common_foo_library PUBLIC ${CMAKE_THREAD_LIBS_INIT}
                                                 opentelemetry_api)

--- a/examples/common/logs_foo_library/CMakeLists.txt
+++ b/examples/common/logs_foo_library/CMakeLists.txt
@@ -6,5 +6,7 @@ if(DEFINED OPENTELEMETRY_BUILD_DLL)
 endif()
 
 add_library(common_logs_foo_library foo_library.h foo_library.cc)
+set_target_version(common_logs_foo_library)
+
 target_link_libraries(common_logs_foo_library PUBLIC ${CMAKE_THREAD_LIBS_INIT}
                                                      opentelemetry_api)

--- a/examples/common/metrics_foo_library/CMakeLists.txt
+++ b/examples/common/metrics_foo_library/CMakeLists.txt
@@ -2,4 +2,5 @@
 # SPDX-License-Identifier: Apache-2.0
 
 add_library(common_metrics_foo_library foo_library.h foo_library.cc)
+set_target_version(common_metrics_foo_library)
 target_link_libraries(common_metrics_foo_library PUBLIC opentelemetry_api)

--- a/exporters/elasticsearch/CMakeLists.txt
+++ b/exporters/elasticsearch/CMakeLists.txt
@@ -7,6 +7,8 @@ add_library(opentelemetry_exporter_elasticsearch_logs
 set_target_properties(opentelemetry_exporter_elasticsearch_logs
                       PROPERTIES EXPORT_NAME elasticsearch_log_record_exporter)
 
+set_target_version(opentelemetry_exporter_elasticsearch_logs)
+
 target_include_directories(
   opentelemetry_exporter_elasticsearch_logs
   PUBLIC "$<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}/include>"

--- a/exporters/elasticsearch/CMakeLists.txt
+++ b/exporters/elasticsearch/CMakeLists.txt
@@ -6,7 +6,6 @@ add_library(opentelemetry_exporter_elasticsearch_logs
 
 set_target_properties(opentelemetry_exporter_elasticsearch_logs
                       PROPERTIES EXPORT_NAME elasticsearch_log_record_exporter)
-
 set_target_version(opentelemetry_exporter_elasticsearch_logs)
 
 target_include_directories(

--- a/exporters/jaeger/CMakeLists.txt
+++ b/exporters/jaeger/CMakeLists.txt
@@ -35,7 +35,6 @@ add_library(opentelemetry_exporter_jaeger_trace ${JAEGER_EXPORTER_SOURCES}
 
 set_target_properties(opentelemetry_exporter_jaeger_trace
                       PROPERTIES EXPORT_NAME jaeger_trace_exporter)
-
 set_target_version(opentelemetry_exporter_jaeger_trace)
 
 target_include_directories(

--- a/exporters/jaeger/CMakeLists.txt
+++ b/exporters/jaeger/CMakeLists.txt
@@ -36,6 +36,8 @@ add_library(opentelemetry_exporter_jaeger_trace ${JAEGER_EXPORTER_SOURCES}
 set_target_properties(opentelemetry_exporter_jaeger_trace
                       PROPERTIES EXPORT_NAME jaeger_trace_exporter)
 
+set_target_version(opentelemetry_exporter_jaeger_trace)
+
 target_include_directories(
   opentelemetry_exporter_jaeger_trace
   PUBLIC "$<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}/include>"

--- a/exporters/memory/CMakeLists.txt
+++ b/exporters/memory/CMakeLists.txt
@@ -12,6 +12,8 @@ target_include_directories(
 set_target_properties(opentelemetry_exporter_in_memory
                       PROPERTIES EXPORT_NAME in_memory_span_exporter)
 
+set_target_version(opentelemetry_exporter_in_memory)
+
 target_link_libraries(opentelemetry_exporter_in_memory
                       PUBLIC opentelemetry_trace)
 

--- a/exporters/memory/CMakeLists.txt
+++ b/exporters/memory/CMakeLists.txt
@@ -11,7 +11,6 @@ target_include_directories(
 
 set_target_properties(opentelemetry_exporter_in_memory
                       PROPERTIES EXPORT_NAME in_memory_span_exporter)
-
 set_target_version(opentelemetry_exporter_in_memory)
 
 target_link_libraries(opentelemetry_exporter_in_memory

--- a/exporters/ostream/CMakeLists.txt
+++ b/exporters/ostream/CMakeLists.txt
@@ -43,7 +43,6 @@ endif() # BUILD_TESTING
 add_library(opentelemetry_exporter_ostream_metrics src/metric_exporter.cc)
 set_target_properties(opentelemetry_exporter_ostream_metrics
                       PROPERTIES EXPORT_NAME ostream_metrics_exporter)
-
 set_target_version(opentelemetry_exporter_ostream_metrics)
 
 target_include_directories(
@@ -80,6 +79,8 @@ if(WITH_LOGS_PREVIEW)
   add_library(opentelemetry_exporter_ostream_logs src/log_record_exporter.cc)
   set_target_properties(opentelemetry_exporter_ostream_logs
                         PROPERTIES EXPORT_NAME ostream_log_record_exporter)
+  set_target_version(opentelemetry_exporter_ostream_logs)
+
   target_include_directories(
     opentelemetry_exporter_ostream_logs
     PUBLIC "$<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}/include>")

--- a/exporters/ostream/CMakeLists.txt
+++ b/exporters/ostream/CMakeLists.txt
@@ -7,6 +7,8 @@ add_library(opentelemetry_exporter_ostream_span src/span_exporter.cc
 set_target_properties(opentelemetry_exporter_ostream_span
                       PROPERTIES EXPORT_NAME ostream_span_exporter)
 
+set_target_version(opentelemetry_exporter_ostream_span)
+
 target_include_directories(
   opentelemetry_exporter_ostream_span
   PUBLIC "$<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}/include>")
@@ -42,6 +44,9 @@ endif() # BUILD_TESTING
 add_library(opentelemetry_exporter_ostream_metrics src/metric_exporter.cc)
 set_target_properties(opentelemetry_exporter_ostream_metrics
                       PROPERTIES EXPORT_NAME ostream_metrics_exporter)
+
+set_target_version(opentelemetry_exporter_ostream_metrics)
+
 target_include_directories(
   opentelemetry_exporter_ostream_metrics
   PUBLIC "$<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}/include>")

--- a/exporters/ostream/CMakeLists.txt
+++ b/exporters/ostream/CMakeLists.txt
@@ -6,7 +6,6 @@ add_library(opentelemetry_exporter_ostream_span src/span_exporter.cc
 
 set_target_properties(opentelemetry_exporter_ostream_span
                       PROPERTIES EXPORT_NAME ostream_span_exporter)
-
 set_target_version(opentelemetry_exporter_ostream_span)
 
 target_include_directories(

--- a/exporters/otlp/CMakeLists.txt
+++ b/exporters/otlp/CMakeLists.txt
@@ -8,6 +8,7 @@ add_library(
   src/otlp_metric_utils.cc)
 set_target_properties(opentelemetry_otlp_recordable PROPERTIES EXPORT_NAME
                                                                otlp_recordable)
+set_target_version(opentelemetry_otlp_recordable)
 
 target_include_directories(
   opentelemetry_otlp_recordable
@@ -31,6 +32,8 @@ if(WITH_OTLP_GRPC)
                                                       src/otlp_grpc_utils.cc)
   set_target_properties(opentelemetry_exporter_otlp_grpc_client
                         PROPERTIES EXPORT_NAME otlp_grpc_client)
+  set_target_version(opentelemetry_exporter_otlp_grpc_client)
+
   target_link_libraries(
     opentelemetry_exporter_otlp_grpc_client
     PUBLIC opentelemetry_sdk opentelemetry_ext opentelemetry_proto)
@@ -57,6 +60,7 @@ if(WITH_OTLP_GRPC)
 
   set_target_properties(opentelemetry_exporter_otlp_grpc
                         PROPERTIES EXPORT_NAME otlp_grpc_exporter)
+  set_target_version(opentelemetry_exporter_otlp_grpc)
 
   target_link_libraries(
     opentelemetry_exporter_otlp_grpc
@@ -72,6 +76,7 @@ if(WITH_OTLP_GRPC)
 
   set_target_properties(opentelemetry_exporter_otlp_grpc_log
                         PROPERTIES EXPORT_NAME otlp_grpc_log_record_exporter)
+  set_target_version(opentelemetry_exporter_otlp_grpc_log)
 
   target_link_libraries(
     opentelemetry_exporter_otlp_grpc_log
@@ -86,6 +91,7 @@ if(WITH_OTLP_GRPC)
 
   set_target_properties(opentelemetry_exporter_otlp_grpc_metrics
                         PROPERTIES EXPORT_NAME otlp_grpc_metrics_exporter)
+  set_target_version(opentelemetry_exporter_otlp_grpc_metrics)
 
   target_link_libraries(
     opentelemetry_exporter_otlp_grpc_metrics
@@ -100,6 +106,8 @@ if(WITH_OTLP_HTTP)
   add_library(opentelemetry_exporter_otlp_http_client src/otlp_http_client.cc)
   set_target_properties(opentelemetry_exporter_otlp_http_client
                         PROPERTIES EXPORT_NAME otlp_http_client)
+  set_target_version(opentelemetry_exporter_otlp_http_client)
+
   target_link_libraries(
     opentelemetry_exporter_otlp_http_client
     PUBLIC opentelemetry_sdk opentelemetry_proto opentelemetry_http_client_curl
@@ -121,6 +129,7 @@ if(WITH_OTLP_HTTP)
 
   set_target_properties(opentelemetry_exporter_otlp_http
                         PROPERTIES EXPORT_NAME otlp_http_exporter)
+  set_target_version(opentelemetry_exporter_otlp_http)
 
   target_link_libraries(
     opentelemetry_exporter_otlp_http
@@ -137,6 +146,7 @@ if(WITH_OTLP_HTTP)
 
     set_target_properties(opentelemetry_exporter_otlp_http_log
                           PROPERTIES EXPORT_NAME otlp_http_log_record_exporter)
+    set_target_version(opentelemetry_exporter_otlp_http_log)
 
     target_link_libraries(
       opentelemetry_exporter_otlp_http_log
@@ -152,6 +162,7 @@ if(WITH_OTLP_HTTP)
 
   set_target_properties(opentelemetry_exporter_otlp_http_metric
                         PROPERTIES EXPORT_NAME otlp_http_metric_exporter)
+  set_target_version(opentelemetry_exporter_otlp_http_metric)
 
   target_link_libraries(
     opentelemetry_exporter_otlp_http_metric

--- a/exporters/prometheus/CMakeLists.txt
+++ b/exporters/prometheus/CMakeLists.txt
@@ -11,6 +11,8 @@ add_library(opentelemetry_exporter_prometheus src/exporter.cc src/collector.cc
 
 set_target_properties(opentelemetry_exporter_prometheus
                       PROPERTIES EXPORT_NAME prometheus_exporter)
+set_target_version(opentelemetry_exporter_prometheus)
+
 target_include_directories(
   opentelemetry_exporter_prometheus
   PUBLIC "$<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}/include>"

--- a/exporters/zipkin/CMakeLists.txt
+++ b/exporters/zipkin/CMakeLists.txt
@@ -12,6 +12,8 @@ target_include_directories(
   PUBLIC "$<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}/include>"
          "$<INSTALL_INTERFACE:include>")
 
+set_target_version(opentelemetry_exporter_zipkin_trace)
+
 target_link_libraries(
   opentelemetry_exporter_zipkin_trace
   PUBLIC opentelemetry_trace opentelemetry_http_client_curl

--- a/ext/src/http/client/curl/CMakeLists.txt
+++ b/ext/src/http/client/curl/CMakeLists.txt
@@ -7,6 +7,7 @@ add_library(
 
 set_target_properties(opentelemetry_http_client_curl
                       PROPERTIES EXPORT_NAME http_client_curl)
+set_target_version(opentelemetry_http_client_curl)
 
 if(TARGET CURL::libcurl)
   target_link_libraries(

--- a/ext/src/zpages/CMakeLists.txt
+++ b/ext/src/zpages/CMakeLists.txt
@@ -12,6 +12,7 @@ add_library(
   ../../include/opentelemetry/ext/zpages/tracez_http_server.h)
 
 set_target_properties(opentelemetry_zpages PROPERTIES EXPORT_NAME zpages)
+set_target_version(opentelemetry_zpages)
 
 target_link_libraries(opentelemetry_zpages PUBLIC opentelemetry_ext
                                                   opentelemetry_trace)

--- a/opentracing-shim/CMakeLists.txt
+++ b/opentracing-shim/CMakeLists.txt
@@ -7,6 +7,7 @@ add_library(${this_target} src/shim_utils.cc src/span_shim.cc
                            src/span_context_shim.cc src/tracer_shim.cc)
 
 set_target_properties(${this_target} PROPERTIES EXPORT_NAME opentracing_shim)
+set_target_version(${this_target})
 
 target_include_directories(
   ${this_target} PUBLIC "$<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}/include>"

--- a/sdk/src/common/CMakeLists.txt
+++ b/sdk/src/common/CMakeLists.txt
@@ -11,7 +11,6 @@ endif()
 add_library(opentelemetry_common ${COMMON_SRCS})
 
 set_target_properties(opentelemetry_common PROPERTIES EXPORT_NAME common)
-
 set_target_version(opentelemetry_common)
 
 target_link_libraries(

--- a/sdk/src/common/CMakeLists.txt
+++ b/sdk/src/common/CMakeLists.txt
@@ -12,6 +12,8 @@ add_library(opentelemetry_common ${COMMON_SRCS})
 
 set_target_properties(opentelemetry_common PROPERTIES EXPORT_NAME common)
 
+set_target_version(opentelemetry_common)
+
 target_link_libraries(
   opentelemetry_common PUBLIC opentelemetry_api opentelemetry_sdk
                               Threads::Threads)

--- a/sdk/src/logs/CMakeLists.txt
+++ b/sdk/src/logs/CMakeLists.txt
@@ -26,6 +26,7 @@ set_target_properties(opentelemetry_logs PROPERTIES EXPORT_NAME logs)
 
 target_link_libraries(opentelemetry_logs PUBLIC opentelemetry_resources
                                                 opentelemetry_common)
+set_target_version(opentelemetry_logs)
 
 target_include_directories(
   opentelemetry_logs

--- a/sdk/src/metrics/CMakeLists.txt
+++ b/sdk/src/metrics/CMakeLists.txt
@@ -23,6 +23,8 @@ add_library(
 
 set_target_properties(opentelemetry_metrics PROPERTIES EXPORT_NAME metrics)
 
+set_target_version(opentelemetry_metrics)
+
 target_link_libraries(opentelemetry_metrics PUBLIC opentelemetry_common)
 
 target_include_directories(

--- a/sdk/src/metrics/CMakeLists.txt
+++ b/sdk/src/metrics/CMakeLists.txt
@@ -22,7 +22,6 @@ add_library(
   sync_instruments.cc)
 
 set_target_properties(opentelemetry_metrics PROPERTIES EXPORT_NAME metrics)
-
 set_target_version(opentelemetry_metrics)
 
 target_link_libraries(opentelemetry_metrics PUBLIC opentelemetry_common)

--- a/sdk/src/resource/CMakeLists.txt
+++ b/sdk/src/resource/CMakeLists.txt
@@ -4,7 +4,6 @@
 add_library(opentelemetry_resources resource.cc resource_detector.cc)
 
 set_target_properties(opentelemetry_resources PROPERTIES EXPORT_NAME resources)
-
 set_target_version(opentelemetry_resources)
 
 target_link_libraries(opentelemetry_resources opentelemetry_common)

--- a/sdk/src/resource/CMakeLists.txt
+++ b/sdk/src/resource/CMakeLists.txt
@@ -5,6 +5,8 @@ add_library(opentelemetry_resources resource.cc resource_detector.cc)
 
 set_target_properties(opentelemetry_resources PROPERTIES EXPORT_NAME resources)
 
+set_target_version(opentelemetry_resources)
+
 target_link_libraries(opentelemetry_resources opentelemetry_common)
 
 target_include_directories(

--- a/sdk/src/trace/CMakeLists.txt
+++ b/sdk/src/trace/CMakeLists.txt
@@ -24,6 +24,8 @@ add_library(
 
 set_target_properties(opentelemetry_trace PROPERTIES EXPORT_NAME trace)
 
+set_target_version(opentelemetry_trace)
+
 target_link_libraries(opentelemetry_trace PUBLIC opentelemetry_common
                                                  opentelemetry_resources)
 

--- a/sdk/src/trace/CMakeLists.txt
+++ b/sdk/src/trace/CMakeLists.txt
@@ -23,7 +23,6 @@ add_library(
   random_id_generator_factory.cc)
 
 set_target_properties(opentelemetry_trace PROPERTIES EXPORT_NAME trace)
-
 set_target_version(opentelemetry_trace)
 
 target_link_libraries(opentelemetry_trace PUBLIC opentelemetry_common

--- a/sdk/src/version/CMakeLists.txt
+++ b/sdk/src/version/CMakeLists.txt
@@ -4,7 +4,6 @@
 add_library(opentelemetry_version version.cc)
 
 set_target_properties(opentelemetry_version PROPERTIES EXPORT_NAME version)
-
 set_target_version(opentelemetry_version)
 
 target_link_libraries(opentelemetry_version PUBLIC opentelemetry_api

--- a/sdk/src/version/CMakeLists.txt
+++ b/sdk/src/version/CMakeLists.txt
@@ -5,6 +5,8 @@ add_library(opentelemetry_version version.cc)
 
 set_target_properties(opentelemetry_version PROPERTIES EXPORT_NAME version)
 
+set_target_version(opentelemetry_version)
+
 target_link_libraries(opentelemetry_version PUBLIC opentelemetry_api
                                                    opentelemetry_sdk)
 


### PR DESCRIPTION
Fixes #2100

## Changes

Versioning policy is described here for debian - https://www.debian.org/doc/debian-policy/ch-sharedlibs.html. In general same is followed across other *unix distributoins. 
- Added CMake option OTELCPP_VERSIONED_LIBS to enable generating versioned shared libs.
- Currently using OPENTELEMETRY_ABI_VERSION_NO as SOVERSION, we can also use MAJOR version. But as per the recommendation, SOVERSION should change for any ABI breaking change.
- The output is as below:

```console
$ ls -ltr /usr/local/lib/libopentelemetry_*common*so*
-rw-r--r-- 1 root root 281640 Apr 20 21:59 /usr/local/lib/libopentelemetry_common.so.1.9.0
lrwxrwxrwx 1 root root     32 Apr 20 22:01 /usr/local/lib/libopentelemetry_common.so.1 -> libopentelemetry_common.so.1.9.0
lrwxrwxrwx 1 root root     28 Apr 20 22:01 /usr/local/lib/libopentelemetry_common.so -> libopentelemetry_common.so.1

$ objdump -p /usr/local/lib/libopentelemetry_common.so.1.9.0 | grep SONAME
  SONAME               libopentelemetry_common.so.1
$
```

For significant contributions please make sure you have completed the following items:

* [ ] `CHANGELOG.md` updated for non-trivial changes
* [ ] Unit tests have been added
* [ ] Changes in public API reviewed