### PR TITLE
[TEST] Fix opentelemetry-collector bind address

### DIFF
--- a/functional/otlp/otel-config-http.yaml
+++ b/functional/otlp/otel-config-http.yaml
@@ -10,6 +10,7 @@ receivers:
   otlp:
     protocols:
       http:
+        endpoint: 0.0.0.0:4318
 
 processors:
   batch:

--- a/functional/otlp/otel-config-https.yaml
+++ b/functional/otlp/otel-config-https.yaml
@@ -10,6 +10,7 @@ receivers:
   otlp:
     protocols:
       http:
+        endpoint: 0.0.0.0:4318
         tls:
           ca_file: ../cert/ca.pem
           cert_file: ../cert/server_cert.pem

--- a/functional/otlp/otel-docker-config-http.yaml
+++ b/functional/otlp/otel-docker-config-http.yaml
@@ -9,6 +9,7 @@ receivers:
   otlp:
     protocols:
       http:
+        endpoint: 0.0.0.0:4318
 
 processors:
   batch:

--- a/functional/otlp/otel-docker-config-https.yaml
+++ b/functional/otlp/otel-docker-config-https.yaml
@@ -9,6 +9,7 @@ receivers:
   otlp:
     protocols:
       http:
+        endpoint: 0.0.0.0:4318
         tls:
           ca_file: /otel-cpp/ca.pem
           cert_file: /otel-cpp/server_cert.pem


### PR DESCRIPTION
## Changes

Please provide a brief description of the changes here.

The opentelemetry-collector release v1.11.0/v0.104.0 contains a breaking change:

* https://github.com/open-telemetry/opentelemetry-collector/releases/tag/v0.104.0

> The otlpreceiver now uses localhost by default instead of 0.0.0.0. This may break the receiver in containerized environments like Kubernetes. If you depend on 0.0.0.0 disable the component.UseLocalHostAsDefaultHost feature gate or explicitly set the endpoint to 0.0.0.0.

This broke the functional tests in CI.

Adjust the opentelemetry-collector configuration files used in functional tests to set explicitly an endpoint.

For significant contributions please make sure you have completed the following items:

* [ ] `CHANGELOG.md` updated for non-trivial changes
* [ ] Unit tests have been added
* [ ] Changes in public API reviewed