### PR TITLE
[SDK] Creating DoubleUpDownCounter with no matching view

### DIFF
--- a/sdk/include/opentelemetry/sdk/metrics/aggregation/default_aggregation.h
+++ b/sdk/include/opentelemetry/sdk/metrics/aggregation/default_aggregation.h
@@ -35,7 +35,8 @@ public:
       case AggregationType::kSum:
         return (instrument_descriptor.value_type_ == InstrumentValueType::kLong)
                    ? std::move(std::unique_ptr<Aggregation>(new LongSumAggregation(is_monotonic)))
-                   : std::move(std::unique_ptr<Aggregation>(new DoubleSumAggregation(true)));
+                   : std::move(
+                         std::unique_ptr<Aggregation>(new DoubleSumAggregation(is_monotonic)));
         break;
       case AggregationType::kHistogram: {
         if (instrument_descriptor.value_type_ == InstrumentValueType::kLong)

--- a/sdk/test/metrics/sum_aggregation_test.cc
+++ b/sdk/test/metrics/sum_aggregation_test.cc
@@ -128,24 +128,25 @@ TEST_P(UpDownCounterToSumFixture, Double)
 {
   bool is_matching_view = GetParam();
   MeterProvider mp;
-  auto m                                  = mp.GetMeter("meter1", "version1", "schema1");
-  std::string instrument_name             = "updowncounter1";
-  std::string instrument_name_nonmatching = "updowncounter1_nonmatching";
-  std::string instrument_desc             = "updowncounter desc";
-  std::string instrument_unit             = "ms";
+  auto m                      = mp.GetMeter("meter1", "version1", "schema1");
+  std::string instrument_name = "updowncounter1";
+  std::string instrument_desc = "updowncounter desc";
+  std::string instrument_unit = "ms";
 
   std::unique_ptr<MockMetricExporter> exporter(new MockMetricExporter());
   std::shared_ptr<MetricReader> reader{new MockMetricReader(std::move(exporter))};
   mp.AddMetricReader(reader);
 
-  std::unique_ptr<View> view{
-      new View("view1", "view1_description", instrument_unit, AggregationType::kSum)};
-  std::unique_ptr<InstrumentSelector> instrument_selector{new InstrumentSelector(
-      InstrumentType::kUpDownCounter,
-      is_matching_view ? instrument_name : instrument_name_nonmatching, instrument_unit)};
-  std::unique_ptr<MeterSelector> meter_selector{new MeterSelector("meter1", "version1", "schema1")};
-  mp.AddView(std::move(instrument_selector), std::move(meter_selector), std::move(view));
-
+  if (is_matching_view)
+  {
+    std::unique_ptr<View> view{
+        new View("view1", "view1_description", instrument_unit, AggregationType::kSum)};
+    std::unique_ptr<InstrumentSelector> instrument_selector{
+        new InstrumentSelector(InstrumentType::kUpDownCounter, instrument_name, instrument_unit)};
+    std::unique_ptr<MeterSelector> meter_selector{
+        new MeterSelector("meter1", "version1", "schema1")};
+    mp.AddView(std::move(instrument_selector), std::move(meter_selector), std::move(view));
+  }
   auto h = m->CreateDoubleUpDownCounter(instrument_name, instrument_desc, instrument_unit);
 
   h->Add(5, {});


### PR DESCRIPTION
Fixes #2377

## Changes

In case of a matching view, the SDK picks the Aggregation with correct monotonic for DoubleUpDownCounter as [here](https://github.com/open-telemetry/opentelemetry-cpp/blob/231ca4ade18c8cf691c9520d174b518feae78f35/sdk/include/opentelemetry/sdk/metrics/aggregation/default_aggregation.h#L106). The problem was in the logic when there is no matching view, which is fixed now. Also added test for this scenario.

For significant contributions please make sure you have completed the following items:

* [ ] `CHANGELOG.md` updated for non-trivial changes
* [x] Unit tests have been added
* [x] Changes in public API reviewed