### PR TITLE
[BUILD] Better handling of OPENTELEMETRY_STL_VERSION under Bazel.

### DIFF
--- a/api/BUILD
+++ b/api/BUILD
@@ -1,7 +1,7 @@
 # Copyright The OpenTelemetry Authors
 # SPDX-License-Identifier: Apache-2.0
 
-load("@bazel_skylib//rules:common_settings.bzl", "bool_flag")
+load("@bazel_skylib//rules:common_settings.bzl", "bool_flag", "string_flag")
 
 package(default_visibility = ["//visibility:public"])
 
@@ -10,11 +10,38 @@ bool_flag(
     build_setting_default = False,
 )
 
+CPP_STDLIBS = [
+    "none",
+    "best",
+    "2014",
+    "2017",
+    "2020",
+    "2023",
+]
+
+string_flag(
+    name = "with_cxx_stdlib",
+    build_setting_default = "best",
+    values = CPP_STDLIBS,
+)
+
 cc_library(
     name = "api",
     hdrs = glob(["include/**/*.h"]),
     defines = select({
         ":with_external_abseil": ["HAVE_ABSEIL"],
+        "//conditions:default": [],
+    }) + select({
+        ":set_cxx_stdlib_none": [],
+        ### automatic selection
+        ":set_cxx_stdlib_best": ["OPENTELEMETRY_STL_VERSION=(__cplusplus/100)"],
+        # See https://learn.microsoft.com/en-us/cpp/build/reference/zc-cplusplus
+        ":set_cxx_stdlib_best_and_msvc": ["OPENTELEMETRY_STL_VERSION=(_MSVC_LANG/100)"],
+        ### manual selection
+        ":set_cxx_stdlib_2014": ["OPENTELEMETRY_STL_VERSION=2014"],
+        ":set_cxx_stdlib_2017": ["OPENTELEMETRY_STL_VERSION=2017"],
+        ":set_cxx_stdlib_2020": ["OPENTELEMETRY_STL_VERSION=2020"],
+        ":set_cxx_stdlib_2023": ["OPENTELEMETRY_STL_VERSION=2023"],
         "//conditions:default": [],
     }),
     strip_include_prefix = "include",
@@ -32,4 +59,15 @@ cc_library(
 config_setting(
     name = "with_external_abseil",
     flag_values = {":with_abseil": "true"},
+)
+
+[config_setting(
+    name = "set_cxx_stdlib_%s" % v,
+    flag_values = {":with_cxx_stdlib": v},
+) for v in CPP_STDLIBS]
+
+config_setting(
+    name = "set_cxx_stdlib_best_and_msvc",
+    constraint_values = ["@bazel_tools//tools/cpp:msvc"],
+    flag_values = {":with_cxx_stdlib": "best"},
 )


### PR DESCRIPTION
Fixes #2470 for Bazel.

## Changes

Make Bazel build, by default, use the "current" actual C++ version as `OPENTELEMETRY_STL_VERSION`.

Note that some compilers use some "interesting" values for `__cplusplus` when asked to compiler for the most recent version they support. This can result in slightly unexpected results, but might actually be a good thing if those values indicate less than perfect support for the version in question and cause a downgrade to a better supported library. 

