### PR TITLE
[TEST] update references to logging exporter

### DIFF
--- a/examples/otlp/opentelemetry-collector-config/config.dev.yaml
+++ b/examples/otlp/opentelemetry-collector-config/config.dev.yaml
@@ -3,7 +3,7 @@
 
 exporters:
   debug:
-    verbosity: debug
+    verbosity: detailed
 receivers:
   otlp:
     protocols:

--- a/functional/otlp/otel-config-http.yaml
+++ b/functional/otlp/otel-config-http.yaml
@@ -23,7 +23,7 @@ processors:
 
 exporters:
   debug:
-    verbosity: debug
+    verbosity: detailed
 
 service:
   pipelines:

--- a/functional/otlp/otel-config-https.yaml
+++ b/functional/otlp/otel-config-https.yaml
@@ -29,12 +29,12 @@ processors:
     check_interval: 5s
 
 exporters:
-  logging:
-    loglevel: debug
+  debug:
+    verbosity: detailed
 
 service:
   pipelines:
     traces:
       receivers: [otlp]
       processors: [memory_limiter, batch]
-      exporters: [logging]
+      exporters: [debug]

--- a/functional/otlp/otel-docker-config-http.yaml
+++ b/functional/otlp/otel-docker-config-http.yaml
@@ -21,12 +21,12 @@ processors:
     check_interval: 5s
 
 exporters:
-  logging:
-    loglevel: debug
+  debug:
+    verbosity: detailed
 
 service:
   pipelines:
     traces:
       receivers: [otlp]
       processors: [memory_limiter, batch]
-      exporters: [logging]
+      exporters: [debug]

--- a/functional/otlp/otel-docker-config-https.yaml
+++ b/functional/otlp/otel-docker-config-https.yaml
@@ -28,12 +28,12 @@ processors:
     check_interval: 5s
 
 exporters:
-  logging:
-    loglevel: debug
+  debug:
+    verbosity: detailed
 
 service:
   pipelines:
     traces:
       receivers: [otlp]
       processors: [memory_limiter, batch]
-      exporters: [logging]
+      exporters: [debug]


### PR DESCRIPTION
## Changes

Missed some references in yesterday's PR and updated the verbosity to `detailed` where it was missed. This exporter has been replaced by the debug exporter and will be removed soon

Related to https://github.com/open-telemetry/opentelemetry-collector/pull/11037
