### PR TITLE
[BUILD] Clang-15 warning about `__has_trivial_destructor`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
         ./ci/do_ci.sh cmake.test
 
   cmake_gcc_maintainer_sync_test:
-    name: CMake gcc 12 (maintainer mode, sync)
+    name: CMake gcc 13 (maintainer mode, sync)
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
@@ -37,8 +37,8 @@ jobs:
         submodules: 'recursive'
     - name: setup
       env:
-        CC: /usr/bin/gcc-12
-        CXX: /usr/bin/g++-12
+        CC: /usr/bin/gcc-13
+        CXX: /usr/bin/g++-13
         PROTOBUF_VERSION: 21.12
       run: |
         sudo -E ./ci/setup_cmake.sh
@@ -46,8 +46,8 @@ jobs:
         sudo -E ./ci/install_protobuf.sh
     - name: run cmake gcc (maintainer mode, sync)
       env:
-        CC: /usr/bin/gcc-12
-        CXX: /usr/bin/g++-12
+        CC: /usr/bin/gcc-13
+        CXX: /usr/bin/g++-13
       run: |
         ./ci/do_ci.sh cmake.maintainer.sync.test
     - name: generate test cert
@@ -61,7 +61,7 @@ jobs:
         (cd ./functional/otlp; ./run_test.sh)
 
   cmake_gcc_maintainer_async_test:
-    name: CMake gcc 12 (maintainer mode, async)
+    name: CMake gcc 13 (maintainer mode, async)
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
@@ -69,8 +69,8 @@ jobs:
         submodules: 'recursive'
     - name: setup
       env:
-        CC: /usr/bin/gcc-12
-        CXX: /usr/bin/g++-12
+        CC: /usr/bin/gcc-13
+        CXX: /usr/bin/g++-13
         PROTOBUF_VERSION: 21.12
       run: |
         sudo -E ./ci/setup_cmake.sh
@@ -78,8 +78,8 @@ jobs:
         sudo -E ./ci/install_protobuf.sh
     - name: run cmake gcc (maintainer mode, async)
       env:
-        CC: /usr/bin/gcc-12
-        CXX: /usr/bin/g++-12
+        CC: /usr/bin/gcc-13
+        CXX: /usr/bin/g++-13
       run: |
         ./ci/do_ci.sh cmake.maintainer.async.test
     - name: generate test cert
@@ -93,7 +93,7 @@ jobs:
         (cd ./functional/otlp; ./run_test.sh)
 
   cmake_clang_maintainer_sync_test:
-    name: CMake clang 14 (maintainer mode, sync)
+    name: CMake clang 15 (maintainer mode, sync)
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
@@ -101,8 +101,8 @@ jobs:
         submodules: 'recursive'
     - name: setup
       env:
-        CC: /usr/bin/clang-14
-        CXX: /usr/bin/clang++-14
+        CC: /usr/bin/clang-15
+        CXX: /usr/bin/clang++-15
         PROTOBUF_VERSION: 21.12
       run: |
         sudo -E ./ci/setup_cmake.sh
@@ -110,8 +110,8 @@ jobs:
         sudo -E ./ci/install_protobuf.sh
     - name: run cmake clang (maintainer mode, sync)
       env:
-        CC: /usr/bin/clang-14
-        CXX: /usr/bin/clang++-14
+        CC: /usr/bin/clang-15
+        CXX: /usr/bin/clang++-15
       run: |
         ./ci/do_ci.sh cmake.maintainer.sync.test
     - name: generate test cert
@@ -125,7 +125,7 @@ jobs:
         (cd ./functional/otlp; ./run_test.sh)
 
   cmake_clang_maintainer_async_test:
-    name: CMake clang 14 (maintainer mode, async)
+    name: CMake clang 15 (maintainer mode, async)
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
@@ -133,8 +133,8 @@ jobs:
         submodules: 'recursive'
     - name: setup
       env:
-        CC: /usr/bin/clang-14
-        CXX: /usr/bin/clang++-14
+        CC: /usr/bin/clang-15
+        CXX: /usr/bin/clang++-15
         PROTOBUF_VERSION: 21.12
       run: |
         sudo -E ./ci/setup_cmake.sh
@@ -142,8 +142,8 @@ jobs:
         sudo -E ./ci/install_protobuf.sh
     - name: run cmake clang (maintainer mode, async)
       env:
-        CC: /usr/bin/clang-14
-        CXX: /usr/bin/clang++-14
+        CC: /usr/bin/clang-15
+        CXX: /usr/bin/clang++-15
       run: |
         ./ci/do_ci.sh cmake.maintainer.async.test
     - name: generate test cert
@@ -157,7 +157,7 @@ jobs:
         (cd ./functional/otlp; ./run_test.sh)
 
   cmake_clang_maintainer_abiv2_test:
-    name: CMake clang 14 (maintainer mode, abiv2)
+    name: CMake clang 15 (maintainer mode, abiv2)
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
@@ -165,8 +165,8 @@ jobs:
         submodules: 'recursive'
     - name: setup
       env:
-        CC: /usr/bin/clang-14
-        CXX: /usr/bin/clang++-14
+        CC: /usr/bin/clang-15
+        CXX: /usr/bin/clang++-15
         PROTOBUF_VERSION: 21.12
       run: |
         sudo -E ./ci/setup_cmake.sh
@@ -174,8 +174,8 @@ jobs:
         sudo -E ./ci/install_protobuf.sh
     - name: run cmake clang (maintainer mode, abiv2)
       env:
-        CC: /usr/bin/clang-14
-        CXX: /usr/bin/clang++-14
+        CC: /usr/bin/clang-15
+        CXX: /usr/bin/clang++-15
       run: |
         ./ci/do_ci.sh cmake.maintainer.abiv2.test
     - name: generate test cert

--- a/api/include/opentelemetry/nostd/internal/absl/base/config.h
+++ b/api/include/opentelemetry/nostd/internal/absl/base/config.h
@@ -172,6 +172,7 @@ static_assert(OTABSL_INTERNAL_INLINE_NAMESPACE_STR[0] != 'h' ||
 #ifdef OTABSL_HAVE_STD_IS_TRIVIALLY_DESTRUCTIBLE
 #error OTABSL_HAVE_STD_IS_TRIVIALLY_DESTRUCTIBLE cannot be directly set
 #elif defined(_LIBCPP_VERSION) ||                                        \
+    (defined(__clang__) && __clang_major__ >= 15) ||                     \
     (!defined(__clang__) && defined(__GNUC__) && defined(__GLIBCXX__) && \
      (__GNUC__ > 4 || (__GNUC__ == 4 && __GNUC_MINOR__ >= 8))) ||        \
     defined(_MSC_VER)
@@ -194,6 +195,7 @@ static_assert(OTABSL_INTERNAL_INLINE_NAMESPACE_STR[0] != 'h' ||
 #elif defined(OTABSL_HAVE_STD_IS_TRIVIALLY_ASSIGNABLE)
 #error OTABSL_HAVE_STD_IS_TRIVIALLY_ASSIGNABLE cannot directly set
 #elif (defined(__clang__) && defined(_LIBCPP_VERSION)) ||        \
+    (defined(__clang__) && __clang_major__ >= 15) ||             \
     (!defined(__clang__) && defined(__GNUC__) &&                 \
      (__GNUC__ > 7 || (__GNUC__ == 7 && __GNUC_MINOR__ >= 4)) && \
      (defined(_LIBCPP_VERSION) || defined(__GLIBCXX__))) ||      \

--- a/api/include/opentelemetry/nostd/internal/absl/base/config.h
+++ b/api/include/opentelemetry/nostd/internal/absl/base/config.h
@@ -202,6 +202,17 @@ static_assert(OTABSL_INTERNAL_INLINE_NAMESPACE_STR[0] != 'h' ||
 #define OTABSL_HAVE_STD_IS_TRIVIALLY_ASSIGNABLE 1
 #endif
 
+// OTABSL_HAVE_STD_IS_TRIVIALLY_COPYABLE
+//
+// Checks whether `std::is_trivially_copyable<T>` is supported.
+//
+// Notes: Clang 15+ with libc++ supports these features, GCC hasn't been tested.
+#if defined(OTABSL_HAVE_STD_IS_TRIVIALLY_COPYABLE)
+#error OTABSL_HAVE_STD_IS_TRIVIALLY_COPYABLE cannot be directly set
+#elif defined(__clang__) && (__clang_major__ >= 15)
+#define OTABSL_HAVE_STD_IS_TRIVIALLY_COPYABLE 1
+#endif
+
 // OTABSL_HAVE_SOURCE_LOCATION_CURRENT
 //
 // Indicates whether `absl::SourceLocation::current()` will return useful

--- a/api/include/opentelemetry/nostd/internal/absl/meta/type_traits.h
+++ b/api/include/opentelemetry/nostd/internal/absl/meta/type_traits.h
@@ -500,9 +500,13 @@ struct is_trivially_move_assignable
 // `is_trivially_assignable<T&, const T&>`.
 template <typename T>
 struct is_trivially_copy_assignable
+#ifdef OTABSL_HAVE_STD_IS_TRIVIALLY_ASSIGNABLE
+    : std::is_trivially_copy_assignable<T> {
+#else
     : std::integral_constant<
           bool, __has_trivial_assign(typename std::remove_reference<T>::type) &&
                     absl::is_copy_assignable<T>::value> {
+#endif
 #ifdef OTABSL_HAVE_STD_IS_TRIVIALLY_ASSIGNABLE
  private:
   static constexpr bool compliant =
@@ -533,6 +537,11 @@ namespace type_traits_internal {
 // destructible. Arrays of trivially copyable types are trivially copyable.
 //
 // We expose this metafunction only for internal use within absl.
+
+#if defined(OTABSL_HAVE_STD_IS_TRIVIALLY_COPYABLE)
+template <typename T>
+struct is_trivially_copyable : std::is_trivially_copyable<T> {};
+#else
 template <typename T>
 class is_trivially_copyable_impl {
   using ExtentsRemoved = typename std::remove_all_extents<T>::type;
@@ -558,6 +567,7 @@ template <typename T>
 struct is_trivially_copyable
     : std::integral_constant<
           bool, type_traits_internal::is_trivially_copyable_impl<T>::kValue> {};
+#endif
 }  // namespace type_traits_internal
 
 // -----------------------------------------------------------------------------

--- a/api/include/opentelemetry/nostd/internal/absl/meta/type_traits.h
+++ b/api/include/opentelemetry/nostd/internal/absl/meta/type_traits.h
@@ -296,8 +296,12 @@ struct is_function
 // https://gcc.gnu.org/onlinedocs/gcc/Type-Traits.html#Type-Traits.
 template <typename T>
 struct is_trivially_destructible
+#ifdef OTABSL_HAVE_STD_IS_TRIVIALLY_DESTRUCTIBLE
+    : std::is_trivially_destructible<T> {
+#else
     : std::integral_constant<bool, __has_trivial_destructor(T) &&
                                    std::is_destructible<T>::value> {
+#endif
 #ifdef OTABSL_HAVE_STD_IS_TRIVIALLY_DESTRUCTIBLE
  private:
   static constexpr bool compliant = std::is_trivially_destructible<T>::value ==
@@ -345,9 +349,13 @@ struct is_trivially_destructible
 // Nontrivially destructible types will cause the expression to be nontrivial.
 template <typename T>
 struct is_trivially_default_constructible
+#if defined(OTABSL_HAVE_STD_IS_TRIVIALLY_CONSTRUCTIBLE)
+    : std::is_trivially_default_constructible<T> {
+#else
     : std::integral_constant<bool, __has_trivial_constructor(T) &&
                                    std::is_default_constructible<T>::value &&
                                    is_trivially_destructible<T>::value> {
+#endif
 #if defined(OTABSL_HAVE_STD_IS_TRIVIALLY_CONSTRUCTIBLE) && \
     !defined(                                            \
         OTABSL_META_INTERNAL_STD_CONSTRUCTION_TRAITS_DONT_CHECK_DESTRUCTION)
@@ -379,10 +387,14 @@ struct is_trivially_default_constructible
 // expression to be nontrivial.
 template <typename T>
 struct is_trivially_move_constructible
+#if defined(OTABSL_HAVE_STD_IS_TRIVIALLY_CONSTRUCTIBLE)
+    : std::is_trivially_move_constructible<T> {
+#else
     : std::conditional<
           std::is_object<T>::value && !std::is_array<T>::value,
           type_traits_internal::IsTriviallyMoveConstructibleObject<T>,
           std::is_reference<T>>::type::type {
+#endif
 #if defined(OTABSL_HAVE_STD_IS_TRIVIALLY_CONSTRUCTIBLE) && \
     !defined(                                            \
         OTABSL_META_INTERNAL_STD_CONSTRUCTION_TRAITS_DONT_CHECK_DESTRUCTION)

--- a/api/test/common/spinlock_benchmark.cc
+++ b/api/test/common/spinlock_benchmark.cc
@@ -24,7 +24,7 @@ inline void SpinThrash(benchmark::State &s, SpinLockType &spinlock, LockF lock, 
   // Value we will increment, fighting over a spinlock.
   // The contention is meant to be brief, as close to our expected
   // use cases of "updating pointers" or "pushing an event onto a buffer".
-  std::int64_t value = 0;
+  std::int64_t value OPENTELEMETRY_MAYBE_UNUSED = 0;
 
   std::vector<std::thread> threads;
   threads.reserve(num_threads);


### PR DESCRIPTION
Fixes #2321

## Changes

Please provide a brief description of the changes here.

* Upgrade gcc from 12 to 13 in CI maintainer mode builds
* Upgrade clang from 14 to 15 in CI maintainer mode builds
* Fixed a new warning `[-Werror,-Wunused-but-set-variable]` in `spinlock_benchmark.cc`
* Backported the following fixes from abseil-cpp, to resolve clang-15 warnings.

1)

```
commit cfe27e79cfcbefb2b4479e04f80cbb299bc46965
Author: Abseil Team <absl-team@google.com>
Date:   Fri Aug 5 06:56:05 2022 -0700

    Map the absl::is_trivially_* functions to their std impl
    
    There's no point redefining these functions if they are supported by the compiler and the version of libstdc++. Also, some of the builtins used by the absl implementation of these functions (e.g. __has_trivial_destructor) have been deprecated in Clang 15.
    
    PiperOrigin-RevId: 465554125
    Change-Id: I8674c3a5270ce3c654cdf58ae7dbd9d2bda8faa5
```

2)

```
commit e61fc6d8da5154c6a665d7a28b9978f11b78eb62
Author: Keith Smiley <keithbsmiley@gmail.com>
Date:   Tue Oct 4 17:22:04 2022 +0000

    Fix more clang deprecated builtins
    
    If you compile with clang 15+, the uses of trivially destructible and
    assignable are deprecated. This sets this configuration correctly as the
    ifdef to fix the build.
    
    Fixes https://github.com/abseil/abseil-cpp/issues/1201
    Related https://github.com/abseil/abseil-cpp/pull/1277
```

Note that the fixes are not applied as is: `ABSL_HAVE_STD_IS_XXX` is also renamed to `OTABSL_HAVE_STD_IS_XXX`


For significant contributions please make sure you have completed the following items:

* [ ] `CHANGELOG.md` updated for non-trivial changes
* [ ] Unit tests have been added
* [ ] Changes in public API reviewed