### PR TITLE
[API] Add InstrumentationScope attributes in TracerProvider::GetTracer()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,18 @@ Increment the:
 
 * [BUILD] Remove WITH_REMOVE_METER_PREVIEW, use WITH_ABI_VERSION_2 instead
   [#2370](https://github.com/open-telemetry/opentelemetry-cpp/pull/2370)
+* [API] Add InstrumentationScope attributes in TracerProvider::GetTracer()
+  [#2371](https://github.com/open-telemetry/opentelemetry-cpp/pull/2371)
+
+Important changes:
+
+* [API] Add InstrumentationScope attributes in TracerProvider::GetTracer()
+  [#2371](https://github.com/open-telemetry/opentelemetry-cpp/pull/2371)
+  * TracerProvider::GetTracer() now accepts InstrumentationScope attributes.
+  * Because this is an `ABI` breaking change, the fix is only available
+    with the `CMake` option `WITH_ABI_VERSION_2=ON`.
+  * When building with `CMake` option `WITH_ABI_VERSION_1=ON` (by default)
+    the `ABI` is unchanged, and the fix is not available.
 
 Breaking changes:
 

--- a/api/include/opentelemetry/trace/noop.h
+++ b/api/include/opentelemetry/trace/noop.h
@@ -108,12 +108,23 @@ public:
       : tracer_{nostd::shared_ptr<trace::NoopTracer>(new trace::NoopTracer)}
   {}
 
-  nostd::shared_ptr<trace::Tracer> GetTracer(nostd::string_view /* library_name */,
-                                             nostd::string_view /* library_version */,
+#if OPENTELEMETRY_ABI_VERSION_NO >= 2
+  nostd::shared_ptr<trace::Tracer> GetTracer(
+      nostd::string_view /* name */,
+      nostd::string_view /* version */,
+      nostd::string_view /* schema_url */,
+      const common::KeyValueIterable * /* attributes */) noexcept override
+  {
+    return tracer_;
+  }
+#else
+  nostd::shared_ptr<trace::Tracer> GetTracer(nostd::string_view /* name */,
+                                             nostd::string_view /* version */,
                                              nostd::string_view /* schema_url */) noexcept override
   {
     return tracer_;
   }
+#endif
 
 private:
   nostd::shared_ptr<trace::Tracer> tracer_;

--- a/api/include/opentelemetry/trace/tracer_provider.h
+++ b/api/include/opentelemetry/trace/tracer_provider.h
@@ -3,6 +3,8 @@
 
 #pragma once
 
+#include "opentelemetry/common/key_value_iterable.h"
+#include "opentelemetry/common/key_value_iterable_view.h"
 #include "opentelemetry/nostd/shared_ptr.h"
 #include "opentelemetry/nostd/string_view.h"
 #include "opentelemetry/version.h"
@@ -20,15 +22,106 @@ class OPENTELEMETRY_EXPORT TracerProvider
 {
 public:
   virtual ~TracerProvider() = default;
+
+#if OPENTELEMETRY_ABI_VERSION_NO >= 2
+
+  /**
+   * Gets or creates a named Tracer instance (ABI).
+   *
+   * @since ABI_VERSION 2
+   *
+   * @param[in] name Tracer instrumentation scope
+   * @param[in] version Instrumentation scope version
+   * @param[in] schema_url Instrumentation scope schema URL
+   * @param[in] attributes Instrumentation scope attributes (optional, may be nullptr)
+   */
+  virtual nostd::shared_ptr<Tracer> GetTracer(
+      nostd::string_view name,
+      nostd::string_view version,
+      nostd::string_view schema_url,
+      const common::KeyValueIterable *attributes) noexcept = 0;
+
+  /**
+   * Gets or creates a named Tracer instance (API helper).
+   *
+   * @since ABI_VERSION 2
+   *
+   * @param[in] name Tracer instrumentation scope
+   * @param[in] version Instrumentation scope version, optional
+   * @param[in] schema_url Instrumentation scope schema URL, optional
+   */
+  nostd::shared_ptr<Tracer> GetTracer(nostd::string_view name,
+                                      nostd::string_view version    = "",
+                                      nostd::string_view schema_url = "")
+  {
+    return GetTracer(name, version, schema_url, nullptr);
+  }
+
+  /**
+   * Gets or creates a named Tracer instance (API helper).
+   *
+   * @since ABI_VERSION 2
+   *
+   * @param[in] name Tracer instrumentation scope
+   * @param[in] version Instrumentation scope version
+   * @param[in] schema_url Instrumentation scope schema URL
+   * @param[in] attributes Instrumentation scope attributes
+   */
+  nostd::shared_ptr<Tracer> GetTracer(
+      nostd::string_view name,
+      nostd::string_view version,
+      nostd::string_view schema_url,
+      std::initializer_list<std::pair<nostd::string_view, common::AttributeValue>> attributes)
+  {
+    /* Build a container from std::initializer_list. */
+    nostd::span<const std::pair<nostd::string_view, common::AttributeValue>> attributes_span{
+        attributes.begin(), attributes.end()};
+
+    /* Build a view on the container. */
+    common::KeyValueIterableView<
+        nostd::span<const std::pair<nostd::string_view, common::AttributeValue>>>
+        iterable_attributes{attributes_span};
+
+    /* Add attributes using the view. */
+    return GetTracer(name, version, schema_url, &iterable_attributes);
+  }
+
+  /**
+   * Gets or creates a named Tracer instance (API helper).
+   *
+   * @since ABI_VERSION 2
+   *
+   * @param[in] name Tracer instrumentation scope
+   * @param[in] version Instrumentation scope version
+   * @param[in] schema_url Instrumentation scope schema URL
+   * @param[in] attributes Instrumentation scope attributes container
+   */
+  template <class T,
+            nostd::enable_if_t<common::detail::is_key_value_iterable<T>::value> * = nullptr>
+  nostd::shared_ptr<Tracer> GetTracer(nostd::string_view name,
+                                      nostd::string_view version,
+                                      nostd::string_view schema_url,
+                                      const T &attributes)
+  {
+    /* Build a view on the container. */
+    common::KeyValueIterableView<T> iterable_attributes(attributes);
+
+    /* Add attributes using the view. */
+    return GetTracer(name, version, schema_url, &iterable_attributes);
+  }
+
+#else
+
   /**
    * Gets or creates a named tracer instance.
    *
    * Optionally a version can be passed to create a named and versioned tracer
    * instance.
    */
-  virtual nostd::shared_ptr<Tracer> GetTracer(nostd::string_view library_name,
-                                              nostd::string_view library_version = "",
-                                              nostd::string_view schema_url      = "") noexcept = 0;
+  virtual nostd::shared_ptr<Tracer> GetTracer(nostd::string_view name,
+                                              nostd::string_view version    = "",
+                                              nostd::string_view schema_url = "") noexcept = 0;
+#endif
 };
 }  // namespace trace
 OPENTELEMETRY_END_NAMESPACE

--- a/api/test/singleton/singleton_test.cc
+++ b/api/test/singleton/singleton_test.cc
@@ -264,13 +264,25 @@ public:
     return result;
   }
 
-  nostd::shared_ptr<trace::Tracer> GetTracer(nostd::string_view /* library_name */,
-                                             nostd::string_view /* library_version */,
+#if OPENTELEMETRY_ABI_VERSION_NO >= 2
+  nostd::shared_ptr<trace::Tracer> GetTracer(
+      nostd::string_view /* name */,
+      nostd::string_view /* version */,
+      nostd::string_view /* schema_url */,
+      const common::KeyValueIterable * /* attributes */) noexcept override
+  {
+    nostd::shared_ptr<trace::Tracer> result(new MyTracer());
+    return result;
+  }
+#else
+  nostd::shared_ptr<trace::Tracer> GetTracer(nostd::string_view /* name */,
+                                             nostd::string_view /* version */,
                                              nostd::string_view /* schema_url */) noexcept override
   {
     nostd::shared_ptr<trace::Tracer> result(new MyTracer());
     return result;
   }
+#endif
 };
 
 void setup_otel()

--- a/api/test/trace/provider_test.cc
+++ b/api/test/trace/provider_test.cc
@@ -3,6 +3,7 @@
 
 #include "opentelemetry/trace/provider.h"
 #include "opentelemetry/nostd/shared_ptr.h"
+#include "opentelemetry/trace/tracer_provider.h"
 
 #include <gtest/gtest.h>
 
@@ -14,12 +15,24 @@ namespace nostd = opentelemetry::nostd;
 
 class TestProvider : public TracerProvider
 {
-  nostd::shared_ptr<Tracer> GetTracer(nostd::string_view /* library_name */,
-                                      nostd::string_view /* library_version */,
+
+#if OPENTELEMETRY_ABI_VERSION_NO >= 2
+  nostd::shared_ptr<Tracer> GetTracer(
+      nostd::string_view /* name */,
+      nostd::string_view /* version */,
+      nostd::string_view /* schema_url */,
+      const opentelemetry::common::KeyValueIterable * /* attributes */) noexcept override
+  {
+    return nostd::shared_ptr<Tracer>(nullptr);
+  }
+#else
+  nostd::shared_ptr<Tracer> GetTracer(nostd::string_view /* name */,
+                                      nostd::string_view /* version */,
                                       nostd::string_view /* schema_url */) noexcept override
   {
     return nostd::shared_ptr<Tracer>(nullptr);
   }
+#endif
 };
 
 TEST(Provider, GetTracerProviderDefault)

--- a/sdk/include/opentelemetry/sdk/trace/tracer_provider.h
+++ b/sdk/include/opentelemetry/sdk/trace/tracer_provider.h
@@ -63,10 +63,23 @@ public:
 
   ~TracerProvider() override;
 
+  /*
+    Make sure GetTracer() helpers from the API are seen in overload resolution.
+  */
+  using opentelemetry::trace::TracerProvider::GetTracer;
+
+#if OPENTELEMETRY_ABI_VERSION_NO >= 2
   opentelemetry::nostd::shared_ptr<opentelemetry::trace::Tracer> GetTracer(
-      nostd::string_view library_name,
-      nostd::string_view library_version = "",
-      nostd::string_view schema_url      = "") noexcept override;
+      nostd::string_view name,
+      nostd::string_view version,
+      nostd::string_view schema_url,
+      const opentelemetry::common::KeyValueIterable *attributes) noexcept override;
+#else
+  opentelemetry::nostd::shared_ptr<opentelemetry::trace::Tracer> GetTracer(
+      nostd::string_view name,
+      nostd::string_view version    = "",
+      nostd::string_view schema_url = "") noexcept override;
+#endif
 
   /**
    * Attaches a span processor to list of configured processors for this tracer provider.

--- a/sdk/test/trace/tracer_provider_test.cc
+++ b/sdk/test/trace/tracer_provider_test.cc
@@ -78,6 +78,143 @@ TEST(TracerProvider, GetTracer)
   ASSERT_EQ(instrumentation_scope3.GetVersion(), "1.0.0");
 }
 
+#if OPENTELEMETRY_ABI_VERSION_NO >= 2
+TEST(TracerProvider, GetTracerAbiv2)
+{
+  std::unique_ptr<SpanProcessor> processor(new SimpleSpanProcessor(nullptr));
+  std::vector<std::unique_ptr<SpanProcessor>> processors;
+  processors.push_back(std::move(processor));
+  std::unique_ptr<TracerContext> context1(
+      new TracerContext(std::move(processors), Resource::Create({})));
+  TracerProvider tp(std::move(context1));
+
+  auto t1 = tp.GetTracer("name1", "version1", "url1");
+  ASSERT_NE(nullptr, t1);
+
+  auto t2 = tp.GetTracer("name2", "version2", "url2", nullptr);
+  ASSERT_NE(nullptr, t2);
+
+  auto t3 = tp.GetTracer("name3", "version3", "url3", {{"accept_single_attr", true}});
+  ASSERT_NE(nullptr, t3);
+  {
+    auto tracer = static_cast<opentelemetry::sdk::trace::Tracer *>(t3.get());
+    auto scope  = tracer->GetInstrumentationScope();
+    auto attrs  = scope.GetAttributes();
+    ASSERT_EQ(attrs.size(), 1);
+    auto attr = attrs.find("accept_single_attr");
+    ASSERT_FALSE(attr == attrs.end());
+    ASSERT_TRUE(opentelemetry::nostd::holds_alternative<bool>(attr->second));
+    EXPECT_EQ(opentelemetry::nostd::get<bool>(attr->second), true);
+  }
+
+  std::pair<opentelemetry::nostd::string_view, opentelemetry::common::AttributeValue> attr4 = {
+      "accept_single_attr", true};
+  auto t4 = tp.GetTracer("name4", "version4", "url4", {attr4});
+  ASSERT_NE(nullptr, t4);
+  {
+    auto tracer = static_cast<opentelemetry::sdk::trace::Tracer *>(t4.get());
+    auto scope  = tracer->GetInstrumentationScope();
+    auto attrs  = scope.GetAttributes();
+    ASSERT_EQ(attrs.size(), 1);
+    auto attr = attrs.find("accept_single_attr");
+    ASSERT_FALSE(attr == attrs.end());
+    ASSERT_TRUE(opentelemetry::nostd::holds_alternative<bool>(attr->second));
+    EXPECT_EQ(opentelemetry::nostd::get<bool>(attr->second), true);
+  }
+
+  auto t5 = tp.GetTracer("name5", "version5", "url5", {{"foo", "1"}, {"bar", "2"}});
+  ASSERT_NE(nullptr, t5);
+  {
+    auto tracer = static_cast<opentelemetry::sdk::trace::Tracer *>(t5.get());
+    auto scope  = tracer->GetInstrumentationScope();
+    auto attrs  = scope.GetAttributes();
+    ASSERT_EQ(attrs.size(), 2);
+    auto attr = attrs.find("bar");
+    ASSERT_FALSE(attr == attrs.end());
+    ASSERT_TRUE(opentelemetry::nostd::holds_alternative<std::string>(attr->second));
+    EXPECT_EQ(opentelemetry::nostd::get<std::string>(attr->second), "2");
+  }
+
+  std::initializer_list<
+      std::pair<opentelemetry::nostd::string_view, opentelemetry::common::AttributeValue>>
+      attrs6 = {{"foo", "1"}, {"bar", 42}};
+
+  auto t6 = tp.GetTracer("name6", "version6", "url6", attrs6);
+  ASSERT_NE(nullptr, t6);
+  {
+    auto tracer = static_cast<opentelemetry::sdk::trace::Tracer *>(t6.get());
+    auto scope  = tracer->GetInstrumentationScope();
+    auto attrs  = scope.GetAttributes();
+    ASSERT_EQ(attrs.size(), 2);
+    auto attr = attrs.find("bar");
+    ASSERT_FALSE(attr == attrs.end());
+    ASSERT_TRUE(opentelemetry::nostd::holds_alternative<int>(attr->second));
+    EXPECT_EQ(opentelemetry::nostd::get<int>(attr->second), 42);
+  }
+
+  typedef std::pair<opentelemetry::nostd::string_view, opentelemetry::common::AttributeValue> KV;
+
+  std::initializer_list<KV> attrs7 = {{"foo", 3.14}, {"bar", "2"}};
+  auto t7                          = tp.GetTracer("name7", "version7", "url7", attrs7);
+  ASSERT_NE(nullptr, t7);
+  {
+    auto tracer = static_cast<opentelemetry::sdk::trace::Tracer *>(t7.get());
+    auto scope  = tracer->GetInstrumentationScope();
+    auto attrs  = scope.GetAttributes();
+    ASSERT_EQ(attrs.size(), 2);
+    auto attr = attrs.find("foo");
+    ASSERT_FALSE(attr == attrs.end());
+    ASSERT_TRUE(opentelemetry::nostd::holds_alternative<double>(attr->second));
+    EXPECT_EQ(opentelemetry::nostd::get<double>(attr->second), 3.14);
+  }
+
+  auto t8 = tp.GetTracer("name8", "version8", "url8",
+                         {{"a", "string"},
+                          {"b", false},
+                          {"c", 314159},
+                          {"d", (unsigned int)314159},
+                          {"e", (int32_t)-20},
+                          {"f", (uint32_t)20},
+                          {"g", (int64_t)-20},
+                          {"h", (uint64_t)20},
+                          {"i", 3.1},
+                          {"j", "string"}});
+  ASSERT_NE(nullptr, t8);
+  {
+    auto tracer = static_cast<opentelemetry::sdk::trace::Tracer *>(t8.get());
+    auto scope  = tracer->GetInstrumentationScope();
+    auto attrs  = scope.GetAttributes();
+    ASSERT_EQ(attrs.size(), 10);
+    auto attr = attrs.find("e");
+    ASSERT_FALSE(attr == attrs.end());
+    ASSERT_TRUE(opentelemetry::nostd::holds_alternative<int32_t>(attr->second));
+    EXPECT_EQ(opentelemetry::nostd::get<int32_t>(attr->second), -20);
+  }
+
+  std::map<std::string, opentelemetry::common::AttributeValue> attr9{
+      {"a", "string"},     {"b", false},        {"c", 314159},       {"d", (unsigned int)314159},
+      {"e", (int32_t)-20}, {"f", (uint32_t)20}, {"g", (int64_t)-20}, {"h", (uint64_t)20},
+      {"i", 3.1},          {"j", "string"}};
+
+  auto t9 = tp.GetTracer("name9", "version9", "url9", attr9);
+  ASSERT_NE(nullptr, t9);
+  {
+    auto tracer = static_cast<opentelemetry::sdk::trace::Tracer *>(t9.get());
+    auto scope  = tracer->GetInstrumentationScope();
+    auto attrs  = scope.GetAttributes();
+    ASSERT_EQ(attrs.size(), 10);
+    auto attr = attrs.find("h");
+    ASSERT_FALSE(attr == attrs.end());
+    ASSERT_TRUE(opentelemetry::nostd::holds_alternative<uint64_t>(attr->second));
+    EXPECT_EQ(opentelemetry::nostd::get<uint64_t>(attr->second), 20);
+  }
+
+  // cleanup properly without crash
+  tp.ForceFlush();
+  tp.Shutdown();
+}
+#endif /* OPENTELEMETRY_ABI_VERSION_NO >= 2 */
+
 TEST(TracerProvider, Shutdown)
 {
   std::unique_ptr<SpanProcessor> processor(new SimpleSpanProcessor(nullptr));


### PR DESCRIPTION
Fixes #2032

## Changes

Please provide a brief description of the changes here.

API:

* Implemented a new `GetTracer()` api with 4 parameters, only available in `ABI VERSION 2`
* Renamed parameters to be consistent with the spec.

For significant contributions please make sure you have completed the following items:

* [X] `CHANGELOG.md` updated for non-trivial changes
* [X] Unit tests have been added
* [X] Changes in public API reviewed