### PR TITLE
[DEPRECATION] Drop C++11 support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,7 +40,8 @@ Breaking changes:
 Deprecations:
 
 * The Jaeger Exporter is deprecated, see [DEPRECATED](./DEPRECATED.md) for details.
-* C++11 support is to end, C++14 will be supported instead, see [DEPRECATED](./DEPRECATED.md) for details.
+* C++11 support is to end, C++14 will be supported instead,
+  see [DEPRECATED](./DEPRECATED.md) for details.
 
 ## [1.9.0] 2023-04-12
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,8 @@ Increment the:
   [#2097](https://github.com/open-telemetry/opentelemetry-cpp/pull/2097)
 * [API] Add user facing Logging API and Benchmarks
   [#2094](https://github.com/open-telemetry/opentelemetry-cpp/pull/2094)
+* [DEPRECATION] Drop C++11 support
+  [#2146](https://github.com/open-telemetry/opentelemetry-cpp/pull/2146)
 
 Breaking changes:
 
@@ -38,6 +40,7 @@ Breaking changes:
 Deprecations:
 
 * The Jaeger Exporter is deprecated, see [DEPRECATED](./DEPRECATED.md) for details.
+* C++11 support is to end, C++14 will be supported instead, see [DEPRECATED](./DEPRECATED.md) for details.
 
 ## [1.9.0] 2023-04-12
 

--- a/DEPRECATED.md
+++ b/DEPRECATED.md
@@ -48,25 +48,25 @@ In this model,
 the build scripts can be configured to:
 
 * pick a given version for a third party library,
-* build opentelemetry-cpp with the third party library given.
+* build opentelemetry-cpp with the library given.
 
-The makefiles do not mandate to use a particular version for a third party,
+The makefiles do not mandate to use a particular version,
 hence the "bring your own" denomination.
 
 To have an up to date build, projects are encouraged to use up to date
 versions of third party libraries, to benefit from bug fixes.
 
-Now, many third party deliver new versions that require C++14, bug fixes
+Now, many libraries deliver new versions that require C++14, bug fixes
 releases for C++11 are no longer available.
 
-In particular, the following libraries:
+In particular, the following components:
 
 * GRPC C++
 * abseil
 * googletest
 
 now require C++14, per
-https://github.com/google/oss-policies-info/blob/main/foundational-cxx-support-matrix.md
+[google support policies](https://github.com/google/oss-policies-info/blob/main/foundational-cxx-support-matrix.md)
 
 As a result, to stay up to date, opentelemetry-cpp needs to upgrade its
 minimum build requirements to use C++14 instead of C++11.

--- a/DEPRECATED.md
+++ b/DEPRECATED.md
@@ -42,7 +42,7 @@ N/A
 
 #### Motivation (C++11)
 
-Opentelemetry-cpp supports a "bring your own dependency" model.
+This repository, opentelemetry-cpp, supports a "bring your own dependency" model.
 
 In this model,
 the build scripts can be configured to:
@@ -85,7 +85,7 @@ instead of C++11.
 
 #### Planned end of life (C++11)
 
-Opentelemetry-cpp support for C++11 will end on September 2023.
+Support for C++11 in opentelemetry-cpp will end on September 2023.
 
 After this date, opentelemetry-cpp may still build properly in C++11 mode,
 assuming a suitable, old, version for each dependency is used,

--- a/DEPRECATED.md
+++ b/DEPRECATED.md
@@ -56,7 +56,7 @@ hence the "bring your own" denomination.
 To have an up to date build, projects are encouraged to use up to date
 versions of third party libraries, to benefit from bug fixes.
 
-Now, many third party now deliver new versions that require C++14, bug fixes
+Now, many third party deliver new versions that require C++14, bug fixes
 releases for C++11 are no longer available.
 
 In particular, the following libraries:

--- a/DEPRECATED.md
+++ b/DEPRECATED.md
@@ -30,7 +30,66 @@ N/A
 
 ## [Compilers]
 
-N/A
+### Drop C++11 support
+
+#### Announcement (C++11)
+
+* Date: 2022-12-01
+* Issue: [DEPRECATION] Drop C++11 support
+  [#1830](https://github.com/open-telemetry/opentelemetry-cpp/pull/1830)
+* This announcement has been pinned,
+  visible in the issues pages since December 2022.
+
+#### Motivation (C++11)
+
+Opentelemetry-cpp supports a "bring your own dependency" model.
+
+In this model,
+the build scripts can be configured to:
+
+* pick a given version for a third party library,
+* build opentelemetry-cpp with the third party library given.
+
+The makefiles do not mandate to use a particular version for a third party,
+hence the "bring your own" denomination.
+
+To have an up to date build, projects are encouraged to use up to date
+versions of third party libraries, to benefit from bug fixes.
+
+Now, many third party now deliver new versions that require C++14, bug fixes
+releases for C++11 are no longer available.
+
+In particular, the following libraries:
+
+* GRPC C++
+* abseil
+* googletest
+
+now require C++14, per
+https://github.com/google/oss-policies-info/blob/main/foundational-cxx-support-matrix.md
+
+As a result, to stay up to date, opentelemetry-cpp needs to upgrade its
+minimum build requirements to use C++14 instead of C++11.
+
+#### Scope (C++11)
+
+Continuous Integration (CI) builds will use C++14 instead of C++11.
+
+The CI build for gcc 4.8 is now deprecated, to be decommissioned when C++11
+support is dropped.
+
+#### Mitigation (C++11)
+
+Building the code with recent third party libraries will require C++14
+instead of C++11.
+
+#### Planned end of life (C++11)
+
+Opentelemetry-cpp support for C++11 will end on September 2023.
+
+After this date, opentelemetry-cpp may still build properly in C++11 mode,
+assuming a suitable, old, version for each dependency is used,
+but the C++11 build will no longer be tested for each new release.
 
 ## [Third party dependencies]
 


### PR DESCRIPTION
Fixes #1830

## Changes

Announce end of C++11 support for September 2023.

For significant contributions please make sure you have completed the following items:

* [X] `CHANGELOG.md` updated for non-trivial changes
* [X] `DEPRECATED.md` updated with announcement
* [ ] Unit tests have been added
* [ ] Changes in public API reviewed