### PR TITLE
[BUILD] Remove defining NOMINMAX from api

### DIFF
--- a/api/CMakeLists.txt
+++ b/api/CMakeLists.txt
@@ -104,7 +104,6 @@ if(WITH_NO_GETENV)
 endif()
 
 if(WIN32)
-  target_compile_definitions(opentelemetry_api INTERFACE NOMINMAX)
   if(WITH_ETW)
     target_compile_definitions(opentelemetry_api INTERFACE HAVE_MSGPACK)
   endif()

--- a/api/include/opentelemetry/common/spin_lock_mutex.h
+++ b/api/include/opentelemetry/common/spin_lock_mutex.h
@@ -10,9 +10,6 @@
 #include "opentelemetry/version.h"
 
 #if defined(_MSC_VER)
-#  ifndef NOMINMAX
-#    define NOMINMAX
-#  endif
 #  define _WINSOCKAPI_  // stops including winsock.h
 #  include <windows.h>
 #elif defined(__i386__) || defined(__x86_64__)

--- a/api/include/opentelemetry/common/timestamp.h
+++ b/api/include/opentelemetry/common/timestamp.h
@@ -178,7 +178,7 @@ public:
       std::chrono::duration<Rep, Period> indefinite_value) noexcept
   {
     // Do not call now() when this duration is max value, now() may have a expensive cost.
-    if (timeout == std::chrono::duration<Rep, Period>::max())
+    if (timeout == (std::chrono::duration<Rep, Period>::max)())
     {
       return indefinite_value;
     }
@@ -186,13 +186,13 @@ public:
     // std::future<T>::wait_for, std::this_thread::sleep_for, and std::condition_variable::wait_for
     // may use steady_clock or system_clock.We need make sure now() + timeout do not overflow.
     auto max_timeout = std::chrono::duration_cast<std::chrono::duration<Rep, Period>>(
-        std::chrono::steady_clock::time_point::max() - std::chrono::steady_clock::now());
+        (std::chrono::steady_clock::time_point::max)() - std::chrono::steady_clock::now());
     if (timeout >= max_timeout)
     {
       return indefinite_value;
     }
     max_timeout = std::chrono::duration_cast<std::chrono::duration<Rep, Period>>(
-        std::chrono::system_clock::time_point::max() - std::chrono::system_clock::now());
+        (std::chrono::system_clock::time_point::max)() - std::chrono::system_clock::now());
     if (timeout >= max_timeout)
     {
       return indefinite_value;

--- a/api/include/opentelemetry/plugin/detail/dynamic_load_windows.h
+++ b/api/include/opentelemetry/plugin/detail/dynamic_load_windows.h
@@ -12,9 +12,6 @@
 #include "opentelemetry/plugin/hook.h"
 #include "opentelemetry/version.h"
 
-#ifndef NOMINMAX
-#  define NOMINMAX
-#endif
 #include <Windows.h>
 
 #include <WinBase.h>

--- a/exporters/ostream/include/opentelemetry/exporters/ostream/log_record_exporter.h
+++ b/exporters/ostream/include/opentelemetry/exporters/ostream/log_record_exporter.h
@@ -47,13 +47,13 @@ public:
    * @return return true when all data are exported, and false when timeout
    */
   bool ForceFlush(
-      std::chrono::microseconds timeout = std::chrono::microseconds::max()) noexcept override;
+      std::chrono::microseconds timeout = (std::chrono::microseconds::max)()) noexcept override;
 
   /**
    * Marks the OStream Log Exporter as shut down.
    */
   bool Shutdown(
-      std::chrono::microseconds timeout = std::chrono::microseconds::max()) noexcept override;
+      std::chrono::microseconds timeout = (std::chrono::microseconds::max)()) noexcept override;
 
 private:
   // The OStream to send the logs to

--- a/exporters/ostream/include/opentelemetry/exporters/ostream/span_exporter.h
+++ b/exporters/ostream/include/opentelemetry/exporters/ostream/span_exporter.h
@@ -44,10 +44,10 @@ public:
    * @return return true when all data are exported, and false when timeout
    */
   bool ForceFlush(
-      std::chrono::microseconds timeout = std::chrono::microseconds::max()) noexcept override;
+      std::chrono::microseconds timeout = (std::chrono::microseconds::max)()) noexcept override;
 
   bool Shutdown(
-      std::chrono::microseconds timeout = std::chrono::microseconds::max()) noexcept override;
+      std::chrono::microseconds timeout = (std::chrono::microseconds::max)()) noexcept override;
 
 private:
   std::ostream &sout_;

--- a/exporters/zipkin/include/opentelemetry/exporters/zipkin/zipkin_exporter.h
+++ b/exporters/zipkin/include/opentelemetry/exporters/zipkin/zipkin_exporter.h
@@ -55,14 +55,14 @@ public:
    * @return return true when all data are exported, and false when timeout
    */
   bool ForceFlush(
-      std::chrono::microseconds timeout = std::chrono::microseconds::max()) noexcept override;
+      std::chrono::microseconds timeout = (std::chrono::microseconds::max)()) noexcept override;
 
   /**
    * Shut down the exporter.
    * @param timeout an optional timeout, default to max.
    */
   bool Shutdown(
-      std::chrono::microseconds timeout = std::chrono::microseconds::max()) noexcept override;
+      std::chrono::microseconds timeout = (std::chrono::microseconds::max)()) noexcept override;
 
 private:
   void InitializeLocalEndpoint();

--- a/sdk/include/opentelemetry/sdk/logs/exporter.h
+++ b/sdk/include/opentelemetry/sdk/logs/exporter.h
@@ -62,7 +62,7 @@ public:
    * @return true if the exporter shutdown succeeded, false otherwise
    */
   virtual bool Shutdown(
-      std::chrono::microseconds timeout = std::chrono::microseconds::max()) noexcept = 0;
+      std::chrono::microseconds timeout = (std::chrono::microseconds::max)()) noexcept = 0;
 };
 }  // namespace logs
 }  // namespace sdk

--- a/sdk/include/opentelemetry/sdk/logs/logger_context.h
+++ b/sdk/include/opentelemetry/sdk/logs/logger_context.h
@@ -70,7 +70,7 @@ public:
   /**
    * Shutdown the log processor associated with this tracer provider.
    */
-  bool Shutdown(std::chrono::microseconds timeout = std::chrono::microseconds::max()) noexcept;
+  bool Shutdown(std::chrono::microseconds timeout = (std::chrono::microseconds::max)()) noexcept;
 
 private:
   //  order of declaration is important here - resource object should be destroyed after processor.

--- a/sdk/include/opentelemetry/sdk/logs/processor.h
+++ b/sdk/include/opentelemetry/sdk/logs/processor.h
@@ -46,7 +46,7 @@ public:
    * @return a result code indicating whether it succeeded, failed or timed out
    */
   virtual bool ForceFlush(
-      std::chrono::microseconds timeout = std::chrono::microseconds::max()) noexcept = 0;
+      std::chrono::microseconds timeout = (std::chrono::microseconds::max)()) noexcept = 0;
 
   /**
    * Shuts down the processor and does any cleanup required.
@@ -56,7 +56,7 @@ public:
    * @return true if the shutdown succeeded, false otherwise
    */
   virtual bool Shutdown(
-      std::chrono::microseconds timeout = std::chrono::microseconds::max()) noexcept = 0;
+      std::chrono::microseconds timeout = (std::chrono::microseconds::max)()) noexcept = 0;
 };
 }  // namespace logs
 }  // namespace sdk

--- a/sdk/include/opentelemetry/sdk/logs/simple_log_record_processor.h
+++ b/sdk/include/opentelemetry/sdk/logs/simple_log_record_processor.h
@@ -39,10 +39,10 @@ public:
   void OnEmit(std::unique_ptr<Recordable> &&record) noexcept override;
 
   bool ForceFlush(
-      std::chrono::microseconds timeout = std::chrono::microseconds::max()) noexcept override;
+      std::chrono::microseconds timeout = (std::chrono::microseconds::max)()) noexcept override;
 
   bool Shutdown(
-      std::chrono::microseconds timeout = std::chrono::microseconds::max()) noexcept override;
+      std::chrono::microseconds timeout = (std::chrono::microseconds::max)()) noexcept override;
 
   bool IsShutdown() const noexcept;
 

--- a/sdk/include/opentelemetry/sdk/metrics/aggregation/histogram_aggregation.h
+++ b/sdk/include/opentelemetry/sdk/metrics/aggregation/histogram_aggregation.h
@@ -93,8 +93,8 @@ void HistogramMerge(HistogramPointData &current,
   merge.record_min_max_ = current.record_min_max_ && delta.record_min_max_;
   if (merge.record_min_max_)
   {
-    merge.min_ = std::min(nostd::get<T>(current.min_), nostd::get<T>(delta.min_));
-    merge.max_ = std::max(nostd::get<T>(current.max_), nostd::get<T>(delta.max_));
+    merge.min_ = (std::min)(nostd::get<T>(current.min_), nostd::get<T>(delta.min_));
+    merge.max_ = (std::max)(nostd::get<T>(current.max_), nostd::get<T>(delta.max_));
   }
 }
 

--- a/sdk/include/opentelemetry/sdk/metrics/metric_reader.h
+++ b/sdk/include/opentelemetry/sdk/metrics/metric_reader.h
@@ -48,12 +48,12 @@ public:
   /**
    * Shutdown the metric reader.
    */
-  bool Shutdown(std::chrono::microseconds timeout = std::chrono::microseconds::max()) noexcept;
+  bool Shutdown(std::chrono::microseconds timeout = (std::chrono::microseconds::max)()) noexcept;
 
   /**
    * Force flush the metric read by the reader.
    */
-  bool ForceFlush(std::chrono::microseconds timeout = std::chrono::microseconds::max()) noexcept;
+  bool ForceFlush(std::chrono::microseconds timeout = (std::chrono::microseconds::max)()) noexcept;
 
   /**
    * Return the status of Metric reader.

--- a/sdk/include/opentelemetry/sdk/metrics/state/metric_collector.h
+++ b/sdk/include/opentelemetry/sdk/metrics/state/metric_collector.h
@@ -53,9 +53,9 @@ public:
    */
   bool Collect(nostd::function_ref<bool(ResourceMetrics &metric_data)> callback) noexcept override;
 
-  bool ForceFlush(std::chrono::microseconds timeout = std::chrono::microseconds::max()) noexcept;
+  bool ForceFlush(std::chrono::microseconds timeout = (std::chrono::microseconds::max)()) noexcept;
 
-  bool Shutdown(std::chrono::microseconds timeout = std::chrono::microseconds::max()) noexcept;
+  bool Shutdown(std::chrono::microseconds timeout = (std::chrono::microseconds::max)()) noexcept;
 
 private:
   MeterContext *meter_context_;

--- a/sdk/include/opentelemetry/sdk/trace/exporter.h
+++ b/sdk/include/opentelemetry/sdk/trace/exporter.h
@@ -61,7 +61,7 @@ public:
    * @return return the status of the operation.
    */
   virtual bool Shutdown(
-      std::chrono::microseconds timeout = std::chrono::microseconds::max()) noexcept = 0;
+      std::chrono::microseconds timeout = (std::chrono::microseconds::max)()) noexcept = 0;
 };
 }  // namespace trace
 }  // namespace sdk

--- a/sdk/src/logs/batch_log_record_processor.cc
+++ b/sdk/src/logs/batch_log_record_processor.cc
@@ -104,7 +104,7 @@ bool BatchLogRecordProcessor::ForceFlush(std::chrono::microseconds timeout) noex
       std::chrono::duration_cast<std::chrono::steady_clock::duration>(timeout);
   if (timeout_steady <= std::chrono::steady_clock::duration::zero())
   {
-    timeout_steady = std::chrono::steady_clock::duration::max();
+    timeout_steady = (std::chrono::steady_clock::duration::max)();
   }
 
   bool result = false;

--- a/sdk/src/metrics/aggregation/histogram_aggregation.cc
+++ b/sdk/src/metrics/aggregation/histogram_aggregation.cc
@@ -38,8 +38,8 @@ LongHistogramAggregation::LongHistogramAggregation(const AggregationConfig *aggr
   point_data_.sum_            = (int64_t)0;
   point_data_.count_          = 0;
   point_data_.record_min_max_ = record_min_max_;
-  point_data_.min_            = std::numeric_limits<int64_t>::max();
-  point_data_.max_            = std::numeric_limits<int64_t>::min();
+  point_data_.min_            = (std::numeric_limits<int64_t>::max)();
+  point_data_.max_            = (std::numeric_limits<int64_t>::min)();
 }
 
 LongHistogramAggregation::LongHistogramAggregation(HistogramPointData &&data)
@@ -58,8 +58,8 @@ void LongHistogramAggregation::Aggregate(int64_t value,
   point_data_.sum_ = nostd::get<int64_t>(point_data_.sum_) + value;
   if (record_min_max_)
   {
-    point_data_.min_ = std::min(nostd::get<int64_t>(point_data_.min_), value);
-    point_data_.max_ = std::max(nostd::get<int64_t>(point_data_.max_), value);
+    point_data_.min_ = (std::min)(nostd::get<int64_t>(point_data_.min_), value);
+    point_data_.max_ = (std::max)(nostd::get<int64_t>(point_data_.max_), value);
   }
   size_t index = BucketBinarySearch(value, point_data_.boundaries_);
   point_data_.counts_[index] += 1;
@@ -118,8 +118,8 @@ DoubleHistogramAggregation::DoubleHistogramAggregation(const AggregationConfig *
   point_data_.sum_            = 0.0;
   point_data_.count_          = 0;
   point_data_.record_min_max_ = record_min_max_;
-  point_data_.min_            = std::numeric_limits<double>::max();
-  point_data_.max_            = std::numeric_limits<double>::min();
+  point_data_.min_            = (std::numeric_limits<double>::max)();
+  point_data_.max_            = (std::numeric_limits<double>::min)();
 }
 
 DoubleHistogramAggregation::DoubleHistogramAggregation(HistogramPointData &&data)
@@ -138,8 +138,8 @@ void DoubleHistogramAggregation::Aggregate(double value,
   point_data_.sum_ = nostd::get<double>(point_data_.sum_) + value;
   if (record_min_max_)
   {
-    point_data_.min_ = std::min(nostd::get<double>(point_data_.min_), value);
-    point_data_.max_ = std::max(nostd::get<double>(point_data_.max_), value);
+    point_data_.min_ = (std::min)(nostd::get<double>(point_data_.min_), value);
+    point_data_.max_ = (std::max)(nostd::get<double>(point_data_.max_), value);
   }
   size_t index = BucketBinarySearch(value, point_data_.boundaries_);
   point_data_.counts_[index] += 1;

--- a/sdk/src/metrics/export/periodic_exporting_metric_reader.cc
+++ b/sdk/src/metrics/export/periodic_exporting_metric_reader.cc
@@ -133,7 +133,7 @@ bool PeriodicExportingMetricReader::OnForceFlush(std::chrono::microseconds timeo
       std::chrono::duration_cast<std::chrono::steady_clock::duration>(wait_timeout);
   if (timeout_steady <= std::chrono::steady_clock::duration::zero())
   {
-    timeout_steady = std::chrono::steady_clock::duration::max();
+    timeout_steady = (std::chrono::steady_clock::duration::max)();
   }
 
   bool result = false;

--- a/sdk/src/metrics/meter_context.cc
+++ b/sdk/src/metrics/meter_context.cc
@@ -136,7 +136,7 @@ bool MeterContext::ForceFlush(std::chrono::microseconds timeout) noexcept
   // Simultaneous flush not allowed.
   const std::lock_guard<opentelemetry::common::SpinLockMutex> locked(forceflush_lock_);
   // Convert to nanos to prevent overflow
-  auto timeout_ns = std::chrono::nanoseconds::max();
+  auto timeout_ns = (std::chrono::nanoseconds::max)();
   if (std::chrono::duration_cast<std::chrono::microseconds>(timeout_ns) > timeout)
   {
     timeout_ns = std::chrono::duration_cast<std::chrono::nanoseconds>(timeout);
@@ -144,7 +144,7 @@ bool MeterContext::ForceFlush(std::chrono::microseconds timeout) noexcept
 
   auto current_time = std::chrono::system_clock::now();
   std::chrono::system_clock::time_point expire_time;
-  auto overflow_checker = std::chrono::system_clock::time_point::max();
+  auto overflow_checker = (std::chrono::system_clock::time_point::max)();
 
   // check if the expected expire time doesn't overflow.
   if (overflow_checker - current_time > timeout_ns)

--- a/sdk/src/trace/batch_span_processor.cc
+++ b/sdk/src/trace/batch_span_processor.cc
@@ -102,7 +102,7 @@ bool BatchSpanProcessor::ForceFlush(std::chrono::microseconds timeout) noexcept
       std::chrono::duration_cast<std::chrono::steady_clock::duration>(timeout);
   if (timeout_steady <= std::chrono::steady_clock::duration::zero())
   {
-    timeout_steady = std::chrono::steady_clock::duration::max();
+    timeout_steady = (std::chrono::steady_clock::duration::max)();
   }
 
   bool result = false;


### PR DESCRIPTION
Currently, including OpenTelemetry API requires NOMINMAX to be defined for Windows user which excludes the min/max macro from the Windows header files. There are cases when both macros are used by the customer code so requiring NOMINMAX will cause incompatibility. This PR wraps the usage of min/max from C++ standard library with parenthesis. This can avoid the naming conflict with the macro names min/max.

## Changes

Please provide a brief description of the changes here.

For significant contributions please make sure you have completed the following items:

* [ ] `CHANGELOG.md` updated for non-trivial changes
* [ ] Unit tests have been added
* [ ] Changes in public API reviewed