### PR TITLE
[Code health] Remove Unicode Text from Source files

### DIFF
--- a/api/include/opentelemetry/baggage/baggage.h
+++ b/api/include/opentelemetry/baggage/baggage.h
@@ -1,4 +1,4 @@
-﻿// Copyright The OpenTelemetry Authors
+// Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
 #pragma once
@@ -297,3 +297,4 @@ private:
 }  // namespace baggage
 
 OPENTELEMETRY_END_NAMESPACE
+

--- a/api/include/opentelemetry/baggage/baggage.h
+++ b/api/include/opentelemetry/baggage/baggage.h
@@ -297,4 +297,3 @@ private:
 }  // namespace baggage
 
 OPENTELEMETRY_END_NAMESPACE
-

--- a/api/include/opentelemetry/context/context.h
+++ b/api/include/opentelemetry/context/context.h
@@ -1,4 +1,4 @@
-﻿// Copyright The OpenTelemetry Authors
+// Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
 #pragma once
@@ -160,3 +160,4 @@ private:
 };
 }  // namespace context
 OPENTELEMETRY_END_NAMESPACE
+

--- a/api/include/opentelemetry/context/context.h
+++ b/api/include/opentelemetry/context/context.h
@@ -160,4 +160,3 @@ private:
 };
 }  // namespace context
 OPENTELEMETRY_END_NAMESPACE
-

--- a/api/include/opentelemetry/context/runtime_context.h
+++ b/api/include/opentelemetry/context/runtime_context.h
@@ -1,4 +1,4 @@
-﻿// Copyright The OpenTelemetry Authors
+// Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
 #pragma once
@@ -333,3 +333,4 @@ static RuntimeContextStorage *GetDefaultStorage() noexcept
 }
 }  // namespace context
 OPENTELEMETRY_END_NAMESPACE
+

--- a/api/include/opentelemetry/context/runtime_context.h
+++ b/api/include/opentelemetry/context/runtime_context.h
@@ -333,4 +333,3 @@ static RuntimeContextStorage *GetDefaultStorage() noexcept
 }
 }  // namespace context
 OPENTELEMETRY_END_NAMESPACE
-

--- a/ext/test/http/url_parser_test.cc
+++ b/ext/test/http/url_parser_test.cc
@@ -140,7 +140,7 @@ TEST(UrlDecoderTests, BasicTests)
   std::map<std::string, std::string> testdata{
       {"Authentication=Basic xxx", "Authentication=Basic xxx"},
       {"Authentication=Basic%20xxx", "Authentication=Basic xxx"},
-      {"%C3%B6%C3%A0%C2%A7%C3%96abcd%C3%84", "\u00F6\u00E0\u00A7\u00D6abcd\u00C4"},
+      {"%C3%B6%C3%A0%C2%A7%C3%96abcd%C3%84", "\xc3\xb6\xc3\xa0\xc2\xa7\xc3\x96\x61\x62\x63\x64\xc3\x84"},
       {"%2x", "%2x"},
       {"%20", " "},
       {"text%2", "text%2"},

--- a/ext/test/http/url_parser_test.cc
+++ b/ext/test/http/url_parser_test.cc
@@ -140,7 +140,8 @@ TEST(UrlDecoderTests, BasicTests)
   std::map<std::string, std::string> testdata{
       {"Authentication=Basic xxx", "Authentication=Basic xxx"},
       {"Authentication=Basic%20xxx", "Authentication=Basic xxx"},
-      {"%C3%B6%C3%A0%C2%A7%C3%96abcd%C3%84", "\xc3\xb6\xc3\xa0\xc2\xa7\xc3\x96\x61\x62\x63\x64\xc3\x84"},
+      {"%C3%B6%C3%A0%C2%A7%C3%96abcd%C3%84", 
+       "\xc3\xb6\xc3\xa0\xc2\xa7\xc3\x96\x61\x62\x63\x64\xc3\x84"},
       {"%2x", "%2x"},
       {"%20", " "},
       {"text%2", "text%2"},

--- a/ext/test/http/url_parser_test.cc
+++ b/ext/test/http/url_parser_test.cc
@@ -140,7 +140,7 @@ TEST(UrlDecoderTests, BasicTests)
   std::map<std::string, std::string> testdata{
       {"Authentication=Basic xxx", "Authentication=Basic xxx"},
       {"Authentication=Basic%20xxx", "Authentication=Basic xxx"},
-      {"%C3%B6%C3%A0%C2%A7%C3%96abcd%C3%84", "öà§ÖabcdÄ"},
+      {"%C3%B6%C3%A0%C2%A7%C3%96abcd%C3%84", "\u00F6\u00E0\u00A7\u00D6abcd\u00C4"},
       {"%2x", "%2x"},
       {"%20", " "},
       {"text%2", "text%2"},

--- a/ext/test/http/url_parser_test.cc
+++ b/ext/test/http/url_parser_test.cc
@@ -140,7 +140,7 @@ TEST(UrlDecoderTests, BasicTests)
   std::map<std::string, std::string> testdata{
       {"Authentication=Basic xxx", "Authentication=Basic xxx"},
       {"Authentication=Basic%20xxx", "Authentication=Basic xxx"},
-      {"%C3%B6%C3%A0%C2%A7%C3%96abcd%C3%84", 
+      {"%C3%B6%C3%A0%C2%A7%C3%96abcd%C3%84",
        "\xc3\xb6\xc3\xa0\xc2\xa7\xc3\x96\x61\x62\x63\x64\xc3\x84"},
       {"%2x", "%2x"},
       {"%20", " "},

--- a/opentracing-shim/src/span_shim.cc
+++ b/opentracing-shim/src/span_shim.cc
@@ -111,7 +111,7 @@ void SpanShim::Log(opentracing::SystemTime timestamp,
 void SpanShim::logImpl(nostd::span<const EventEntry> fields,
                        const opentracing::SystemTime *const timestamp) noexcept
 {
-  // The Add Event’s name parameter MUST be the value with the event key
+  // The Add Event's name parameter MUST be the value with the event key
   // in the pair set, or else fallback to use the log literal string.
   const auto &event = std::find_if(fields.begin(), fields.end(),
                                    [](const EventEntry &item) { return item.first == "event"; });

--- a/sdk/test/metrics/instrument_metadata_validator_test.cc
+++ b/sdk/test/metrics/instrument_metadata_validator_test.cc
@@ -21,7 +21,7 @@ TEST(InstrumentMetadataValidator, TestName)
   std::vector<std::string> invalid_names = {
       "",                               // empty string
       "1sdf",                           // string starting with number
-      "123€AAA€BBB",                    // unicode characters
+      "123\u20ACAAA\u20ACBBB"           // unicode characters
       "/\\sdsd",                        // string starting with special character
       "***sSSs",                        // string starting with special character
       "a\\broken\\path",                // contains backward slash
@@ -56,7 +56,7 @@ TEST(InstrumentMetadataValidator, TestUnit)
   std::vector<std::string> invalid_units = {
       CreateVeryLargeString(5) + "ABCERTYGJ",  // total 64 charactes
       CreateVeryLargeString(7),                // string bigger than 63 chars
-      "123€AAA€BBB",                           // unicode string
+      "123\u20ACAAA\u20ACBBB",                 // unicode string
   };
   for (auto const &str : invalid_units)
   {

--- a/sdk/test/metrics/instrument_metadata_validator_test.cc
+++ b/sdk/test/metrics/instrument_metadata_validator_test.cc
@@ -19,14 +19,14 @@ TEST(InstrumentMetadataValidator, TestName)
 {
   opentelemetry::sdk::metrics::InstrumentMetaDataValidator validator;
   std::vector<std::string> invalid_names = {
-      "",                               // empty string
-      "1sdf",                           // string starting with number
-      "123\u20ACAAA\u20ACBBB"           // unicode characters
-      "/\\sdsd",                        // string starting with special character
-      "***sSSs",                        // string starting with special character
-      "a\\broken\\path",                // contains backward slash
-      CreateVeryLargeString(25) + "X",  // total 256 characters
-      CreateVeryLargeString(26),        // string much bigger than 255 characters
+      "",                                                               // empty string
+      "1sdf",                                                           // string starting with number
+      "\x31\x32\x33\xe2\x82\xac\x41\x41\x41\xe2\x82\xac\x42\x42\x42"    // unicode characters
+      "/\\sdsd",                                                        // string starting with special character
+      "***sSSs",                                                        // string starting with special character
+      "a\\broken\\path",                                                // contains backward slash
+      CreateVeryLargeString(25) + "X",                                  // total 256 characters
+      CreateVeryLargeString(26),                                        // string much bigger than 255 characters
   };
   for (auto const &str : invalid_names)
   {
@@ -54,9 +54,9 @@ TEST(InstrumentMetadataValidator, TestUnit)
 {
   opentelemetry::sdk::metrics::InstrumentMetaDataValidator validator;
   std::vector<std::string> invalid_units = {
-      CreateVeryLargeString(5) + "ABCERTYGJ",  // total 64 charactes
-      CreateVeryLargeString(7),                // string bigger than 63 chars
-      "123\u20ACAAA\u20ACBBB",                 // unicode string
+      CreateVeryLargeString(5) + "ABCERTYGJ",                         // total 64 charactes
+      CreateVeryLargeString(7),                                       // string bigger than 63 chars
+      "\x31\x32\x33\xe2\x82\xac\x41\x41\x41\xe2\x82\xac\x42\x42\x42", // unicode string
   };
   for (auto const &str : invalid_units)
   {

--- a/sdk/test/metrics/instrument_metadata_validator_test.cc
+++ b/sdk/test/metrics/instrument_metadata_validator_test.cc
@@ -19,14 +19,14 @@ TEST(InstrumentMetadataValidator, TestName)
 {
   opentelemetry::sdk::metrics::InstrumentMetaDataValidator validator;
   std::vector<std::string> invalid_names = {
-      "",                                                               // empty string
-      "1sdf",                                                           // string starting with number
-      "\x31\x32\x33\xe2\x82\xac\x41\x41\x41\xe2\x82\xac\x42\x42\x42"    // unicode characters
-      "/\\sdsd",                                                        // string starting with special character
-      "***sSSs",                                                        // string starting with special character
-      "a\\broken\\path",                                                // contains backward slash
-      CreateVeryLargeString(25) + "X",                                  // total 256 characters
-      CreateVeryLargeString(26),                                        // string much bigger than 255 characters
+      "",                                                             // empty string
+      "1sdf",                                                         // string starting with number
+      "\x31\x32\x33\xe2\x82\xac\x41\x41\x41\xe2\x82\xac\x42\x42\x42"  // unicode characters
+      "/\\sdsd",                        // string starting with special character
+      "***sSSs",                        // string starting with special character
+      "a\\broken\\path",                // contains backward slash
+      CreateVeryLargeString(25) + "X",  // total 256 characters
+      CreateVeryLargeString(26),        // string much bigger than 255 character
   };
   for (auto const &str : invalid_names)
   {
@@ -54,9 +54,9 @@ TEST(InstrumentMetadataValidator, TestUnit)
 {
   opentelemetry::sdk::metrics::InstrumentMetaDataValidator validator;
   std::vector<std::string> invalid_units = {
-      CreateVeryLargeString(5) + "ABCERTYGJ",                         // total 64 charactes
-      CreateVeryLargeString(7),                                       // string bigger than 63 chars
-      "\x31\x32\x33\xe2\x82\xac\x41\x41\x41\xe2\x82\xac\x42\x42\x42", // unicode string
+      CreateVeryLargeString(5) + "ABCERTYGJ",  // total 64 charactes
+      CreateVeryLargeString(7),                // string bigger than 63 chars
+      "\x31\x32\x33\xe2\x82\xac\x41\x41\x41\xe2\x82\xac\x42\x42\x42",  // unicode string
   };
   for (auto const &str : invalid_units)
   {


### PR DESCRIPTION
Fixes #2706 

## Changes

Removed Unicode characters from API headers and `opentracing-shim/src/span_shim.cc`.

Escaped UTF-8 characters from test file data:

```
./ext/test/http/url_parser_test.cc: c program text, Unicode text, UTF-8 text
./sdk/test/metrics/instrument_metadata_validator_test.cc: c program text, Unicode text, UTF-8 text
```

For significant contributions please make sure you have completed the following items:

* [ ] `CHANGELOG.md` updated for non-trivial changes
* [ ] Unit tests have been added
* [X] Changes in public API reviewed