### PR TITLE
[CI] Do not tag pull_request with the "need-triage" label.

### DIFF
--- a/.github/workflows/project_management_issue_open.yml
+++ b/.github/workflows/project_management_issue_open.yml
@@ -4,10 +4,6 @@ on:
     types:
       - reopened
       - opened
-  pull_request:
-    types:
-      - reopened
-      - opened
 jobs:
   label_issues:
     runs-on: ubuntu-latest


### PR DESCRIPTION

## Changes

[CI] Do not tag pull_request with the "need-triage" label.

For significant contributions please make sure you have completed the following items:

* [ ] `CHANGELOG.md` updated for non-trivial changes
* [ ] Unit tests have been added
* [ ] Changes in public API reviewed