### PR TITLE
[BUILD] Remove option WITH_OTLP

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -161,7 +161,7 @@ endif()
 
 if(DEFINED WITH_OTLP)
   message(
-      FATAL_ERROR
+    FATAL_ERROR
       "WITH_OTLP is deprecated. Please set either WITH_OTLP_GRPC=ON, WITH_OTLP_HTTP=ON, or both to ON."
   )
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -159,12 +159,10 @@ if(WITH_STL)
   endif()
 endif()
 
-option(WITH_OTLP "Whether to include the OpenTelemetry Protocol in the SDK" OFF)
-
-if(WITH_OTLP)
+if(DEFINED WITH_OTLP)
   message(
-    WARNING
-      "WITH_OTLP is deprecated and will be removed in future. Please set either WITH_OTLP_GRPC or WITH_OTLP_HTTP, or even both."
+      FATAL_ERROR
+      "WITH_OTLP is deprecated. Please set either WITH_OTLP_GRPC=ON, WITH_OTLP_HTTP=ON, or both to ON."
   )
 endif()
 
@@ -355,11 +353,10 @@ if(WITH_PROMETHEUS)
   endif()
 endif()
 
-if(WITH_OTLP)
+if(WITH_OTLP_GRPC OR WITH_OTLP_HTTP)
   set(protobuf_MODULE_COMPATIBLE ON)
   find_package(Protobuf)
-  if(WITH_OTLP_GRPC OR (NOT DEFINED WITH_OTLP_GRPC AND NOT DEFINED
-                                                       CACHE{WITH_OTLP_GRPC}))
+  if(WITH_OTLP_GRPC)
     find_package(gRPC)
   endif()
   if((NOT Protobuf_FOUND AND NOT PROTOBUF_FOUND) OR (NOT gRPC_FOUND))
@@ -377,9 +374,7 @@ if(WITH_OTLP)
     if(NOT Protobuf_FOUND AND NOT PROTOBUF_FOUND)
       find_package(Protobuf REQUIRED)
     endif()
-    if(NOT gRPC_FOUND
-       AND (WITH_OTLP_GRPC OR (NOT DEFINED WITH_OTLP_GRPC
-                               AND NOT DEFINED CACHE{WITH_OTLP_GRPC})))
+    if(NOT gRPC_FOUND AND WITH_OTLP_GRPC)
       find_package(gRPC)
     endif()
     if(WIN32)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -166,6 +166,9 @@ if(DEFINED WITH_OTLP)
   )
 endif()
 
+option(WITH_OTLP_GRPC "Whether to include the OTLP gRPC exporter in the SDK"
+       OFF)
+
 option(WITH_OTLP_HTTP "Whether to include the OTLP http exporter in the SDK"
        OFF)
 
@@ -391,10 +394,6 @@ if(WITH_OTLP_GRPC OR WITH_OTLP_HTTP)
     endif()
   endif()
   include(CMakeDependentOption)
-
-  cmake_dependent_option(
-    WITH_OTLP_GRPC "Whether to include the OTLP gRPC exporter in the SDK" ON
-    "gRPC_FOUND" OFF)
 
   message(STATUS "PROTOBUF_PROTOC_EXECUTABLE=${PROTOBUF_PROTOC_EXECUTABLE}")
   include(cmake/opentelemetry-proto.cmake)

--- a/CMakeSettings.json
+++ b/CMakeSettings.json
@@ -14,7 +14,7 @@
       "ctestCommandArgs": "",
       "variables": [
         {
-          "name": "WITH_OTLP",
+          "name": "WITH_OTLP_GRPC",
           "value": "True",
           "type": "BOOL"
         },
@@ -40,7 +40,7 @@
       "cmakeToolchain": "",
       "variables": [
         {
-          "name": "WITH_OTLP",
+          "name": "WITH_OTLP_GRPC",
           "value": "True",
           "type": "BOOL"
         },
@@ -70,7 +70,7 @@
           "type": "BOOL"
         },
         {
-          "name": "WITH_OTLP",
+          "name": "WITH_OTLP_GRPC",
           "value": "True",
           "type": "BOOL"
         },
@@ -106,7 +106,7 @@
           "type": "BOOL"
         },
         {
-          "name": "WITH_OTLP",
+          "name": "WITH_OTLP_GRPC",
           "value": "True",
           "type": "BOOL"
         },

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -82,7 +82,7 @@ You can link OpenTelemetry C++ SDK with libraries provided in
    - `-DBUILD_SHARED_LIBS=ON` : To build shared libraries for the targets.
       Please refer to note [below](#building-shared-libs-for-windows) for
       Windows DLL support.
-   - `-DWITH_OTLP=ON` : To enable building OTLP exporter.
+   - `-DWITH_OTLP_GRPC=ON` : To enable building OTLP exporter.
    - `-DWITH_PROMETHEUS=ON` : To enable building prometheus exporter.
 
 3. Once the build configuration is created, build the CMake targets - this

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -82,7 +82,8 @@ You can link OpenTelemetry C++ SDK with libraries provided in
    - `-DBUILD_SHARED_LIBS=ON` : To build shared libraries for the targets.
       Please refer to note [below](#building-shared-libs-for-windows) for
       Windows DLL support.
-   - `-DWITH_OTLP_GRPC=ON` : To enable building OTLP exporter.
+   - `-DWITH_OTLP_GRPC=ON` : To enable building OTLP GRPC exporter.
+   - `-DWITH_OTLP_HTTP=ON` : To enable building OTLP HTTP exporter.
    - `-DWITH_PROMETHEUS=ON` : To enable building prometheus exporter.
 
 3. Once the build configuration is created, build the CMake targets - this

--- a/ci/do_ci.sh
+++ b/ci/do_ci.sh
@@ -141,7 +141,6 @@ elif [[ "$1" == "cmake.maintainer.cpp11.async.test" ]]; then
   rm -rf *
   cmake -DCMAKE_BUILD_TYPE=Debug  \
         -DCMAKE_CXX_STANDARD=11 \
-        -DWITH_OTLP=ON \
         -DWITH_OTLP_HTTP=ON \
         -DWITH_OTLP_HTTP_SSL_PREVIEW=ON \
         -DWITH_OTLP_HTTP_SSL_TLS_PREVIEW=ON \

--- a/ci/do_ci.sh
+++ b/ci/do_ci.sh
@@ -94,7 +94,6 @@ elif [[ "$1" == "cmake.maintainer.sync.test" ]]; then
   cd "${BUILD_DIR}"
   rm -rf *
   cmake -DCMAKE_BUILD_TYPE=Debug  \
-        -DWITH_OTLP=ON \
         -DWITH_OTLP_HTTP=ON \
         -DWITH_OTLP_HTTP_SSL_PREVIEW=ON \
         -DWITH_OTLP_HTTP_SSL_TLS_PREVIEW=ON \
@@ -118,7 +117,6 @@ elif [[ "$1" == "cmake.maintainer.async.test" ]]; then
   cd "${BUILD_DIR}"
   rm -rf *
   cmake -DCMAKE_BUILD_TYPE=Debug  \
-        -DWITH_OTLP=ON \
         -DWITH_OTLP_HTTP=ON \
         -DWITH_OTLP_HTTP_SSL_PREVIEW=ON \
         -DWITH_OTLP_HTTP_SSL_TLS_PREVIEW=ON \
@@ -245,7 +243,7 @@ elif [[ "$1" == "cmake.legacy.exporter.otprotocol.test" ]]; then
   ${SRC_DIR}/tools/build-benchmark.sh
   cmake -DCMAKE_BUILD_TYPE=Debug  \
         -DCMAKE_CXX_STANDARD=11 \
-        -DWITH_OTLP=ON \
+        -DWITH_OTLP_GRPC=ON \
         -DWITH_OTLP_HTTP=ON \
         -DWITH_ASYNC_EXPORT_PREVIEW=ON \
         "${SRC_DIR}"
@@ -259,7 +257,7 @@ elif [[ "$1" == "cmake.exporter.otprotocol.test" ]]; then
   cd "${BUILD_DIR}"
   rm -rf *
   cmake -DCMAKE_BUILD_TYPE=Debug  \
-        -DWITH_OTLP=ON \
+        -DWITH_OTLP_GRPC=ON \
         -DWITH_OTLP_HTTP=ON \
         "${SRC_DIR}"
   grpc_cpp_plugin=`which grpc_cpp_plugin`
@@ -272,7 +270,7 @@ elif [[ "$1" == "cmake.exporter.otprotocol.shared_libs.with_static_grpc.test" ]]
   cd "${BUILD_DIR}"
   rm -rf *
   cmake -DCMAKE_BUILD_TYPE=Debug  \
-        -DWITH_OTLP=ON \
+        -DWITH_OTLP_GRPC=ON \
         -DWITH_OTLP_HTTP=ON \
         -DBUILD_SHARED_LIBS=ON \
         "${SRC_DIR}"
@@ -286,7 +284,7 @@ elif [[ "$1" == "cmake.exporter.otprotocol.with_async_export.test" ]]; then
   cd "${BUILD_DIR}"
   rm -rf *
   cmake -DCMAKE_BUILD_TYPE=Debug  \
-        -DWITH_OTLP=ON \
+        -DWITH_OTLP_GRPC=ON \
         -DWITH_OTLP_HTTP=ON \
         -DWITH_ASYNC_EXPORT_PREVIEW=ON \
         "${SRC_DIR}"
@@ -300,7 +298,7 @@ elif [[ "$1" == "cmake.do_not_install.test" ]]; then
   cd "${BUILD_DIR}"
   rm -rf *
   cmake -DCMAKE_BUILD_TYPE=Debug  \
-        -DWITH_OTLP=ON \
+        -DWITH_OTLP_GRPC=ON \
         -DWITH_OTLP_HTTP=ON \
         -DWITH_ASYNC_EXPORT_PREVIEW=ON \
         -DOPENTELEMETRY_INSTALL=OFF \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -28,7 +28,6 @@ RUN git clone --recurse-submodules -j ${CORES} --depth=1 \
         -DWITH_JAEGER=ON \
         -DCMAKE_INSTALL_PREFIX=/opt/third_party/install \
         -DBUILD_TESTING=OFF \
-        -DWITH_OTLP=ON \
         -DWITH_OTLP_GRPC=ON \
         -DBUILD_SHARED_LIBS=ON \
         .. \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -29,6 +29,7 @@ RUN git clone --recurse-submodules -j ${CORES} --depth=1 \
         -DCMAKE_INSTALL_PREFIX=/opt/third_party/install \
         -DBUILD_TESTING=OFF \
         -DWITH_OTLP_GRPC=ON \
+        -DWITH_OTLP_HTTP=ON \
         -DBUILD_SHARED_LIBS=ON \
         .. \
     && cmake --build . -j ${CORES} --target install

--- a/docker/Dockerfile.centos
+++ b/docker/Dockerfile.centos
@@ -80,6 +80,6 @@ RUN git clone --depth=1 https://github.com/open-telemetry/opentelemetry-cpp.git 
         -DWITH_ZIPKIN=ON \
         -DWITH_JAEGER=ON \
         -DBUILD_TESTING=OFF \
-        -DWITH_OTLP=ON \
+        -DWITH_OTLP_GRPC=ON \
         .. \
     && make -j${nproc} install && ldconfig

--- a/docker/Dockerfile.centos
+++ b/docker/Dockerfile.centos
@@ -81,5 +81,6 @@ RUN git clone --depth=1 https://github.com/open-telemetry/opentelemetry-cpp.git 
         -DWITH_JAEGER=ON \
         -DBUILD_TESTING=OFF \
         -DWITH_OTLP_GRPC=ON \
+        -DWITH_OTLP_HTTP=ON \
         .. \
     && make -j${nproc} install && ldconfig

--- a/docker/ubuntuLatest/Dockerfile
+++ b/docker/ubuntuLatest/Dockerfile
@@ -59,7 +59,7 @@ RUN apt-get install -y --no-install-recommends libcurl4-openssl-dev && git clone
         -DWITH_ZIPKIN=ON \
         -DWITH_JAEGER=ON \
         -DBUILD_TESTING=OFF \
-        -DWITH_OTLP=ON \
+        -DWITH_OTLP_GRPC=ON \
         .. && \
     make -j${nproc} install && ldconfig && \
     cd ../..

--- a/docker/ubuntuLatest/Dockerfile
+++ b/docker/ubuntuLatest/Dockerfile
@@ -60,6 +60,7 @@ RUN apt-get install -y --no-install-recommends libcurl4-openssl-dev && git clone
         -DWITH_JAEGER=ON \
         -DBUILD_TESTING=OFF \
         -DWITH_OTLP_GRPC=ON \
+        -DWITH_OTLP_HTTP=ON \
         .. && \
     make -j${nproc} install && ldconfig && \
     cd ../..

--- a/exporters/CMakeLists.txt
+++ b/exporters/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright The OpenTelemetry Authors
 # SPDX-License-Identifier: Apache-2.0
 
-if(WITH_OTLP)
+if(WITH_OTLP_GRPC OR WITH_OTLP_HTTP)
   add_subdirectory(otlp)
 endif()
 


### PR DESCRIPTION
Fixes #1926, #2160.

## Changes

Remove `WITH_OTLP` option and raise error on its definition as it causes confusions (see the above issues). Also make `WITH_OTLP_GRPC` as a plain option like `WITH_OTLP_HTTP`.

For significant contributions please make sure you have completed the following items:

* [ ] `CHANGELOG.md` updated for non-trivial changes
* [ ] Unit tests have been added
* [ ] Changes in public API reviewed