### PR TITLE
[EXPORTER] Rename populate_otel_scope to without_otel_scope

### DIFF
--- a/exporters/prometheus/include/opentelemetry/exporters/prometheus/collector.h
+++ b/exporters/prometheus/include/opentelemetry/exporters/prometheus/collector.h
@@ -33,7 +33,7 @@ public:
    */
   explicit PrometheusCollector(sdk::metrics::MetricReader *reader,
                                bool populate_target_info,
-                               bool populate_otel_scope);
+                               bool without_otel_scope);
 
   /**
    * Collects all metrics data from metricsToCollect collection.
@@ -45,7 +45,7 @@ public:
 private:
   sdk::metrics::MetricReader *reader_;
   bool populate_target_info_;
-  bool populate_otel_scope_;
+  bool without_otel_scope_;
 
   /*
    * Lock when operating the metricsToCollect collection

--- a/exporters/prometheus/include/opentelemetry/exporters/prometheus/exporter_options.h
+++ b/exporters/prometheus/include/opentelemetry/exporters/prometheus/exporter_options.h
@@ -27,7 +27,7 @@ struct PrometheusExporterOptions
   bool populate_target_info = true;
 
   // Populating otel_scope_name/otel_scope_labels attributes
-  bool populate_otel_scope = true;
+  bool without_otel_scope = false;
 };
 
 }  // namespace metrics

--- a/exporters/prometheus/include/opentelemetry/exporters/prometheus/exporter_utils.h
+++ b/exporters/prometheus/include/opentelemetry/exporters/prometheus/exporter_utils.h
@@ -28,14 +28,14 @@ public:
    *
    * @param records a collection of metrics in OpenTelemetry
    * @param populate_target_info whether to populate target_info
-   * @param populate_otel_scope whether to populate otel_scope_name and otel_scope_version
+   * @param without_otel_scope whether to populate otel_scope_name and otel_scope_version
    * attributes
    * @return a collection of translated metrics that is acceptable by Prometheus
    */
   static std::vector<::prometheus::MetricFamily> TranslateToPrometheus(
       const sdk::metrics::ResourceMetrics &data,
       bool populate_target_info = true,
-      bool populate_otel_scope  = true);
+      bool without_otel_scope   = false);
 
 private:
   /**

--- a/exporters/prometheus/src/collector.cc
+++ b/exporters/prometheus/src/collector.cc
@@ -19,10 +19,10 @@ namespace metrics
  */
 PrometheusCollector::PrometheusCollector(sdk::metrics::MetricReader *reader,
                                          bool populate_target_info,
-                                         bool populate_otel_scope)
+                                         bool without_otel_scope)
     : reader_(reader),
       populate_target_info_(populate_target_info),
-      populate_otel_scope_(populate_otel_scope)
+      without_otel_scope_(without_otel_scope)
 {}
 
 /**
@@ -45,7 +45,7 @@ std::vector<prometheus_client::MetricFamily> PrometheusCollector::Collect() cons
 
   reader_->Collect([&result, this](sdk::metrics::ResourceMetrics &metric_data) {
     auto prometheus_metric_data = PrometheusExporterUtils::TranslateToPrometheus(
-        metric_data, this->populate_target_info_, this->populate_otel_scope_);
+        metric_data, this->populate_target_info_, this->without_otel_scope_);
     for (auto &data : prometheus_metric_data)
       result.emplace_back(data);
     return true;

--- a/exporters/prometheus/src/exporter.cc
+++ b/exporters/prometheus/src/exporter.cc
@@ -31,7 +31,7 @@ PrometheusExporter::PrometheusExporter(const PrometheusExporterOptions &options)
     return;
   }
   collector_ = std::shared_ptr<PrometheusCollector>(
-      new PrometheusCollector(this, options_.populate_target_info, options_.populate_otel_scope));
+      new PrometheusCollector(this, options_.populate_target_info, options_.without_otel_scope));
 
   exposer_->RegisterCollectable(collector_);
 }

--- a/exporters/prometheus/src/exporter_options.cc
+++ b/exporters/prometheus/src/exporter_options.cc
@@ -25,14 +25,13 @@ inline const std::string GetPrometheusDefaultHttpEndpoint()
   return exists ? endpoint : kPrometheusEndpointDefault;
 }
 
-inline bool GetPrometheusPopulateOtelScope()
+inline bool GetPrometheusWithoutOtelScope()
 {
-  constexpr char kPrometheusPopulateOtelScope[] =
-      "OTEL_CPP_PROMETHEUS_EXPORTER_POPULATE_OTEL_SCOPE";
+  constexpr char kPrometheusWithoutOtelScope[] = "OTEL_CPP_PROMETHEUS_EXPORTER_WITHOUT_OTEL_SCOPE";
 
   bool setting;
   auto exists =
-      opentelemetry::sdk::common::GetBoolEnvironmentVariable(kPrometheusPopulateOtelScope, setting);
+      opentelemetry::sdk::common::GetBoolEnvironmentVariable(kPrometheusWithoutOtelScope, setting);
 
   return exists ? setting : true;
 }
@@ -52,7 +51,7 @@ inline bool GetPrometheusPopulateTargetInfo()
 PrometheusExporterOptions::PrometheusExporterOptions()
     : url(GetPrometheusDefaultHttpEndpoint()),
       populate_target_info(GetPrometheusPopulateTargetInfo()),
-      populate_otel_scope(GetPrometheusPopulateOtelScope())
+      without_otel_scope(GetPrometheusWithoutOtelScope())
 {}
 
 }  // namespace metrics

--- a/exporters/prometheus/src/exporter_utils.cc
+++ b/exporters/prometheus/src/exporter_utils.cc
@@ -108,7 +108,7 @@ std::string SanitizeLabel(std::string label_key)
 std::vector<prometheus_client::MetricFamily> PrometheusExporterUtils::TranslateToPrometheus(
     const sdk::metrics::ResourceMetrics &data,
     bool populate_target_info,
-    bool populate_otel_scope)
+    bool without_otel_scope)
 {
 
   // initialize output vector
@@ -129,7 +129,7 @@ std::vector<prometheus_client::MetricFamily> PrometheusExporterUtils::TranslateT
   {
     SetTarget(data,
               data.scope_metric_data_.begin()->metric_data_.begin()->end_ts.time_since_epoch(),
-              populate_otel_scope ? (*data.scope_metric_data_.begin()).scope_ : nullptr, &output);
+              without_otel_scope ? nullptr : (*data.scope_metric_data_.begin()).scope_, &output);
   }
 
   for (const auto &instrumentation_info : data.scope_metric_data_)
@@ -153,7 +153,7 @@ std::vector<prometheus_client::MetricFamily> PrometheusExporterUtils::TranslateT
                                                metric_data.instrument_descriptor.unit_, type);
       metric_family.type = type;
       const opentelemetry::sdk::instrumentationscope::InstrumentationScope *scope =
-          populate_otel_scope ? instrumentation_info.scope_ : nullptr;
+          without_otel_scope ? nullptr : instrumentation_info.scope_;
 
       for (const auto &point_data_attr : metric_data.point_data_attr_)
       {

--- a/exporters/prometheus/test/collector_test.cc
+++ b/exporters/prometheus/test/collector_test.cc
@@ -73,7 +73,7 @@ TEST(PrometheusCollector, BasicTests)
   MockMetricReader *reader     = new MockMetricReader();
   MockMetricProducer *producer = new MockMetricProducer();
   reader->SetMetricProducer(producer);
-  PrometheusCollector collector(reader, true, true);
+  PrometheusCollector collector(reader, true, false);
   auto data = collector.Collect();
 
   // Collection size should be the same as the size


### PR DESCRIPTION
Fixes #2442

## Changes

This renames the recently-new `populate_otel_scope` option to `without_otel_scope` to match the related docs changes.

For significant contributions please make sure you have completed the following items:

* [ ] `CHANGELOG.md` updated for non-trivial changes
* [ ] Unit tests have been added
* [ ] Changes in public API reviewed