### PR TITLE
Single character wrapped by std::string to get rid of warning

### DIFF
--- a/ext/include/opentelemetry/ext/http/common/url_parser.h
+++ b/ext/include/opentelemetry/ext/http/common/url_parser.h
@@ -83,7 +83,7 @@ public:
     pos = url_.find_first_of("/?", cpos);
     if (pos == std::string::npos)
     {
-      path_ = "/";  // use default path
+      path_ = std::string("/");  // use default path
       if (is_port)
       {
         port_ = static_cast<uint16_t>(
@@ -122,7 +122,7 @@ public:
       }
       return;
     }
-    path_ = "/";
+    path_ = std::string("/");
     if (url_[cpos] == '?')
     {
       query_ = std::string(url_.begin() + cpos, url_.begin() + url_.length());


### PR DESCRIPTION
Fixes #2134

## Changes

Single character assignment causes a warning with GCC 12 and get rid of it by wrapping this with `std::string`.

For significant contributions please make sure you have completed the following items:

* [ ] `CHANGELOG.md` updated for non-trivial changes
* [ ] Unit tests have been added
* [ ] Changes in public API reviewed