### PR TITLE
[EXPORTER] Add option to disable Prometheus otel_scope_name and otel_scope_version attributes

### DIFF
--- a/exporters/prometheus/include/opentelemetry/exporters/prometheus/collector.h
+++ b/exporters/prometheus/include/opentelemetry/exporters/prometheus/collector.h
@@ -31,7 +31,9 @@ public:
    * This constructor initializes the collection for metrics to export
    * in this class with default capacity
    */
-  explicit PrometheusCollector(sdk::metrics::MetricReader *reader, bool populate_target_info);
+  explicit PrometheusCollector(sdk::metrics::MetricReader *reader,
+                               bool populate_target_info,
+                               bool populate_otel_scope);
 
   /**
    * Collects all metrics data from metricsToCollect collection.
@@ -43,6 +45,7 @@ public:
 private:
   sdk::metrics::MetricReader *reader_;
   bool populate_target_info_;
+  bool populate_otel_scope_;
 
   /*
    * Lock when operating the metricsToCollect collection

--- a/exporters/prometheus/include/opentelemetry/exporters/prometheus/exporter_options.h
+++ b/exporters/prometheus/include/opentelemetry/exporters/prometheus/exporter_options.h
@@ -25,6 +25,9 @@ struct PrometheusExporterOptions
 
   // Populating target_info
   bool populate_target_info = true;
+
+  // Populating otel_scope_name/otel_scope_labels attributes
+  bool populate_otel_scope = true;
 };
 
 }  // namespace metrics

--- a/exporters/prometheus/include/opentelemetry/exporters/prometheus/exporter_utils.h
+++ b/exporters/prometheus/include/opentelemetry/exporters/prometheus/exporter_utils.h
@@ -28,11 +28,14 @@ public:
    *
    * @param records a collection of metrics in OpenTelemetry
    * @param populate_target_info whether to populate target_info
+   * @param populate_otel_scope whether to populate otel_scope_name and otel_scope_version
+   * attributes
    * @return a collection of translated metrics that is acceptable by Prometheus
    */
   static std::vector<::prometheus::MetricFamily> TranslateToPrometheus(
       const sdk::metrics::ResourceMetrics &data,
-      bool populate_target_info = true);
+      bool populate_target_info = true,
+      bool populate_otel_scope  = true);
 
 private:
   /**

--- a/exporters/prometheus/src/collector.cc
+++ b/exporters/prometheus/src/collector.cc
@@ -44,8 +44,8 @@ std::vector<prometheus_client::MetricFamily> PrometheusCollector::Collect() cons
   std::vector<prometheus_client::MetricFamily> result;
 
   reader_->Collect([&result, this](sdk::metrics::ResourceMetrics &metric_data) {
-    auto prometheus_metric_data =
-        PrometheusExporterUtils::TranslateToPrometheus(metric_data, this->populate_target_info_);
+    auto prometheus_metric_data = PrometheusExporterUtils::TranslateToPrometheus(
+        metric_data, this->populate_target_info_, this->populate_otel_scope_);
     for (auto &data : prometheus_metric_data)
       result.emplace_back(data);
     return true;

--- a/exporters/prometheus/src/collector.cc
+++ b/exporters/prometheus/src/collector.cc
@@ -18,8 +18,11 @@ namespace metrics
  * in this class with default capacity
  */
 PrometheusCollector::PrometheusCollector(sdk::metrics::MetricReader *reader,
-                                         bool populate_target_info)
-    : reader_(reader), populate_target_info_(populate_target_info)
+                                         bool populate_target_info,
+                                         bool populate_otel_scope)
+    : reader_(reader),
+      populate_target_info_(populate_target_info),
+      populate_otel_scope_(populate_otel_scope)
 {}
 
 /**

--- a/exporters/prometheus/src/exporter.cc
+++ b/exporters/prometheus/src/exporter.cc
@@ -31,7 +31,7 @@ PrometheusExporter::PrometheusExporter(const PrometheusExporterOptions &options)
     return;
   }
   collector_ = std::shared_ptr<PrometheusCollector>(
-      new PrometheusCollector(this, options_.populate_target_info));
+      new PrometheusCollector(this, options_.populate_target_info, options_.populate_otel_scope));
 
   exposer_->RegisterCollectable(collector_);
 }

--- a/exporters/prometheus/src/exporter_options.cc
+++ b/exporters/prometheus/src/exporter_options.cc
@@ -25,7 +25,20 @@ inline const std::string GetPrometheusDefaultHttpEndpoint()
   return exists ? endpoint : kPrometheusEndpointDefault;
 }
 
-PrometheusExporterOptions::PrometheusExporterOptions() : url(GetPrometheusDefaultHttpEndpoint()) {}
+inline bool GetPrometheusPopulateOtelScope()
+{
+  constexpr char kPrometheusPopulateOtelScope[] = "PROMETHEUS_EXPORTER_POPULATE_OTEL_SCOPE";
+
+  bool setting;
+  auto exists =
+      opentelemetry::sdk::common::GetBoolEnvironmentVariable(kPrometheusPopulateOtelScope, setting);
+
+  return exists ? setting : true;
+}
+
+PrometheusExporterOptions::PrometheusExporterOptions()
+    : url(GetPrometheusDefaultHttpEndpoint()), populate_otel_scope(GetPrometheusPopulateOtelScope())
+{}
 
 }  // namespace metrics
 }  // namespace exporter

--- a/exporters/prometheus/src/exporter_options.cc
+++ b/exporters/prometheus/src/exporter_options.cc
@@ -36,8 +36,21 @@ inline bool GetPrometheusPopulateOtelScope()
   return exists ? setting : true;
 }
 
+inline bool GetPrometheusPopulateTargetInfo()
+{
+  constexpr char kPrometheusPopulateTargetInfo[] = "PROMETHEUS_EXPORTER_POPULATE_TARGET_INFO";
+
+  bool setting;
+  auto exists = opentelemetry::sdk::common::GetBoolEnvironmentVariable(
+      kPrometheusPopulateTargetInfo, setting);
+
+  return exists ? setting : true;
+}
+
 PrometheusExporterOptions::PrometheusExporterOptions()
-    : url(GetPrometheusDefaultHttpEndpoint()), populate_otel_scope(GetPrometheusPopulateOtelScope())
+    : url(GetPrometheusDefaultHttpEndpoint()),
+      populate_target_info(GetPrometheusPopulateTargetInfo()),
+      populate_otel_scope(GetPrometheusPopulateOtelScope())
 {}
 
 }  // namespace metrics

--- a/exporters/prometheus/src/exporter_options.cc
+++ b/exporters/prometheus/src/exporter_options.cc
@@ -27,7 +27,8 @@ inline const std::string GetPrometheusDefaultHttpEndpoint()
 
 inline bool GetPrometheusPopulateOtelScope()
 {
-  constexpr char kPrometheusPopulateOtelScope[] = "PROMETHEUS_EXPORTER_POPULATE_OTEL_SCOPE";
+  constexpr char kPrometheusPopulateOtelScope[] =
+      "OTEL_CPP_PROMETHEUS_EXPORTER_POPULATE_OTEL_SCOPE";
 
   bool setting;
   auto exists =
@@ -38,7 +39,8 @@ inline bool GetPrometheusPopulateOtelScope()
 
 inline bool GetPrometheusPopulateTargetInfo()
 {
-  constexpr char kPrometheusPopulateTargetInfo[] = "PROMETHEUS_EXPORTER_POPULATE_TARGET_INFO";
+  constexpr char kPrometheusPopulateTargetInfo[] =
+      "OTEL_CPP_PROMETHEUS_EXPORTER_POPULATE_TARGET_INFO";
 
   bool setting;
   auto exists = opentelemetry::sdk::common::GetBoolEnvironmentVariable(

--- a/exporters/prometheus/test/collector_test.cc
+++ b/exporters/prometheus/test/collector_test.cc
@@ -73,7 +73,7 @@ TEST(PrometheusCollector, BasicTests)
   MockMetricReader *reader     = new MockMetricReader();
   MockMetricProducer *producer = new MockMetricProducer();
   reader->SetMetricProducer(producer);
-  PrometheusCollector collector(reader, true);
+  PrometheusCollector collector(reader, true, true);
   auto data = collector.Collect();
 
   // Collection size should be the same as the size


### PR DESCRIPTION
Fixes #2442 (plus one bonus fix)

## Changes

- Adds a new `populate_otel_scope` option to the `PrometheusExporterOptions` object defaulting to enabled, including an environment variable to control it
- Uses the option to enable/disable the `otel_scope_name` and `otel_scope_version` attributes added to instruments in Prometheus output
- Adds a new environment variable for controlling the `populate_target_info` option of `PrometheusExporterOptions`

I opted to use (abuse) the side effect of the scope variable being null for the actual disabling of the attributes here, instead of passing the option down through the method chain to where it's used. If that's undesirable, I can switch to passing it.

For significant contributions please make sure you have completed the following items:

* [ ] `CHANGELOG.md` updated for non-trivial changes
* [ ] Unit tests have been added
* [ ] Changes in public API reviewed