### PR TITLE
[BUILD] Provide LIKELY / UNLIKELY macros

### DIFF
--- a/api/include/opentelemetry/common/macros.h
+++ b/api/include/opentelemetry/common/macros.h
@@ -43,9 +43,9 @@
 #endif
 
 #if !defined(OPENTELEMETRY_UNLIKELY_CONDITION) && defined(__cplusplus)
-// Only use likely with C++20
+// Only use unlikely with C++20
 #  if __cplusplus >= 202002L
-// GCC 9 has likely attribute but do not support declare it at the beginning of statement
+// GCC 9 has unlikely attribute but do not support declare it at the beginning of statement
 #    if defined(__has_cpp_attribute) && (defined(__clang__) || !defined(__GNUC__) || __GNUC__ > 9)
 #      if __has_cpp_attribute(unlikely)
 #        define OPENTELEMETRY_UNLIKELY_CONDITION(C) (C) [[unlikely]]

--- a/api/include/opentelemetry/common/macros.h
+++ b/api/include/opentelemetry/common/macros.h
@@ -3,22 +3,36 @@
 
 #pragma once
 
-#if !defined(OPENTELEMETRY_LIKELY_IF) && defined(__cplusplus)
+#if !defined(OPENTELEMETRY_LIKELY) && defined(__cplusplus)
+// Only use likely with C++20
+#  if __cplusplus >= 202002L
 // GCC 9 has likely attribute but do not support declare it at the beginning of statement
-#  if defined(__has_cpp_attribute) && (defined(__clang__) || !defined(__GNUC__) || __GNUC__ > 9)
-#    if __has_cpp_attribute(likely)
-#      define OPENTELEMETRY_LIKELY_IF(...) \
-        if (__VA_ARGS__)                   \
-        [[likely]]
-
+#    if defined(__has_cpp_attribute) && (defined(__clang__) || !defined(__GNUC__) || __GNUC__ > 9)
+#      if __has_cpp_attribute(likely)
+#        define OPENTELEMETRY_LIKELY [[likely]]
+#      endif
 #    endif
 #  endif
 #endif
-#if !defined(OPENTELEMETRY_LIKELY_IF) && (defined(__clang__) || defined(__GNUC__))
-#  define OPENTELEMETRY_LIKELY_IF(...) if (__builtin_expect(!!(__VA_ARGS__), true))
+
+#ifndef OPENTELEMETRY_LIKELY
+#  define OPENTELEMETRY_LIKELY
 #endif
-#ifndef OPENTELEMETRY_LIKELY_IF
-#  define OPENTELEMETRY_LIKELY_IF(...) if (__VA_ARGS__)
+
+#if !defined(OPENTELEMETRY_UNLIKELY) && defined(__cplusplus)
+// Only use unlikely with C++20
+#  if __cplusplus >= 202002L
+// GCC 9 has unlikely attribute but do not support declare it at the beginning of statement
+#    if defined(__has_cpp_attribute) && (defined(__clang__) || !defined(__GNUC__) || __GNUC__ > 9)
+#      if __has_cpp_attribute(unlikely)
+#        define OPENTELEMETRY_UNLIKELY [[unlikely]]
+#      endif
+#    endif
+#  endif
+#endif
+
+#ifndef OPENTELEMETRY_UNLIKELY
+#  define OPENTELEMETRY_UNLIKELY
 #endif
 
 /// \brief Declare variable as maybe unused

--- a/api/include/opentelemetry/logs/logger.h
+++ b/api/include/opentelemetry/logs/logger.h
@@ -258,15 +258,19 @@ public:
 
   inline bool Enabled(Severity severity, const EventId &event_id) const noexcept
   {
-    if (!Enabled(severity))
-      OPENTELEMETRY_LIKELY { return false; }
+    if OPENTELEMETRY_LIKELY_CONDITION (!Enabled(severity))
+    {
+      return false;
+    }
     return EnabledImplementation(severity, event_id);
   }
 
   inline bool Enabled(Severity severity, int64_t event_id) const noexcept
   {
-    if (!Enabled(severity))
-      OPENTELEMETRY_LIKELY { return false; }
+    if OPENTELEMETRY_LIKELY_CONDITION (!Enabled(severity))
+    {
+      return false;
+    }
     return EnabledImplementation(severity, event_id);
   }
 

--- a/api/include/opentelemetry/logs/logger.h
+++ b/api/include/opentelemetry/logs/logger.h
@@ -258,13 +258,15 @@ public:
 
   inline bool Enabled(Severity severity, const EventId &event_id) const noexcept
   {
-    OPENTELEMETRY_LIKELY_IF(Enabled(severity) == false) { return false; }
+    if (!Enabled(severity))
+      OPENTELEMETRY_LIKELY { return false; }
     return EnabledImplementation(severity, event_id);
   }
 
   inline bool Enabled(Severity severity, int64_t event_id) const noexcept
   {
-    OPENTELEMETRY_LIKELY_IF(Enabled(severity) == false) { return false; }
+    if (!Enabled(severity))
+      OPENTELEMETRY_LIKELY { return false; }
     return EnabledImplementation(severity, event_id);
   }
 

--- a/exporters/otlp/src/otlp_log_recordable.cc
+++ b/exporters/otlp/src/otlp_log_recordable.cc
@@ -18,8 +18,10 @@ namespace otlp
 
 const opentelemetry::sdk::resource::Resource &OtlpLogRecordable::GetResource() const noexcept
 {
-  if (nullptr != resource_)
-    OPENTELEMETRY_LIKELY { return *resource_; }
+  if OPENTELEMETRY_LIKELY_CONDITION (nullptr != resource_)
+  {
+    return *resource_;
+  }
 
   return opentelemetry::sdk::logs::ReadableLogRecord::GetDefaultResource();
 }
@@ -27,8 +29,10 @@ const opentelemetry::sdk::resource::Resource &OtlpLogRecordable::GetResource() c
 const opentelemetry::sdk::instrumentationscope::InstrumentationScope &
 OtlpLogRecordable::GetInstrumentationScope() const noexcept
 {
-  if (nullptr != instrumentation_scope_)
-    OPENTELEMETRY_LIKELY { return *instrumentation_scope_; }
+  if OPENTELEMETRY_LIKELY_CONDITION (nullptr != instrumentation_scope_)
+  {
+    return *instrumentation_scope_;
+  }
 
   return opentelemetry::sdk::logs::ReadableLogRecord::GetDefaultInstrumentationScope();
 }

--- a/exporters/otlp/src/otlp_log_recordable.cc
+++ b/exporters/otlp/src/otlp_log_recordable.cc
@@ -18,7 +18,8 @@ namespace otlp
 
 const opentelemetry::sdk::resource::Resource &OtlpLogRecordable::GetResource() const noexcept
 {
-  OPENTELEMETRY_LIKELY_IF(nullptr != resource_) { return *resource_; }
+  if (nullptr != resource_)
+    OPENTELEMETRY_LIKELY { return *resource_; }
 
   return opentelemetry::sdk::logs::ReadableLogRecord::GetDefaultResource();
 }
@@ -26,7 +27,8 @@ const opentelemetry::sdk::resource::Resource &OtlpLogRecordable::GetResource() c
 const opentelemetry::sdk::instrumentationscope::InstrumentationScope &
 OtlpLogRecordable::GetInstrumentationScope() const noexcept
 {
-  OPENTELEMETRY_LIKELY_IF(nullptr != instrumentation_scope_) { return *instrumentation_scope_; }
+  if (nullptr != instrumentation_scope_)
+    OPENTELEMETRY_LIKELY { return *instrumentation_scope_; }
 
   return opentelemetry::sdk::logs::ReadableLogRecord::GetDefaultInstrumentationScope();
 }

--- a/sdk/src/logs/read_write_log_record.cc
+++ b/sdk/src/logs/read_write_log_record.cc
@@ -158,7 +158,8 @@ const std::unordered_map<std::string, opentelemetry::common::AttributeValue>
 
 const opentelemetry::sdk::resource::Resource &ReadWriteLogRecord::GetResource() const noexcept
 {
-  OPENTELEMETRY_LIKELY_IF(nullptr != resource_) { return *resource_; }
+  if (nullptr != resource_)
+    OPENTELEMETRY_LIKELY { return *resource_; }
 
   return GetDefaultResource();
 }
@@ -172,7 +173,8 @@ void ReadWriteLogRecord::SetResource(
 const opentelemetry::sdk::instrumentationscope::InstrumentationScope &
 ReadWriteLogRecord::GetInstrumentationScope() const noexcept
 {
-  OPENTELEMETRY_LIKELY_IF(nullptr != instrumentation_scope_) { return *instrumentation_scope_; }
+  if (nullptr != instrumentation_scope_)
+    OPENTELEMETRY_LIKELY { return *instrumentation_scope_; }
 
   return GetDefaultInstrumentationScope();
 }

--- a/sdk/src/logs/read_write_log_record.cc
+++ b/sdk/src/logs/read_write_log_record.cc
@@ -158,8 +158,10 @@ const std::unordered_map<std::string, opentelemetry::common::AttributeValue>
 
 const opentelemetry::sdk::resource::Resource &ReadWriteLogRecord::GetResource() const noexcept
 {
-  if (nullptr != resource_)
-    OPENTELEMETRY_LIKELY { return *resource_; }
+  if OPENTELEMETRY_LIKELY_CONDITION (nullptr != resource_)
+  {
+    return *resource_;
+  }
 
   return GetDefaultResource();
 }
@@ -173,8 +175,10 @@ void ReadWriteLogRecord::SetResource(
 const opentelemetry::sdk::instrumentationscope::InstrumentationScope &
 ReadWriteLogRecord::GetInstrumentationScope() const noexcept
 {
-  if (nullptr != instrumentation_scope_)
-    OPENTELEMETRY_LIKELY { return *instrumentation_scope_; }
+  if OPENTELEMETRY_LIKELY_CONDITION (nullptr != instrumentation_scope_)
+  {
+    return *instrumentation_scope_;
+  }
 
   return GetDefaultInstrumentationScope();
 }

--- a/sdk/src/metrics/data/circular_buffer.cc
+++ b/sdk/src/metrics/data/circular_buffer.cc
@@ -21,11 +21,12 @@ struct AdaptingIntegerArrayIncrement
   uint64_t operator()(std::vector<T> &backing)
   {
     const uint64_t result = backing[index] + count;
-    OPENTELEMETRY_LIKELY_IF(result <= uint64_t(std::numeric_limits<T>::max()))
-    {
-      backing[index] = static_cast<T>(result);
-      return 0;
-    }
+    if (result <= uint64_t(std::numeric_limits<T>::max()))
+      OPENTELEMETRY_LIKELY
+      {
+        backing[index] = static_cast<T>(result);
+        return 0;
+      }
     return result;
   }
 };
@@ -76,7 +77,8 @@ struct AdaptingIntegerArrayCopy
 void AdaptingIntegerArray::Increment(size_t index, uint64_t count)
 {
   const uint64_t result = nostd::visit(AdaptingIntegerArrayIncrement{index, count}, backing_);
-  OPENTELEMETRY_LIKELY_IF(result == 0) { return; }
+  if (result == 0)
+    OPENTELEMETRY_LIKELY { return; }
   EnlargeToFit(result);
   Increment(index, count);
 }

--- a/sdk/src/metrics/data/circular_buffer.cc
+++ b/sdk/src/metrics/data/circular_buffer.cc
@@ -21,12 +21,11 @@ struct AdaptingIntegerArrayIncrement
   uint64_t operator()(std::vector<T> &backing)
   {
     const uint64_t result = backing[index] + count;
-    if (result <= uint64_t(std::numeric_limits<T>::max()))
-      OPENTELEMETRY_LIKELY
-      {
-        backing[index] = static_cast<T>(result);
-        return 0;
-      }
+    if OPENTELEMETRY_LIKELY_CONDITION (result <= uint64_t(std::numeric_limits<T>::max()))
+    {
+      backing[index] = static_cast<T>(result);
+      return 0;
+    }
     return result;
   }
 };
@@ -77,8 +76,10 @@ struct AdaptingIntegerArrayCopy
 void AdaptingIntegerArray::Increment(size_t index, uint64_t count)
 {
   const uint64_t result = nostd::visit(AdaptingIntegerArrayIncrement{index, count}, backing_);
-  if (result == 0)
-    OPENTELEMETRY_LIKELY { return; }
+  if OPENTELEMETRY_LIKELY_CONDITION (result == 0)
+  {
+    return;
+  }
   EnlargeToFit(result);
   Increment(index, count);
 }


### PR DESCRIPTION
Contributes to #2572

## Changes

Please provide a brief description of the changes here.

* Remove the `OPENTELEMETRY_LIKELY_IF` macro
  * This macro does not make sense because it includes the `if` itself, making it unusable for other constructs (for loops, while loops)
* Provide a `OPENTELEMETRY_LIKELY_CONDITION` macro
  * To be used instead of `OPENTELEMETRY_LIKELY_IF`.
  * Only one argument is supported instead of a `__VA_ARGS__`, to discourage `if OPENTELEMETRY_LIKELY_CONDITION (a = foo(), b = bar(), a > b)`
  * This macro supports both compiler builtins for gcc and clang, and C++20.
* Provide a `OPENTELEMETRY_UNLIKELY_CONDITION` macro
* Provide a `OPENTELEMETRY_LIKELY` macro
* Provide a `OPENTELEMETRY_UNLIKELY` macro

With this change, likely / unlikely hints can be placed anywhere (for loops, while loops, switch case, etc). These hints are not used only for if conditions.

For significant contributions please make sure you have completed the following items:

* [ ] `CHANGELOG.md` updated for non-trivial changes
* [ ] Unit tests have been added
* [X] Changes in public API reviewed