### PR TITLE
[SDK] Increase metric name maximum length from 63 to 255 characters

### DIFF
--- a/sdk/include/opentelemetry/sdk/metrics/meter.h
+++ b/sdk/include/opentelemetry/sdk/metrics/meter.h
@@ -130,7 +130,6 @@ private:
   std::unique_ptr<AsyncWritableMetricStorage> RegisterAsyncMetricStorage(
       InstrumentDescriptor &instrument_descriptor);
   opentelemetry::common::SpinLockMutex storage_lock_;
-  const InstrumentMetaDataValidator instrument_metadata_validator;
 
   static nostd::shared_ptr<opentelemetry::metrics::ObservableInstrument>
   GetNoopObservableInsrument()

--- a/sdk/src/metrics/instrument_metadata_validator.cc
+++ b/sdk/src/metrics/instrument_metadata_validator.cc
@@ -17,8 +17,8 @@ namespace sdk
 {
 namespace metrics
 {
-// instrument-name = ALPHA 0*62 ("_" / "." / "-" / ALPHA / DIGIT)
-const std::string kInstrumentNamePattern = "[a-zA-Z][-_.a-zA-Z0-9]{0,62}";
+// instrument-name = ALPHA 0*254 ("_" / "." / "-" / ALPHA / DIGIT)
+const std::string kInstrumentNamePattern = "[a-zA-Z][-_.a-zA-Z0-9]{0,254}";
 //
 const std::string kInstrumentUnitPattern = "[\x01-\x7F]{0,63}";
 // instrument-unit = It can have a maximum length of 63 ASCII chars
@@ -38,8 +38,8 @@ bool InstrumentMetaDataValidator::ValidateName(nostd::string_view name) const
 #if OPENTELEMETRY_HAVE_WORKING_REGEX
   return std::regex_match(name.data(), name_reg_key_);
 #else
-  const size_t kMaxSize = 63;
-  // size atmost 63 chars
+  const size_t kMaxSize = 255;
+  // size atmost 255 chars
   if (name.size() > kMaxSize)
   {
     return false;

--- a/sdk/test/metrics/instrument_metadata_validator_test.cc
+++ b/sdk/test/metrics/instrument_metadata_validator_test.cc
@@ -19,13 +19,13 @@ TEST(InstrumentMetadataValidator, TestName)
 {
   opentelemetry::sdk::metrics::InstrumentMetaDataValidator validator;
   std::vector<std::string> invalid_names = {
-      "",                                      // empty string
-      "1sdf",                                  // string starting with number
-      "123€AAA€BBB",                           // unicode characters
-      "/\\sdsd",                               // string starting with special character
-      "***sSSs",                               // string starting with special character
-      CreateVeryLargeString(5) + "ABCERTYGJ",  // total 64 charactes
-      CreateVeryLargeString(7),                // string much bigger than 63 chars
+      "",                               // empty string
+      "1sdf",                           // string starting with number
+      "123€AAA€BBB",                    // unicode characters
+      "/\\sdsd",                        // string starting with special character
+      "***sSSs",                        // string starting with special character
+      CreateVeryLargeString(25) + "X",  // total 256 characters
+      CreateVeryLargeString(26),        // string much bigger than 255 characters
   };
   for (auto const &str : invalid_names)
   {
@@ -33,11 +33,14 @@ TEST(InstrumentMetadataValidator, TestName)
   }
 
   std::vector<std::string> valid_names = {
-      "T",                                    // single char string
-      "s123",                                 // starting with char, followed by numbers
-      "dsdsdsd_-.",                           // string , and valid nonalphanumeric
-      "d1234_-sDSDs.sdsd344",                 // combination of all valid characters
-      CreateVeryLargeString(5) + "ABCERTYG",  // total 63 charactes
+      "T",                                      // single char string
+      "s123",                                   // starting with char, followed by numbers
+      "dsdsdsd_-.",                             // string , and valid nonalphanumeric
+      "d1234_-sDSDs.sdsd344",                   // combination of all valid characters
+      CreateVeryLargeString(5) + "ABCERTYG",    // total 63 characters
+      CreateVeryLargeString(5) + "ABCERTYGJ",   // total 64 characters
+      CreateVeryLargeString(24) + "ABCDEFGHI",  // total 254 characters
+      CreateVeryLargeString(25),                // total 255 characters
   };
   for (auto const &str : valid_names)
   {


### PR DESCRIPTION
Fixes #2281

## Changes

* Increased metric name max length to 255 (in regexp and non regexp code)
* Removed unused attribute `Meter::instrument_metadata_validator`

For significant contributions please make sure you have completed the following items:

* [ ] `CHANGELOG.md` updated for non-trivial changes
* [X] Unit tests have been added
* [ ] Changes in public API reviewed