### PR TITLE
[CI] Build failures with ABSEIL 20240116 and CMAKE 3.30

### DIFF
--- a/ci/fix-abseil-cpp-issue-1536.patch
+++ b/ci/fix-abseil-cpp-issue-1536.patch
@@ -1,0 +1,23 @@
+commit 779a3565ac6c5b69dd1ab9183e500a27633117d5
+Author: Derek Mauro <dmauro@google.com>
+Date:   Tue Jan 30 10:13:25 2024 -0800
+
+    Avoid export of testonly target absl::test_allocator in CMake builds
+    
+    Closes #1536
+    
+    PiperOrigin-RevId: 602764437
+    Change-Id: Ia5c20a3874262a2ddb8797f608af17d7e86dd6d6
+
+diff --git a/absl/container/CMakeLists.txt b/absl/container/CMakeLists.txt
+index 449a2cad..ee9ca9c3 100644
+--- a/absl/container/CMakeLists.txt
++++ b/absl/container/CMakeLists.txt
+@@ -213,6 +213,7 @@ absl_cc_library(
+   DEPS
+     absl::config
+     GTest::gmock
++  TESTONLY
+ )
+ 
+ absl_cc_test(

--- a/ci/install_abseil.sh
+++ b/ci/install_abseil.sh
@@ -49,9 +49,10 @@ fi
 #
 # TODO(marcalff) Cleanup once abseil is upgraded to the next LTS
 
-echo "Patching abseil"
 
-patch -p1 << EOF
+if [ "${ABSEIL_CPP_VERSION}" -eq "20240116.1" ] || [ "${ABSEIL_CPP_VERSION}" -eq "20240116.2" ]; then
+  echo "Patching abseil"
+  patch -p1 << EOF
 commit 779a3565ac6c5b69dd1ab9183e500a27633117d5
 Author: Derek Mauro <dmauro@google.com>
 Date:   Tue Jan 30 10:13:25 2024 -0800
@@ -76,6 +77,9 @@ index 449a2cad..ee9ca9c3 100644
  
  absl_cc_test(
 EOF
+else
+  echo "Not patching abseil"
+fi
 
 mkdir build && pushd build
 cmake "${ABSEIL_CPP_BUILD_OPTIONS[@]}" ..

--- a/ci/install_abseil.sh
+++ b/ci/install_abseil.sh
@@ -55,7 +55,6 @@ fi
 if [ "${ABSEIL_CPP_VERSION}" = "20240116.1" ] || [ "${ABSEIL_CPP_VERSION}" = "20240116.2" ]; then
   echo "Patching abseil"
   patch -p1 < ${TOPDIR}/ci/fix-abseil-cpp-issue-1536.patch
-EOF
 else
   echo "Not patching abseil"
 fi

--- a/ci/install_abseil.sh
+++ b/ci/install_abseil.sh
@@ -50,7 +50,7 @@ fi
 # TODO(marcalff) Cleanup once abseil is upgraded to the next LTS
 
 
-if [ "${ABSEIL_CPP_VERSION}" -eq "20240116.1" ] || [ "${ABSEIL_CPP_VERSION}" -eq "20240116.2" ]; then
+if [ "${ABSEIL_CPP_VERSION}" = "20240116.1" ] || [ "${ABSEIL_CPP_VERSION}" = "20240116.2" ]; then
   echo "Patching abseil"
   patch -p1 << EOF
 commit 779a3565ac6c5b69dd1ab9183e500a27633117d5

--- a/ci/install_abseil.sh
+++ b/ci/install_abseil.sh
@@ -7,6 +7,8 @@ set -ex
 export DEBIAN_FRONTEND=noninteractive
 [ -z "${ABSEIL_CPP_VERSION}" ] && export ABSEIL_CPP_VERSION="20240116.1"
 
+TOPDIR=`pwd`
+
 BUILD_DIR=/tmp/
 INSTALL_DIR=/usr/local/
 pushd $BUILD_DIR
@@ -52,30 +54,7 @@ fi
 
 if [ "${ABSEIL_CPP_VERSION}" = "20240116.1" ] || [ "${ABSEIL_CPP_VERSION}" = "20240116.2" ]; then
   echo "Patching abseil"
-  patch -p1 << EOF
-commit 779a3565ac6c5b69dd1ab9183e500a27633117d5
-Author: Derek Mauro <dmauro@google.com>
-Date:   Tue Jan 30 10:13:25 2024 -0800
-
-    Avoid export of testonly target absl::test_allocator in CMake builds
-    
-    Closes #1536
-    
-    PiperOrigin-RevId: 602764437
-    Change-Id: Ia5c20a3874262a2ddb8797f608af17d7e86dd6d6
-
-diff --git a/absl/container/CMakeLists.txt b/absl/container/CMakeLists.txt
-index 449a2cad..ee9ca9c3 100644
---- a/absl/container/CMakeLists.txt
-+++ b/absl/container/CMakeLists.txt
-@@ -213,6 +213,7 @@ absl_cc_library(
-   DEPS
-     absl::config
-     GTest::gmock
-+  TESTONLY
- )
- 
- absl_cc_test(
+  patch -p1 < ${TOPDIR}/ci/fix-abseil-cpp-issue-1536.patch
 EOF
 else
   echo "Not patching abseil"

--- a/tools/format.sh
+++ b/tools/format.sh
@@ -23,8 +23,8 @@ fi
 # No CRLF line endings, except Windows files.
 "${SED[@]}" 's/\r$//' $($FIND -name '*.ps1' -prune -o \
   -name '*.cmd' -prune -o -type f -print)
-# No trailing spaces.
-"${SED[@]}" 's/ \+$//' $($FIND -type f -print)
+# No trailing spaces, except in patch.
+"${SED[@]}" 's/ \+$//' $($FIND -name "*.patch" -prune -o -type f -print)
 
 # If not overridden, try to use clang-format-18 or clang-format.
 if [[ -z "$CLANG_FORMAT" ]]; then


### PR DESCRIPTION
Fixes #2998

## Changes

Please provide a brief description of the changes here.

* Backported a fix for abseil issue 1536, applied to abseil-cpp 20240116
* Fixed the CI format to ignore `*.patch` files

For significant contributions please make sure you have completed the following items:

* [ ] `CHANGELOG.md` updated for non-trivial changes
* [ ] Unit tests have been added
* [ ] Changes in public API reviewed