### PR TITLE
[SDK] PeriodicExportingMetricReader: future is never set, blocks until timeout

### DIFF
--- a/sdk/src/metrics/export/periodic_exporting_metric_reader.cc
+++ b/sdk/src/metrics/export/periodic_exporting_metric_reader.cc
@@ -120,7 +120,7 @@ bool PeriodicExportingMetricReader::CollectAndExportOnce()
             return true;
           });
 
-          sender.set_value();
+          const_cast<std::promise<void> &>(sender).set_value();
         }));
 
     std::future_status status;


### PR DESCRIPTION
Fixes #3026

## Changes

Please provide a brief description of the changes here.

For significant contributions please make sure you have completed the following items:

* [ ] `CHANGELOG.md` updated for non-trivial changes
* [ ] Unit tests have been added
* [x] Changes in public API reviewed