### PR TITLE
[METRICS SDK] Remove extra OfferMeasurement call in SyncMetricsStorage::OfferMeasurement

### DIFF
--- a/sdk/include/opentelemetry/sdk/metrics/state/sync_metric_storage.h
+++ b/sdk/include/opentelemetry/sdk/metrics/state/sync_metric_storage.h
@@ -125,10 +125,6 @@ public:
                     const opentelemetry::context::Context &context
                         OPENTELEMETRY_MAYBE_UNUSED) noexcept override
   {
-#ifdef ENABLE_METRICS_EXEMPLAR_PREVIEW
-    exemplar_reservoir_->OfferMeasurement(value, attributes, context,
-                                          std::chrono::system_clock::now());
-#endif
     if (instrument_descriptor_.value_type_ != InstrumentValueType::kDouble)
     {
       return;


### PR DESCRIPTION
Fixes # (issue)

## Changes

Please provide a brief description of the changes here.

For significant contributions please make sure you have completed the following items:

* [ ] `CHANGELOG.md` updated for non-trivial changes
* [ ] Unit tests have been added
* [ ] Changes in public API reviewed