### PR TITLE
Fix protoc searching with non-imported protobuf::protoc target.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -430,6 +430,10 @@ if(WITH_OTLP_GRPC OR WITH_OTLP_HTTP)
   if(TARGET protobuf::protoc)
     project_build_tools_get_imported_location(PROTOBUF_PROTOC_EXECUTABLE
                                               protobuf::protoc)
+    # If protobuf::protoc is not a imported target, then we use the target directly for fallback
+    if(NOT PROTOBUF_PROTOC_EXECUTABLE)
+      set(PROTOBUF_PROTOC_EXECUTABLE protobuf::protoc)
+    endif()
   elseif(Protobuf_PROTOC_EXECUTABLE)
     # Some versions of FindProtobuf.cmake uses mixed case instead of uppercase
     set(PROTOBUF_PROTOC_EXECUTABLE ${Protobuf_PROTOC_EXECUTABLE})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -430,7 +430,8 @@ if(WITH_OTLP_GRPC OR WITH_OTLP_HTTP)
   if(TARGET protobuf::protoc)
     project_build_tools_get_imported_location(PROTOBUF_PROTOC_EXECUTABLE
                                               protobuf::protoc)
-    # If protobuf::protoc is not a imported target, then we use the target directly for fallback
+    # If protobuf::protoc is not a imported target, then we use the target
+    # directly for fallback
     if(NOT PROTOBUF_PROTOC_EXECUTABLE)
       set(PROTOBUF_PROTOC_EXECUTABLE protobuf::protoc)
     endif()


### PR DESCRIPTION
Fixes #2360 

## Changes

Please provide a brief description of the changes here.

+ Fix protoc searching with non-imported protobuf::protoc target.

For significant contributions please make sure you have completed the following items:

* [ ] `CHANGELOG.md` updated for non-trivial changes
* [ ] Unit tests have been added
* [ ] Changes in public API reviewed