### PR TITLE
[CI] Benchmark workflow fails, C++14 required to build grpc

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -25,12 +25,12 @@ jobs:
           key: bazel_benchmark
       - name: setup
         run: |
-          sudo -E ./ci/setup_cmake.sh
-          sudo -E ./ci/setup_ci_environment.sh
+          sudo ./ci/setup_ci_environment.sh
+          sudo ./ci/install_bazelisk.sh
       - name: Run benchmark
         id: run_benchmarks
         run: |
-          CC=/usr/bin/gcc-10 CXX=/usr/bin/g++-10 ci/do_ci.sh bazel.benchmark
+          ./ci/do_ci.sh bazel.benchmark
           mkdir -p benchmarks
           mv api-benchmark_result.json benchmarks
           mv sdk-benchmark_result.json benchmarks

--- a/ci/do_ci.sh
+++ b/ci/do_ci.sh
@@ -25,7 +25,7 @@ function run_benchmarks
 
   [ -z "${BENCHMARK_DIR}" ] && export BENCHMARK_DIR=$HOME/benchmark
   mkdir -p $BENCHMARK_DIR
-  bazel $BAZEL_STARTUP_OPTIONS build --cxxopt=-std=c++14 $BAZEL_OPTIONS_ASYNC -c opt -- \
+  bazel $BAZEL_STARTUP_OPTIONS build --host_cxxopt=-std=c++14 --cxxopt=-std=c++14 $BAZEL_OPTIONS_ASYNC -c opt -- \
     $(bazel query 'attr("tags", "benchmark_result", ...)')
   echo ""
   echo "Benchmark results in $BENCHMARK_DIR:"


### PR DESCRIPTION
Fixes #2083 

## Changes

There are two benchmarks workflows defined in CI:

* per PR push benchmark (`ci.yml`)
* benchmark on the main branch (`benchmark.yml`)

The former uses local tests, while the later uses an opentelemetry collector in docker.

Currently, `ci.yml` builds properly, while `benchmark.yml` fails to build.

Fixed the build for `benchmark.yml`:

* aligned the workflow definition on `ci.yml`
* in `do_ci.sh`, aligned compiler flags for `bazel.benchmark` on flags used in `benchmark`

For significant contributions please make sure you have completed the following items:

* [ ] `CHANGELOG.md` updated for non-trivial changes
* [ ] Unit tests have been added
* [ ] Changes in public API reviewed