### PR TITLE
Show warning message if WITH_OTLP is enabled

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -161,6 +161,13 @@ endif()
 
 option(WITH_OTLP "Whether to include the OpenTelemetry Protocol in the SDK" OFF)
 
+if(WITH_OTLP)
+  message(
+    WARNING
+      "WITH_OTLP is deprecated and will be removed in future. Please set either WITH_OTLP_GRPC or WITH_OTLP_HTTP, or even both."
+  )
+endif()
+
 option(WITH_OTLP_HTTP "Whether to include the OTLP http exporter in the SDK"
        OFF)
 


### PR DESCRIPTION
## Changes

To resolve #1926, we'll remove `WITH_OTLP` CMake option as we discussed. But this option could be used by users, so emit warning for now to about its deprecation.

For significant contributions please make sure you have completed the following items:

* [ ] `CHANGELOG.md` updated for non-trivial changes
* [ ] Unit tests have been added
* [ ] Changes in public API reviewed