### PR TITLE
[EXPORTER] Fix references in AttributeValueVisitor

### DIFF
--- a/exporters/ostream/include/opentelemetry/exporters/ostream/common_utils.h
+++ b/exporters/ostream/include/opentelemetry/exporters/ostream/common_utils.h
@@ -87,7 +87,7 @@ public:
     print_value(arg, sout_);
   }
 
-  void operator()(const nostd::string_view &arg) { sout_.write(arg.data(), arg.size()); }
+  void operator()(nostd::string_view &&arg) { sout_.write(arg.data(), arg.size()); }
 
 private:
   std::ostream &sout_;

--- a/exporters/ostream/include/opentelemetry/exporters/ostream/common_utils.h
+++ b/exporters/ostream/include/opentelemetry/exporters/ostream/common_utils.h
@@ -87,7 +87,7 @@ public:
     print_value(arg, sout_);
   }
 
-  void operator()(const nostd::string_view &&arg) { sout_.write(arg.data(), arg.size()); }
+  void operator()(const nostd::string_view &arg) { sout_.write(arg.data(), arg.size()); }
 
 private:
   std::ostream &sout_;


### PR DESCRIPTION
Just a small fix - I think the correct fix is `void operator()(nostd::string_view &&arg)` (i.e. without const), at least if it was intended to overload the forwarding reference function above . Might also need `void operator()(const nostd::string_view &arg)` if both variants should be covered.