### PR TITLE
Mozbuild

### DIFF
--- a/api/moz.build
+++ b/api/moz.build
@@ -1,0 +1,201 @@
+# -*- Mode: python; indent-tabs-mode: nil; tab-width: 40 -*-
+# vim: set filetype=python:
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+EXPORTS.opentelemetry += [
+  "include/opentelemetry/config.h",
+  "include/opentelemetry/version.h",
+]
+
+EXPORTS.opentelemetry.baggage += [
+  "include/opentelemetry/baggage/baggage.h",
+  "include/opentelemetry/baggage/baggage_context.h",
+]
+
+EXPORTS.opentelemetry.baggage.propagation += [
+  "include/opentelemetry/baggage/propagation/baggage_propagator.h",
+]
+
+EXPORTS.opentelemetry.common += [
+  "include/opentelemetry/common/attribute_value.h",
+  "include/opentelemetry/common/key_value_iterable.h",
+  "include/opentelemetry/common/key_value_iterable_view.h",
+  "include/opentelemetry/common/kv_properties.h",
+  "include/opentelemetry/common/macros.h",
+  "include/opentelemetry/common/spin_lock_mutex.h",
+  "include/opentelemetry/common/string_util.h",
+  "include/opentelemetry/common/timestamp.h",
+]
+
+EXPORTS.opentelemetry.context += [
+  "include/opentelemetry/context/context.h",
+  "include/opentelemetry/context/context_value.h",
+  "include/opentelemetry/context/runtime_context.h",
+]
+
+EXPORTS.opentelemetry.context.propagation += [
+  "include/opentelemetry/context/propagation/composite_propagator.h",
+  "include/opentelemetry/context/propagation/global_propagator.h",
+  "include/opentelemetry/context/propagation/noop_propagator.h",
+  "include/opentelemetry/context/propagation/text_map_propagator.h",
+]
+
+EXPORTS.opentelemetry.detail += [
+  "include/opentelemetry/detail/preprocessor.h",
+]
+
+EXPORTS.opentelemetry.logs += [
+  "include/opentelemetry/logs/event_id.h",
+  "include/opentelemetry/logs/event_logger.h",
+  "include/opentelemetry/logs/event_logger_provider.h",
+  "include/opentelemetry/logs/log_record.h",
+  "include/opentelemetry/logs/logger.h",
+  "include/opentelemetry/logs/logger_provider.h",
+  "include/opentelemetry/logs/logger_type_traits.h",
+  "include/opentelemetry/logs/noop.h",
+  "include/opentelemetry/logs/provider.h",
+  "include/opentelemetry/logs/severity.h",
+]
+
+EXPORTS.opentelemetry.metrics += [
+  "include/opentelemetry/metrics/async_instruments.h",
+  "include/opentelemetry/metrics/meter.h",
+  "include/opentelemetry/metrics/meter_provider.h",
+  "include/opentelemetry/metrics/noop.h",
+  "include/opentelemetry/metrics/observer_result.h",
+  "include/opentelemetry/metrics/provider.h",
+  "include/opentelemetry/metrics/sync_instruments.h",
+]
+
+# Probably this is where we can bind to custom mozilla types.
+EXPORTS.opentelemetry.nostd += [
+  "include/opentelemetry/nostd/function_ref.h",
+  "include/opentelemetry/nostd/shared_ptr.h",
+  "include/opentelemetry/nostd/span.h",
+  "include/opentelemetry/nostd/string_view.h",
+  "include/opentelemetry/nostd/type_traits.h",
+  "include/opentelemetry/nostd/unique_ptr.h",
+  "include/opentelemetry/nostd/utility.h",
+  "include/opentelemetry/nostd/variant.h",
+]
+
+EXPORTS.opentelemetry.nostd.detail += [
+  "include/opentelemetry/nostd/detail/all.h",
+  "include/opentelemetry/nostd/detail/decay.h",
+  "include/opentelemetry/nostd/detail/dependent_type.h",
+  "include/opentelemetry/nostd/detail/functional.h",
+  "include/opentelemetry/nostd/detail/invoke.h",
+  "include/opentelemetry/nostd/detail/trait.h",
+  "include/opentelemetry/nostd/detail/type_pack_element.h",
+  "include/opentelemetry/nostd/detail/valueless.h",
+  "include/opentelemetry/nostd/detail/variant_alternative.h",
+  "include/opentelemetry/nostd/detail/variant_fwd.h",
+  "include/opentelemetry/nostd/detail/variant_size.h",
+  "include/opentelemetry/nostd/detail/void.h",
+]
+
+# Do we even need absl?
+EXPORTS.opentelemetry.nostd.internal.absl += [
+  "include/opentelemetry/nostd/internal/absl/.clang-format",
+  "include/opentelemetry/nostd/internal/absl/README.md",
+]
+
+# Do we even need absl?
+EXPORTS.opentelemetry.nostd.internal.absl.base += [
+  "include/opentelemetry/nostd/internal/absl/base/attributes.h",
+  "include/opentelemetry/nostd/internal/absl/base/config.h",
+  "include/opentelemetry/nostd/internal/absl/base/macros.h",
+  "include/opentelemetry/nostd/internal/absl/base/optimization.h",
+  "include/opentelemetry/nostd/internal/absl/base/options.h",
+  "include/opentelemetry/nostd/internal/absl/base/policy_checks.h",
+  "include/opentelemetry/nostd/internal/absl/base/port.h",
+]
+
+EXPORTS.opentelemetry.nostd.internal.absl.base.internal += [
+  "include/opentelemetry/nostd/internal/absl/base/internal/identity.h",
+  "include/opentelemetry/nostd/internal/absl/base/internal/inline_variable.h",
+  "include/opentelemetry/nostd/internal/absl/base/internal/invoke.h",
+]
+
+# Do we even need absl?
+EXPORTS.opentelemetry.nostd.internal.absl.meta += [
+  "include/opentelemetry/nostd/internal/absl/meta/type_traits.h",
+]
+
+# Do we even need absl?
+EXPORTS.opentelemetry.nostd.internal.absl.types += [
+  "include/opentelemetry/nostd/internal/absl/types/bad_variant_access.h",
+  "include/opentelemetry/nostd/internal/absl/types/variant.h",
+]
+
+EXPORTS.opentelemetry.nostd.internal.absl.types.internal += [
+  "include/opentelemetry/nostd/internal/absl/types/internal/variant.h",
+]
+
+# Do we even need absl?
+EXPORTS.opentelemetry.nostd.internal.absl.utility += [
+  "include/opentelemetry/nostd/internal/absl/utility/utility.h",
+]
+
+# Do we even need plugin?
+EXPORTS.opentelemetry.plugin += [
+  "include/opentelemetry/plugin/dynamic_load.h",
+  "include/opentelemetry/plugin/factory.h",
+  "include/opentelemetry/plugin/hook.h",
+  "include/opentelemetry/plugin/tracer.h",
+]
+
+# Do we even need plugin?
+EXPORTS.opentelemetry.plugin.detail += [
+  "include/opentelemetry/plugin/detail/dynamic_library_handle.h",
+  "include/opentelemetry/plugin/detail/dynamic_load_unix.h",
+  "include/opentelemetry/plugin/detail/dynamic_load_windows.h",
+  "include/opentelemetry/plugin/detail/loader_info.h",
+  "include/opentelemetry/plugin/detail/tracer_handle.h",
+  "include/opentelemetry/plugin/detail/utility.h",
+]
+
+# Probably we would rather bind to mozilla types.
+EXPORTS.opentelemetry.std += [
+  "include/opentelemetry/std/shared_ptr.h",
+  "include/opentelemetry/std/span.h",
+  "include/opentelemetry/std/string_view.h",
+  "include/opentelemetry/std/type_traits.h",
+  "include/opentelemetry/std/unique_ptr.h",
+  "include/opentelemetry/std/utility.h",
+  "include/opentelemetry/std/variant.h",
+]
+
+EXPORTS.opentelemetry.trace += [
+  "include/opentelemetry/trace/context.h",
+  "include/opentelemetry/trace/default_span.h",
+  "include/opentelemetry/trace/noop.h",
+  "include/opentelemetry/trace/provider.h",
+  "include/opentelemetry/trace/scope.h",
+  "include/opentelemetry/trace/semantic_conventions.h",
+  "include/opentelemetry/trace/span.h",
+  "include/opentelemetry/trace/span_context.h",
+  "include/opentelemetry/trace/span_context_kv_iterable.h",
+  "include/opentelemetry/trace/span_context_kv_iterable_view.h",
+  "include/opentelemetry/trace/span_id.h",
+  "include/opentelemetry/trace/span_metadata.h",
+  "include/opentelemetry/trace/span_startoptions.h",
+  "include/opentelemetry/trace/trace_flags.h",
+  "include/opentelemetry/trace/trace_id.h",
+  "include/opentelemetry/trace/trace_state.h",
+  "include/opentelemetry/trace/tracer.h",
+  "include/opentelemetry/trace/tracer_provider.h",
+]
+
+EXPORTS.opentelemetry.trace.propagation += [
+  "include/opentelemetry/trace/propagation/b3_propagator.h",
+  "include/opentelemetry/trace/propagation/http_trace_context.h",
+  "include/opentelemetry/trace/propagation/jaeger.h",
+]
+
+EXPORTS.opentelemetry.trace.propagation.detail += [
+  "include/opentelemetry/trace/propagation/detail/hex.h",
+  "include/opentelemetry/trace/propagation/detail/string.h",
+]

--- a/examples/moz.build
+++ b/examples/moz.build
@@ -1,0 +1,9 @@
+# -*- Mode: python; indent-tabs-mode: nil; tab-width: 40 -*-
+# vim: set filetype=python:
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+DIRS += [
+  "multithreaded",
+]

--- a/examples/multithreaded/moz.build
+++ b/examples/multithreaded/moz.build
@@ -1,0 +1,23 @@
+# -*- Mode: python; indent-tabs-mode: nil; tab-width: 40 -*-
+# vim: set filetype=python:
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+Program("otel_example_multithreaded")
+
+SOURCES += [
+  "main.cc",
+]
+
+LOCAL_INCLUDES += [
+  "/third_party/opentelemetry-cpp/api/include",
+  "/third_party/opentelemetry-cpp/exporters/ostream/include",
+  "/third_party/opentelemetry-cpp/sdk/include",
+]
+
+USE_LIBS += [
+  "gkopentelemetry",
+  "mozglue",
+  "opentelemetry_exporter_ostream_span",
+]

--- a/exporters/moz.build
+++ b/exporters/moz.build
@@ -1,0 +1,9 @@
+# -*- Mode: python; indent-tabs-mode: nil; tab-width: 40 -*-
+# vim: set filetype=python:
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+DIRS += [
+  "ostream",
+]

--- a/exporters/ostream/moz.build
+++ b/exporters/ostream/moz.build
@@ -1,0 +1,22 @@
+# -*- Mode: python; indent-tabs-mode: nil; tab-width: 40 -*-
+# vim: set filetype=python:
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+Library("opentelemetry_exporter_ostream_span")
+
+SOURCES += [
+  "src/span_exporter.cc",
+  "src/span_exporter_factory.cc",
+]
+
+LOCAL_INCLUDES += [
+  "/third_party/opentelemetry-cpp/api/include",
+  "/third_party/opentelemetry-cpp/exporters/ostream/include",
+  "/third_party/opentelemetry-cpp/sdk/include",
+]
+
+USE_LIBS += [
+  "gkopentelemetry",
+]

--- a/moz.build
+++ b/moz.build
@@ -1,0 +1,11 @@
+# -*- Mode: python; indent-tabs-mode: nil; tab-width: 40 -*-
+# vim: set filetype=python:
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+DIRS += [
+  "examples",
+  "exporters",
+  "sdk",
+]

--- a/sdk/moz.build
+++ b/sdk/moz.build
@@ -1,0 +1,14 @@
+# -*- Mode: python; indent-tabs-mode: nil; tab-width: 40 -*-
+# vim: set filetype=python:
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+LOCAL_INCLUDES += [
+    "/third_party/opentelemetry-cpp/api/include",
+    "/third_party/opentelemetry-cpp/sdk/include",
+]
+
+DIRS += ["src"]
+
+# TEST_DIRS += ["test"]

--- a/sdk/src/common/moz.build
+++ b/sdk/src/common/moz.build
@@ -1,0 +1,28 @@
+# -*- Mode: python; indent-tabs-mode: nil; tab-width: 40 -*-
+# vim: set filetype=python:
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+Library("opentelemetry_common")
+
+LOCAL_INCLUDES += [
+  "/third_party/opentelemetry-cpp/api/include",
+  "/third_party/opentelemetry-cpp/sdk",
+  "/third_party/opentelemetry-cpp/sdk/include",
+]
+
+SOURCES += [
+    "base64.cc",
+    "core.cc",
+    "env_variables.cc",
+    "global_log_handler.cc",
+    "random.cc",
+]
+
+if CONFIG["OS_ARCH"] == "WINNT":
+  SOURCES += [ "platform/fork_windows.cc" ]
+else:
+  SOURCES += [ "platform/fork_unix.cc" ]
+
+FINAL_LIBRARY = "gkopentelemetry"

--- a/sdk/src/logs/moz.build
+++ b/sdk/src/logs/moz.build
@@ -1,0 +1,35 @@
+# -*- Mode: python; indent-tabs-mode: nil; tab-width: 40 -*-
+# vim: set filetype=python:
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+Library("opentelemetry_logs")
+
+LOCAL_INCLUDES += [
+  "/third_party/opentelemetry-cpp/api/include",
+  "/third_party/opentelemetry-cpp/sdk/include",
+]
+
+SOURCES += [
+  "batch_log_record_processor.cc",
+  "batch_log_record_processor_factory.cc",
+  "event_logger.cc",
+  "event_logger_provider.cc",
+  "event_logger_provider_factory.cc",
+  "exporter.cc",
+  "logger.cc",
+  "logger_context.cc",
+  "logger_context_factory.cc",
+  "logger_provider.cc",
+  "logger_provider_factory.cc",
+  "multi_log_record_processor.cc",
+  "multi_log_record_processor_factory.cc",
+  "multi_recordable.cc",
+  "read_write_log_record.cc",
+  "readable_log_record.cc",
+  "simple_log_record_processor.cc",
+  "simple_log_record_processor_factory.cc",
+]
+
+FINAL_LIBRARY = "gkopentelemetry"

--- a/sdk/src/metrics/moz.build
+++ b/sdk/src/metrics/moz.build
@@ -1,0 +1,44 @@
+# -*- Mode: python; indent-tabs-mode: nil; tab-width: 40 -*-
+# vim: set filetype=python:
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+Library("opentelemetry_metrics")
+
+LOCAL_INCLUDES += [
+  "/third_party/opentelemetry-cpp/api/include",
+  "/third_party/opentelemetry-cpp/sdk/include",
+]
+
+SOURCES += [
+  "aggregation/base2_exponential_histogram_indexer.cc",
+  "aggregation/histogram_aggregation.cc",
+  "aggregation/lastvalue_aggregation.cc",
+  "aggregation/sum_aggregation.cc",
+  "async_instruments.cc",
+  "data/circular_buffer.cc",
+  "exemplar/filter.cc",
+  "exemplar/reservoir.cc",
+  "export/periodic_exporting_metric_reader.cc",
+  "export/periodic_exporting_metric_reader_factory.cc",
+  "instrument_metadata_validator.cc",
+  "meter.cc",
+  "meter_context.cc",
+  "meter_context_factory.cc",
+  "meter_provider.cc",
+  "meter_provider_factory.cc",
+  "metric_reader.cc",
+  "state/filtered_ordered_attribute_map.cc",
+  "state/metric_collector.cc",
+  "state/observable_registry.cc",
+  "state/sync_metric_storage.cc",
+  "state/temporal_metric_storage.cc",
+  "sync_instruments.cc",
+  "view/instrument_selector_factory.cc",
+  "view/meter_selector_factory.cc",
+  "view/view_factory.cc",
+  "view/view_registry_factory.cc",
+]
+
+FINAL_LIBRARY = "gkopentelemetry"

--- a/sdk/src/moz.build
+++ b/sdk/src/moz.build
@@ -1,0 +1,25 @@
+# -*- Mode: python; indent-tabs-mode: nil; tab-width: 40 -*-
+# vim: set filetype=python:
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+Library("gkopentelemetry")
+
+DIRS += [
+    "common",
+    "logs",
+    "metrics",
+    "resource",
+    "trace",
+    "version",
+]
+
+USE_LIBS += [
+    "opentelemetry_common",
+    "opentelemetry_logs",
+    "opentelemetry_metrics",
+    "opentelemetry_resource",
+    "opentelemetry_trace",
+    "opentelemetry_version",
+]

--- a/sdk/src/resource/moz.build
+++ b/sdk/src/resource/moz.build
@@ -1,0 +1,19 @@
+# -*- Mode: python; indent-tabs-mode: nil; tab-width: 40 -*-
+# vim: set filetype=python:
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+Library("opentelemetry_resource")
+
+LOCAL_INCLUDES += [
+  "/third_party/opentelemetry-cpp/api/include",
+  "/third_party/opentelemetry-cpp/sdk/include",
+]
+
+SOURCES += [
+  "resource.cc",
+  "resource_detector.cc",
+]
+
+FINAL_LIBRARY = "gkopentelemetry"

--- a/sdk/src/trace/moz.build
+++ b/sdk/src/trace/moz.build
@@ -1,0 +1,36 @@
+# -*- Mode: python; indent-tabs-mode: nil; tab-width: 40 -*-
+# vim: set filetype=python:
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+Library("opentelemetry_trace")
+
+LOCAL_INCLUDES += [
+  "/third_party/opentelemetry-cpp/api/include",
+  "/third_party/opentelemetry-cpp/sdk",
+  "/third_party/opentelemetry-cpp/sdk/include",
+]
+
+SOURCES += [
+  "batch_span_processor.cc",
+  "batch_span_processor_factory.cc",
+  "exporter.cc",
+  "random_id_generator.cc",
+  "random_id_generator_factory.cc",
+  "samplers/always_off_factory.cc",
+  "samplers/always_on_factory.cc",
+  "samplers/parent.cc",
+  "samplers/parent_factory.cc",
+  "samplers/trace_id_ratio.cc",
+  "samplers/trace_id_ratio_factory.cc",
+  "simple_processor_factory.cc",
+  "span.cc",
+  "tracer.cc",
+  "tracer_context.cc",
+  "tracer_context_factory.cc",
+  "tracer_provider.cc",
+  "tracer_provider_factory.cc",
+]
+
+FINAL_LIBRARY = "gkopentelemetry"

--- a/sdk/src/version/moz.build
+++ b/sdk/src/version/moz.build
@@ -1,0 +1,18 @@
+# -*- Mode: python; indent-tabs-mode: nil; tab-width: 40 -*-
+# vim: set filetype=python:
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+Library("opentelemetry_version")
+
+LOCAL_INCLUDES += [
+  "/third_party/opentelemetry-cpp/api/include",
+  "/third_party/opentelemetry-cpp/sdk/include",
+]
+
+SOURCES += [
+  "version.cc",
+]
+
+FINAL_LIBRARY = "gkopentelemetry"


### PR DESCRIPTION
## Changes

With these patches, the sdk and the multithreaded example can be built as a third-party dependency for Firefox.