### PR TITLE
[BUILD] Link CoreFoundation on apple systems because some dependency packages require it

### DIFF
--- a/api/CMakeLists.txt
+++ b/api/CMakeLists.txt
@@ -131,6 +131,10 @@ if(WITH_OTLP_HTTP_COMPRESSION)
                              INTERFACE ENABLE_OTLP_COMPRESSION_PREVIEW)
 endif()
 
+if(APPLE)
+  target_link_libraries(opentelemetry_api INTERFACE "-framework CoreFoundation")
+endif()
+
 include(${PROJECT_SOURCE_DIR}/cmake/pkgconfig.cmake)
 
 if(OPENTELEMETRY_INSTALL)


### PR DESCRIPTION

Fixes #2649 

## Changes

+ Link CoreFoundation on apple systems

For significant contributions please make sure you have completed the following items:

* [ ] `CHANGELOG.md` updated for non-trivial changes
* [ ] Unit tests have been added
* [x] Changes in public API reviewed