### PR TITLE
[EXPORTER] set is_monotonic only for instrument type kCounter

### DIFF
--- a/exporters/otlp/src/otlp_metric_utils.cc
+++ b/exporters/otlp/src/otlp_metric_utils.cc
@@ -50,7 +50,8 @@ void OtlpMetricUtils::ConvertSumMetric(const metric_sdk::MetricData &metric_data
 {
   sum->set_aggregation_temporality(
       GetProtoAggregationTemporality(metric_data.aggregation_temporality));
-  sum->set_is_monotonic(true);
+  sum->set_is_monotonic(metric_data.instrument_descriptor.type_ ==
+                        metric_sdk::InstrumentType::kCounter);
   auto start_ts = metric_data.start_ts.time_since_epoch().count();
   auto ts       = metric_data.end_ts.time_since_epoch().count();
   for (auto &point_data_with_attributes : metric_data.point_data_attr_)

--- a/exporters/otlp/test/otlp_metrics_serialization_test.cc
+++ b/exporters/otlp/test/otlp_metrics_serialization_test.cc
@@ -35,7 +35,7 @@ static metrics_sdk::MetricData CreateSumAggregationData()
   point_data_attr_1.point_data = s_data_1;
 
   point_data_attr_2.attributes = {{"k2", "v2"}};
-  point_data_attr_2.point_data = s_data_1;
+  point_data_attr_2.point_data = s_data_2;
   std::vector<metrics_sdk::PointDataAttributes> point_data_attr;
   point_data_attr.push_back(point_data_attr_1);
   point_data_attr.push_back(point_data_attr_2);
@@ -51,7 +51,7 @@ static metrics_sdk::MetricData CreateUpDownCounterAggregationData()
                                                  metrics_sdk::InstrumentType::kUpDownCounter,
                                                  metrics_sdk::InstrumentValueType::kDouble};
   metrics_sdk::SumPointData s_data_1, s_data_2;
-  s_data_2.value_ = 1.35;
+  s_data_1.value_ = 1.35;
   s_data_2.value_ = 1.37;
 
   data.aggregation_temporality = metrics_sdk::AggregationTemporality::kCumulative;
@@ -62,7 +62,7 @@ static metrics_sdk::MetricData CreateUpDownCounterAggregationData()
   point_data_attr_1.point_data = s_data_1;
 
   point_data_attr_2.attributes = {{"robot_id", "DEV-AYS-03-02"}};
-  point_data_attr_2.point_data = s_data_1;
+  point_data_attr_2.point_data = s_data_2;
   std::vector<metrics_sdk::PointDataAttributes> point_data_attr;
   point_data_attr.push_back(point_data_attr_1);
   point_data_attr.push_back(point_data_attr_2);
@@ -95,7 +95,7 @@ static metrics_sdk::MetricData CreateHistogramAggregationData()
   point_data_attr_1.point_data = s_data_1;
 
   point_data_attr_2.attributes = {{"k2", "v2"}};
-  point_data_attr_2.point_data = s_data_1;
+  point_data_attr_2.point_data = s_data_2;
   std::vector<metrics_sdk::PointDataAttributes> point_data_attr;
   point_data_attr.push_back(point_data_attr_1);
   point_data_attr.push_back(point_data_attr_2);
@@ -122,7 +122,7 @@ static metrics_sdk::MetricData CreateObservableGaugeAggregationData()
   point_data_attr_1.point_data = s_data_1;
 
   point_data_attr_2.attributes = {{"k2", "v2"}};
-  point_data_attr_2.point_data = s_data_1;
+  point_data_attr_2.point_data = s_data_2;
   std::vector<metrics_sdk::PointDataAttributes> point_data_attr;
   point_data_attr.push_back(point_data_attr_1);
   point_data_attr.push_back(point_data_attr_2);


### PR DESCRIPTION
Fixes #2170
Metrics that are inherently non-monotonic nature are exported by OTLP exporter with `IsMonotonic` set to `true`.

# Changes
Updates the OTLP exporter to set `IsMonotonic` to `true` only when the instrument type in use is `kCounter` and otherwise `false`.

* [X] Unit tests have been added