### PR TITLE
Add _total suffix to prometheus counters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,9 @@ Increment the:
 
 ## [Unreleased]
 
+* [EXPORTER] Add _total suffixes to Prometheus counters
+  [#2288](https://github.com/open-telemetry/opentelemetry-cpp/pull/2288)
+
 ## [1.11.0] 2023-08-21
 
 * [BUILD] Fix more cases for symbol name for 32-bit win32 DLL build

--- a/exporters/prometheus/include/opentelemetry/exporters/prometheus/exporter_utils.h
+++ b/exporters/prometheus/include/opentelemetry/exporters/prometheus/exporter_utils.h
@@ -44,6 +44,8 @@ private:
   static opentelemetry::sdk::metrics::AggregationType getAggregationType(
       const opentelemetry::sdk::metrics::PointType &point_type);
 
+  static inline bool endsWith(std::string const &value, std::string const &ending);
+
   /**
    * Translate the OTel metric type to Prometheus metric type
    */

--- a/exporters/prometheus/test/exporter_utils_test.cc
+++ b/exporters/prometheus/test/exporter_utils_test.cc
@@ -38,9 +38,9 @@ void assert_basic(prometheus_client::MetricFamily &metric,
                   int label_num,
                   std::vector<T> vals)
 {
-  ASSERT_EQ(metric.name, sanitized_name + "_unit");  // name sanitized
-  ASSERT_EQ(metric.help, description);               // description not changed
-  ASSERT_EQ(metric.type, type);                      // type translated
+  ASSERT_EQ(metric.name, sanitized_name);  // name sanitized
+  ASSERT_EQ(metric.help, description);     // description not changed
+  ASSERT_EQ(metric.type, type);            // type translated
 
   auto metric_data = metric.metric[0];
   ASSERT_EQ(metric_data.label.size(), label_num);
@@ -114,8 +114,8 @@ TEST(PrometheusExporterUtils, TranslateToPrometheusIntegerCounter)
 
   auto metric1          = translated[0];
   std::vector<int> vals = {10};
-  assert_basic(metric1, "library_name", "description", prometheus_client::MetricType::Counter, 1,
-               vals);
+  assert_basic(metric1, "library_name_unit_total", "description",
+               prometheus_client::MetricType::Counter, 1, vals);
 }
 
 TEST(PrometheusExporterUtils, TranslateToPrometheusIntegerLastValue)
@@ -127,7 +127,7 @@ TEST(PrometheusExporterUtils, TranslateToPrometheusIntegerLastValue)
 
   auto metric1          = translated[0];
   std::vector<int> vals = {10};
-  assert_basic(metric1, "library_name", "description", prometheus_client::MetricType::Gauge, 1,
+  assert_basic(metric1, "library_name_unit", "description", prometheus_client::MetricType::Gauge, 1,
                vals);
 }
 
@@ -140,8 +140,8 @@ TEST(PrometheusExporterUtils, TranslateToPrometheusHistogramNormal)
 
   auto metric              = translated[0];
   std::vector<double> vals = {3, 900.5, 4};
-  assert_basic(metric, "library_name", "description", prometheus_client::MetricType::Histogram, 1,
-               vals);
+  assert_basic(metric, "library_name_unit", "description", prometheus_client::MetricType::Histogram,
+               1, vals);
   assert_histogram(metric, std::list<double>{10.1, 20.2, 30.2}, {200, 300, 400, 500});
 }
 


### PR DESCRIPTION
Fixes #2287

## Changes

Append _total suffix to Prometheus counters.  This is done by:

* Determine type of a metric based on the first data point.  This assumes all data points within a metric translated have the same type.
* Trim _total suffixes from counter metric names before appending the unit (_total must come after the unit suffix).
* Add _total suffix to counters after the unit suffix.