### PR TITLE
[SDK] Allow metric instrument names to contain / characters

### DIFF
--- a/sdk/src/metrics/instrument_metadata_validator.cc
+++ b/sdk/src/metrics/instrument_metadata_validator.cc
@@ -52,7 +52,7 @@ bool InstrumentMetaDataValidator::ValidateName(nostd::string_view name) const
   // subsequent chars should be either of alphabets, digits, underscore,
   // minus, dot, slash
   return !std::any_of(std::next(name.begin()), name.end(), [](char c) {
-    return !isalnum(c) && (c != '-') && (c != '_') && (c != '.') && (c != "/");
+    return !isalnum(c) && (c != '-') && (c != '_') && (c != '.') && (c != '/');
   });
 #endif
 }

--- a/sdk/src/metrics/instrument_metadata_validator.cc
+++ b/sdk/src/metrics/instrument_metadata_validator.cc
@@ -17,8 +17,8 @@ namespace sdk
 {
 namespace metrics
 {
-// instrument-name = ALPHA 0*254 ("_" / "." / "-" / ALPHA / DIGIT)
-const std::string kInstrumentNamePattern = "[a-zA-Z][-_.a-zA-Z0-9]{0,254}";
+// instrument-name = ALPHA 0*254 ("_" / "." / "-" / "/" / ALPHA / DIGIT)
+const std::string kInstrumentNamePattern = "[a-zA-Z][-_./a-zA-Z0-9]{0,254}";
 //
 const std::string kInstrumentUnitPattern = "[\x01-\x7F]{0,63}";
 // instrument-unit = It can have a maximum length of 63 ASCII chars
@@ -49,9 +49,11 @@ bool InstrumentMetaDataValidator::ValidateName(nostd::string_view name) const
   {
     return false;
   }
-  // subsequent chars should be either of alphabets, digits, underscore, minus, dot
-  return !std::any_of(std::next(name.begin()), name.end(),
-                      [](char c) { return !isalnum(c) && c != '-' && c != '_' && c != '.'; });
+  // subsequent chars should be either of alphabets, digits, underscore,
+  // minus, dot, slash
+  return !std::any_of(std::next(name.begin()), name.end(), [](char c) {
+    return !isalnum(c) && (c != '-') && (c != '_') && (c != '.') && (c != "/");
+  });
 #endif
 }
 

--- a/sdk/test/metrics/instrument_metadata_validator_test.cc
+++ b/sdk/test/metrics/instrument_metadata_validator_test.cc
@@ -24,6 +24,7 @@ TEST(InstrumentMetadataValidator, TestName)
       "123€AAA€BBB",                    // unicode characters
       "/\\sdsd",                        // string starting with special character
       "***sSSs",                        // string starting with special character
+      "a\\broken\\path",                // contains backward slash
       CreateVeryLargeString(25) + "X",  // total 256 characters
       CreateVeryLargeString(26),        // string much bigger than 255 characters
   };
@@ -37,6 +38,7 @@ TEST(InstrumentMetadataValidator, TestName)
       "s123",                                   // starting with char, followed by numbers
       "dsdsdsd_-.",                             // string , and valid nonalphanumeric
       "d1234_-sDSDs.sdsd344",                   // combination of all valid characters
+      "a/path/to/some/metric",                  // contains forward slash
       CreateVeryLargeString(5) + "ABCERTYG",    // total 63 characters
       CreateVeryLargeString(5) + "ABCERTYGJ",   // total 64 characters
       CreateVeryLargeString(24) + "ABCDEFGHI",  // total 254 characters


### PR DESCRIPTION
Fixes #2303

## Changes

Allow `/` in metric instrument names.

For significant contributions please make sure you have completed the following items:

* [ ] `CHANGELOG.md` updated for non-trivial changes
* [X] Unit tests have been added
* [ ] Changes in public API reviewed