### PR TITLE
Fix compile with clang 16 and libc++

### DIFF
--- a/sdk/include/opentelemetry/sdk/logs/simple_log_record_processor.h
+++ b/sdk/include/opentelemetry/sdk/logs/simple_log_record_processor.h
@@ -33,7 +33,7 @@ class SimpleLogRecordProcessor : public LogRecordProcessor
 
 public:
   explicit SimpleLogRecordProcessor(std::unique_ptr<LogRecordExporter> &&exporter);
-  ~SimpleLogRecordProcessor() override = default;
+  ~SimpleLogRecordProcessor() override;
 
   std::unique_ptr<Recordable> MakeRecordable() noexcept override;
 

--- a/sdk/src/logs/simple_log_record_processor.cc
+++ b/sdk/src/logs/simple_log_record_processor.cc
@@ -23,6 +23,8 @@ SimpleLogRecordProcessor::SimpleLogRecordProcessor(std::unique_ptr<LogRecordExpo
     : exporter_(std::move(exporter)), is_shutdown_(false)
 {}
 
+SimpleLogRecordProcessor::~SimpleLogRecordProcessor() {}
+
 std::unique_ptr<Recordable> SimpleLogRecordProcessor::MakeRecordable() noexcept
 {
   return exporter_->MakeRecordable();

--- a/sdk/src/metrics/data/circular_buffer.cc
+++ b/sdk/src/metrics/data/circular_buffer.cc
@@ -55,7 +55,7 @@ struct AdaptingIntegerArrayClear
   template <typename T>
   void operator()(std::vector<T> &backing)
   {
-    std::fill(backing.begin(), backing.end(), static_cast<T>(0));
+    backing.assign(backing.size(), static_cast<T>(0));
   }
 };
 


### PR DESCRIPTION
Fixes #2241 

## Changes

+ Move destructor of `SimpleLogRecordProcessor` into `.cc` .
+ Use `std::vector::assign` to replace `std::fill` .

For significant contributions please make sure you have completed the following items:

* [ ] `CHANGELOG.md` updated for non-trivial changes
* [ ] Unit tests have been added
* [x] Changes in public API reviewed