### PR TITLE
[BUILD] 'uint8_t' not declared in this scope with gcc 13.2.1

### DIFF
--- a/api/include/opentelemetry/trace/propagation/detail/hex.h
+++ b/api/include/opentelemetry/trace/propagation/detail/hex.h
@@ -4,6 +4,7 @@
 #pragma once
 
 #include <algorithm>
+#include <cstdint>
 #include <cstring>
 
 #include "opentelemetry/nostd/string_view.h"


### PR DESCRIPTION
## Changes

Added missing header file in `hex.h`, required to declare `uint8_t`

For significant contributions please make sure you have completed the following items:

* [ ] `CHANGELOG.md` updated for non-trivial changes
* [ ] Unit tests have been added
* [X] Changes in public API reviewed