### PR TITLE
[exporters/prometheus] Several refactors

### DIFF
--- a/exporters/prometheus/include/opentelemetry/exporters/prometheus/collector.h
+++ b/exporters/prometheus/include/opentelemetry/exporters/prometheus/collector.h
@@ -12,8 +12,6 @@
 #include "opentelemetry/exporters/prometheus/exporter_utils.h"
 #include "opentelemetry/sdk/metrics/metric_reader.h"
 
-namespace prometheus_client = ::prometheus;
-
 OPENTELEMETRY_BEGIN_NAMESPACE
 namespace exporter
 {
@@ -22,7 +20,7 @@ namespace metrics
 /**
  * The Prometheus Collector maintains the intermediate collection in Prometheus Exporter
  */
-class PrometheusCollector : public prometheus_client::Collectable
+class PrometheusCollector : public ::prometheus::Collectable
 {
 public:
   /**
@@ -38,7 +36,7 @@ public:
    *
    * @return all metrics in the metricsToCollect snapshot
    */
-  std::vector<prometheus_client::MetricFamily> Collect() const override;
+  std::vector<::prometheus::MetricFamily> Collect() const override;
 
 private:
   sdk::metrics::MetricReader *reader_;

--- a/exporters/prometheus/include/opentelemetry/exporters/prometheus/exporter_utils.h
+++ b/exporters/prometheus/include/opentelemetry/exporters/prometheus/exporter_utils.h
@@ -31,7 +31,6 @@ public:
   static std::vector<::prometheus::MetricFamily> TranslateToPrometheus(
       const sdk::metrics::ResourceMetrics &data);
 
-private:
   /**
    * Sanitize the given metric name or label according to Prometheus rule.
    *
@@ -49,27 +48,6 @@ private:
    */
   static ::prometheus::MetricType TranslateType(opentelemetry::sdk::metrics::AggregationType kind,
                                                 bool is_monotonic = true);
-
-  /**
-   * Set metric data for:
-   * Counter => Prometheus Counter
-   */
-  template <typename T>
-  static void SetData(std::vector<T> values,
-                      const opentelemetry::sdk::metrics::PointAttributes &labels,
-                      ::prometheus::MetricType type,
-                      ::prometheus::MetricFamily *metric_family);
-
-  /**
-   * Set metric data for:
-   * Histogram => Prometheus Histogram
-   */
-  template <typename T>
-  static void SetData(std::vector<T> values,
-                      const std::vector<double> &boundaries,
-                      const std::vector<uint64_t> &counts,
-                      const opentelemetry::sdk::metrics::PointAttributes &labels,
-                      ::prometheus::MetricFamily *metric_family);
 
   /**
    * Set time and labels to metric data

--- a/exporters/prometheus/include/opentelemetry/exporters/prometheus/exporter_utils.h
+++ b/exporters/prometheus/include/opentelemetry/exporters/prometheus/exporter_utils.h
@@ -31,6 +31,7 @@ public:
   static std::vector<::prometheus::MetricFamily> TranslateToPrometheus(
       const sdk::metrics::ResourceMetrics &data);
 
+private:
   /**
    * Sanitize the given metric name or label according to Prometheus rule.
    *
@@ -39,49 +40,6 @@ public:
    * name should only contain alphanumeric characters and '_'.
    */
   static std::string SanitizeNames(std::string name);
-
-  static opentelemetry::sdk::metrics::AggregationType getAggregationType(
-      const opentelemetry::sdk::metrics::PointType &point_type);
-
-  /**
-   * Translate the OTel metric type to Prometheus metric type
-   */
-  static ::prometheus::MetricType TranslateType(opentelemetry::sdk::metrics::AggregationType kind,
-                                                bool is_monotonic = true);
-
-  /**
-   * Set time and labels to metric data
-   */
-  static void SetMetricBasic(::prometheus::ClientMetric &metric,
-                             const opentelemetry::sdk::metrics::PointAttributes &labels);
-
-  /**
-   * Convert attribute value to string
-   */
-  static std::string AttributeValueToString(
-      const opentelemetry::sdk::common::OwnedAttributeValue &value);
-
-  /**
-   * Handle Counter and Gauge.
-   */
-  template <typename T>
-  static void SetValue(std::vector<T> values,
-                       ::prometheus::MetricType type,
-                       ::prometheus::ClientMetric *metric);
-
-  /**
-   * Handle Gauge from MinMaxSumCount
-   */
-  static void SetValue(double value, ::prometheus::ClientMetric *metric);
-
-  /**
-   * Handle Histogram
-   */
-  template <typename T>
-  static void SetValue(std::vector<T> values,
-                       const std::vector<double> &boundaries,
-                       const std::vector<uint64_t> &counts,
-                       ::prometheus::ClientMetric *metric);
 
   // For testing
   friend class SanitizeNameTester;

--- a/exporters/prometheus/include/opentelemetry/exporters/prometheus/exporter_utils.h
+++ b/exporters/prometheus/include/opentelemetry/exporters/prometheus/exporter_utils.h
@@ -25,24 +25,11 @@ public:
    * Helper function to convert OpenTelemetry metrics data collection
    * to Prometheus metrics data collection
    *
-   * @param records a collection of metrics in OpenTelemetry
+   * @param data a collection of metrics in OpenTelemetry
    * @return a collection of translated metrics that is acceptable by Prometheus
    */
   static std::vector<::prometheus::MetricFamily> TranslateToPrometheus(
       const sdk::metrics::ResourceMetrics &data);
-
-private:
-  /**
-   * Sanitize the given metric name or label according to Prometheus rule.
-   *
-   * This function is needed because names in OpenTelemetry can contain
-   * alphanumeric characters, '_', '.', and '-', whereas in Prometheus the
-   * name should only contain alphanumeric characters and '_'.
-   */
-  static std::string SanitizeNames(std::string name);
-
-  // For testing
-  friend class SanitizeNameTester;
 };
 }  // namespace metrics
 }  // namespace exporter

--- a/exporters/prometheus/include/opentelemetry/exporters/prometheus/exporter_utils.h
+++ b/exporters/prometheus/include/opentelemetry/exporters/prometheus/exporter_utils.h
@@ -16,21 +16,13 @@ namespace exporter
 namespace metrics
 {
 /**
- * The Prometheus Utils contains utility functions for Prometheus Exporter
+ * Convert OpenTelemetry metrics data collection to Prometheus metrics data collection
+ *
+ * @param data a collection of metrics in OpenTelemetry
+ * @return a collection of translated metrics that is acceptable by Prometheus
  */
-class PrometheusExporterUtils
-{
-public:
-  /**
-   * Helper function to convert OpenTelemetry metrics data collection
-   * to Prometheus metrics data collection
-   *
-   * @param data a collection of metrics in OpenTelemetry
-   * @return a collection of translated metrics that is acceptable by Prometheus
-   */
-  static std::vector<::prometheus::MetricFamily> TranslateToPrometheus(
-      const sdk::metrics::ResourceMetrics &data);
-};
+std::vector<::prometheus::MetricFamily> TranslateToPrometheus(
+    const sdk::metrics::ResourceMetrics &data);
 }  // namespace metrics
 }  // namespace exporter
 OPENTELEMETRY_END_NAMESPACE

--- a/exporters/prometheus/src/collector.cc
+++ b/exporters/prometheus/src/collector.cc
@@ -4,9 +4,11 @@
 #include "opentelemetry/exporters/prometheus/collector.h"
 #include "opentelemetry/sdk/common/global_log_handler.h"
 
-namespace metric_sdk = opentelemetry::sdk::metrics;
 
 OPENTELEMETRY_BEGIN_NAMESPACE
+
+namespace metric_sdk = sdk::metrics;
+
 namespace exporter
 {
 namespace metrics
@@ -24,7 +26,7 @@ PrometheusCollector::PrometheusCollector(sdk::metrics::MetricReader *reader) : r
  *
  * @return all metrics in the metricsToCollect snapshot
  */
-std::vector<prometheus_client::MetricFamily> PrometheusCollector::Collect() const
+std::vector<::prometheus::MetricFamily> PrometheusCollector::Collect() const
 {
   if (reader_->IsShutdown())
   {
@@ -35,7 +37,7 @@ std::vector<prometheus_client::MetricFamily> PrometheusCollector::Collect() cons
   }
   collection_lock_.lock();
 
-  std::vector<prometheus_client::MetricFamily> result;
+  std::vector<::prometheus::MetricFamily> result;
   reader_->Collect([&result](sdk::metrics::ResourceMetrics &metric_data) {
     auto prometheus_metric_data = TranslateToPrometheus(metric_data);
     for (auto &data : prometheus_metric_data)

--- a/exporters/prometheus/src/collector.cc
+++ b/exporters/prometheus/src/collector.cc
@@ -37,7 +37,7 @@ std::vector<prometheus_client::MetricFamily> PrometheusCollector::Collect() cons
 
   std::vector<prometheus_client::MetricFamily> result;
   reader_->Collect([&result](sdk::metrics::ResourceMetrics &metric_data) {
-    auto prometheus_metric_data = PrometheusExporterUtils::TranslateToPrometheus(metric_data);
+    auto prometheus_metric_data = TranslateToPrometheus(metric_data);
     for (auto &data : prometheus_metric_data)
       result.emplace_back(data);
     return true;

--- a/exporters/prometheus/src/exporter_utils.cc
+++ b/exporters/prometheus/src/exporter_utils.cc
@@ -112,7 +112,14 @@ std::string AttributeValueToString(const opentelemetry::sdk::common::OwnedAttrib
   return result;
 }
 
-std::string SanitizeNamesLocal(std::string name)
+/**
+ * Sanitize the given metric name or label according to Prometheus rule.
+ *
+ * This function is needed because names in OpenTelemetry can contain
+ * alphanumeric characters, '_', '.', and '-', whereas in Prometheus the
+ * name should only contain alphanumeric characters and '_'.
+ */
+std::string SanitizeNames(std::string name)
 {
   constexpr const auto replacement     = '_';
   constexpr const auto replacement_dup = '=';
@@ -166,7 +173,7 @@ struct ClientMetricWrapper
       size_t i = 0;
       for (auto const &label : labels)
       {
-        auto sanitized          = SanitizeNamesLocal(label.first);
+        auto sanitized          = SanitizeNames(label.first);
         metric.label[i].name    = sanitized;
         metric.label[i++].value = AttributeValueToString(label.second);
       }
@@ -354,18 +361,6 @@ std::vector<prometheus_client::MetricFamily> PrometheusExporterUtils::TranslateT
     }
   }
   return output;
-}
-
-/**
- * Sanitize the given metric name or label according to Prometheus rule.
- *
- * This function is needed because names in OpenTelemetry can contain
- * alphanumeric characters, '_', '.', and '-', whereas in Prometheus the
- * name should only contain alphanumeric characters and '_'.
- */
-std::string PrometheusExporterUtils::SanitizeNames(std::string name)
-{
-  return SanitizeNamesLocal(name);
 }
 
 }  // namespace metrics

--- a/exporters/prometheus/src/exporter_utils.cc
+++ b/exporters/prometheus/src/exporter_utils.cc
@@ -268,7 +268,7 @@ struct MetricFamilyWrapper
  * @param records a collection of metrics in OpenTelemetry
  * @return a collection of translated metrics that is acceptable by Prometheus
  */
-std::vector<prometheus_client::MetricFamily> PrometheusExporterUtils::TranslateToPrometheus(
+std::vector<prometheus_client::MetricFamily> TranslateToPrometheus(
     const sdk::metrics::ResourceMetrics &data)
 {
 
@@ -362,7 +362,6 @@ std::vector<prometheus_client::MetricFamily> PrometheusExporterUtils::TranslateT
   }
   return output;
 }
-
 }  // namespace metrics
 }  // namespace exporter
 OPENTELEMETRY_END_NAMESPACE

--- a/exporters/prometheus/test/collector_test.cc
+++ b/exporters/prometheus/test/collector_test.cc
@@ -11,11 +11,13 @@
 #include <map>
 #include <thread>
 
-using opentelemetry::exporter::metrics::PrometheusCollector;
-using opentelemetry::sdk::metrics::ResourceMetrics;
-namespace metric_api      = opentelemetry::metrics;
-namespace metric_sdk      = opentelemetry::sdk::metrics;
-namespace metric_exporter = opentelemetry::exporter::metrics;
+OPENTELEMETRY_BEGIN_NAMESPACE
+
+using exporter::metrics::PrometheusCollector;
+using sdk::metrics::ResourceMetrics;
+namespace metric_api      = metrics;
+namespace metric_sdk      = sdk::metrics;
+namespace metric_exporter = exporter::metrics;
 
 class MockMetricProducer : public opentelemetry::sdk::metrics::MetricProducer
 {
@@ -82,3 +84,5 @@ TEST(PrometheusCollector, BasicTests)
   delete reader;
   delete producer;
 }
+
+OPENTELEMETRY_END_NAMESPACE

--- a/exporters/prometheus/test/exporter_test.cc
+++ b/exporters/prometheus/test/exporter_test.cc
@@ -9,6 +9,8 @@
 #include "opentelemetry/version.h"
 #include "prometheus_test_helper.h"
 
+OPENTELEMETRY_BEGIN_NAMESPACE
+
 /**
  * PrometheusExporterTest is a friend class of PrometheusExporter.
  * It has access to a private constructor that does not take in
@@ -16,11 +18,12 @@
  * private constructor is only to be used here for testing
  */
 
-using opentelemetry::exporter::metrics::PrometheusCollector;
-using opentelemetry::exporter::metrics::PrometheusExporter;
-using opentelemetry::exporter::metrics::PrometheusExporterOptions;
-using opentelemetry::sdk::metrics::AggregationTemporality;
-using opentelemetry::sdk::metrics::InstrumentType;
+using exporter::metrics::PrometheusCollector;
+using exporter::metrics::PrometheusExporter;
+using exporter::metrics::PrometheusExporterOptions;
+using sdk::metrics::AggregationTemporality;
+using sdk::metrics::InstrumentType;
+
 /**
  * When a PrometheusExporter is initialized,
  * isShutdown should be false.
@@ -77,3 +80,5 @@ TEST(PrometheusExporter, CheckAggregationTemporality)
   ASSERT_EQ(exporter.GetAggregationTemporality(InstrumentType::kUpDownCounter),
             AggregationTemporality::kCumulative);
 }
+
+OPENTELEMETRY_END_NAMESPACE

--- a/exporters/prometheus/test/exporter_utils_test.cc
+++ b/exporters/prometheus/test/exporter_utils_test.cc
@@ -13,13 +13,12 @@ OPENTELEMETRY_BEGIN_NAMESPACE
 using exporter::metrics::TranslateToPrometheus;
 namespace metric_sdk        = sdk::metrics;
 namespace metric_api        = metrics;
-namespace prometheus_client = ::prometheus;
 
 template <typename T>
-void assert_basic(prometheus_client::MetricFamily &metric,
+void assert_basic(::prometheus::MetricFamily &metric,
                   const std::string &sanitized_name,
                   const std::string &description,
-                  prometheus_client::MetricType type,
+                  ::prometheus::MetricType type,
                   int label_num,
                   std::vector<T> vals)
 {
@@ -38,23 +37,23 @@ void assert_basic(prometheus_client::MetricFamily &metric,
 
   switch (type)
   {
-    case prometheus_client::MetricType::Counter: {
+    case ::prometheus::MetricType::Counter: {
       ASSERT_DOUBLE_EQ(metric_data.counter.value, vals[0]);
       break;
     }
-    case prometheus_client::MetricType::Histogram: {
+    case ::prometheus::MetricType::Histogram: {
       ASSERT_DOUBLE_EQ(metric_data.histogram.sample_count, vals[0]);
       ASSERT_DOUBLE_EQ(metric_data.histogram.sample_sum, vals[1]);
       auto buckets = metric_data.histogram.bucket;
       ASSERT_EQ(buckets.size(), vals[2]);
       break;
     }
-    case prometheus_client::MetricType::Gauge: {
+    case ::prometheus::MetricType::Gauge: {
       ASSERT_DOUBLE_EQ(metric_data.gauge.value, vals[0]);
       break;
     }
     break;
-    case prometheus_client::MetricType::Summary:
+    case ::prometheus::MetricType::Summary:
       // Summary and Info type not supported
       ASSERT_TRUE(false);
       break;
@@ -65,7 +64,7 @@ void assert_basic(prometheus_client::MetricFamily &metric,
   }
 }
 
-void assert_histogram(prometheus_client::MetricFamily &metric,
+void assert_histogram(::prometheus::MetricFamily &metric,
                       std::list<double> boundaries,
                       std::vector<int> correct)
 {
@@ -105,7 +104,7 @@ TEST(PrometheusExporterUtils, TranslateToPrometheusIntegerCounter)
 
   auto metric1          = translated[0];
   std::vector<int> vals = {10};
-  assert_basic(metric1, "library_name", "description", prometheus_client::MetricType::Counter, 1,
+  assert_basic(metric1, "library_name", "description", ::prometheus::MetricType::Counter, 1,
                vals);
 }
 
@@ -119,7 +118,7 @@ TEST(PrometheusExporterUtils, TranslateToPrometheusIntegerLastValue)
 
   auto metric1          = translated[0];
   std::vector<int> vals = {10};
-  assert_basic(metric1, "library_name", "description", prometheus_client::MetricType::Gauge, 1,
+  assert_basic(metric1, "library_name", "description", ::prometheus::MetricType::Gauge, 1,
                vals);
 }
 
@@ -133,7 +132,7 @@ TEST(PrometheusExporterUtils, TranslateToPrometheusHistogramNormal)
 
   auto metric              = translated[0];
   std::vector<double> vals = {3, 900.5, 4};
-  assert_basic(metric, "library_name", "description", prometheus_client::MetricType::Histogram, 1,
+  assert_basic(metric, "library_name", "description", ::prometheus::MetricType::Histogram, 1,
                vals);
   assert_histogram(metric, std::list<double>{10.1, 20.2, 30.2}, {200, 300, 400, 500});
 }

--- a/exporters/prometheus/test/exporter_utils_test.cc
+++ b/exporters/prometheus/test/exporter_utils_test.cc
@@ -8,12 +8,12 @@
 #include "opentelemetry/exporters/prometheus/exporter_utils.h"
 #include "prometheus_test_helper.h"
 
-using opentelemetry::exporter::metrics::PrometheusExporterUtils;
-namespace metric_sdk        = opentelemetry::sdk::metrics;
-namespace metric_api        = opentelemetry::metrics;
-namespace prometheus_client = ::prometheus;
-
 OPENTELEMETRY_BEGIN_NAMESPACE
+
+using exporter::metrics::TranslateToPrometheus;
+namespace metric_sdk        = sdk::metrics;
+namespace metric_api        = metrics;
+namespace prometheus_client = ::prometheus;
 
 template <typename T>
 void assert_basic(prometheus_client::MetricFamily &metric,
@@ -91,7 +91,7 @@ void assert_histogram(prometheus_client::MetricFamily &metric,
 TEST(PrometheusExporterUtils, TranslateToPrometheusEmptyInputReturnsEmptyCollection)
 {
   metric_sdk::ResourceMetrics metrics_data = {};
-  auto translated = PrometheusExporterUtils::TranslateToPrometheus(metrics_data);
+  auto translated                          = TranslateToPrometheus(metrics_data);
   ASSERT_EQ(translated.size(), 0);
 }
 
@@ -100,7 +100,7 @@ TEST(PrometheusExporterUtils, TranslateToPrometheusIntegerCounter)
   TestDataPoints dp;
   metric_sdk::ResourceMetrics metrics_data = dp.CreateSumPointData();
 
-  auto translated = PrometheusExporterUtils::TranslateToPrometheus(metrics_data);
+  auto translated = TranslateToPrometheus(metrics_data);
   ASSERT_EQ(translated.size(), 1);
 
   auto metric1          = translated[0];
@@ -114,7 +114,7 @@ TEST(PrometheusExporterUtils, TranslateToPrometheusIntegerLastValue)
   TestDataPoints dp;
   metric_sdk::ResourceMetrics metrics_data = dp.CreateLastValuePointData();
 
-  auto translated = PrometheusExporterUtils::TranslateToPrometheus(metrics_data);
+  auto translated = TranslateToPrometheus(metrics_data);
   ASSERT_EQ(translated.size(), 1);
 
   auto metric1          = translated[0];
@@ -128,7 +128,7 @@ TEST(PrometheusExporterUtils, TranslateToPrometheusHistogramNormal)
   TestDataPoints dp;
   metric_sdk::ResourceMetrics metrics_data = dp.CreateHistogramPointData();
 
-  auto translated = PrometheusExporterUtils::TranslateToPrometheus(metrics_data);
+  auto translated = TranslateToPrometheus(metrics_data);
   ASSERT_EQ(translated.size(), 1);
 
   auto metric              = translated[0];
@@ -150,7 +150,7 @@ protected:
     metric_sdk::InstrumentDescriptor instrument_descriptor{
         original, "description", "unit", metric_sdk::InstrumentType::kCounter,
         metric_sdk::InstrumentValueType::kDouble};
-    std::vector<prometheus::MetricFamily> result = PrometheusExporterUtils::TranslateToPrometheus(
+    std::vector<prometheus::MetricFamily> result = TranslateToPrometheus(
         {&resource_,
          {{instrumentation_scope_.get(), {{instrument_descriptor, {}, {}, {}, {{}}}}}}});
     EXPECT_EQ(result.begin()->name, sanitized + "_unit");

--- a/exporters/prometheus/test/exporter_utils_test.cc
+++ b/exporters/prometheus/test/exporter_utils_test.cc
@@ -15,21 +15,6 @@ namespace prometheus_client = ::prometheus;
 
 OPENTELEMETRY_BEGIN_NAMESPACE
 
-namespace exporter
-{
-namespace metrics
-{
-class SanitizeNameTester
-{
-public:
-  static std::string sanitize(std::string name)
-  {
-    return PrometheusExporterUtils::SanitizeNames(name);
-  }
-};
-}  // namespace metrics
-}  // namespace exporter
-
 template <typename T>
 void assert_basic(prometheus_client::MetricFamily &metric,
                   const std::string &sanitized_name,
@@ -153,14 +138,32 @@ TEST(PrometheusExporterUtils, TranslateToPrometheusHistogramNormal)
   assert_histogram(metric, std::list<double>{10.1, 20.2, 30.2}, {200, 300, 400, 500});
 }
 
-TEST(PrometheusExporterUtils, SanitizeName)
+class SanitizeNameTest : public ::testing::Test
 {
-  ASSERT_EQ(exporter::metrics::SanitizeNameTester::sanitize("name"), "name");
-  ASSERT_EQ(exporter::metrics::SanitizeNameTester::sanitize("name?"), "name_");
-  ASSERT_EQ(exporter::metrics::SanitizeNameTester::sanitize("name???"), "name_");
-  ASSERT_EQ(exporter::metrics::SanitizeNameTester::sanitize("name?__"), "name_");
-  ASSERT_EQ(exporter::metrics::SanitizeNameTester::sanitize("name?__name"), "name_name");
-  ASSERT_EQ(exporter::metrics::SanitizeNameTester::sanitize("name?__name:"), "name_name:");
+  Resource resource_ = Resource::Create(ResourceAttributes{});
+  nostd::unique_ptr<InstrumentationScope> instrumentation_scope_ =
+      InstrumentationScope::Create("library_name", "1.2.0");
+
+protected:
+  void CheckSanitation(const std::string &original, const std::string &sanitized)
+  {
+    metric_sdk::InstrumentDescriptor instrument_descriptor{
+        original, "description", "unit", metric_sdk::InstrumentType::kCounter,
+        metric_sdk::InstrumentValueType::kDouble};
+    std::vector<prometheus::MetricFamily> result = PrometheusExporterUtils::TranslateToPrometheus(
+        {&resource_,
+         {{instrumentation_scope_.get(), {{instrument_descriptor, {}, {}, {}, {{}}}}}}});
+    EXPECT_EQ(result.begin()->name, sanitized + "_unit");
+  }
+};
+
+TEST_F(SanitizeNameTest, SanitizeName)
+{
+  CheckSanitation("name", "name");
+  CheckSanitation("name?", "name_");
+  CheckSanitation("name???", "name_");
+  CheckSanitation("name?__name", "name_name");
+  CheckSanitation("name?__name:", "name_name:");
 }
 
 OPENTELEMETRY_END_NAMESPACE

--- a/exporters/prometheus/test/prometheus_test_helper.h
+++ b/exporters/prometheus/test/prometheus_test_helper.h
@@ -5,16 +5,18 @@
 
 #include "opentelemetry/version.h"
 
-namespace metric_sdk      = opentelemetry::sdk::metrics;
-namespace nostd           = opentelemetry::nostd;
-namespace exportermetrics = opentelemetry::exporter::metrics;
+OPENTELEMETRY_BEGIN_NAMESPACE
+
+namespace metric_sdk      = sdk::metrics;
+namespace nostd           = nostd;
+namespace exportermetrics = exporter::metrics;
 
 namespace
 {
 
-using opentelemetry::sdk::instrumentationscope::InstrumentationScope;
-using opentelemetry::sdk::resource::Resource;
-using opentelemetry::sdk::resource::ResourceAttributes;
+using sdk::instrumentationscope::InstrumentationScope;
+using sdk::resource::Resource;
+using sdk::resource::ResourceAttributes;
 
 struct TestDataPoints
 {
@@ -123,7 +125,6 @@ struct TestDataPoints
 };
 }  // namespace
 
-OPENTELEMETRY_BEGIN_NAMESPACE
 namespace sdk
 {
 namespace metrics


### PR DESCRIPTION
* Use ABI-specific namespace correctly
* Switch from static methods to PrometheusExporterUtils to namespaced or file-local functions
* Clean up some conversion logic using struct wrappers
