### PR TITLE
[BUILD] Fix checks on __cplusplus under MSVC, do not assume /Zc

### DIFF
--- a/api/include/opentelemetry/nostd/internal/absl/base/policy_checks.h
+++ b/api/include/opentelemetry/nostd/internal/absl/base/policy_checks.h
@@ -71,13 +71,15 @@
 // C++ Version Check
 // -----------------------------------------------------------------------------
 
-// Enforce C++11 as the minimum.  Note that Visual Studio has not
-// advanced __cplusplus despite being good enough for our purposes, so
-// so we exempt it from the check.
-#if defined(__cplusplus) && !defined(_MSC_VER)
+// Enforce C++11 as the minimum.
+#if defined(_MSVC_LANG)
+#if _MSVC_LANG < 201103L
+#error "C++ versions less than C++11 are not supported."
+#endif  // _MSVC_LANG < 201103L
+#elif defined(__cplusplus)
 #if __cplusplus < 201103L
 #error "C++ versions less than C++11 are not supported."
-#endif
+#endif  // __cplusplus < 201103L
 #endif
 
 // -----------------------------------------------------------------------------

--- a/api/include/opentelemetry/nostd/internal/absl/meta/type_traits.h
+++ b/api/include/opentelemetry/nostd/internal/absl/meta/type_traits.h
@@ -618,7 +618,8 @@ using underlying_type_t = typename std::underlying_type<T>::type;
 
 namespace type_traits_internal {
 
-#if __cplusplus >= 201703L
+#if (!defined(_MSVC_LANG) && (__cplusplus >= 201703L)) || \
+    (defined(_MSVC_LANG) && (_MSVC_LANG >= 201703L))
 // std::result_of is deprecated (C++17) or removed (C++20)
 template<typename> struct result_of;
 template<typename F, typename... Args>

--- a/exporters/ostream/include/opentelemetry/exporters/ostream/common_utils.h
+++ b/exporters/ostream/include/opentelemetry/exporters/ostream/common_utils.h
@@ -58,7 +58,8 @@ void print_value(const nostd::span<T> &vec, std::ostream &sout)
 }
 
 // Prior to C++14, generic lambda is not available so fallback to functor.
-#if __cplusplus < 201402L
+#if (!defined(_MSVC_LANG) && (__cplusplus < 201402L)) || \
+    (defined(_MSVC_LANG) && (_MSVC_LANG < 201402L))
 
 class OwnedAttributeValueVisitor
 {
@@ -97,7 +98,8 @@ private:
 inline void print_value(const opentelemetry::sdk::common::OwnedAttributeValue &value,
                         std::ostream &sout)
 {
-#if __cplusplus < 201402L
+#if (!defined(_MSVC_LANG) && (__cplusplus < 201402L)) || \
+    (defined(_MSVC_LANG) && (_MSVC_LANG < 201402L))
   opentelemetry::nostd::visit(OwnedAttributeValueVisitor(sout), value);
 #else
   opentelemetry::nostd::visit(
@@ -111,7 +113,8 @@ inline void print_value(const opentelemetry::sdk::common::OwnedAttributeValue &v
 
 inline void print_value(const opentelemetry::common::AttributeValue &value, std::ostream &sout)
 {
-#if __cplusplus < 201402L
+#if (!defined(_MSVC_LANG) && (__cplusplus < 201402L)) || \
+    (defined(_MSVC_LANG) && (_MSVC_LANG < 201402L))
   opentelemetry::nostd::visit(AttributeValueVisitor(sout), value);
 #else
   opentelemetry::nostd::visit(


### PR DESCRIPTION
- https://learn.microsoft.com/en-us/cpp/build/reference/zc-cplusplus
- The change to `.../absl/base/policy_checks.h` is a back port from the same lines in the current Abseil `HEAD`
- I _think_ the rest of the uses of `__cplusplus` are correct under MSVC, but I'm not totally sure on that.