### PR TITLE
[EXPORTER and SDK] Additional fixes after NOMINMAX removal on Windows

### DIFF
--- a/docs/cpp-ostream-exporter-design.md
+++ b/docs/cpp-ostream-exporter-design.md
@@ -154,7 +154,7 @@ public:
         return sdktrace::ExportResult::kSuccess;
     }
 
-    bool Shutdown(std::chrono::microseconds timeout = std::chrono::microseconds::max()) noexcept
+    bool Shutdown(std::chrono::microseconds timeout = (std::chrono::microseconds::max())) noexcept
     {
         isShutdown = true;
         return true;

--- a/docs/cpp-ostream-exporter-design.md
+++ b/docs/cpp-ostream-exporter-design.md
@@ -154,7 +154,7 @@ public:
         return sdktrace::ExportResult::kSuccess;
     }
 
-    bool Shutdown(std::chrono::microseconds timeout = (std::chrono::microseconds::max())) noexcept
+    bool Shutdown(std::chrono::microseconds timeout = (std::chrono::microseconds::max)()) noexcept
     {
         isShutdown = true;
         return true;

--- a/exporters/elasticsearch/include/opentelemetry/exporters/elasticsearch/es_log_record_exporter.h
+++ b/exporters/elasticsearch/include/opentelemetry/exporters/elasticsearch/es_log_record_exporter.h
@@ -100,14 +100,14 @@ public:
    * @return return true when all data are exported, and false when timeout
    */
   bool ForceFlush(
-      std::chrono::microseconds timeout = (std::chrono::microseconds::max())) noexcept override;
+      std::chrono::microseconds timeout = (std::chrono::microseconds::max)()) noexcept override;
 
   /**
    * Shutdown this exporter.
    * @param timeout The maximum time to wait for the shutdown method to return
    */
   bool Shutdown(
-      std::chrono::microseconds timeout = (std::chrono::microseconds::max())) noexcept override;
+      std::chrono::microseconds timeout = (std::chrono::microseconds::max)()) noexcept override;
 
 private:
   // Stores if this exporter had its Shutdown() method called

--- a/exporters/elasticsearch/include/opentelemetry/exporters/elasticsearch/es_log_record_exporter.h
+++ b/exporters/elasticsearch/include/opentelemetry/exporters/elasticsearch/es_log_record_exporter.h
@@ -100,14 +100,14 @@ public:
    * @return return true when all data are exported, and false when timeout
    */
   bool ForceFlush(
-      std::chrono::microseconds timeout = std::chrono::microseconds::max()) noexcept override;
+      std::chrono::microseconds timeout = (std::chrono::microseconds::max())) noexcept override;
 
   /**
    * Shutdown this exporter.
    * @param timeout The maximum time to wait for the shutdown method to return
    */
   bool Shutdown(
-      std::chrono::microseconds timeout = std::chrono::microseconds::max()) noexcept override;
+      std::chrono::microseconds timeout = (std::chrono::microseconds::max())) noexcept override;
 
 private:
   // Stores if this exporter had its Shutdown() method called

--- a/exporters/elasticsearch/src/es_log_record_exporter.cc
+++ b/exporters/elasticsearch/src/es_log_record_exporter.cc
@@ -430,7 +430,7 @@ bool ElasticsearchLogRecordExporter::ForceFlush(
       std::chrono::duration_cast<std::chrono::steady_clock::duration>(timeout);
   if (timeout_steady <= std::chrono::steady_clock::duration::zero())
   {
-    timeout_steady = std::chrono::steady_clock::duration::max();
+    timeout_steady = (std::chrono::steady_clock::duration::max)();
   }
 
   std::unique_lock<std::mutex> lk_cv(synchronization_data_->force_flush_cv_m);

--- a/exporters/otlp/include/opentelemetry/exporters/otlp/otlp_grpc_exporter.h
+++ b/exporters/otlp/include/opentelemetry/exporters/otlp/otlp_grpc_exporter.h
@@ -58,7 +58,7 @@ public:
    * @return return true when all data are exported, and false when timeout
    */
   bool ForceFlush(
-      std::chrono::microseconds timeout = std::chrono::microseconds::max()) noexcept override;
+      std::chrono::microseconds timeout = (std::chrono::microseconds::max())) noexcept override;
 
   /**
    * Shut down the exporter.
@@ -67,7 +67,7 @@ public:
    * @return return the status of this operation
    */
   bool Shutdown(
-      std::chrono::microseconds timeout = std::chrono::microseconds::max()) noexcept override;
+      std::chrono::microseconds timeout = (std::chrono::microseconds::max())) noexcept override;
 
 private:
   // The configuration options associated with this exporter.

--- a/exporters/otlp/include/opentelemetry/exporters/otlp/otlp_grpc_exporter.h
+++ b/exporters/otlp/include/opentelemetry/exporters/otlp/otlp_grpc_exporter.h
@@ -58,7 +58,7 @@ public:
    * @return return true when all data are exported, and false when timeout
    */
   bool ForceFlush(
-      std::chrono::microseconds timeout = (std::chrono::microseconds::max())) noexcept override;
+      std::chrono::microseconds timeout = (std::chrono::microseconds::max)()) noexcept override;
 
   /**
    * Shut down the exporter.
@@ -67,7 +67,7 @@ public:
    * @return return the status of this operation
    */
   bool Shutdown(
-      std::chrono::microseconds timeout = (std::chrono::microseconds::max())) noexcept override;
+      std::chrono::microseconds timeout = (std::chrono::microseconds::max)()) noexcept override;
 
 private:
   // The configuration options associated with this exporter.

--- a/exporters/otlp/include/opentelemetry/exporters/otlp/otlp_grpc_log_record_exporter.h
+++ b/exporters/otlp/include/opentelemetry/exporters/otlp/otlp_grpc_log_record_exporter.h
@@ -60,14 +60,14 @@ public:
    * @return return true when all data are exported, and false when timeout
    */
   bool ForceFlush(
-      std::chrono::microseconds timeout = std::chrono::microseconds::max()) noexcept override;
+      std::chrono::microseconds timeout = (std::chrono::microseconds::max())) noexcept override;
 
   /**
    * Shutdown this exporter.
    * @param timeout The maximum time to wait for the shutdown method to return.
    */
   bool Shutdown(
-      std::chrono::microseconds timeout = std::chrono::microseconds::max()) noexcept override;
+      std::chrono::microseconds timeout = (std::chrono::microseconds::max())) noexcept override;
 
 private:
   // Configuration options for the exporter

--- a/exporters/otlp/include/opentelemetry/exporters/otlp/otlp_grpc_log_record_exporter.h
+++ b/exporters/otlp/include/opentelemetry/exporters/otlp/otlp_grpc_log_record_exporter.h
@@ -60,14 +60,14 @@ public:
    * @return return true when all data are exported, and false when timeout
    */
   bool ForceFlush(
-      std::chrono::microseconds timeout = (std::chrono::microseconds::max())) noexcept override;
+      std::chrono::microseconds timeout = (std::chrono::microseconds::max)()) noexcept override;
 
   /**
    * Shutdown this exporter.
    * @param timeout The maximum time to wait for the shutdown method to return.
    */
   bool Shutdown(
-      std::chrono::microseconds timeout = (std::chrono::microseconds::max())) noexcept override;
+      std::chrono::microseconds timeout = (std::chrono::microseconds::max)()) noexcept override;
 
 private:
   // Configuration options for the exporter

--- a/exporters/otlp/include/opentelemetry/exporters/otlp/otlp_http_exporter.h
+++ b/exporters/otlp/include/opentelemetry/exporters/otlp/otlp_http_exporter.h
@@ -59,7 +59,7 @@ public:
    * @return return true when all data are exported, and false when timeout
    */
   bool ForceFlush(
-      std::chrono::microseconds timeout = std::chrono::microseconds::max()) noexcept override;
+      std::chrono::microseconds timeout = (std::chrono::microseconds::max())) noexcept override;
 
   /**
    * Shut down the exporter.
@@ -68,7 +68,7 @@ public:
    * @return return the status of this operation
    */
   bool Shutdown(
-      std::chrono::microseconds timeout = std::chrono::microseconds::max()) noexcept override;
+      std::chrono::microseconds timeout = (std::chrono::microseconds::max())) noexcept override;
 
 private:
   // The configuration options associated with this exporter.

--- a/exporters/otlp/include/opentelemetry/exporters/otlp/otlp_http_exporter.h
+++ b/exporters/otlp/include/opentelemetry/exporters/otlp/otlp_http_exporter.h
@@ -59,7 +59,7 @@ public:
    * @return return true when all data are exported, and false when timeout
    */
   bool ForceFlush(
-      std::chrono::microseconds timeout = (std::chrono::microseconds::max())) noexcept override;
+      std::chrono::microseconds timeout = (std::chrono::microseconds::max)()) noexcept override;
 
   /**
    * Shut down the exporter.
@@ -68,7 +68,7 @@ public:
    * @return return the status of this operation
    */
   bool Shutdown(
-      std::chrono::microseconds timeout = (std::chrono::microseconds::max())) noexcept override;
+      std::chrono::microseconds timeout = (std::chrono::microseconds::max)()) noexcept override;
 
 private:
   // The configuration options associated with this exporter.

--- a/exporters/otlp/include/opentelemetry/exporters/otlp/otlp_http_log_record_exporter.h
+++ b/exporters/otlp/include/opentelemetry/exporters/otlp/otlp_http_log_record_exporter.h
@@ -58,14 +58,14 @@ public:
    * @return return true when all data are exported, and false when timeout
    */
   bool ForceFlush(
-      std::chrono::microseconds timeout = std::chrono::microseconds::max()) noexcept override;
+      std::chrono::microseconds timeout = (std::chrono::microseconds::max())) noexcept override;
 
   /**
    * Shutdown this exporter.
    * @param timeout The maximum time to wait for the shutdown method to return
    */
   bool Shutdown(
-      std::chrono::microseconds timeout = std::chrono::microseconds::max()) noexcept override;
+      std::chrono::microseconds timeout = (std::chrono::microseconds::max())) noexcept override;
 
 private:
   // Configuration options for the exporter

--- a/exporters/otlp/include/opentelemetry/exporters/otlp/otlp_http_log_record_exporter.h
+++ b/exporters/otlp/include/opentelemetry/exporters/otlp/otlp_http_log_record_exporter.h
@@ -58,14 +58,14 @@ public:
    * @return return true when all data are exported, and false when timeout
    */
   bool ForceFlush(
-      std::chrono::microseconds timeout = (std::chrono::microseconds::max())) noexcept override;
+      std::chrono::microseconds timeout = (std::chrono::microseconds::max)()) noexcept override;
 
   /**
    * Shutdown this exporter.
    * @param timeout The maximum time to wait for the shutdown method to return
    */
   bool Shutdown(
-      std::chrono::microseconds timeout = (std::chrono::microseconds::max())) noexcept override;
+      std::chrono::microseconds timeout = (std::chrono::microseconds::max)()) noexcept override;
 
 private:
   // Configuration options for the exporter

--- a/exporters/otlp/src/otlp_http_client.cc
+++ b/exporters/otlp/src/otlp_http_client.cc
@@ -782,7 +782,7 @@ bool OtlpHttpClient::ForceFlush(std::chrono::microseconds timeout) noexcept
       std::chrono::duration_cast<std::chrono::steady_clock::duration>(timeout);
   if (timeout_steady <= std::chrono::steady_clock::duration::zero())
   {
-    timeout_steady = std::chrono::steady_clock::duration::max();
+    timeout_steady = (std::chrono::steady_clock::duration::max)();
   }
 
   while (timeout_steady > std::chrono::steady_clock::duration::zero())

--- a/sdk/include/opentelemetry/sdk/logs/batch_log_record_processor.h
+++ b/sdk/include/opentelemetry/sdk/logs/batch_log_record_processor.h
@@ -72,7 +72,7 @@ public:
    * NOTE: Timeout functionality not supported yet.
    */
   bool ForceFlush(
-      std::chrono::microseconds timeout = std::chrono::microseconds::max()) noexcept override;
+      std::chrono::microseconds timeout = (std::chrono::microseconds::max())) noexcept override;
 
   /**
    * Shuts down the processor and does any cleanup required. Completely drains the buffer/queue of
@@ -82,7 +82,7 @@ public:
    * NOTE: Timeout functionality not supported yet.
    */
   bool Shutdown(
-      std::chrono::microseconds timeout = std::chrono::microseconds::max()) noexcept override;
+      std::chrono::microseconds timeout = (std::chrono::microseconds::max())) noexcept override;
 
   /**
    * Class destructor which invokes the Shutdown() method.

--- a/sdk/include/opentelemetry/sdk/logs/batch_log_record_processor.h
+++ b/sdk/include/opentelemetry/sdk/logs/batch_log_record_processor.h
@@ -72,7 +72,7 @@ public:
    * NOTE: Timeout functionality not supported yet.
    */
   bool ForceFlush(
-      std::chrono::microseconds timeout = (std::chrono::microseconds::max())) noexcept override;
+      std::chrono::microseconds timeout = (std::chrono::microseconds::max)()) noexcept override;
 
   /**
    * Shuts down the processor and does any cleanup required. Completely drains the buffer/queue of
@@ -82,7 +82,7 @@ public:
    * NOTE: Timeout functionality not supported yet.
    */
   bool Shutdown(
-      std::chrono::microseconds timeout = (std::chrono::microseconds::max())) noexcept override;
+      std::chrono::microseconds timeout = (std::chrono::microseconds::max)()) noexcept override;
 
   /**
    * Class destructor which invokes the Shutdown() method.

--- a/sdk/include/opentelemetry/sdk/logs/multi_log_record_processor.h
+++ b/sdk/include/opentelemetry/sdk/logs/multi_log_record_processor.h
@@ -45,7 +45,7 @@ public:
    * @return a result code indicating whether it succeeded, failed or timed out
    */
   bool ForceFlush(
-      std::chrono::microseconds timeout = (std::chrono::microseconds::max())) noexcept override;
+      std::chrono::microseconds timeout = (std::chrono::microseconds::max)()) noexcept override;
 
   /**
    * Shuts down the processor and does any cleanup required.
@@ -55,7 +55,7 @@ public:
    * @return true if the shutdown succeeded, false otherwise
    */
   bool Shutdown(
-      std::chrono::microseconds timeout = (std::chrono::microseconds::max())) noexcept override;
+      std::chrono::microseconds timeout = (std::chrono::microseconds::max)()) noexcept override;
 
 private:
   std::vector<std::unique_ptr<LogRecordProcessor>> processors_;

--- a/sdk/include/opentelemetry/sdk/logs/multi_log_record_processor.h
+++ b/sdk/include/opentelemetry/sdk/logs/multi_log_record_processor.h
@@ -45,7 +45,7 @@ public:
    * @return a result code indicating whether it succeeded, failed or timed out
    */
   bool ForceFlush(
-      std::chrono::microseconds timeout = std::chrono::microseconds::max()) noexcept override;
+      std::chrono::microseconds timeout = (std::chrono::microseconds::max())) noexcept override;
 
   /**
    * Shuts down the processor and does any cleanup required.
@@ -55,7 +55,7 @@ public:
    * @return true if the shutdown succeeded, false otherwise
    */
   bool Shutdown(
-      std::chrono::microseconds timeout = std::chrono::microseconds::max()) noexcept override;
+      std::chrono::microseconds timeout = (std::chrono::microseconds::max())) noexcept override;
 
 private:
   std::vector<std::unique_ptr<LogRecordProcessor>> processors_;

--- a/sdk/include/opentelemetry/sdk/trace/batch_span_processor.h
+++ b/sdk/include/opentelemetry/sdk/trace/batch_span_processor.h
@@ -69,7 +69,7 @@ public:
    * NOTE: Timeout functionality not supported yet.
    */
   bool ForceFlush(
-      std::chrono::microseconds timeout = (std::chrono::microseconds::max())) noexcept override;
+      std::chrono::microseconds timeout = (std::chrono::microseconds::max)()) noexcept override;
 
   /**
    * Shuts down the processor and does any cleanup required. Completely drains the buffer/queue of
@@ -79,7 +79,7 @@ public:
    * NOTE: Timeout functionality not supported yet.
    */
   bool Shutdown(
-      std::chrono::microseconds timeout = (std::chrono::microseconds::max())) noexcept override;
+      std::chrono::microseconds timeout = (std::chrono::microseconds::max)()) noexcept override;
 
   /**
    * Class destructor which invokes the Shutdown() method. The Shutdown() method is supposed to be

--- a/sdk/include/opentelemetry/sdk/trace/batch_span_processor.h
+++ b/sdk/include/opentelemetry/sdk/trace/batch_span_processor.h
@@ -69,7 +69,7 @@ public:
    * NOTE: Timeout functionality not supported yet.
    */
   bool ForceFlush(
-      std::chrono::microseconds timeout = std::chrono::microseconds::max()) noexcept override;
+      std::chrono::microseconds timeout = (std::chrono::microseconds::max())) noexcept override;
 
   /**
    * Shuts down the processor and does any cleanup required. Completely drains the buffer/queue of
@@ -79,7 +79,7 @@ public:
    * NOTE: Timeout functionality not supported yet.
    */
   bool Shutdown(
-      std::chrono::microseconds timeout = std::chrono::microseconds::max()) noexcept override;
+      std::chrono::microseconds timeout = (std::chrono::microseconds::max())) noexcept override;
 
   /**
    * Class destructor which invokes the Shutdown() method. The Shutdown() method is supposed to be


### PR DESCRIPTION
Fixes build failures after removal of NOMINMAX - previous commits from @ThomsonTan didn't have full coverage.