### PR TITLE
[REMOVAL] Remove option WITH_OTLP_HTTP_SSL_PREVIEW

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,19 @@ Increment the:
 
 ## [Unreleased]
 
+* [REMOVAL] Remove option WITH_OTLP_HTTP_SSL_PREVIEW
+  [#2435](https://github.com/open-telemetry/opentelemetry-cpp/pull/2435)
+
+Important changes:
+
+Breaking changes:
+
+* [REMOVAL] Remove option WITH_OTLP_HTTP_SSL_PREVIEW
+  [#2435](https://github.com/open-telemetry/opentelemetry-cpp/pull/2435)
+  * CMake options `WITH_OTLP_HTTP_SSL_PREVIEW`
+    and `WITH_OTLP_HTTP_SSL_TLS_PREVIEW` are removed.
+    Building opentelemetry-cpp without SSL support is no longer possible.
+
 ## [1.13.0] 2023-12-06
 
 * [BUILD] Remove WITH_REMOVE_METER_PREVIEW, use WITH_ABI_VERSION_2 instead

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -276,13 +276,6 @@ endif()
 
 option(WITH_ASYNC_EXPORT_PREVIEW "Whether to enable async export" OFF)
 
-# STABLE
-option(WITH_OTLP_HTTP_SSL_PREVIEW "Whether to enable otlp http ssl export" ON)
-
-# STABLE
-option(WITH_OTLP_HTTP_SSL_TLS_PREVIEW
-       "Whether to enable otlp http ssl tls min/max/cipher options" ON)
-
 # Exemplar specs status is experimental, so behind feature flag by default
 option(WITH_METRICS_EXEMPLAR_PREVIEW
        "Whether to enable exemplar within metrics" OFF)
@@ -293,13 +286,6 @@ option(WITH_METRICS_EXEMPLAR_PREVIEW
 
 if(WITH_EXAMPLES_HTTP AND NOT WITH_EXAMPLES)
   message(FATAL_ERROR "WITH_EXAMPLES_HTTP=ON requires WITH_EXAMPLES=ON")
-endif()
-
-if(WITH_OTLP_HTTP_SSL_TLS_PREVIEW AND NOT WITH_OTLP_HTTP_SSL_PREVIEW)
-  message(
-    FATAL_ERROR
-      "WITH_OTLP_HTTP_SSL_TLS_PREVIEW=ON requires WITH_OTLP_HTTP_SSL_PREVIEW=ON"
-  )
 endif()
 
 find_package(Threads)

--- a/api/CMakeLists.txt
+++ b/api/CMakeLists.txt
@@ -117,21 +117,6 @@ target_compile_definitions(
   opentelemetry_api
   INTERFACE OPENTELEMETRY_ABI_VERSION_NO=${OPENTELEMETRY_ABI_VERSION_NO})
 
-# A better place should be in sdk, not api
-if(WITH_OTLP_HTTP_SSL_PREVIEW)
-  target_compile_definitions(opentelemetry_api
-                             INTERFACE ENABLE_OTLP_HTTP_SSL_PREVIEW)
-  target_compile_definitions(opentelemetry_api
-                             INTERFACE ENABLE_HTTP_SSL_PREVIEW)
-
-  if(WITH_OTLP_HTTP_SSL_TLS_PREVIEW)
-    target_compile_definitions(opentelemetry_api
-                               INTERFACE ENABLE_OTLP_HTTP_SSL_TLS_PREVIEW)
-    target_compile_definitions(opentelemetry_api
-                               INTERFACE ENABLE_HTTP_SSL_TLS_PREVIEW)
-  endif()
-endif()
-
 if(WITH_OTLP_GRPC_SSL_MTLS_PREVIEW)
   target_compile_definitions(opentelemetry_api
                              INTERFACE ENABLE_OTLP_GRPC_SSL_MTLS_PREVIEW)

--- a/ci/do_ci.sh
+++ b/ci/do_ci.sh
@@ -110,8 +110,6 @@ elif [[ "$1" == "cmake.maintainer.sync.test" ]]; then
   rm -rf *
   cmake ${CMAKE_OPTIONS[@]}  \
         -DWITH_OTLP_HTTP=ON \
-        -DWITH_OTLP_HTTP_SSL_PREVIEW=ON \
-        -DWITH_OTLP_HTTP_SSL_TLS_PREVIEW=ON \
         -DWITH_PROMETHEUS=ON \
         -DWITH_EXAMPLES=ON \
         -DWITH_EXAMPLES_HTTP=ON \
@@ -132,8 +130,6 @@ elif [[ "$1" == "cmake.maintainer.async.test" ]]; then
   rm -rf *
   cmake ${CMAKE_OPTIONS[@]}  \
         -DWITH_OTLP_HTTP=ON \
-        -DWITH_OTLP_HTTP_SSL_PREVIEW=ON \
-        -DWITH_OTLP_HTTP_SSL_TLS_PREVIEW=ON \
         -DWITH_PROMETHEUS=ON \
         -DWITH_EXAMPLES=ON \
         -DWITH_EXAMPLES_HTTP=ON \
@@ -155,8 +151,6 @@ elif [[ "$1" == "cmake.maintainer.cpp11.async.test" ]]; then
   cmake ${CMAKE_OPTIONS[@]}  \
         -DCMAKE_CXX_STANDARD=11 \
         -DWITH_OTLP_HTTP=ON \
-        -DWITH_OTLP_HTTP_SSL_PREVIEW=ON \
-        -DWITH_OTLP_HTTP_SSL_TLS_PREVIEW=ON \
         -DWITH_PROMETHEUS=ON \
         -DWITH_EXAMPLES=ON \
         -DWITH_EXAMPLES_HTTP=ON \
@@ -176,8 +170,6 @@ elif [[ "$1" == "cmake.maintainer.abiv2.test" ]]; then
   rm -rf *
   cmake ${CMAKE_OPTIONS[@]}  \
         -DWITH_OTLP_HTTP=ON \
-        -DWITH_OTLP_HTTP_SSL_PREVIEW=ON \
-        -DWITH_OTLP_HTTP_SSL_TLS_PREVIEW=ON \
         -DWITH_PROMETHEUS=ON \
         -DWITH_EXAMPLES=ON \
         -DWITH_EXAMPLES_HTTP=ON \

--- a/exporters/otlp/include/opentelemetry/exporters/otlp/otlp_environment.h
+++ b/exporters/otlp/include/opentelemetry/exporters/otlp/otlp_environment.h
@@ -99,7 +99,6 @@ std::string GetOtlpDefaultTracesSslClientCertificateString();
 std::string GetOtlpDefaultMetricsSslClientCertificateString();
 std::string GetOtlpDefaultLogsSslClientCertificateString();
 
-#ifdef ENABLE_OTLP_HTTP_SSL_TLS_PREVIEW
 std::string GetOtlpDefaultTracesSslTlsMinVersion();
 std::string GetOtlpDefaultMetricsSslTlsMinVersion();
 std::string GetOtlpDefaultLogsSslTlsMinVersion();
@@ -117,7 +116,6 @@ std::string GetOtlpDefaultLogsSslTlsCipher();
 std::string GetOtlpDefaultTracesSslTlsCipherSuite();
 std::string GetOtlpDefaultMetricsSslTlsCipherSuite();
 std::string GetOtlpDefaultLogsSslTlsCipherSuite();
-#endif /* ENABLE_OTLP_HTTP_SSL_TLS_PREVIEW */
 
 std::chrono::system_clock::duration GetOtlpDefaultTracesTimeout();
 std::chrono::system_clock::duration GetOtlpDefaultMetricsTimeout();

--- a/exporters/otlp/include/opentelemetry/exporters/otlp/otlp_http_client.h
+++ b/exporters/otlp/include/opentelemetry/exporters/otlp/otlp_http_client.h
@@ -113,8 +113,7 @@ struct OtlpHttpClientOptions
                     input_ssl_min_tls,
                     input_ssl_max_tls,
                     input_ssl_cipher,
-                    input_ssl_cipher_suite
-                    ),
+                    input_ssl_cipher_suite),
         content_type(input_content_type),
         json_bytes_mapping(input_json_bytes_mapping),
         use_json_name(input_use_json_name),

--- a/exporters/otlp/include/opentelemetry/exporters/otlp/otlp_http_client.h
+++ b/exporters/otlp/include/opentelemetry/exporters/otlp/otlp_http_client.h
@@ -49,10 +49,8 @@ struct OtlpHttpClientOptions
 {
   std::string url;
 
-#ifdef ENABLE_OTLP_HTTP_SSL_PREVIEW
   /** SSL options. */
   ext::http::client::HttpSslOptions ssl_options;
-#endif /* ENABLE_OTLP_HTTP_SSL_PREVIEW */
 
   // By default, post json data
   HttpRequestContentType content_type = HttpRequestContentType::kJson;
@@ -83,7 +81,6 @@ struct OtlpHttpClientOptions
   std::string user_agent;
 
   inline OtlpHttpClientOptions(nostd::string_view input_url,
-#ifdef ENABLE_OTLP_HTTP_SSL_PREVIEW
                                bool input_ssl_insecure_skip_verify,
                                nostd::string_view input_ssl_ca_cert_path,
                                nostd::string_view input_ssl_ca_cert_string,
@@ -91,13 +88,10 @@ struct OtlpHttpClientOptions
                                nostd::string_view input_ssl_client_key_string,
                                nostd::string_view input_ssl_client_cert_path,
                                nostd::string_view input_ssl_client_cert_string,
-#endif /* ENABLE_OTLP_HTTP_SSL_PREVIEW */
-#ifdef ENABLE_OTLP_HTTP_SSL_TLS_PREVIEW
                                nostd::string_view input_ssl_min_tls,
                                nostd::string_view input_ssl_max_tls,
                                nostd::string_view input_ssl_cipher,
                                nostd::string_view input_ssl_cipher_suite,
-#endif /* ENABLE_OTLP_HTTP_SSL_TLS_PREVIEW */
                                HttpRequestContentType input_content_type,
                                JsonBytesMappingKind input_json_bytes_mapping,
                                bool input_use_json_name,
@@ -108,7 +102,6 @@ struct OtlpHttpClientOptions
                                std::size_t input_max_requests_per_connection = 8,
                                nostd::string_view input_user_agent = GetOtlpDefaultUserAgent())
       : url(input_url),
-#ifdef ENABLE_OTLP_HTTP_SSL_PREVIEW
         ssl_options(input_url,
                     input_ssl_insecure_skip_verify,
                     input_ssl_ca_cert_path,
@@ -116,16 +109,12 @@ struct OtlpHttpClientOptions
                     input_ssl_client_key_path,
                     input_ssl_client_key_string,
                     input_ssl_client_cert_path,
-                    input_ssl_client_cert_string
-#  ifdef ENABLE_OTLP_HTTP_SSL_TLS_PREVIEW
-                    ,
+                    input_ssl_client_cert_string,
                     input_ssl_min_tls,
                     input_ssl_max_tls,
                     input_ssl_cipher,
                     input_ssl_cipher_suite
-#  endif /* ENABLE_OTLP_HTTP_SSL_TLS_PREVIEW */
                     ),
-#endif /* ENABLE_OTLP_HTTP_SSL_PREVIEW */
         content_type(input_content_type),
         json_bytes_mapping(input_json_bytes_mapping),
         use_json_name(input_use_json_name),

--- a/exporters/otlp/include/opentelemetry/exporters/otlp/otlp_http_exporter_options.h
+++ b/exporters/otlp/include/opentelemetry/exporters/otlp/otlp_http_exporter_options.h
@@ -68,7 +68,6 @@ struct OPENTELEMETRY_EXPORT OtlpHttpExporterOptions
   std::size_t max_requests_per_connection;
 #endif
 
-#ifdef ENABLE_OTLP_HTTP_SSL_PREVIEW
   /** True do disable SSL. */
   bool ssl_insecure_skip_verify;
 
@@ -89,9 +88,7 @@ struct OPENTELEMETRY_EXPORT OtlpHttpExporterOptions
 
   /** CLIENT CERT, as a string. */
   std::string ssl_client_cert_string;
-#endif /* ENABLE_OTLP_HTTP_SSL_PREVIEW */
 
-#ifdef ENABLE_OTLP_HTTP_SSL_TLS_PREVIEW
   /** Minimum TLS version. */
   std::string ssl_min_tls;
 
@@ -103,7 +100,6 @@ struct OPENTELEMETRY_EXPORT OtlpHttpExporterOptions
 
   /** TLS cipher suite. */
   std::string ssl_cipher_suite;
-#endif /* ENABLE_OTLP_HTTP_SSL_TLS_PREVIEW */
 };
 
 }  // namespace otlp

--- a/exporters/otlp/include/opentelemetry/exporters/otlp/otlp_http_log_record_exporter_options.h
+++ b/exporters/otlp/include/opentelemetry/exporters/otlp/otlp_http_log_record_exporter_options.h
@@ -68,7 +68,6 @@ struct OPENTELEMETRY_EXPORT OtlpHttpLogRecordExporterOptions
   std::size_t max_requests_per_connection;
 #endif
 
-#ifdef ENABLE_OTLP_HTTP_SSL_PREVIEW
   /** True do disable SSL. */
   bool ssl_insecure_skip_verify;
 
@@ -89,9 +88,7 @@ struct OPENTELEMETRY_EXPORT OtlpHttpLogRecordExporterOptions
 
   /** CLIENT CERT, as a string. */
   std::string ssl_client_cert_string;
-#endif /* ENABLE_OTLP_HTTP_SSL_PREVIEW */
 
-#ifdef ENABLE_OTLP_HTTP_SSL_TLS_PREVIEW
   /** Minimum TLS version. */
   std::string ssl_min_tls;
 
@@ -103,7 +100,6 @@ struct OPENTELEMETRY_EXPORT OtlpHttpLogRecordExporterOptions
 
   /** TLS cipher suite. */
   std::string ssl_cipher_suite;
-#endif /* ENABLE_OTLP_HTTP_SSL_TLS_PREVIEW */
 };
 
 }  // namespace otlp

--- a/exporters/otlp/include/opentelemetry/exporters/otlp/otlp_http_metric_exporter_options.h
+++ b/exporters/otlp/include/opentelemetry/exporters/otlp/otlp_http_metric_exporter_options.h
@@ -71,7 +71,6 @@ struct OPENTELEMETRY_EXPORT OtlpHttpMetricExporterOptions
   std::size_t max_requests_per_connection;
 #endif
 
-#ifdef ENABLE_OTLP_HTTP_SSL_PREVIEW
   /** True do disable SSL. */
   bool ssl_insecure_skip_verify;
 
@@ -92,9 +91,7 @@ struct OPENTELEMETRY_EXPORT OtlpHttpMetricExporterOptions
 
   /** CLIENT CERT, as a string. */
   std::string ssl_client_cert_string;
-#endif /* ENABLE_OTLP_HTTP_SSL_PREVIEW */
 
-#ifdef ENABLE_OTLP_HTTP_SSL_TLS_PREVIEW
   /** Minimum TLS version. */
   std::string ssl_min_tls;
 
@@ -106,7 +103,6 @@ struct OPENTELEMETRY_EXPORT OtlpHttpMetricExporterOptions
 
   /** TLS cipher suite. */
   std::string ssl_cipher_suite;
-#endif /* ENABLE_OTLP_HTTP_SSL_TLS_PREVIEW */
 };
 
 }  // namespace otlp

--- a/exporters/otlp/src/otlp_environment.cc
+++ b/exporters/otlp/src/otlp_environment.cc
@@ -660,8 +660,6 @@ std::string GetOtlpDefaultLogsSslClientCertificateString()
   return std::string{};
 }
 
-#ifdef ENABLE_OTLP_HTTP_SSL_TLS_PREVIEW
-
 /*
   EXPERIMENTAL:
   Environment variable names do not exist in the spec,
@@ -871,8 +869,6 @@ std::string GetOtlpDefaultLogsSslTlsCipherSuite()
 
   return std::string{};
 }
-
-#endif /* ENABLE_OTLP_HTTP_SSL_TLS_PREVIEW */
 
 std::chrono::system_clock::duration GetOtlpDefaultTracesTimeout()
 {

--- a/exporters/otlp/src/otlp_http_client.cc
+++ b/exporters/otlp/src/otlp_http_client.cc
@@ -951,9 +951,7 @@ OtlpHttpClient::createSession(
     request->AddHeader(header.first, header.second);
   }
   request->SetUri(http_uri_);
-#ifdef ENABLE_OTLP_HTTP_SSL_PREVIEW
   request->SetSslOptions(options_.ssl_options);
-#endif /* ENABLE_OTLP_HTTP_SSL_PREVIEW */
   request->SetTimeoutMs(std::chrono::duration_cast<std::chrono::milliseconds>(options_.timeout));
   request->SetMethod(http_client::Method::Post);
   request->SetBody(body_vec);

--- a/exporters/otlp/src/otlp_http_exporter.cc
+++ b/exporters/otlp/src/otlp_http_exporter.cc
@@ -26,7 +26,6 @@ OtlpHttpExporter::OtlpHttpExporter() : OtlpHttpExporter(OtlpHttpExporterOptions(
 OtlpHttpExporter::OtlpHttpExporter(const OtlpHttpExporterOptions &options)
     : options_(options),
       http_client_(new OtlpHttpClient(OtlpHttpClientOptions(options.url,
-#ifdef ENABLE_OTLP_HTTP_SSL_PREVIEW
                                                             options.ssl_insecure_skip_verify,
                                                             options.ssl_ca_cert_path,
                                                             options.ssl_ca_cert_string,
@@ -34,13 +33,10 @@ OtlpHttpExporter::OtlpHttpExporter(const OtlpHttpExporterOptions &options)
                                                             options.ssl_client_key_string,
                                                             options.ssl_client_cert_path,
                                                             options.ssl_client_cert_string,
-#endif /* ENABLE_OTLP_HTTP_SSL_PREVIEW */
-#ifdef ENABLE_OTLP_HTTP_SSL_TLS_PREVIEW
                                                             options.ssl_min_tls,
                                                             options.ssl_max_tls,
                                                             options.ssl_cipher,
                                                             options.ssl_cipher_suite,
-#endif /* ENABLE_OTLP_HTTP_SSL_TLS_PREVIEW */
                                                             options.content_type,
                                                             options.json_bytes_mapping,
                                                             options.use_json_name,

--- a/exporters/otlp/src/otlp_http_exporter_options.cc
+++ b/exporters/otlp/src/otlp_http_exporter_options.cc
@@ -29,7 +29,6 @@ OtlpHttpExporterOptions::OtlpHttpExporterOptions()
   max_requests_per_connection = 8;
 #endif /* ENABLE_ASYNC_EXPORT */
 
-#ifdef ENABLE_OTLP_HTTP_SSL_PREVIEW
   ssl_insecure_skip_verify = false;
   ssl_ca_cert_path         = GetOtlpDefaultTracesSslCertificatePath();
   ssl_ca_cert_string       = GetOtlpDefaultTracesSslCertificateString();
@@ -37,14 +36,11 @@ OtlpHttpExporterOptions::OtlpHttpExporterOptions()
   ssl_client_key_string    = GetOtlpDefaultTracesSslClientKeyString();
   ssl_client_cert_path     = GetOtlpDefaultTracesSslClientCertificatePath();
   ssl_client_cert_string   = GetOtlpDefaultTracesSslClientCertificateString();
-#endif /* ENABLE_OTLP_HTTP_SSL_PREVIEW */
 
-#ifdef ENABLE_OTLP_HTTP_SSL_TLS_PREVIEW
   ssl_min_tls      = GetOtlpDefaultTracesSslTlsMinVersion();
   ssl_max_tls      = GetOtlpDefaultTracesSslTlsMaxVersion();
   ssl_cipher       = GetOtlpDefaultTracesSslTlsCipher();
   ssl_cipher_suite = GetOtlpDefaultTracesSslTlsCipherSuite();
-#endif /* ENABLE_OTLP_HTTP_SSL_TLS_PREVIEW */
 }
 
 OtlpHttpExporterOptions::~OtlpHttpExporterOptions() {}

--- a/exporters/otlp/src/otlp_http_log_record_exporter.cc
+++ b/exporters/otlp/src/otlp_http_log_record_exporter.cc
@@ -29,7 +29,6 @@ OtlpHttpLogRecordExporter::OtlpHttpLogRecordExporter(
     const OtlpHttpLogRecordExporterOptions &options)
     : options_(options),
       http_client_(new OtlpHttpClient(OtlpHttpClientOptions(options.url,
-#ifdef ENABLE_OTLP_HTTP_SSL_PREVIEW
                                                             options.ssl_insecure_skip_verify,
                                                             options.ssl_ca_cert_path,
                                                             options.ssl_ca_cert_string,
@@ -37,13 +36,10 @@ OtlpHttpLogRecordExporter::OtlpHttpLogRecordExporter(
                                                             options.ssl_client_key_string,
                                                             options.ssl_client_cert_path,
                                                             options.ssl_client_cert_string,
-#endif /* ENABLE_OTLP_HTTP_SSL_PREVIEW */
-#ifdef ENABLE_OTLP_HTTP_SSL_TLS_PREVIEW
                                                             options.ssl_min_tls,
                                                             options.ssl_max_tls,
                                                             options.ssl_cipher,
                                                             options.ssl_cipher_suite,
-#endif /* ENABLE_OTLP_HTTP_SSL_TLS_PREVIEW */
                                                             options.content_type,
                                                             options.json_bytes_mapping,
                                                             options.use_json_name,

--- a/exporters/otlp/src/otlp_http_log_record_exporter_options.cc
+++ b/exporters/otlp/src/otlp_http_log_record_exporter_options.cc
@@ -29,7 +29,6 @@ OtlpHttpLogRecordExporterOptions::OtlpHttpLogRecordExporterOptions()
   max_requests_per_connection = 8;
 #endif
 
-#ifdef ENABLE_OTLP_HTTP_SSL_PREVIEW
   ssl_insecure_skip_verify = false;
   ssl_ca_cert_path         = GetOtlpDefaultLogsSslCertificatePath();
   ssl_ca_cert_string       = GetOtlpDefaultLogsSslCertificateString();
@@ -37,14 +36,11 @@ OtlpHttpLogRecordExporterOptions::OtlpHttpLogRecordExporterOptions()
   ssl_client_key_string    = GetOtlpDefaultLogsSslClientKeyString();
   ssl_client_cert_path     = GetOtlpDefaultLogsSslClientCertificatePath();
   ssl_client_cert_string   = GetOtlpDefaultLogsSslClientCertificateString();
-#endif /* ENABLE_OTLP_HTTP_SSL_PREVIEW */
 
-#ifdef ENABLE_OTLP_HTTP_SSL_TLS_PREVIEW
   ssl_min_tls      = GetOtlpDefaultLogsSslTlsMinVersion();
   ssl_max_tls      = GetOtlpDefaultLogsSslTlsMaxVersion();
   ssl_cipher       = GetOtlpDefaultLogsSslTlsCipher();
   ssl_cipher_suite = GetOtlpDefaultLogsSslTlsCipherSuite();
-#endif /* ENABLE_OTLP_HTTP_SSL_TLS_PREVIEW */
 }
 
 OtlpHttpLogRecordExporterOptions::~OtlpHttpLogRecordExporterOptions() {}

--- a/exporters/otlp/src/otlp_http_metric_exporter.cc
+++ b/exporters/otlp/src/otlp_http_metric_exporter.cc
@@ -29,7 +29,6 @@ OtlpHttpMetricExporter::OtlpHttpMetricExporter(const OtlpHttpMetricExporterOptio
       aggregation_temporality_selector_{
           OtlpMetricUtils::ChooseTemporalitySelector(options_.aggregation_temporality)},
       http_client_(new OtlpHttpClient(OtlpHttpClientOptions(options.url,
-#ifdef ENABLE_OTLP_HTTP_SSL_PREVIEW
                                                             options.ssl_insecure_skip_verify,
                                                             options.ssl_ca_cert_path,
                                                             options.ssl_ca_cert_string,
@@ -37,13 +36,10 @@ OtlpHttpMetricExporter::OtlpHttpMetricExporter(const OtlpHttpMetricExporterOptio
                                                             options.ssl_client_key_string,
                                                             options.ssl_client_cert_path,
                                                             options.ssl_client_cert_string,
-#endif /* ENABLE_OTLP_HTTP_SSL_PREVIEW */
-#ifdef ENABLE_OTLP_HTTP_SSL_TLS_PREVIEW
                                                             options.ssl_min_tls,
                                                             options.ssl_max_tls,
                                                             options.ssl_cipher,
                                                             options.ssl_cipher_suite,
-#endif /* ENABLE_OTLP_HTTP_SSL_TLS_PREVIEW */
                                                             options.content_type,
                                                             options.json_bytes_mapping,
                                                             options.use_json_name,

--- a/exporters/otlp/src/otlp_http_metric_exporter_options.cc
+++ b/exporters/otlp/src/otlp_http_metric_exporter_options.cc
@@ -30,7 +30,6 @@ OtlpHttpMetricExporterOptions::OtlpHttpMetricExporterOptions()
   max_requests_per_connection = 8;
 #endif
 
-#ifdef ENABLE_OTLP_HTTP_SSL_PREVIEW
   ssl_insecure_skip_verify = false;
   ssl_ca_cert_path         = GetOtlpDefaultMetricsSslCertificatePath();
   ssl_ca_cert_string       = GetOtlpDefaultMetricsSslCertificateString();
@@ -38,14 +37,11 @@ OtlpHttpMetricExporterOptions::OtlpHttpMetricExporterOptions()
   ssl_client_key_string    = GetOtlpDefaultMetricsSslClientKeyString();
   ssl_client_cert_path     = GetOtlpDefaultMetricsSslClientCertificatePath();
   ssl_client_cert_string   = GetOtlpDefaultMetricsSslClientCertificateString();
-#endif /* ENABLE_OTLP_HTTP_SSL_PREVIEW */
 
-#ifdef ENABLE_OTLP_HTTP_SSL_TLS_PREVIEW
   ssl_min_tls      = GetOtlpDefaultMetricsSslTlsMinVersion();
   ssl_max_tls      = GetOtlpDefaultMetricsSslTlsMaxVersion();
   ssl_cipher       = GetOtlpDefaultMetricsSslTlsCipher();
   ssl_cipher_suite = GetOtlpDefaultMetricsSslTlsCipherSuite();
-#endif /* ENABLE_OTLP_HTTP_SSL_TLS_PREVIEW */
 }
 
 OtlpHttpMetricExporterOptions::~OtlpHttpMetricExporterOptions() {}

--- a/exporters/otlp/test/otlp_http_exporter_test.cc
+++ b/exporters/otlp/test/otlp_http_exporter_test.cc
@@ -61,16 +61,15 @@ OtlpHttpClientOptions MakeOtlpHttpClientOptions(HttpRequestContentType content_t
   options.http_headers.insert(
       std::make_pair<const std::string, std::string>("Custom-Header-Key", "Custom-Header-Value"));
   OtlpHttpClientOptions otlp_http_client_options(
-      options.url,
-      false,                              /* ssl_insecure_skip_verify */
+      options.url, false,                 /* ssl_insecure_skip_verify */
       "", /* ssl_ca_cert_path */ "",      /* ssl_ca_cert_string */
       "",                                 /* ssl_client_key_path */
       "", /* ssl_client_key_string */ "", /* ssl_client_cert_path */
       "",                                 /* ssl_client_cert_string */
-      "", /* ssl_min_tls */
-      "", /* ssl_max_tls */
-      "", /* ssl_cipher */
-      "", /* ssl_cipher_suite */
+      "",                                 /* ssl_min_tls */
+      "",                                 /* ssl_max_tls */
+      "",                                 /* ssl_cipher */
+      "",                                 /* ssl_cipher_suite */
       options.content_type, options.json_bytes_mapping, options.use_json_name,
       options.console_debug, options.timeout, options.http_headers);
   if (!async_mode)

--- a/exporters/otlp/test/otlp_http_exporter_test.cc
+++ b/exporters/otlp/test/otlp_http_exporter_test.cc
@@ -62,19 +62,15 @@ OtlpHttpClientOptions MakeOtlpHttpClientOptions(HttpRequestContentType content_t
       std::make_pair<const std::string, std::string>("Custom-Header-Key", "Custom-Header-Value"));
   OtlpHttpClientOptions otlp_http_client_options(
       options.url,
-#  ifdef ENABLE_OTLP_HTTP_SSL_PREVIEW
       false,                              /* ssl_insecure_skip_verify */
       "", /* ssl_ca_cert_path */ "",      /* ssl_ca_cert_string */
       "",                                 /* ssl_client_key_path */
       "", /* ssl_client_key_string */ "", /* ssl_client_cert_path */
       "",                                 /* ssl_client_cert_string */
-#  endif                                  /* ENABLE_OTLP_HTTP_SSL_PREVIEW */
-#  ifdef ENABLE_OTLP_HTTP_SSL_TLS_PREVIEW
       "", /* ssl_min_tls */
       "", /* ssl_max_tls */
       "", /* ssl_cipher */
       "", /* ssl_cipher_suite */
-#  endif  /* ENABLE_OTLP_HTTP_SSL_TLS_PREVIEW */
       options.content_type, options.json_bytes_mapping, options.use_json_name,
       options.console_debug, options.timeout, options.http_headers);
   if (!async_mode)

--- a/exporters/otlp/test/otlp_http_log_record_exporter_test.cc
+++ b/exporters/otlp/test/otlp_http_log_record_exporter_test.cc
@@ -60,16 +60,15 @@ OtlpHttpClientOptions MakeOtlpHttpClientOptions(HttpRequestContentType content_t
   options.http_headers.insert(
       std::make_pair<const std::string, std::string>("Custom-Header-Key", "Custom-Header-Value"));
   OtlpHttpClientOptions otlp_http_client_options(
-      options.url,
-      false,                              /* ssl_insecure_skip_verify */
+      options.url, false,                 /* ssl_insecure_skip_verify */
       "", /* ssl_ca_cert_path */ "",      /* ssl_ca_cert_string */
       "",                                 /* ssl_client_key_path */
       "", /* ssl_client_key_string */ "", /* ssl_client_cert_path */
       "",                                 /* ssl_client_cert_string */
-      "", /* ssl_min_tls */
-      "", /* ssl_max_tls */
-      "", /* ssl_cipher */
-      "", /* ssl_cipher_suite */
+      "",                                 /* ssl_min_tls */
+      "",                                 /* ssl_max_tls */
+      "",                                 /* ssl_cipher */
+      "",                                 /* ssl_cipher_suite */
       options.content_type, options.json_bytes_mapping, options.use_json_name,
       options.console_debug, options.timeout, options.http_headers);
   if (!async_mode)

--- a/exporters/otlp/test/otlp_http_log_record_exporter_test.cc
+++ b/exporters/otlp/test/otlp_http_log_record_exporter_test.cc
@@ -61,19 +61,15 @@ OtlpHttpClientOptions MakeOtlpHttpClientOptions(HttpRequestContentType content_t
       std::make_pair<const std::string, std::string>("Custom-Header-Key", "Custom-Header-Value"));
   OtlpHttpClientOptions otlp_http_client_options(
       options.url,
-#  ifdef ENABLE_OTLP_HTTP_SSL_PREVIEW
       false,                              /* ssl_insecure_skip_verify */
       "", /* ssl_ca_cert_path */ "",      /* ssl_ca_cert_string */
       "",                                 /* ssl_client_key_path */
       "", /* ssl_client_key_string */ "", /* ssl_client_cert_path */
       "",                                 /* ssl_client_cert_string */
-#  endif                                  /* ENABLE_OTLP_HTTP_SSL_PREVIEW */
-#  ifdef ENABLE_OTLP_HTTP_SSL_TLS_PREVIEW
       "", /* ssl_min_tls */
       "", /* ssl_max_tls */
       "", /* ssl_cipher */
       "", /* ssl_cipher_suite */
-#  endif  /* ENABLE_OTLP_HTTP_SSL_TLS_PREVIEW */
       options.content_type, options.json_bytes_mapping, options.use_json_name,
       options.console_debug, options.timeout, options.http_headers);
   if (!async_mode)

--- a/exporters/otlp/test/otlp_http_metric_exporter_test.cc
+++ b/exporters/otlp/test/otlp_http_metric_exporter_test.cc
@@ -68,19 +68,15 @@ OtlpHttpClientOptions MakeOtlpHttpClientOptions(HttpRequestContentType content_t
       std::make_pair<const std::string, std::string>("Custom-Header-Key", "Custom-Header-Value"));
   OtlpHttpClientOptions otlp_http_client_options(
       options.url,
-#ifdef ENABLE_OTLP_HTTP_SSL_PREVIEW
       false,                              /* ssl_insecure_skip_verify */
       "", /* ssl_ca_cert_path */ "",      /* ssl_ca_cert_string */
       "",                                 /* ssl_client_key_path */
       "", /* ssl_client_key_string */ "", /* ssl_client_cert_path */
       "",                                 /* ssl_client_cert_string */
-#endif                                    /* ENABLE_OTLP_HTTP_SSL_PREVIEW */
-#ifdef ENABLE_OTLP_HTTP_SSL_TLS_PREVIEW
       "", /* ssl_min_tls */
       "", /* ssl_max_tls */
       "", /* ssl_cipher */
       "", /* ssl_cipher_suite */
-#endif    /* ENABLE_OTLP_HTTP_SSL_TLS_PREVIEW */
       options.content_type, options.json_bytes_mapping, options.use_json_name,
       options.console_debug, options.timeout, options.http_headers);
   if (!async_mode)

--- a/exporters/otlp/test/otlp_http_metric_exporter_test.cc
+++ b/exporters/otlp/test/otlp_http_metric_exporter_test.cc
@@ -67,16 +67,15 @@ OtlpHttpClientOptions MakeOtlpHttpClientOptions(HttpRequestContentType content_t
   options.http_headers.insert(
       std::make_pair<const std::string, std::string>("Custom-Header-Key", "Custom-Header-Value"));
   OtlpHttpClientOptions otlp_http_client_options(
-      options.url,
-      false,                              /* ssl_insecure_skip_verify */
+      options.url, false,                 /* ssl_insecure_skip_verify */
       "", /* ssl_ca_cert_path */ "",      /* ssl_ca_cert_string */
       "",                                 /* ssl_client_key_path */
       "", /* ssl_client_key_string */ "", /* ssl_client_cert_path */
       "",                                 /* ssl_client_cert_string */
-      "", /* ssl_min_tls */
-      "", /* ssl_max_tls */
-      "", /* ssl_cipher */
-      "", /* ssl_cipher_suite */
+      "",                                 /* ssl_min_tls */
+      "",                                 /* ssl_max_tls */
+      "",                                 /* ssl_cipher */
+      "",                                 /* ssl_cipher_suite */
       options.content_type, options.json_bytes_mapping, options.use_json_name,
       options.console_debug, options.timeout, options.http_headers);
   if (!async_mode)

--- a/exporters/zipkin/test/zipkin_exporter_test.cc
+++ b/exporters/zipkin/test/zipkin_exporter_test.cc
@@ -60,7 +60,6 @@ public:
 class MockHttpClient : public opentelemetry::ext::http::client::HttpClientSync
 {
 public:
-#  ifdef ENABLE_HTTP_SSL_PREVIEW
   MOCK_METHOD(ext::http::client::Result,
               Post,
               (const nostd::string_view &,
@@ -68,28 +67,13 @@ public:
                const ext::http::client::Body &,
                const ext::http::client::Headers &),
               (noexcept, override));
-#  else
-  MOCK_METHOD(ext::http::client::Result,
-              Post,
-              (const nostd::string_view &,
-               const ext::http::client::Body &,
-               const ext::http::client::Headers &),
-              (noexcept, override));
-#  endif /* ENABLE_HTTP_SSL_PREVIEW */
 
-#  ifdef ENABLE_HTTP_SSL_PREVIEW
   MOCK_METHOD(ext::http::client::Result,
               Get,
               (const nostd::string_view &,
                const ext::http::client::HttpSslOptions &,
                const ext::http::client::Headers &),
               (noexcept, override));
-#  else
-  MOCK_METHOD(ext::http::client::Result,
-              Get,
-              (const nostd::string_view &, const ext::http::client::Headers &),
-              (noexcept, override));
-#  endif /* ENABLE_HTTP_SSL_PREVIEW */
 };
 
 class IsValidMessageMatcher
@@ -169,11 +153,7 @@ TEST_F(ZipkinExporterTestPeer, ExportJsonIntegrationTest)
 
   auto expected_url = nostd::string_view{"http://localhost:9411/api/v2/spans"};
 
-#  ifdef ENABLE_HTTP_SSL_PREVIEW
   EXPECT_CALL(*mock_http_client, Post(expected_url, _, IsValidMessage(report_trace_id), _))
-#  else
-  EXPECT_CALL(*mock_http_client, Post(expected_url, IsValidMessage(report_trace_id), _))
-#  endif /* ENABLE_HTTP_SSL_PREVIEW */
 
       .Times(Exactly(1))
       .WillOnce(Return(ByMove(ext::http::client::Result{
@@ -199,11 +179,7 @@ TEST_F(ZipkinExporterTestPeer, ShutdownTest)
   // exporter should not be shutdown by default
   nostd::span<std::unique_ptr<sdk::trace::Recordable>> batch_1(&recordable_1, 1);
 
-#  ifdef ENABLE_HTTP_SSL_PREVIEW
   EXPECT_CALL(*mock_http_client, Post(_, _, _, _))
-#  else
-  EXPECT_CALL(*mock_http_client, Post(_, _, _))
-#  endif /* ENABLE_HTTP_SSL_PREVIEW */
 
       .Times(Exactly(1))
       .WillOnce(Return(ByMove(ext::http::client::Result{

--- a/ext/include/opentelemetry/ext/http/client/curl/http_client_curl.h
+++ b/ext/include/opentelemetry/ext/http/client/curl/http_client_curl.h
@@ -225,8 +225,7 @@ public:
     opentelemetry::ext::http::client::Body body;
 
     HttpOperation curl_operation(opentelemetry::ext::http::client::Method::Get, url.data(),
-                                 ssl_options,
-                                 nullptr, headers, body);
+                                 ssl_options, nullptr, headers, body);
 
     curl_operation.SendSync();
     auto session_state = curl_operation.GetSessionState();
@@ -253,8 +252,7 @@ public:
       const opentelemetry::ext::http::client::Headers &headers) noexcept override
   {
     HttpOperation curl_operation(opentelemetry::ext::http::client::Method::Post, url.data(),
-                                 ssl_options,
-                                 nullptr, headers, body);
+                                 ssl_options, nullptr, headers, body);
     curl_operation.SendSync();
     auto session_state = curl_operation.GetSessionState();
     if (curl_operation.WasAborted())

--- a/ext/include/opentelemetry/ext/http/client/curl/http_client_curl.h
+++ b/ext/include/opentelemetry/ext/http/client/curl/http_client_curl.h
@@ -58,12 +58,10 @@ public:
     method_ = method;
   }
 
-#ifdef ENABLE_HTTP_SSL_PREVIEW
   void SetSslOptions(const HttpSslOptions &ssl_options) noexcept override
   {
     ssl_options_ = ssl_options;
   }
-#endif /* ENABLE_HTTP_SSL_PREVIEW */
 
   void SetBody(opentelemetry::ext::http::client::Body &body) noexcept override
   {
@@ -93,11 +91,7 @@ public:
 
 public:
   opentelemetry::ext::http::client::Method method_;
-
-#ifdef ENABLE_HTTP_SSL_PREVIEW
   opentelemetry::ext::http::client::HttpSslOptions ssl_options_;
-#endif /* ENABLE_HTTP_SSL_PREVIEW */
-
   opentelemetry::ext::http::client::Body body_;
   opentelemetry::ext::http::client::Headers headers_;
   std::string uri_;
@@ -225,17 +219,13 @@ public:
 
   opentelemetry::ext::http::client::Result Get(
       const nostd::string_view &url,
-#ifdef ENABLE_HTTP_SSL_PREVIEW
       const opentelemetry::ext::http::client::HttpSslOptions &ssl_options,
-#endif /* ENABLE_HTTP_SSL_PREVIEW */
       const opentelemetry::ext::http::client::Headers &headers) noexcept override
   {
     opentelemetry::ext::http::client::Body body;
 
     HttpOperation curl_operation(opentelemetry::ext::http::client::Method::Get, url.data(),
-#ifdef ENABLE_HTTP_SSL_PREVIEW
                                  ssl_options,
-#endif /* ENABLE_HTTP_SSL_PREVIEW */
                                  nullptr, headers, body);
 
     curl_operation.SendSync();
@@ -258,16 +248,12 @@ public:
 
   opentelemetry::ext::http::client::Result Post(
       const nostd::string_view &url,
-#ifdef ENABLE_HTTP_SSL_PREVIEW
       const opentelemetry::ext::http::client::HttpSslOptions &ssl_options,
-#endif /* ENABLE_HTTP_SSL_PREVIEW */
       const Body &body,
       const opentelemetry::ext::http::client::Headers &headers) noexcept override
   {
     HttpOperation curl_operation(opentelemetry::ext::http::client::Method::Post, url.data(),
-#ifdef ENABLE_HTTP_SSL_PREVIEW
                                  ssl_options,
-#endif /* ENABLE_HTTP_SSL_PREVIEW */
                                  nullptr, headers, body);
     curl_operation.SendSync();
     auto session_state = curl_operation.GetSessionState();

--- a/ext/include/opentelemetry/ext/http/client/curl/http_operation_curl.h
+++ b/ext/include/opentelemetry/ext/http/client/curl/http_operation_curl.h
@@ -139,9 +139,7 @@ public:
    */
   HttpOperation(opentelemetry::ext::http::client::Method method,
                 std::string url,
-#ifdef ENABLE_HTTP_SSL_PREVIEW
                 const opentelemetry::ext::http::client::HttpSslOptions &ssl_options,
-#endif /* ENABLE_HTTP_SSL_PREVIEW */
                 opentelemetry::ext::http::client::EventHandler *event_handle,
                 // Default empty headers and empty request body
                 const opentelemetry::ext::http::client::Headers &request_headers =
@@ -290,9 +288,7 @@ private:
   opentelemetry::ext::http::client::Method method_;
   std::string url_;
 
-#ifdef ENABLE_HTTP_SSL_PREVIEW
   const opentelemetry::ext::http::client::HttpSslOptions &ssl_options_;
-#endif /* ENABLE_HTTP_SSL_PREVIEW */
 
   const Headers &request_headers_;
   const opentelemetry::ext::http::client::Body &request_body_;

--- a/ext/include/opentelemetry/ext/http/client/http_client.h
+++ b/ext/include/opentelemetry/ext/http/client/http_client.h
@@ -110,7 +110,6 @@ struct cmp_ic
 };
 using Headers = std::multimap<std::string, std::string, cmp_ic>;
 
-#ifdef ENABLE_HTTP_SSL_PREVIEW
 struct HttpSslOptions
 {
   HttpSslOptions() {}
@@ -122,14 +121,11 @@ struct HttpSslOptions
                  nostd::string_view input_ssl_client_key_path,
                  nostd::string_view input_ssl_client_key_string,
                  nostd::string_view input_ssl_client_cert_path,
-                 nostd::string_view input_ssl_client_cert_string
-#  ifdef ENABLE_HTTP_SSL_TLS_PREVIEW
-                 ,
+                 nostd::string_view input_ssl_client_cert_string,
                  nostd::string_view input_ssl_min_tls,
                  nostd::string_view input_ssl_max_tls,
                  nostd::string_view input_ssl_cipher,
                  nostd::string_view input_ssl_cipher_suite
-#  endif /* ENABLE_HTTP_SSL_TLS_PREVIEW */
                  )
       : use_ssl(false),
         ssl_insecure_skip_verify(input_ssl_insecure_skip_verify),
@@ -138,15 +134,11 @@ struct HttpSslOptions
         ssl_client_key_path(input_ssl_client_key_path),
         ssl_client_key_string(input_ssl_client_key_string),
         ssl_client_cert_path(input_ssl_client_cert_path),
-        ssl_client_cert_string(input_ssl_client_cert_string)
-
-#  ifdef ENABLE_HTTP_SSL_TLS_PREVIEW
-        ,
+        ssl_client_cert_string(input_ssl_client_cert_string),
         ssl_min_tls(input_ssl_min_tls),
         ssl_max_tls(input_ssl_max_tls),
         ssl_cipher(input_ssl_cipher),
         ssl_cipher_suite(input_ssl_cipher_suite)
-#  endif /* ENABLE_HTTP_SSL_TLS_PREVIEW */
   {
     /* Use SSL if url starts with "https:" */
     if (strncmp(url.data(), "https:", 6) == 0)
@@ -192,7 +184,6 @@ struct HttpSslOptions
   */
   std::string ssl_client_cert_string{};
 
-#  ifdef ENABLE_HTTP_SSL_TLS_PREVIEW
   /**
     Minimum SSL version to use.
     Valid values are:
@@ -230,9 +221,7 @@ struct HttpSslOptions
     Cipher names depends on the underlying CURL implementation.
   */
   std::string ssl_cipher_suite{};
-#  endif /* ENABLE_HTTP_SSL_TLS_PREVIEW */
 };
-#endif /* ENABLE_HTTP_SSL_PREVIEW */
 
 class Request
 {
@@ -241,9 +230,7 @@ public:
 
   virtual void SetUri(nostd::string_view uri) noexcept = 0;
 
-#ifdef ENABLE_HTTP_SSL_PREVIEW
   virtual void SetSslOptions(const HttpSslOptions &options) noexcept = 0;
-#endif /* ENABLE_HTTP_SSL_PREVIEW */
 
   virtual void SetBody(Body &body) noexcept = 0;
 
@@ -368,36 +355,24 @@ class HttpClientSync
 public:
   Result GetNoSsl(const nostd::string_view &url, const Headers &headers = {{}}) noexcept
   {
-#ifdef ENABLE_HTTP_SSL_PREVIEW
     static const HttpSslOptions no_ssl;
     return Get(url, no_ssl, headers);
-#else
-    return Get(url, headers);
-#endif /* ENABLE_HTTP_SSL_PREVIEW */
   }
 
   virtual Result PostNoSsl(const nostd::string_view &url,
                            const Body &body,
                            const Headers &headers = {{"content-type", "application/json"}}) noexcept
   {
-#ifdef ENABLE_HTTP_SSL_PREVIEW
     static const HttpSslOptions no_ssl;
     return Post(url, no_ssl, body, headers);
-#else
-    return Post(url, body, headers);
-#endif /* ENABLE_HTTP_SSL_PREVIEW */
   }
 
   virtual Result Get(const nostd::string_view &url,
-#ifdef ENABLE_HTTP_SSL_PREVIEW
                      const HttpSslOptions &ssl_options,
-#endif /* ENABLE_HTTP_SSL_PREVIEW */
                      const Headers & = {{}}) noexcept = 0;
 
   virtual Result Post(const nostd::string_view &url,
-#ifdef ENABLE_HTTP_SSL_PREVIEW
                       const HttpSslOptions &ssl_options,
-#endif /* ENABLE_HTTP_SSL_PREVIEW */
                       const Body &body,
                       const Headers & = {{"content-type", "application/json"}}) noexcept = 0;
 

--- a/ext/include/opentelemetry/ext/http/client/http_client.h
+++ b/ext/include/opentelemetry/ext/http/client/http_client.h
@@ -125,8 +125,7 @@ struct HttpSslOptions
                  nostd::string_view input_ssl_min_tls,
                  nostd::string_view input_ssl_max_tls,
                  nostd::string_view input_ssl_cipher,
-                 nostd::string_view input_ssl_cipher_suite
-                 )
+                 nostd::string_view input_ssl_cipher_suite)
       : use_ssl(false),
         ssl_insecure_skip_verify(input_ssl_insecure_skip_verify),
         ssl_ca_cert_path(input_ssl_ca_cert_path),

--- a/ext/src/http/client/curl/http_client_curl.cc
+++ b/ext/src/http/client/curl/http_client_curl.cc
@@ -49,9 +49,7 @@ void Session::SendRequest(
   }
 
   curl_operation_.reset(new HttpOperation(http_request_->method_, url,
-#ifdef ENABLE_HTTP_SSL_PREVIEW
                                           http_request_->ssl_options_,
-#endif /* ENABLE_HTTP_SSL_PREVIEW */
                                           callback_ptr, http_request_->headers_,
                                           http_request_->body_, false, http_request_->timeout_ms_,
                                           reuse_connection));

--- a/ext/src/http/client/curl/http_client_curl.cc
+++ b/ext/src/http/client/curl/http_client_curl.cc
@@ -48,8 +48,7 @@ void Session::SendRequest(
     reuse_connection = session_id_ % http_client_.GetMaxSessionsPerConnection() != 0;
   }
 
-  curl_operation_.reset(new HttpOperation(http_request_->method_, url,
-                                          http_request_->ssl_options_,
+  curl_operation_.reset(new HttpOperation(http_request_->method_, url, http_request_->ssl_options_,
                                           callback_ptr, http_request_->headers_,
                                           http_request_->body_, false, http_request_->timeout_ms_,
                                           reuse_connection));

--- a/ext/src/http/client/curl/http_operation_curl.cc
+++ b/ext/src/http/client/curl/http_operation_curl.cc
@@ -235,9 +235,7 @@ void HttpOperation::DispatchEvent(opentelemetry::ext::http::client::SessionState
 
 HttpOperation::HttpOperation(opentelemetry::ext::http::client::Method method,
                              std::string url,
-#ifdef ENABLE_HTTP_SSL_PREVIEW
                              const HttpSslOptions &ssl_options,
-#endif /* ENABLE_HTTP_SSL_PREVIEW */
                              opentelemetry::ext::http::client::EventHandler *event_handle,
                              // Default empty headers and empty request body
                              const opentelemetry::ext::http::client::Headers &request_headers,
@@ -258,9 +256,7 @@ HttpOperation::HttpOperation(opentelemetry::ext::http::client::Method method,
       event_handle_(event_handle),
       method_(method),
       url_(url),
-#ifdef ENABLE_HTTP_SSL_PREVIEW
       ssl_options_(ssl_options),
-#endif /* ENABLE_HTTP_SSL_PREVIEW */
       // Local vars
       request_headers_(request_headers),
       request_body_(request_body),
@@ -438,7 +434,6 @@ void HttpOperation::Cleanup()
 #  define HAVE_TLS_VERSION
 #endif
 
-#ifdef ENABLE_HTTP_SSL_TLS_PREVIEW
 static long parse_min_ssl_version(std::string version)
 {
 #  ifdef HAVE_TLS_VERSION
@@ -492,7 +487,6 @@ static long parse_max_ssl_version(std::string version)
 
   return 0;
 }
-#endif /* ENABLE_HTTP_SSL_TLS_PREVIEW */
 
 const char *HttpOperation::GetCurlErrorMessage(CURLcode code)
 {
@@ -601,7 +595,6 @@ CURLcode HttpOperation::Setup()
     return rc;
   }
 
-#ifdef ENABLE_HTTP_SSL_PREVIEW
   if (ssl_options_.use_ssl)
   {
     /* 1 - CA CERT */
@@ -733,7 +726,6 @@ CURLcode HttpOperation::Setup()
 #  endif
     }
 
-#  ifdef ENABLE_HTTP_SSL_TLS_PREVIEW
     /* 4 - TLS */
 
     long min_ssl_version = 0;
@@ -814,7 +806,6 @@ CURLcode HttpOperation::Setup()
         return rc;
       }
     }
-#  endif /* ENABLE_HTTP_SSL_TLS_PREVIEW */
 
     if (ssl_options_.ssl_insecure_skip_verify)
     {
@@ -860,7 +851,6 @@ CURLcode HttpOperation::Setup()
     }
   }
   else
-#endif /* ENABLE_HTTP_SSL_PREVIEW */
   {
     rc = SetCurlLongOption(CURLOPT_SSL_VERIFYPEER, 0L);
     if (rc != CURLE_OK)

--- a/ext/src/http/client/curl/http_operation_curl.cc
+++ b/ext/src/http/client/curl/http_operation_curl.cc
@@ -436,7 +436,7 @@ void HttpOperation::Cleanup()
 
 static long parse_min_ssl_version(std::string version)
 {
-#  ifdef HAVE_TLS_VERSION
+#ifdef HAVE_TLS_VERSION
   if (version == "1.0")
   {
     return CURL_SSLVERSION_TLSv1_0;
@@ -456,14 +456,14 @@ static long parse_min_ssl_version(std::string version)
   {
     return CURL_SSLVERSION_TLSv1_3;
   }
-#  endif
+#endif
 
   return 0;
 }
 
 static long parse_max_ssl_version(std::string version)
 {
-#  ifdef HAVE_TLS_VERSION
+#ifdef HAVE_TLS_VERSION
   if (version == "1.0")
   {
     return CURL_SSLVERSION_MAX_TLSv1_0;
@@ -483,7 +483,7 @@ static long parse_max_ssl_version(std::string version)
   {
     return CURL_SSLVERSION_MAX_TLSv1_3;
   }
-#  endif
+#endif
 
   return 0;
 }
@@ -611,7 +611,7 @@ CURLcode HttpOperation::Setup()
     }
     else if (!ssl_options_.ssl_ca_cert_string.empty())
     {
-#  if LIBCURL_VERSION_NUM >= CURL_VERSION_BITS(7, 77, 0)
+#if LIBCURL_VERSION_NUM >= CURL_VERSION_BITS(7, 77, 0)
       const char *data = ssl_options_.ssl_ca_cert_string.c_str();
       size_t data_len  = ssl_options_.ssl_ca_cert_string.length();
 
@@ -625,11 +625,11 @@ CURLcode HttpOperation::Setup()
       {
         return rc;
       }
-#  else
+#else
       // CURL 7.77.0 required for CURLOPT_CAINFO_BLOB.
       OTEL_INTERNAL_LOG_ERROR("CURL 7.77.0 required for CA CERT STRING");
       return CURLE_UNKNOWN_OPTION;
-#  endif
+#endif
     }
 
     /* 2 - CLIENT KEY */
@@ -652,7 +652,7 @@ CURLcode HttpOperation::Setup()
     }
     else if (!ssl_options_.ssl_client_key_string.empty())
     {
-#  if LIBCURL_VERSION_NUM >= CURL_VERSION_BITS(7, 71, 0)
+#if LIBCURL_VERSION_NUM >= CURL_VERSION_BITS(7, 71, 0)
       const char *data = ssl_options_.ssl_client_key_string.c_str();
       size_t data_len  = ssl_options_.ssl_client_key_string.length();
 
@@ -672,11 +672,11 @@ CURLcode HttpOperation::Setup()
       {
         return rc;
       }
-#  else
+#else
       // CURL 7.71.0 required for CURLOPT_SSLKEY_BLOB.
       OTEL_INTERNAL_LOG_ERROR("CURL 7.71.0 required for CLIENT KEY STRING");
       return CURLE_UNKNOWN_OPTION;
-#  endif
+#endif
     }
 
     /* 3 - CLIENT CERT */
@@ -699,7 +699,7 @@ CURLcode HttpOperation::Setup()
     }
     else if (!ssl_options_.ssl_client_cert_string.empty())
     {
-#  if LIBCURL_VERSION_NUM >= CURL_VERSION_BITS(7, 71, 0)
+#if LIBCURL_VERSION_NUM >= CURL_VERSION_BITS(7, 71, 0)
       const char *data = ssl_options_.ssl_client_cert_string.c_str();
       size_t data_len  = ssl_options_.ssl_client_cert_string.length();
 
@@ -719,11 +719,11 @@ CURLcode HttpOperation::Setup()
       {
         return rc;
       }
-#  else
+#else
       // CURL 7.71.0 required for CURLOPT_SSLCERT_BLOB.
       OTEL_INTERNAL_LOG_ERROR("CURL 7.71.0 required for CLIENT CERT STRING");
       return CURLE_UNKNOWN_OPTION;
-#  endif
+#endif
     }
 
     /* 4 - TLS */
@@ -732,7 +732,7 @@ CURLcode HttpOperation::Setup()
 
     if (!ssl_options_.ssl_min_tls.empty())
     {
-#    ifdef HAVE_TLS_VERSION
+#ifdef HAVE_TLS_VERSION
       min_ssl_version = parse_min_ssl_version(ssl_options_.ssl_min_tls);
 
       if (min_ssl_version == 0)
@@ -740,17 +740,17 @@ CURLcode HttpOperation::Setup()
         OTEL_INTERNAL_LOG_ERROR("Unknown min TLS version <" << ssl_options_.ssl_min_tls << ">");
         return CURLE_UNKNOWN_OPTION;
       }
-#    else
+#else
       OTEL_INTERNAL_LOG_ERROR("CURL 7.54.0 required for MIN TLS");
       return CURLE_UNKNOWN_OPTION;
-#    endif
+#endif
     }
 
     long max_ssl_version = 0;
 
     if (!ssl_options_.ssl_max_tls.empty())
     {
-#    ifdef HAVE_TLS_VERSION
+#ifdef HAVE_TLS_VERSION
       max_ssl_version = parse_max_ssl_version(ssl_options_.ssl_max_tls);
 
       if (max_ssl_version == 0)
@@ -758,10 +758,10 @@ CURLcode HttpOperation::Setup()
         OTEL_INTERNAL_LOG_ERROR("Unknown max TLS version <" << ssl_options_.ssl_max_tls << ">");
         return CURLE_UNKNOWN_OPTION;
       }
-#    else
+#else
       OTEL_INTERNAL_LOG_ERROR("CURL 7.54.0 required for MAX TLS");
       return CURLE_UNKNOWN_OPTION;
-#    endif
+#endif
     }
 
     long version_range = min_ssl_version | max_ssl_version;
@@ -790,16 +790,16 @@ CURLcode HttpOperation::Setup()
 
     if (!ssl_options_.ssl_cipher_suite.empty())
     {
-#    if LIBCURL_VERSION_NUM >= CURL_VERSION_BITS(7, 61, 0)
+#if LIBCURL_VERSION_NUM >= CURL_VERSION_BITS(7, 61, 0)
       /* TLS 1.3 */
       const char *cipher_list = ssl_options_.ssl_cipher_suite.c_str();
 
       rc = SetCurlStrOption(CURLOPT_TLS13_CIPHERS, cipher_list);
-#    else
+#else
       // CURL 7.61.0 required for CURLOPT_TLS13_CIPHERS.
       OTEL_INTERNAL_LOG_ERROR("CURL 7.61.0 required for CIPHER SUITE");
       return CURLE_UNKNOWN_OPTION;
-#    endif
+#endif
 
       if (rc != CURLE_OK)
       {

--- a/ext/test/http/curl_http_test.cc
+++ b/ext/test/http/curl_http_test.cc
@@ -300,19 +300,16 @@ TEST_F(BasicCurlHttpTests, CurlHttpOperations)
   http_client::Headers headers = {
       {"name1", "value1_1"}, {"name1", "value1_2"}, {"name2", "value3"}, {"name3", "value3"}};
 
-  curl::HttpOperation http_operations1(http_client::Method::Head, "/get",
-                                       no_ssl,
-                                       handler, headers, body, true);
+  curl::HttpOperation http_operations1(http_client::Method::Head, "/get", no_ssl, handler, headers,
+                                       body, true);
   http_operations1.Send();
 
-  curl::HttpOperation http_operations2(http_client::Method::Get, "/get",
-                                       no_ssl,
-                                       handler, headers, body, true);
+  curl::HttpOperation http_operations2(http_client::Method::Get, "/get", no_ssl, handler, headers,
+                                       body, true);
   http_operations2.Send();
 
-  curl::HttpOperation http_operations3(http_client::Method::Get, "/get",
-                                       no_ssl,
-                                       handler, headers, body, false);
+  curl::HttpOperation http_operations3(http_client::Method::Get, "/get", no_ssl, handler, headers,
+                                       body, false);
   http_operations3.Send();
   delete handler;
 }

--- a/ext/test/http/curl_http_test.cc
+++ b/ext/test/http/curl_http_test.cc
@@ -290,9 +290,7 @@ TEST_F(BasicCurlHttpTests, RequestTimeout)
 
 TEST_F(BasicCurlHttpTests, CurlHttpOperations)
 {
-#ifdef ENABLE_HTTP_SSL_PREVIEW
   http_client::HttpSslOptions no_ssl;
-#endif /* ENABLE_HTTP_SSL_PREVIEW */
 
   GetEventHandler *handler = new GetEventHandler();
 
@@ -303,23 +301,17 @@ TEST_F(BasicCurlHttpTests, CurlHttpOperations)
       {"name1", "value1_1"}, {"name1", "value1_2"}, {"name2", "value3"}, {"name3", "value3"}};
 
   curl::HttpOperation http_operations1(http_client::Method::Head, "/get",
-#ifdef ENABLE_HTTP_SSL_PREVIEW
                                        no_ssl,
-#endif /* ENABLE_HTTP_SSL_PREVIEW */
                                        handler, headers, body, true);
   http_operations1.Send();
 
   curl::HttpOperation http_operations2(http_client::Method::Get, "/get",
-#ifdef ENABLE_HTTP_SSL_PREVIEW
                                        no_ssl,
-#endif /* ENABLE_HTTP_SSL_PREVIEW */
                                        handler, headers, body, true);
   http_operations2.Send();
 
   curl::HttpOperation http_operations3(http_client::Method::Get, "/get",
-#ifdef ENABLE_HTTP_SSL_PREVIEW
                                        no_ssl,
-#endif /* ENABLE_HTTP_SSL_PREVIEW */
                                        handler, headers, body, false);
   http_operations3.Send();
   delete handler;

--- a/functional/otlp/func_http_main.cc
+++ b/functional/otlp/func_http_main.cc
@@ -308,7 +308,6 @@ struct test_case
 
 int test_basic();
 
-#ifdef ENABLE_OTLP_HTTP_SSL_PREVIEW
 int test_cert_not_found();
 int test_cert_invalid();
 int test_cert_unreadable();
@@ -321,9 +320,7 @@ int test_client_key_not_found();
 int test_client_key_invalid();
 int test_client_key_unreadable();
 int test_client_key_ok();
-#endif /* ENABLE_OTLP_HTTP_SSL_PREVIEW */
 
-#ifdef ENABLE_OTLP_HTTP_SSL_TLS_PREVIEW
 int test_min_tls_unknown();
 int test_min_tls_10();
 int test_min_tls_11();
@@ -350,10 +347,8 @@ int test_range_tls_12_13();
 int test_range_tls_13_10();
 int test_range_tls_13_11();
 int test_range_tls_13_12();
-#endif /* ENABLE_OTLP_HTTP_SSL_TLS_PREVIEW */
 
 static const test_case all_tests[] = {{"basic", test_basic},
-#ifdef ENABLE_OTLP_HTTP_SSL_PREVIEW
                                       {"cert-not-found", test_cert_not_found},
                                       {"cert-invalid", test_cert_invalid},
                                       {"cert-unreadable", test_cert_unreadable},
@@ -366,9 +361,6 @@ static const test_case all_tests[] = {{"basic", test_basic},
                                       {"client-key-invalid", test_client_key_invalid},
                                       {"client-key-unreadable", test_client_key_unreadable},
                                       {"client-key-ok", test_client_key_ok},
-#endif /* ENABLE_OTLP_HTTP_SSL_PREVIEW */
-
-#ifdef ENABLE_OTLP_HTTP_SSL_TLS_PREVIEW
                                       {"min-tls-unknown", test_min_tls_unknown},
                                       {"min-tls-10", test_min_tls_10},
                                       {"min-tls-11", test_min_tls_11},
@@ -395,7 +387,6 @@ static const test_case all_tests[] = {{"basic", test_basic},
                                       {"range-tls-13-10", test_range_tls_13_10},
                                       {"range-tls-13-11", test_range_tls_13_11},
                                       {"range-tls-13-12", test_range_tls_13_12},
-#endif /* ENABLE_OTLP_HTTP_SSL_TLS_PREVIEW */
                                       {"", nullptr}};
 
 void list_test_cases()
@@ -560,8 +551,6 @@ int test_basic()
 
   return expect_connection_failed();
 }
-
-#ifdef ENABLE_OTLP_HTTP_SSL_PREVIEW
 
 int test_cert_not_found()
 {
@@ -908,9 +897,6 @@ int test_client_key_ok()
 
   return expect_success();
 }
-#endif /* ENABLE_OTLP_HTTP_SSL_PREVIEW */
-
-#ifdef ENABLE_OTLP_HTTP_SSL_TLS_PREVIEW
 
 int test_min_tls_unknown()
 {
@@ -1808,5 +1794,3 @@ int test_range_tls_13_12()
   // Impossible
   return expect_connection_failed();
 }
-
-#endif /* ENABLE_OTLP_HTTP_SSL_TLS_PREVIEW */

--- a/test_common/include/opentelemetry/test_common/ext/http/client/nosend/http_client_nosend.h
+++ b/test_common/include/opentelemetry/test_common/ext/http/client/nosend/http_client_nosend.h
@@ -36,12 +36,10 @@ public:
     method_ = method;
   }
 
-#ifdef ENABLE_HTTP_SSL_PREVIEW
   void SetSslOptions(const HttpSslOptions &ssl_options) noexcept override
   {
     ssl_options_ = ssl_options;
   }
-#endif /* ENABLE_HTTP_SSL_PREVIEW */
 
   void SetBody(opentelemetry::ext::http::client::Body &body) noexcept override
   {
@@ -65,9 +63,7 @@ public:
 
 public:
   opentelemetry::ext::http::client::Method method_;
-#ifdef ENABLE_HTTP_SSL_PREVIEW
   opentelemetry::ext::http::client::HttpSslOptions ssl_options_;
-#endif /* ENABLE_HTTP_SSL_PREVIEW */
   opentelemetry::ext::http::client::Body body_;
   opentelemetry::ext::http::client::Headers headers_;
   std::string uri_;


### PR DESCRIPTION
Fixes #2383

## Changes

CMake options `WITH_OTLP_HTTP_SSL_PREVIEW`
and `WITH_OTLP_HTTP_SSL_TLS_PREVIEW` are removed.
Building opentelemetry-cpp without SSL support is no longer possible.

For significant contributions please make sure you have completed the following items:

* [X] `CHANGELOG.md` updated for non-trivial changes
* [ ] Unit tests have been added
* [ ] Changes in public API reviewed