### PR TITLE
[SDK] MeterProvider should own MeterContext, not share it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,12 +21,21 @@ Increment the:
 * [API] Remove include_trace_context
   [#2194](https://github.com/open-telemetry/opentelemetry-cpp/pull/2194)
 
+* [SDK] MeterProvider should own MeterContext, not share it
+  [#2218](https://github.com/open-telemetry/opentelemetry-cpp/pull/2218)
+
 Important changes:
 
 * [REMOVAL] Remove the jaeger exporter
   [#2031](https://github.com/open-telemetry/opentelemetry-cpp/pull/2031)
   * The CMake `WITH_JAEGER` option has been removed
   * Please remove usage of `WITH_JAEGER` from user scripts and makefiles.
+
+* [SDK] MeterProvider should own MeterContext, not share it
+  [#2218](https://github.com/open-telemetry/opentelemetry-cpp/pull/2218)
+  * The `MeterProvider` constructor now takes a `unique_ptr` on
+    `MeterContext`, instead of a `shared_ptr`.
+  * Please adjust SDK configuration code accordingly.
 
 ## [1.9.1] 2023-05-26
 

--- a/examples/otlp/grpc_metric_main.cc
+++ b/examples/otlp/grpc_metric_main.cc
@@ -48,9 +48,7 @@ void InitMetrics()
   auto context = metric_sdk::MeterContextFactory::Create();
   context->AddMetricReader(std::move(reader));
 
-  std::shared_ptr<metric_sdk::MeterContext> s_context(std::move(context));
-
-  auto u_provider = metric_sdk::MeterProviderFactory::Create(s_context);
+  auto u_provider = metric_sdk::MeterProviderFactory::Create(std::move(context));
   std::shared_ptr<opentelemetry::metrics::MeterProvider> provider(std::move(u_provider));
 
   metrics_api::Provider::SetMeterProvider(provider);

--- a/examples/otlp/http_metric_main.cc
+++ b/examples/otlp/http_metric_main.cc
@@ -52,9 +52,7 @@ void InitMetrics()
   auto context = metric_sdk::MeterContextFactory::Create();
   context->AddMetricReader(std::move(reader));
 
-  std::shared_ptr<metric_sdk::MeterContext> s_context(std::move(context));
-
-  auto u_provider = metric_sdk::MeterProviderFactory::Create(s_context);
+  auto u_provider = metric_sdk::MeterProviderFactory::Create(std::move(context));
   std::shared_ptr<opentelemetry::metrics::MeterProvider> provider(std::move(u_provider));
 
   metrics_api::Provider::SetMeterProvider(provider);

--- a/sdk/include/opentelemetry/sdk/metrics/meter_provider.h
+++ b/sdk/include/opentelemetry/sdk/metrics/meter_provider.h
@@ -44,9 +44,9 @@ public:
 
   /**
    * Initialize a new meter provider with a specified context
-   * @param context The shared meter configuration/pipeline for this provider.
+   * @param context The owned meter configuration/pipeline for this provider.
    */
-  explicit MeterProvider(std::shared_ptr<MeterContext> context) noexcept;
+  explicit MeterProvider(std::unique_ptr<MeterContext> context) noexcept;
 
   nostd::shared_ptr<opentelemetry::metrics::Meter> GetMeter(
       nostd::string_view name,

--- a/sdk/include/opentelemetry/sdk/metrics/meter_provider_factory.h
+++ b/sdk/include/opentelemetry/sdk/metrics/meter_provider_factory.h
@@ -69,7 +69,7 @@ public:
       const opentelemetry::sdk::resource::Resource &resource);
 
   static std::unique_ptr<opentelemetry::metrics::MeterProvider> Create(
-      std::shared_ptr<sdk::metrics::MeterContext> context);
+      std::unique_ptr<sdk::metrics::MeterContext> context);
 };
 
 }  // namespace metrics

--- a/sdk/src/metrics/meter_provider.cc
+++ b/sdk/src/metrics/meter_provider.cc
@@ -21,7 +21,9 @@ namespace metrics
 namespace resource    = opentelemetry::sdk::resource;
 namespace metrics_api = opentelemetry::metrics;
 
-MeterProvider::MeterProvider(std::shared_ptr<MeterContext> context) noexcept : context_{context} {}
+MeterProvider::MeterProvider(std::unique_ptr<MeterContext> context) noexcept
+    : context_(std::move(context))
+{}
 
 MeterProvider::MeterProvider(std::unique_ptr<ViewRegistry> views,
                              sdk::resource::Resource resource) noexcept

--- a/sdk/src/metrics/meter_provider_factory.cc
+++ b/sdk/src/metrics/meter_provider_factory.cc
@@ -46,7 +46,7 @@ std::unique_ptr<opentelemetry::metrics::MeterProvider> MeterProviderFactory::Cre
 }
 
 std::unique_ptr<opentelemetry::metrics::MeterProvider> MeterProviderFactory::Create(
-    std::shared_ptr<sdk::metrics::MeterContext> context)
+    std::unique_ptr<sdk::metrics::MeterContext> context)
 {
   std::unique_ptr<opentelemetry::metrics::MeterProvider> provider(
       new metrics_sdk::MeterProvider(std::move(context)));


### PR DESCRIPTION
Fixes #2204

## Changes

Fixed the `MeterProvider` constructor to use a `unique_ptr<MeterContext>`, assuming ownership.

For significant contributions please make sure you have completed the following items:

* [X] `CHANGELOG.md` updated for non-trivial changes
* [ ] Unit tests have been added
* [ ] Changes in public API reviewed