### PR TITLE
[BUILD] Remove WITH_REMOVE_METER_PREVIEW, use WITH_ABI_VERSION_2 instead

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,16 @@ Increment the:
 
 ## [Unreleased]
 
+* [BUILD] Remove WITH_REMOVE_METER_PREVIEW, use WITH_ABI_VERSION_2 instead
+  [#2370](https://github.com/open-telemetry/opentelemetry-cpp/pull/2370)
+
+Breaking changes:
+
+* [BUILD] Remove WITH_REMOVE_METER_PREVIEW, use WITH_ABI_VERSION_2 instead
+  [#2370](https://github.com/open-telemetry/opentelemetry-cpp/pull/2370)
+  * The experimental `CMake` option `WITH_REMOVE_METER_PREVIEW` is removed,
+    use option `WITH_ABI_VERSION_2` instead.
+
 ## [1.12.0] 2023-10-16
 
 * [BUILD] Support `pkg-config`

--- a/api/CMakeLists.txt
+++ b/api/CMakeLists.txt
@@ -114,11 +114,6 @@ if(WITH_ASYNC_EXPORT_PREVIEW)
   target_compile_definitions(opentelemetry_api INTERFACE ENABLE_ASYNC_EXPORT)
 endif()
 
-if(WITH_REMOVE_METER_PREVIEW)
-  target_compile_definitions(opentelemetry_api
-                             INTERFACE ENABLE_REMOVE_METER_PREVIEW)
-endif()
-
 target_compile_definitions(
   opentelemetry_api
   INTERFACE OPENTELEMETRY_ABI_VERSION_NO=${OPENTELEMETRY_ABI_VERSION_NO})

--- a/api/include/opentelemetry/metrics/meter_provider.h
+++ b/api/include/opentelemetry/metrics/meter_provider.h
@@ -126,7 +126,19 @@ public:
                                             nostd::string_view schema_url = "") noexcept = 0;
 #endif
 
-#ifdef ENABLE_REMOVE_METER_PREVIEW
+#if OPENTELEMETRY_ABI_VERSION_NO >= 2
+  /**
+   * Remove a named Meter instance (ABI).
+   *
+   * This API is experimental, see
+   * https://github.com/open-telemetry/opentelemetry-specification/issues/2232
+   *
+   * @since ABI_VERSION 2
+   *
+   * @param[in] name Meter instrumentation scope
+   * @param[in] version Instrumentation scope version, optional
+   * @param[in] schema_url Instrumentation scope schema URL, optional
+   */
   virtual void RemoveMeter(nostd::string_view name,
                            nostd::string_view version    = "",
                            nostd::string_view schema_url = "") noexcept = 0;

--- a/api/include/opentelemetry/metrics/noop.h
+++ b/api/include/opentelemetry/metrics/noop.h
@@ -214,7 +214,7 @@ public:
   }
 #endif
 
-#ifdef ENABLE_REMOVE_METER_PREVIEW
+#if OPENTELEMETRY_ABI_VERSION_NO >= 2
   void RemoveMeter(nostd::string_view /* name */,
                    nostd::string_view /* version */,
                    nostd::string_view /* schema_url */) noexcept override

--- a/ci/do_ci.sh
+++ b/ci/do_ci.sh
@@ -112,7 +112,6 @@ elif [[ "$1" == "cmake.maintainer.sync.test" ]]; then
         -DWITH_OTLP_HTTP=ON \
         -DWITH_OTLP_HTTP_SSL_PREVIEW=ON \
         -DWITH_OTLP_HTTP_SSL_TLS_PREVIEW=ON \
-        -DWITH_REMOVE_METER_PREVIEW=ON \
         -DWITH_PROMETHEUS=ON \
         -DWITH_EXAMPLES=ON \
         -DWITH_EXAMPLES_HTTP=ON \
@@ -135,7 +134,6 @@ elif [[ "$1" == "cmake.maintainer.async.test" ]]; then
         -DWITH_OTLP_HTTP=ON \
         -DWITH_OTLP_HTTP_SSL_PREVIEW=ON \
         -DWITH_OTLP_HTTP_SSL_TLS_PREVIEW=ON \
-        -DWITH_REMOVE_METER_PREVIEW=ON \
         -DWITH_PROMETHEUS=ON \
         -DWITH_EXAMPLES=ON \
         -DWITH_EXAMPLES_HTTP=ON \
@@ -159,7 +157,6 @@ elif [[ "$1" == "cmake.maintainer.cpp11.async.test" ]]; then
         -DWITH_OTLP_HTTP=ON \
         -DWITH_OTLP_HTTP_SSL_PREVIEW=ON \
         -DWITH_OTLP_HTTP_SSL_TLS_PREVIEW=ON \
-        -DWITH_REMOVE_METER_PREVIEW=ON \
         -DWITH_PROMETHEUS=ON \
         -DWITH_EXAMPLES=ON \
         -DWITH_EXAMPLES_HTTP=ON \
@@ -181,7 +178,6 @@ elif [[ "$1" == "cmake.maintainer.abiv2.test" ]]; then
         -DWITH_OTLP_HTTP=ON \
         -DWITH_OTLP_HTTP_SSL_PREVIEW=ON \
         -DWITH_OTLP_HTTP_SSL_TLS_PREVIEW=ON \
-        -DWITH_REMOVE_METER_PREVIEW=ON \
         -DWITH_PROMETHEUS=ON \
         -DWITH_EXAMPLES=ON \
         -DWITH_EXAMPLES_HTTP=ON \

--- a/sdk/include/opentelemetry/sdk/metrics/meter_provider.h
+++ b/sdk/include/opentelemetry/sdk/metrics/meter_provider.h
@@ -66,7 +66,7 @@ public:
       nostd::string_view schema_url = "") noexcept override;
 #endif
 
-#ifdef ENABLE_REMOVE_METER_PREVIEW
+#if OPENTELEMETRY_ABI_VERSION_NO >= 2
   void RemoveMeter(nostd::string_view name,
                    nostd::string_view version,
                    nostd::string_view schema_url) noexcept override;

--- a/sdk/src/metrics/meter_provider.cc
+++ b/sdk/src/metrics/meter_provider.cc
@@ -75,7 +75,7 @@ nostd::shared_ptr<metrics_api::Meter> MeterProvider::GetMeter(
   return nostd::shared_ptr<metrics_api::Meter>{meter};
 }
 
-#ifdef ENABLE_REMOVE_METER_PREVIEW
+#if OPENTELEMETRY_ABI_VERSION_NO >= 2
 void MeterProvider::RemoveMeter(nostd::string_view name,
                                 nostd::string_view version,
                                 nostd::string_view schema_url) noexcept

--- a/sdk/test/metrics/meter_provider_sdk_test.cc
+++ b/sdk/test/metrics/meter_provider_sdk_test.cc
@@ -191,7 +191,7 @@ TEST(MeterProvider, GetMeterAbiv2)
 }
 #endif /* OPENTELEMETRY_ABI_VERSION_NO >= 2 */
 
-#ifdef ENABLE_REMOVE_METER_PREVIEW
+#if OPENTELEMETRY_ABI_VERSION_NO >= 2
 TEST(MeterProvider, RemoveMeter)
 {
   MeterProvider mp;
@@ -225,4 +225,4 @@ TEST(MeterProvider, RemoveMeter)
   mp.ForceFlush();
   mp.Shutdown();
 }
-#endif
+#endif /* OPENTELEMETRY_ABI_VERSION_NO >= 2 */


### PR DESCRIPTION
Fixes #2363

## Changes

Please provide a brief description of the changes here.

* Removed redundant option `WITH_REMOVE_METER_PREVIEW`, used `WITH_ABI_VERSION_2`

For significant contributions please make sure you have completed the following items:

* [X] `CHANGELOG.md` updated for non-trivial changes
* [ ] Unit tests have been added
* [ ] Changes in public API reviewed