### PR TITLE
[api/logs] Return NoopLogRecord from NoopLogger

### DIFF
--- a/api/include/opentelemetry/logs/noop.h
+++ b/api/include/opentelemetry/logs/noop.h
@@ -34,11 +34,34 @@ class NoopLogger final : public Logger
 public:
   const nostd::string_view GetName() noexcept override { return "noop logger"; }
 
-  nostd::unique_ptr<LogRecord> CreateLogRecord() noexcept override { return nullptr; }
+  nostd::unique_ptr<LogRecord> CreateLogRecord() noexcept override {
+    return nostd::unique_ptr<LogRecord>(&record_);
+  }
 
   using Logger::EmitLogRecord;
 
   void EmitLogRecord(nostd::unique_ptr<LogRecord> &&) noexcept override {}
+
+private:
+  class NoopLogRecord : public LogRecord {
+  public:
+    void SetTimestamp(common::SystemTimestamp timestamp) noexcept override {};
+    void SetObservedTimestamp(common::SystemTimestamp timestamp) noexcept override {};
+    void SetSeverity(logs::Severity severity) noexcept override {};
+    void SetBody(const common::AttributeValue &message) noexcept override {};
+    void SetAttribute(nostd::string_view key,
+                              const common::AttributeValue &value) noexcept override {};
+    void SetEventId(int64_t id, nostd::string_view name = {}) noexcept override {};
+    void SetTraceId(const trace::TraceId &trace_id) noexcept override {};
+    void SetSpanId(const trace::SpanId &span_id) noexcept override {};
+    void SetTraceFlags(const trace::TraceFlags &trace_flags) noexcept override {};
+
+    // In CreateLogRecord we return unique_ptr to the same record_ object,
+    // so we do not want to delete it when the unique_ptr is destroyed.
+    void operator delete(void*) noexcept {}
+  };
+
+  NoopLogRecord record_;
 };
 
 /**

--- a/api/include/opentelemetry/logs/noop.h
+++ b/api/include/opentelemetry/logs/noop.h
@@ -51,7 +51,7 @@ private:
     void SetBody(const common::AttributeValue & /* message */) noexcept override {}
     void SetAttribute(nostd::string_view /* key */,
                               const common::AttributeValue & /* value */) noexcept override {}
-    void SetEventId(int64_t id, nostd::string_view /* name */) noexcept override {}
+    void SetEventId(int64_t /* id */, nostd::string_view /* name */) noexcept override {}
     void SetTraceId(const trace::TraceId & /* trace_id */) noexcept override {}
     void SetSpanId(const trace::SpanId & /* span_id */) noexcept override {}
     void SetTraceFlags(const trace::TraceFlags & /* trace_flags */) noexcept override {}

--- a/api/include/opentelemetry/logs/noop.h
+++ b/api/include/opentelemetry/logs/noop.h
@@ -35,7 +35,7 @@ public:
   const nostd::string_view GetName() noexcept override { return "noop logger"; }
 
   nostd::unique_ptr<LogRecord> CreateLogRecord() noexcept override {
-    return nostd::unique_ptr<LogRecord>(&record_);
+    return nostd::unique_ptr<LogRecord>(new NoopLogRecord());
   }
 
   using Logger::EmitLogRecord;
@@ -60,8 +60,6 @@ private:
     // so we do not want to delete it when the unique_ptr is destroyed.
     void operator delete(void*) noexcept {}
   };
-
-  NoopLogRecord record_;
 };
 
 /**

--- a/api/include/opentelemetry/logs/noop.h
+++ b/api/include/opentelemetry/logs/noop.h
@@ -45,16 +45,16 @@ public:
 private:
   class NoopLogRecord : public LogRecord {
   public:
-    void SetTimestamp(common::SystemTimestamp timestamp) noexcept override {};
-    void SetObservedTimestamp(common::SystemTimestamp timestamp) noexcept override {};
-    void SetSeverity(logs::Severity severity) noexcept override {};
-    void SetBody(const common::AttributeValue &message) noexcept override {};
-    void SetAttribute(nostd::string_view key,
-                              const common::AttributeValue &value) noexcept override {};
-    void SetEventId(int64_t id, nostd::string_view name = {}) noexcept override {};
-    void SetTraceId(const trace::TraceId &trace_id) noexcept override {};
-    void SetSpanId(const trace::SpanId &span_id) noexcept override {};
-    void SetTraceFlags(const trace::TraceFlags &trace_flags) noexcept override {};
+    void SetTimestamp(common::SystemTimestamp /* timestamp */) noexcept override {}
+    void SetObservedTimestamp(common::SystemTimestamp /* timestamp */) noexcept override {}
+    void SetSeverity(logs::Severity /* severity */) noexcept override {}
+    void SetBody(const common::AttributeValue & /* message */) noexcept override {}
+    void SetAttribute(nostd::string_view /* key */,
+                              const common::AttributeValue & /* value */) noexcept override {}
+    void SetEventId(int64_t id, nostd::string_view /* name */) noexcept override {}
+    void SetTraceId(const trace::TraceId & /* trace_id */) noexcept override {}
+    void SetSpanId(const trace::SpanId & /* span_id */) noexcept override {}
+    void SetTraceFlags(const trace::TraceFlags & /* trace_flags */) noexcept override {}
 
     // In CreateLogRecord we return unique_ptr to the same record_ object,
     // so we do not want to delete it when the unique_ptr is destroyed.

--- a/api/include/opentelemetry/logs/noop.h
+++ b/api/include/opentelemetry/logs/noop.h
@@ -55,10 +55,6 @@ private:
     void SetTraceId(const trace::TraceId & /* trace_id */) noexcept override {}
     void SetSpanId(const trace::SpanId & /* span_id */) noexcept override {}
     void SetTraceFlags(const trace::TraceFlags & /* trace_flags */) noexcept override {}
-
-    // In CreateLogRecord we return unique_ptr to the same record_ object,
-    // so we do not want to delete it when the unique_ptr is destroyed.
-    void operator delete(void*) noexcept {}
   };
 };
 

--- a/api/test/logs/logger_test.cc
+++ b/api/test/logs/logger_test.cc
@@ -28,9 +28,11 @@ TEST(Logger, GetLoggerDefault)
   auto lp = Provider::GetLoggerProvider();
   const std::string schema_url{"https://opentelemetry.io/schemas/1.11.0"};
   auto logger = lp->GetLogger("TestLogger", "opentelelemtry_library", "", schema_url);
-  auto name   = logger->GetName();
   EXPECT_NE(nullptr, logger);
+  auto name   = logger->GetName();
+  auto record = logger->CreateLogRecord();
   EXPECT_EQ(name, "noop logger");
+  EXPECT_NE(nullptr, record);
 }
 
 // Test the two additional overloads for GetLogger()

--- a/api/test/logs/logger_test.cc
+++ b/api/test/logs/logger_test.cc
@@ -28,10 +28,10 @@ TEST(Logger, GetLoggerDefault)
   auto lp = Provider::GetLoggerProvider();
   const std::string schema_url{"https://opentelemetry.io/schemas/1.11.0"};
   auto logger = lp->GetLogger("TestLogger", "opentelelemtry_library", "", schema_url);
-  EXPECT_NE(nullptr, logger);
+  ASSERT_NE(nullptr, logger);
   auto name   = logger->GetName();
-  auto record = logger->CreateLogRecord();
   EXPECT_EQ(name, "noop logger");
+  auto record = logger->CreateLogRecord();
   EXPECT_NE(nullptr, record);
 }
 


### PR DESCRIPTION
Fixes #2656

## Changes

NoopLogger was incorrectly returning nullptr, causing segfaults in client code. After this change it returns a dummy no-op log record.

* [ ] `CHANGELOG.md` updated for non-trivial changes
* [x] Unit tests have been added
* [ ] Changes in public API reviewed