### PR TITLE
[BUILD] Fix multiple assignment operators for SpinLockMutex

### DIFF
--- a/api/include/opentelemetry/common/spin_lock_mutex.h
+++ b/api/include/opentelemetry/common/spin_lock_mutex.h
@@ -55,7 +55,6 @@ public:
   SpinLockMutex() noexcept {}
   ~SpinLockMutex() noexcept            = default;
   SpinLockMutex(const SpinLockMutex &) = delete;
-  SpinLockMutex &operator=(const SpinLockMutex &) = delete;
   SpinLockMutex &operator=(const SpinLockMutex &) volatile = delete;
 
   static inline void fast_yield() noexcept

--- a/api/include/opentelemetry/common/spin_lock_mutex.h
+++ b/api/include/opentelemetry/common/spin_lock_mutex.h
@@ -55,7 +55,7 @@ public:
   SpinLockMutex() noexcept {}
   ~SpinLockMutex() noexcept            = default;
   SpinLockMutex(const SpinLockMutex &) = delete;
-  SpinLockMutex &operator=(const SpinLockMutex &) volatile = delete;
+  SpinLockMutex &operator=(const SpinLockMutex &) = delete;
 
   static inline void fast_yield() noexcept
   {


### PR DESCRIPTION
Fixes #2500 

## Changes

Please provide a brief description of the changes here.
The multiple assignment operators for SpinLockMutex throws warnings in consumer build for these headers. This would require them to explicitly add #Pragma to ignore C4522.

This PR removes the redundant assignment to let the build pass without these warnings. Tested locally as I was able to repro this issue before this change.

For significant contributions please make sure you have completed the following items:

* [ ] `CHANGELOG.md` updated for non-trivial changes
* [ ] Unit tests have been added
* [ ] Changes in public API reviewed