### PR TITLE
[SDK] Support for OTEL_SERVICE_NAME

### DIFF
--- a/sdk/src/resource/resource_detector.cc
+++ b/sdk/src/resource/resource_detector.cc
@@ -15,14 +15,16 @@ namespace resource
 {
 
 const char *OTEL_RESOURCE_ATTRIBUTES = "OTEL_RESOURCE_ATTRIBUTES";
-const char *OTEL_SERVICE_NAME = "OTEL_SERVICE_NAME";
+const char *OTEL_SERVICE_NAME        = "OTEL_SERVICE_NAME";
 
 Resource OTELResourceDetector::Detect() noexcept
 {
   std::string attributes_str, service_name;
 
-  bool attributes_exists = opentelemetry::sdk::common::GetStringEnvironmentVariable(OTEL_RESOURCE_ATTRIBUTES, attributes_str);
-  bool service_name_exists = opentelemetry::sdk::common::GetStringEnvironmentVariable(OTEL_SERVICE_NAME, service_name);
+  bool attributes_exists = opentelemetry::sdk::common::GetStringEnvironmentVariable(
+      OTEL_RESOURCE_ATTRIBUTES, attributes_str);
+  bool service_name_exists =
+      opentelemetry::sdk::common::GetStringEnvironmentVariable(OTEL_SERVICE_NAME, service_name);
 
   if (!attributes_exists && !service_name_exists)
   {

--- a/sdk/src/resource/resource_detector.cc
+++ b/sdk/src/resource/resource_detector.cc
@@ -4,6 +4,7 @@
 #include "opentelemetry/sdk/resource/resource_detector.h"
 #include "opentelemetry/sdk/common/env_variables.h"
 #include "opentelemetry/sdk/resource/resource.h"
+#include "opentelemetry/sdk/resource/semantic_conventions.h"
 
 #include <sstream>
 #include <string>
@@ -39,16 +40,19 @@ Resource OTELResourceDetector::Detect() noexcept
     std::string token;
     while (std::getline(iss, token, ','))
     {
-      size_t pos        = token.find('=');
-      std::string key   = token.substr(0, pos);
-      std::string value = token.substr(pos + 1);
-      attributes[key]   = value;
+      size_t pos = token.find('=');
+      if (pos != std::string::npos)
+      {
+        std::string key   = token.substr(0, pos);
+        std::string value = token.substr(pos + 1);
+        attributes[key]   = value;
+      }
     }
   }
 
   if (service_name_exists)
   {
-    attributes["service.name"] = service_name;
+    attributes[SemanticConventions::kServiceName] = service_name;
   }
 
   return Resource(attributes);

--- a/sdk/test/resource/resource_test.cc
+++ b/sdk/test/resource/resource_test.cc
@@ -220,6 +220,30 @@ TEST(ResourceTest, OtelResourceDetector)
   unsetenv("OTEL_RESOURCE_ATTRIBUTES");
 }
 
+TEST(ResourceTest, OtelResourceDetectorServiceNameOverride)
+{
+  std::map<std::string, std::string> expected_attributes = {{"service.name", "new_name"}};
+
+  setenv("OTEL_RESOURCE_ATTRIBUTES", "service.name=old_name", 1);
+  setenv("OTEL_SERVICE_NAME", "new_name", 1);
+
+  OTELResourceDetector detector;
+  auto resource            = detector.Detect();
+  auto received_attributes = resource.GetAttributes();
+  for (auto &e : received_attributes)
+  {
+    EXPECT_TRUE(expected_attributes.find(e.first) != expected_attributes.end());
+    if (expected_attributes.find(e.first) != expected_attributes.end())
+    {
+      EXPECT_EQ(expected_attributes.find(e.first)->second, nostd::get<std::string>(e.second));
+    }
+  }
+  EXPECT_EQ(received_attributes.size(), expected_attributes.size());
+
+  unsetenv("OTEL_SERVICE_NAME");
+  unsetenv("OTEL_RESOURCE_ATTRIBUTES");
+}
+
 TEST(ResourceTest, OtelResourceDetectorEmptyEnv)
 {
   std::map<std::string, std::string> expected_attributes = {};


### PR DESCRIPTION
OTEL_SERVICE_NAME overrides OTEL_RESOURCE_ATTRIBUTES when it is defined.

Fixes #2559

## Changes

Adds support for `OTEL_SERVICE_NAME` environmental variable to set "service.name".