### PR TITLE
Use `nostd::enable_if_t` instead of `std::enable_if_t`

### DIFF
--- a/exporters/etw/include/opentelemetry/exporters/etw/etw_properties.h
+++ b/exporters/etw/include/opentelemetry/exporters/etw/etw_properties.h
@@ -223,8 +223,8 @@ public:
         break;
       }
       case opentelemetry::common::AttributeType::kTypeString: {
-        PropertyVariant::operator=(
-            std::string{nostd::string_view(nostd::get<nostd::string_view>(v)).data()});
+        PropertyVariant::operator=
+              (std::string{nostd::string_view(nostd::get<nostd::string_view>(v)).data()});
         break;
       }
 

--- a/exporters/etw/include/opentelemetry/exporters/etw/etw_properties.h
+++ b/exporters/etw/include/opentelemetry/exporters/etw/etw_properties.h
@@ -224,7 +224,7 @@ public:
       }
       case opentelemetry::common::AttributeType::kTypeString: {
         PropertyVariant::operator=
-              (std::string{nostd::string_view(nostd::get<nostd::string_view>(v)).data()});
+            (std::string{nostd::string_view(nostd::get<nostd::string_view>(v)).data()});
         break;
       }
 

--- a/exporters/etw/include/opentelemetry/exporters/etw/etw_properties.h
+++ b/exporters/etw/include/opentelemetry/exporters/etw/etw_properties.h
@@ -7,6 +7,7 @@
 #include "opentelemetry/common/key_value_iterable_view.h"
 
 #include <opentelemetry/nostd/span.h>
+#include <opentelemetry/nostd/type_traits.h>
 #include <map>
 #include <string>
 #include <vector>
@@ -106,7 +107,7 @@ class PropertyValue : public PropertyVariant
    * @param vec Vector of integral type primitives to convert to span.
    * @return Span of integral type primitives.
    */
-  template <typename T, std::enable_if_t<std::is_integral<T>::value, bool> = true>
+  template <typename T, nostd::enable_if_t<std::is_integral<T>::value, bool> = true>
   static nostd::span<const T> to_span(const std::vector<T> &vec)
   {
     nostd::span<const T> result(vec.data(), vec.size());
@@ -119,7 +120,7 @@ class PropertyValue : public PropertyVariant
    * @param vec Vector of float type primitives to convert to span.
    * @return Span of float type primitives.
    */
-  template <typename T, std::enable_if_t<std::is_floating_point<T>::value, bool> = true>
+  template <typename T, nostd::enable_if_t<std::is_floating_point<T>::value, bool> = true>
   static nostd::span<const T> to_span(const std::vector<T> &vec)
   {
     nostd::span<const T> result(vec.data(), vec.size());
@@ -139,7 +140,7 @@ public:
    * @param v
    * @return
    */
-  template <typename TInteger, std::enable_if_t<std::is_integral<TInteger>::value, bool> = true>
+  template <typename TInteger, nostd::enable_if_t<std::is_integral<TInteger>::value, bool> = true>
   PropertyValue(TInteger number) : PropertyVariant(number)
   {}
 
@@ -148,7 +149,7 @@ public:
    * @param v
    * @return
    */
-  template <typename TFloat, std::enable_if_t<std::is_floating_point<TFloat>::value, bool> = true>
+  template <typename TFloat, nostd::enable_if_t<std::is_floating_point<TFloat>::value, bool> = true>
   PropertyValue(TFloat number) : PropertyVariant(double(number))
   {}
 
@@ -222,8 +223,8 @@ public:
         break;
       }
       case opentelemetry::common::AttributeType::kTypeString: {
-        PropertyVariant::operator=
-            (std::string{nostd::string_view(nostd::get<nostd::string_view>(v)).data()});
+        PropertyVariant::operator=(
+            std::string{nostd::string_view(nostd::get<nostd::string_view>(v)).data()});
         break;
       }
 

--- a/sdk/include/opentelemetry/sdk/instrumentationscope/instrumentation_scope.h
+++ b/sdk/include/opentelemetry/sdk/instrumentationscope/instrumentation_scope.h
@@ -8,6 +8,7 @@
 
 #include "opentelemetry/common/key_value_iterable_view.h"
 #include "opentelemetry/nostd/string_view.h"
+#include "opentelemetry/nostd/type_traits.h"
 #include "opentelemetry/nostd/unique_ptr.h"
 #include "opentelemetry/nostd/variant.h"
 #include "opentelemetry/sdk/common/attribute_utils.h"
@@ -73,7 +74,7 @@ public:
    */
   template <
       class ArgumentType,
-      std::enable_if_t<opentelemetry::common::detail::is_key_value_iterable<ArgumentType>::value>
+      nostd::enable_if_t<opentelemetry::common::detail::is_key_value_iterable<ArgumentType>::value>
           * = nullptr>
   static nostd::unique_ptr<InstrumentationScope> Create(nostd::string_view name,
                                                         nostd::string_view version,


### PR DESCRIPTION
Fixes #2647 

## Changes

Please provide a brief description of the changes here.

+ Use `nostd::enable_if_t` instead of `std::enable_if_t`

For significant contributions please make sure you have completed the following items:

* [ ] `CHANGELOG.md` updated for non-trivial changes
* [ ] Unit tests have been added
* [x] Changes in public API reviewed