### PR TITLE
[CI] Make cmake.c++20*.test actualy use C++20 and add cmake.c++23*.test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -360,7 +360,7 @@ jobs:
 
   cmake_test_cxx23_gcc:
     name: CMake C++23 test(GCC)
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
       with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -358,6 +358,59 @@ jobs:
         CXX_STANDARD: '20'
       run: ./ci/do_ci.sh cmake.c++20.stl.test
 
+  cmake_test_cxx23_gcc:
+    name: CMake C++23 test(GCC)
+    runs-on: ubuntu-20.04
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        submodules: 'recursive'
+    - name: setup
+      env:
+        CMAKE_VERSION: 3.20.6
+      run: |
+        sudo -E ./ci/setup_ci_environment.sh
+        sudo -E ./ci/setup_cmake.sh
+    - name: run tests
+      env:
+        CXX_STANDARD: '23'
+      run: ./ci/do_ci.sh cmake.c++23.test
+    - name: run tests (enable stl)
+      env:
+        CXX_STANDARD: '23'
+      run: ./ci/do_ci.sh cmake.c++23.stl.test
+
+  cmake_test_cxx23_clang:
+    name: CMake C++23 test(Clang with libc++)
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        submodules: 'recursive'
+    - name: setup
+      env:
+        CC: /usr/bin/clang
+        CXX: /usr/bin/clang++
+        CXXFLAGS: "-stdlib=libc++"
+        CMAKE_VERSION: 3.20.6
+      run: |
+        sudo -E ./ci/setup_ci_environment.sh
+        sudo -E ./ci/setup_cmake.sh
+    - name: run tests
+      env:
+        CC: /usr/bin/clang
+        CXX: /usr/bin/clang++
+        CXXFLAGS: "-stdlib=libc++"
+        CXX_STANDARD: '23'
+      run: ./ci/do_ci.sh cmake.c++23.test
+    - name: run tests (enable stl)
+      env:
+        CC: /usr/bin/clang
+        CXX: /usr/bin/clang++
+        CXXFLAGS: "-stdlib=libc++"
+        CXX_STANDARD: '23'
+      run: ./ci/do_ci.sh cmake.c++23.stl.test
+
   cmake_otprotocol_test:
     name: CMake test (with otlp-exporter)
     runs-on: ubuntu-20.04

--- a/ci/do_ci.sh
+++ b/ci/do_ci.sh
@@ -229,6 +229,19 @@ elif [[ "$1" == "cmake.c++20.test" ]]; then
   cmake ${CMAKE_OPTIONS[@]}  \
         -DCMAKE_CXX_FLAGS="-Werror $CXXFLAGS" \
         -DWITH_ASYNC_EXPORT_PREVIEW=ON \
+        -DWITH_STL=CXX20 \
+        ${IWYU} \
+        "${SRC_DIR}"
+  eval "$MAKE_COMMAND"
+  make test
+  exit 0
+elif [[ "$1" == "cmake.c++23.test" ]]; then
+  cd "${BUILD_DIR}"
+  rm -rf *
+  cmake ${CMAKE_OPTIONS[@]}  \
+        -DCMAKE_CXX_FLAGS="-Werror $CXXFLAGS" \
+        -DWITH_ASYNC_EXPORT_PREVIEW=ON \
+        -DWITH_STL=CXX23 \
         ${IWYU} \
         "${SRC_DIR}"
   eval "$MAKE_COMMAND"
@@ -267,7 +280,20 @@ elif [[ "$1" == "cmake.c++20.stl.test" ]]; then
         -DWITH_METRICS_EXEMPLAR_PREVIEW=ON \
         -DCMAKE_CXX_FLAGS="-Werror $CXXFLAGS" \
         -DWITH_ASYNC_EXPORT_PREVIEW=ON \
-        -DWITH_STL=ON \
+        -DWITH_STL=CXX20 \
+        ${IWYU} \
+        "${SRC_DIR}"
+  eval "$MAKE_COMMAND"
+  make test
+  exit 0
+elif [[ "$1" == "cmake.c++23.stl.test" ]]; then
+  cd "${BUILD_DIR}"
+  rm -rf *
+  cmake ${CMAKE_OPTIONS[@]}  \
+        -DWITH_METRICS_EXEMPLAR_PREVIEW=ON \
+        -DCMAKE_CXX_FLAGS="-Werror $CXXFLAGS" \
+        -DWITH_ASYNC_EXPORT_PREVIEW=ON \
+        -DWITH_STL=CXX23 \
         ${IWYU} \
         "${SRC_DIR}"
   eval "$MAKE_COMMAND"


### PR DESCRIPTION
Part of #2470

## Changes

The existing `cmake.c++20*.test` cases don't actually pin C++2020 but either don't use `WITH_STL=` at all or set it to `ON`. This results in a strange mix of "version" between the name of the test, the version the library _thinks_ is being used and what is actually being used by the build

Also, there was no explicit C++2023 tests.