### PR TITLE
Valgrind errors on std::atomic variables

### DIFF
--- a/exporters/elasticsearch/include/opentelemetry/exporters/elasticsearch/es_log_record_exporter.h
+++ b/exporters/elasticsearch/include/opentelemetry/exporters/elasticsearch/es_log_record_exporter.h
@@ -125,8 +125,8 @@ private:
 #  ifdef ENABLE_ASYNC_EXPORT
   struct SynchronizationData
   {
-    std::atomic<std::size_t> session_counter_;
-    std::atomic<std::size_t> finished_session_counter_;
+    std::atomic<std::size_t> session_counter_{0};
+    std::atomic<std::size_t> finished_session_counter_{0};
     std::condition_variable force_flush_cv;
     std::mutex force_flush_cv_m;
     std::recursive_mutex force_flush_m;

--- a/exporters/otlp/src/otlp_http_client.cc
+++ b/exporters/otlp/src/otlp_http_client.cc
@@ -64,7 +64,7 @@ namespace
 {
 
 /**
- * This class handles the response message from the Elasticsearch request
+ * This class handles the response message from the HTTP request
  */
 class ResponseHandler : public http_client::EventHandler
 {
@@ -75,9 +75,7 @@ public:
   ResponseHandler(std::function<bool(opentelemetry::sdk::common::ExportResult)> &&callback,
                   bool console_debug = false)
       : result_callback_{std::move(callback)}, console_debug_{console_debug}
-  {
-    stopping_.store(false);
-  }
+  {}
 
   std::string BuildResponseLogMessage(http_client::Response &response,
                                       const std::string &body) noexcept
@@ -356,7 +354,7 @@ private:
   const opentelemetry::ext::http::client::Session *session_ = nullptr;
 
   // Whether notify has been called
-  std::atomic<bool> stopping_;
+  std::atomic<bool> stopping_{false};
 
   // A string to store the response body
   std::string body_ = "";

--- a/ext/include/opentelemetry/ext/http/client/curl/http_client_curl.h
+++ b/ext/include/opentelemetry/ext/http/client/curl/http_client_curl.h
@@ -159,7 +159,7 @@ public:
           std::string scheme      = "http",
           const std::string &host = "",
           uint16_t port           = 80)
-      : http_client_(http_client), is_session_active_(false)
+      : http_client_(http_client)
   {
     host_ = scheme + "://" + host + ":" + std::to_string(port) + "/";
   }
@@ -216,7 +216,7 @@ private:
   std::unique_ptr<HttpOperation> curl_operation_;
   uint64_t session_id_;
   HttpClient &http_client_;
-  std::atomic<bool> is_session_active_;
+  std::atomic<bool> is_session_active_{false};
 };
 
 class HttpClientSync : public opentelemetry::ext::http::client::HttpClientSync
@@ -352,7 +352,7 @@ private:
 
   std::mutex multi_handle_m_;
   CURLM *multi_handle_;
-  std::atomic<uint64_t> next_session_id_;
+  std::atomic<uint64_t> next_session_id_{0};
   uint64_t max_sessions_per_connection_;
 
   std::mutex sessions_m_;

--- a/ext/include/opentelemetry/ext/http/client/curl/http_operation_curl.h
+++ b/ext/include/opentelemetry/ext/http/client/curl/http_operation_curl.h
@@ -273,11 +273,11 @@ private:
 
   const char *GetCurlErrorMessage(CURLcode code);
 
-  std::atomic<bool> is_aborted_;   // Set to 'true' when async callback is aborted
-  std::atomic<bool> is_finished_;  // Set to 'true' when async callback is finished.
-  std::atomic<bool> is_cleaned_;   // Set to 'true' when async callback is cleaned.
-  const bool is_raw_response_;     // Do not split response headers from response body
-  const bool reuse_connection_;    // Reuse connection
+  std::atomic<bool> is_aborted_{false};   // Set to 'true' when async callback is aborted
+  std::atomic<bool> is_finished_{false};  // Set to 'true' when async callback is finished.
+  std::atomic<bool> is_cleaned_{false};   // Set to 'true' when async callback is cleaned.
+  const bool is_raw_response_;            // Do not split response headers from response body
+  const bool reuse_connection_;           // Reuse connection
   const std::chrono::milliseconds http_conn_timeout_;  // Timeout for connect.  Default: 5000ms
 
   char curl_error_message_[CURL_ERROR_SIZE];
@@ -311,7 +311,7 @@ private:
 
     std::thread::id callback_thread;
     std::function<void(HttpOperation &)> callback;
-    std::atomic<bool> is_promise_running;
+    std::atomic<bool> is_promise_running{false};
     std::promise<CURLcode> result_promise;
     std::future<CURLcode> result_future;
   };

--- a/ext/include/opentelemetry/ext/zpages/tracez_data_aggregator.h
+++ b/ext/include/opentelemetry/ext/zpages/tracez_data_aggregator.h
@@ -155,7 +155,7 @@ private:
 
   /** A boolean that is set to true in the constructor and false in the
    * destructor to start and end execution of aggregate spans **/
-  std::atomic<bool> execute_;
+  std::atomic<bool> execute_{false};
 
   /** Thread that executes aggregate spans at regurlar intervals during this
   object's lifetime**/

--- a/ext/test/http/curl_http_test.cc
+++ b/ext/test/http/curl_http_test.cc
@@ -99,8 +99,8 @@ class BasicCurlHttpTests : public ::testing::Test, public HTTP_SERVER_NS::HttpRe
 protected:
   HTTP_SERVER_NS::HttpServer server_;
   std::string server_address_;
-  std::atomic<bool> is_setup_;
-  std::atomic<bool> is_running_;
+  std::atomic<bool> is_setup_{false};
+  std::atomic<bool> is_running_{false};
   std::vector<HTTP_SERVER_NS::HttpRequest> received_requests_;
   std::mutex mtx_requests;
   std::condition_variable cv_got_events;

--- a/sdk/include/opentelemetry/sdk/logs/batch_log_record_processor.h
+++ b/sdk/include/opentelemetry/sdk/logs/batch_log_record_processor.h
@@ -115,11 +115,11 @@ protected:
     std::mutex cv_m, force_flush_cv_m, shutdown_m;
 
     /* Important boolean flags to handle the workflow of the processor */
-    std::atomic<bool> is_force_wakeup_background_worker;
-    std::atomic<bool> is_force_flush_pending;
-    std::atomic<bool> is_force_flush_notified;
-    std::atomic<std::chrono::microseconds::rep> force_flush_timeout_us;
-    std::atomic<bool> is_shutdown;
+    std::atomic<bool> is_force_wakeup_background_worker{false};
+    std::atomic<bool> is_force_flush_pending{false};
+    std::atomic<bool> is_force_flush_notified{false};
+    std::atomic<std::chrono::microseconds::rep> force_flush_timeout_us{0};
+    std::atomic<bool> is_shutdown{false};
   };
 
   /**

--- a/sdk/include/opentelemetry/sdk/logs/simple_log_record_processor.h
+++ b/sdk/include/opentelemetry/sdk/logs/simple_log_record_processor.h
@@ -53,7 +53,7 @@ private:
   // The lock used to ensure the exporter is not called concurrently
   opentelemetry::common::SpinLockMutex lock_;
   // The atomic boolean to ensure the ShutDown() function is only called once
-  std::atomic<bool> is_shutdown_;
+  std::atomic<bool> is_shutdown_{false};
 };
 }  // namespace logs
 }  // namespace sdk

--- a/sdk/include/opentelemetry/sdk/metrics/export/periodic_exporting_metric_reader.h
+++ b/sdk/include/opentelemetry/sdk/metrics/export/periodic_exporting_metric_reader.h
@@ -50,9 +50,9 @@ private:
   std::thread worker_thread_;
 
   /* Synchronization primitives */
-  std::atomic<bool> is_force_flush_pending_;
-  std::atomic<bool> is_force_wakeup_background_worker_;
-  std::atomic<bool> is_force_flush_notified_;
+  std::atomic<bool> is_force_flush_pending_{false};
+  std::atomic<bool> is_force_wakeup_background_worker_{false};
+  std::atomic<bool> is_force_flush_notified_{false};
   std::condition_variable cv_, force_flush_cv_;
   std::mutex cv_m_, force_flush_m_;
 };

--- a/sdk/include/opentelemetry/sdk/trace/batch_span_processor.h
+++ b/sdk/include/opentelemetry/sdk/trace/batch_span_processor.h
@@ -114,11 +114,11 @@ protected:
     std::mutex cv_m, force_flush_cv_m, shutdown_m;
 
     /* Important boolean flags to handle the workflow of the processor */
-    std::atomic<bool> is_force_wakeup_background_worker;
-    std::atomic<bool> is_force_flush_pending;
-    std::atomic<bool> is_force_flush_notified;
-    std::atomic<std::chrono::microseconds::rep> force_flush_timeout_us;
-    std::atomic<bool> is_shutdown;
+    std::atomic<bool> is_force_wakeup_background_worker{false};
+    std::atomic<bool> is_force_flush_pending{false};
+    std::atomic<bool> is_force_flush_notified{false};
+    std::atomic<std::chrono::microseconds::rep> force_flush_timeout_us{0};
+    std::atomic<bool> is_shutdown{false};
   };
 
   /**

--- a/sdk/src/logs/batch_log_record_processor.cc
+++ b/sdk/src/logs/batch_log_record_processor.cc
@@ -30,12 +30,7 @@ BatchLogRecordProcessor::BatchLogRecordProcessor(
       buffer_(max_queue_size_),
       synchronization_data_(std::make_shared<SynchronizationData>()),
       worker_thread_(&BatchLogRecordProcessor::DoBackgroundWork, this)
-{
-  synchronization_data_->is_force_wakeup_background_worker.store(false);
-  synchronization_data_->is_force_flush_pending.store(false);
-  synchronization_data_->is_force_flush_notified.store(false);
-  synchronization_data_->is_shutdown.store(false);
-}
+{}
 
 BatchLogRecordProcessor::BatchLogRecordProcessor(std::unique_ptr<LogRecordExporter> &&exporter,
                                                  const BatchLogRecordProcessorOptions &options)
@@ -46,13 +41,7 @@ BatchLogRecordProcessor::BatchLogRecordProcessor(std::unique_ptr<LogRecordExport
       buffer_(options.max_queue_size),
       synchronization_data_(std::make_shared<SynchronizationData>()),
       worker_thread_(&BatchLogRecordProcessor::DoBackgroundWork, this)
-{
-  synchronization_data_->is_force_wakeup_background_worker.store(false);
-  synchronization_data_->is_force_flush_pending.store(false);
-  synchronization_data_->is_force_flush_notified.store(false);
-  synchronization_data_->force_flush_timeout_us.store(0);
-  synchronization_data_->is_shutdown.store(false);
-}
+{}
 
 std::unique_ptr<Recordable> BatchLogRecordProcessor::MakeRecordable() noexcept
 {

--- a/sdk/src/trace/batch_span_processor.cc
+++ b/sdk/src/trace/batch_span_processor.cc
@@ -31,13 +31,7 @@ BatchSpanProcessor::BatchSpanProcessor(std::unique_ptr<SpanExporter> &&exporter,
       buffer_(max_queue_size_),
       synchronization_data_(std::make_shared<SynchronizationData>()),
       worker_thread_(&BatchSpanProcessor::DoBackgroundWork, this)
-{
-  synchronization_data_->is_force_wakeup_background_worker.store(false);
-  synchronization_data_->is_force_flush_pending.store(false);
-  synchronization_data_->is_force_flush_notified.store(false);
-  synchronization_data_->force_flush_timeout_us.store(0);
-  synchronization_data_->is_shutdown.store(false);
-}
+{}
 
 std::unique_ptr<Recordable> BatchSpanProcessor::MakeRecordable() noexcept
 {


### PR DESCRIPTION
Fixes #2243 

## Changes

Using only the default constructor to initialize `std::atomic` objects is incorrect.
This is a particularity of `std::atomic` itself, that does not follow the same rules as C++ in general.

See: https://en.cppreference.com/w/cpp/atomic/atomic/atomic

In the entire code base, reviewed every use of `std::atomic`,
and changed initialization to use the _direct list initialization syntax_.

see: https://en.cppreference.com/w/cpp/language/list_initialization

This form is the most robust and maintainable:

* auditing the source code for correctness is easier
* this form guarantees a proper initialization will be done, in all cases

This fixed the bug reported on the periodic metric reader, tested under valgrind.

This fixed a missing initialization in one of the `BatchLogRecordProcessor` constructors,
found by code review.

This also fixed the following pattern, which _technically_, is incorrect:

```
std::atomic<bool> flag;
flag.store(true);
```

With the fix, code such as:

```
std::atomic<bool> flag{false};
flag.store(true);
```

is correct, because it is now legal to call `store()` as the object _**is initialized**_.


* [ ] `CHANGELOG.md` updated for non-trivial changes
* [ ] Unit tests have been added
* [X] Changes in public API reviewed