### PR TITLE
[bazel] Move -std=c++14 to .bazelrc

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -7,6 +7,9 @@
 # Needed by gRPC to build on some platforms.
 build --copt -DGRPC_BAZEL_BUILD
 
+# Set minimum supported C++ version
+build --host_cxxopt=-std=c++14 --cxxopt=-std=c++14
+
 # --config=asan : Address Sanitizer.
 common:asan --copt -DADDRESS_SANITIZER
 common:asan --copt -fsanitize=address,bool,float-cast-overflow,integer-divide-by-zero,null,return,returns-nonnull-attribute,shift-exponent,signed-integer-overflow,unreachable,vla-bound
@@ -25,4 +28,3 @@ common:tsan --cc_output_directory_tag=tsan
 # This is needed to address false positive problem with abseil.The same setting as gRPC
 # https://github.com/google/sanitizers/issues/953
 common:tsan --test_env=TSAN_OPTIONS=report_atomic_races=0
-

--- a/ci/do_ci.sh
+++ b/ci/do_ci.sh
@@ -25,7 +25,7 @@ function run_benchmarks
 
   [ -z "${BENCHMARK_DIR}" ] && export BENCHMARK_DIR=$HOME/benchmark
   mkdir -p $BENCHMARK_DIR
-  bazel $BAZEL_STARTUP_OPTIONS build --host_cxxopt=-std=c++14 --cxxopt=-std=c++14 $BAZEL_OPTIONS_ASYNC -c opt -- \
+  bazel $BAZEL_STARTUP_OPTIONS build $BAZEL_OPTIONS_ASYNC -c opt -- \
     $(bazel query 'attr("tags", "benchmark_result", ...)')
   echo ""
   echo "Benchmark results in $BENCHMARK_DIR:"
@@ -70,7 +70,7 @@ echo "make command: ${MAKE_COMMAND}"
 echo "IWYU option: ${IWYU}"
 
 BAZEL_OPTIONS_DEFAULT="--copt=-DENABLE_METRICS_EXEMPLAR_PREVIEW"
-BAZEL_OPTIONS="--cxxopt=-std=c++14 $BAZEL_OPTIONS_DEFAULT"
+BAZEL_OPTIONS="$BAZEL_OPTIONS_DEFAULT"
 
 BAZEL_TEST_OPTIONS="$BAZEL_OPTIONS --test_output=errors"
 
@@ -493,7 +493,7 @@ elif [[ "$1" == "bazel.e2e" ]]; then
   exit 0
 elif [[ "$1" == "benchmark" ]]; then
   [ -z "${BENCHMARK_DIR}" ] && export BENCHMARK_DIR=$HOME/benchmark
-  bazel $BAZEL_STARTUP_OPTIONS build --host_cxxopt=-std=c++14 --cxxopt=-std=c++14 $BAZEL_OPTIONS_ASYNC -c opt -- \
+  bazel $BAZEL_STARTUP_OPTIONS build $BAZEL_OPTIONS_ASYNC -c opt -- \
     $(bazel query 'attr("tags", "benchmark_result", ...)')
   echo ""
   echo "Benchmark results in $BENCHMARK_DIR:"


### PR DESCRIPTION
This way it applies to local builds as well as CI builds

Related: https://github.com/open-telemetry/opentelemetry-cpp/pull/2599#issuecomment-2013188043