### PR TITLE
[BUILD] Accept path list in OPENTELEMETRY_EXTERNAL_COMPONENT_PATH

### DIFF
--- a/cmake/opentelemetry-build-external-component.cmake
+++ b/cmake/opentelemetry-build-external-component.cmake
@@ -3,8 +3,7 @@
 
 function(get_directory_name_in_path PATH_VAR RESULT_VAR)
   # get_filename_component does not work with paths ending in / or \, so remove it.
-  string(REGEX REPLACE "/$" "" PATH_TRIMMED "${PATH_VAR}")
-  string(REGEX REPLACE "\\$" "" PATH_TRIMMED "${PATH_VAR}")
+  string(REGEX REPLACE "[/\\]$" "" PATH_TRIMMED "${PATH_VAR}")
 
   get_filename_component(DIR_NAME ${PATH_TRIMMED} NAME)
 

--- a/cmake/opentelemetry-build-external-component.cmake
+++ b/cmake/opentelemetry-build-external-component.cmake
@@ -13,14 +13,14 @@
 if(OPENTELEMETRY_EXTERNAL_COMPONENT_PATH)
   # Add custom component path to build tree and consolidate binary artifacts in
   # current project binary output directory.
-  foreach(DIR IN LSITS OPENTELEMETRY_EXTERNAL_COMPONENT_PATH)
+  foreach(DIR IN LISTS OPENTELEMETRY_EXTERNAL_COMPONENT_PATH)
     add_subdirectory(${DIR} ${PROJECT_BINARY_DIR}/external)
   endforeach()
 elseif(DEFINED ENV{OPENTELEMETRY_EXTERNAL_COMPONENT_PATH})
   # Add custom component path to build tree and consolidate binary artifacts in
   # current project binary output directory.
   set(OPENTELEMETRY_EXTERNAL_COMPONENT_PATH_VAR $ENV{OPENTELEMETRY_EXTERNAL_COMPONENT_PATH})
-  foreach(DIR IN LSITS OPENTELEMETRY_EXTERNAL_COMPONENT_PATH_VAR)
+  foreach(DIR IN LISTS OPENTELEMETRY_EXTERNAL_COMPONENT_PATH_VAR)
     add_subdirectory(${DIR} ${PROJECT_BINARY_DIR}/external)
   endforeach()
 elseif(DEFINED $ENV{OPENTELEMETRY_EXTERNAL_COMPONENT_URL})

--- a/cmake/opentelemetry-build-external-component.cmake
+++ b/cmake/opentelemetry-build-external-component.cmake
@@ -3,8 +3,8 @@
 
 # Enable building external components through otel-cpp build
 # The config options are
-#  - OPENTELEMETRY_EXTERNAL_COMPONENT_PATH - Setting local path of the external
-# component as env variable
+#  - OPENTELEMETRY_EXTERNAL_COMPONENT_PATH - Setting local paths of the external
+# component as env variable. Multiple paths can be set by separating them with.
 #  - OPENTELEMETRY_EXTERNAL_COMPONENT_URL Setting github-repo of external component
 #  as env variable
 
@@ -13,13 +13,16 @@
 if(OPENTELEMETRY_EXTERNAL_COMPONENT_PATH)
   # Add custom component path to build tree and consolidate binary artifacts in
   # current project binary output directory.
-  add_subdirectory(${OPENTELEMETRY_EXTERNAL_COMPONENT_PATH}
-                   ${PROJECT_BINARY_DIR}/external)
+  foreach(DIR IN LSITS OPENTELEMETRY_EXTERNAL_COMPONENT_PATH)
+    add_subdirectory(${DIR} ${PROJECT_BINARY_DIR}/external)
+  endforeach()
 elseif(DEFINED ENV{OPENTELEMETRY_EXTERNAL_COMPONENT_PATH})
   # Add custom component path to build tree and consolidate binary artifacts in
   # current project binary output directory.
-  add_subdirectory($ENV{OPENTELEMETRY_EXTERNAL_COMPONENT_PATH}
-                   ${PROJECT_BINARY_DIR}/external)
+  set(OPENTELEMETRY_EXTERNAL_COMPONENT_PATH_VAR $ENV{OPENTELEMETRY_EXTERNAL_COMPONENT_PATH})
+  foreach(DIR IN LSITS OPENTELEMETRY_EXTERNAL_COMPONENT_PATH_VAR)
+    add_subdirectory(${DIR} ${PROJECT_BINARY_DIR}/external)
+  endforeach()
 elseif(DEFINED $ENV{OPENTELEMETRY_EXTERNAL_COMPONENT_URL})
   # This option requires CMake 3.11+: add standard remote repo to build tree.
   include(FetchContent)

--- a/cmake/opentelemetry-build-external-component.cmake
+++ b/cmake/opentelemetry-build-external-component.cmake
@@ -1,6 +1,16 @@
 # Copyright The OpenTelemetry Authors
 # SPDX-License-Identifier: Apache-2.0
 
+function(get_directory_name_in_path PATH_VAR RESULT_VAR)
+  # get_filename_component does not work with paths ending in / or \, so remove it.
+  string(REGEX REPLACE "/$" "" PATH_TRIMMED "${PATH_VAR}")
+  string(REGEX REPLACE "\\$" "" PATH_TRIMMED "${PATH_VAR}")
+
+  get_filename_component(DIR_NAME ${PATH_TRIMMED} NAME)
+
+  set(${RESULT_VAR} "${DIR_NAME}" PARENT_SCOPE)
+endfunction()
+
 # Enable building external components through otel-cpp build
 # The config options are
 #  - OPENTELEMETRY_EXTERNAL_COMPONENT_PATH - Setting local paths of the external
@@ -14,14 +24,16 @@ if(OPENTELEMETRY_EXTERNAL_COMPONENT_PATH)
   # Add custom component path to build tree and consolidate binary artifacts in
   # current project binary output directory.
   foreach(DIR IN LISTS OPENTELEMETRY_EXTERNAL_COMPONENT_PATH)
-    add_subdirectory(${DIR} ${PROJECT_BINARY_DIR}/external)
+    get_directory_name_in_path(${DIR} EXTERNAL_EXPORTER_DIR_NAME)
+    add_subdirectory(${DIR} ${PROJECT_BINARY_DIR}/external/${EXTERNAL_EXPORTER_DIR_NAME})
   endforeach()
 elseif(DEFINED ENV{OPENTELEMETRY_EXTERNAL_COMPONENT_PATH})
   # Add custom component path to build tree and consolidate binary artifacts in
   # current project binary output directory.
   set(OPENTELEMETRY_EXTERNAL_COMPONENT_PATH_VAR $ENV{OPENTELEMETRY_EXTERNAL_COMPONENT_PATH})
   foreach(DIR IN LISTS OPENTELEMETRY_EXTERNAL_COMPONENT_PATH_VAR)
-    add_subdirectory(${DIR} ${PROJECT_BINARY_DIR}/external)
+    get_directory_name_in_path(${DIR} EXTERNAL_EXPORTER_DIR_NAME)
+    add_subdirectory(${DIR} ${PROJECT_BINARY_DIR}/external/${EXTERNAL_EXPORTER_DIR_NAME})
   endforeach()
 elseif(DEFINED $ENV{OPENTELEMETRY_EXTERNAL_COMPONENT_URL})
   # This option requires CMake 3.11+: add standard remote repo to build tree.


### PR DESCRIPTION
Extend `OPENTELEMETRY_EXTERNAL_COMPONENT_PATH` to support path list will help integration with multiple external exporters.

## Changes

Please provide a brief description of the changes here.

For significant contributions please make sure you have completed the following items:

* [ ] `CHANGELOG.md` updated for non-trivial changes
* [ ] Unit tests have been added
* [ ] Changes in public API reviewed