### PR TITLE
[Bazel] Add missing BUILD file

### DIFF
--- a/examples/etw_threads/BUILD
+++ b/examples/etw_threads/BUILD
@@ -1,0 +1,18 @@
+# Copyright The OpenTelemetry Authors
+# SPDX-License-Identifier: Apache-2.0
+
+cc_binary(
+    name = "example_etw_threads",
+    srcs = [
+        "main.cc",
+    ],
+    tags = [
+        "etw",
+        "examples",
+    ],
+    target_compatible_with = ["@platforms//os:windows"],
+    deps = [
+        "//api",
+        "//exporters/etw:etw_exporter",
+    ],
+)


### PR DESCRIPTION
## Fixes
- None

## Changes
* `etw_threads` example doesn't have `BUILD` file, we cannot run the example using Bazel as described here https://github.com/open-telemetry/opentelemetry-cpp/blob/main/CONTRIBUTING.md#build-and-run-code-examples
* This change adds the `BUILD` file for that example.