### PR TITLE
Change EmitLogRecord to return success/fail

### DIFF
--- a/api/include/opentelemetry/logs/logger.h
+++ b/api/include/opentelemetry/logs/logger.h
@@ -43,8 +43,9 @@ public:
    * Emit a Log Record object
    *
    * @param log_record
+   * @return true if the record was successfully exported, false otherwise
    */
-  virtual void EmitLogRecord(nostd::unique_ptr<LogRecord> &&log_record) noexcept = 0;
+  virtual bool EmitLogRecord(nostd::unique_ptr<LogRecord> &&log_record) noexcept = 0;
 
   /**
    * Emit a Log Record object with arguments
@@ -65,18 +66,18 @@ public:
    *  span<pair<string_view, AttributeValue>> -> attributes(return type of MakeAttributes)
    */
   template <class... ArgumentType>
-  void EmitLogRecord(nostd::unique_ptr<LogRecord> &&log_record, ArgumentType &&...args)
+  bool EmitLogRecord(nostd::unique_ptr<LogRecord> &&log_record, ArgumentType &&...args)
   {
     if (!log_record)
     {
-      return;
+      return false;
     }
 
     IgnoreTraitResult(
         detail::LogRecordSetterTrait<typename std::decay<ArgumentType>::type>::template Set(
             log_record.get(), std::forward<ArgumentType>(args))...);
 
-    EmitLogRecord(std::move(log_record));
+    return EmitLogRecord(std::move(log_record));
   }
 
   /**
@@ -97,11 +98,11 @@ public:
    *  span<pair<string_view, AttributeValue>> -> attributes(return type of MakeAttributes)
    */
   template <class... ArgumentType>
-  void EmitLogRecord(ArgumentType &&...args)
+  bool EmitLogRecord(ArgumentType &&...args)
   {
     nostd::unique_ptr<LogRecord> log_record = CreateLogRecord();
 
-    EmitLogRecord(std::move(log_record), std::forward<ArgumentType>(args)...);
+    return EmitLogRecord(std::move(log_record), std::forward<ArgumentType>(args)...);
   }
 
   /**

--- a/api/include/opentelemetry/logs/noop.h
+++ b/api/include/opentelemetry/logs/noop.h
@@ -46,7 +46,7 @@ public:
 
   using Logger::EmitLogRecord;
 
-  void EmitLogRecord(nostd::unique_ptr<LogRecord> &&) noexcept override {}
+  bool EmitLogRecord(nostd::unique_ptr<LogRecord> &&) noexcept override { return true; }
 
 private:
   class NoopLogRecord : public LogRecord

--- a/exporters/otlp/src/otlp_http_log_record_exporter.cc
+++ b/exporters/otlp/src/otlp_http_log_record_exporter.cc
@@ -149,7 +149,7 @@ opentelemetry::sdk::common::ExportResult OtlpHttpLogRecordExporter::Export(
   {
     OTEL_INTERNAL_LOG_DEBUG("[OTLP LOG HTTP Exporter] Export " << log_count << " log(s) success");
   }
-  return opentelemetry::sdk::common::ExportResult::kSuccess;
+  return result;
 #endif
 }
 

--- a/sdk/include/opentelemetry/sdk/logs/batch_log_record_processor.h
+++ b/sdk/include/opentelemetry/sdk/logs/batch_log_record_processor.h
@@ -66,9 +66,10 @@ public:
   /**
    * Called when the Logger's log method creates a log record
    * @param record the log record
+   * @return true if the record was successfully exported, false otherwise
    */
 
-  void OnEmit(std::unique_ptr<Recordable> &&record) noexcept override;
+  bool OnEmit(std::unique_ptr<Recordable> &&record) noexcept override;
 
   /**
    * Export all log records that have not been exported yet.

--- a/sdk/include/opentelemetry/sdk/logs/logger.h
+++ b/sdk/include/opentelemetry/sdk/logs/logger.h
@@ -43,7 +43,7 @@ public:
 
   using opentelemetry::logs::Logger::EmitLogRecord;
 
-  void EmitLogRecord(
+  bool EmitLogRecord(
       nostd::unique_ptr<opentelemetry::logs::LogRecord> &&log_record) noexcept override;
 
   /** Returns the associated instrumentation scope */

--- a/sdk/include/opentelemetry/sdk/logs/multi_log_record_processor.h
+++ b/sdk/include/opentelemetry/sdk/logs/multi_log_record_processor.h
@@ -35,8 +35,9 @@ public:
   /**
    * OnEmit is called by the SDK once a log record has been successfully created.
    * @param record the log record
+   * @return true if the record was successfully exported, false otherwise
    */
-  void OnEmit(std::unique_ptr<Recordable> &&record) noexcept override;
+  bool OnEmit(std::unique_ptr<Recordable> &&record) noexcept override;
 
   /**
    * Exports all log records that have not yet been exported to the configured Exporter.

--- a/sdk/include/opentelemetry/sdk/logs/processor.h
+++ b/sdk/include/opentelemetry/sdk/logs/processor.h
@@ -37,8 +37,9 @@ public:
   /**
    * OnEmit is called by the SDK once a log record has been successfully created.
    * @param record the log recordable object
+   * @return true if the record was successfully exported, false otherwise
    */
-  virtual void OnEmit(std::unique_ptr<Recordable> &&record) noexcept = 0;
+  virtual bool OnEmit(std::unique_ptr<Recordable> &&record) noexcept = 0;
 
   /**
    * Exports all log records that have not yet been exported to the configured Exporter.

--- a/sdk/include/opentelemetry/sdk/logs/simple_log_record_processor.h
+++ b/sdk/include/opentelemetry/sdk/logs/simple_log_record_processor.h
@@ -35,7 +35,7 @@ public:
 
   std::unique_ptr<Recordable> MakeRecordable() noexcept override;
 
-  void OnEmit(std::unique_ptr<Recordable> &&record) noexcept override;
+  bool OnEmit(std::unique_ptr<Recordable> &&record) noexcept override;
 
   bool ForceFlush(
       std::chrono::microseconds timeout = (std::chrono::microseconds::max)()) noexcept override;

--- a/sdk/src/logs/logger.cc
+++ b/sdk/src/logs/logger.cc
@@ -88,12 +88,12 @@ opentelemetry::nostd::unique_ptr<opentelemetry::logs::LogRecord> Logger::CreateL
   return opentelemetry::nostd::unique_ptr<opentelemetry::logs::LogRecord>(recordable.release());
 }
 
-void Logger::EmitLogRecord(
+bool Logger::EmitLogRecord(
     opentelemetry::nostd::unique_ptr<opentelemetry::logs::LogRecord> &&log_record) noexcept
 {
   if (!log_record)
   {
-    return;
+    return false;
   }
 
   std::unique_ptr<Recordable> recordable =
@@ -106,7 +106,7 @@ void Logger::EmitLogRecord(
   // TODO: Sampler (should include check for minSeverity)
 
   // Send the log recordable to the processor
-  processor.OnEmit(std::move(recordable));
+  return processor.OnEmit(std::move(recordable));
 }
 
 const opentelemetry::sdk::instrumentationscope::InstrumentationScope &

--- a/sdk/src/logs/multi_log_record_processor.cc
+++ b/sdk/src/logs/multi_log_record_processor.cc
@@ -54,11 +54,11 @@ std::unique_ptr<Recordable> MultiLogRecordProcessor::MakeRecordable() noexcept
   return recordable;
 }
 
-void MultiLogRecordProcessor::OnEmit(std::unique_ptr<Recordable> &&record) noexcept
+bool MultiLogRecordProcessor::OnEmit(std::unique_ptr<Recordable> &&record) noexcept
 {
   if (!record)
   {
-    return;
+    return false;
   }
   auto multi_recordable = static_cast<MultiRecordable *>(record.get());
 
@@ -67,9 +67,13 @@ void MultiLogRecordProcessor::OnEmit(std::unique_ptr<Recordable> &&record) noexc
     auto recordable = multi_recordable->ReleaseRecordable(*processor);
     if (recordable)
     {
-      processor->OnEmit(std::move(recordable));
+      if (!processor->OnEmit(std::move(recordable)))
+      {
+        return false;
+      };
     }
   }
+  return true;
 }
 
 bool MultiLogRecordProcessor::ForceFlush(std::chrono::microseconds timeout) noexcept

--- a/sdk/src/logs/simple_log_record_processor.cc
+++ b/sdk/src/logs/simple_log_record_processor.cc
@@ -39,17 +39,15 @@ std::unique_ptr<Recordable> SimpleLogRecordProcessor::MakeRecordable() noexcept
  * Batches the log record it receives in a batch of 1 and immediately sends it
  * to the configured exporter
  */
-void SimpleLogRecordProcessor::OnEmit(std::unique_ptr<Recordable> &&record) noexcept
+bool SimpleLogRecordProcessor::OnEmit(std::unique_ptr<Recordable> &&record) noexcept
 {
   nostd::span<std::unique_ptr<Recordable>> batch(&record, 1);
   // Get lock to ensure Export() is never called concurrently
   const std::lock_guard<opentelemetry::common::SpinLockMutex> locked(lock_);
 
-  if (exporter_->Export(batch) != sdk::common::ExportResult::kSuccess)
-  {
-    /* Alert user of the failed export */
-  }
+  return (exporter_->Export(batch) == sdk::common::ExportResult::kSuccess);
 }
+
 /**
  *  The simple processor does not have any log records to flush so this method is not used
  */


### PR DESCRIPTION
Summary:
Minor change to the API to return a boolean (true if succeed) when sending a log. so caller can consume and do proper retry, otherwise, there is no way for caller to know if a log has been sent successfully or not

Test Plan:
Please suggest what tests I need to run, thanks!

Reviewers:

Subscribers:

Tasks:

Tags:

Fixes # (issue)

## Changes

Please provide a brief description of the changes here.

For significant contributions please make sure you have completed the following items:

* [ ] `CHANGELOG.md` updated for non-trivial changes
* [ ] Unit tests have been added
* [ ] Changes in public API reviewed