### PR TITLE
[EXPORTER] All 2xx return codes should be considered successful.

### DIFF
--- a/exporters/elasticsearch/src/es_log_record_exporter.cc
+++ b/exporters/elasticsearch/src/es_log_record_exporter.cc
@@ -59,7 +59,7 @@ public:
       // Store the body of the request
       body_ = std::string(response.GetBody().begin(), response.GetBody().end());
 
-      if (response.GetStatusCode() != 200 && response.GetStatusCode() != 202)
+      if (!(response.GetStatusCode() >= 200 && response.GetStatusCode() <= 299))
       {
         log_message = BuildResponseLogMessage(response, body_);
 

--- a/exporters/otlp/src/otlp_http_client.cc
+++ b/exporters/otlp/src/otlp_http_client.cc
@@ -100,7 +100,7 @@ public:
       // Store the body of the request
       body_ = std::string(response.GetBody().begin(), response.GetBody().end());
 
-      if (response.GetStatusCode() != 200 && response.GetStatusCode() != 202)
+      if (!(response.GetStatusCode() >= 200 && response.GetStatusCode() <= 299))
       {
         log_message = BuildResponseLogMessage(response, body_);
 

--- a/exporters/zipkin/src/zipkin_exporter.cc
+++ b/exporters/zipkin/src/zipkin_exporter.cc
@@ -78,7 +78,7 @@ sdk::common::ExportResult ZipkinExporter::Export(
   http_client::Body body_v(body_s.begin(), body_s.end());
   auto result = http_client_->PostNoSsl(url_parser_.url_, body_v, options_.headers);
   if (result &&
-      (result.GetResponse().GetStatusCode() >= 200 || result.GetResponse().GetStatusCode() <= 299))
+      (result.GetResponse().GetStatusCode() >= 200 && result.GetResponse().GetStatusCode() <= 299))
   {
     return sdk::common::ExportResult::kSuccess;
   }

--- a/exporters/zipkin/src/zipkin_exporter.cc
+++ b/exporters/zipkin/src/zipkin_exporter.cc
@@ -78,7 +78,7 @@ sdk::common::ExportResult ZipkinExporter::Export(
   http_client::Body body_v(body_s.begin(), body_s.end());
   auto result = http_client_->PostNoSsl(url_parser_.url_, body_v, options_.headers);
   if (result &&
-      (result.GetResponse().GetStatusCode() == 200 || result.GetResponse().GetStatusCode() == 202))
+      (result.GetResponse().GetStatusCode() >= 200 || result.GetResponse().GetStatusCode() <= 299))
   {
     return sdk::common::ExportResult::kSuccess;
   }


### PR DESCRIPTION
Fixes #2632 

## Changes

According to https://datatracker.ietf.org/doc/html/rfc7231#page-47 . All 2xx return codes should be considered successful.

For significant contributions please make sure you have completed the following items:

* [ ] `CHANGELOG.md` updated for non-trivial changes
* [x] Unit tests have been added
* [x] Changes in public API reviewed