### PR TITLE
[BUILD] Add missing includes to runtime_context_test

### DIFF
--- a/api/test/context/runtime_context_test.cc
+++ b/api/test/context/runtime_context_test.cc
@@ -4,6 +4,9 @@
 #include "opentelemetry/context/runtime_context.h"
 #include "opentelemetry/context/context.h"
 
+#include <algorithm>
+#include <map>
+
 #include <gtest/gtest.h>
 
 using namespace opentelemetry;


### PR DESCRIPTION
Fixes a build error when building opentelemetry-cpp with the following config:
```
cmake .. -DWITH_STL=ON -DCMAKE_CXX_STANDARD=20
```
Building ``WITH_STL=ON`` in Windows x64 with Visual Studio 2022 causes the following errors:
```
D:\repos\test\opentelemetry-cpp\api\test\context\runtime_context_test.cc(134,17): error C2039: 'next_permutation': is not a member of 'std' [D:\repos\test\opentelemetry-cpp\build\api\test\context\runtime_cont
ext_test.vcxproj]
D:\vcpkg\installed\x64-windows\include\gtest/internal/gtest-internal.h(1324,11): message : see declaration of 'std' [D:\repos\test\opentelemetry-cpp\build\api\test\context\runtime_context_test.vcxproj]
D:\repos\test\opentelemetry-cpp\api\test\context\runtime_context_test.cc(134,33): error C3861: 'next_permutation': identifier not found [D:\repos\test\opentelemetry-cpp\build\api\test\context\runtime_context_
test.vcxproj]
```
Building in linux with the same configuration using gcc 11.4.0 or clang-14 does not produce any errors, so the issue must be specific to MSVC. 

Thanks to @Dangeroustuber for pointing out this issue. 

## Changes

Added the missing includes to the runtime_context_test.cc file. 

For significant contributions please make sure you have completed the following items:

* [ ] `CHANGELOG.md` updated for non-trivial changes
* [ ] Unit tests have been added
* [ ] Changes in public API reviewed