### PR TITLE
[EXPORTER] General cleanup for is_shutdown_ flags in exporters.

### DIFF
--- a/exporters/elasticsearch/include/opentelemetry/exporters/elasticsearch/es_log_record_exporter.h
+++ b/exporters/elasticsearch/include/opentelemetry/exporters/elasticsearch/es_log_record_exporter.h
@@ -4,7 +4,6 @@
 #pragma once
 
 #include "nlohmann/json.hpp"
-#include "opentelemetry/common/spin_lock_mutex.h"
 #include "opentelemetry/ext/http/client/http_client_factory.h"
 #include "opentelemetry/nostd/shared_ptr.h"
 #include "opentelemetry/sdk/logs/exporter.h"
@@ -110,14 +109,13 @@ public:
 
 private:
   // Stores if this exporter had its Shutdown() method called
-  bool is_shutdown_ = false;
+  std::atomic<bool> is_shutdown_{false};
 
   // Configuration options for the exporter
   ElasticsearchExporterOptions options_;
 
   // Object that stores the HTTP sessions that have been created
   std::shared_ptr<ext::http::client::HttpClient> http_client_;
-  mutable opentelemetry::common::SpinLockMutex lock_;
   bool isShutdown() const noexcept;
 
 #ifdef ENABLE_ASYNC_EXPORT

--- a/exporters/elasticsearch/src/es_log_record_exporter.cc
+++ b/exporters/elasticsearch/src/es_log_record_exporter.cc
@@ -460,7 +460,6 @@ bool ElasticsearchLogRecordExporter::ForceFlush(
 
 bool ElasticsearchLogRecordExporter::Shutdown(std::chrono::microseconds /* timeout */) noexcept
 {
-  const std::lock_guard<opentelemetry::common::SpinLockMutex> locked(lock_);
   is_shutdown_ = true;
 
   // Shutdown the session manager
@@ -472,7 +471,6 @@ bool ElasticsearchLogRecordExporter::Shutdown(std::chrono::microseconds /* timeo
 
 bool ElasticsearchLogRecordExporter::isShutdown() const noexcept
 {
-  const std::lock_guard<opentelemetry::common::SpinLockMutex> locked(lock_);
   return is_shutdown_;
 }
 }  // namespace logs

--- a/exporters/memory/include/opentelemetry/exporters/memory/in_memory_span_exporter.h
+++ b/exporters/memory/include/opentelemetry/exporters/memory/in_memory_span_exporter.h
@@ -2,12 +2,15 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #pragma once
+
+#include <atomic>
 #include <mutex>
-#include "opentelemetry/common/spin_lock_mutex.h"
+
 #include "opentelemetry/exporters/memory/in_memory_span_data.h"
 #include "opentelemetry/sdk/trace/exporter.h"
 #include "opentelemetry/sdk/trace/span_data.h"
 #include "opentelemetry/sdk_config.h"
+#include "opentelemetry/version.h"
 
 OPENTELEMETRY_BEGIN_NAMESPACE
 namespace exporter
@@ -72,7 +75,6 @@ public:
    */
   bool Shutdown(std::chrono::microseconds /* timeout */) noexcept override
   {
-    const std::lock_guard<opentelemetry::common::SpinLockMutex> locked(lock_);
     is_shutdown_ = true;
     return true;
   }
@@ -84,13 +86,8 @@ public:
 
 private:
   std::shared_ptr<InMemorySpanData> data_;
-  bool is_shutdown_ = false;
-  mutable opentelemetry::common::SpinLockMutex lock_;
-  bool isShutdown() const noexcept
-  {
-    const std::lock_guard<opentelemetry::common::SpinLockMutex> locked(lock_);
-    return is_shutdown_;
-  }
+  std::atomic<bool> is_shutdown_{false};
+  bool isShutdown() const noexcept { return is_shutdown_; }
 };
 }  // namespace memory
 }  // namespace exporter

--- a/exporters/ostream/include/opentelemetry/exporters/ostream/log_record_exporter.h
+++ b/exporters/ostream/include/opentelemetry/exporters/ostream/log_record_exporter.h
@@ -4,13 +4,12 @@
 #pragma once
 
 #include "opentelemetry/common/attribute_value.h"
-#include "opentelemetry/common/spin_lock_mutex.h"
 #include "opentelemetry/nostd/span.h"
 #include "opentelemetry/sdk/common/attribute_utils.h"
 #include "opentelemetry/sdk/logs/exporter.h"
-
 #include "opentelemetry/version.h"
 
+#include <atomic>
 #include <iostream>
 #include <sstream>
 #include <unordered_map>
@@ -59,8 +58,7 @@ private:
   // The OStream to send the logs to
   std::ostream &sout_;
   // Whether this exporter has been shut down
-  bool is_shutdown_ = false;
-  mutable opentelemetry::common::SpinLockMutex lock_;
+  std::atomic<bool> is_shutdown_{false};
   bool isShutdown() const noexcept;
   void printAttributes(
       const std::unordered_map<std::string, opentelemetry::sdk::common::OwnedAttributeValue> &map,

--- a/exporters/ostream/include/opentelemetry/exporters/ostream/metric_exporter.h
+++ b/exporters/ostream/include/opentelemetry/exporters/ostream/metric_exporter.h
@@ -3,10 +3,11 @@
 
 #pragma once
 
+#include <atomic>
 #include <iostream>
+#include <mutex>
 #include <string>
 
-#include "opentelemetry/common/spin_lock_mutex.h"
 #include "opentelemetry/sdk/metrics/data/metric_data.h"
 #include "opentelemetry/sdk/metrics/export/metric_producer.h"
 #include "opentelemetry/sdk/metrics/instruments.h"
@@ -72,8 +73,8 @@ public:
 
 private:
   std::ostream &sout_;
-  bool is_shutdown_ = false;
-  mutable opentelemetry::common::SpinLockMutex lock_;
+  std::atomic<bool> is_shutdown_{false};
+  std::mutex serialize_lock_;
   sdk::metrics::AggregationTemporality aggregation_temporality_;
   bool isShutdown() const noexcept;
   void printInstrumentationInfoMetricData(const sdk::metrics::ScopeMetrics &info_metrics,

--- a/exporters/ostream/include/opentelemetry/exporters/ostream/span_exporter.h
+++ b/exporters/ostream/include/opentelemetry/exporters/ostream/span_exporter.h
@@ -3,12 +3,12 @@
 
 #pragma once
 
-#include "opentelemetry/common/spin_lock_mutex.h"
 #include "opentelemetry/nostd/span.h"
 #include "opentelemetry/sdk/trace/exporter.h"
 #include "opentelemetry/sdk/trace/span_data.h"
 #include "opentelemetry/version.h"
 
+#include <atomic>
 #include <iostream>
 #include <map>
 #include <sstream>
@@ -51,8 +51,7 @@ public:
 
 private:
   std::ostream &sout_;
-  bool is_shutdown_ = false;
-  mutable opentelemetry::common::SpinLockMutex lock_;
+  std::atomic<bool> is_shutdown_{false};
   bool isShutdown() const noexcept;
 
   // Mapping status number to the string from api/include/opentelemetry/trace/span_metadata.h

--- a/exporters/ostream/src/log_record_exporter.cc
+++ b/exporters/ostream/src/log_record_exporter.cc
@@ -126,14 +126,12 @@ bool OStreamLogRecordExporter::ForceFlush(std::chrono::microseconds /* timeout *
 
 bool OStreamLogRecordExporter::Shutdown(std::chrono::microseconds) noexcept
 {
-  const std::lock_guard<opentelemetry::common::SpinLockMutex> locked(lock_);
   is_shutdown_ = true;
   return true;
 }
 
 bool OStreamLogRecordExporter::isShutdown() const noexcept
 {
-  const std::lock_guard<opentelemetry::common::SpinLockMutex> locked(lock_);
   return is_shutdown_;
 }
 

--- a/exporters/ostream/src/metric_exporter.cc
+++ b/exporters/ostream/src/metric_exporter.cc
@@ -129,7 +129,7 @@ void OStreamMetricExporter::printInstrumentationInfoMetricData(
     const sdk::metrics::ResourceMetrics &data)
 {
   // sout_ is shared
-  const std::lock_guard<opentelemetry::common::SpinLockMutex> locked(lock_);
+  const std::lock_guard<std::mutex> serialize(serialize_lock_);
   sout_ << "{";
   sout_ << "\n  scope name\t: " << info_metric.scope_->GetName()
         << "\n  schema url\t: " << info_metric.scope_->GetSchemaURL()
@@ -246,20 +246,19 @@ void OStreamMetricExporter::printPointAttributes(
 
 bool OStreamMetricExporter::ForceFlush(std::chrono::microseconds /* timeout */) noexcept
 {
-  const std::lock_guard<opentelemetry::common::SpinLockMutex> locked(lock_);
+  const std::lock_guard<std::mutex> serialize(serialize_lock_);
+  sout_.flush();
   return true;
 }
 
 bool OStreamMetricExporter::Shutdown(std::chrono::microseconds /* timeout */) noexcept
 {
-  const std::lock_guard<opentelemetry::common::SpinLockMutex> locked(lock_);
   is_shutdown_ = true;
   return true;
 }
 
 bool OStreamMetricExporter::isShutdown() const noexcept
 {
-  const std::lock_guard<opentelemetry::common::SpinLockMutex> locked(lock_);
   return is_shutdown_;
 }
 

--- a/exporters/ostream/src/span_exporter.cc
+++ b/exporters/ostream/src/span_exporter.cc
@@ -106,16 +106,15 @@ bool OStreamSpanExporter::ForceFlush(std::chrono::microseconds /* timeout */) no
 
 bool OStreamSpanExporter::Shutdown(std::chrono::microseconds /* timeout */) noexcept
 {
-  const std::lock_guard<opentelemetry::common::SpinLockMutex> locked(lock_);
   is_shutdown_ = true;
   return true;
 }
 
 bool OStreamSpanExporter::isShutdown() const noexcept
 {
-  const std::lock_guard<opentelemetry::common::SpinLockMutex> locked(lock_);
   return is_shutdown_;
 }
+
 void OStreamSpanExporter::printAttributes(
     const std::unordered_map<std::string, sdkcommon::OwnedAttributeValue> &map,
     const std::string prefix)

--- a/exporters/otlp/include/opentelemetry/exporters/otlp/otlp_grpc_exporter.h
+++ b/exporters/otlp/include/opentelemetry/exporters/otlp/otlp_grpc_exporter.h
@@ -3,11 +3,11 @@
 
 #pragma once
 
+#include <atomic>
 #include <chrono>
 
 #include "opentelemetry/exporters/otlp/protobuf_include_prefix.h"
 
-#include "opentelemetry/common/spin_lock_mutex.h"
 #include "opentelemetry/proto/collector/trace/v1/trace_service.grpc.pb.h"
 
 #include "opentelemetry/exporters/otlp/protobuf_include_suffix.h"
@@ -92,8 +92,7 @@ private:
    * @param stub the service stub to be used for exporting
    */
   OtlpGrpcExporter(std::unique_ptr<proto::collector::trace::v1::TraceService::StubInterface> stub);
-  bool is_shutdown_ = false;
-  mutable opentelemetry::common::SpinLockMutex lock_;
+  std::atomic<bool> is_shutdown_{false};
   bool isShutdown() const noexcept;
 };
 }  // namespace otlp

--- a/exporters/otlp/include/opentelemetry/exporters/otlp/otlp_grpc_log_record_exporter.h
+++ b/exporters/otlp/include/opentelemetry/exporters/otlp/otlp_grpc_log_record_exporter.h
@@ -7,7 +7,6 @@
 
 #include "opentelemetry/exporters/otlp/protobuf_include_prefix.h"
 #include "opentelemetry/proto/collector/logs/v1/logs_service.grpc.pb.h"
-#include "opentelemetry/common/spin_lock_mutex.h"
 #include "opentelemetry/exporters/otlp/protobuf_include_suffix.h"
 
 // clang-format on
@@ -15,6 +14,8 @@
 #include "opentelemetry/exporters/otlp/otlp_environment.h"
 #include "opentelemetry/exporters/otlp/otlp_grpc_log_record_exporter_options.h"
 #include "opentelemetry/sdk/logs/exporter.h"
+
+#include <atomic>
 
 OPENTELEMETRY_BEGIN_NAMESPACE
 namespace exporter
@@ -92,8 +93,7 @@ private:
    */
   OtlpGrpcLogRecordExporter(
       std::unique_ptr<proto::collector::logs::v1::LogsService::StubInterface> stub);
-  bool is_shutdown_ = false;
-  mutable opentelemetry::common::SpinLockMutex lock_;
+  std::atomic<bool> is_shutdown_{false};
   bool isShutdown() const noexcept;
 };
 

--- a/exporters/otlp/include/opentelemetry/exporters/otlp/otlp_grpc_metric_exporter.h
+++ b/exporters/otlp/include/opentelemetry/exporters/otlp/otlp_grpc_metric_exporter.h
@@ -7,7 +7,6 @@
 
 #include "opentelemetry/exporters/otlp/protobuf_include_prefix.h"
 #include "opentelemetry/proto/collector/metrics/v1/metrics_service.grpc.pb.h"
-#include "opentelemetry/common/spin_lock_mutex.h"
 #include "opentelemetry/exporters/otlp/protobuf_include_suffix.h"
 
 // clang-format on
@@ -15,6 +14,8 @@
 #include "opentelemetry/exporters/otlp/otlp_environment.h"
 #include "opentelemetry/exporters/otlp/otlp_grpc_metric_exporter_options.h"
 #include "opentelemetry/sdk/metrics/push_metric_exporter.h"
+
+#include <atomic>
 
 OPENTELEMETRY_BEGIN_NAMESPACE
 namespace exporter
@@ -82,8 +83,7 @@ private:
    */
   OtlpGrpcMetricExporter(
       std::unique_ptr<proto::collector::metrics::v1::MetricsService::StubInterface> stub);
-  bool is_shutdown_ = false;
-  mutable opentelemetry::common::SpinLockMutex lock_;
+  std::atomic<bool> is_shutdown_{false};
   bool isShutdown() const noexcept;
 };
 }  // namespace otlp

--- a/exporters/otlp/include/opentelemetry/exporters/otlp/otlp_http_client.h
+++ b/exporters/otlp/include/opentelemetry/exporters/otlp/otlp_http_client.h
@@ -3,7 +3,6 @@
 
 #pragma once
 
-#include "opentelemetry/common/spin_lock_mutex.h"
 #include "opentelemetry/ext/http/client/http_client.h"
 #include "opentelemetry/nostd/variant.h"
 #include "opentelemetry/sdk/common/exporter_utils.h"

--- a/exporters/otlp/src/otlp_grpc_exporter.cc
+++ b/exporters/otlp/src/otlp_grpc_exporter.cc
@@ -135,7 +135,6 @@ bool OtlpGrpcExporter::ForceFlush(
 bool OtlpGrpcExporter::Shutdown(
     OPENTELEMETRY_MAYBE_UNUSED std::chrono::microseconds timeout) noexcept
 {
-  const std::lock_guard<opentelemetry::common::SpinLockMutex> locked(lock_);
   is_shutdown_ = true;
 #ifdef ENABLE_ASYNC_EXPORT
   return client_->Shutdown(timeout);
@@ -146,7 +145,6 @@ bool OtlpGrpcExporter::Shutdown(
 
 bool OtlpGrpcExporter::isShutdown() const noexcept
 {
-  const std::lock_guard<opentelemetry::common::SpinLockMutex> locked(lock_);
   return is_shutdown_;
 }
 

--- a/exporters/otlp/src/otlp_grpc_log_record_exporter.cc
+++ b/exporters/otlp/src/otlp_grpc_log_record_exporter.cc
@@ -138,7 +138,6 @@ opentelemetry::sdk::common::ExportResult OtlpGrpcLogRecordExporter::Export(
 bool OtlpGrpcLogRecordExporter::Shutdown(
     OPENTELEMETRY_MAYBE_UNUSED std::chrono::microseconds timeout) noexcept
 {
-  const std::lock_guard<opentelemetry::common::SpinLockMutex> locked(lock_);
   is_shutdown_ = true;
 #ifdef ENABLE_ASYNC_EXPORT
   return client_->Shutdown(timeout);
@@ -159,7 +158,6 @@ bool OtlpGrpcLogRecordExporter::ForceFlush(
 
 bool OtlpGrpcLogRecordExporter::isShutdown() const noexcept
 {
-  const std::lock_guard<opentelemetry::common::SpinLockMutex> locked(lock_);
   return is_shutdown_;
 }
 

--- a/exporters/otlp/src/otlp_grpc_metric_exporter.cc
+++ b/exporters/otlp/src/otlp_grpc_metric_exporter.cc
@@ -141,7 +141,6 @@ bool OtlpGrpcMetricExporter::ForceFlush(
 bool OtlpGrpcMetricExporter::Shutdown(
     OPENTELEMETRY_MAYBE_UNUSED std::chrono::microseconds timeout) noexcept
 {
-  const std::lock_guard<opentelemetry::common::SpinLockMutex> locked(lock_);
   is_shutdown_ = true;
 #ifdef ENABLE_ASYNC_EXPORT
   return client_->Shutdown(timeout);
@@ -152,7 +151,6 @@ bool OtlpGrpcMetricExporter::Shutdown(
 
 bool OtlpGrpcMetricExporter::isShutdown() const noexcept
 {
-  const std::lock_guard<opentelemetry::common::SpinLockMutex> locked(lock_);
   return is_shutdown_;
 }
 

--- a/exporters/prometheus/include/opentelemetry/exporters/prometheus/exporter.h
+++ b/exporters/prometheus/include/opentelemetry/exporters/prometheus/exporter.h
@@ -8,7 +8,7 @@
 #include <vector>
 
 #include <prometheus/exposer.h>
-#include "opentelemetry/common/spin_lock_mutex.h"
+
 #include "opentelemetry/exporters/prometheus/collector.h"
 #include "opentelemetry/exporters/prometheus/exporter_options.h"
 #include "opentelemetry/nostd/span.h"

--- a/exporters/zipkin/include/opentelemetry/exporters/zipkin/zipkin_exporter.h
+++ b/exporters/zipkin/include/opentelemetry/exporters/zipkin/zipkin_exporter.h
@@ -3,7 +3,6 @@
 
 #pragma once
 
-#include "opentelemetry/common/spin_lock_mutex.h"
 #include "opentelemetry/exporters/zipkin/zipkin_exporter_options.h"
 #include "opentelemetry/ext/http/client/http_client_factory.h"
 #include "opentelemetry/ext/http/common/url_parser.h"
@@ -12,6 +11,8 @@
 #include "opentelemetry/sdk/trace/span_data.h"
 
 #include "nlohmann/json.hpp"
+
+#include <atomic>
 
 OPENTELEMETRY_BEGIN_NAMESPACE
 namespace exporter
@@ -69,7 +70,7 @@ private:
 
 private:
   // The configuration options associated with this exporter.
-  bool is_shutdown_ = false;
+  std::atomic<bool> is_shutdown_{false};
   ZipkinExporterOptions options_;
   std::shared_ptr<opentelemetry::ext::http::client::HttpClientSync> http_client_;
   opentelemetry::ext::http::common::UrlParser url_parser_;
@@ -84,7 +85,6 @@ private:
    */
   ZipkinExporter(std::shared_ptr<opentelemetry::ext::http::client::HttpClientSync> http_client);
 
-  mutable opentelemetry::common::SpinLockMutex lock_;
   bool isShutdown() const noexcept;
 };
 }  // namespace zipkin

--- a/exporters/zipkin/src/zipkin_exporter.cc
+++ b/exporters/zipkin/src/zipkin_exporter.cc
@@ -117,14 +117,12 @@ bool ZipkinExporter::ForceFlush(std::chrono::microseconds /* timeout */) noexcep
 
 bool ZipkinExporter::Shutdown(std::chrono::microseconds /* timeout */) noexcept
 {
-  const std::lock_guard<opentelemetry::common::SpinLockMutex> locked(lock_);
   is_shutdown_ = true;
   return true;
 }
 
 bool ZipkinExporter::isShutdown() const noexcept
 {
-  const std::lock_guard<opentelemetry::common::SpinLockMutex> locked(lock_);
   return is_shutdown_;
 }
 


### PR DESCRIPTION
This is a follow up on PR #2553, to simplify `bool is_shutdown_` in general.

## Changes

Please provide a brief description of the changes here.

* Replace every use of a spin lock + boolean by an `std::atomic<bool>`
* Replace a spin lock by a mutex, when serializing to a file in the ostream metric exporter
* Implemented the missing call to `sout_.flush()` in `OStreamMetricExporter::ForceFlush()`

For significant contributions please make sure you have completed the following items:

* [ ] `CHANGELOG.md` updated for non-trivial changes
* [ ] Unit tests have been added
* [ ] Changes in public API reviewed