### PR TITLE
[EXPORTER] Error when grpc endpoint is empty

### DIFF
--- a/exporters/otlp/src/otlp_grpc_client.cc
+++ b/exporters/otlp/src/otlp_grpc_client.cc
@@ -264,8 +264,13 @@ OtlpGrpcClient::~OtlpGrpcClient()
 
 std::shared_ptr<grpc::Channel> OtlpGrpcClient::MakeChannel(const OtlpGrpcClientOptions &options)
 {
-  std::shared_ptr<grpc::Channel> channel;
 
+  if (options.endpoint.empty())
+  {
+    OTEL_INTERNAL_LOG_ERROR("[OTLP GRPC Client] empty endpoint");
+
+    return nullptr;
+  }
   //
   // Scheme is allowed in OTLP endpoint definition, but is not allowed for creating gRPC
   // channel. Passing URI with scheme to grpc::CreateChannel could resolve the endpoint to some
@@ -280,6 +285,7 @@ std::shared_ptr<grpc::Channel> OtlpGrpcClient::MakeChannel(const OtlpGrpcClientO
     return nullptr;
   }
 
+  std::shared_ptr<grpc::Channel> channel;
   std::string grpc_target = url.host_ + ":" + std::to_string(static_cast<int>(url.port_));
   grpc::ChannelArguments grpc_arguments;
   grpc_arguments.SetUserAgentPrefix(options.user_agent);


### PR DESCRIPTION
## Changes

It seems like there is nothing checking whether the grpc exporter is actually empty, in which case it doesn't make sense to create a gRPC channel. This causes a problem in my application where we accidentally create a GrpcExporter with empty endpoint, which we never use because of a NOOP sampler. 

I believe it could be useful to log an error here, similar to when the endpoint is no valid URI.