### PR TITLE
[BUILD] add loongarch info

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -77,6 +77,8 @@ else()
     set(ARCH s390x)
   elseif(CMAKE_SYSTEM_PROCESSOR MATCHES "^(sparc.*|SPARC.*)")
     set(ARCH sparc)
+  elseif(CMAKE_SYSTEM_PROCESSOR MATCHES "^(loongarch.*|LOONGARCH.*)")
+    set(ARCH loongarch)
   else()
     message(
       FATAL_ERROR


### PR DESCRIPTION
about loongarch： https://docs.kernel.org/arch/loongarch/introduction.html

`
......
     Start 413: exporter.OstreamLogExporter.DefaultLogRecordToCout
413/421 Test #413: exporter.OstreamLogExporter.DefaultLogRecordToCout ...................................................   Passed    0.00 sec
        Start 414: exporter.OStreamLogRecordExporter.SimpleLogToCout
414/421 Test #414: exporter.OStreamLogRecordExporter.SimpleLogToCout ....................................................   Passed    0.00 sec
        Start 415: exporter.OStreamLogRecordExporter.LogWithStringAttributesToCerr
415/421 Test #415: exporter.OStreamLogRecordExporter.LogWithStringAttributesToCerr ......................................   Passed    0.00 sec
        Start 416: exporter.OStreamLogRecordExporter.LogWithVariantTypesToClog
416/421 Test #416: exporter.OStreamLogRecordExporter.LogWithVariantTypesToClog ..........................................   Passed    0.00 sec
        Start 417: exporter.OStreamLogRecordExporter.IntegrationTest
417/421 Test #417: exporter.OStreamLogRecordExporter.IntegrationTest ....................................................   Passed    0.00 sec
        Start 418: exporter.OStreamLogRecordExporter.IntegrationTestWithEventId
418/421 Test #418: exporter.OStreamLogRecordExporter.IntegrationTestWithEventId .........................................   Passed    0.00 sec
        Start 419: exporter.OStreamLogRecordExporter.Factory
419/421 Test #419: exporter.OStreamLogRecordExporter.Factory ............................................................   Passed    0.00 sec
        Start 420: exporter.InMemorySpanData.AddRecordable
420/421 Test #420: exporter.InMemorySpanData.AddRecordable ..............................................................   Passed    0.00 sec
        Start 421: exporter.InMemorySpanExporter.ExportBatch
421/421 Test #421: exporter.InMemorySpanExporter.ExportBatch ............................................................   Passed    0.00 sec

100% tests passed, 0 tests failed out of 421

Total Test time (real) =  11.78 sec

`