### PR TITLE
Do not use regex in `CleanUpString` because some implementations of STL may crash.

### DIFF
--- a/exporters/prometheus/src/exporter_utils.cc
+++ b/exporters/prometheus/src/exporter_utils.cc
@@ -423,8 +423,8 @@ std::string PrometheusExporterUtils::CleanUpString(const std::string &str)
     if (trim_end != i)
     {
       cleaned_string[trim_end] = cleaned_string[i];
-      ++trim_end;
     }
+    ++trim_end;
   }
 
   while (trim_end > 0 && cleaned_string[trim_end - 1] == '_')

--- a/exporters/prometheus/src/exporter_utils.cc
+++ b/exporters/prometheus/src/exporter_utils.cc
@@ -1,6 +1,7 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
+#include <algorithm>
 #include <limits>
 #include <regex>
 #include <sstream>
@@ -280,11 +281,7 @@ std::string PrometheusExporterUtils::SanitizeNames(std::string name)
   return name;
 }
 
-std::regex INVALID_CHARACTERS_PATTERN("[^a-zA-Z0-9]");
 std::regex CHARACTERS_BETWEEN_BRACES_PATTERN("\\{(.*?)\\}");
-std::regex SANITIZE_LEADING_UNDERSCORES("^_+");
-std::regex SANITIZE_TRAILING_UNDERSCORES("_+$");
-std::regex SANITIZE_CONSECUTIVE_UNDERSCORES("[_]{2,}");
 
 std::string PrometheusExporterUtils::GetEquivalentPrometheusUnit(
     const std::string &raw_metric_unit_name)
@@ -360,7 +357,7 @@ std::string PrometheusExporterUtils::GetPrometheusPerUnit(const std::string &per
 
 std::string PrometheusExporterUtils::RemoveUnitPortionInBraces(const std::string &unit)
 {
-  return std::regex_replace(unit, CHARACTERS_BETWEEN_BRACES_PATTERN, "");
+  return std::regex_replace(unit, CHARACTERS_BETWEEN_BRACES_PATTERN, std::string(""));
 }
 
 std::string PrometheusExporterUtils::ConvertRateExpressedToPrometheusUnit(
@@ -389,10 +386,65 @@ std::string PrometheusExporterUtils::ConvertRateExpressedToPrometheusUnit(
 
 std::string PrometheusExporterUtils::CleanUpString(const std::string &str)
 {
-  std::string cleaned_string = std::regex_replace(str, INVALID_CHARACTERS_PATTERN, "_");
-  cleaned_string = std::regex_replace(cleaned_string, SANITIZE_CONSECUTIVE_UNDERSCORES, "_");
-  cleaned_string = std::regex_replace(cleaned_string, SANITIZE_TRAILING_UNDERSCORES, "");
-  cleaned_string = std::regex_replace(cleaned_string, SANITIZE_LEADING_UNDERSCORES, "");
+  std::string cleaned_string = str;
+  if (cleaned_string.empty())
+  {
+    return cleaned_string;
+  }
+
+  std::transform(cleaned_string.begin(), cleaned_string.end(), cleaned_string.begin(),
+                 [](const char c) {
+                   if ((c >= '0' && c <= '9') || (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z'))
+                   {
+                     return c;
+                   }
+                   return '_';
+                 });
+
+  std::string::size_type trim_start = 0;
+  std::string::size_type trim_end   = 0;
+  bool previous_underscore          = false;
+  for (std::string::size_type i = 0; i < cleaned_string.size(); ++i)
+  {
+    if (cleaned_string[i] == '_')
+    {
+      if (previous_underscore)
+      {
+        continue;
+      }
+
+      previous_underscore = true;
+    }
+    else
+    {
+      previous_underscore = false;
+    }
+
+    if (trim_end != i)
+    {
+      cleaned_string[trim_end] = cleaned_string[i];
+      ++trim_end;
+    }
+  }
+
+  while (trim_end > 0 && cleaned_string[trim_end - 1] == '_')
+  {
+    --trim_end;
+  }
+  while (trim_start < trim_end && cleaned_string[trim_start] == '_')
+  {
+    ++trim_start;
+  }
+
+  // All characters are underscore
+  if (trim_start >= trim_end)
+  {
+    return "_";
+  }
+  if (0 != trim_start || cleaned_string.size() != trim_end)
+  {
+    return cleaned_string.substr(trim_start, trim_end - trim_start);
+  }
 
   return cleaned_string;
 }


### PR DESCRIPTION
Fixes #2463 

## Changes

+ Remove the usage of regex in `PrometheusExporterUtils::CleanUpString`
  + I didn't tested but it should have better performance than using `std::regex_replace`, because it allocate less `std::string` objects.
+ Use explicit `std::string` constructor in `std::regex_replace` because some versions of gcc can not detect the types correctly.

For significant contributions please make sure you have completed the following items:

* [ ] `CHANGELOG.md` updated for non-trivial changes
* [ ] Unit tests have been added
* [ ] Changes in public API reviewed