### PR TITLE
[EXPORTER] Fixed HTTP CURL for 32bits platforms

### DIFF
--- a/ext/include/opentelemetry/ext/http/client/curl/http_operation_curl.h
+++ b/ext/include/opentelemetry/ext/http/client/curl/http_operation_curl.h
@@ -269,6 +269,8 @@ private:
 
   CURLcode SetCurlLongOption(CURLoption option, long value);
 
+  CURLcode SetCurlOffOption(CURLoption option, curl_off_t value);
+
   const char *GetCurlErrorMessage(CURLcode code);
 
   std::atomic<bool> is_aborted_;   // Set to 'true' when async callback is aborted

--- a/ext/src/http/client/curl/http_operation_curl.cc
+++ b/ext/src/http/client/curl/http_operation_curl.cc
@@ -556,6 +556,26 @@ CURLcode HttpOperation::SetCurlLongOption(CURLoption option, long value)
   return rc;
 }
 
+CURLcode HttpOperation::SetCurlOffOption(CURLoption option, curl_off_t value)
+{
+  CURLcode rc;
+
+  /*
+    curl_easy_setopt() is a macro with variadic arguments, type unsafe.
+    SetCurlOffOption() ensures it is called with a curl_off_t.
+  */
+  rc = curl_easy_setopt(curl_resource_.easy_handle, option, value);
+
+  if (rc != CURLE_OK)
+  {
+    const char *message = GetCurlErrorMessage(rc);
+    OTEL_INTERNAL_LOG_ERROR("CURL, set option <" << std::to_string(option) << "> failed: <"
+                                                 << message << ">");
+  }
+
+  return rc;
+}
+
 CURLcode HttpOperation::Setup()
 {
   if (!curl_resource_.easy_handle)
@@ -980,7 +1000,7 @@ CURLcode HttpOperation::Setup()
       return rc;
     }
 
-    rc = SetCurlLongOption(CURLOPT_POSTFIELDSIZE_LARGE, req_size);
+    rc = SetCurlOffOption(CURLOPT_POSTFIELDSIZE_LARGE, req_size);
     if (rc != CURLE_OK)
     {
       return rc;


### PR DESCRIPTION
Fixes #2175

## Changes

Fixed the HTTP CURL implementation to use the proper data types, when using options with type `curl_off_t`.

This fixes 32 bits builds, like WIN32.

For significant contributions please make sure you have completed the following items:

* [ ] `CHANGELOG.md` updated for non-trivial changes
* [ ] Unit tests have been added
* [ ] Changes in public API reviewed