### PR TITLE
Fix overflow in timeout logic

### DIFF
--- a/sdk/src/metrics/export/periodic_exporting_metric_reader.cc
+++ b/sdk/src/metrics/export/periodic_exporting_metric_reader.cc
@@ -218,7 +218,7 @@ bool PeriodicExportingMetricReader::OnForceFlush(std::chrono::microseconds timeo
     // - If original `timeout` is `zero`, use that in exporter::forceflush
     // - Else if remaining `timeout_steady` more than zero, use that in exporter::forceflush
     // - Else don't invoke exporter::forceflush ( as remaining time is zero or less)
-    if (timeout <= std::chrono::steady_clock::duration::zero())
+    if (timeout <= std::chrono::milliseconds::duration::zero())
     {
       result =
           exporter_->ForceFlush(std::chrono::duration_cast<std::chrono::microseconds>(timeout));


### PR DESCRIPTION
Also use steady clock consistently.

Prior to this change, the test would fail under ASAN:

```
$ bazel test --config=asan --test_output=errors //sdk/test/metrics:meter_provider_sdk_test
INFO: Analyzed target //sdk/test/metrics:meter_provider_sdk_test (0 packages loaded, 0 targets configured).
FAIL: //sdk/test/metrics:meter_provider_sdk_test (see /private/var/tmp/_bazel_punya/e3bd968ba61238cdeb1a5537fc3dbf7d/execroot/_main/bazel-out/darwin_arm64-fastbuild-asan/testlogs/sdk/test/metrics/meter_provider_sdk_test/test.log)
INFO: From Testing //sdk/test/metrics:meter_provider_sdk_test:
==================== Test output for //sdk/test/metrics:meter_provider_sdk_test:
Running main() from gmock_main.cc
[==========] Running 1 test from 1 test suite.
[----------] Global test environment set-up.
[----------] 1 test from MeterProvider
[ RUN      ] MeterProvider.GetMeter
[Warning] File: sdk/src/metrics/meter_provider.cc:65 [MeterProvider::GetMeter] Library name is empty.
[Warning] File: sdk/src/metrics/meter_provider.cc:65 [MeterProvider::GetMeter] Library name is empty.
/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/include/c++/v1/__chrono/duration.h:102:59: runtime error: signed integer overflow: 9221646818050376183 * 1000 cannot be represented in type '_Ct' (aka 'long long')
SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior /Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/include/c++/v1/__chrono/duration.h:102:59 in 
================================================================================
INFO: Found 1 test target...
Target //sdk/test/metrics:meter_provider_sdk_test up-to-date:
  bazel-bin/sdk/test/metrics/meter_provider_sdk_test
INFO: Elapsed time: 2.251s, Critical Path: 2.13s
INFO: 5 processes: 5 darwin-sandbox.
INFO: Build completed, 1 test FAILED, 5 total actions
//sdk/test/metrics:meter_provider_sdk_test                               FAILED in 0.6s
  /private/var/tmp/_bazel_punya/e3bd968ba61238cdeb1a5537fc3dbf7d/execroot/_main/bazel-out/darwin_arm64-fastbuild-asan/testlogs/sdk/test/metrics/meter_provider_sdk_test/test.log

Executed 1 out of 1 test: 1 fails locally.
```