### PR TITLE
[BUILD] Add abi_version_no bazel flag.

### DIFF
--- a/api/BUILD
+++ b/api/BUILD
@@ -1,7 +1,7 @@
 # Copyright The OpenTelemetry Authors
 # SPDX-License-Identifier: Apache-2.0
 
-load("@bazel_skylib//rules:common_settings.bzl", "bool_flag", "string_flag")
+load("@bazel_skylib//rules:common_settings.bzl", "bool_flag", "int_flag", "string_flag")
 
 package(default_visibility = ["//visibility:public"])
 
@@ -35,6 +35,9 @@ cc_library(
         ":set_cxx_stdlib_2020": ["OPENTELEMETRY_STL_VERSION=2020"],
         ":set_cxx_stdlib_2023": ["OPENTELEMETRY_STL_VERSION=2023"],
         "//conditions:default": [],
+    }) + select({
+        ":abi_version_no_1": ["OPENTELEMETRY_ABI_VERSION_NO=1"],
+        ":abi_version_no_2": ["OPENTELEMETRY_ABI_VERSION_NO=2"],
     }),
     strip_include_prefix = "include",
     tags = ["api"],
@@ -60,4 +63,19 @@ bool_flag(
     name = "with_abseil",
     build_setting_default = False,
     deprecation = "The value of this flag is ignored. Bazel builds always depend on Abseil for its pre-adopted `std::` types. You should remove this flag from your build command.",
+)
+
+int_flag(
+    name = "abi_version_no",
+    build_setting_default = 1,
+)
+
+config_setting(
+    name = "abi_version_no_1",
+    flag_values = {":abi_version_no": "1"},
+)
+
+config_setting(
+    name = "abi_version_no_2",
+    flag_values = {":abi_version_no": "2"},
 )


### PR DESCRIPTION
Fixes #3019

## Changes

This change allows Bazel users to change the `OPENTELEMETRY_ABI_VERSION_NO`.

To specify the `OPENTELEMETRY_ABI_VERSION_NO` in a client project, simply add `build --@opentelemetry-cpp//api:abi_version_no=2` in the `.bazelrc`.