### PR TITLE
[BUILD] Fix cpack broken package version

### DIFF
--- a/cmake/package.cmake
+++ b/cmake/package.cmake
@@ -1,6 +1,7 @@
 # Copyright The OpenTelemetry Authors
 # SPDX-License-Identifier: Apache-2.0
 
+set(CPACK_PACKAGE_VERSION "${OPENTELEMETRY_VERSION}")
 set(CPACK_PACKAGE_DESCRIPTION "OpenTelemetry C++ for Linux")
 set(CPACK_PACKAGE_DESCRIPTION_SUMMARY "OpenTelemetry C++ for Linux - C++ Implementation of OpenTelemetry Specification")
 set(CPACK_PACKAGE_VENDOR "OpenTelemetry")


### PR DESCRIPTION
## Changes

At the moment, when I follow the instructions for generating binary packages ([link](https://github.com/open-telemetry/opentelemetry-cpp/blob/main/INSTALL.md#generating-binary-packages)), I can create a rpm with the correct name, but it has the wrong version configured (e.g. `0.1.1` instead of `1.12.0`):

```bash
$ rpm -qip opentelemetry-cpp-1.12.0-centos-7-x86_64.rpm
Name        : opentelemetry-cpp
----> Version     : 0.1.1
Release     : 1
Architecture: x86_64
Install Date: (not installed)
Group       : unknown
Size        : 55377670
License     : Apache-2.0
Signature   : (none)
Source RPM  : opentelemetry-cpp-0.1.1-1.src.rpm
Build Date  : Wed Oct 25 17:31:13 2023
Build Host  : [removed]
Relocations : /usr
Vendor      : OpenTelemetry
URL         : https://opentelemetry.io/
Summary     : OpenTelemetry C++ for Linux - C++ Implementation of OpenTelemetry Specification
Description :
DESCRIPTION
===========

This is an installer created using CPack (https://cmake.org). No additional installation instructions provided.
```

This minor fix solves that problem:

```bash
$ rpm -qip opentelemetry-cpp-1.12.0-centos-7-x86_64.rpm
Name        : opentelemetry-cpp
----> Version     : 1.12.0
Release     : 1
Architecture: x86_64
Install Date: (not installed)
Group       : unknown
Size        : 60969267
License     : Apache-2.0
Signature   : (none)
Source RPM  : opentelemetry-cpp-1.12.0-1.src.rpm
Build Date  : Wed Oct 25 16:33:02 2023
Build Host  : [removed]
Relocations : /usr
Vendor      : OpenTelemetry
Summary     : OpenTelemetry C++ for Linux - C++ Implementation of OpenTelemetry Specification
Description :
DESCRIPTION
===========

This is an installer created using CPack (https://cmake.org). No additional installation instructions provided.
```