### PR TITLE
Fix behavior of opentracing-shim when added as subdirectory of a larger project

### DIFF
--- a/opentracing-shim/CMakeLists.txt
+++ b/opentracing-shim/CMakeLists.txt
@@ -14,10 +14,13 @@ target_include_directories(
                         "$<INSTALL_INTERFACE:include>")
 
 if(OPENTRACING_DIR)
-  include_directories(
-    "${CMAKE_BINARY_DIR}/${OPENTRACING_DIR}/include"
-    "${CMAKE_SOURCE_DIR}/${OPENTRACING_DIR}/include"
-    "${CMAKE_SOURCE_DIR}/${OPENTRACING_DIR}/3rd_party/include")
+  target_include_directories(
+    ${this_target}
+    PUBLIC
+      "$<BUILD_INTERFACE:${PROJECT_BINARY_DIR}/${OPENTRACING_DIR}/include>"
+      "$<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/${OPENTRACING_DIR}/include>"
+      "$<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/${OPENTRACING_DIR}/3rd_party/include>"
+  )
   target_link_libraries(${this_target} opentelemetry_api opentracing)
 else()
   target_link_libraries(${this_target} opentelemetry_api


### PR DESCRIPTION

Fixes #2355

## Changes

Change the opentracing-shim include paths to be relative to opentelemetry-cpp directory, rather than the root cmake project directory. Those two directories will be different if opentelemetry-cpp is added to a larger project.

I also switched `include_directories` to `target_include_directories` as my understanding is that the latter is current best-practice. This necessitated gating the includes with a BUILD_INTERFACE generator expression. However, I don't think this change is required for this fix. I just wanted to improve it a little bit.