### PR TITLE
[BUILD] Fix if check on environment variable and add CMake variable

### DIFF
--- a/cmake/opentelemetry-build-external-component.cmake
+++ b/cmake/opentelemetry-build-external-component.cmake
@@ -8,9 +8,14 @@
 #  - OPENTELEMETRY_EXTERNAL_COMPONENT_URL Setting github-repo of external component
 #  as env variable
 
-
 # Add custom vendor component from local path, or GitHub repo
-if(DEFINED $ENV{OPENTELEMETRY_EXTERNAL_COMPONENT_PATH})
+# Prefer CMake option, then env variable, then URL.
+if(OPENTELEMETRY_EXTERNAL_COMPONENT_PATH)
+  # Add custom component path to build tree and consolidate binary artifacts in
+  # current project binary output directory.
+  add_subdirectory(${OPENTELEMETRY_EXTERNAL_COMPONENT_PATH}
+                   ${PROJECT_BINARY_DIR}/external)
+elseif(DEFINED ENV{OPENTELEMETRY_EXTERNAL_COMPONENT_PATH})
   # Add custom component path to build tree and consolidate binary artifacts in
   # current project binary output directory.
   add_subdirectory($ENV{OPENTELEMETRY_EXTERNAL_COMPONENT_PATH}


### PR DESCRIPTION
Fixes #2206 

## Changes

Fix the environment variable check, and also check if the same name (OPENTELEMETRY_EXTERNAL_COMPONENT_PATH) is defined as CMake variable. I'd prefer the cmake variable as it shows in the command line and help troubleshoot and create reproducible build, and env var is also taking effect in session global scope while CMake var is only for the CMake instance which is more restricted in scope.

For significant contributions please make sure you have completed the following items:

* [ ] `CHANGELOG.md` updated for non-trivial changes
* [ ] Unit tests have been added
* [ ] Changes in public API reviewed