### PR TITLE
[CI] Simplify bazel CI setup

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -10,6 +10,9 @@ common --enable_platform_specific_config
 # Needed by gRPC to build on some platforms.
 build --copt -DGRPC_BAZEL_BUILD
 
+# Reduce output from bazel test
+build --test_output=errors
+
 # Set minimum supported C++ version
 build:macos --host_cxxopt=-std=c++14 --cxxopt=-std=c++14
 build:linux --host_cxxopt=-std=c++14 --cxxopt=-std=c++14

--- a/ci/do_ci.sh
+++ b/ci/do_ci.sh
@@ -472,12 +472,12 @@ elif [[ "$1" == "bazel.nortti" ]]; then
   bazel $BAZEL_STARTUP_OPTIONS test --cxxopt=-fno-rtti $BAZEL_OPTIONS_ASYNC -- //... -//exporters/prometheus/...
   exit 0
 elif [[ "$1" == "bazel.asan" ]]; then
-  bazel $BAZEL_STARTUP_OPTIONS test --config=asan $BAZEL_OPTIONS_ASYNC
+  bazel $BAZEL_STARTUP_OPTIONS test --config=asan $BAZEL_OPTIONS_ASYNC //...
   exit 0
 elif [[ "$1" == "bazel.tsan" ]]; then
 # TODO - potential race condition in Civetweb server used by prometheus-cpp during shutdown
 # https://github.com/civetweb/civetweb/issues/861, so removing prometheus from the test
-  bazel $BAZEL_STARTUP_OPTIONS test --config=tsan $BAZEL_OPTIONS_ASYNC
+  bazel $BAZEL_STARTUP_OPTIONS test --config=tsan $BAZEL_OPTIONS_ASYNC -- //... -//exporters/prometheus/...
   exit 0
 elif [[ "$1" == "bazel.valgrind" ]]; then
   bazel $BAZEL_STARTUP_OPTIONS test --run_under="/usr/bin/valgrind --leak-check=full --error-exitcode=1 --suppressions=\"${SRC_DIR}/ci/valgrind-suppressions\"" $BAZEL_OPTIONS_ASYNC //...


### PR DESCRIPTION
Doing bazel test //... is the same as doing a build first and then test. In some cases it might be better to do directly for increased parallelism.