### PR TITLE
[TEST] update collector example with debug exporter

### DIFF
--- a/functional/otlp/otel-config-http.yaml
+++ b/functional/otlp/otel-config-http.yaml
@@ -22,12 +22,12 @@ processors:
     check_interval: 5s
 
 exporters:
-  logging:
-    loglevel: debug
+  debug:
+    verbosity: debug
 
 service:
   pipelines:
     traces:
       receivers: [otlp]
       processors: [memory_limiter, batch]
-      exporters: [logging]
+      exporters: [debug]


### PR DESCRIPTION
The logging exporter was renamed debug in 2023, the logging exporter will be removed in the near future, updating the example accordingly.
