### PR TITLE
[SDK] Update MetricProducer interface to match spec

### DIFF
--- a/exporters/prometheus/test/collector_test.cc
+++ b/exporters/prometheus/test/collector_test.cc
@@ -12,12 +12,13 @@
 #include <thread>
 
 using opentelemetry::exporter::metrics::PrometheusCollector;
+using opentelemetry::sdk::metrics::MetricProducer;
 using opentelemetry::sdk::metrics::ResourceMetrics;
 namespace metric_api      = opentelemetry::metrics;
 namespace metric_sdk      = opentelemetry::sdk::metrics;
 namespace metric_exporter = opentelemetry::exporter::metrics;
 
-class MockMetricProducer : public opentelemetry::sdk::metrics::MetricProducer
+class MockMetricProducer : public MetricProducer
 {
   TestDataPoints test_data_points_;
 
@@ -26,13 +27,12 @@ public:
       : sleep_ms_{sleep_ms}
   {}
 
-  bool Collect(nostd::function_ref<bool(ResourceMetrics &)> callback) noexcept override
+  MetricProducer::Result Produce() noexcept override
   {
     std::this_thread::sleep_for(sleep_ms_);
     data_sent_size_++;
     ResourceMetrics data = test_data_points_.CreateSumPointData();
-    callback(data);
-    return true;
+    return {data, MetricProducer::Status::kSuccess};
   }
 
   size_t GetDataCount() { return data_sent_size_; }
@@ -70,15 +70,13 @@ private:
  */
 TEST(PrometheusCollector, BasicTests)
 {
-  MockMetricReader *reader     = new MockMetricReader();
-  MockMetricProducer *producer = new MockMetricProducer();
-  reader->SetMetricProducer(producer);
-  PrometheusCollector collector(reader, true, false);
+  MockMetricReader reader;
+  MockMetricProducer producer;
+  reader.SetMetricProducer(&producer);
+  PrometheusCollector collector(&reader, true, false);
   auto data = collector.Collect();
 
   // Collection size should be the same as the size
   // of the records collection produced by MetricProducer.
   ASSERT_EQ(data.size(), 2);
-  delete reader;
-  delete producer;
 }

--- a/sdk/include/opentelemetry/sdk/metrics/state/metric_collector.h
+++ b/sdk/include/opentelemetry/sdk/metrics/state/metric_collector.h
@@ -53,7 +53,7 @@ public:
    *
    * @return a status of completion of method.
    */
-  bool Collect(nostd::function_ref<bool(ResourceMetrics &metric_data)> callback) noexcept override;
+  Result Produce() noexcept override;
 
   bool ForceFlush(std::chrono::microseconds timeout = (std::chrono::microseconds::max)()) noexcept;
 

--- a/sdk/test/metrics/metric_reader_test.cc
+++ b/sdk/test/metrics/metric_reader_test.cc
@@ -25,5 +25,5 @@ TEST(MetricReaderTest, BasicTests)
   std::shared_ptr<MeterContext> meter_context2(new MeterContext());
   std::shared_ptr<MetricProducer> metric_producer{
       new MetricCollector(meter_context2.get(), std::move(metric_reader2))};
-  metric_producer->Collect([](ResourceMetrics & /* metric_data */) { return true; });
+  metric_producer->Produce();
 }

--- a/sdk/test/metrics/periodic_exporting_metric_reader_test.cc
+++ b/sdk/test/metrics/periodic_exporting_metric_reader_test.cc
@@ -54,13 +54,12 @@ public:
       : sleep_ms_{sleep_ms}
   {}
 
-  bool Collect(nostd::function_ref<bool(ResourceMetrics &)> callback) noexcept override
+  MetricProducer::Result Produce() noexcept override
   {
     std::this_thread::sleep_for(sleep_ms_);
     data_sent_size_++;
     ResourceMetrics data;
-    callback(data);
-    return true;
+    return {data, MetricProducer::Status::kSuccess};
   }
 
   size_t GetDataCount() { return data_sent_size_; }


### PR DESCRIPTION
Following https://github.com/open-telemetry/opentelemetry-specification/blob/v1.36.0/specification/metrics/sdk.md#metricproducer.

Updates #1831

## Changes

Updates `MetricProducer` to return a batch of metric points instead of receiving a callback.

* According to the spec, `Produce` SHOULD also take a Resource parameter, but I have chosen not to do that (because existing implementations pull the resource from the metric context). I'm not familiar with this area so I'd appreciate any advice.

* `MetricFilter` support isn't stable yet so I've kept it out of this initial PR.

For significant contributions please make sure you have completed the following items:

* [ ] `CHANGELOG.md` updated for non-trivial changes
* [ ] Unit tests have been added
* [ ] Changes in public API reviewed