### PR TITLE
[BUILD] Remove the incorrect set of CMAKE_MSVC_RUNTIME_LIBRARY for vcpkg

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -343,12 +343,6 @@ if(MSVC)
     # __cplusplus flag is not supported by Visual Studio 2015
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /Zc:__cplusplus")
   endif()
-  # When using vcpkg, all targets build with the same runtime
-  if(VCPKG_TOOLCHAIN)
-    set(CMAKE_MSVC_RUNTIME_LIBRARY
-        "MultiThreaded$<$<CONFIG:Debug>:Debug>$<$<STREQUAL:${VCPKG_CRT_LINKAGE},dynamic>:DLL>"
-        CACHE STRING "")
-  endif()
 endif()
 
 # include GNUInstallDirs before include cmake/opentelemetry-proto.cmake because


### PR DESCRIPTION
## Changes

[VCPKG_LIBRARY_LINKAGE](https://learn.microsoft.com/en-us/vcpkg/users/triplets#vcpkg_crt_linkage) should only be visible to triplet file, not he cmake file using vcpkg as toolchain. So the setting of `CMAKE_MSVC_RUNTIME_LIBRARY` is incorrect with `VCPKG_LIBRARY_LINKAGE` referenced in the generator expression. It will always be "" (empty) instead of the expected "static" or "dynamic".

For significant contributions please make sure you have completed the following items:

* [ ] `CHANGELOG.md` updated for non-trivial changes
* [ ] Unit tests have been added
* [ ] Changes in public API reviewed