### PR TITLE
[BUILD] Bump CMake minimum required version to 3.9

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright The OpenTelemetry Authors
 # SPDX-License-Identifier: Apache-2.0
 
-cmake_minimum_required(VERSION 3.1)
+cmake_minimum_required(VERSION 3.9)
 
 # See https://cmake.org/cmake/help/v3.3/policy/CMP0057.html required by certain
 # versions of gtest


### PR DESCRIPTION
Fixes #1399

Also resolves the following deprecation warnings:

Starting with CMake 3.27, support for CMake < 3.5 is deprecated.

```
Changed in version 3.27: Compatibility with versions of CMake older than 3.5 is deprecated.
```

For some platforms, `CI` logs for opentelemetry-cpp now shows:

```
CMake Deprecation Warning at CMakeLists.txt:4 (cmake_minimum_required):
  Compatibility with CMake < 3.5 will be removed from a future version of
  CMake.
```

## Changes

Please provide a brief description of the changes here.

* Bump cmake_minimum_required to 3.9
  * at least 3.5 is required to clear the deprecation warning
  * at least 3.9 is required because gtest is used, the previous requirement of 3.1 was incorrect.

For significant contributions please make sure you have completed the following items:

* [ ] `CHANGELOG.md` updated for non-trivial changes
* [ ] Unit tests have been added
* [ ] Changes in public API reviewed