### PR TITLE
[BUILD] Avoid buggy "should be explicitly initialized in the copy constructor" warning with gcc <= 8

### DIFF
--- a/api/include/opentelemetry/trace/default_span.h
+++ b/api/include/opentelemetry/trace/default_span.h
@@ -66,8 +66,8 @@ public:
   DefaultSpan(SpanContext span_context) noexcept : span_context_(span_context) {}
 
   // movable and copiable
-  DefaultSpan(DefaultSpan &&spn) noexcept : span_context_(spn.GetContext()) {}
-  DefaultSpan(const DefaultSpan &spn) noexcept : span_context_(spn.GetContext()) {}
+  DefaultSpan(DefaultSpan &&spn) noexcept : Span(), span_context_(spn.GetContext()) {}
+  DefaultSpan(const DefaultSpan &spn) noexcept : Span(), span_context_(spn.GetContext()) {}
 
 private:
   SpanContext span_context_;


### PR DESCRIPTION
gcc <= 8, when building with -Wextra (and -Werror) wrongly raises this:

```
/data/mwrep/res/mdw/SIOTF/internal/opentelemetry_cpp/trace/18-0-0-7/include/opentelemetry/trace/default_span.h: In copy constructor 'opentelemetry::v1::trace::DefaultSpan::DefaultSpan(const opentelemetry::v1::trace::DefaultSpan&)':
/data/mwrep/res/mdw/SIOTF/internal/opentelemetry_cpp/trace/18-0-0-7/include/opentelemetry/trace/default_span.h:70:3: error: base class 'class opentelemetry::v1::trace::Span' should be explicitly initialized in the copy constructor [-Werror=extra]
   DefaultSpan(const DefaultSpan &spn) noexcept : span_context_(spn.GetContext()) {}
   ^~~~~~~~~~~
```

See on Compiler Explorer here: https://godbolt.org/z/ed5rv74nT

I believe Jason Merrill fixed it in gcc for all gcc >= 9 with: https://gcc.gnu.org/git/?p=gcc.git;a=commitdiff;h=f3f7cefecc833b4ab652215ceb8b408c21dca225;hp=777083bb806dbe31ab97002b7d445191d3ee7a2d

Workaround this by calling explicitly the empty Span constructor.