### PR TITLE
[exporters/prometheus] Get rid of friend test

### DIFF
--- a/exporters/prometheus/include/opentelemetry/exporters/prometheus/exporter_utils.h
+++ b/exporters/prometheus/include/opentelemetry/exporters/prometheus/exporter_utils.h
@@ -104,9 +104,6 @@ private:
                        const std::vector<double> &boundaries,
                        const std::vector<uint64_t> &counts,
                        ::prometheus::ClientMetric *metric);
-
-  // For testing
-  friend class SanitizeNameTester;
 };
 }  // namespace metrics
 }  // namespace exporter

--- a/exporters/prometheus/test/exporter_utils_test.cc
+++ b/exporters/prometheus/test/exporter_utils_test.cc
@@ -15,21 +15,6 @@ namespace prometheus_client = ::prometheus;
 
 OPENTELEMETRY_BEGIN_NAMESPACE
 
-namespace exporter
-{
-namespace metrics
-{
-class SanitizeNameTester
-{
-public:
-  static std::string sanitize(std::string name)
-  {
-    return PrometheusExporterUtils::SanitizeNames(name);
-  }
-};
-}  // namespace metrics
-}  // namespace exporter
-
 template <typename T>
 void assert_basic(prometheus_client::MetricFamily &metric,
                   const std::string &sanitized_name,
@@ -153,14 +138,33 @@ TEST(PrometheusExporterUtils, TranslateToPrometheusHistogramNormal)
   assert_histogram(metric, std::list<double>{10.1, 20.2, 30.2}, {200, 300, 400, 500});
 }
 
-TEST(PrometheusExporterUtils, SanitizeName)
+class SanitizeNameTest : public ::testing::Test
 {
-  ASSERT_EQ(exporter::metrics::SanitizeNameTester::sanitize("name"), "name");
-  ASSERT_EQ(exporter::metrics::SanitizeNameTester::sanitize("name?"), "name_");
-  ASSERT_EQ(exporter::metrics::SanitizeNameTester::sanitize("name???"), "name_");
-  ASSERT_EQ(exporter::metrics::SanitizeNameTester::sanitize("name?__"), "name_");
-  ASSERT_EQ(exporter::metrics::SanitizeNameTester::sanitize("name?__name"), "name_name");
-  ASSERT_EQ(exporter::metrics::SanitizeNameTester::sanitize("name?__name:"), "name_name:");
+  Resource resource_ = Resource::Create({});
+  nostd::unique_ptr<InstrumentationScope> instrumentation_scope_ =
+      InstrumentationScope::Create("library_name", "1.2.0");
+
+protected:
+  void CheckSanitation(const std::string &original, const std::string &sanitized)
+  {
+    metric_sdk::InstrumentDescriptor instrument_descriptor_{
+        original, "description", "unit", metric_sdk::InstrumentType::kCounter,
+        metric_sdk::InstrumentValueType::kDouble};
+    std::vector<prometheus::MetricFamily> result = PrometheusExporterUtils::TranslateToPrometheus(
+        {&resource_,
+         {{instrumentation_scope_.get(), {{instrument_descriptor_, {}, {}, {}, {{{}, {}}}}}}}});
+    EXPECT_EQ(result.begin()->name, sanitized + "_unit");
+  }
+};
+
+TEST_F(SanitizeNameTest, All)
+{
+  CheckSanitation("name", "name");
+  CheckSanitation("name?", "name_");
+  CheckSanitation("name???", "name_");
+  CheckSanitation("name?__", "name_");
+  CheckSanitation("name?__name", "name_name");
+  CheckSanitation("name?__name:", "name_name:");
 }
 
 class AttributeCollisionTest : public ::testing::Test


### PR DESCRIPTION
Instead, test using the TranslateToPrometheus public API.