### PR TITLE
[BUILD] Restore Bazel flag removed from public API

### DIFF
--- a/api/BUILD
+++ b/api/BUILD
@@ -1,7 +1,7 @@
 # Copyright The OpenTelemetry Authors
 # SPDX-License-Identifier: Apache-2.0
 
-load("@bazel_skylib//rules:common_settings.bzl", "string_flag")
+load("@bazel_skylib//rules:common_settings.bzl", "bool_flag", "string_flag")
 
 package(default_visibility = ["//visibility:public"])
 
@@ -54,4 +54,10 @@ config_setting(
     name = "set_cxx_stdlib_best_and_msvc",
     constraint_values = ["@bazel_tools//tools/cpp:msvc"],
     flag_values = {":with_cxx_stdlib": "best"},
+)
+
+bool_flag(
+    name = "with_abseil",
+    build_setting_default = False,
+    deprecation = "The value of this flag is ignored. Bazel builds always depend on Abseil for its pre-adopted `std::` types. You should remove this flag from your build command."
 )

--- a/api/BUILD
+++ b/api/BUILD
@@ -59,5 +59,5 @@ config_setting(
 bool_flag(
     name = "with_abseil",
     build_setting_default = False,
-    deprecation = "The value of this flag is ignored. Bazel builds always depend on Abseil for its pre-adopted `std::` types. You should remove this flag from your build command."
+    deprecation = "The value of this flag is ignored. Bazel builds always depend on Abseil for its pre-adopted `std::` types. You should remove this flag from your build command.",
 )


### PR DESCRIPTION
A follow up to #2679.

This `bool_flag` was a part of the public API. If we remove it, anyone using it in downstream code have broken build commands.

So instead of removing it, I think we should mark it as deprecated.

```sh
$ bazelist build --//api:with_abseil //api:api

WARNING: opentelemetry-cpp/api/BUILD:8:10: target '//api:with_abseil' is deprecated: The value of this flag is ignored. Bazel builds always use Abseil's pre-adopted `std::` types. You should remove this flag from your build command.
INFO: Analyzed target //api:api (0 packages loaded, 545 targets configured).
INFO: Found 1 target...
Target //api:api up-to-date (nothing to build)
INFO: Elapsed time: 0.574s, Critical Path: 0.00s
INFO: 1 process: 1 internal.
INFO: Build completed successfully, 1 total action
```

---

On removing the now useless flag...

I do not know what OpenTelemetry's breaking change policy is. But consider something like:
- removing the flag in the next major version bump (`v2.x`). That is [Google's policy](https://opensource.google/documentation/policies/library-breaking-change#policy) (don't laugh).
- OR giving the flag a few releases in the deprecated state, so downstream projects have a wider window to remove it.

In my own repo, I would typically open a new issue and tag the code so we remember to clean it up later.
```
TODO(#XXXX) - Remove this flag when ...
bool_flag( ... )
```

I am happy to do that here. You will have to tell me when you want to remove it. (If I have convinced y'all to take this PR).