### PR TITLE
[SDK] Restore Recordable API compatibility with versions < 1.14.0

### DIFF
--- a/sdk/include/opentelemetry/sdk/trace/recordable.h
+++ b/sdk/include/opentelemetry/sdk/trace/recordable.h
@@ -139,7 +139,7 @@ public:
    * Set the trace flags of the span.
    * @param flags the flags to set
    */
-  virtual void SetTraceFlags(opentelemetry::trace::TraceFlags flags) noexcept { (void)flags; };
+  virtual void SetTraceFlags(opentelemetry::trace::TraceFlags flags) noexcept { (void)flags; }
 
   /**
    * Set the spankind of the span.

--- a/sdk/include/opentelemetry/sdk/trace/recordable.h
+++ b/sdk/include/opentelemetry/sdk/trace/recordable.h
@@ -139,7 +139,7 @@ public:
    * Set the trace flags of the span.
    * @param flags the flags to set
    */
-  virtual void SetTraceFlags(opentelemetry::trace::TraceFlags flags) noexcept = 0;
+  virtual void SetTraceFlags(opentelemetry::trace::TraceFlags flags) noexcept {};
 
   /**
    * Set the spankind of the span.

--- a/sdk/include/opentelemetry/sdk/trace/recordable.h
+++ b/sdk/include/opentelemetry/sdk/trace/recordable.h
@@ -139,7 +139,7 @@ public:
    * Set the trace flags of the span.
    * @param flags the flags to set
    */
-  virtual void SetTraceFlags(opentelemetry::trace::TraceFlags flags) noexcept {};
+  virtual void SetTraceFlags(opentelemetry::trace::TraceFlags flags) noexcept { (void)flags; };
 
   /**
    * Set the spankind of the span.

--- a/sdk/include/opentelemetry/sdk/trace/recordable.h
+++ b/sdk/include/opentelemetry/sdk/trace/recordable.h
@@ -139,7 +139,7 @@ public:
    * Set the trace flags of the span.
    * @param flags the flags to set
    */
-  virtual void SetTraceFlags(opentelemetry::trace::TraceFlags flags) noexcept { (void)flags; }
+  virtual void SetTraceFlags(opentelemetry::trace::TraceFlags /* flags */) noexcept {}
 
   /**
    * Set the spankind of the span.


### PR DESCRIPTION
Issue:

`Recordable::SetTraceFlags(...)` was added in v1.14.0. This was a breaking change. Consumers of this library would have to define an override for this method. Also, the latest version of opentelemetry-cpp would not be API compatible with older versions of consumers (which could not know about this new, pure virtual method).

https://github.com/open-telemetry/opentelemetry-cpp/pull/2488#discussion_r1493959370

Solution:

Provides a default implementation for `Recordable::SetTraceFlags(...)`.

The default implementation is sufficient for W3C Trace Context version 1, which is actually used.

To later support W3C Trace Context version 2, exporters are encouraged to capture trace flags, by providing an implementation in Recordable sub classes.

Limitation:

Note that this PR does not restore ABI compatibility for older versions.

The ABI change is required to support opentelemetry-proto 1.1.0, used by the OTLP exporter.