### PR TITLE
Do not link `prometheus-cpp::util` when it doesn't exist

### DIFF
--- a/exporters/prometheus/CMakeLists.txt
+++ b/exporters/prometheus/CMakeLists.txt
@@ -30,10 +30,12 @@ endif()
 if(TARGET util)
   list(APPEND PROMETHEUS_EXPORTER_TARGETS util)
 endif()
-target_link_libraries(
-  opentelemetry_exporter_prometheus
-  PUBLIC opentelemetry_metrics prometheus-cpp::pull prometheus-cpp::core
-         prometheus-cpp::util)
+set(PROMETHEUS_CPP_TARGETS prometheus-cpp::pull prometheus-cpp::core)
+if(TARGET prometheus-cpp::util)
+  list(APPEND PROMETHEUS_CPP_TARGETS prometheus-cpp::util)
+endif()
+target_link_libraries(opentelemetry_exporter_prometheus
+                      PUBLIC opentelemetry_metrics ${PROMETHEUS_CPP_TARGETS})
 
 if(OPENTELEMETRY_INSTALL)
   install(


### PR DESCRIPTION
Fixes #2605 

## Changes

+ Do not link `prometheus-cpp::util` when it doesn't exist

For significant contributions please make sure you have completed the following items:

* [ ] `CHANGELOG.md` updated for non-trivial changes
* [ ] Unit tests have been added
* [x] Changes in public API reviewed