### PR TITLE
Fix lifetime issues in test utils

### DIFF
--- a/exporters/prometheus/test/collector_test.cc
+++ b/exporters/prometheus/test/collector_test.cc
@@ -19,6 +19,8 @@ namespace metric_exporter = opentelemetry::exporter::metrics;
 
 class MockMetricProducer : public opentelemetry::sdk::metrics::MetricProducer
 {
+  TestDataPoints test_data_points_;
+
 public:
   MockMetricProducer(std::chrono::microseconds sleep_ms = std::chrono::microseconds::zero())
       : sleep_ms_{sleep_ms}, data_sent_size_(0)
@@ -28,7 +30,7 @@ public:
   {
     std::this_thread::sleep_for(sleep_ms_);
     data_sent_size_++;
-    ResourceMetrics data = CreateSumPointData();
+    ResourceMetrics data = test_data_points_.CreateSumPointData();
     callback(data);
     return true;
   }

--- a/exporters/prometheus/test/exporter_utils_test.cc
+++ b/exporters/prometheus/test/exporter_utils_test.cc
@@ -106,8 +106,8 @@ TEST(PrometheusExporterUtils, TranslateToPrometheusEmptyInputReturnsEmptyCollect
 
 TEST(PrometheusExporterUtils, TranslateToPrometheusIntegerCounter)
 {
-
-  metric_sdk::ResourceMetrics metrics_data = CreateSumPointData();
+  TestDataPoints dp;
+  metric_sdk::ResourceMetrics metrics_data = dp.CreateSumPointData();
 
   auto translated = PrometheusExporterUtils::TranslateToPrometheus(metrics_data);
   ASSERT_EQ(translated.size(), 1);
@@ -120,7 +120,8 @@ TEST(PrometheusExporterUtils, TranslateToPrometheusIntegerCounter)
 
 TEST(PrometheusExporterUtils, TranslateToPrometheusIntegerLastValue)
 {
-  metric_sdk::ResourceMetrics metrics_data = CreateLastValuePointData();
+  TestDataPoints dp;
+  metric_sdk::ResourceMetrics metrics_data = dp.CreateLastValuePointData();
 
   auto translated = PrometheusExporterUtils::TranslateToPrometheus(metrics_data);
   ASSERT_EQ(translated.size(), 1);
@@ -133,7 +134,8 @@ TEST(PrometheusExporterUtils, TranslateToPrometheusIntegerLastValue)
 
 TEST(PrometheusExporterUtils, TranslateToPrometheusHistogramNormal)
 {
-  metric_sdk::ResourceMetrics metrics_data = CreateHistogramPointData();
+  TestDataPoints dp;
+  metric_sdk::ResourceMetrics metrics_data = dp.CreateHistogramPointData();
 
   auto translated = PrometheusExporterUtils::TranslateToPrometheus(metrics_data);
   ASSERT_EQ(translated.size(), 1);

--- a/exporters/prometheus/test/prometheus_test_helper.h
+++ b/exporters/prometheus/test/prometheus_test_helper.h
@@ -11,124 +11,116 @@ namespace exportermetrics = opentelemetry::exporter::metrics;
 
 namespace
 {
-/**
- * Helper function to create ResourceMetrics
- */
-inline metric_sdk::ResourceMetrics CreateSumPointData()
-{
-  metric_sdk::SumPointData sum_point_data{};
-  sum_point_data.value_ = 10.0;
-  metric_sdk::SumPointData sum_point_data2{};
-  sum_point_data2.value_ = 20.0;
-  metric_sdk::ResourceMetrics data;
-  auto resource = opentelemetry::sdk::resource::Resource::Create(
-      opentelemetry::sdk::resource::ResourceAttributes{});
-  data.resource_ = &resource;
-  auto instrumentation_scope =
-      opentelemetry::sdk::instrumentationscope::InstrumentationScope::Create("library_name",
-                                                                             "1.2.0");
-  metric_sdk::MetricData metric_data{
-      metric_sdk::InstrumentDescriptor{"library_name", "description", "unit",
-                                       metric_sdk::InstrumentType::kCounter,
-                                       metric_sdk::InstrumentValueType::kDouble},
-      metric_sdk::AggregationTemporality::kDelta, opentelemetry::common::SystemTimestamp{},
-      opentelemetry::common::SystemTimestamp{},
-      std::vector<metric_sdk::PointDataAttributes>{
-          {metric_sdk::PointAttributes{{"a1", "b1"}}, sum_point_data},
-          {metric_sdk::PointAttributes{{"a2", "b2"}}, sum_point_data2}}};
-  data.scope_metric_data_ = std::vector<metric_sdk::ScopeMetrics>{
-      {instrumentation_scope.get(), std::vector<metric_sdk::MetricData>{metric_data}}};
-  return data;
-}
 
-inline metric_sdk::ResourceMetrics CreateHistogramPointData()
-{
-  metric_sdk::HistogramPointData histogram_point_data{};
-  histogram_point_data.boundaries_ = {10.1, 20.2, 30.2};
-  histogram_point_data.count_      = 3;
-  histogram_point_data.counts_     = {200, 300, 400, 500};
-  histogram_point_data.sum_        = 900.5;
-  metric_sdk::HistogramPointData histogram_point_data2{};
-  histogram_point_data2.boundaries_ = {10.0, 20.0, 30.0};
-  histogram_point_data2.count_      = 3;
-  histogram_point_data2.counts_     = {200, 300, 400, 500};
-  histogram_point_data2.sum_        = (int64_t)900;
-  metric_sdk::ResourceMetrics data;
-  auto resource = opentelemetry::sdk::resource::Resource::Create(
-      opentelemetry::sdk::resource::ResourceAttributes{});
-  data.resource_ = &resource;
-  auto instrumentation_scope =
-      opentelemetry::sdk::instrumentationscope::InstrumentationScope::Create("library_name",
-                                                                             "1.2.0");
-  metric_sdk::MetricData metric_data{
-      metric_sdk::InstrumentDescriptor{"library_name", "description", "unit",
-                                       metric_sdk::InstrumentType::kHistogram,
-                                       metric_sdk::InstrumentValueType::kDouble},
-      metric_sdk::AggregationTemporality::kDelta, opentelemetry::common::SystemTimestamp{},
-      opentelemetry::common::SystemTimestamp{},
-      std::vector<metric_sdk::PointDataAttributes>{
-          {metric_sdk::PointAttributes{{"a1", "b1"}}, histogram_point_data},
-          {metric_sdk::PointAttributes{{"a2", "b2"}}, histogram_point_data2}}};
-  data.scope_metric_data_ = std::vector<metric_sdk::ScopeMetrics>{
-      {instrumentation_scope.get(), std::vector<metric_sdk::MetricData>{metric_data}}};
-  return data;
-}
+using opentelemetry::sdk::instrumentationscope::InstrumentationScope;
+using opentelemetry::sdk::resource::Resource;
+using opentelemetry::sdk::resource::ResourceAttributes;
 
-inline metric_sdk::ResourceMetrics CreateLastValuePointData()
+struct TestDataPoints
 {
-  metric_sdk::ResourceMetrics data;
-  auto resource = opentelemetry::sdk::resource::Resource::Create(
-      opentelemetry::sdk::resource::ResourceAttributes{});
-  data.resource_ = &resource;
-  auto instrumentation_scope =
-      opentelemetry::sdk::instrumentationscope::InstrumentationScope::Create("library_name",
-                                                                             "1.2.0");
-  metric_sdk::LastValuePointData last_value_point_data{};
-  last_value_point_data.value_              = 10.0;
-  last_value_point_data.is_lastvalue_valid_ = true;
-  last_value_point_data.sample_ts_          = opentelemetry::common::SystemTimestamp{};
-  metric_sdk::LastValuePointData last_value_point_data2{};
-  last_value_point_data2.value_              = (int64_t)20;
-  last_value_point_data2.is_lastvalue_valid_ = true;
-  last_value_point_data2.sample_ts_          = opentelemetry::common::SystemTimestamp{};
-  metric_sdk::MetricData metric_data{
-      metric_sdk::InstrumentDescriptor{"library_name", "description", "unit",
-                                       metric_sdk::InstrumentType::kCounter,
-                                       metric_sdk::InstrumentValueType::kDouble},
-      metric_sdk::AggregationTemporality::kDelta, opentelemetry::common::SystemTimestamp{},
-      opentelemetry::common::SystemTimestamp{},
-      std::vector<metric_sdk::PointDataAttributes>{
-          {metric_sdk::PointAttributes{{"a1", "b1"}}, last_value_point_data},
-          {metric_sdk::PointAttributes{{"a2", "b2"}}, last_value_point_data2}}};
-  data.scope_metric_data_ = std::vector<metric_sdk::ScopeMetrics>{
-      {instrumentation_scope.get(), std::vector<metric_sdk::MetricData>{metric_data}}};
-  return data;
-}
+  Resource resource = Resource::Create(ResourceAttributes{});
+  nostd::unique_ptr<InstrumentationScope> instrumentation_scope =
+      InstrumentationScope::Create("library_name", "1.2.0");
 
-inline metric_sdk::ResourceMetrics CreateDropPointData()
-{
-  metric_sdk::ResourceMetrics data;
-  auto resource = opentelemetry::sdk::resource::Resource::Create(
-      opentelemetry::sdk::resource::ResourceAttributes{});
-  data.resource_ = &resource;
-  auto instrumentation_scope =
-      opentelemetry::sdk::instrumentationscope::InstrumentationScope::Create("library_name",
-                                                                             "1.2.0");
-  metric_sdk::DropPointData drop_point_data{};
-  metric_sdk::DropPointData drop_point_data2{};
-  metric_sdk::MetricData metric_data{
-      metric_sdk::InstrumentDescriptor{"library_name", "description", "unit",
-                                       metric_sdk::InstrumentType::kCounter,
-                                       metric_sdk::InstrumentValueType::kDouble},
-      metric_sdk::AggregationTemporality::kDelta, opentelemetry::common::SystemTimestamp{},
-      opentelemetry::common::SystemTimestamp{},
-      std::vector<metric_sdk::PointDataAttributes>{
-          {metric_sdk::PointAttributes{{"a1", "b1"}}, drop_point_data},
-          {metric_sdk::PointAttributes{{"a2", "b2"}}, drop_point_data2}}};
-  data.scope_metric_data_ = std::vector<metric_sdk::ScopeMetrics>{
-      {instrumentation_scope.get(), std::vector<metric_sdk::MetricData>{metric_data}}};
-  return data;
-}
+  /**
+   * Helper function to create ResourceMetrics
+   */
+  inline metric_sdk::ResourceMetrics CreateSumPointData()
+  {
+    metric_sdk::SumPointData sum_point_data{};
+    sum_point_data.value_ = 10.0;
+    metric_sdk::SumPointData sum_point_data2{};
+    sum_point_data2.value_ = 20.0;
+    metric_sdk::ResourceMetrics data;
+    data.resource_ = &resource;
+    metric_sdk::MetricData metric_data{
+        metric_sdk::InstrumentDescriptor{"library_name", "description", "unit",
+                                         metric_sdk::InstrumentType::kCounter,
+                                         metric_sdk::InstrumentValueType::kDouble},
+        metric_sdk::AggregationTemporality::kDelta, opentelemetry::common::SystemTimestamp{},
+        opentelemetry::common::SystemTimestamp{},
+        std::vector<metric_sdk::PointDataAttributes>{
+            {metric_sdk::PointAttributes{{"a1", "b1"}}, sum_point_data},
+            {metric_sdk::PointAttributes{{"a2", "b2"}}, sum_point_data2}}};
+    data.scope_metric_data_ = std::vector<metric_sdk::ScopeMetrics>{
+        {instrumentation_scope.get(), std::vector<metric_sdk::MetricData>{metric_data}}};
+    return data;
+  }
+
+  inline metric_sdk::ResourceMetrics CreateHistogramPointData()
+  {
+    metric_sdk::HistogramPointData histogram_point_data{};
+    histogram_point_data.boundaries_ = {10.1, 20.2, 30.2};
+    histogram_point_data.count_      = 3;
+    histogram_point_data.counts_     = {200, 300, 400, 500};
+    histogram_point_data.sum_        = 900.5;
+    metric_sdk::HistogramPointData histogram_point_data2{};
+    histogram_point_data2.boundaries_ = {10.0, 20.0, 30.0};
+    histogram_point_data2.count_      = 3;
+    histogram_point_data2.counts_     = {200, 300, 400, 500};
+    histogram_point_data2.sum_        = (int64_t)900;
+    metric_sdk::ResourceMetrics data;
+    data.resource_ = &resource;
+    metric_sdk::MetricData metric_data{
+        metric_sdk::InstrumentDescriptor{"library_name", "description", "unit",
+                                         metric_sdk::InstrumentType::kHistogram,
+                                         metric_sdk::InstrumentValueType::kDouble},
+        metric_sdk::AggregationTemporality::kDelta, opentelemetry::common::SystemTimestamp{},
+        opentelemetry::common::SystemTimestamp{},
+        std::vector<metric_sdk::PointDataAttributes>{
+            {metric_sdk::PointAttributes{{"a1", "b1"}}, histogram_point_data},
+            {metric_sdk::PointAttributes{{"a2", "b2"}}, histogram_point_data2}}};
+    data.scope_metric_data_ = std::vector<metric_sdk::ScopeMetrics>{
+        {instrumentation_scope.get(), std::vector<metric_sdk::MetricData>{metric_data}}};
+    return data;
+  }
+
+  inline metric_sdk::ResourceMetrics CreateLastValuePointData()
+  {
+    metric_sdk::ResourceMetrics data;
+    data.resource_ = &resource;
+    metric_sdk::LastValuePointData last_value_point_data{};
+    last_value_point_data.value_              = 10.0;
+    last_value_point_data.is_lastvalue_valid_ = true;
+    last_value_point_data.sample_ts_          = opentelemetry::common::SystemTimestamp{};
+    metric_sdk::LastValuePointData last_value_point_data2{};
+    last_value_point_data2.value_              = (int64_t)20;
+    last_value_point_data2.is_lastvalue_valid_ = true;
+    last_value_point_data2.sample_ts_          = opentelemetry::common::SystemTimestamp{};
+    metric_sdk::MetricData metric_data{
+        metric_sdk::InstrumentDescriptor{"library_name", "description", "unit",
+                                         metric_sdk::InstrumentType::kCounter,
+                                         metric_sdk::InstrumentValueType::kDouble},
+        metric_sdk::AggregationTemporality::kDelta, opentelemetry::common::SystemTimestamp{},
+        opentelemetry::common::SystemTimestamp{},
+        std::vector<metric_sdk::PointDataAttributes>{
+            {metric_sdk::PointAttributes{{"a1", "b1"}}, last_value_point_data},
+            {metric_sdk::PointAttributes{{"a2", "b2"}}, last_value_point_data2}}};
+    data.scope_metric_data_ = std::vector<metric_sdk::ScopeMetrics>{
+        {instrumentation_scope.get(), std::vector<metric_sdk::MetricData>{metric_data}}};
+    return data;
+  }
+
+  inline metric_sdk::ResourceMetrics CreateDropPointData()
+  {
+    metric_sdk::ResourceMetrics data;
+    data.resource_ = &resource;
+    metric_sdk::DropPointData drop_point_data{};
+    metric_sdk::DropPointData drop_point_data2{};
+    metric_sdk::MetricData metric_data{
+        metric_sdk::InstrumentDescriptor{"library_name", "description", "unit",
+                                         metric_sdk::InstrumentType::kCounter,
+                                         metric_sdk::InstrumentValueType::kDouble},
+        metric_sdk::AggregationTemporality::kDelta, opentelemetry::common::SystemTimestamp{},
+        opentelemetry::common::SystemTimestamp{},
+        std::vector<metric_sdk::PointDataAttributes>{
+            {metric_sdk::PointAttributes{{"a1", "b1"}}, drop_point_data},
+            {metric_sdk::PointAttributes{{"a2", "b2"}}, drop_point_data2}}};
+    data.scope_metric_data_ = std::vector<metric_sdk::ScopeMetrics>{
+        {instrumentation_scope.get(), std::vector<metric_sdk::MetricData>{metric_data}}};
+    return data;
+  }
+};
 }  // namespace
 
 OPENTELEMETRY_BEGIN_NAMESPACE


### PR DESCRIPTION
The MetricsData instance returned from these helpers outlived the  
Resource and InstrumentationScope instances that it pointed to.