### PR TITLE
[ETW] Add table name mapping for Logs other than the default Log table

### DIFF
--- a/exporters/etw/include/opentelemetry/exporters/etw/etw_config.h
+++ b/exporters/etw/include/opentelemetry/exporters/etw/etw_config.h
@@ -23,8 +23,9 @@ namespace etw
 /**
  * @brief TelemetryProvider Options passed via SDK API.
  */
-using TelemetryProviderOptions =
-    std::map<std::string, nostd::variant<std::string, uint64_t, float, bool, std::map<std::string, std::string>>>;
+using TelemetryProviderOptions = std::map<
+    std::string,
+    nostd::variant<std::string, uint64_t, float, bool, std::map<std::string, std::string>>>;
 
 /**
  * @brief TelemetryProvider runtime configuration class. Internal representation
@@ -38,10 +39,11 @@ typedef struct
   bool enableActivityTracking;   // Emit TraceLogging events for Span/Start and Span/Stop Not used
                                  // for Logs
   bool enableRelatedActivityId;  // Assign parent `SpanId` to `RelatedActivityId`
-  bool enableAutoParent;         // Start new spans as children of current active span, Not used for Logs
+  bool enableAutoParent;  // Start new spans as children of current active span, Not used for Logs
   ETWProvider::EventFormat
-    encoding;                    // Event encoding to use for this provider (TLD, MsgPack, XML, etc.).
-  bool enableTableNameMappings;  // Map instrumentation scope name to table name with `tableNameMappings`
+      encoding;  // Event encoding to use for this provider (TLD, MsgPack, XML, etc.).
+  bool enableTableNameMappings;  // Map instrumentation scope name to table name with
+                                 // `tableNameMappings`
   std::map<std::string, std::string> tableNameMappings;
 } TelemetryProviderConfiguration;
 

--- a/exporters/etw/include/opentelemetry/exporters/etw/etw_config.h
+++ b/exporters/etw/include/opentelemetry/exporters/etw/etw_config.h
@@ -24,7 +24,7 @@ namespace etw
  * @brief TelemetryProvider Options passed via SDK API.
  */
 using TelemetryProviderOptions =
-    std::map<std::string, nostd::variant<std::string, uint64_t, float, bool>>;
+    std::map<std::string, nostd::variant<std::string, uint64_t, float, bool, std::map<std::string, std::string>>>;
 
 /**
  * @brief TelemetryProvider runtime configuration class. Internal representation
@@ -38,9 +38,11 @@ typedef struct
   bool enableActivityTracking;   // Emit TraceLogging events for Span/Start and Span/Stop Not used
                                  // for Logs
   bool enableRelatedActivityId;  // Assign parent `SpanId` to `RelatedActivityId`
-  bool enableAutoParent;  // Start new spans as children of current active span, Not used for Logs
+  bool enableAutoParent;         // Start new spans as children of current active span, Not used for Logs
   ETWProvider::EventFormat
-      encoding;  // Event encoding to use for this provider (TLD, MsgPack, XML, etc.).
+    encoding;                    // Event encoding to use for this provider (TLD, MsgPack, XML, etc.).
+  bool enableTableNameMappings;  // Map instrumentation scope name to table name with `tableNameMappings`
+  std::map<std::string, std::string> tableNameMappings;
 } TelemetryProviderConfiguration;
 
 /**

--- a/exporters/etw/include/opentelemetry/exporters/etw/etw_logger.h
+++ b/exporters/etw/include/opentelemetry/exporters/etw/etw_logger.h
@@ -366,8 +366,8 @@ public:
   nostd::shared_ptr<opentelemetry::logs::Logger> GetLogger(
       opentelemetry::nostd::string_view logger_name,
       opentelemetry::nostd::string_view library_name = "",
-      opentelemetry::nostd::string_view version    = "",
-      opentelemetry::nostd::string_view schema_url = "",
+      opentelemetry::nostd::string_view version      = "",
+      opentelemetry::nostd::string_view schema_url   = "",
       const opentelemetry::common::KeyValueIterable &attributes =
           opentelemetry::common::NoopKeyValueIterable()) override
   {
@@ -378,7 +378,8 @@ public:
     std::string event_name{ETW_VALUE_LOG};
     if (config_.enableTableNameMappings)
     {
-      auto it = config_.tableNameMappings.find(std::string(library_name.data(), library_name.size()));
+      auto it =
+          config_.tableNameMappings.find(std::string(library_name.data(), library_name.size()));
       if (it != config_.tableNameMappings.end())
       {
         event_name = it->second;

--- a/exporters/etw/test/etw_logger_test.cc
+++ b/exporters/etw/test/etw_logger_test.cc
@@ -133,15 +133,17 @@ TEST(ETWLogger, LoggerCheckWithTableNameMappings)
 {
   std::string providerName = kGlobalProviderName;  // supply unique instrumentation name here
   std::map<std::string, std::string> tableNameMappings = {{"name1", "table1"}, {"name2", "table2"}};
-  exporter::etw::TelemetryProviderOptions options = {{"enableTableNameMappings", true}, {"tableNameMappings", tableNameMappings}};
-  exporter::etw::LoggerProvider lp {options};
+  exporter::etw::TelemetryProviderOptions options      = {{"enableTableNameMappings", true},
+                                                          {"tableNameMappings", tableNameMappings}};
+  exporter::etw::LoggerProvider lp{options};
 
   auto logger = lp.GetLogger(providerName, "name1");
 
   // Log attributes
   Properties attribs = {{"attrib1", 1}, {"attrib2", "value2"}};
 
-  EXPECT_NO_THROW(logger->Debug("This is a debug log body", opentelemetry::common::MakeAttributes(attribs)));
+  EXPECT_NO_THROW(
+      logger->Debug("This is a debug log body", opentelemetry::common::MakeAttributes(attribs)));
 }
 
 #endif  // _WIN32

--- a/exporters/etw/test/etw_logger_test.cc
+++ b/exporters/etw/test/etw_logger_test.cc
@@ -14,6 +14,7 @@ using namespace OPENTELEMETRY_NAMESPACE;
 
 using namespace opentelemetry::exporter::etw;
 
+// The ETW provider ID is {4533CB59-77E2-54E9-E340-F0F0549058B7}
 const char *kGlobalProviderName = "OpenTelemetry-ETW-TLD";
 
 /**
@@ -96,6 +97,51 @@ TEST(ETWLogger, LoggerCheckWithAttributes)
   Properties attribs = {{"attrib1", 1}, {"attrib2", 2}};
   EXPECT_NO_THROW(logger->EmitLogRecord(opentelemetry::logs::Severity::kDebug,
                                         opentelemetry::common::MakeAttributes(attribs)));
+}
+
+/**
+ * @brief Logger Test with structured attributes
+ *
+ * Example Event for below test:
+ * {
+ *  "Timestamp": "2024-06-02T15:04:15.4227815-07:00",
+ *  "ProviderName": "OpenTelemetry-ETW-TLD",
+ *  "Id": 1,
+ *  "Message": null,
+ *  "ProcessId": 37696,
+ *  "Level": "Always",
+ *  "Keywords": "0x0000000000000000",
+ *  "EventName": "table1",
+ *  "ActivityID": null,
+ *  "RelatedActivityID": null,
+ *  "Payload": {
+ *   "SpanId": "0000000000000000",
+ *   "Timestamp": "2021-09-30T22:04:15.066411500Z",
+ *   "TraceId": "00000000000000000000000000000000",
+ *   "_name": "table1",
+ *   "attrib1": 1,
+ *   "attrib2": "value2",
+ *   "body": "This is a debug log body",
+ *   "severityNumber": 5,
+ *   "severityText": "DEBUG"
+ *  }
+ * }
+ *
+ */
+
+TEST(ETWLogger, LoggerCheckWithTableNameMappings)
+{
+  std::string providerName = kGlobalProviderName;  // supply unique instrumentation name here
+  std::map<std::string, std::string> tableNameMappings = {{"name1", "table1"}, {"name2", "table2"}};
+  exporter::etw::TelemetryProviderOptions options = {{"enableTableNameMappings", true}, {"tableNameMappings", tableNameMappings}};
+  exporter::etw::LoggerProvider lp {options};
+
+  auto logger = lp.GetLogger(providerName, "name1");
+
+  // Log attributes
+  Properties attribs = {{"attrib1", 1}, {"attrib2", "value2"}};
+
+  EXPECT_NO_THROW(logger->Debug("This is a debug log body", opentelemetry::common::MakeAttributes(attribs)));
 }
 
 #endif  // _WIN32


### PR DESCRIPTION
Fixes #2680, this is the option 1 in the proposal with minor extension on defining a mapping for the table names. This makes it more flexible for the SDK users for configure the table name in the ETW exporter, without changing the API call in the instrumented libraries.

## Changes

Please provide a brief description of the changes here.

For significant contributions please make sure you have completed the following items:

* [ ] `CHANGELOG.md` updated for non-trivial changes
* [x] Unit tests have been added
* [ ] Changes in public API reviewed