### PR TITLE
Fix Aggregation type detection in OTLP Exporter

### DIFF
--- a/exporters/otlp/include/opentelemetry/exporters/otlp/otlp_metric_utils.h
+++ b/exporters/otlp/include/opentelemetry/exporters/otlp/otlp_metric_utils.h
@@ -26,7 +26,7 @@ class OtlpMetricUtils
 {
 public:
   static opentelemetry::sdk::metrics::AggregationType GetAggregationType(
-      const opentelemetry::v1::sdk::metrics::MetricData &metric_data) noexcept;
+      const opentelemetry::sdk::metrics::MetricData &metric_data) noexcept;
 
   static proto::metrics::v1::AggregationTemporality GetProtoAggregationTemporality(
       const opentelemetry::sdk::metrics::AggregationTemporality &aggregation_temporality) noexcept;

--- a/exporters/otlp/include/opentelemetry/exporters/otlp/otlp_metric_utils.h
+++ b/exporters/otlp/include/opentelemetry/exporters/otlp/otlp_metric_utils.h
@@ -26,7 +26,7 @@ class OtlpMetricUtils
 {
 public:
   static opentelemetry::sdk::metrics::AggregationType GetAggregationType(
-      const opentelemetry::sdk::metrics::InstrumentType &instrument_type) noexcept;
+      const opentelemetry::v1::sdk::metrics::MetricData &metric_data) noexcept;
 
   static proto::metrics::v1::AggregationTemporality GetProtoAggregationTemporality(
       const opentelemetry::sdk::metrics::AggregationTemporality &aggregation_temporality) noexcept;

--- a/exporters/otlp/src/otlp_metric_utils.cc
+++ b/exporters/otlp/src/otlp_metric_utils.cc
@@ -46,6 +46,7 @@ metric_sdk::AggregationType OtlpMetricUtils::GetAggregationType(
   {
     return metric_sdk::AggregationType::kLastValue;
   }
+  return metric_sdk::AggregationType::kDrop;
 }
 
 void OtlpMetricUtils::ConvertSumMetric(const metric_sdk::MetricData &metric_data,

--- a/exporters/otlp/src/otlp_metric_utils.cc
+++ b/exporters/otlp/src/otlp_metric_utils.cc
@@ -25,7 +25,7 @@ proto::metrics::v1::AggregationTemporality OtlpMetricUtils::GetProtoAggregationT
 }
 
 metric_sdk::AggregationType OtlpMetricUtils::GetAggregationType(
-    const opentelemetry::v1::sdk::metrics::MetricData &metric_data) noexcept
+    const opentelemetry::sdk::metrics::MetricData &metric_data) noexcept
 {
   if (metric_data.point_data_attr_.size() == 0)
   {


### PR DESCRIPTION
Fixes #2466 

## Changes

The Aggregation type should be detected by checking the variant type, and not the instrument type. As it is possible to change the Aggregation type for an instrument through View configuration.

For significant contributions please make sure you have completed the following items:

* [ ] `CHANGELOG.md` updated for non-trivial changes
* [ ] Unit tests have been added
* [ ] Changes in public API reviewed