### PR TITLE
[MISC] Use set -e on all shell scripts and pass shellcheck --severity=error

### DIFF
--- a/buildscripts/pre_release.sh
+++ b/buildscripts/pre_release.sh
@@ -2,6 +2,7 @@
 
 # Copyright The OpenTelemetry Authors
 # SPDX-License-Identifier: Apache-2.0
+set -e
 
 usage() { echo "Usage: $0 -t <tag>" 1>&2; exit 1; }
 
@@ -25,13 +26,13 @@ if [[ ${tag} =~ ${semver_regex} ]]; then
     echo "${tag} is valid semver tag"
 else
     echo "Error: ${tag} is not a valid semver tag. Exiting"
-    exit -1
+    exit 1
 fi
 
 #ensure tag doesn't exits
 if [[ $(git tag --list ${tag}) ]]; then
    echo "Error: Tag ${tag} already exists. Exiting"
-   exit -1
+   exit 1
 fi
 
 if ! git diff --quiet; then \

--- a/buildscripts/semantic-convention/generate.sh
+++ b/buildscripts/semantic-convention/generate.sh
@@ -8,6 +8,7 @@
 # opentelemetry-java/buildscripts/semantic-convention/generate.sh
 # for opentelemetry-cpp
 #
+set -e
 
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 ROOT_DIR="${SCRIPT_DIR}/../../"

--- a/ci/do_ci.sh
+++ b/ci/do_ci.sh
@@ -95,7 +95,7 @@ export CTEST_OUTPUT_ON_FAILURE=1
 if [[ "$1" == "cmake.test" ]]; then
   cd "${BUILD_DIR}"
   rm -rf *
-  cmake ${CMAKE_OPTIONS[@]}  \
+  cmake "${CMAKE_OPTIONS[@]}"  \
         -DWITH_PROMETHEUS=ON \
         -DWITH_ZIPKIN=ON \
         -DWITH_ELASTICSEARCH=ON \
@@ -108,7 +108,7 @@ if [[ "$1" == "cmake.test" ]]; then
 elif [[ "$1" == "cmake.maintainer.sync.test" ]]; then
   cd "${BUILD_DIR}"
   rm -rf *
-  cmake ${CMAKE_OPTIONS[@]}  \
+  cmake "${CMAKE_OPTIONS[@]}"  \
         -DWITH_OTLP_HTTP=ON \
         -DWITH_PROMETHEUS=ON \
         -DWITH_EXAMPLES=ON \
@@ -129,7 +129,7 @@ elif [[ "$1" == "cmake.maintainer.sync.test" ]]; then
 elif [[ "$1" == "cmake.maintainer.async.test" ]]; then
   cd "${BUILD_DIR}"
   rm -rf *
-  cmake ${CMAKE_OPTIONS[@]}  \
+  cmake "${CMAKE_OPTIONS[@]}"  \
         -DWITH_OTLP_HTTP=ON \
         -DWITH_PROMETHEUS=ON \
         -DWITH_EXAMPLES=ON \
@@ -150,7 +150,7 @@ elif [[ "$1" == "cmake.maintainer.async.test" ]]; then
 elif [[ "$1" == "cmake.maintainer.cpp11.async.test" ]]; then
   cd "${BUILD_DIR}"
   rm -rf *
-  cmake ${CMAKE_OPTIONS[@]}  \
+  cmake "${CMAKE_OPTIONS[@]}"  \
         -DCMAKE_CXX_STANDARD=11 \
         -DWITH_OTLP_HTTP=ON \
         -DWITH_PROMETHEUS=ON \
@@ -171,7 +171,7 @@ elif [[ "$1" == "cmake.maintainer.cpp11.async.test" ]]; then
 elif [[ "$1" == "cmake.maintainer.abiv2.test" ]]; then
   cd "${BUILD_DIR}"
   rm -rf *
-  cmake ${CMAKE_OPTIONS[@]}  \
+  cmake "${CMAKE_OPTIONS[@]}"  \
         -DWITH_OTLP_HTTP=ON \
         -DWITH_PROMETHEUS=ON \
         -DWITH_EXAMPLES=ON \
@@ -194,7 +194,7 @@ elif [[ "$1" == "cmake.maintainer.abiv2.test" ]]; then
 elif [[ "$1" == "cmake.with_async_export.test" ]]; then
   cd "${BUILD_DIR}"
   rm -rf *
-  cmake ${CMAKE_OPTIONS[@]}  \
+  cmake "${CMAKE_OPTIONS[@]}"  \
         -DWITH_PROMETHEUS=ON \
         -DWITH_ZIPKIN=ON \
         -DWITH_ELASTICSEARCH=ON \
@@ -208,7 +208,7 @@ elif [[ "$1" == "cmake.with_async_export.test" ]]; then
 elif [[ "$1" == "cmake.abseil.test" ]]; then
   cd "${BUILD_DIR}"
   rm -rf *
-  cmake ${CMAKE_OPTIONS[@]}  \
+  cmake "${CMAKE_OPTIONS[@]}"  \
         -DWITH_METRICS_EXEMPLAR_PREVIEW=ON \
         -DCMAKE_CXX_FLAGS="-Werror $CXXFLAGS" \
         -DWITH_ASYNC_EXPORT_PREVIEW=ON \
@@ -220,7 +220,7 @@ elif [[ "$1" == "cmake.abseil.test" ]]; then
 elif [[ "$1" == "cmake.opentracing_shim.test" ]]; then
   cd "${BUILD_DIR}"
   rm -rf *
-  cmake ${CMAKE_OPTIONS[@]} \
+  cmake "${CMAKE_OPTIONS[@]}" \
         -DCMAKE_CXX_FLAGS="-Werror -Wno-error=redundant-move $CXXFLAGS" \
         -DWITH_OPENTRACING=ON \
         "${SRC_DIR}"
@@ -230,7 +230,7 @@ elif [[ "$1" == "cmake.opentracing_shim.test" ]]; then
 elif [[ "$1" == "cmake.c++20.test" ]]; then
   cd "${BUILD_DIR}"
   rm -rf *
-  cmake ${CMAKE_OPTIONS[@]}  \
+  cmake "${CMAKE_OPTIONS[@]}"  \
         -DCMAKE_CXX_FLAGS="-Werror $CXXFLAGS" \
         -DWITH_ASYNC_EXPORT_PREVIEW=ON \
         -DWITH_STL=CXX20 \
@@ -242,7 +242,7 @@ elif [[ "$1" == "cmake.c++20.test" ]]; then
 elif [[ "$1" == "cmake.c++23.test" ]]; then
   cd "${BUILD_DIR}"
   rm -rf *
-  cmake ${CMAKE_OPTIONS[@]}  \
+  cmake "${CMAKE_OPTIONS[@]}"  \
         -DCMAKE_CXX_FLAGS="-Werror $CXXFLAGS" \
         -DWITH_ASYNC_EXPORT_PREVIEW=ON \
         -DWITH_STL=CXX23 \
@@ -254,7 +254,7 @@ elif [[ "$1" == "cmake.c++23.test" ]]; then
 elif [[ "$1" == "cmake.c++14.stl.test" ]]; then
   cd "${BUILD_DIR}"
   rm -rf *
-  cmake ${CMAKE_OPTIONS[@]}  \
+  cmake "${CMAKE_OPTIONS[@]}"  \
         -DWITH_METRICS_EXEMPLAR_PREVIEW=ON \
         -DCMAKE_CXX_FLAGS="-Werror $CXXFLAGS" \
         -DWITH_ASYNC_EXPORT_PREVIEW=ON \
@@ -267,7 +267,7 @@ elif [[ "$1" == "cmake.c++14.stl.test" ]]; then
 elif [[ "$1" == "cmake.c++17.stl.test" ]]; then
   cd "${BUILD_DIR}"
   rm -rf *
-  cmake ${CMAKE_OPTIONS[@]}  \
+  cmake "${CMAKE_OPTIONS[@]}"  \
         -DWITH_METRICS_EXEMPLAR_PREVIEW=ON \
         -DCMAKE_CXX_FLAGS="-Werror $CXXFLAGS" \
         -DWITH_ASYNC_EXPORT_PREVIEW=ON \
@@ -280,7 +280,7 @@ elif [[ "$1" == "cmake.c++17.stl.test" ]]; then
 elif [[ "$1" == "cmake.c++20.stl.test" ]]; then
   cd "${BUILD_DIR}"
   rm -rf *
-  cmake ${CMAKE_OPTIONS[@]}  \
+  cmake "${CMAKE_OPTIONS[@]}"  \
         -DWITH_METRICS_EXEMPLAR_PREVIEW=ON \
         -DCMAKE_CXX_FLAGS="-Werror $CXXFLAGS" \
         -DWITH_ASYNC_EXPORT_PREVIEW=ON \
@@ -293,7 +293,7 @@ elif [[ "$1" == "cmake.c++20.stl.test" ]]; then
 elif [[ "$1" == "cmake.c++23.stl.test" ]]; then
   cd "${BUILD_DIR}"
   rm -rf *
-  cmake ${CMAKE_OPTIONS[@]}  \
+  cmake "${CMAKE_OPTIONS[@]}"  \
         -DWITH_METRICS_EXEMPLAR_PREVIEW=ON \
         -DCMAKE_CXX_FLAGS="-Werror $CXXFLAGS" \
         -DWITH_ASYNC_EXPORT_PREVIEW=ON \
@@ -308,7 +308,7 @@ elif [[ "$1" == "cmake.legacy.test" ]]; then
   rm -rf *
   export BUILD_ROOT="${BUILD_DIR}"
   ${SRC_DIR}/tools/build-benchmark.sh
-  cmake ${CMAKE_OPTIONS[@]}  \
+  cmake "${CMAKE_OPTIONS[@]}"  \
         -DCMAKE_CXX_FLAGS="-Werror $CXXFLAGS" \
         "${SRC_DIR}"
   make -j $(nproc)
@@ -319,7 +319,7 @@ elif [[ "$1" == "cmake.legacy.exporter.otprotocol.test" ]]; then
   rm -rf *
   export BUILD_ROOT="${BUILD_DIR}"
   ${SRC_DIR}/tools/build-benchmark.sh
-  cmake ${CMAKE_OPTIONS[@]}  \
+  cmake "${CMAKE_OPTIONS[@]}"  \
         -DCMAKE_CXX_STANDARD=11 \
         -DWITH_OTLP_GRPC=ON \
         -DWITH_OTLP_HTTP=ON \
@@ -337,7 +337,7 @@ elif [[ "$1" == "cmake.exporter.otprotocol.test" ]]; then
   if [[ ! -z "${WITH_ABSEIL}" ]]; then
     CMAKE_OPTIONS=(${CMAKE_OPTIONS[@]} "-DWITH_ABSEIL=${WITH_ABSEIL}")
   fi
-  cmake ${CMAKE_OPTIONS[@]}  \
+  cmake "${CMAKE_OPTIONS[@]}"  \
         -DWITH_OTLP_GRPC=ON \
         -DWITH_OTLP_HTTP=ON \
         -DWITH_OTLP_GRPC_SSL_MTLS_PREVIEW=ON \
@@ -351,7 +351,7 @@ elif [[ "$1" == "cmake.exporter.otprotocol.test" ]]; then
 elif [[ "$1" == "cmake.exporter.otprotocol.shared_libs.with_static_grpc.test" ]]; then
   cd "${BUILD_DIR}"
   rm -rf *
-  cmake ${CMAKE_OPTIONS[@]}  \
+  cmake "${CMAKE_OPTIONS[@]}"  \
         -DWITH_OTLP_GRPC=ON \
         -DWITH_OTLP_HTTP=ON \
         -DBUILD_SHARED_LIBS=ON \
@@ -365,7 +365,7 @@ elif [[ "$1" == "cmake.exporter.otprotocol.shared_libs.with_static_grpc.test" ]]
 elif [[ "$1" == "cmake.exporter.otprotocol.with_async_export.test" ]]; then
   cd "${BUILD_DIR}"
   rm -rf *
-  cmake ${CMAKE_OPTIONS[@]}  \
+  cmake "${CMAKE_OPTIONS[@]}"  \
         -DWITH_OTLP_GRPC=ON \
         -DWITH_OTLP_HTTP=ON \
         -DWITH_ASYNC_EXPORT_PREVIEW=ON \
@@ -379,7 +379,7 @@ elif [[ "$1" == "cmake.exporter.otprotocol.with_async_export.test" ]]; then
 elif [[ "$1" == "cmake.do_not_install.test" ]]; then
   cd "${BUILD_DIR}"
   rm -rf *
-  cmake ${CMAKE_OPTIONS[@]}  \
+  cmake "${CMAKE_OPTIONS[@]}"  \
         -DWITH_OTLP_GRPC=ON \
         -DWITH_OTLP_HTTP=ON \
         -DWITH_ASYNC_EXPORT_PREVIEW=ON \
@@ -394,7 +394,7 @@ elif [[ "$1" == "cmake.do_not_install.test" ]]; then
 elif [[ "$1" == "cmake.install.test" ]]; then
   cd "${BUILD_DIR}"
   rm -rf *
-  cmake ${CMAKE_OPTIONS[@]}  \
+  cmake "${CMAKE_OPTIONS[@]}"  \
         -DWITH_METRICS_EXEMPLAR_PREVIEW=ON \
         -DCMAKE_CXX_FLAGS="-Werror $CXXFLAGS" \
         -DWITH_ASYNC_EXPORT_PREVIEW=ON \
@@ -424,7 +424,7 @@ EOF
     -static-libgcc \
     -Wl,--version-script=${PWD}/export.map \
   "
-  cmake ${CMAKE_OPTIONS[@]}  \
+  cmake "${CMAKE_OPTIONS[@]}"  \
         -DCMAKE_CXX_FLAGS="-Werror $CXXFLAGS" \
         -DCMAKE_EXE_LINKER_FLAGS="$LINKER_FLAGS" \
         -DCMAKE_SHARED_LINKER_FLAGS="$LINKER_FLAGS" \
@@ -435,7 +435,7 @@ EOF
   # Verify we can load the plugin
   cd "${BUILD_DIR}"
   rm -rf *
-  cmake ${CMAKE_OPTIONS[@]}  \
+  cmake "${CMAKE_OPTIONS[@]}"  \
         -DCMAKE_CXX_FLAGS="-Werror $CXXFLAGS" \
         "${SRC_DIR}"
   make load_plugin_example
@@ -517,7 +517,7 @@ elif [[ "$1" == "format" ]]; then
 elif [[ "$1" == "code.coverage" ]]; then
   cd "${BUILD_DIR}"
   rm -rf *
-  cmake ${CMAKE_OPTIONS[@]}  \
+  cmake "${CMAKE_OPTIONS[@]}"  \
         -DCMAKE_CXX_FLAGS="-Werror --coverage $CXXFLAGS" \
         "${SRC_DIR}"
   make

--- a/ci/install_abseil.sh
+++ b/ci/install_abseil.sh
@@ -23,7 +23,7 @@ if [ ! -z "${CXX_STANDARD}" ]; then
 fi
 
 mkdir build && pushd build
-cmake ${ABSEIL_CPP_BUILD_OPTIONS[@]} ..
+cmake "${ABSEIL_CPP_BUILD_OPTIONS[@]}" ..
 make -j $(nproc)
 make install
 popd

--- a/ci/install_protobuf.sh
+++ b/ci/install_protobuf.sh
@@ -61,9 +61,9 @@ tar zxf ${CPP_PROTOBUF_PACKAGE_NAME}.tar.gz --no-same-owner
 
 mkdir protobuf-${CPP_PROTOBUF_VERSION}/build && pushd protobuf-${CPP_PROTOBUF_VERSION}/build
 if [ -e "../CMakeLists.txt" ]; then
-  cmake .. ${CPP_PROTOBUF_BUILD_OPTIONS[@]}
+  cmake .. "${CPP_PROTOBUF_BUILD_OPTIONS[@]}"
 else
-  cmake ../cmake ${CPP_PROTOBUF_BUILD_OPTIONS[@]}
+  cmake ../cmake "${CPP_PROTOBUF_BUILD_OPTIONS[@]}"
 fi
 cmake --build . -j $(nproc)
 cmake --install .

--- a/ci/setup_grpc.sh
+++ b/ci/setup_grpc.sh
@@ -107,7 +107,7 @@ if [[ $build_internal_abseil_cpp -ne 0 ]]; then
     if [ ! -z "$build_shared_libs" ]; then
         ABSEIL_CPP_BUILD_OPTIONS=(${ABSEIL_CPP_BUILD_OPTIONS[@]} "-DBUILD_SHARED_LIBS=$build_shared_libs")
     fi
-    cmake  ${ABSEIL_CPP_BUILD_OPTIONS[@]} ..
+    cmake  "${ABSEIL_CPP_BUILD_OPTIONS[@]}" ..
     cmake --build . -j${nproc} --target install && popd
 fi
 mkdir -p build && pushd build
@@ -124,7 +124,7 @@ if [ ! -z "$build_shared_libs" ]; then
     GRPC_BUILD_OPTIONS=(${GRPC_BUILD_OPTIONS[@]} "-DBUILD_SHARED_LIBS=$build_shared_libs")
 fi
 
-cmake ${GRPC_BUILD_OPTIONS[@]} ..
+cmake "${GRPC_BUILD_OPTIONS[@]}" ..
 cmake --build . -j$(nproc)
 cmake --install .
 popd

--- a/examples/prometheus/run.sh
+++ b/examples/prometheus/run.sh
@@ -1,4 +1,6 @@
+#!/bin/bash
 # Copyright The OpenTelemetry Authors
 # SPDX-License-Identifier: Apache-2.0
+set -e
 
 docker run -p 9090:9090 -v $(pwd):/etc/prometheus --network="host" prom/prometheus

--- a/functional/otlp/run_test.sh
+++ b/functional/otlp/run_test.sh
@@ -3,7 +3,7 @@
 # Copyright The OpenTelemetry Authors
 # SPDX-License-Identifier: Apache-2.0
 
-# set -e
+set -e
 
 # To run tests in a local dev environment:
 # - make sure docker is running

--- a/functional/otlp/run_test_mode.sh
+++ b/functional/otlp/run_test_mode.sh
@@ -16,7 +16,7 @@
 # Https collector listening on endpoint.
 #
 
-# set -e
+set -e
 
 [ -z "${BUILD_DIR}" ] && export BUILD_DIR=$HOME/build
 

--- a/tools/build-benchmark.sh
+++ b/tools/build-benchmark.sh
@@ -2,6 +2,7 @@
 
 # Copyright The OpenTelemetry Authors
 # SPDX-License-Identifier: Apache-2.0
+set -e
 
 # Switch to workspace root directory first
 DIR="$( cd "$(dirname "$0")" >/dev/null 2>&1 ; pwd -P )"

--- a/tools/build-gtest.sh
+++ b/tools/build-gtest.sh
@@ -2,6 +2,7 @@
 
 # Copyright The OpenTelemetry Authors
 # SPDX-License-Identifier: Apache-2.0
+set -e
 
 # Switch to workspace root directory first
 DIR="$( cd "$(dirname "$0")" >/dev/null 2>&1 ; pwd -P )"

--- a/tools/build-vcpkg.sh
+++ b/tools/build-vcpkg.sh
@@ -2,6 +2,7 @@
 
 # Copyright The OpenTelemetry Authors
 # SPDX-License-Identifier: Apache-2.0
+set -e
 
 export PATH=/usr/local/bin:$PATH
 DIR="$(

--- a/tools/build.sh
+++ b/tools/build.sh
@@ -2,6 +2,7 @@
 
 # Copyright The OpenTelemetry Authors
 # SPDX-License-Identifier: Apache-2.0
+set -e
 
 export PATH=/usr/local/bin:$PATH
 

--- a/tools/git-cl.sh
+++ b/tools/git-cl.sh
@@ -2,6 +2,7 @@
 
 # Copyright The OpenTelemetry Authors
 # SPDX-License-Identifier: Apache-2.0
+set -e
 
 if [ "format" = "$1" ]; then
   if [ -z "$2" ]; then

--- a/tools/install.sh
+++ b/tools/install.sh
@@ -2,6 +2,7 @@
 
 # Copyright The OpenTelemetry Authors
 # SPDX-License-Identifier: Apache-2.0
+set -e
 
 DIR="$( cd "$(dirname "$0")" >/dev/null 2>&1 ; pwd -P )"
 WORKSPACE_ROOT=$DIR/..

--- a/tools/setup-buildtools-mac.sh
+++ b/tools/setup-buildtools-mac.sh
@@ -2,6 +2,7 @@
 
 # Copyright The OpenTelemetry Authors
 # SPDX-License-Identifier: Apache-2.0
+set -e
 
 
 # TODO: it's not ideal experience, but we use have to use brew-provided deps.

--- a/tools/setup-buildtools.sh
+++ b/tools/setup-buildtools.sh
@@ -2,6 +2,7 @@
 
 # Copyright The OpenTelemetry Authors
 # SPDX-License-Identifier: Apache-2.0
+set -e
 
 # Switch to workspace root directory first
 DIR="$( cd "$(dirname "$0")" >/dev/null 2>&1 ; pwd -P )"

--- a/tools/setup-cmake.sh
+++ b/tools/setup-cmake.sh
@@ -6,6 +6,8 @@
 #
 # This script installs latest CMake on Linux machine
 #
+set -e
+
 export PATH=/usr/local/bin:$PATH
 # Min required CMake version
 export CMAKE_MIN_VERSION=${1:-3.1.0}

--- a/tools/setup-devenv.sh
+++ b/tools/setup-devenv.sh
@@ -2,6 +2,7 @@
 
 # Copyright The OpenTelemetry Authors
 # SPDX-License-Identifier: Apache-2.0
+set -e
 
 # Try to autodetect the tools dir
 if [ "$BASH_SOURCE" != "" ]; then

--- a/tools/setup-ninja.sh
+++ b/tools/setup-ninja.sh
@@ -2,6 +2,7 @@
 
 # Copyright The OpenTelemetry Authors
 # SPDX-License-Identifier: Apache-2.0
+set -e
 
 # TODO: add support for Ninja on Mac OS X
 wget -O /tmp/ninja.zip https://github.com/ninja-build/ninja/releases/download/v1.10.1/ninja-linux.zip


### PR DESCRIPTION
## Changes

Numerous shell scripts were not using `set -e` or equivalent.  Additionally, make all scripts pass at least `shellcheck --severity=error` (basically just argument array quoting and exit values).  I can add an additional PR for using `shellcheck` in CI.
