### PR TITLE
sdk: include batch_span_processor_options to fix build

### DIFF
--- a/sdk/include/opentelemetry/sdk/trace/batch_span_processor.h
+++ b/sdk/include/opentelemetry/sdk/trace/batch_span_processor.h
@@ -10,6 +10,7 @@
 #include <thread>
 
 #include "opentelemetry/sdk/common/circular_buffer.h"
+#include "opentelemetry/sdk/trace/batch_span_processor_options.h"
 #include "opentelemetry/sdk/trace/processor.h"
 #include "opentelemetry/version.h"
 


### PR DESCRIPTION
We should include `batch_span_processor_options` in the sdk as the `otel_ngx_module` is unable to compile.
I think, instead of adding an include in that project, we should add it in the sdk.

```bash
../otel-cpp-contrib/opentelemetry-cpp-contrib-866351ce2422a9d953ded4447bcdea0e587d6a53/instrumentation/nginx/src/otel_ngx_module.cpp: In function 'std::unique_ptr<opentelemetry::v1::sdk::trace::SpanProcessor> CreateProcessor(const OtelNgxAgentConfig*, std::unique_ptr<opentelemetry::v1::sdk::trace::SpanExporter>)':
../otel-cpp-contrib/opentelemetry-cpp-contrib-866351ce2422a9d953ded4447bcdea0e587d6a53/instrumentation/nginx/src/otel_ngx_module.cpp:1039:41: error: aggregate 'opentelemetry::v1::sdk::trace::BatchSpanProcessorOptions opts' has incomplete type and cannot be defined
 1039 |     sdktrace::BatchSpanProcessorOptions opts;
```