### PR TITLE
[EXAMPLE] update collector example with debug exporter

### DIFF
--- a/examples/otlp/opentelemetry-collector-config/config.dev.yaml
+++ b/examples/otlp/opentelemetry-collector-config/config.dev.yaml
@@ -2,8 +2,8 @@
 # SPDX-License-Identifier: Apache-2.0
 
 exporters:
-  logging:
-    loglevel: DEBUG
+  debug:
+    verbosity: debug
 receivers:
   otlp:
     protocols:
@@ -17,14 +17,14 @@ service:
       receivers:
       - otlp
       exporters:
-      - logging
+      - debug
     logs:
       receivers:
       - otlp
       exporters:
-      - logging
+      - debug
     metrics:
       receivers:
       - otlp
       exporters:
-      - logging
+      - debug


### PR DESCRIPTION
The logging exporter was renamed debug in 2023, the logging exporter will be removed in the near future, updating the example accordingly.
