### PR TITLE
[CI] Benchmark, provide units with --benchmark_min_time

### DIFF
--- a/bazel/otel_cc_benchmark.bzl
+++ b/bazel/otel_cc_benchmark.bzl
@@ -37,7 +37,7 @@ def otel_cc_benchmark(name, srcs, deps, tags = [""]):
         tools = [":" + name],
         tags = tags + ["benchmark_result", "manual"],
         testonly = True,
-        cmd = "$(location :" + name + (") --benchmark_format=json --benchmark_color=false --benchmark_min_time=.1 &> $@"),
+        cmd = "$(location :" + name + (") --benchmark_format=json --benchmark_color=false --benchmark_min_time=.1s &> $@"),
     )
 
     # This is run as part of "bazel test ..." to smoke-test benchmarks. It's
@@ -46,7 +46,7 @@ def otel_cc_benchmark(name, srcs, deps, tags = [""]):
         name = name + "_smoketest",
         srcs = srcs,
         deps = deps + ["@com_github_google_benchmark//:benchmark"],
-        args = ["--benchmark_min_time=0"],
+        args = ["--benchmark_min_time=1x"],
         tags = tags + ["benchmark"],
         defines = ["BAZEL_BUILD"],
     )

--- a/ci/do_ci.sh
+++ b/ci/do_ci.sh
@@ -43,6 +43,10 @@ function run_benchmarks
   do
     out=$component-benchmark_result.json
     find ./$component -type f -name "*_result.json" -exec cat {} \; > $component_tmp_bench.json
+    # Print each result in CI logs, so it can be inspected.
+    echo "BENCHMARK result (begin)"
+    cat $component_tmp_bench.json
+    echo "BENCHMARK result (end)"
     cat $component_tmp_bench.json | docker run -i --rm itchyny/gojq:0.12.6 -s \
       '.[0].benchmarks = ([.[].benchmarks] | add) |
       if .[0].benchmarks == null then null else .[0] end' > $BENCHMARK_DIR/$out


### PR DESCRIPTION
Fixes #2620

## Changes

Please provide a brief description of the changes here.

* Fix benchmark scripts to provide units to option --benchmark_min_time
* See related https://github.com/google/benchmark/pull/1525
* Dump benchmark results in CI logs, to help troubleshooting.

For significant contributions please make sure you have completed the following items:

* [ ] `CHANGELOG.md` updated for non-trivial changes
* [ ] Unit tests have been added
* [ ] Changes in public API reviewed