### PR TITLE
[BUILD] Remove aligned_storage from nostd

### DIFF
--- a/api/include/opentelemetry/nostd/internal/absl/meta/type_traits.h
+++ b/api/include/opentelemetry/nostd/internal/absl/meta/type_traits.h
@@ -106,18 +106,6 @@ struct VoidTImpl {
   using type = void;
 };
 
-// This trick to retrieve a default alignment is necessary for our
-// implementation of aligned_storage_t to be consistent with any implementation
-// of std::aligned_storage.
-template <size_t Len, typename T = std::aligned_storage<Len>>
-struct default_alignment_of_aligned_storage;
-
-template <size_t Len, size_t Align>
-struct default_alignment_of_aligned_storage<Len,
-                                            std::aligned_storage<Len, Align>> {
-  static constexpr size_t value = Align;
-};
-
 ////////////////////////////////
 // Library Fundamentals V2 TS //
 ////////////////////////////////
@@ -618,10 +606,6 @@ using remove_extent_t = typename std::remove_extent<T>::type;
 
 template <typename T>
 using remove_all_extents_t = typename std::remove_all_extents<T>::type;
-
-template <size_t Len, size_t Align = type_traits_internal::
-                          default_alignment_of_aligned_storage<Len>::value>
-using aligned_storage_t = typename std::aligned_storage<Len, Align>::type;
 
 template <typename T>
 using decay_t = typename std::decay<T>::type;


### PR DESCRIPTION
Fixes #3111

## Changes

Removes `absl::aligned_storage`, which uses `std::aligned_storage`, which was deprecated in C++23.

Abseil removed its `aligned_storage` in https://github.com/abseil/abseil-cpp/commit/42133464db0ae5383fef723067835ef768b849f8
