### PR TITLE
[SDK] Metrics ObservableRegistry Cleanup

### DIFF
--- a/sdk/include/opentelemetry/sdk/metrics/async_instruments.h
+++ b/sdk/include/opentelemetry/sdk/metrics/async_instruments.h
@@ -25,6 +25,7 @@ public:
   ObservableInstrument(InstrumentDescriptor instrument_descriptor,
                        std::unique_ptr<AsyncWritableMetricStorage> storage,
                        std::shared_ptr<ObservableRegistry> observable_registry);
+  ~ObservableInstrument() override;
 
   void AddCallback(opentelemetry::metrics::ObservableCallbackPtr callback,
                    void *state) noexcept override;

--- a/sdk/include/opentelemetry/sdk/metrics/state/observable_registry.h
+++ b/sdk/include/opentelemetry/sdk/metrics/state/observable_registry.h
@@ -35,6 +35,8 @@ public:
                       void *state,
                       opentelemetry::metrics::ObservableInstrument *instrument);
 
+  void CleanupCallback(opentelemetry::metrics::ObservableInstrument *instrument);
+
   void Observe(opentelemetry::common::SystemTimestamp collection_ts);
 
 private:

--- a/sdk/src/metrics/async_instruments.cc
+++ b/sdk/src/metrics/async_instruments.cc
@@ -21,6 +21,11 @@ ObservableInstrument::ObservableInstrument(InstrumentDescriptor instrument_descr
 
 {}
 
+ObservableInstrument::~ObservableInstrument()
+{
+  observable_registry_->CleanupCallback(this);
+}
+
 void ObservableInstrument::AddCallback(opentelemetry::metrics::ObservableCallbackPtr callback,
                                        void *state) noexcept
 {

--- a/sdk/src/metrics/state/observable_registry.cc
+++ b/sdk/src/metrics/state/observable_registry.cc
@@ -41,11 +41,10 @@ void ObservableRegistry::RemoveCallback(opentelemetry::metrics::ObservableCallba
 void ObservableRegistry::CleanupCallback(opentelemetry::metrics::ObservableInstrument *instrument)
 {
   std::lock_guard<std::mutex> lock_guard{callbacks_m_};
-  auto iter = std::remove_if(
-      callbacks_.begin(), callbacks_.end(),
-      [instrument](const std::unique_ptr<ObservableCallbackRecord> &record) {
-        return record->instrument == instrument;
-      });
+  auto iter = std::remove_if(callbacks_.begin(), callbacks_.end(),
+                             [instrument](const std::unique_ptr<ObservableCallbackRecord> &record) {
+                               return record->instrument == instrument;
+                             });
   callbacks_.erase(iter, callbacks_.end());
 }
 

--- a/sdk/src/metrics/state/observable_registry.cc
+++ b/sdk/src/metrics/state/observable_registry.cc
@@ -38,6 +38,17 @@ void ObservableRegistry::RemoveCallback(opentelemetry::metrics::ObservableCallba
   callbacks_.erase(new_end, callbacks_.end());
 }
 
+void ObservableRegistry::CleanupCallback(opentelemetry::metrics::ObservableInstrument *instrument)
+{
+  std::lock_guard<std::mutex> lock_guard{callbacks_m_};
+  auto iter = std::remove_if(
+      callbacks_.begin(), callbacks_.end(),
+      [instrument](const std::unique_ptr<ObservableCallbackRecord> &record) {
+        return record->instrument == instrument;
+      });
+  callbacks_.erase(iter, callbacks_.end());
+}
+
 void ObservableRegistry::Observe(opentelemetry::common::SystemTimestamp collection_ts)
 {
   std::lock_guard<std::mutex> lock_guard{callbacks_m_};


### PR DESCRIPTION
Fixes #2373, #2081 

## Changes

Added a function called CleanupCallbacks to ObservableRegistry that is called from the destructor of ObservableInstrument to remove back pointers from the registry. 

For significant contributions please make sure you have completed the following items:

* [ ] `CHANGELOG.md` updated for non-trivial changes
* [ ] Unit tests have been added
* [ ] Changes in public API reviewed