### PR TITLE
[BUILD] Fix build without vcpkg on Windows when gRPC is disabled

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -385,7 +385,8 @@ if(WITH_OTLP_GRPC
   if(WITH_OTLP_GRPC)
     find_package(gRPC)
   endif()
-  if((NOT Protobuf_FOUND AND NOT PROTOBUF_FOUND) OR (NOT gRPC_FOUND))
+  if((NOT Protobuf_FOUND AND NOT PROTOBUF_FOUND) OR (WITH_OTLP_GRPC
+                                                     AND NOT gRPC_FOUND))
     if(WIN32 AND (NOT DEFINED CMAKE_TOOLCHAIN_FILE))
       install_windows_deps()
     endif()


### PR DESCRIPTION
Currently, if support for gRPC is disabled by configuring the build with `-DWITH_OTLP_GRPC=OFF`, you are on Windows and do not use a toolchain file then the build will always use all third-party dependencies from vcpkg, regardless of whether nlohmann-json, abseil and protobuf were found or not.

The root cause for this behavior is a bug in the condition meant to check that all dependencies have been found, which unconditionally checks for `NOT gRPC_FOUND`, but the corresponding `find_package` call is only performed if `WITH_OTLP_GRPC` is true, and thus causing that condition to always evaluate to `true` if `WITH_OTLP_GRPC` is false.