### PR TITLE
[Code Health] Clang Tidy cleanup, Part 2

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -31,10 +31,12 @@ Checks: >
   -misc-unused-alias-decls,
   -misc-use-anonymous-namespace,
   cppcoreguidelines-*,
+  -cppcoreguidelines-owning-memory,
   -cppcoreguidelines-avoid-do-while,
   -cppcoreguidelines-avoid-c-arrays,
   -cppcoreguidelines-avoid-magic-numbers,
   -cppcoreguidelines-init-variables,
   -cppcoreguidelines-macro-usage,
   -cppcoreguidelines-non-private-member-variables-in-classes,
+  -cppcoreguidelines-avoid-non-const-global-variables,
   -cppcoreguidelines-pro-*

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -31,6 +31,7 @@ Checks: >
   -misc-unused-alias-decls,
   -misc-use-anonymous-namespace,
   cppcoreguidelines-*,
+  -cppcoreguidelines-avoid-do-while,
   -cppcoreguidelines-avoid-c-arrays,
   -cppcoreguidelines-avoid-magic-numbers,
   -cppcoreguidelines-init-variables,

--- a/.github/workflows/clang-tidy.yaml
+++ b/.github/workflows/clang-tidy.yaml
@@ -68,7 +68,7 @@ jobs:
       - name: Run clang-tidy
         run: |
           cd build
-          make -j$(nproc) 2>&1 | tee -a clang-tidy.log || exit 1
+          make 2>&1 | tee -a clang-tidy.log || exit 1
 
       - uses: actions/upload-artifact@v4
         with:

--- a/api/test/baggage/propagation/baggage_propagator_test.cc
+++ b/api/test/baggage/propagation/baggage_propagator_test.cc
@@ -15,7 +15,7 @@ class BaggageCarrierTest : public context::propagation::TextMapCarrier
 {
 public:
   BaggageCarrierTest() = default;
-  virtual nostd::string_view Get(nostd::string_view key) const noexcept override
+  nostd::string_view Get(nostd::string_view key) const noexcept override
   {
     auto it = headers_.find(std::string(key));
     if (it != headers_.end())
@@ -24,7 +24,7 @@ public:
     }
     return "";
   }
-  virtual void Set(nostd::string_view key, nostd::string_view value) noexcept override
+  void Set(nostd::string_view key, nostd::string_view value) noexcept override
   {
     headers_[std::string(key)] = std::string(value);
   }

--- a/api/test/context/propagation/composite_propagator_test.cc
+++ b/api/test/context/propagation/composite_propagator_test.cc
@@ -31,7 +31,7 @@ static std::string Hex(const T &id_item)
 class TextMapCarrierTest : public context::propagation::TextMapCarrier
 {
 public:
-  virtual nostd::string_view Get(nostd::string_view key) const noexcept override
+  nostd::string_view Get(nostd::string_view key) const noexcept override
   {
     auto it = headers_.find(std::string(key));
     if (it != headers_.end())
@@ -40,7 +40,7 @@ public:
     }
     return "";
   }
-  virtual void Set(nostd::string_view key, nostd::string_view value) noexcept override
+  void Set(nostd::string_view key, nostd::string_view value) noexcept override
   {
     headers_[std::string(key)] = std::string(value);
   }
@@ -66,7 +66,7 @@ public:
         new context::propagation::CompositePropagator(std::move(propogator_list));
   }
 
-  ~CompositePropagatorTest() { delete composite_propagator_; }
+  ~CompositePropagatorTest() override { delete composite_propagator_; }
 
 protected:
   context::propagation::CompositePropagator *composite_propagator_;

--- a/api/test/logs/logger_benchmark.cc
+++ b/api/test/logs/logger_benchmark.cc
@@ -91,7 +91,7 @@ void MultiThreadRunner(benchmark::State &state, const std::function<void()> &fun
   std::vector<std::thread> threads;
 
   threads.reserve(num_threads);
-  for (int i = 0; i < num_threads; i++)
+  for (uint i = 0; i < num_threads; i++)
   {
     threads.emplace_back(ThreadRoutine, std::ref(barrier), std::ref(state), i, func);
   }

--- a/api/test/logs/logger_benchmark.cc
+++ b/api/test/logs/logger_benchmark.cc
@@ -32,7 +32,7 @@ constexpr int64_t kMaxIterations = 1000000000;
 class Barrier
 {
 public:
-  explicit Barrier(std::size_t iCount) : mThreshold(iCount), mCount(iCount), mGeneration(0) {}
+  explicit Barrier(std::size_t iCount) : mThreshold(iCount), mCount(iCount) {}
 
   void Wait()
   {
@@ -55,7 +55,7 @@ private:
   std::condition_variable mCond;
   std::size_t mThreshold;
   std::size_t mCount;
-  std::size_t mGeneration;
+  std::size_t mGeneration{0};
 };
 
 static void ThreadRoutine(Barrier &barrier,

--- a/api/test/logs/logger_benchmark.cc
+++ b/api/test/logs/logger_benchmark.cc
@@ -84,7 +84,7 @@ static void ThreadRoutine(Barrier &barrier,
 
 void MultiThreadRunner(benchmark::State &state, const std::function<void()> &func)
 {
-  int num_threads = std::thread::hardware_concurrency();
+  uint num_threads = std::thread::hardware_concurrency();
 
   Barrier barrier(num_threads);
 

--- a/api/test/logs/logger_benchmark.cc
+++ b/api/test/logs/logger_benchmark.cc
@@ -84,7 +84,7 @@ static void ThreadRoutine(Barrier &barrier,
 
 void MultiThreadRunner(benchmark::State &state, const std::function<void()> &func)
 {
-    uint32_t num_threads = std::thread::hardware_concurrency();
+  uint32_t num_threads = std::thread::hardware_concurrency();
 
   Barrier barrier(num_threads);
 

--- a/api/test/logs/logger_benchmark.cc
+++ b/api/test/logs/logger_benchmark.cc
@@ -84,14 +84,14 @@ static void ThreadRoutine(Barrier &barrier,
 
 void MultiThreadRunner(benchmark::State &state, const std::function<void()> &func)
 {
-  uint num_threads = std::thread::hardware_concurrency();
+    uint32_t num_threads = std::thread::hardware_concurrency();
 
   Barrier barrier(num_threads);
 
   std::vector<std::thread> threads;
 
   threads.reserve(num_threads);
-  for (uint i = 0; i < num_threads; i++)
+  for (uint32_t i = 0; i < num_threads; i++)
   {
     threads.emplace_back(ThreadRoutine, std::ref(barrier), std::ref(state), i, func);
   }

--- a/api/test/nostd/shared_ptr_test.cc
+++ b/api/test/nostd/shared_ptr_test.cc
@@ -35,7 +35,7 @@ public:
 class D : public C
 {
 public:
-  virtual ~D() {}
+  ~D() override {}
 };
 
 TEST(SharedPtrTest, DefaultConstruction)

--- a/api/test/trace/propagation/b3_propagation_test.cc
+++ b/api/test/trace/propagation/b3_propagation_test.cc
@@ -15,7 +15,7 @@ using namespace opentelemetry;
 class TextMapCarrierTest : public context::propagation::TextMapCarrier
 {
 public:
-  virtual nostd::string_view Get(nostd::string_view key) const noexcept override
+  nostd::string_view Get(nostd::string_view key) const noexcept override
   {
     auto it = headers_.find(std::string(key));
     if (it != headers_.end())
@@ -24,7 +24,7 @@ public:
     }
     return "";
   }
-  virtual void Set(nostd::string_view key, nostd::string_view value) noexcept override
+  void Set(nostd::string_view key, nostd::string_view value) noexcept override
   {
     headers_[std::string(key)] = std::string(value);
   }

--- a/api/test/trace/propagation/http_text_format_test.cc
+++ b/api/test/trace/propagation/http_text_format_test.cc
@@ -18,7 +18,7 @@ using namespace opentelemetry;
 class TextMapCarrierTest : public context::propagation::TextMapCarrier
 {
 public:
-  virtual nostd::string_view Get(nostd::string_view key) const noexcept override
+  nostd::string_view Get(nostd::string_view key) const noexcept override
   {
     auto it = headers_.find(std::string(key));
     if (it != headers_.end())
@@ -27,7 +27,7 @@ public:
     }
     return "";
   }
-  virtual void Set(nostd::string_view key, nostd::string_view value) noexcept override
+  void Set(nostd::string_view key, nostd::string_view value) noexcept override
   {
     headers_[std::string(key)] = std::string(value);
   }

--- a/api/test/trace/propagation/jaeger_propagation_test.cc
+++ b/api/test/trace/propagation/jaeger_propagation_test.cc
@@ -14,7 +14,7 @@ using namespace opentelemetry;
 class TextMapCarrierTest : public context::propagation::TextMapCarrier
 {
 public:
-  virtual nostd::string_view Get(nostd::string_view key) const noexcept override
+  nostd::string_view Get(nostd::string_view key) const noexcept override
   {
     auto it = headers_.find(std::string(key));
     if (it != headers_.end())
@@ -23,7 +23,7 @@ public:
     }
     return "";
   }
-  virtual void Set(nostd::string_view key, nostd::string_view value) noexcept override
+  void Set(nostd::string_view key, nostd::string_view value) noexcept override
   {
     headers_[std::string(key)] = std::string(value);
   }

--- a/examples/http/server.cc
+++ b/examples/http/server.cc
@@ -22,7 +22,7 @@ class RequestHandler : public HTTP_SERVER_NS::HttpRequestCallback
 {
 public:
   int onHttpRequest(HTTP_SERVER_NS::HttpRequest const &request,
-                            HTTP_SERVER_NS::HttpResponse &response) override
+                    HTTP_SERVER_NS::HttpResponse &response) override
   {
     StartSpanOptions options;
     options.kind          = SpanKind::kServer;  // server

--- a/examples/http/server.cc
+++ b/examples/http/server.cc
@@ -21,7 +21,7 @@ constexpr const char *server_name = "localhost";
 class RequestHandler : public HTTP_SERVER_NS::HttpRequestCallback
 {
 public:
-  virtual int onHttpRequest(HTTP_SERVER_NS::HttpRequest const &request,
+  int onHttpRequest(HTTP_SERVER_NS::HttpRequest const &request,
                             HTTP_SERVER_NS::HttpResponse &response) override
   {
     StartSpanOptions options;

--- a/exporters/otlp/src/otlp_file_client.cc
+++ b/exporters/otlp/src/otlp_file_client.cc
@@ -966,7 +966,7 @@ class OPENTELEMETRY_LOCAL_SYMBOL OtlpFileSystemBackend : public OtlpFileAppender
 {
 public:
   explicit OtlpFileSystemBackend(const OtlpFileClientFileSystemOptions &options)
-      : options_(options), is_initialized_{false}, check_file_path_interval_{0}
+      : options_(options), is_initialized_{false} 
   {
     file_ = std::make_shared<FileStats>();
     file_->is_shutdown.store(false);
@@ -1539,7 +1539,7 @@ private:
   std::shared_ptr<FileStats> file_;
 
   std::atomic<bool> is_initialized_;
-  std::time_t check_file_path_interval_;
+  std::time_t check_file_path_interval_{0};
 };
 
 class OPENTELEMETRY_LOCAL_SYMBOL OtlpFileOstreamBackend : public OtlpFileAppender

--- a/exporters/otlp/src/otlp_file_client.cc
+++ b/exporters/otlp/src/otlp_file_client.cc
@@ -1568,7 +1568,7 @@ private:
 };
 
 OtlpFileClient::OtlpFileClient(OtlpFileClientOptions &&options)
-    : is_shutdown_(false), options_(options)
+    : is_shutdown_(false), options_(std::move(options))
 {
   if (nostd::holds_alternative<OtlpFileClientFileSystemOptions>(options_.backend_options))
   {

--- a/exporters/otlp/src/otlp_file_client.cc
+++ b/exporters/otlp/src/otlp_file_client.cc
@@ -966,7 +966,7 @@ class OPENTELEMETRY_LOCAL_SYMBOL OtlpFileSystemBackend : public OtlpFileAppender
 {
 public:
   explicit OtlpFileSystemBackend(const OtlpFileClientFileSystemOptions &options)
-      : options_(options), is_initialized_{false} 
+      : options_(options), is_initialized_{false}
   {
     file_ = std::make_shared<FileStats>();
     file_->is_shutdown.store(false);

--- a/exporters/otlp/src/otlp_file_metric_exporter_options.cc
+++ b/exporters/otlp/src/otlp_file_metric_exporter_options.cc
@@ -12,7 +12,7 @@ namespace exporter
 namespace otlp
 {
 
-OtlpFileMetricExporterOptions::OtlpFileMetricExporterOptions()
+OtlpFileMetricExporterOptions::OtlpFileMetricExporterOptions() : aggregation_temporality(PreferredAggregationTemporality::kCumulative)
 {
   console_debug = false;
 
@@ -26,7 +26,7 @@ OtlpFileMetricExporterOptions::OtlpFileMetricExporterOptions()
 
   backend_options = fs_options;
 
-  aggregation_temporality = PreferredAggregationTemporality::kCumulative;
+  
 }
 
 OtlpFileMetricExporterOptions::~OtlpFileMetricExporterOptions() {}

--- a/exporters/otlp/src/otlp_file_metric_exporter_options.cc
+++ b/exporters/otlp/src/otlp_file_metric_exporter_options.cc
@@ -12,7 +12,8 @@ namespace exporter
 namespace otlp
 {
 
-OtlpFileMetricExporterOptions::OtlpFileMetricExporterOptions() : aggregation_temporality(PreferredAggregationTemporality::kCumulative)
+OtlpFileMetricExporterOptions::OtlpFileMetricExporterOptions()
+    : aggregation_temporality(PreferredAggregationTemporality::kCumulative)
 {
   console_debug = false;
 
@@ -25,8 +26,6 @@ OtlpFileMetricExporterOptions::OtlpFileMetricExporterOptions() : aggregation_tem
   fs_options.rotate_size    = 10;
 
   backend_options = fs_options;
-
-  
 }
 
 OtlpFileMetricExporterOptions::~OtlpFileMetricExporterOptions() {}

--- a/exporters/otlp/src/otlp_grpc_metric_exporter_options.cc
+++ b/exporters/otlp/src/otlp_grpc_metric_exporter_options.cc
@@ -10,7 +10,7 @@ namespace exporter
 namespace otlp
 {
 
-OtlpGrpcMetricExporterOptions::OtlpGrpcMetricExporterOptions()
+OtlpGrpcMetricExporterOptions::OtlpGrpcMetricExporterOptions() : aggregation_temporality(PreferredAggregationTemporality::kCumulative)
 {
   endpoint                    = GetOtlpDefaultGrpcMetricsEndpoint();
   use_ssl_credentials         = !GetOtlpDefaultGrpcMetricsIsInsecure(); /* negation intended. */
@@ -28,7 +28,7 @@ OtlpGrpcMetricExporterOptions::OtlpGrpcMetricExporterOptions()
   metadata   = GetOtlpDefaultMetricsHeaders();
   user_agent = GetOtlpDefaultUserAgent();
 
-  aggregation_temporality = PreferredAggregationTemporality::kCumulative;
+  
 
   max_threads = 0;
 

--- a/exporters/otlp/src/otlp_grpc_metric_exporter_options.cc
+++ b/exporters/otlp/src/otlp_grpc_metric_exporter_options.cc
@@ -10,7 +10,8 @@ namespace exporter
 namespace otlp
 {
 
-OtlpGrpcMetricExporterOptions::OtlpGrpcMetricExporterOptions() : aggregation_temporality(PreferredAggregationTemporality::kCumulative)
+OtlpGrpcMetricExporterOptions::OtlpGrpcMetricExporterOptions()
+    : aggregation_temporality(PreferredAggregationTemporality::kCumulative)
 {
   endpoint                    = GetOtlpDefaultGrpcMetricsEndpoint();
   use_ssl_credentials         = !GetOtlpDefaultGrpcMetricsIsInsecure(); /* negation intended. */
@@ -27,8 +28,6 @@ OtlpGrpcMetricExporterOptions::OtlpGrpcMetricExporterOptions() : aggregation_tem
   timeout    = GetOtlpDefaultMetricsTimeout();
   metadata   = GetOtlpDefaultMetricsHeaders();
   user_agent = GetOtlpDefaultUserAgent();
-
-  
 
   max_threads = 0;
 

--- a/exporters/otlp/src/otlp_http_client.cc
+++ b/exporters/otlp/src/otlp_http_client.cc
@@ -707,7 +707,7 @@ OtlpHttpClient::~OtlpHttpClient()
 OtlpHttpClient::OtlpHttpClient(OtlpHttpClientOptions &&options,
                                std::shared_ptr<ext::http::client::HttpClient> http_client)
     : is_shutdown_(false),
-      options_(options),
+      options_(std::move(options)),
       http_client_(std::move(http_client)),
       start_session_counter_(0),
       finished_session_counter_(0)

--- a/exporters/otlp/src/otlp_http_exporter_options.cc
+++ b/exporters/otlp/src/otlp_http_exporter_options.cc
@@ -15,15 +15,17 @@ namespace exporter
 namespace otlp
 {
 
-OtlpHttpExporterOptions::OtlpHttpExporterOptions() : json_bytes_mapping(JsonBytesMappingKind::kHexId), use_json_name(false), console_debug(false), ssl_insecure_skip_verify(false)
+OtlpHttpExporterOptions::OtlpHttpExporterOptions()
+    : json_bytes_mapping(JsonBytesMappingKind::kHexId),
+      use_json_name(false),
+      console_debug(false),
+      ssl_insecure_skip_verify(false)
 {
-  url                = GetOtlpDefaultHttpTracesEndpoint();
-  content_type       = GetOtlpHttpProtocolFromString(GetOtlpDefaultHttpTracesProtocol());
-  
-  
-  
-  timeout            = GetOtlpDefaultTracesTimeout();
-  http_headers       = GetOtlpDefaultTracesHeaders();
+  url          = GetOtlpDefaultHttpTracesEndpoint();
+  content_type = GetOtlpHttpProtocolFromString(GetOtlpDefaultHttpTracesProtocol());
+
+  timeout      = GetOtlpDefaultTracesTimeout();
+  http_headers = GetOtlpDefaultTracesHeaders();
 
 #ifdef ENABLE_ASYNC_EXPORT
   max_concurrent_requests     = 64;

--- a/exporters/otlp/src/otlp_http_exporter_options.cc
+++ b/exporters/otlp/src/otlp_http_exporter_options.cc
@@ -32,12 +32,12 @@ OtlpHttpExporterOptions::OtlpHttpExporterOptions()
   max_requests_per_connection = 8;
 #endif /* ENABLE_ASYNC_EXPORT */
 
-  ssl_ca_cert_path         = GetOtlpDefaultTracesSslCertificatePath();
-  ssl_ca_cert_string       = GetOtlpDefaultTracesSslCertificateString();
-  ssl_client_key_path      = GetOtlpDefaultTracesSslClientKeyPath();
-  ssl_client_key_string    = GetOtlpDefaultTracesSslClientKeyString();
-  ssl_client_cert_path     = GetOtlpDefaultTracesSslClientCertificatePath();
-  ssl_client_cert_string   = GetOtlpDefaultTracesSslClientCertificateString();
+  ssl_ca_cert_path       = GetOtlpDefaultTracesSslCertificatePath();
+  ssl_ca_cert_string     = GetOtlpDefaultTracesSslCertificateString();
+  ssl_client_key_path    = GetOtlpDefaultTracesSslClientKeyPath();
+  ssl_client_key_string  = GetOtlpDefaultTracesSslClientKeyString();
+  ssl_client_cert_path   = GetOtlpDefaultTracesSslClientCertificatePath();
+  ssl_client_cert_string = GetOtlpDefaultTracesSslClientCertificateString();
 
   ssl_min_tls      = GetOtlpDefaultTracesSslTlsMinVersion();
   ssl_max_tls      = GetOtlpDefaultTracesSslTlsMaxVersion();

--- a/exporters/otlp/src/otlp_http_exporter_options.cc
+++ b/exporters/otlp/src/otlp_http_exporter_options.cc
@@ -15,13 +15,13 @@ namespace exporter
 namespace otlp
 {
 
-OtlpHttpExporterOptions::OtlpHttpExporterOptions()
+OtlpHttpExporterOptions::OtlpHttpExporterOptions() : json_bytes_mapping(JsonBytesMappingKind::kHexId), use_json_name(false), console_debug(false), ssl_insecure_skip_verify(false)
 {
   url                = GetOtlpDefaultHttpTracesEndpoint();
   content_type       = GetOtlpHttpProtocolFromString(GetOtlpDefaultHttpTracesProtocol());
-  json_bytes_mapping = JsonBytesMappingKind::kHexId;
-  use_json_name      = false;
-  console_debug      = false;
+  
+  
+  
   timeout            = GetOtlpDefaultTracesTimeout();
   http_headers       = GetOtlpDefaultTracesHeaders();
 

--- a/exporters/otlp/src/otlp_http_exporter_options.cc
+++ b/exporters/otlp/src/otlp_http_exporter_options.cc
@@ -32,7 +32,6 @@ OtlpHttpExporterOptions::OtlpHttpExporterOptions()
   max_requests_per_connection = 8;
 #endif /* ENABLE_ASYNC_EXPORT */
 
-  ssl_insecure_skip_verify = false;
   ssl_ca_cert_path         = GetOtlpDefaultTracesSslCertificatePath();
   ssl_ca_cert_string       = GetOtlpDefaultTracesSslCertificateString();
   ssl_client_key_path      = GetOtlpDefaultTracesSslClientKeyPath();

--- a/exporters/otlp/src/otlp_http_log_record_exporter_options.cc
+++ b/exporters/otlp/src/otlp_http_log_record_exporter_options.cc
@@ -15,28 +15,29 @@ namespace exporter
 namespace otlp
 {
 
-OtlpHttpLogRecordExporterOptions::OtlpHttpLogRecordExporterOptions() : json_bytes_mapping(JsonBytesMappingKind::kHexId), use_json_name(false), console_debug(false), max_concurrent_requests(64), max_requests_per_connection(8), ssl_insecure_skip_verify(false)
+OtlpHttpLogRecordExporterOptions::OtlpHttpLogRecordExporterOptions()
+    : json_bytes_mapping(JsonBytesMappingKind::kHexId),
+      use_json_name(false),
+      console_debug(false),
+      ssl_insecure_skip_verify(false)
 {
-  url                = GetOtlpDefaultHttpLogsEndpoint();
-  content_type       = GetOtlpHttpProtocolFromString(GetOtlpDefaultHttpLogsProtocol());
-  
-  
-  
-  timeout            = GetOtlpDefaultLogsTimeout();
-  http_headers       = GetOtlpDefaultLogsHeaders();
+  url          = GetOtlpDefaultHttpLogsEndpoint();
+  content_type = GetOtlpHttpProtocolFromString(GetOtlpDefaultHttpLogsProtocol());
+
+  timeout      = GetOtlpDefaultLogsTimeout();
+  http_headers = GetOtlpDefaultLogsHeaders();
 
 #ifdef ENABLE_ASYNC_EXPORT
   max_concurrent_requests     = 64;
   max_requests_per_connection = 8;
 #endif
 
-  
-  ssl_ca_cert_path         = GetOtlpDefaultLogsSslCertificatePath();
-  ssl_ca_cert_string       = GetOtlpDefaultLogsSslCertificateString();
-  ssl_client_key_path      = GetOtlpDefaultLogsSslClientKeyPath();
-  ssl_client_key_string    = GetOtlpDefaultLogsSslClientKeyString();
-  ssl_client_cert_path     = GetOtlpDefaultLogsSslClientCertificatePath();
-  ssl_client_cert_string   = GetOtlpDefaultLogsSslClientCertificateString();
+  ssl_ca_cert_path       = GetOtlpDefaultLogsSslCertificatePath();
+  ssl_ca_cert_string     = GetOtlpDefaultLogsSslCertificateString();
+  ssl_client_key_path    = GetOtlpDefaultLogsSslClientKeyPath();
+  ssl_client_key_string  = GetOtlpDefaultLogsSslClientKeyString();
+  ssl_client_cert_path   = GetOtlpDefaultLogsSslClientCertificatePath();
+  ssl_client_cert_string = GetOtlpDefaultLogsSslClientCertificateString();
 
   ssl_min_tls      = GetOtlpDefaultLogsSslTlsMinVersion();
   ssl_max_tls      = GetOtlpDefaultLogsSslTlsMaxVersion();

--- a/exporters/otlp/src/otlp_http_log_record_exporter_options.cc
+++ b/exporters/otlp/src/otlp_http_log_record_exporter_options.cc
@@ -15,13 +15,13 @@ namespace exporter
 namespace otlp
 {
 
-OtlpHttpLogRecordExporterOptions::OtlpHttpLogRecordExporterOptions()
+OtlpHttpLogRecordExporterOptions::OtlpHttpLogRecordExporterOptions() : json_bytes_mapping(JsonBytesMappingKind::kHexId), use_json_name(false), console_debug(false), max_concurrent_requests(64), max_requests_per_connection(8), ssl_insecure_skip_verify(false)
 {
   url                = GetOtlpDefaultHttpLogsEndpoint();
   content_type       = GetOtlpHttpProtocolFromString(GetOtlpDefaultHttpLogsProtocol());
-  json_bytes_mapping = JsonBytesMappingKind::kHexId;
-  use_json_name      = false;
-  console_debug      = false;
+  
+  
+  
   timeout            = GetOtlpDefaultLogsTimeout();
   http_headers       = GetOtlpDefaultLogsHeaders();
 
@@ -30,7 +30,7 @@ OtlpHttpLogRecordExporterOptions::OtlpHttpLogRecordExporterOptions()
   max_requests_per_connection = 8;
 #endif
 
-  ssl_insecure_skip_verify = false;
+  
   ssl_ca_cert_path         = GetOtlpDefaultLogsSslCertificatePath();
   ssl_ca_cert_string       = GetOtlpDefaultLogsSslCertificateString();
   ssl_client_key_path      = GetOtlpDefaultLogsSslClientKeyPath();

--- a/exporters/otlp/src/otlp_http_metric_exporter_options.cc
+++ b/exporters/otlp/src/otlp_http_metric_exporter_options.cc
@@ -16,23 +16,22 @@ namespace exporter
 namespace otlp
 {
 
-OtlpHttpMetricExporterOptions::OtlpHttpMetricExporterOptions()
+OtlpHttpMetricExporterOptions::OtlpHttpMetricExporterOptions() : json_bytes_mapping(JsonBytesMappingKind::kHexId), use_json_name(false), console_debug(false), aggregation_temporality(PreferredAggregationTemporality::kCumulative), ssl_insecure_skip_verify(false)
 {
   url                     = GetOtlpDefaultMetricsEndpoint();
   content_type            = GetOtlpHttpProtocolFromString(GetOtlpDefaultHttpMetricsProtocol());
-  json_bytes_mapping      = JsonBytesMappingKind::kHexId;
-  use_json_name           = false;
-  console_debug           = false;
+  
+  
+  
   timeout                 = GetOtlpDefaultMetricsTimeout();
   http_headers            = GetOtlpDefaultMetricsHeaders();
-  aggregation_temporality = PreferredAggregationTemporality::kCumulative;
+  
 
 #ifdef ENABLE_ASYNC_EXPORT
   max_concurrent_requests     = 64;
   max_requests_per_connection = 8;
 #endif
 
-  ssl_insecure_skip_verify = false;
   ssl_ca_cert_path         = GetOtlpDefaultMetricsSslCertificatePath();
   ssl_ca_cert_string       = GetOtlpDefaultMetricsSslCertificateString();
   ssl_client_key_path      = GetOtlpDefaultMetricsSslClientKeyPath();

--- a/exporters/otlp/src/otlp_http_metric_exporter_options.cc
+++ b/exporters/otlp/src/otlp_http_metric_exporter_options.cc
@@ -16,28 +16,30 @@ namespace exporter
 namespace otlp
 {
 
-OtlpHttpMetricExporterOptions::OtlpHttpMetricExporterOptions() : json_bytes_mapping(JsonBytesMappingKind::kHexId), use_json_name(false), console_debug(false), aggregation_temporality(PreferredAggregationTemporality::kCumulative), ssl_insecure_skip_verify(false)
+OtlpHttpMetricExporterOptions::OtlpHttpMetricExporterOptions()
+    : json_bytes_mapping(JsonBytesMappingKind::kHexId),
+      use_json_name(false),
+      console_debug(false),
+      aggregation_temporality(PreferredAggregationTemporality::kCumulative),
+      ssl_insecure_skip_verify(false)
 {
-  url                     = GetOtlpDefaultMetricsEndpoint();
-  content_type            = GetOtlpHttpProtocolFromString(GetOtlpDefaultHttpMetricsProtocol());
-  
-  
-  
-  timeout                 = GetOtlpDefaultMetricsTimeout();
-  http_headers            = GetOtlpDefaultMetricsHeaders();
-  
+  url          = GetOtlpDefaultMetricsEndpoint();
+  content_type = GetOtlpHttpProtocolFromString(GetOtlpDefaultHttpMetricsProtocol());
+
+  timeout      = GetOtlpDefaultMetricsTimeout();
+  http_headers = GetOtlpDefaultMetricsHeaders();
 
 #ifdef ENABLE_ASYNC_EXPORT
   max_concurrent_requests     = 64;
   max_requests_per_connection = 8;
 #endif
 
-  ssl_ca_cert_path         = GetOtlpDefaultMetricsSslCertificatePath();
-  ssl_ca_cert_string       = GetOtlpDefaultMetricsSslCertificateString();
-  ssl_client_key_path      = GetOtlpDefaultMetricsSslClientKeyPath();
-  ssl_client_key_string    = GetOtlpDefaultMetricsSslClientKeyString();
-  ssl_client_cert_path     = GetOtlpDefaultMetricsSslClientCertificatePath();
-  ssl_client_cert_string   = GetOtlpDefaultMetricsSslClientCertificateString();
+  ssl_ca_cert_path       = GetOtlpDefaultMetricsSslCertificatePath();
+  ssl_ca_cert_string     = GetOtlpDefaultMetricsSslCertificateString();
+  ssl_client_key_path    = GetOtlpDefaultMetricsSslClientKeyPath();
+  ssl_client_key_string  = GetOtlpDefaultMetricsSslClientKeyString();
+  ssl_client_cert_path   = GetOtlpDefaultMetricsSslClientCertificatePath();
+  ssl_client_cert_string = GetOtlpDefaultMetricsSslClientCertificateString();
 
   ssl_min_tls      = GetOtlpDefaultMetricsSslTlsMinVersion();
   ssl_max_tls      = GetOtlpDefaultMetricsSslTlsMaxVersion();

--- a/exporters/otlp/src/otlp_populate_attribute_utils.cc
+++ b/exporters/otlp/src/otlp_populate_attribute_utils.cc
@@ -72,7 +72,8 @@ void OtlpPopulateAttributeUtils::PopulateAnyValue(
   }
   else if (nostd::holds_alternative<uint64_t>(value))
   {
-    proto_value->set_int_value(nostd::get<uint64_t>(value));
+    proto_value->set_int_value(
+        nostd::get<uint64_t>(value));  // NOLINT(cppcoreguidelines-narrowing-conversions)
   }
   else if (nostd::holds_alternative<double>(value))
   {
@@ -132,7 +133,8 @@ void OtlpPopulateAttributeUtils::PopulateAnyValue(
     auto array_value = proto_value->mutable_array_value();
     for (const auto &val : nostd::get<nostd::span<const uint64_t>>(value))
     {
-      array_value->add_values()->set_int_value(val);
+      array_value->add_values()->set_int_value(
+          val);  // NOLINT(cppcoreguidelines-narrowing-conversions)
     }
   }
   else if (nostd::holds_alternative<nostd::span<const double>>(value))
@@ -186,7 +188,8 @@ void OtlpPopulateAttributeUtils::PopulateAnyValue(
   }
   else if (nostd::holds_alternative<uint64_t>(value))
   {
-    proto_value->set_int_value(nostd::get<uint64_t>(value));
+    proto_value->set_int_value(
+        nostd::get<uint64_t>(value));  // NOLINT(cppcoreguidelines-narrowing-conversions)
   }
   else if (nostd::holds_alternative<double>(value))
   {
@@ -217,7 +220,8 @@ void OtlpPopulateAttributeUtils::PopulateAnyValue(
     auto array_value = proto_value->mutable_array_value();
     for (const auto &val : nostd::get<std::vector<uint32_t>>(value))
     {
-      array_value->add_values()->set_int_value(val);
+      array_value->add_values()->set_int_value(
+          val);  // NOLINT(cppcoreguidelines-narrowing-conversions)
     }
   }
   else if (nostd::holds_alternative<std::vector<int64_t>>(value))
@@ -233,7 +237,8 @@ void OtlpPopulateAttributeUtils::PopulateAnyValue(
     auto array_value = proto_value->mutable_array_value();
     for (const auto &val : nostd::get<std::vector<uint64_t>>(value))
     {
-      array_value->add_values()->set_int_value(val);
+      array_value->add_values()->set_int_value(
+          val);  // NOLINT(cppcoreguidelines-narrowing-conversions)
     }
   }
   else if (nostd::holds_alternative<std::vector<double>>(value))

--- a/exporters/prometheus/src/exporter_utils.cc
+++ b/exporters/prometheus/src/exporter_utils.cc
@@ -284,11 +284,11 @@ std::string PrometheusExporterUtils::SanitizeNames(std::string name)
 }
 
 #if OPENTELEMETRY_HAVE_WORKING_REGEX
-std::regex INVALID_CHARACTERS_PATTERN("[^a-zA-Z0-9]");
-std::regex CHARACTERS_BETWEEN_BRACES_PATTERN("\\{(.*?)\\}");
-std::regex SANITIZE_LEADING_UNDERSCORES("^_+");
-std::regex SANITIZE_TRAILING_UNDERSCORES("_+$");
-std::regex SANITIZE_CONSECUTIVE_UNDERSCORES("[_]{2,}");
+const std::regex INVALID_CHARACTERS_PATTERN("[^a-zA-Z0-9]");
+const std::regex CHARACTERS_BETWEEN_BRACES_PATTERN("\\{(.*?)\\}");
+const std::regex SANITIZE_LEADING_UNDERSCORES("^_+");
+const std::regex SANITIZE_TRAILING_UNDERSCORES("_+$");
+const std::regex SANITIZE_CONSECUTIVE_UNDERSCORES("[_]{2,}");
 #endif
 
 std::string PrometheusExporterUtils::GetEquivalentPrometheusUnit(

--- a/exporters/prometheus/test/collector_test.cc
+++ b/exporters/prometheus/test/collector_test.cc
@@ -23,7 +23,7 @@ class MockMetricProducer : public opentelemetry::sdk::metrics::MetricProducer
 
 public:
   MockMetricProducer(std::chrono::microseconds sleep_ms = std::chrono::microseconds::zero())
-      : sleep_ms_{sleep_ms}, data_sent_size_(0)
+      : sleep_ms_{sleep_ms} 
   {}
 
   bool Collect(nostd::function_ref<bool(ResourceMetrics &)> callback) noexcept override
@@ -39,7 +39,7 @@ public:
 
 private:
   std::chrono::microseconds sleep_ms_;
-  size_t data_sent_size_;
+  size_t data_sent_size_{0};
 };
 
 class MockMetricReader : public opentelemetry::sdk::metrics::MetricReader

--- a/exporters/prometheus/test/collector_test.cc
+++ b/exporters/prometheus/test/collector_test.cc
@@ -23,7 +23,7 @@ class MockMetricProducer : public opentelemetry::sdk::metrics::MetricProducer
 
 public:
   MockMetricProducer(std::chrono::microseconds sleep_ms = std::chrono::microseconds::zero())
-      : sleep_ms_{sleep_ms} 
+      : sleep_ms_{sleep_ms}
   {}
 
   bool Collect(nostd::function_ref<bool(ResourceMetrics &)> callback) noexcept override

--- a/exporters/zipkin/src/zipkin_exporter.cc
+++ b/exporters/zipkin/src/zipkin_exporter.cc
@@ -50,9 +50,9 @@ ZipkinExporter::ZipkinExporter() : options_(ZipkinExporterOptions()), url_parser
 
 ZipkinExporter::ZipkinExporter(
     std::shared_ptr<opentelemetry::ext::http::client::HttpClientSync> http_client)
-    : options_(ZipkinExporterOptions()), url_parser_(options_.endpoint)
+    : options_(ZipkinExporterOptions()), http_client_(http_client), url_parser_(options_.endpoint)
 {
-  http_client_ = http_client;
+  
   InitializeLocalEndpoint();
 }
 

--- a/exporters/zipkin/src/zipkin_exporter.cc
+++ b/exporters/zipkin/src/zipkin_exporter.cc
@@ -52,7 +52,7 @@ ZipkinExporter::ZipkinExporter(
     std::shared_ptr<opentelemetry::ext::http::client::HttpClientSync> http_client)
     : options_(ZipkinExporterOptions()), http_client_(http_client), url_parser_(options_.endpoint)
 {
-  
+
   InitializeLocalEndpoint();
 }
 

--- a/exporters/zipkin/src/zipkin_exporter.cc
+++ b/exporters/zipkin/src/zipkin_exporter.cc
@@ -50,7 +50,9 @@ ZipkinExporter::ZipkinExporter() : options_(ZipkinExporterOptions()), url_parser
 
 ZipkinExporter::ZipkinExporter(
     std::shared_ptr<opentelemetry::ext::http::client::HttpClientSync> http_client)
-    : options_(ZipkinExporterOptions()), http_client_(http_client), url_parser_(options_.endpoint)
+    : options_(ZipkinExporterOptions()),
+      http_client_(std::move(http_client)),
+      url_parser_(options_.endpoint)
 {
 
   InitializeLocalEndpoint();

--- a/ext/src/http/client/curl/http_client_curl.cc
+++ b/ext/src/http/client/curl/http_client_curl.cc
@@ -185,12 +185,12 @@ void Session::FinishOperation()
 }
 
 HttpClient::HttpClient()
-    : next_session_id_{0},
+    : multi_handle_(curl_multi_init()), next_session_id_{0},
       max_sessions_per_connection_{8},
       scheduled_delay_milliseconds_{std::chrono::milliseconds(256)},
       curl_global_initializer_(HttpCurlGlobalInitializer::GetInstance())
 {
-  multi_handle_ = curl_multi_init();
+  
 }
 
 HttpClient::~HttpClient()

--- a/ext/src/http/client/curl/http_client_curl.cc
+++ b/ext/src/http/client/curl/http_client_curl.cc
@@ -185,13 +185,12 @@ void Session::FinishOperation()
 }
 
 HttpClient::HttpClient()
-    : multi_handle_(curl_multi_init()), next_session_id_{0},
+    : multi_handle_(curl_multi_init()),
+      next_session_id_{0},
       max_sessions_per_connection_{8},
       scheduled_delay_milliseconds_{std::chrono::milliseconds(256)},
       curl_global_initializer_(HttpCurlGlobalInitializer::GetInstance())
-{
-  
-}
+{}
 
 HttpClient::~HttpClient()
 {

--- a/ext/test/http/curl_http_test.cc
+++ b/ext/test/http/curl_http_test.cc
@@ -26,11 +26,11 @@ namespace nostd       = opentelemetry::nostd;
 class CustomEventHandler : public http_client::EventHandler
 {
 public:
-  virtual void OnResponse(http_client::Response & /* response */) noexcept override
+  void OnResponse(http_client::Response & /* response */) noexcept override
   {
     got_response_ = true;
   }
-  virtual void OnEvent(http_client::SessionState state,
+  void OnEvent(http_client::SessionState state,
                        nostd::string_view /* reason */) noexcept override
   {
     switch (state)
@@ -113,7 +113,7 @@ protected:
 public:
   BasicCurlHttpTests() : is_setup_(false), is_running_(false) {}
 
-  virtual void SetUp() override
+  void SetUp() override
   {
     if (is_setup_.exchange(true))
     {
@@ -132,7 +132,7 @@ public:
     is_running_ = true;
   }
 
-  virtual void TearDown() override
+  void TearDown() override
   {
     if (!is_setup_.exchange(false))
       return;
@@ -140,7 +140,7 @@ public:
     is_running_ = false;
   }
 
-  virtual int onHttpRequest(HTTP_SERVER_NS::HttpRequest const &request,
+  int onHttpRequest(HTTP_SERVER_NS::HttpRequest const &request,
                             HTTP_SERVER_NS::HttpResponse &response) override
   {
     int response_status = 404;

--- a/ext/test/http/curl_http_test.cc
+++ b/ext/test/http/curl_http_test.cc
@@ -30,8 +30,7 @@ public:
   {
     got_response_ = true;
   }
-  void OnEvent(http_client::SessionState state,
-                       nostd::string_view /* reason */) noexcept override
+  void OnEvent(http_client::SessionState state, nostd::string_view /* reason */) noexcept override
   {
     switch (state)
     {
@@ -141,7 +140,7 @@ public:
   }
 
   int onHttpRequest(HTTP_SERVER_NS::HttpRequest const &request,
-                            HTTP_SERVER_NS::HttpResponse &response) override
+                    HTTP_SERVER_NS::HttpResponse &response) override
   {
     int response_status = 404;
     if (request.uri == "/get/")

--- a/ext/test/w3c_tracecontext_test/main.cc
+++ b/ext/test/w3c_tracecontext_test/main.cc
@@ -30,7 +30,7 @@ class TextMapCarrierTest : public context::propagation::TextMapCarrier
 {
 public:
   TextMapCarrierTest(std::map<std::string, std::string> &headers) : headers_(headers) {}
-  virtual nostd::string_view Get(nostd::string_view key) const noexcept override
+  nostd::string_view Get(nostd::string_view key) const noexcept override
   {
     auto it = headers_.find(std::string(key));
     if (it != headers_.end())
@@ -39,7 +39,7 @@ public:
     }
     return "";
   }
-  virtual void Set(nostd::string_view key, nostd::string_view value) noexcept override
+  void Set(nostd::string_view key, nostd::string_view value) noexcept override
   {
     headers_[std::string(key)] = std::string(value);
   }

--- a/sdk/include/opentelemetry/sdk/common/circular_buffer.h
+++ b/sdk/include/opentelemetry/sdk/common/circular_buffer.h
@@ -113,7 +113,6 @@ public:
         data_[head_index].Swap(ptr);
       }
     }
-    return true;
   }
 
   bool Add(std::unique_ptr<T> &&ptr) noexcept

--- a/sdk/src/common/base64.cc
+++ b/sdk/src/common/base64.cc
@@ -200,13 +200,8 @@ static int Base64UnescapeInternal(unsigned char *dst,
     ++line_len;
     if (src[i] == padding_char)
     {
-      if (++j > 2)
+      if (++j > 2 || (valid_slen & 3) == 1 || (valid_slen & 3) == 2)
       {
-        return -2;
-      }
-      else if ((valid_slen & 3) == 1 || (valid_slen & 3) == 2)
-      {
-        // First and second char of every group can not be padding char
         return -2;
       }
     }

--- a/sdk/src/logs/logger_provider.cc
+++ b/sdk/src/logs/logger_provider.cc
@@ -31,13 +31,13 @@ LoggerProvider::LoggerProvider(std::unique_ptr<LogRecordProcessor> &&processor,
 {
   std::vector<std::unique_ptr<LogRecordProcessor>> processors;
   processors.emplace_back(std::move(processor));
-  context_ = std::make_shared<LoggerContext>(std::move(processors), std::move(resource));
+  context_ = std::make_shared<LoggerContext>(std::move(processors), resource);
   OTEL_INTERNAL_LOG_DEBUG("[LoggerProvider] LoggerProvider created.");
 }
 
 LoggerProvider::LoggerProvider(std::vector<std::unique_ptr<LogRecordProcessor>> &&processors,
                                const opentelemetry::sdk::resource::Resource &resource) noexcept
-    : context_{std::make_shared<LoggerContext>(std::move(processors), std::move(resource))}
+    : context_{std::make_shared<LoggerContext>(std::move(processors), resource)}
 {}
 
 LoggerProvider::LoggerProvider() noexcept

--- a/sdk/src/metrics/aggregation/lastvalue_aggregation.cc
+++ b/sdk/src/metrics/aggregation/lastvalue_aggregation.cc
@@ -28,9 +28,7 @@ LongLastValueAggregation::LongLastValueAggregation()
   point_data_.value_              = static_cast<int64_t>(0);
 }
 
-LongLastValueAggregation::LongLastValueAggregation(LastValuePointData &&data)
-    : point_data_{data}
-{}
+LongLastValueAggregation::LongLastValueAggregation(LastValuePointData &&data) : point_data_{data} {}
 
 LongLastValueAggregation::LongLastValueAggregation(const LastValuePointData &data)
     : point_data_{data}

--- a/sdk/src/metrics/aggregation/lastvalue_aggregation.cc
+++ b/sdk/src/metrics/aggregation/lastvalue_aggregation.cc
@@ -29,7 +29,7 @@ LongLastValueAggregation::LongLastValueAggregation()
 }
 
 LongLastValueAggregation::LongLastValueAggregation(LastValuePointData &&data)
-    : point_data_{std::move(data)}
+    : point_data_{data}
 {}
 
 LongLastValueAggregation::LongLastValueAggregation(const LastValuePointData &data)
@@ -51,12 +51,12 @@ std::unique_ptr<Aggregation> LongLastValueAggregation::Merge(
   if (nostd::get<LastValuePointData>(ToPoint()).sample_ts_.time_since_epoch() >
       nostd::get<LastValuePointData>(delta.ToPoint()).sample_ts_.time_since_epoch())
   {
-    LastValuePointData merge_data = std::move(nostd::get<LastValuePointData>(ToPoint()));
+    LastValuePointData merge_data = nostd::get<LastValuePointData>(ToPoint());
     return std::unique_ptr<Aggregation>(new LongLastValueAggregation(std::move(merge_data)));
   }
   else
   {
-    LastValuePointData merge_data = std::move(nostd::get<LastValuePointData>(delta.ToPoint()));
+    LastValuePointData merge_data = nostd::get<LastValuePointData>(delta.ToPoint());
     return std::unique_ptr<Aggregation>(new LongLastValueAggregation(std::move(merge_data)));
   }
 }
@@ -66,12 +66,12 @@ std::unique_ptr<Aggregation> LongLastValueAggregation::Diff(const Aggregation &n
   if (nostd::get<LastValuePointData>(ToPoint()).sample_ts_.time_since_epoch() >
       nostd::get<LastValuePointData>(next.ToPoint()).sample_ts_.time_since_epoch())
   {
-    LastValuePointData diff_data = std::move(nostd::get<LastValuePointData>(ToPoint()));
+    LastValuePointData diff_data = nostd::get<LastValuePointData>(ToPoint());
     return std::unique_ptr<Aggregation>(new LongLastValueAggregation(std::move(diff_data)));
   }
   else
   {
-    LastValuePointData diff_data = std::move(nostd::get<LastValuePointData>(next.ToPoint()));
+    LastValuePointData diff_data = nostd::get<LastValuePointData>(next.ToPoint());
     return std::unique_ptr<Aggregation>(new LongLastValueAggregation(std::move(diff_data)));
   }
 }
@@ -89,7 +89,7 @@ DoubleLastValueAggregation::DoubleLastValueAggregation()
 }
 
 DoubleLastValueAggregation::DoubleLastValueAggregation(LastValuePointData &&data)
-    : point_data_{std::move(data)}
+    : point_data_{data}
 {}
 
 DoubleLastValueAggregation::DoubleLastValueAggregation(const LastValuePointData &data)
@@ -111,12 +111,12 @@ std::unique_ptr<Aggregation> DoubleLastValueAggregation::Merge(
   if (nostd::get<LastValuePointData>(ToPoint()).sample_ts_.time_since_epoch() >
       nostd::get<LastValuePointData>(delta.ToPoint()).sample_ts_.time_since_epoch())
   {
-    LastValuePointData merge_data = std::move(nostd::get<LastValuePointData>(ToPoint()));
+    LastValuePointData merge_data = nostd::get<LastValuePointData>(ToPoint());
     return std::unique_ptr<Aggregation>(new DoubleLastValueAggregation(std::move(merge_data)));
   }
   else
   {
-    LastValuePointData merge_data = std::move(nostd::get<LastValuePointData>(delta.ToPoint()));
+    LastValuePointData merge_data = nostd::get<LastValuePointData>(delta.ToPoint());
     return std::unique_ptr<Aggregation>(new DoubleLastValueAggregation(std::move(merge_data)));
   }
 }
@@ -127,12 +127,12 @@ std::unique_ptr<Aggregation> DoubleLastValueAggregation::Diff(
   if (nostd::get<LastValuePointData>(ToPoint()).sample_ts_.time_since_epoch() >
       nostd::get<LastValuePointData>(next.ToPoint()).sample_ts_.time_since_epoch())
   {
-    LastValuePointData diff_data = std::move(nostd::get<LastValuePointData>(ToPoint()));
+    LastValuePointData diff_data = nostd::get<LastValuePointData>(ToPoint());
     return std::unique_ptr<Aggregation>(new DoubleLastValueAggregation(std::move(diff_data)));
   }
   else
   {
-    LastValuePointData diff_data = std::move(nostd::get<LastValuePointData>(next.ToPoint()));
+    LastValuePointData diff_data = nostd::get<LastValuePointData>(next.ToPoint());
     return std::unique_ptr<Aggregation>(new DoubleLastValueAggregation(std::move(diff_data)));
   }
 }

--- a/sdk/src/metrics/aggregation/sum_aggregation.cc
+++ b/sdk/src/metrics/aggregation/sum_aggregation.cc
@@ -27,7 +27,7 @@ LongSumAggregation::LongSumAggregation(bool is_monotonic)
   point_data_.is_monotonic_ = is_monotonic;
 }
 
-LongSumAggregation::LongSumAggregation(SumPointData &&data) : point_data_{std::move(data)} {}
+LongSumAggregation::LongSumAggregation(SumPointData &&data) : point_data_{data} {}
 
 LongSumAggregation::LongSumAggregation(const SumPointData &data) : point_data_{data} {}
 
@@ -81,7 +81,7 @@ DoubleSumAggregation::DoubleSumAggregation(bool is_monotonic)
   point_data_.is_monotonic_ = is_monotonic;
 }
 
-DoubleSumAggregation::DoubleSumAggregation(SumPointData &&data) : point_data_(std::move(data)) {}
+DoubleSumAggregation::DoubleSumAggregation(SumPointData &&data) : point_data_(data) {}
 
 DoubleSumAggregation::DoubleSumAggregation(const SumPointData &data) : point_data_(data) {}
 

--- a/sdk/src/metrics/state/sync_metric_storage.cc
+++ b/sdk/src/metrics/state/sync_metric_storage.cc
@@ -39,7 +39,7 @@ bool SyncMetricStorage::Collect(CollectorHandle *collector,
   }
 
   return temporal_metric_storage_.buildMetrics(collector, collectors, sdk_start_ts, collection_ts,
-                                               std::move(delta_metrics), callback);
+                                               delta_metrics, callback);
 }
 
 }  // namespace metrics

--- a/sdk/src/trace/batch_span_processor.cc
+++ b/sdk/src/trace/batch_span_processor.cc
@@ -66,7 +66,7 @@ void BatchSpanProcessor::OnEnd(std::unique_ptr<Recordable> &&span) noexcept
     return;
   }
 
-  if (buffer_.Add(span) == false)
+  if (buffer_.Add(std::move(span)) == false)
   {
     OTEL_INTERNAL_LOG_WARN("BatchSpanProcessor queue is full - dropping span.");
     return;

--- a/sdk/src/trace/samplers/parent_factory.cc
+++ b/sdk/src/trace/samplers/parent_factory.cc
@@ -16,7 +16,7 @@ namespace trace
 std::unique_ptr<Sampler> ParentBasedSamplerFactory::Create(
     const std::shared_ptr<Sampler> &delegate_sampler)
 {
-  std::unique_ptr<Sampler> sampler(new ParentBasedSampler(std::move(delegate_sampler)));
+  std::unique_ptr<Sampler> sampler(new ParentBasedSampler(delegate_sampler));
   return sampler;
 }
 

--- a/sdk/test/common/random_test.cc
+++ b/sdk/test/common/random_test.cc
@@ -52,7 +52,7 @@ TEST(RandomTest, AtomicFlagMultiThreadTest)
   std::vector<std::thread> threads;
   std::atomic_uint count(0);
   threads.reserve(10);
-for (int i = 0; i < 10; ++i)
+  for (int i = 0; i < 10; ++i)
   {
     threads.push_back(std::thread(doSomethingOnce, &count));
   }

--- a/sdk/test/common/random_test.cc
+++ b/sdk/test/common/random_test.cc
@@ -51,7 +51,8 @@ TEST(RandomTest, AtomicFlagMultiThreadTest)
 {
   std::vector<std::thread> threads;
   std::atomic_uint count(0);
-  for (int i = 0; i < 10; ++i)
+  threads.reserve(10);
+for (int i = 0; i < 10; ++i)
   {
     threads.push_back(std::thread(doSomethingOnce, &count));
   }

--- a/sdk/test/metrics/periodic_exporting_metric_reader_test.cc
+++ b/sdk/test/metrics/periodic_exporting_metric_reader_test.cc
@@ -51,7 +51,7 @@ class MockMetricProducer : public MetricProducer
 {
 public:
   MockMetricProducer(std::chrono::microseconds sleep_ms = std::chrono::microseconds::zero())
-      : sleep_ms_{sleep_ms}, data_sent_size_(0)
+      : sleep_ms_{sleep_ms} 
   {}
 
   bool Collect(nostd::function_ref<bool(ResourceMetrics &)> callback) noexcept override
@@ -67,7 +67,7 @@ public:
 
 private:
   std::chrono::microseconds sleep_ms_;
-  size_t data_sent_size_;
+  size_t data_sent_size_{0};
 };
 
 TEST(PeriodicExporingMetricReader, BasicTests)

--- a/sdk/test/metrics/periodic_exporting_metric_reader_test.cc
+++ b/sdk/test/metrics/periodic_exporting_metric_reader_test.cc
@@ -51,7 +51,7 @@ class MockMetricProducer : public MetricProducer
 {
 public:
   MockMetricProducer(std::chrono::microseconds sleep_ms = std::chrono::microseconds::zero())
-      : sleep_ms_{sleep_ms} 
+      : sleep_ms_{sleep_ms}
   {}
 
   bool Collect(nostd::function_ref<bool(ResourceMetrics &)> callback) noexcept override


### PR DESCRIPTION
Contributes to #2053 

## Changes

In continuation to Cleanup 1, this changes reduces a lot of clang-tidy warnings and removed some checks that are not relevant. 

For significant contributions please make sure you have completed the following items:

* [ ] `CHANGELOG.md` updated for non-trivial changes
* [ ] Unit tests have been added
* [ ] Changes in public API reviewed