### PR TITLE
[BUILD] Avoid dependency on protobuf from the OTLP HTTP metrics exporter header

### DIFF
--- a/exporters/otlp/include/opentelemetry/exporters/otlp/otlp_http_metric_exporter.h
+++ b/exporters/otlp/include/opentelemetry/exporters/otlp/otlp_http_metric_exporter.h
@@ -8,7 +8,6 @@
 #include "opentelemetry/exporters/otlp/otlp_environment.h"
 #include "opentelemetry/exporters/otlp/otlp_http_client.h"
 #include "opentelemetry/exporters/otlp/otlp_http_metric_exporter_options.h"
-#include "opentelemetry/exporters/otlp/otlp_metric_utils.h"
 
 #include <chrono>
 #include <cstddef>


### PR DESCRIPTION
Fixes #2169

## Changes

Simplify the header dependencies for file:
- `exporters/otlp/include/opentelemetry/exporters/otlp/otlp_http_metric_exporter.h`

The declaration of class `OtlpHttpMetricExporter` does not need to see code in `otlp_metric_utils.h`, only the implementation does.

Depending on `otlp_metric_utils.h` from a header file is problematic, because it brings a transitive dependency on protobuf generated code, which is not installed.

This fix allows an application to instantiate a `OtlpHttpMetricExporter` object, to configure the SDK to export metrics.

For significant contributions please make sure you have completed the following items:

* [ ] `CHANGELOG.md` updated for non-trivial changes
* [ ] Unit tests have been added
* [ ] Changes in public API reviewed