### PR TITLE
Add ctime header to metrics_exporter.cc

### DIFF
--- a/exporters/ostream/src/metric_exporter.cc
+++ b/exporters/ostream/src/metric_exporter.cc
@@ -3,8 +3,8 @@
 
 #include "opentelemetry/exporters/ostream/metric_exporter.h"
 #include <algorithm>
-#include <ctime>
 #include <chrono>
+#include <ctime>
 #include <map>
 #include "opentelemetry/exporters/ostream/common_utils.h"
 #include "opentelemetry/sdk/metrics/aggregation/default_aggregation.h"

--- a/exporters/ostream/src/metric_exporter.cc
+++ b/exporters/ostream/src/metric_exporter.cc
@@ -3,6 +3,7 @@
 
 #include "opentelemetry/exporters/ostream/metric_exporter.h"
 #include <algorithm>
+#include <ctime>
 #include <chrono>
 #include <map>
 #include "opentelemetry/exporters/ostream/common_utils.h"


### PR DESCRIPTION
Fixes #2186 

Header file `ctime` is needed for using `std::time_t` in `std::strftime`.

## Changes

Please provide a brief description of the changes here.

For significant contributions please make sure you have completed the following items:

* [ ] `CHANGELOG.md` updated for non-trivial changes
* [ ] Unit tests have been added
* [ ] Changes in public API reviewed