### PR TITLE
Add missing target dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -467,7 +467,7 @@ update the semantic convention in instrumentation library is needed.
 * [BUILD] Don't require applications using jaeger exporter to know about libcurl
   [#1518](https://github.com/open-telemetry/opentelemetry-cpp/pull/1518)
 * [EXPORTER] Inline print_value() in ostream exporter [#1512](https://github.com/open-telemetry/opentelemetry-cpp/pull/1512)
-* [SDK] fix: urlPaser will incorrect parsing url like "http://abc.com/xxx@xxx/a/b"
+* [SDK] fix: urlPaser will incorrect parsing url like `http://abc.com/xxx@xxx/a/b`
   [#1511](https://github.com/open-telemetry/opentelemetry-cpp/pull/1511)
 * [SDK] Rename `InstrumentationLibrary` to `InstrumentationScope` [#1507](https://github.com/open-telemetry/opentelemetry-cpp/pull/1507)
 * [BUILD] Try to build nlohmann-json only it's depended. [#1505](https://github.com/open-telemetry/opentelemetry-cpp/pull/1505)

--- a/exporters/otlp/CMakeLists.txt
+++ b/exporters/otlp/CMakeLists.txt
@@ -36,7 +36,8 @@ if(WITH_OTLP_GRPC)
 
   target_link_libraries(
     opentelemetry_exporter_otlp_grpc_client
-    PUBLIC opentelemetry_sdk opentelemetry_ext opentelemetry_proto)
+    PUBLIC opentelemetry_sdk opentelemetry_common opentelemetry_ext
+           opentelemetry_proto)
 
   target_link_libraries(opentelemetry_exporter_otlp_grpc_client
                         PRIVATE gRPC::grpc++)

--- a/ext/src/http/client/curl/CMakeLists.txt
+++ b/ext/src/http/client/curl/CMakeLists.txt
@@ -8,7 +8,7 @@ add_library(
 set_target_properties(opentelemetry_http_client_curl
                       PROPERTIES EXPORT_NAME http_client_curl)
 set_target_version(opentelemetry_http_client_curl)
-
+target_link_libraries(opentelemetry_http_client_curl PUBLIC opentelemetry_common)
 if(TARGET CURL::libcurl)
   target_link_libraries(
     opentelemetry_http_client_curl

--- a/ext/src/http/client/curl/CMakeLists.txt
+++ b/ext/src/http/client/curl/CMakeLists.txt
@@ -8,7 +8,8 @@ add_library(
 set_target_properties(opentelemetry_http_client_curl
                       PROPERTIES EXPORT_NAME http_client_curl)
 set_target_version(opentelemetry_http_client_curl)
-target_link_libraries(opentelemetry_http_client_curl PUBLIC opentelemetry_common)
+target_link_libraries(opentelemetry_http_client_curl
+                      PUBLIC opentelemetry_common)
 if(TARGET CURL::libcurl)
   target_link_libraries(
     opentelemetry_http_client_curl

--- a/sdk/src/metrics/CMakeLists.txt
+++ b/sdk/src/metrics/CMakeLists.txt
@@ -24,7 +24,8 @@ add_library(
 set_target_properties(opentelemetry_metrics PROPERTIES EXPORT_NAME metrics)
 set_target_version(opentelemetry_metrics)
 
-target_link_libraries(opentelemetry_metrics PUBLIC opentelemetry_common)
+target_link_libraries(opentelemetry_metrics PUBLIC opentelemetry_common
+                                                   opentelemetry_resources)
 
 target_include_directories(
   opentelemetry_metrics


### PR DESCRIPTION
Fixes #2113 

## Changes

Fixes missing target dependencies for 3 libraries:
Before fix:
```
$ ldd -r -d libopentelemetry_*so  2>&1 | grep undefin
undefined symbol: _ZNK13opentelemetry2v13sdk8resource8Resource13GetAttributesEv (./libopentelemetry_exporter_ostream_metrics.so)
undefined symbol: _ZN13opentelemetry2v13sdk6common12internal_log16GlobalLogHandler18GetHandlerAndLevelEv        (./libopentelemetry_exporter_otlp_grpc_client.so)
undefined symbol: _ZN13opentelemetry2v13sdk6common12internal_log16GlobalLogHandler18GetHandlerAndLevelEv        (./libopentelemetry_http_client_curl.so)
undefined symbol: _ZN13opentelemetry2v13sdk6common12internal_log16GlobalLogHandler18GetHandlerAndLevelEv        (./libopentelemetry_exporter_otlp_http_client.so)
undefined symbol: _ZN13opentelemetry2v13sdk6common12internal_log16GlobalLogHandler18GetHandlerAndLevelEv        (./libopentelemetry_http_client_curl.so)
$
```

After fix:
```
$ ldd -r -d libopentelemetry_*so  2>&1 | grep undefin
$
```
For significant contributions please make sure you have completed the following items:

* [ ] `CHANGELOG.md` updated for non-trivial changes
* [ ] Unit tests have been added
* [ ] Changes in public API reviewed