### PR TITLE
[Exporter] Group spans by resource and instrumentation scope in OTLP export requests

### DIFF
--- a/exporters/otlp/include/opentelemetry/exporters/otlp/otlp_recordable.h
+++ b/exporters/otlp/include/opentelemetry/exporters/otlp/otlp_recordable.h
@@ -27,7 +27,10 @@ public:
   /** Dynamically converts the resource of this span into a proto. */
   proto::resource::v1::Resource ProtoResource() const noexcept;
 
+  const opentelemetry::sdk::resource::Resource *GetResource() const noexcept;
   const std::string GetResourceSchemaURL() const noexcept;
+  const opentelemetry::sdk::instrumentationscope::InstrumentationScope *GetInstrumentationScope()
+      const noexcept;
   const std::string GetInstrumentationLibrarySchemaURL() const noexcept;
 
   proto::common::v1::InstrumentationScope GetProtoInstrumentationScope() const noexcept;

--- a/exporters/otlp/src/otlp_recordable.cc
+++ b/exporters/otlp/src/otlp_recordable.cc
@@ -40,6 +40,11 @@ proto::resource::v1::Resource OtlpRecordable::ProtoResource() const noexcept
   return proto;
 }
 
+const opentelemetry::sdk::resource::Resource *OtlpRecordable::GetResource() const noexcept
+{
+  return resource_;
+}
+
 const std::string OtlpRecordable::GetResourceSchemaURL() const noexcept
 {
   std::string schema_url;
@@ -49,6 +54,12 @@ const std::string OtlpRecordable::GetResourceSchemaURL() const noexcept
   }
 
   return schema_url;
+}
+
+const opentelemetry::sdk::instrumentationscope::InstrumentationScope *
+OtlpRecordable::GetInstrumentationScope() const noexcept
+{
+  return instrumentation_scope_;
 }
 
 const std::string OtlpRecordable::GetInstrumentationLibrarySchemaURL() const noexcept

--- a/exporters/otlp/src/otlp_recordable_utils.cc
+++ b/exporters/otlp/src/otlp_recordable_utils.cc
@@ -77,21 +77,27 @@ void OtlpRecordableUtils::PopulateRequest(
   {
     // Add the resource
     auto resource_spans = request->add_resource_spans();
-    proto::resource::v1::Resource resource_proto;
-    OtlpPopulateAttributeUtils::PopulateAttribute(&resource_proto, *input_resource_spans.first);
-    *resource_spans->mutable_resource() = resource_proto;
-    resource_spans->set_schema_url(input_resource_spans.first->GetSchemaURL());
+    if (input_resource_spans.first)
+    {
+      proto::resource::v1::Resource resource_proto;
+      OtlpPopulateAttributeUtils::PopulateAttribute(&resource_proto, *input_resource_spans.first);
+      *resource_spans->mutable_resource() = resource_proto;
+      resource_spans->set_schema_url(input_resource_spans.first->GetSchemaURL());
+    }
 
     // Add all scope spans
     for (auto &input_scope_spans : input_resource_spans.second)
     {
       // Add the instrumentation scope
       auto scope_spans = resource_spans->add_scope_spans();
-      proto::common::v1::InstrumentationScope instrumentation_scope_proto;
-      instrumentation_scope_proto.set_name(input_scope_spans.first->GetName());
-      instrumentation_scope_proto.set_version(input_scope_spans.first->GetVersion());
-      *scope_spans->mutable_scope() = instrumentation_scope_proto;
-      scope_spans->set_schema_url(input_scope_spans.first->GetSchemaURL());
+      if (input_scope_spans.first)
+      {
+        proto::common::v1::InstrumentationScope instrumentation_scope_proto;
+        instrumentation_scope_proto.set_name(input_scope_spans.first->GetName());
+        instrumentation_scope_proto.set_version(input_scope_spans.first->GetVersion());
+        *scope_spans->mutable_scope() = instrumentation_scope_proto;
+        scope_spans->set_schema_url(input_scope_spans.first->GetSchemaURL());
+      }
 
       // Add all spans to this scope spans
       for (auto &input_span : input_scope_spans.second)

--- a/exporters/otlp/src/otlp_recordable_utils.cc
+++ b/exporters/otlp/src/otlp_recordable_utils.cc
@@ -94,9 +94,9 @@ void OtlpRecordableUtils::PopulateRequest(
       scope_spans->set_schema_url(input_scope_spans.first->GetSchemaURL());
 
       // Add all spans to this scope spans
-      for (auto &input_scope_spans : input_scope_spans.second)
+      for (auto &input_span : input_scope_spans.second)
       {
-        *scope_spans->add_spans() = std::move(input_scope_spans->span());
+        *scope_spans->add_spans() = std::move(input_span->span());
       }
     }
   }

--- a/exporters/otlp/src/otlp_recordable_utils.cc
+++ b/exporters/otlp/src/otlp_recordable_utils.cc
@@ -58,7 +58,7 @@ void OtlpRecordableUtils::PopulateRequest(
 
   using spans_by_scope =
       std::unordered_map<const opentelemetry::sdk::instrumentationscope::InstrumentationScope *,
-                         std::list<std::unique_ptr<OtlpRecordable>>,
+                         std::vector<std::unique_ptr<OtlpRecordable>>,
                          InstrumentationScopePointerHasher, InstrumentationScopePointerEqual>;
   std::unordered_map<const opentelemetry::sdk::resource::Resource *, spans_by_scope> spans_index;
 

--- a/exporters/otlp/src/otlp_recordable_utils.cc
+++ b/exporters/otlp/src/otlp_recordable_utils.cc
@@ -58,8 +58,7 @@ void OtlpRecordableUtils::PopulateRequest(
 
   using spans_by_scope =
       std::unordered_map<const opentelemetry::sdk::instrumentationscope::InstrumentationScope *,
-                         std::vector<std::unique_ptr<OtlpRecordable>>,
-                         InstrumentationScopePointerHasher, InstrumentationScopePointerEqual>;
+                         std::vector<std::unique_ptr<OtlpRecordable>>>;
   std::unordered_map<const opentelemetry::sdk::resource::Resource *, spans_by_scope> spans_index;
 
   // Collect spans per resource and instrumentation scope

--- a/exporters/otlp/test/otlp_recordable_test.cc
+++ b/exporters/otlp/test/otlp_recordable_test.cc
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "opentelemetry/exporters/otlp/otlp_recordable.h"
+#include "opentelemetry/exporters/otlp/otlp_recordable_utils.h"
 #include "opentelemetry/sdk/resource/resource.h"
 
 #if defined(__GNUC__)
@@ -282,6 +283,55 @@ TEST(OtlpRecordable, SetArrayAttribute)
     EXPECT_EQ(rec.span().attributes(1).value().array_value().values(i).double_value(),
               double_span[i]);
     EXPECT_EQ(rec.span().attributes(2).value().array_value().values(i).string_value(), str_span[i]);
+  }
+}
+
+// Test otlp resource populate request util
+TEST(OtlpRecordable, PopulateRequest)
+{
+  auto rec1                          = std::unique_ptr<sdk::trace::Recordable>(new OtlpRecordable);
+  const std::string service_name_key = "service.name";
+  std::string service_name1          = "one";
+  auto resource1 = resource::Resource::Create({{service_name_key, service_name1}});
+  rec1->SetResource(resource1);
+  auto inst_lib1 = trace_sdk::InstrumentationScope::Create("one", "1");
+  rec1->SetInstrumentationScope(*inst_lib1);
+
+  auto rec2                 = std::unique_ptr<sdk::trace::Recordable>(new OtlpRecordable);
+  std::string service_name2 = "two";
+  auto resource2            = resource::Resource::Create({{service_name_key, service_name2}});
+  rec2->SetResource(resource2);
+  auto inst_lib2 = trace_sdk::InstrumentationScope::Create("two", "2");
+  rec2->SetInstrumentationScope(*inst_lib2);
+
+  // This has the same resource as rec2, but a different scope
+  auto rec3 = std::unique_ptr<sdk::trace::Recordable>(new OtlpRecordable);
+  rec3->SetResource(resource2);
+  auto inst_lib3 = trace_sdk::InstrumentationScope::Create("three", "3");
+  rec3->SetInstrumentationScope(*inst_lib3);
+
+  proto::collector::trace::v1::ExportTraceServiceRequest req;
+  std::vector<std::unique_ptr<sdk::trace::Recordable>> spans;
+  spans.push_back(std::move(rec1));
+  spans.push_back(std::move(rec2));
+  spans.push_back(std::move(rec3));
+  const nostd::span<std::unique_ptr<sdk::trace::Recordable>, 3> spans_span(spans.data(), 3);
+  OtlpRecordableUtils::PopulateRequest(spans_span, &req);
+
+  EXPECT_EQ(req.resource_spans().size(), 2);
+  for (auto resource_spans : req.resource_spans())
+  {
+    auto service_name     = resource_spans.resource().attributes(0).value().string_value();
+    auto scope_spans_size = resource_spans.scope_spans().size();
+    if (service_name == "one")
+    {
+      EXPECT_EQ(scope_spans_size, 1);
+      EXPECT_EQ(resource_spans.scope_spans(0).scope().name(), "one");
+    }
+    if (service_name == "two")
+    {
+      EXPECT_EQ(scope_spans_size, 2);
+    }
   }
 }
 

--- a/exporters/otlp/test/otlp_recordable_test.cc
+++ b/exporters/otlp/test/otlp_recordable_test.cc
@@ -357,20 +357,18 @@ TEST(OtlpRecordable, PopulateRequestMissing)
   {
     // Both should have scope spans
     EXPECT_EQ(resource_spans.scope_spans().size(), 1);
+    auto scope = resource_spans.scope_spans(0).scope();
     // Select the one with missing scope
-    if (resource_spans.resource().attributes().size() > 0 &&
-        resource_spans.resource().attributes(0).value().string_value() == "one")
+    if (scope.name() == "")
     {
-      // Scope data is missing
-      EXPECT_EQ(resource_spans.scope_spans(0).scope().name(), "");
-      EXPECT_EQ(resource_spans.scope_spans(0).scope().version(), "");
+      // Version is also empty
+      EXPECT_EQ(scope.version(), "");
     }
     else
     {
-      // The other has no resource attributes
-      EXPECT_EQ(resource_spans.resource().attributes().size(), 0);
-      EXPECT_EQ(resource_spans.scope_spans(0).scope().name(), "two");
-      EXPECT_EQ(resource_spans.scope_spans(0).scope().version(), "2");
+      // The other has a name and version
+      EXPECT_EQ(scope.name(), "two");
+      EXPECT_EQ(scope.version(), "2");
     }
   }
 }

--- a/exporters/otlp/test/otlp_recordable_test.cc
+++ b/exporters/otlp/test/otlp_recordable_test.cc
@@ -289,23 +289,20 @@ TEST(OtlpRecordable, SetArrayAttribute)
 // Test otlp resource populate request util
 TEST(OtlpRecordable, PopulateRequest)
 {
-  auto rec1                          = std::unique_ptr<sdk::trace::Recordable>(new OtlpRecordable);
-  const std::string service_name_key = "service.name";
-  std::string service_name1          = "one";
-  auto resource1 = resource::Resource::Create({{service_name_key, service_name1}});
+  std::unique_ptr<sdk::trace::Recordable> rec1 = std::make_unique<OtlpRecordable>();
+  auto resource1 = resource::Resource::Create({{"service.name", "one"}});
   rec1->SetResource(resource1);
   auto inst_lib1 = trace_sdk::InstrumentationScope::Create("one", "1");
   rec1->SetInstrumentationScope(*inst_lib1);
 
-  auto rec2                 = std::unique_ptr<sdk::trace::Recordable>(new OtlpRecordable);
-  std::string service_name2 = "two";
-  auto resource2            = resource::Resource::Create({{service_name_key, service_name2}});
+  std::unique_ptr<sdk::trace::Recordable> rec2 = std::make_unique<OtlpRecordable>();
+  auto resource2 = resource::Resource::Create({{"service.name", "two"}});
   rec2->SetResource(resource2);
   auto inst_lib2 = trace_sdk::InstrumentationScope::Create("two", "2");
   rec2->SetInstrumentationScope(*inst_lib2);
 
   // This has the same resource as rec2, but a different scope
-  auto rec3 = std::unique_ptr<sdk::trace::Recordable>(new OtlpRecordable);
+  std::unique_ptr<sdk::trace::Recordable> rec3 = std::make_unique<OtlpRecordable>();
   rec3->SetResource(resource2);
   auto inst_lib3 = trace_sdk::InstrumentationScope::Create("three", "3");
   rec3->SetInstrumentationScope(*inst_lib3);

--- a/exporters/otlp/test/otlp_recordable_test.cc
+++ b/exporters/otlp/test/otlp_recordable_test.cc
@@ -355,23 +355,22 @@ TEST(OtlpRecordable, PopulateRequestMissing)
   EXPECT_EQ(req.resource_spans().size(), 2);
   for (auto resource_spans : req.resource_spans())
   {
+    // Both should have scope spans
+    EXPECT_EQ(resource_spans.scope_spans().size(), 1);
     // Select the one with missing scope
-    if (resource_spans.resource().attributes().size() != 0)
+    if (resource_spans.resource().attributes().size() > 0 &&
+        resource_spans.resource().attributes(0).value().string_value() == "one")
     {
-      // It has a service name
-      EXPECT_EQ(resource_spans.resource().attributes(0).value().string_value(), "one");
-      // And scope spans
-      EXPECT_EQ(resource_spans.scope_spans().size(), 1);
-      // But the scope data is missing
+      // Scope data is missing
       EXPECT_EQ(resource_spans.scope_spans(0).scope().name(), "");
+      EXPECT_EQ(resource_spans.scope_spans(0).scope().version(), "");
     }
     else
     {
-      // It has no resource attributes
+      // The other has no resource attributes
       EXPECT_EQ(resource_spans.resource().attributes().size(), 0);
-      // It has a scope
-      EXPECT_EQ(resource_spans.scope_spans().size(), 1);
       EXPECT_EQ(resource_spans.scope_spans(0).scope().name(), "two");
+      EXPECT_EQ(resource_spans.scope_spans(0).scope().version(), "2");
     }
   }
 }

--- a/exporters/otlp/test/otlp_recordable_test.cc
+++ b/exporters/otlp/test/otlp_recordable_test.cc
@@ -289,20 +289,23 @@ TEST(OtlpRecordable, SetArrayAttribute)
 // Test otlp resource populate request util
 TEST(OtlpRecordable, PopulateRequest)
 {
-  std::unique_ptr<sdk::trace::Recordable> rec1 = std::make_unique<OtlpRecordable>();
-  auto resource1 = resource::Resource::Create({{"service.name", "one"}});
+  auto rec1                          = std::unique_ptr<sdk::trace::Recordable>(new OtlpRecordable);
+  const std::string service_name_key = "service.name";
+  std::string service_name1          = "one";
+  auto resource1 = resource::Resource::Create({{service_name_key, service_name1}});
   rec1->SetResource(resource1);
   auto inst_lib1 = trace_sdk::InstrumentationScope::Create("one", "1");
   rec1->SetInstrumentationScope(*inst_lib1);
 
-  std::unique_ptr<sdk::trace::Recordable> rec2 = std::make_unique<OtlpRecordable>();
-  auto resource2 = resource::Resource::Create({{"service.name", "two"}});
+  auto rec2                 = std::unique_ptr<sdk::trace::Recordable>(new OtlpRecordable);
+  std::string service_name2 = "two";
+  auto resource2            = resource::Resource::Create({{service_name_key, service_name2}});
   rec2->SetResource(resource2);
   auto inst_lib2 = trace_sdk::InstrumentationScope::Create("two", "2");
   rec2->SetInstrumentationScope(*inst_lib2);
 
   // This has the same resource as rec2, but a different scope
-  std::unique_ptr<sdk::trace::Recordable> rec3 = std::make_unique<OtlpRecordable>();
+  auto rec3 = std::unique_ptr<sdk::trace::Recordable>(new OtlpRecordable);
   rec3->SetResource(resource2);
   auto inst_lib3 = trace_sdk::InstrumentationScope::Create("three", "3");
   rec3->SetInstrumentationScope(*inst_lib3);


### PR DESCRIPTION
This PR changes the implementation of `OtlpRecordableUtils::PopulateRequest` to group spans by their resource and instrumentation scope.

Instead of duplicating the resource and instrumentation scope for every span this now collects spans with the same resources and instrumentation scopes, reducing the size of the resulting `proto::collector::trace::v1::ExportTraceServiceRequest`.

For significant contributions please make sure you have completed the following items:

* [ ] `CHANGELOG.md` updated for non-trivial changes
* [x] Unit tests have been added
* [ ] Changes in public API reviewed