### PR TITLE
[BUILD] Build break with external CMake nlohman_json package

### DIFF
--- a/exporters/otlp/CMakeLists.txt
+++ b/exporters/otlp/CMakeLists.txt
@@ -342,7 +342,8 @@ if(BUILD_TESTING)
       ${GMOCK_LIB}
       opentelemetry_exporter_otlp_http_log
       opentelemetry_logs
-      opentelemetry_http_client_nosend)
+      opentelemetry_http_client_nosend
+      nlohmann_json::nlohmann_json)
     gtest_add_tests(
       TARGET otlp_http_log_record_exporter_test
       TEST_PREFIX exporter.otlp.


### PR DESCRIPTION
Fixes #2352

## Changes

The unit test program `otlp_http_log_record_exporter_test` depends on `nlohman_json`.

Because of this, the dependency should be made explicit in CMakeList.tst

* [ ] `CHANGELOG.md` updated for non-trivial changes
* [ ] Unit tests have been added
* [ ] Changes in public API reviewed