### PR TITLE
[EXPORTER] Add HttpHeaders in ElasticsearchLogRecordExporter

### DIFF
--- a/exporters/elasticsearch/include/opentelemetry/exporters/elasticsearch/es_log_record_exporter.h
+++ b/exporters/elasticsearch/include/opentelemetry/exporters/elasticsearch/es_log_record_exporter.h
@@ -26,6 +26,8 @@ namespace logs
  */
 struct ElasticsearchExporterOptions
 {
+  using HttpHeaders = std::multimap<std::string, std::string>;
+
   // Configuration options to establish Elasticsearch connection
   std::string host_;
   int port_;
@@ -37,6 +39,9 @@ struct ElasticsearchExporterOptions
   // Whether to print the status of the exporter in the console
   bool console_debug_;
 
+  /** Additional HTTP headers. */
+  HttpHeaders http_headers_;
+
   /**
    * Constructor for the ElasticsearchExporterOptions. By default, the endpoint is
    * localhost:9200/logs with a timeout of 30 seconds and disabled console debugging
@@ -47,16 +52,18 @@ struct ElasticsearchExporterOptions
    * from elasticsearch
    * @param console_debug If true, print the status of the exporter methods in the console
    */
-  ElasticsearchExporterOptions(std::string host     = "localhost",
-                               int port             = 9200,
-                               std::string index    = "logs",
-                               int response_timeout = 30,
-                               bool console_debug   = false)
+  ElasticsearchExporterOptions(std::string host         = "localhost",
+                               int port                 = 9200,
+                               std::string index        = "logs",
+                               int response_timeout     = 30,
+                               bool console_debug       = false,
+                               HttpHeaders http_headers = {})
       : host_{host},
         port_{port},
         index_{index},
         response_timeout_{response_timeout},
-        console_debug_{console_debug}
+        console_debug_{console_debug},
+        http_headers_{http_headers}
   {}
 };
 

--- a/exporters/elasticsearch/src/es_log_record_exporter.cc
+++ b/exporters/elasticsearch/src/es_log_record_exporter.cc
@@ -330,6 +330,13 @@ sdk::common::ExportResult ElasticsearchLogRecordExporter::Export(
   request->SetUri(options_.index_ + "/_bulk?pretty");
   request->SetMethod(http_client::Method::Post);
   request->AddHeader("Content-Type", "application/json");
+
+  // Add options headers
+  for (auto it = options_.http_headers_.cbegin(); it != options_.http_headers_.cend(); ++it)
+  {
+    request->AddHeader(it->first, it->second);
+  }
+
   request->SetTimeoutMs(std::chrono::milliseconds(1000 * options_.response_timeout_));
 
   // Create the request body


### PR DESCRIPTION
Fixes #3080 

When using the `ElasticsearchLogRecordExporter` we might need to add some http headers (auth or other required headers by our server). As of today there was no way of doing it for this exporter.

This PR aims to add this feature.

## Changes

Like for the HttpLogRecordExporter, add the possibility to give custom http headers that will be added to each request. This is done by adding a `std::multimap` in which headers are added and then parsed when the request is being sent.