### PR TITLE
[EXPORTER] Add config options to prometheus exporter

### DIFF
--- a/exporters/prometheus/include/opentelemetry/exporters/prometheus/exporter_options.h
+++ b/exporters/prometheus/include/opentelemetry/exporters/prometheus/exporter_options.h
@@ -28,6 +28,12 @@ struct PrometheusExporterOptions
 
   // Populating otel_scope_name/otel_scope_labels attributes
   bool without_otel_scope = false;
+
+  // Option to export metrics without the unit suffix
+  bool without_units = false;
+
+  // Option to export metrics without the type suffix
+  bool without_type_suffix = false;
 };
 
 }  // namespace metrics

--- a/exporters/prometheus/include/opentelemetry/exporters/prometheus/exporter_utils.h
+++ b/exporters/prometheus/include/opentelemetry/exporters/prometheus/exporter_utils.h
@@ -40,7 +40,7 @@ public:
       const sdk::metrics::ResourceMetrics &data,
       bool populate_target_info = true,
       bool without_otel_scope   = false,
-      bool without_units  = false,
+      bool without_units        = false,
       bool without_type_suffix  = false);
 
 private:

--- a/exporters/prometheus/include/opentelemetry/exporters/prometheus/exporter_utils.h
+++ b/exporters/prometheus/include/opentelemetry/exporters/prometheus/exporter_utils.h
@@ -30,12 +30,18 @@ public:
    * @param populate_target_info whether to populate target_info
    * @param without_otel_scope whether to populate otel_scope_name and otel_scope_version
    * attributes
+   * @param without_units exporter configuration controlling whether to append unit suffix in
+   * the exported metrics.
+   * @param without_type_suffix exporter configuration controlling whether to append type suffix in
+   * the exported metrics.
    * @return a collection of translated metrics that is acceptable by Prometheus
    */
   static std::vector<::prometheus::MetricFamily> TranslateToPrometheus(
       const sdk::metrics::ResourceMetrics &data,
       bool populate_target_info = true,
-      bool without_otel_scope   = false);
+      bool without_otel_scope   = false,
+      bool without_units  = false,
+      bool without_type_suffix  = false);
 
 private:
   /**
@@ -61,7 +67,9 @@ private:
 
   static std::string MapToPrometheusName(const std::string &name,
                                          const std::string &unit,
-                                         ::prometheus::MetricType prometheus_type);
+                                         ::prometheus::MetricType prometheus_type,
+                                         bool without_units,
+                                         bool without_type_suffix);
 
   /**
    * A utility function that returns the equivalent Prometheus name for the provided OTLP metric

--- a/exporters/prometheus/src/exporter_options.cc
+++ b/exporters/prometheus/src/exporter_options.cc
@@ -50,8 +50,7 @@ inline bool GetPrometheusPopulateTargetInfo()
 
 inline bool GetPrometheusWithoutUnits()
 {
-  constexpr char kPrometheusWithoutUnits[] =
-      "OTEL_CPP_PROMETHEUS_EXPORTER_WITHOUT_UNITS";
+  constexpr char kPrometheusWithoutUnits[] = "OTEL_CPP_PROMETHEUS_EXPORTER_WITHOUT_UNITS";
   bool setting;
   const auto exists =
       opentelemetry::sdk::common::GetBoolEnvironmentVariable(kPrometheusWithoutUnits, setting);

--- a/exporters/prometheus/src/exporter_options.cc
+++ b/exporters/prometheus/src/exporter_options.cc
@@ -48,10 +48,34 @@ inline bool GetPrometheusPopulateTargetInfo()
   return exists ? setting : true;
 }
 
+inline bool GetPrometheusWithoutUnits()
+{
+  constexpr char kPrometheusWithoutUnits[] =
+      "OTEL_CPP_PROMETHEUS_EXPORTER_WITHOUT_UNITS";
+  bool setting;
+  const auto exists =
+      opentelemetry::sdk::common::GetBoolEnvironmentVariable(kPrometheusWithoutUnits, setting);
+
+  return exists ? setting : false;
+}
+
+inline bool GetPrometheusWithoutTypeSuffix()
+{
+  constexpr char kPrometheusWithoutTypeSuffix[] =
+      "OTEL_CPP_PROMETHEUS_EXPORTER_WITHOUT_TYPE_SUFFIX";
+  bool setting;
+  const auto exists =
+      opentelemetry::sdk::common::GetBoolEnvironmentVariable(kPrometheusWithoutTypeSuffix, setting);
+
+  return exists ? setting : false;
+}
+
 PrometheusExporterOptions::PrometheusExporterOptions()
     : url(GetPrometheusDefaultHttpEndpoint()),
       populate_target_info(GetPrometheusPopulateTargetInfo()),
-      without_otel_scope(GetPrometheusWithoutOtelScope())
+      without_otel_scope(GetPrometheusWithoutOtelScope()),
+      without_units(GetPrometheusWithoutUnits()),
+      without_type_suffix(GetPrometheusWithoutTypeSuffix())
 {}
 
 }  // namespace metrics

--- a/exporters/prometheus/src/exporter_utils.cc
+++ b/exporters/prometheus/src/exporter_utils.cc
@@ -154,7 +154,6 @@ std::vector<prometheus_client::MetricFamily> PrometheusExporterUtils::TranslateT
       metric_family.name = MapToPrometheusName(metric_data.instrument_descriptor.name_,
                                                metric_data.instrument_descriptor.unit_, type,
                                                without_units, without_type_suffix);
-      // TODO (psx95): Add tests to check compliance
       metric_family.type = type;
       const opentelemetry::sdk::instrumentationscope::InstrumentationScope *scope =
           without_otel_scope ? nullptr : instrumentation_info.scope_;
@@ -500,12 +499,13 @@ std::string PrometheusExporterUtils::MapToPrometheusName(
     bool without_units,
     bool without_type_suffix)
 {
-  auto sanitized_name                    = SanitizeNames(name);
+  auto sanitized_name = SanitizeNames(name);
   std::string prometheus_equivalent_unit;
   if (without_units)
   {
     prometheus_equivalent_unit = "";
-  } else
+  }
+  else
   {
     prometheus_equivalent_unit = GetEquivalentPrometheusUnit(unit);
   }

--- a/exporters/prometheus/src/exporter_utils.cc
+++ b/exporters/prometheus/src/exporter_utils.cc
@@ -530,8 +530,9 @@ std::string PrometheusExporterUtils::MapToPrometheusName(
 
   // Special case - gauge
   if (unit == "1" && prometheus_type == prometheus_client::MetricType::Gauge &&
-      sanitized_name.find("ratio") == std::string::npos && !without_type_suffix)
+      sanitized_name.find("ratio") == std::string::npos && !without_units)
   {
+    // this is replacing the unit name
     sanitized_name += "_ratio";
   }
 

--- a/exporters/prometheus/test/exporter_utils_test.cc
+++ b/exporters/prometheus/test/exporter_utils_test.cc
@@ -56,7 +56,7 @@ public:
                                          const std::string &unit,
                                          prometheus_client::MetricType prometheus_type)
   {
-    return PrometheusExporterUtils::MapToPrometheusName(name, unit, prometheus_type);
+    return PrometheusExporterUtils::MapToPrometheusName(name, unit, prometheus_type, false, false);
   }
 };
 }  // namespace metrics


### PR DESCRIPTION
Fixes #2453 

## Changes

Added the following optional configuration options (booleans) to the prometheus exporter:
 - `without_units` : controls whether to add unit suffixes (e.g. `_seconds`) to the metric names.
 - `without_type_suffix`: controls whether to add type suffixes (e.g. `_total`) to the metric names.

* [ ] `CHANGELOG.md` updated for non-trivial changes
* [X] Unit tests have been added
* [ ] Changes in public API reviewed