### PR TITLE
[EXPORTERS] Fix curl calls from otlp_http_exporter for versions >=7.5 and <7.80

### DIFF
--- a/ext/include/opentelemetry/ext/http/client/curl/http_operation_curl.h
+++ b/ext/include/opentelemetry/ext/http/client/curl/http_operation_curl.h
@@ -102,7 +102,7 @@ private:
 
   static size_t ReadMemoryCallback(char *buffer, size_t size, size_t nitems, void *userp);
 
-#if LIBCURL_VERSION_NUM >= 0x075000
+#if LIBCURL_VERSION_NUM >= 0x078000
   static int PreRequestCallback(void *clientp,
                                 char *conn_primary_ip,
                                 char *conn_local_ip,

--- a/ext/src/http/client/curl/http_operation_curl.cc
+++ b/ext/src/http/client/curl/http_operation_curl.cc
@@ -152,7 +152,7 @@ size_t HttpOperation::ReadMemoryCallback(char *buffer, size_t size, size_t nitem
   return nwrite;
 }
 
-#if LIBCURL_VERSION_NUM >= 0x075000
+#if LIBCURL_VERSION_NUM >= 0x078000
 int HttpOperation::PreRequestCallback(void *clientp, char *, char *, int, int)
 {
   HttpOperation *self = reinterpret_cast<HttpOperation *>(clientp);
@@ -1044,7 +1044,7 @@ CURLcode HttpOperation::Setup()
   }
 #endif
 
-#if LIBCURL_VERSION_NUM >= 0x075000
+#if LIBCURL_VERSION_NUM >= 0x078000
   rc = SetCurlPtrOption(CURLOPT_PREREQFUNCTION, (void *)&HttpOperation::PreRequestCallback);
   if (rc != CURLE_OK)
   {


### PR DESCRIPTION
Fixes #2520

## Changes
Just changed the `#if` from version `0x075000` to `0x078000`

Trivial change, no changelog change