### PR TITLE
Set is_monotonic flag for Observable Counters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@ Increment the:
   [#2449](https://github.com/open-telemetry/opentelemetry-cpp/pull/2449)
 * [BUILD] Introduce CXX 20 CI pipeline for MSVC/Windows
   [#2450](https://github.com/open-telemetry/opentelemetry-cpp/pull/2450)
+* [EXPORTER] Set `is_monotonic` flag for Observable Counters
+  [#2478](https://github.com/open-telemetry/opentelemetry-cpp/pull/2478)
 
 Important changes:
 

--- a/exporters/otlp/src/otlp_metric_utils.cc
+++ b/exporters/otlp/src/otlp_metric_utils.cc
@@ -54,8 +54,9 @@ void OtlpMetricUtils::ConvertSumMetric(const metric_sdk::MetricData &metric_data
 {
   sum->set_aggregation_temporality(
       GetProtoAggregationTemporality(metric_data.aggregation_temporality));
-  sum->set_is_monotonic(metric_data.instrument_descriptor.type_ ==
-                        metric_sdk::InstrumentType::kCounter);
+  sum->set_is_monotonic(
+      (metric_data.instrument_descriptor.type_ == metric_sdk::InstrumentType::kCounter) ||
+      (metric_data.instrument_descriptor.type_ == metric_sdk::InstrumentType::kObservableCounter));
   auto start_ts = metric_data.start_ts.time_since_epoch().count();
   auto ts       = metric_data.end_ts.time_since_epoch().count();
   for (auto &point_data_with_attributes : metric_data.point_data_attr_)


### PR DESCRIPTION
Fixes #2469 

## Changes

Please provide a brief description of the changes here.

The `is_monotonic` flag is now set to `true` for both synchronous and asynchronous/observable counters. 

For significant contributions please make sure you have completed the following items:

* [x] `CHANGELOG.md` updated for non-trivial changes
* [x] Unit tests have been added
* [ ] Changes in public API reviewed