### PR TITLE
[REMOVAL] Drop C++11 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,43 +28,6 @@ jobs:
       run: |
         ./ci/do_ci.sh cmake.test
 
-  #
-  # This build uses the latest libraries compatible
-  # with C++11
-  #
-  cmake_gcc_maintainer_cpp11_async_test:
-    name: CMake gcc 12 (maintainer mode, C++11, async)
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v4
-      with:
-        submodules: 'recursive'
-    - name: setup
-      env:
-        CC: /usr/bin/gcc-12
-        CXX: /usr/bin/g++-12
-        GOOGLETEST_VERSION: 1.12.1
-        PROTOBUF_VERSION: 21.12
-      run: |
-        sudo -E ./ci/setup_cmake.sh
-        sudo -E ./ci/setup_ci_environment.sh
-        sudo -E ./ci/install_protobuf.sh
-    - name: run cmake gcc (maintainer mode, C++11, async)
-      env:
-        CC: /usr/bin/gcc-12
-        CXX: /usr/bin/g++-12
-      run: |
-        ./ci/do_ci.sh cmake.maintainer.cpp11.async.test
-    - name: generate test cert
-      env:
-        CFSSL_VERSION: 1.6.3
-      run: |
-        sudo -E ./tools/setup-cfssl.sh
-        (cd ./functional/cert; ./generate_cert.sh)
-    - name: run func test
-      run: |
-        (cd ./functional/otlp; ./run_test.sh)
-
   cmake_gcc_maintainer_sync_test:
     name: CMake gcc 12 (maintainer mode, sync)
     runs-on: ubuntu-latest
@@ -257,64 +220,6 @@ jobs:
         sudo -E ./ci/setup_ci_environment.sh
     - name: run cmake tests (enable opentracing-shim)
       run: ./ci/do_ci.sh cmake.opentracing_shim.test
-
-  cmake_gcc_48_test:
-    name: CMake gcc 4.8 (without otlp exporter)
-    runs-on: ubuntu-20.04
-    steps:
-    - uses: actions/checkout@v4
-      with:
-        submodules: 'recursive'
-    - name: Add Ubuntu Xenial package sources
-      run: |
-          sudo apt-add-repository 'deb http://archive.ubuntu.com/ubuntu/ xenial main'
-          sudo apt-add-repository 'deb http://archive.ubuntu.com/ubuntu/ xenial universe'
-    - name: setup
-      run: |
-        sudo ./ci/setup_ci_environment.sh
-        sudo ./ci/install_gcc48.sh
-    - name: setup cmake
-      env:
-        CC: /usr/bin/gcc-4.8
-        CXX: /usr/bin/g++-4.8
-        GOOGLETEST_VERSION: 1.10.0
-      run: |
-        sudo -E ./ci/setup_cmake.sh
-    - name: run tests
-      env:
-        CC: /usr/bin/gcc-4.8
-        CXX: /usr/bin/g++-4.8
-        CXX_STANDARD: '11'
-      run: ./ci/do_ci.sh cmake.legacy.test
-
-  cmake_gcc_48_otlp_exporter_test:
-    name: CMake gcc 4.8 (with otlp exporter)
-    runs-on: ubuntu-20.04
-    steps:
-    - uses: actions/checkout@v4
-      with:
-        submodules: 'recursive'
-    - name: Add Ubuntu Xenial package sources
-      run: |
-          sudo apt-add-repository 'deb http://archive.ubuntu.com/ubuntu/ xenial main'
-          sudo apt-add-repository 'deb http://archive.ubuntu.com/ubuntu/ xenial universe'
-    - name: setup
-      run: |
-        sudo ./ci/setup_ci_environment.sh
-        sudo ./ci/install_gcc48.sh
-    - name: setup cmake and grpc
-      env:
-        CC: /usr/bin/gcc-4.8
-        CXX: /usr/bin/g++-4.8
-        GOOGLETEST_VERSION: 1.10.0
-      run: |
-        sudo -E ./ci/setup_cmake.sh
-        sudo -E ./ci/setup_grpc.sh -v 4.8
-    - name: run tests
-      env:
-        CC: /usr/bin/gcc-4.8
-        CXX: /usr/bin/g++-4.8
-      run: ./ci/do_ci.sh cmake.legacy.exporter.otprotocol.test
 
   cmake_test_cxx14_gcc:
     name: CMake C++14 test(GCC)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,9 +20,11 @@ Increment the:
 * [EXPORTER] Remove explicit timestamps from metric points exported by Prometheus
   [#2324](https://github.com/open-telemetry/opentelemetry-cpp/pull/2324)
 * [EXPORTER] Handle attribute key collisions caused by sanitation
-  [#2324](https://github.com/open-telemetry/opentelemetry-cpp/pull/2326)
+  [#2326](https://github.com/open-telemetry/opentelemetry-cpp/pull/2326)
 * [EXPORTER] Replace colons with underscores when converting to Prometheus label
-  [#2324](https://github.com/open-telemetry/opentelemetry-cpp/pull/2330)
+  [#2330](https://github.com/open-telemetry/opentelemetry-cpp/pull/2330)
+* [REMOVAL] Drop C++11 support
+  [#2342](https://github.com/open-telemetry/opentelemetry-cpp/pull/2342)
 
 Breaking changes:
 
@@ -46,6 +48,10 @@ Breaking changes:
     by the caller are honored.
   * Applications that set neither CMAKE_CXX_STANDARD nor -stdc++
     options may need to provide a C++ standard in their makefiles.
+
+* [REMOVAL] Drop C++11 support
+  [#2342](https://github.com/open-telemetry/opentelemetry-cpp/pull/2342)
+  * Building with C++11 is no longer supported.
 
 ## [1.11.0] 2023-08-21
 

--- a/DEPRECATED.md
+++ b/DEPRECATED.md
@@ -30,66 +30,7 @@ N/A
 
 ## [Compilers]
 
-### Drop C++11 support
-
-#### Announcement (C++11)
-
-* Date: 2022-12-01
-* Issue: [DEPRECATION] Drop C++11 support
-  [#1830](https://github.com/open-telemetry/opentelemetry-cpp/pull/1830)
-* This announcement has been pinned,
-  visible in the issues pages since December 2022.
-
-#### Motivation (C++11)
-
-This repository, opentelemetry-cpp, supports a "bring your own dependency" model.
-
-In this model,
-the build scripts can be configured to:
-
-* pick a given version for a third party library,
-* build opentelemetry-cpp with the library given.
-
-The makefiles do not mandate to use a particular version,
-hence the "bring your own" denomination.
-
-To have an up to date build, projects are encouraged to use up to date
-versions of third party libraries, to benefit from bug fixes.
-
-Now, many libraries deliver new versions that require C++14, bug fixes
-releases for C++11 are no longer available.
-
-In particular, the following components:
-
-* GRPC C++
-* abseil
-* googletest
-
-now require C++14, per
-[google support policies](https://github.com/google/oss-policies-info/blob/main/foundational-cxx-support-matrix.md)
-
-As a result, to stay up to date, opentelemetry-cpp needs to upgrade its
-minimum build requirements to use C++14 instead of C++11.
-
-#### Scope (C++11)
-
-Continuous Integration (CI) builds will use C++14 instead of C++11.
-
-The CI build for gcc 4.8 is now deprecated, to be decommissioned when C++11
-support is dropped.
-
-#### Mitigation (C++11)
-
-Building the code with recent third party libraries will require C++14
-instead of C++11.
-
-#### Planned end of life (C++11)
-
-Support for C++11 in opentelemetry-cpp will end on September 2023.
-
-After this date, opentelemetry-cpp may still build properly in C++11 mode,
-assuming a suitable, old, version for each dependency is used,
-but the C++11 build will no longer be tested for each new release.
+N/A
 
 ## [Third party dependencies]
 

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -16,7 +16,7 @@ You can link OpenTelemetry C++ SDK with libraries provided in
 
 - A supported platform (e.g. Windows, macOS or Linux). Refer to [Platforms
   Supported](./README.md#supported-development-platforms) for more information.
-- A compatible C++ compiler supporting at least C++11. Major compilers are
+- A compatible C++ compiler supporting at least C++14. Major compilers are
   supported. Refer to [Supported Compilers](./README.md#supported-c-versions)
   for more information.
 - [Git](https://git-scm.com/) for fetching opentelemetry-cpp source code from
@@ -158,7 +158,7 @@ path.
 
 - A supported platform (e.g. Windows, macOS or Linux). Refer to [Platforms
 Supported](./README.md#supported-development-platforms) for more information.
-- A compatible C++ compiler supporting at least C++11. Major compilers are
+- A compatible C++ compiler supporting at least C++14. Major compilers are
 supported. Refer to [Supported Compilers](./README.md#supported-c-versions) for
 more information.
 - [Git](https://git-scm.com/) for fetching opentelemetry-cpp source code from

--- a/README.md
+++ b/README.md
@@ -39,9 +39,9 @@ of the current project.
 | Platform                                                            |   Build type  |
 |---------------------------------------------------------------------|---------------|
 | ubuntu-22.04 (GCC 10, GCC 12, Clang 14)                             | CMake, Bazel  |
-| ubuntu-20.04 (GCC 9.4.0)                                            | CMake, Bazel  |
-| ubuntu-20.04 (Default GCC Compiler - 9.4.0 with -std=c++20 flags)   | CMake, Bazel  |
-| macOS 12.0 (Xcode 14.2)                                             | Bazel         |
+| ubuntu-20.04 (GCC 9.4.0 - default compiler)                         | CMake, Bazel  |
+| ubuntu-20.04 (GCC 9.4.0 with -std=c++14/17/20 flags)                | CMake, Bazel  |
+| macOS 12.7 (Xcode 14.2)                                             | Bazel         |
 | Windows Server 2019 (Visual Studio Enterprise 2019)                 | CMake, Bazel  |
 | Windows Server 2022 (Visual Studio Enterprise 2022)                 | CMake         |
 

--- a/README.md
+++ b/README.md
@@ -22,9 +22,8 @@ repo.
 Code shipped from this repository generally supports the following versions of
 C++ standards:
 
-* ISO/IEC 14882:2011 (C++11, C++0x)
-* ISO/IEC 14882:2014 (C++14, C++1y)
-* ISO/IEC 14882:2017 (C++17, C++1z)
+* ISO/IEC 14882:2014 (C++14)
+* ISO/IEC 14882:2017 (C++17)
 * ISO/IEC 14882:2020 (C++20)
 
 Any exceptions to this are noted in the individual `README.md` files.
@@ -39,18 +38,12 @@ of the current project.
 
 | Platform                                                            |   Build type  |
 |---------------------------------------------------------------------|---------------|
-| ubuntu-22.04 (GCC - 10, 12)                                         | CMake, Bazel  |
-| ubuntu-20.04 (GCC 4.8 with -std=c++11 flag)                         | CMake [1]     |
+| ubuntu-22.04 (GCC 10, GCC 12, Clang 14)                             | CMake, Bazel  |
 | ubuntu-20.04 (GCC 9.4.0)                                            | CMake, Bazel  |
 | ubuntu-20.04 (Default GCC Compiler - 9.4.0 with -std=c++20 flags)   | CMake, Bazel  |
 | macOS 12.0 (Xcode 14.2)                                             | Bazel         |
 | Windows Server 2019 (Visual Studio Enterprise 2019)                 | CMake, Bazel  |
 | Windows Server 2022 (Visual Studio Enterprise 2022)                 | CMake         |
-
-[1]: Bazel build is disabled for GCC 4.8, as gRPC library 1.38 and above
-  (required by OTLP exporter) don't build with this compiler. See gRPC [official
-  support](https://grpc.io/docs/#official-support) document. CMake build doesn't
-  build OTLP exporter with GCC 4.8.
 
 In general, the code shipped from this repository should build on all platforms
 having C++ compiler with [supported C++ standards](#supported-c-versions).

--- a/docs/building-with-stdlib.md
+++ b/docs/building-with-stdlib.md
@@ -19,7 +19,7 @@ API surface classes with [Abseil classes](https://abseil.io/) instead of
 
 * ABI stability: scenario where different modules are compiled with different
   compiler and incompatible standard library.
-* backport of C++17 and above features to C++11 compiler.
+* backport of C++17 and above features to C++14 compiler.
 
 The need for custom `nostd` classes is significantly diminished when the SDK is
 compiled with C++17 or above compiler. Only `std::span` needs to be backported.
@@ -137,9 +137,9 @@ Visual Studio provides 1st class debug experience for the standard library.
 
 Supported build flavors:
 
-* `nostd` - OpenTelemetry backport of classes for C++11. Not using standard lib.
+* `nostd` - OpenTelemetry backport of classes for C++14. Not using standard lib.
 * `stdlib` - Standard Library.
-  Native experience with C++11/C++14/C++17/C++20/C++23 compiler.
+  Native experience with C++14/C++17/C++20/C++23 compiler.
   Depending on the stdlib level in effect,
   C++ features are used from the standard library,
   completed with `nostd` replacement implementations.

--- a/docs/dependencies.md
+++ b/docs/dependencies.md
@@ -27,7 +27,7 @@ Both these dependencies are listed here:
     compiler if cmake option `WITH_STL` is enabled
     or macro `OPENTELEMETRY_STL_VERSION` is defined.
     License: `GNU General Public License`
-    - For C++11/14/17 compilers, fallback to gsl::span if [GSL C++
+    - For C++14/17 compilers, fallback to gsl::span if [GSL C++
       library](https://github.com/microsoft/GSL) is installed. License: `MIT
       License`
     - libc++ 14.0.0 do not support construct std::span from a range or container

--- a/docs/google-test.md
+++ b/docs/google-test.md
@@ -93,7 +93,7 @@ this, Google Test also allows us to easily integrate code coverage tools such as
 ## Integration and Usage
 
 One of the base requirements to build and use Google Test from a source package
-are to use either Bazel or CMake; the other is a C++11-standard-compliant
+are to use either Bazel or CMake; the other is a C++14-standard-compliant
 compiler like GCC or Clang.
 
 ### Bazel

--- a/docs/public/api/Overview.rst
+++ b/docs/public/api/Overview.rst
@@ -15,7 +15,7 @@ Library design
 --------------
 
 The OpenTelemetry C++ API is provided as a header-only library and
-supports all recent versions of the C++ standard, down to C++11.
+supports all recent versions of the C++ standard, down to C++14.
 
 A single application might dynamically or statically link to different
 libraries that were compiled with different compilers, while several of


### PR DESCRIPTION
Fixes #2147

## Changes

* Drop C++11 support from CI.
* Adjust documentation.

Note that building in C++11 may still work for a while, as the code and makefiles have not changed.
Opentelemetry-cpp makes however no commitments to maintain the C++11 build.
Bug fixes, new features, or third party dependencies may require C++14 from this point, without notice.

For significant contributions please make sure you have completed the following items:

* [X] `CHANGELOG.md` updated for non-trivial changes
* [ ] Unit tests have been added
* [ ] Changes in public API reviewed