### PR TITLE
 [SDK] Added reserve for spans array in BatchSpanProcessor.

### DIFF
--- a/sdk/src/logs/batch_log_record_processor.cc
+++ b/sdk/src/logs/batch_log_record_processor.cc
@@ -209,7 +209,7 @@ void BatchLogRecordProcessor::Export()
     }
 
     // Reserve space for the number of records
-    records_arr.reserve(num_records_to_export); 
+    records_arr.reserve(num_records_to_export);
     buffer_.Consume(num_records_to_export,
                     [&](CircularBufferRange<AtomicUniquePtr<Recordable>> range) noexcept {
                       range.ForEach([&](AtomicUniquePtr<Recordable> &ptr) {

--- a/sdk/src/logs/batch_log_record_processor.cc
+++ b/sdk/src/logs/batch_log_record_processor.cc
@@ -208,7 +208,7 @@ void BatchLogRecordProcessor::Export()
       break;
     }
 
-    // Reserve space for number of records and avoid reallocation of vector.
+    // Reserve space for the number of records
     records_arr.reserve(num_records_to_export); 
     buffer_.Consume(num_records_to_export,
                     [&](CircularBufferRange<AtomicUniquePtr<Recordable>> range) noexcept {

--- a/sdk/src/logs/batch_log_record_processor.cc
+++ b/sdk/src/logs/batch_log_record_processor.cc
@@ -208,6 +208,8 @@ void BatchLogRecordProcessor::Export()
       break;
     }
 
+    // Reserve space for number of records and avoid reallocation of vector.
+    records_arr.reserve(num_records_to_export); 
     buffer_.Consume(num_records_to_export,
                     [&](CircularBufferRange<AtomicUniquePtr<Recordable>> range) noexcept {
                       range.ForEach([&](AtomicUniquePtr<Recordable> &ptr) {

--- a/sdk/src/trace/batch_span_processor.cc
+++ b/sdk/src/trace/batch_span_processor.cc
@@ -207,9 +207,9 @@ void BatchSpanProcessor::Export()
       break;
     }
 
-    //reserves the space for the number of records to be exported
+    // reserves the space for the number of records to be exported
     spans_arr.reserve(num_records_to_export);
-    
+
     buffer_.Consume(num_records_to_export,
                     [&](CircularBufferRange<AtomicUniquePtr<Recordable>> range) noexcept {
                       range.ForEach([&](AtomicUniquePtr<Recordable> &ptr) {

--- a/sdk/src/trace/batch_span_processor.cc
+++ b/sdk/src/trace/batch_span_processor.cc
@@ -206,6 +206,10 @@ void BatchSpanProcessor::Export()
       NotifyCompletion(notify_force_flush, exporter_, synchronization_data_);
       break;
     }
+
+    //reserves the space for the number of records to be exported
+    spans_arr.reserve(num_records_to_export);
+    
     buffer_.Consume(num_records_to_export,
                     [&](CircularBufferRange<AtomicUniquePtr<Recordable>> range) noexcept {
                       range.ForEach([&](AtomicUniquePtr<Recordable> &ptr) {

--- a/sdk/src/trace/batch_span_processor.cc
+++ b/sdk/src/trace/batch_span_processor.cc
@@ -207,7 +207,7 @@ void BatchSpanProcessor::Export()
       break;
     }
 
-    // reserves the space for the number of records to be exported
+    // Reserve space for the number of records
     spans_arr.reserve(num_records_to_export);
 
     buffer_.Consume(num_records_to_export,


### PR DESCRIPTION
## Changes 

  Added `.reserve` for `spans_arr` in BatchSpanProcessor (Small Optimization)
  
  Helps to allocate the amount of memory needed for number of records so that dynamic memory allocation doesn't happen in the consume method.
  
  `.push_back()` reallocates memory each time the method is called.
  
  Using `.reserve()` would avoid memory reallocation as already the memory is allocated.
  
  References:
  [C++ Vector push_back](https://cplusplus.com/reference/vector/vector/push_back/)
  [C++ Vector reserve](https://cplusplus.com/reference/vector/vector/reserve/)

* [ ] `CHANGELOG.md` updated for non-trivial changes
* [ ] Unit tests have been added
* [ ] Changes in public API reviewed