### PR TITLE
[BUILD] Build break in OLTP_FILE tests

### DIFF
--- a/exporters/otlp/CMakeLists.txt
+++ b/exporters/otlp/CMakeLists.txt
@@ -489,8 +489,11 @@ if(BUILD_TESTING)
   if(WITH_OTLP_FILE)
     add_executable(otlp_file_client_test test/otlp_file_client_test.cc)
     target_link_libraries(
-      otlp_file_client_test ${GTEST_BOTH_LIBRARIES} ${CMAKE_THREAD_LIBS_INIT}
-      ${GMOCK_LIB} opentelemetry_exporter_otlp_file
+      otlp_file_client_test
+      ${GTEST_BOTH_LIBRARIES}
+      ${CMAKE_THREAD_LIBS_INIT}
+      ${GMOCK_LIB}
+      opentelemetry_exporter_otlp_file
       opentelemetry_otlp_recordable
       nlohmann_json::nlohmann_json)
     gtest_add_tests(

--- a/exporters/otlp/CMakeLists.txt
+++ b/exporters/otlp/CMakeLists.txt
@@ -491,7 +491,8 @@ if(BUILD_TESTING)
     target_link_libraries(
       otlp_file_client_test ${GTEST_BOTH_LIBRARIES} ${CMAKE_THREAD_LIBS_INIT}
       ${GMOCK_LIB} opentelemetry_exporter_otlp_file
-      opentelemetry_otlp_recordable)
+      opentelemetry_otlp_recordable
+      nlohmann_json::nlohmann_json)
     gtest_add_tests(
       TARGET otlp_file_client_test
       TEST_PREFIX exporter.otlp.


### PR DESCRIPTION
Fixes #2658

## Changes

Please provide a brief description of the changes here.

* Add an explicit dependency to `nlohmann_json` in test `otlp_file_client_test`.
* This is required to build with non standard install locations.

For significant contributions please make sure you have completed the following items:

* [ ] `CHANGELOG.md` updated for non-trivial changes
* [ ] Unit tests have been added
* [ ] Changes in public API reviewed