### PR TITLE
[exporters/prometheus] Omit underscore suffix for unitless metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ Increment the:
 
 * [DEPRECATION] Deprecate ZPAGES
   [#2291](https://github.com/open-telemetry/opentelemetry-cpp/pull/2291)
+* [EXPORTER] Omit underscore suffix for unitless metrics
+  [#2323](https://github.com/open-telemetry/opentelemetry-cpp/pull/2323)
 
 ## [1.11.0] 2023-08-21
 

--- a/exporters/prometheus/src/exporter_utils.cc
+++ b/exporters/prometheus/src/exporter_utils.cc
@@ -42,7 +42,11 @@ std::vector<prometheus_client::MetricFamily> PrometheusExporterUtils::TranslateT
       auto unit        = metric_data.instrument_descriptor.unit_;
       auto sanitized   = SanitizeNames(origin_name);
       prometheus_client::MetricFamily metric_family;
-      metric_family.name = sanitized + "_" + unit;
+      metric_family.name = sanitized;
+      if (!unit.empty())
+      {
+        metric_family.name += "_" + unit;
+      };
       metric_family.help = metric_data.instrument_descriptor.description_;
       auto time          = metric_data.end_ts.time_since_epoch();
       for (const auto &point_data_attr : metric_data.point_data_attr_)

--- a/exporters/prometheus/test/exporter_utils_test.cc
+++ b/exporters/prometheus/test/exporter_utils_test.cc
@@ -157,4 +157,13 @@ TEST(PrometheusExporterUtils, SanitizeName)
   ASSERT_EQ(exporter::metrics::SanitizeNameTester::sanitize("name?__name:"), "name_name:");
 }
 
+TEST(PrometheusExporterUtils, HandleMissingUnit)
+{
+  TestDataPoints dp;
+  metric_sdk::ResourceMetrics data = dp.CreateSumPointData("");
+  std::vector<prometheus::MetricFamily> family =
+      PrometheusExporterUtils::TranslateToPrometheus(data);
+  ASSERT_EQ(family.begin()->name, "library_name");
+}
+
 OPENTELEMETRY_END_NAMESPACE

--- a/exporters/prometheus/test/prometheus_test_helper.h
+++ b/exporters/prometheus/test/prometheus_test_helper.h
@@ -25,7 +25,7 @@ struct TestDataPoints
   /**
    * Helper function to create ResourceMetrics
    */
-  inline metric_sdk::ResourceMetrics CreateSumPointData()
+  inline metric_sdk::ResourceMetrics CreateSumPointData(std::string unit = "unit")
   {
     metric_sdk::SumPointData sum_point_data{};
     sum_point_data.value_ = 10.0;
@@ -34,7 +34,7 @@ struct TestDataPoints
     metric_sdk::ResourceMetrics data;
     data.resource_ = &resource;
     metric_sdk::MetricData metric_data{
-        metric_sdk::InstrumentDescriptor{"library_name", "description", "unit",
+        metric_sdk::InstrumentDescriptor{"library_name", "description", unit,
                                          metric_sdk::InstrumentType::kCounter,
                                          metric_sdk::InstrumentValueType::kDouble},
         metric_sdk::AggregationTemporality::kDelta, opentelemetry::common::SystemTimestamp{},


### PR DESCRIPTION
Fixes #2317

## Changes

Please provide a brief description of the changes here.

For significant contributions please make sure you have completed the following items:

*   [x] `CHANGELOG.md` updated for non-trivial changes
*   [x] Unit tests have been added
*   [x] Changes in public API reviewed