### PR TITLE
[EXPORTER] Log SSL Connection Information

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -215,7 +215,8 @@ option(
   "Whether to include gzip compression for the OTLP http exporter in the SDK"
   OFF)
 
-option(WITH_CURL_LOGGING "Whether to enable select CURL verbosity in OTel logs" OFF)
+option(WITH_CURL_LOGGING "Whether to enable select CURL verbosity in OTel logs"
+       OFF)
 
 option(WITH_ZIPKIN "Whether to include the Zipkin exporter in the SDK" OFF)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -215,6 +215,8 @@ option(
   "Whether to include gzip compression for the OTLP http exporter in the SDK"
   OFF)
 
+option(WITH_CURL_LOGGING "Whether to enable select CURL verbosity in OTel logs" OFF)
+
 option(WITH_ZIPKIN "Whether to include the Zipkin exporter in the SDK" OFF)
 
 option(WITH_PROMETHEUS "Whether to include the Prometheus Client in the SDK"

--- a/exporters/otlp/src/otlp_http_client.cc
+++ b/exporters/otlp/src/otlp_http_client.cc
@@ -989,6 +989,7 @@ OtlpHttpClient::createSession(
   request->SetBody(body_vec);
   request->ReplaceHeader("Content-Type", content_type);
   request->ReplaceHeader("User-Agent", options_.user_agent);
+  request->EnableLogging(options_.console_debug);
 
   if (options_.compression == "gzip")
   {

--- a/ext/include/opentelemetry/ext/http/client/curl/http_client_curl.h
+++ b/ext/include/opentelemetry/ext/http/client/curl/http_client_curl.h
@@ -102,7 +102,7 @@ public:
     compression_ = compression;
   }
 
-  void EnableLogging(bool needs_to_log) noexcept override { needs_to_log_ = needs_to_log; };
+  void EnableLogging(bool needs_to_log) noexcept override { needs_to_log_ = needs_to_log; }
 
 public:
   opentelemetry::ext::http::client::Method method_;

--- a/ext/include/opentelemetry/ext/http/client/curl/http_client_curl.h
+++ b/ext/include/opentelemetry/ext/http/client/curl/http_client_curl.h
@@ -102,7 +102,7 @@ public:
     compression_ = compression;
   }
 
-  void EnableLogging(bool needs_to_log) noexcept override { needs_to_log_ = needs_to_log; }
+  void EnableLogging(bool is_log_enabled) noexcept override { is_log_enabled_ = is_log_enabled; }
 
 public:
   opentelemetry::ext::http::client::Method method_;
@@ -113,7 +113,7 @@ public:
   std::chrono::milliseconds timeout_ms_{5000};  // ms
   opentelemetry::ext::http::client::Compression compression_{
       opentelemetry::ext::http::client::Compression::kNone};
-  bool needs_to_log_{false};
+  bool is_log_enabled_{false};
 };
 
 class Response : public opentelemetry::ext::http::client::Response

--- a/ext/include/opentelemetry/ext/http/client/curl/http_client_curl.h
+++ b/ext/include/opentelemetry/ext/http/client/curl/http_client_curl.h
@@ -102,6 +102,8 @@ public:
     compression_ = compression;
   }
 
+  void EnableLogging(bool needs_to_log) noexcept override { needs_to_log_ = needs_to_log; };
+
 public:
   opentelemetry::ext::http::client::Method method_;
   opentelemetry::ext::http::client::HttpSslOptions ssl_options_;
@@ -111,6 +113,7 @@ public:
   std::chrono::milliseconds timeout_ms_{5000};  // ms
   opentelemetry::ext::http::client::Compression compression_{
       opentelemetry::ext::http::client::Compression::kNone};
+  bool needs_to_log_{false};
 };
 
 class Response : public opentelemetry::ext::http::client::Response

--- a/ext/include/opentelemetry/ext/http/client/curl/http_operation_curl.h
+++ b/ext/include/opentelemetry/ext/http/client/curl/http_operation_curl.h
@@ -159,7 +159,7 @@ public:
                 bool is_raw_response                        = false,
                 std::chrono::milliseconds http_conn_timeout = default_http_conn_timeout,
                 bool reuse_connection                       = false,
-                bool needs_to_log                           = false);
+                bool is_log_enabled                         = false);
 
   /**
    * Destroy CURL instance
@@ -307,7 +307,7 @@ private:
 
   const opentelemetry::ext::http::client::Compression &compression_;
 
-  const bool needs_to_log_;
+  const bool is_log_enabled_;
 
   // Processed response headers and body
   long response_code_;

--- a/ext/include/opentelemetry/ext/http/client/curl/http_operation_curl.h
+++ b/ext/include/opentelemetry/ext/http/client/curl/http_operation_curl.h
@@ -102,6 +102,12 @@ private:
 
   static size_t ReadMemoryCallback(char *buffer, size_t size, size_t nitems, void *userp);
 
+  static int CurlLoggerCallback(const CURL * /* handle */,
+                                curl_infotype type,
+                                const char *data,
+                                size_t size,
+                                void * /* clientp */) noexcept;
+
 #if LIBCURL_VERSION_NUM >= 0x075000
   static int PreRequestCallback(void *clientp,
                                 char *conn_primary_ip,

--- a/ext/include/opentelemetry/ext/http/client/curl/http_operation_curl.h
+++ b/ext/include/opentelemetry/ext/http/client/curl/http_operation_curl.h
@@ -158,7 +158,8 @@ public:
                 // Default connectivity and response size options
                 bool is_raw_response                        = false,
                 std::chrono::milliseconds http_conn_timeout = default_http_conn_timeout,
-                bool reuse_connection                       = false);
+                bool reuse_connection                       = false,
+                bool needs_to_log_                          = false);
 
   /**
    * Destroy CURL instance
@@ -305,6 +306,8 @@ private:
   opentelemetry::ext::http::client::SessionState session_state_;
 
   const opentelemetry::ext::http::client::Compression &compression_;
+
+  const bool needs_to_log_;
 
   // Processed response headers and body
   long response_code_;

--- a/ext/include/opentelemetry/ext/http/client/curl/http_operation_curl.h
+++ b/ext/include/opentelemetry/ext/http/client/curl/http_operation_curl.h
@@ -159,7 +159,7 @@ public:
                 bool is_raw_response                        = false,
                 std::chrono::milliseconds http_conn_timeout = default_http_conn_timeout,
                 bool reuse_connection                       = false,
-                bool needs_to_log_                          = false);
+                bool needs_to_log                           = false);
 
   /**
    * Destroy CURL instance

--- a/ext/include/opentelemetry/ext/http/client/http_client.h
+++ b/ext/include/opentelemetry/ext/http/client/http_client.h
@@ -245,6 +245,8 @@ public:
 
   virtual void SetCompression(const Compression &compression) noexcept = 0;
 
+  virtual void EnableLogging(bool needs_to_log) noexcept = 0;
+
   virtual ~Request() = default;
 };
 

--- a/ext/include/opentelemetry/ext/http/client/http_client.h
+++ b/ext/include/opentelemetry/ext/http/client/http_client.h
@@ -245,7 +245,7 @@ public:
 
   virtual void SetCompression(const Compression &compression) noexcept = 0;
 
-  virtual void EnableLogging(bool needs_to_log) noexcept = 0;
+  virtual void EnableLogging(bool is_log_enabled) noexcept = 0;
 
   virtual ~Request() = default;
 };

--- a/ext/src/http/client/curl/CMakeLists.txt
+++ b/ext/src/http/client/curl/CMakeLists.txt
@@ -24,6 +24,11 @@ else()
     PRIVATE ${CURL_LIBRARIES})
 endif()
 
+if(WITH_CURL_LOGGING)
+  target_compile_definitions(opentelemetry_http_client_curl
+                             PRIVATE ENABLE_CURL_LOGGING)
+endif()
+
 if(WITH_OTLP_HTTP_COMPRESSION)
   if(TARGET ZLIB::ZLIB)
     target_link_libraries(

--- a/ext/src/http/client/curl/http_client_curl.cc
+++ b/ext/src/http/client/curl/http_client_curl.cc
@@ -116,10 +116,10 @@ void Session::SendRequest(
 #endif
   }
 
-  curl_operation_.reset(new HttpOperation(http_request_->method_, url, http_request_->ssl_options_,
-                                          callback_ptr, http_request_->headers_,
-                                          http_request_->body_, http_request_->compression_, false,
-                                          http_request_->timeout_ms_, reuse_connection));
+  curl_operation_.reset(new HttpOperation(
+      http_request_->method_, url, http_request_->ssl_options_, callback_ptr,
+      http_request_->headers_, http_request_->body_, http_request_->compression_, false,
+      http_request_->timeout_ms_, reuse_connection, http_request_->needs_to_log_));
   bool success =
       CURLE_OK == curl_operation_->SendAsync(this, [this, callback](HttpOperation &operation) {
         if (operation.WasAborted())

--- a/ext/src/http/client/curl/http_client_curl.cc
+++ b/ext/src/http/client/curl/http_client_curl.cc
@@ -119,7 +119,7 @@ void Session::SendRequest(
   curl_operation_.reset(new HttpOperation(
       http_request_->method_, url, http_request_->ssl_options_, callback_ptr,
       http_request_->headers_, http_request_->body_, http_request_->compression_, false,
-      http_request_->timeout_ms_, reuse_connection, http_request_->needs_to_log_));
+      http_request_->timeout_ms_, reuse_connection, http_request_->is_log_enabled_));
   bool success =
       CURLE_OK == curl_operation_->SendAsync(this, [this, callback](HttpOperation &operation) {
         if (operation.WasAborted())

--- a/ext/src/http/client/curl/http_operation_curl.cc
+++ b/ext/src/http/client/curl/http_operation_curl.cc
@@ -263,7 +263,7 @@ HttpOperation::HttpOperation(opentelemetry::ext::http::client::Method method,
                              bool is_raw_response,
                              std::chrono::milliseconds http_conn_timeout,
                              bool reuse_connection,
-                             bool needs_to_log)
+                             bool is_log_enabled)
     : is_aborted_(false),
       is_finished_(false),
       is_cleaned_(false),
@@ -283,7 +283,7 @@ HttpOperation::HttpOperation(opentelemetry::ext::http::client::Method method,
       request_nwrite_(0),
       session_state_(opentelemetry::ext::http::client::SessionState::Created),
       compression_(compression),
-      needs_to_log_(needs_to_log),
+      is_log_enabled_(is_log_enabled),
       response_code_(0)
 {
   /* get a curl handle */
@@ -658,7 +658,7 @@ CURLcode HttpOperation::Setup()
     return rc;
   }
 #else
-  rc = SetCurlLongOption(CURLOPT_VERBOSE, static_cast<long>(needs_to_log_ || kEnableCurlLogging));
+  rc = SetCurlLongOption(CURLOPT_VERBOSE, static_cast<long>(is_log_enabled_ || kEnableCurlLogging));
   if (rc != CURLE_OK)
   {
     return rc;

--- a/ext/src/http/client/curl/http_operation_curl.cc
+++ b/ext/src/http/client/curl/http_operation_curl.cc
@@ -598,6 +598,8 @@ int HttpOperation::CurlLoggerCallback(const CURL * /* handle */,
     {
       OTEL_INTERNAL_LOG_ERROR(text_to_log);
     }
+// This guard serves as a catch-all block for all other less interesting output that should
+// remain available for maintainer internal use and for debugging purposes only.
 #ifdef CURL_DEBUG
     else
     {
@@ -605,6 +607,8 @@ int HttpOperation::CurlLoggerCallback(const CURL * /* handle */,
     }
 #endif  // CURL_DEBUG
   }
+// Same as above, this guard is meant only for internal use by maintainers, and should not be used
+// in production (information leak).
 #ifdef CURL_DEBUG
   else if (type == CURLINFO_HEADER_OUT)
   {
@@ -658,7 +662,7 @@ CURLcode HttpOperation::Setup()
     return rc;
   }
 #else
-  rc = SetCurlLongOption(CURLOPT_VERBOSE, static_cast<long>(is_log_enabled_ || kEnableCurlLogging));
+  rc = SetCurlLongOption(CURLOPT_VERBOSE, (is_log_enabled_ && kEnableCurlLogging) ? 1L : 0L);
   if (rc != CURLE_OK)
   {
     return rc;

--- a/ext/src/http/client/curl/http_operation_curl.cc
+++ b/ext/src/http/client/curl/http_operation_curl.cc
@@ -600,16 +600,16 @@ int HttpOperation::CurlLoggerCallback(const CURL * /* handle */,
     }
 // This guard serves as a catch-all block for all other less interesting output that should
 // remain available for maintainer internal use and for debugging purposes only.
-#ifdef CURL_DEBUG
+#ifdef OTEL_CURL_DEBUG
     else
     {
       OTEL_INTERNAL_LOG_DEBUG(text_to_log);
     }
-#endif  // CURL_DEBUG
+#endif  // OTEL_CURL_DEBUG
   }
 // Same as above, this guard is meant only for internal use by maintainers, and should not be used
 // in production (information leak).
-#ifdef CURL_DEBUG
+#ifdef OTEL_CURL_DEBUG
   else if (type == CURLINFO_HEADER_OUT)
   {
     static const auto kHeaderSent = nostd::string_view("Send header => ");
@@ -630,7 +630,7 @@ int HttpOperation::CurlLoggerCallback(const CURL * /* handle */,
     static const auto kHeaderRecv = nostd::string_view("Recv header => ");
     OTEL_INTERNAL_LOG_DEBUG(kHeaderRecv << text_to_log);
   }
-#endif  // CURL_DEBUG
+#endif  // OTEL_CURL_DEBUG
 
   return 0;
 }

--- a/ext/src/http/client/curl/http_operation_curl.cc
+++ b/ext/src/http/client/curl/http_operation_curl.cc
@@ -649,6 +649,15 @@ CURLcode HttpOperation::Setup()
   curl_error_message_[0] = '\0';
   curl_easy_setopt(curl_resource_.easy_handle, CURLOPT_ERRORBUFFER, curl_error_message_);
 
+// Support for custom debug function callback was added in version 7.9.6 so we guard against
+// exposing the default CURL output by keeping verbosity always disabled in lower versions.
+#if LIBCURL_VERSION_NUM < CURL_VERSION_BITS(7, 9, 6)
+  rc = SetCurlLongOption(CURLOPT_VERBOSE, 0L);
+  if (rc != CURLE_OK)
+  {
+    return rc;
+  }
+#else
   rc = SetCurlLongOption(CURLOPT_VERBOSE, static_cast<long>(needs_to_log_ || kEnableCurlLogging));
   if (rc != CURLE_OK)
   {
@@ -661,6 +670,7 @@ CURLcode HttpOperation::Setup()
   {
     return rc;
   }
+#endif
 
   // Specify target URL
   rc = SetCurlStrOption(CURLOPT_URL, url_.c_str());

--- a/ext/src/http/client/curl/http_operation_curl.cc
+++ b/ext/src/http/client/curl/http_operation_curl.cc
@@ -633,6 +633,12 @@ int HttpOperation::CurlLoggerCallback(const CURL * /* handle */,
 
 CURLcode HttpOperation::Setup()
 {
+#ifdef ENABLE_CURL_LOGGING
+  static constexpr auto kEnableCurlLogging = true;
+#else
+  static constexpr auto kEnableCurlLogging = false;
+#endif  // ENABLE_CURL_LOGGING
+
   if (!curl_resource_.easy_handle)
   {
     return CURLE_FAILED_INIT;
@@ -643,7 +649,7 @@ CURLcode HttpOperation::Setup()
   curl_error_message_[0] = '\0';
   curl_easy_setopt(curl_resource_.easy_handle, CURLOPT_ERRORBUFFER, curl_error_message_);
 
-  rc = SetCurlLongOption(CURLOPT_VERBOSE, static_cast<long>(needs_to_log_));
+  rc = SetCurlLongOption(CURLOPT_VERBOSE, static_cast<long>(needs_to_log_ || kEnableCurlLogging));
   if (rc != CURLE_OK)
   {
     return rc;

--- a/ext/src/http/client/curl/http_operation_curl.cc
+++ b/ext/src/http/client/curl/http_operation_curl.cc
@@ -262,7 +262,8 @@ HttpOperation::HttpOperation(opentelemetry::ext::http::client::Method method,
                              // Default connectivity and response size options
                              bool is_raw_response,
                              std::chrono::milliseconds http_conn_timeout,
-                             bool reuse_connection)
+                             bool reuse_connection,
+                             bool needs_to_log)
     : is_aborted_(false),
       is_finished_(false),
       is_cleaned_(false),
@@ -282,6 +283,7 @@ HttpOperation::HttpOperation(opentelemetry::ext::http::client::Method method,
       request_nwrite_(0),
       session_state_(opentelemetry::ext::http::client::SessionState::Created),
       compression_(compression),
+      needs_to_log_(needs_to_log),
       response_code_(0)
 {
   /* get a curl handle */
@@ -641,7 +643,7 @@ CURLcode HttpOperation::Setup()
   curl_error_message_[0] = '\0';
   curl_easy_setopt(curl_resource_.easy_handle, CURLOPT_ERRORBUFFER, curl_error_message_);
 
-  rc = SetCurlLongOption(CURLOPT_VERBOSE, 1L);
+  rc = SetCurlLongOption(CURLOPT_VERBOSE, static_cast<long>(needs_to_log_));
   if (rc != CURLE_OK)
   {
     return rc;

--- a/ext/src/http/client/curl/http_operation_curl.cc
+++ b/ext/src/http/client/curl/http_operation_curl.cc
@@ -578,9 +578,9 @@ int HttpOperation::CurlLoggerCallback(const CURL * /* handle */,
 {
   nostd::string_view text_to_log{data, size};
 
-  if (text_to_log.empty() || std::iscntrl(text_to_log[0]))
+  if (!text_to_log.empty() && text_to_log[size - 1] == '\n')
   {
-    return 0;
+    text_to_log = text_to_log.substr(0, size - 1);
   }
 
   if (type == CURLINFO_TEXT)
@@ -614,7 +614,7 @@ int HttpOperation::CurlLoggerCallback(const CURL * /* handle */,
 
       if (pos != nostd::string_view::npos)
       {
-        OTEL_INTERNAL_LOG_DEBUG(kHeaderSent << text_to_log.substr(0, pos));
+        OTEL_INTERNAL_LOG_DEBUG(kHeaderSent << text_to_log.substr(0, pos - 1));
         text_to_log = text_to_log.substr(pos + 1);
       }
     }

--- a/test_common/include/opentelemetry/test_common/ext/http/client/nosend/http_client_nosend.h
+++ b/test_common/include/opentelemetry/test_common/ext/http/client/nosend/http_client_nosend.h
@@ -69,7 +69,7 @@ public:
     compression_ = compression;
   }
 
-  void EnableLogging(bool needs_to_log) noexcept override { needs_to_log_ = needs_to_log; };
+  void EnableLogging(bool needs_to_log) noexcept override { needs_to_log_ = needs_to_log; }
 
 public:
   opentelemetry::ext::http::client::Method method_;

--- a/test_common/include/opentelemetry/test_common/ext/http/client/nosend/http_client_nosend.h
+++ b/test_common/include/opentelemetry/test_common/ext/http/client/nosend/http_client_nosend.h
@@ -69,7 +69,7 @@ public:
     compression_ = compression;
   }
 
-  void EnableLogging(bool needs_to_log) noexcept override { needs_to_log_ = needs_to_log; }
+  void EnableLogging(bool is_log_enabled) noexcept override { is_log_enabled_ = is_log_enabled; }
 
 public:
   opentelemetry::ext::http::client::Method method_;
@@ -80,7 +80,7 @@ public:
   std::chrono::milliseconds timeout_ms_{5000};  // ms
   opentelemetry::ext::http::client::Compression compression_{
       opentelemetry::ext::http::client::Compression::kNone};
-  bool needs_to_log_{false};
+  bool is_log_enabled_{false};
 };
 
 class Response : public opentelemetry::ext::http::client::Response

--- a/test_common/include/opentelemetry/test_common/ext/http/client/nosend/http_client_nosend.h
+++ b/test_common/include/opentelemetry/test_common/ext/http/client/nosend/http_client_nosend.h
@@ -69,6 +69,8 @@ public:
     compression_ = compression;
   }
 
+  void EnableLogging(bool needs_to_log) noexcept override { needs_to_log_ = needs_to_log; };
+
 public:
   opentelemetry::ext::http::client::Method method_;
   opentelemetry::ext::http::client::HttpSslOptions ssl_options_;
@@ -78,6 +80,7 @@ public:
   std::chrono::milliseconds timeout_ms_{5000};  // ms
   opentelemetry::ext::http::client::Compression compression_{
       opentelemetry::ext::http::client::Compression::kNone};
+  bool needs_to_log_{false};
 };
 
 class Response : public opentelemetry::ext::http::client::Response


### PR DESCRIPTION
Fixes #2250

## Changes

Enable curl verbose output and add debug function callback to intercept the "interesting" logs.

This functionality is controlled by the compile-time flag/option `WITH_CURL_LOGGING=ON` but can also be enabled at runtime by setting `OtlpHttpExporterOptions::console_debug = true`.

By default, all the headers and other information are not available and protected by a compile-time flag since they could contain sensitive information.

An example of info logging related to TLS handshake, available by default:

```
[Info] File: /otel/ext/src/http/client/curl/http_operation_curl.cc:593 SSL connection using TLSv1.3 / TLS_AES_128_GCM_SHA256 / X25519 / RSASSA-PSS
```

An example of debug logging, enabled via `-DCURL_DEBUG`:

```
[Debug] File: /otel/ext/src/http/client/curl/http_operation_curl.cc:613 Send header => POST /v1/traces HTTP/2
[Debug] File: /otel/ext/src/http/client/curl/http_operation_curl.cc:613 Send header => Host: localhost:4318
[Debug] File: /otel/ext/src/http/client/curl/http_operation_curl.cc:613 Send header => Accept: */*
[Debug] File: /otel/ext/src/http/client/curl/http_operation_curl.cc:613 Send header => Content-Type: application/x-protobuf
[Debug] File: /otel/ext/src/http/client/curl/http_operation_curl.cc:613 Send header => User-Agent: OTel-OTLP-Exporter-Cpp/1.17.0
[Debug] File: /otel/ext/src/http/client/curl/http_operation_curl.cc:613 Send header => Content-Length: 238
[Debug] File: /otel/exporters/otlp/src/otlp_http_client.cc:226 [OTLP HTTP Client] Session state: sending request
[Debug] File: /otel/ext/src/http/client/curl/http_operation_curl.cc:602 We are completely uploaded and fine
[Debug] File: /otel/ext/src/http/client/curl/http_operation_curl.cc:620 Recv header => HTTP/2 200
[Debug] File: /otel/ext/src/http/client/curl/http_operation_curl.cc:620 Recv header => content-type: application/x-protobuf
[Debug] File: /otel/ext/src/http/client/curl/http_operation_curl.cc:620 Recv header => content-length: 2
```

For significant contributions please make sure you have completed the following items:

* [ ] `CHANGELOG.md` updated for non-trivial changes
* [ ] Unit tests have been added
* [ ] Changes in public API reviewed