### PR TITLE
[BUILD] Include nostd/string_view which is used severity.h

### DIFF
--- a/api/include/opentelemetry/logs/severity.h
+++ b/api/include/opentelemetry/logs/severity.h
@@ -4,6 +4,7 @@
 #pragma once
 #ifdef ENABLE_LOGS_PREVIEW
 
+#  include "opentelemetry/nostd/string_view.h"
 #  include "opentelemetry/version.h"
 
 OPENTELEMETRY_BEGIN_NAMESPACE


### PR DESCRIPTION
## Changes

Please provide a brief description of the changes here.

`nostd::string_view` is used in severity.h, but the header file is not included which then require the user to include it. This PR add "nostd/string_view.h" to include explicitly.

For significant contributions please make sure you have completed the following items:

* [ ] `CHANGELOG.md` updated for non-trivial changes
* [ ] Unit tests have been added
* [ ] Changes in public API reviewed