### PR TITLE
[opentracing-shim] Add check for sampled context

### DIFF
--- a/opentracing-shim/test/tracer_shim_test.cc
+++ b/opentracing-shim/test/tracer_shim_test.cc
@@ -211,6 +211,7 @@ TEST_F(TracerShimTest, ExtractOnlyBaggage)
   auto span_context_shim = static_cast<shim::SpanContextShim *>(span_context.value().get());
   ASSERT_TRUE(span_context_shim != nullptr);
   ASSERT_FALSE(span_context_shim->context().IsValid());
+  ASSERT_FALSE(span_context_shim->context().IsSampled());
   ASSERT_FALSE(shim::utils::isBaggageEmpty(span_context_shim->baggage()));
 
   std::string value;


### PR DESCRIPTION
Fixes # (issue)

## Changes

Adhere to change in opentelemetry-specification commit [Allow invalid but sampled SpanContext to be returned](https://github.com/open-telemetry/opentelemetry-specification/commit/b9c8a02f64ba86501b995649e957bba44e6712f5)

For significant contributions please make sure you have completed the following items:

* [ ] `CHANGELOG.md` updated for non-trivial changes
* [ ] Unit tests have been added
* [ ] Changes in public API reviewed