### PR TITLE
add api reference documentation for logs

### DIFF
--- a/docs/public/Doxyfile
+++ b/docs/public/Doxyfile
@@ -794,6 +794,7 @@ INPUT                  =  \
                          ../../api/include/opentelemetry/baggage \
                          ../../api/include/opentelemetry/context \
                          ../../api/include/opentelemetry/common \
+                         ../../api/include/opentelemetry/logs \
                          ../../api/include/opentelemetry/nostd/shared_ptr.h \
                          ../../api/include/opentelemetry/nostd/span.h \
                          ../../api/include/opentelemetry/nostd/string_view.h \
@@ -803,6 +804,7 @@ INPUT                  =  \
                          ../../api/include/opentelemetry/trace \
                           ../../sdk/include/opentelemetry/sdk/instrumentationlibrary \
                           ../../sdk/include/opentelemetry/sdk/instrumentationscope \
+                          ../../sdk/include/opentelemetry/sdk/logs \
                           ../../sdk/include/opentelemetry/sdk/metrics \
                           ../../sdk/include/opentelemetry/sdk/resource \
                           ../../sdk/include/opentelemetry/sdk/trace \

--- a/docs/public/Doxyfile
+++ b/docs/public/Doxyfile
@@ -796,15 +796,15 @@ INPUT                  =  \
                          ../../api/include/opentelemetry/common \
                          ../../api/include/opentelemetry/nostd/shared_ptr.h \
                          ../../api/include/opentelemetry/nostd/span.h \
-                         ../../api//include/opentelemetry/nostd/string_view.h \
+                         ../../api/include/opentelemetry/nostd/string_view.h \
                          ../../api/include/opentelemetry/nostd/unique_ptr.h \
                          ../../api/include/opentelemetry/nostd/variant.h \
                          ../../api/include/opentelemetry/metrics \
                          ../../api/include/opentelemetry/trace \
-                          ../../sdk/include/opentelemetry/sdk/instrumentationscope \
                           ../../sdk/include/opentelemetry/sdk/instrumentationlibrary \
-                          ../../sdk/include/opentelemetry/sdk/resource \
+                          ../../sdk/include/opentelemetry/sdk/instrumentationscope \
                           ../../sdk/include/opentelemetry/sdk/metrics \
+                          ../../sdk/include/opentelemetry/sdk/resource \
                           ../../sdk/include/opentelemetry/sdk/trace \
 
 

--- a/docs/public/index.rst
+++ b/docs/public/index.rst
@@ -28,6 +28,7 @@ OpenTelemetry C++
    otel_docs/namespace_opentelemetry__common
    otel_docs/namespace_opentelemetry__context
    otel_docs/namespace_opentelemetry__metrics
+   otel_docs/namespace_opentelemetry__logs
 
 .. toctree::
    :maxdepth: 1
@@ -37,7 +38,7 @@ OpenTelemetry C++
    otel_docs/namespace_opentelemetry__sdk__instrumentationlibrary
    otel_docs/namespace_opentelemetry__sdk__resource
    otel_docs/namespace_opentelemetry__sdk__metrics
-
+   otel_docs/namespace_opentelemetry__sdk__logs
 
 .. toctree::
     :maxdepth: 1


### PR DESCRIPTION
Fixes (partiall)y #1695 

## Changes

Adds the logs directory to the doxygen file to ensure the logs api is included in the api reference

For significant contributions please make sure you have completed the following items:

* [ ] `CHANGELOG.md` updated for non-trivial changes
* [ ] Unit tests have been added
* [ ] Changes in public API reviewed