### PR TITLE
[API] Return NoopLogRecord from NoopLogger

### DIFF
--- a/api/include/opentelemetry/logs/event_logger.h
+++ b/api/include/opentelemetry/logs/event_logger.h
@@ -64,10 +64,6 @@ public:
       return;
     }
     nostd::unique_ptr<LogRecord> log_record = delegate_logger->CreateLogRecord();
-    if (!log_record)
-    {
-      return;
-    }
 
     IgnoreTraitResult(
         detail::LogRecordSetterTrait<typename std::decay<ArgumentType>::type>::template Set(

--- a/api/include/opentelemetry/logs/logger.h
+++ b/api/include/opentelemetry/logs/logger.h
@@ -100,10 +100,6 @@ public:
   void EmitLogRecord(ArgumentType &&... args)
   {
     nostd::unique_ptr<LogRecord> log_record = CreateLogRecord();
-    if (!log_record)
-    {
-      return;
-    }
 
     EmitLogRecord(std::move(log_record), std::forward<ArgumentType>(args)...);
   }

--- a/api/include/opentelemetry/logs/noop.h
+++ b/api/include/opentelemetry/logs/noop.h
@@ -38,7 +38,7 @@ public:
   {
     /*
      * Do not return memory shared between threads,
-     * a new + delete for each noop record can not be avoided,
+     * a `new` + `delete` for each noop record can not be avoided,
      * due to the semantic of unique_ptr.
      */
     return nostd::unique_ptr<LogRecord>(new NoopLogRecord());

--- a/api/include/opentelemetry/logs/noop.h
+++ b/api/include/opentelemetry/logs/noop.h
@@ -34,11 +34,39 @@ class NoopLogger final : public Logger
 public:
   const nostd::string_view GetName() noexcept override { return "noop logger"; }
 
-  nostd::unique_ptr<LogRecord> CreateLogRecord() noexcept override { return nullptr; }
+  nostd::unique_ptr<LogRecord> CreateLogRecord() noexcept override
+  {
+    /*
+     * Do not return memory shared between threads,
+     * a new + delete for each noop record can not be avoided,
+     * due to the semantic of unique_ptr.
+     */
+    return nostd::unique_ptr<LogRecord>(new NoopLogRecord());
+  }
 
   using Logger::EmitLogRecord;
 
   void EmitLogRecord(nostd::unique_ptr<LogRecord> &&) noexcept override {}
+
+private:
+  class NoopLogRecord : public LogRecord
+  {
+  public:
+    NoopLogRecord()           = default;
+    ~NoopLogRecord() override = default;
+
+    void SetTimestamp(common::SystemTimestamp /* timestamp */) noexcept override {}
+    void SetObservedTimestamp(common::SystemTimestamp /* timestamp */) noexcept override {}
+    void SetSeverity(logs::Severity /* severity */) noexcept override {}
+    void SetBody(const common::AttributeValue & /* message */) noexcept override {}
+    void SetAttribute(nostd::string_view /* key */,
+                      const common::AttributeValue & /* value */) noexcept override
+    {}
+    void SetEventId(int64_t /* id */, nostd::string_view /* name */) noexcept override {}
+    void SetTraceId(const trace::TraceId & /* trace_id */) noexcept override {}
+    void SetSpanId(const trace::SpanId & /* span_id */) noexcept override {}
+    void SetTraceFlags(const trace::TraceFlags & /* trace_flags */) noexcept override {}
+  };
 };
 
 /**

--- a/api/test/logs/logger_test.cc
+++ b/api/test/logs/logger_test.cc
@@ -28,9 +28,11 @@ TEST(Logger, GetLoggerDefault)
   auto lp = Provider::GetLoggerProvider();
   const std::string schema_url{"https://opentelemetry.io/schemas/1.11.0"};
   auto logger = lp->GetLogger("TestLogger", "opentelelemtry_library", "", schema_url);
-  auto name   = logger->GetName();
   EXPECT_NE(nullptr, logger);
+  auto name   = logger->GetName();
+  auto record = logger->CreateLogRecord();
   EXPECT_EQ(name, "noop logger");
+  EXPECT_NE(nullptr, record);
 }
 
 // Test the two additional overloads for GetLogger()

--- a/api/test/logs/logger_test.cc
+++ b/api/test/logs/logger_test.cc
@@ -29,7 +29,7 @@ TEST(Logger, GetLoggerDefault)
   const std::string schema_url{"https://opentelemetry.io/schemas/1.11.0"};
   auto logger = lp->GetLogger("TestLogger", "opentelelemtry_library", "", schema_url);
   EXPECT_NE(nullptr, logger);
-  auto name   = logger->GetName();
+  auto name = logger->GetName();
   EXPECT_EQ(name, "noop logger");
   auto record = logger->CreateLogRecord();
   EXPECT_NE(nullptr, record);

--- a/api/test/logs/logger_test.cc
+++ b/api/test/logs/logger_test.cc
@@ -30,8 +30,8 @@ TEST(Logger, GetLoggerDefault)
   auto logger = lp->GetLogger("TestLogger", "opentelelemtry_library", "", schema_url);
   EXPECT_NE(nullptr, logger);
   auto name   = logger->GetName();
-  auto record = logger->CreateLogRecord();
   EXPECT_EQ(name, "noop logger");
+  auto record = logger->CreateLogRecord();
   EXPECT_NE(nullptr, record);
 }
 

--- a/sdk/src/logs/logger.cc
+++ b/sdk/src/logs/logger.cc
@@ -33,12 +33,6 @@ const nostd::string_view Logger::GetName() noexcept
 
 nostd::unique_ptr<opentelemetry::logs::LogRecord> Logger::CreateLogRecord() noexcept
 {
-  // If this logger does not have a processor, no need to create a log recordable
-  if (!context_)
-  {
-    return nullptr;
-  }
-
   auto recordable = context_->GetProcessor().MakeRecordable();
 
   recordable->SetObservedTimestamp(std::chrono::system_clock::now());


### PR DESCRIPTION
Fixes #2656

Based on PR contribution #2662 from @yurishkuro

## Changes

Please provide a brief description of the changes here.

NoopLogger was incorrectly returning nullptr, causing segfaults in client code. After this change it returns a dummy no-op log record.

For significant contributions please make sure you have completed the following items:

* [ ] `CHANGELOG.md` updated for non-trivial changes
* [X] Unit tests have been added
* [X] Changes in public API reviewed