### PR TITLE
[EXPORTER] Support empty arrays in `OtlpRecordable` attributes

### DIFF
--- a/exporters/otlp/src/otlp_populate_attribute_utils.cc
+++ b/exporters/otlp/src/otlp_populate_attribute_utils.cc
@@ -67,58 +67,66 @@ void OtlpPopulateAttributeUtils::PopulateAnyValue(
   }
   else if (nostd::holds_alternative<nostd::span<const uint8_t>>(value))
   {
+    auto array_value = proto_value->mutable_array_value();
     for (const auto &val : nostd::get<nostd::span<const uint8_t>>(value))
     {
-      proto_value->mutable_array_value()->add_values()->set_int_value(val);
+      array_value->add_values()->set_int_value(val);
     }
   }
   else if (nostd::holds_alternative<nostd::span<const bool>>(value))
   {
+    auto array_value = proto_value->mutable_array_value();
     for (const auto &val : nostd::get<nostd::span<const bool>>(value))
     {
-      proto_value->mutable_array_value()->add_values()->set_bool_value(val);
+      array_value->add_values()->set_bool_value(val);
     }
   }
   else if (nostd::holds_alternative<nostd::span<const int>>(value))
   {
+    auto array_value = proto_value->mutable_array_value();
     for (const auto &val : nostd::get<nostd::span<const int>>(value))
     {
-      proto_value->mutable_array_value()->add_values()->set_int_value(val);
+      array_value->add_values()->set_int_value(val);
     }
   }
   else if (nostd::holds_alternative<nostd::span<const int64_t>>(value))
   {
+    auto array_value = proto_value->mutable_array_value();
     for (const auto &val : nostd::get<nostd::span<const int64_t>>(value))
     {
-      proto_value->mutable_array_value()->add_values()->set_int_value(val);
+      array_value->add_values()->set_int_value(val);
     }
   }
   else if (nostd::holds_alternative<nostd::span<const unsigned int>>(value))
   {
+    auto array_value = proto_value->mutable_array_value();
     for (const auto &val : nostd::get<nostd::span<const unsigned int>>(value))
     {
-      proto_value->mutable_array_value()->add_values()->set_int_value(val);
+      array_value->add_values()->set_int_value(val);
     }
   }
   else if (nostd::holds_alternative<nostd::span<const uint64_t>>(value))
   {
+    auto array_value = proto_value->mutable_array_value();
     for (const auto &val : nostd::get<nostd::span<const uint64_t>>(value))
     {
-      proto_value->mutable_array_value()->add_values()->set_int_value(val);
+      array_value->add_values()->set_int_value(val);
     }
   }
   else if (nostd::holds_alternative<nostd::span<const double>>(value))
   {
+    auto array_value = proto_value->mutable_array_value();
     for (const auto &val : nostd::get<nostd::span<const double>>(value))
     {
-      proto_value->mutable_array_value()->add_values()->set_double_value(val);
+      array_value->add_values()->set_double_value(val);
     }
   }
   else if (nostd::holds_alternative<nostd::span<const nostd::string_view>>(value))
   {
+    auto array_value = proto_value->mutable_array_value();
     for (const auto &val : nostd::get<nostd::span<const nostd::string_view>>(value))
     {
-      proto_value->mutable_array_value()->add_values()->set_string_value(val.data(), val.size());
+      array_value->add_values()->set_string_value(val.data(), val.size());
     }
   }
 }
@@ -168,51 +176,58 @@ void OtlpPopulateAttributeUtils::PopulateAnyValue(
   }
   else if (nostd::holds_alternative<std::vector<bool>>(value))
   {
+    auto array_value = proto_value->mutable_array_value();
     for (const auto val : nostd::get<std::vector<bool>>(value))
     {
-      proto_value->mutable_array_value()->add_values()->set_bool_value(val);
+      array_value->add_values()->set_bool_value(val);
     }
   }
   else if (nostd::holds_alternative<std::vector<int32_t>>(value))
   {
+    auto array_value = proto_value->mutable_array_value();
     for (const auto &val : nostd::get<std::vector<int32_t>>(value))
     {
-      proto_value->mutable_array_value()->add_values()->set_int_value(val);
+      array_value->add_values()->set_int_value(val);
     }
   }
   else if (nostd::holds_alternative<std::vector<uint32_t>>(value))
   {
+    auto array_value = proto_value->mutable_array_value();
     for (const auto &val : nostd::get<std::vector<uint32_t>>(value))
     {
-      proto_value->mutable_array_value()->add_values()->set_int_value(val);
+      array_value->add_values()->set_int_value(val);
     }
   }
   else if (nostd::holds_alternative<std::vector<int64_t>>(value))
   {
+    auto array_value = proto_value->mutable_array_value();
     for (const auto &val : nostd::get<std::vector<int64_t>>(value))
     {
-      proto_value->mutable_array_value()->add_values()->set_int_value(val);
+      array_value->add_values()->set_int_value(val);
     }
   }
   else if (nostd::holds_alternative<std::vector<uint64_t>>(value))
   {
+    auto array_value = proto_value->mutable_array_value();
     for (const auto &val : nostd::get<std::vector<uint64_t>>(value))
     {
-      proto_value->mutable_array_value()->add_values()->set_int_value(val);
+      array_value->add_values()->set_int_value(val);
     }
   }
   else if (nostd::holds_alternative<std::vector<double>>(value))
   {
+    auto array_value = proto_value->mutable_array_value();
     for (const auto &val : nostd::get<std::vector<double>>(value))
     {
-      proto_value->mutable_array_value()->add_values()->set_double_value(val);
+      array_value->add_values()->set_double_value(val);
     }
   }
   else if (nostd::holds_alternative<std::vector<std::string>>(value))
   {
+    auto array_value = proto_value->mutable_array_value();
     for (const auto &val : nostd::get<std::vector<std::string>>(value))
     {
-      proto_value->mutable_array_value()->add_values()->set_string_value(val);
+      array_value->add_values()->set_string_value(val);
     }
   }
 }

--- a/exporters/otlp/test/otlp_recordable_test.cc
+++ b/exporters/otlp/test/otlp_recordable_test.cc
@@ -284,13 +284,23 @@ TEST(OtlpRecordable, SetArrayAttribute)
   }
 }
 
-// Test empty array.
-TEST(OtlpRecordable, SetEmptyArrayAttribute)
+template <typename T>
+struct EmptyArrayAttributeTest : public testing::Test
 {
+  using ElementType = T;
+};
+
+using ArrayElementTypes =
+    testing::Types<bool, double, nostd::string_view, uint8_t, int, int64_t, unsigned int, uint64_t>;
+TYPED_TEST_SUITE(EmptyArrayAttributeTest, ArrayElementTypes);
+
+// Test empty arrays.
+TYPED_TEST(EmptyArrayAttributeTest, SetEmptyArrayAttribute)
+{
+  using ArrayElementType = typename TestFixture::ElementType;
   OtlpRecordable rec;
 
-  std::vector<int64_t> empty_array = {};
-  nostd::span<const int64_t> span(empty_array);
+  nostd::span<const ArrayElementType> span = {};
   rec.SetAttribute("empty_arr_attr", span);
 
   EXPECT_TRUE(rec.span().attributes(0).value().has_array_value());

--- a/exporters/otlp/test/otlp_recordable_test.cc
+++ b/exporters/otlp/test/otlp_recordable_test.cc
@@ -284,6 +284,19 @@ TEST(OtlpRecordable, SetArrayAttribute)
   }
 }
 
+// Test empty array.
+TEST(OtlpRecordable, SetEmptyArrayAttribute)
+{
+  OtlpRecordable rec;
+
+  std::vector<int64_t> empty_array = {};
+  nostd::span<const int64_t> span(empty_array);
+  rec.SetAttribute("empty_arr_attr", span);
+
+  EXPECT_TRUE(rec.span().attributes(0).value().has_array_value());
+  EXPECT_TRUE(rec.span().attributes(0).value().array_value().values().empty());
+}
+
 /**
  * AttributeValue can contain different int types, such as int, int64_t,
  * unsigned int, and uint64_t. To avoid writing test cases for each, we can


### PR DESCRIPTION
## Changes

This PR changes behavior for empty array attribute values in `OtlpRecordable`. Empty array attribute values did not set the  `AnyValue` field to `ArrayValue`.

However, following the spec it seems we should forward empty arrays.

https://github.com/open-telemetry/opentelemetry-specification/blob/ce2c5946faa9c961ea01d89c7aed83621865b67b/specification/common/README.md?plain=1#L37-L39

Invoking `mutable_array_value()` before looping over the values sets the `AnyValue` variant to `ArrayValue` regardless of the number of items in the iterator.
