### PR TITLE
[DOC] Remove comment for unused LoggerProvider initialization params

### DIFF
--- a/sdk/include/opentelemetry/sdk/logs/logger_provider.h
+++ b/sdk/include/opentelemetry/sdk/logs/logger_provider.h
@@ -36,10 +36,6 @@ public:
    * @param processor The span processor for this logger provider. This must
    * not be a nullptr.
    * @param resource  The resources for this logger provider.
-   * @param sampler The sampler for this logger provider. This must
-   * not be a nullptr.
-   * @param id_generator The custom id generator for this logger provider. This must
-   * not be a nullptr
    */
   explicit LoggerProvider(std::unique_ptr<LogRecordProcessor> &&processor,
                           opentelemetry::sdk::resource::Resource resource =


### PR DESCRIPTION
## Changes

Removes `@param` comments  for `id_generator` and `sampler` in the `LoggerProvider` constructor, which are not present in the constructor.