### PR TITLE
[BUILD] Fix compiling problems for gcc 4.8

### DIFF
--- a/exporters/memory/src/in_memory_metric_data.cc
+++ b/exporters/memory/src/in_memory_metric_data.cc
@@ -31,7 +31,8 @@ void SimpleAggregateInMemoryMetricData::Add(std::unique_ptr<ResourceMetrics> res
       const auto &metric = m.instrument_descriptor.name_;
       for (const auto &pda : m.point_data_attr_)
       {
-        data_[{scope, metric}].insert({pda.attributes, pda.point_data});
+        data_[std::tuple<std::string, std::string>{scope, metric}].insert(
+            {pda.attributes, pda.point_data});
       }
     }
   }
@@ -41,7 +42,7 @@ const SimpleAggregateInMemoryMetricData::AttributeToPoint &SimpleAggregateInMemo
     const std::string &scope,
     const std::string &metric)
 {
-  return data_[{scope, metric}];
+  return data_[std::tuple<std::string, std::string>{scope, metric}];
 }
 
 void SimpleAggregateInMemoryMetricData::Clear()

--- a/exporters/memory/src/in_memory_metric_data.cc
+++ b/exporters/memory/src/in_memory_metric_data.cc
@@ -31,6 +31,7 @@ void SimpleAggregateInMemoryMetricData::Add(std::unique_ptr<ResourceMetrics> res
       const auto &metric = m.instrument_descriptor.name_;
       for (const auto &pda : m.point_data_attr_)
       {
+        // NOTE: Explicit type conversion added for C++11 (gcc 4.8)
         data_[std::tuple<std::string, std::string>{scope, metric}].insert(
             {pda.attributes, pda.point_data});
       }
@@ -42,6 +43,7 @@ const SimpleAggregateInMemoryMetricData::AttributeToPoint &SimpleAggregateInMemo
     const std::string &scope,
     const std::string &metric)
 {
+  // NOTE: Explicit type conversion added for C++11 (gcc 4.8)
   return data_[std::tuple<std::string, std::string>{scope, metric}];
 }
 

--- a/exporters/memory/src/in_memory_metric_exporter_factory.cc
+++ b/exporters/memory/src/in_memory_metric_exporter_factory.cc
@@ -78,7 +78,8 @@ private:
 std::unique_ptr<PushMetricExporter> InMemoryMetricExporterFactory::Create(
     const std::shared_ptr<InMemoryMetricData> &data)
 {
-  return Create(data, [](auto) { return AggregationTemporality::kCumulative; });
+  return Create(data,
+                [](sdk::metrics::InstrumentType) { return AggregationTemporality::kCumulative; });
 }
 
 std::unique_ptr<PushMetricExporter> InMemoryMetricExporterFactory::Create(


### PR DESCRIPTION
Fixes #3099

## Changes

Fix remaining issues preventing a C++11 build with gcc 4.8.

For significant contributions please make sure you have completed the following items:

* [ ] `CHANGELOG.md` updated for non-trivial changes
* [ ] Unit tests have been added
* [ ] Changes in public API reviewed