### PR TITLE
[BUILD] Fix removing of NOMINMAX on Windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,9 @@ Increment the:
 
 ## [Unreleased]
 
+* [BUILD] Fix removing of NOMINMAX on Windows
+  [#2449](https://github.com/open-telemetry/opentelemetry-cpp/pull/2449)
+
 ## [1.13.0] 2023-12-06
 
 * [BUILD] Remove WITH_REMOVE_METER_PREVIEW, use WITH_ABI_VERSION_2 instead

--- a/api/include/opentelemetry/std/span.h
+++ b/api/include/opentelemetry/std/span.h
@@ -60,7 +60,7 @@ OPENTELEMETRY_END_NAMESPACE
 OPENTELEMETRY_BEGIN_NAMESPACE
 namespace nostd
 {
-constexpr std::size_t dynamic_extent = (std::numeric_limits<std::size_t>::max());
+constexpr std::size_t dynamic_extent = (std::numeric_limits<std::size_t>::max)();
 
 template <class ElementType, std::size_t Extent = nostd::dynamic_extent>
 using span = std::span<ElementType, Extent>;


### PR DESCRIPTION
## Changes

NOMINMAX was removed in our API in below PR, but one more fix needed for a call of `::max` in the API. It was missed because this line is only hit when building for C++ 17 and above.

https://github.com/open-telemetry/opentelemetry-cpp/pull/2420

For significant contributions please make sure you have completed the following items:

* [x] `CHANGELOG.md` updated for non-trivial changes
* [ ] Unit tests have been added
* [ ] Changes in public API reviewed