### PR TITLE
[BUILD] Make WITH_OTLP_HTTP_SSL_PREVIEW mainstream

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,19 @@ Increment the:
 
 * [BUILD] Remove WITH_REMOVE_METER_PREVIEW, use WITH_ABI_VERSION_2 instead
   [#2370](https://github.com/open-telemetry/opentelemetry-cpp/pull/2370)
+* [BUILD] Make WITH_OTLP_HTTP_SSL_PREVIEW mainstream
+  [#2378](https://github.com/open-telemetry/opentelemetry-cpp/pull/2378)
+
+Important changes:
+
+* [BUILD] Make WITH_OTLP_HTTP_SSL_PREVIEW mainstream
+  [#2378](https://github.com/open-telemetry/opentelemetry-cpp/pull/2378)
+  * The experimental `CMake` option `WITH_OTLP_HTTP_SSL_PREVIEW`
+    is now promoted to stable. The default is changed to `ON`.
+  * The experimental `CMake` option `WITH_OTLP_HTTP_SSL_TLS_PREVIEW`
+    is now promoted to stable. The default is changed to `ON`.
+  * These build options are scheduled to be removed by the next release,
+    building without SSL/TLS will no longer be possible.
 
 Breaking changes:
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -275,12 +275,12 @@ endif()
 
 option(WITH_ASYNC_EXPORT_PREVIEW "Whether to enable async export" OFF)
 
-# EXPERIMENTAL
-option(WITH_OTLP_HTTP_SSL_PREVIEW "Whether to enable otlp http ssl export" OFF)
+# STABLE
+option(WITH_OTLP_HTTP_SSL_PREVIEW "Whether to enable otlp http ssl export" ON)
 
-# EXPERIMENTAL
+# STABLE
 option(WITH_OTLP_HTTP_SSL_TLS_PREVIEW
-       "Whether to enable otlp http ssl tls min/max/cipher options" OFF)
+       "Whether to enable otlp http ssl tls min/max/cipher options" ON)
 
 # Exemplar specs status is experimental, so behind feature flag by default
 option(WITH_METRICS_EXEMPLAR_PREVIEW


### PR DESCRIPTION
Fixes #2365

## Changes

Please provide a brief description of the changes here.

* Promote option `WITH_OTLP_HTTP_SSL_PREVIEW` from experimental to stable
* Promote option `WITH_OTLP_HTTP_SSL_TLS_PREVIEW` from experimental to stable
* Change default for both to `ON`

After this change, SSL and TLS options will be included by default in the build.
It will still be possible to exclude the feature from the build, by setting options to `OFF`, only in release 1.13.0.

## Future planned changes

Once this change is shipped as part of the next release (v1.13.0), a subsequent PR will remove the options entirely for release 1.14.0.

For significant contributions please make sure you have completed the following items:

* [X] `CHANGELOG.md` updated for non-trivial changes
* [ ] Unit tests have been added
* [ ] Changes in public API reviewed