### PR TITLE
[API] Comply with W3C Trace Context

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -938,7 +938,6 @@ jobs:
         env:
           CC: /usr/bin/gcc-10
           CXX: /usr/bin/g++-10
-          PROTOBUF_VERSION: 21.12
         run: |
           sudo -E ./ci/setup_googletest.sh
           sudo -E ./ci/setup_ci_environment.sh

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -960,3 +960,4 @@ jobs:
         run:
           |
           python ${GITHUB_WORKSPACE}/trace-context/test/test.py http://localhost:30000/test
+          curl http://localhost:30000/stop

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -923,3 +923,40 @@ jobs:
     - name: run ./ci/docfx.cmd
       shell: cmd
       run: ./ci/docfx.cmd
+
+  w3c_trace_context_compliance_v1:
+    name: W3C Distributed Tracing Validation V1
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout open-telemetry/opentelemetry-cpp
+        uses: actions/checkout@v4
+        with:
+          submodules: 'recursive'
+      - name: setup
+        env:
+          CC: /usr/bin/gcc-14
+          CXX: /usr/bin/g++-14
+          PROTOBUF_VERSION: 21.12
+        run: |
+          sudo -E ./ci/setup_googletest.sh
+          sudo -E ./ci/setup_ci_environment.sh
+      - name: run w3c trace-context test server (background)
+        env:
+          CXX_STANDARD: '14'
+        run: |
+          ./ci/do_ci.sh cmake.w3c.trace-context.build-server
+          cd $HOME/build/ext/test/w3c_tracecontext_test
+          ./w3c_tracecontext_test &
+      - name: Checkout w3c/trace-context repo
+        uses: actions/checkout@v4
+        with:
+          repository: w3c/trace-context
+          path: trace-context
+      - name: install dependencies
+        run: |
+          sudo apt update && sudo apt install python3-pip
+          sudo pip3 install aiohttp
+      - name: run w3c trace-context test suite
+        run:
+          |
+          python ${GITHUB_WORKSPACE}/trace-context/test/test.py http://localhost:30000/test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -957,7 +957,9 @@ jobs:
           sudo apt update && sudo apt install python3-pip
           sudo pip3 install aiohttp
       - name: run w3c trace-context test suite
+        env:
+          SPEC_LEVEL: 1
         run:
           |
-          python ${GITHUB_WORKSPACE}/trace-context/test/test.py http://localhost:30000/test
+          python ${GITHUB_WORKSPACE}/trace-context/test/test.py http://localhost:30000/test TraceContextTest AdvancedTest
           curl http://localhost:30000/stop

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -926,7 +926,7 @@ jobs:
 
   w3c_trace_context_compliance_v1:
     name: W3C Distributed Tracing Validation V1
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout open-telemetry/opentelemetry-cpp
         uses: actions/checkout@v4
@@ -934,8 +934,8 @@ jobs:
           submodules: 'recursive'
       - name: setup
         env:
-          CC: /usr/bin/gcc-14
-          CXX: /usr/bin/g++-14
+          CC: /usr/bin/gcc-10
+          CXX: /usr/bin/g++-10
           PROTOBUF_VERSION: 21.12
         run: |
           sudo -E ./ci/setup_googletest.sh

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,9 @@ Increment the:
 
 ## [Unreleased]
 
+* [TEST] Fix failing W3C Trace Context compliance tests [#3115](https://github.com/open-telemetry/opentelemetry-cpp/pull/3115)
+  * Also adds CI check to ensure continued compliance
+
 * [API] Jaeger Propagator should not be deprecated
   [#3086](https://github.com/open-telemetry/opentelemetry-cpp/pull/3086)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ Increment the:
 
 ## [Unreleased]
 
-* [TEST] Fix failing W3C Trace Context compliance tests [#3115](https://github.com/open-telemetry/opentelemetry-cpp/pull/3115)
+* [API] Comply with W3C Trace Context [#3115](https://github.com/open-telemetry/opentelemetry-cpp/pull/3115)
   * Also adds CI check to ensure continued compliance
 
 * [API] Jaeger Propagator should not be deprecated

--- a/api/include/opentelemetry/common/string_util.h
+++ b/api/include/opentelemetry/common/string_util.h
@@ -15,11 +15,11 @@ class StringUtil
 public:
   static nostd::string_view Trim(nostd::string_view str, size_t left, size_t right) noexcept
   {
-    while (left <= right && str[static_cast<std::size_t>(left)] == ' ')
+    while (left <= right && isspace(str[left]))
     {
       left++;
     }
-    while (left <= right && str[static_cast<std::size_t>(right)] == ' ')
+    while (left <= right && isspace(str[right]))
     {
       right--;
     }

--- a/api/include/opentelemetry/trace/propagation/detail/string.h
+++ b/api/include/opentelemetry/trace/propagation/detail/string.h
@@ -56,31 +56,6 @@ inline size_t SplitString(nostd::string_view s,
 
   return filled;
 }
-
-inline nostd::string_view TrimString(nostd::string_view s)
-{
-  size_t str_size = s.size();
-  size_t trimmed_str_start_pos = 0;
-  size_t trimmed_str_end_pos = 0;
-  bool start_pos_found = false;
-  for (size_t i = 0; i < str_size; i++)
-  {
-    if (!isspace(s[i]))
-    {
-      if (!start_pos_found)
-      {
-        trimmed_str_start_pos = i;
-        trimmed_str_end_pos = i;
-        start_pos_found = true;
-      } else
-      {
-        trimmed_str_end_pos = i;
-      }
-    }
-  }
-  return s.substr(trimmed_str_start_pos, trimmed_str_end_pos - trimmed_str_start_pos + 1);
-}
-
 }  // namespace detail
 }  // namespace propagation
 }  // namespace trace

--- a/api/include/opentelemetry/trace/propagation/detail/string.h
+++ b/api/include/opentelemetry/trace/propagation/detail/string.h
@@ -56,6 +56,7 @@ inline size_t SplitString(nostd::string_view s,
 
   return filled;
 }
+
 }  // namespace detail
 }  // namespace propagation
 }  // namespace trace

--- a/api/include/opentelemetry/trace/propagation/detail/string.h
+++ b/api/include/opentelemetry/trace/propagation/detail/string.h
@@ -57,6 +57,30 @@ inline size_t SplitString(nostd::string_view s,
   return filled;
 }
 
+inline nostd::string_view TrimString(nostd::string_view s)
+{
+  size_t str_size = s.size();
+  size_t trimmed_str_start_pos = 0;
+  size_t trimmed_str_end_pos = 0;
+  bool start_pos_found = false;
+  for (size_t i = 0; i < str_size; i++)
+  {
+    if (!isspace(s[i]))
+    {
+      if (!start_pos_found)
+      {
+        trimmed_str_start_pos = i;
+        trimmed_str_end_pos = i;
+        start_pos_found = true;
+      } else
+      {
+        trimmed_str_end_pos = i;
+      }
+    }
+  }
+  return s.substr(trimmed_str_start_pos, trimmed_str_end_pos - trimmed_str_start_pos + 1);
+}
+
 }  // namespace detail
 }  // namespace propagation
 }  // namespace trace

--- a/api/include/opentelemetry/trace/propagation/http_trace_context.h
+++ b/api/include/opentelemetry/trace/propagation/http_trace_context.h
@@ -89,18 +89,14 @@ private:
   static constexpr uint8_t kInvalidVersion        = 0xFF;
   static constexpr uint8_t kDefaultAssumedVersion = 0x00;
 
-  static bool IsValidVersion(nostd::string_view version_hex)
+  static bool IsValidVersion(uint8_t version_binary)
   {
-    uint8_t version;
-    detail::HexToBinary(version_hex, &version, sizeof(version));
-    return version != kInvalidVersion;
+    return version_binary != kInvalidVersion;
   }
 
-  static bool IsHigherVersion(nostd::string_view version_hex)
+  static bool IsHigherVersion(uint8_t version_binary)
   {
-    uint8_t version;
-    detail::HexToBinary(version_hex, &version, sizeof(version));
-    return version > kDefaultAssumedVersion;
+    return version_binary > kDefaultAssumedVersion;
   }
 
   static void InjectImpl(context::propagation::TextMapCarrier &carrier,
@@ -153,17 +149,20 @@ private:
       return SpanContext::GetInvalid();
     }
 
-    if (!IsValidVersion(version_hex))
+    // hex is valid, convert it to binary
+    uint8_t version_binary;
+    detail::HexToBinary(version_hex, &version_binary, sizeof(version_binary));
+    if (!IsValidVersion(version_binary))
     {
       return SpanContext::GetInvalid();
     }
 
-    if (IsHigherVersion(version_hex) && trace_parent.size() < kTraceParentSize)
+    if (IsHigherVersion(version_binary) && trace_parent.size() < kTraceParentSize)
     {
       return SpanContext::GetInvalid();
     }
 
-    if (!IsHigherVersion(version_hex) && trace_parent.size() != kTraceParentSize)
+    if (!IsHigherVersion(version_binary) && trace_parent.size() != kTraceParentSize)
     {
       return SpanContext::GetInvalid();
     }

--- a/api/include/opentelemetry/trace/propagation/http_trace_context.h
+++ b/api/include/opentelemetry/trace/propagation/http_trace_context.h
@@ -183,7 +183,7 @@ private:
   static SpanContext ExtractImpl(const context::propagation::TextMapCarrier &carrier)
   {
     // Get trace_parent after trimming the leading and trailing whitespaces
-    nostd::string_view trace_parent = detail::TrimString(carrier.Get(kTraceParent));
+    nostd::string_view trace_parent = common::StringUtil::Trim(carrier.Get(kTraceParent));
     nostd::string_view trace_state  = carrier.Get(kTraceState);
     if (trace_parent == "")
     {

--- a/api/include/opentelemetry/trace/propagation/http_trace_context.h
+++ b/api/include/opentelemetry/trace/propagation/http_trace_context.h
@@ -182,7 +182,8 @@ private:
 
   static SpanContext ExtractImpl(const context::propagation::TextMapCarrier &carrier)
   {
-    nostd::string_view trace_parent = carrier.Get(kTraceParent);
+    // Get trace_parent after trimming the leading and trailing whitespaces
+    nostd::string_view trace_parent = detail::TrimString(carrier.Get(kTraceParent));
     nostd::string_view trace_state  = carrier.Get(kTraceState);
     if (trace_parent == "")
     {

--- a/api/include/opentelemetry/trace/propagation/http_trace_context.h
+++ b/api/include/opentelemetry/trace/propagation/http_trace_context.h
@@ -86,7 +86,7 @@ public:
   }
 
 private:
-  static constexpr uint8_t kInvalidVersion = 0xFF;
+  static constexpr uint8_t kInvalidVersion        = 0xFF;
   static constexpr uint8_t kDefaultAssumedVersion = 0x00;
 
   static bool IsValidVersion(nostd::string_view version_hex)

--- a/api/include/opentelemetry/trace/trace_state.h
+++ b/api/include/opentelemetry/trace/trace_state.h
@@ -59,7 +59,8 @@ public:
     size_t cnt = kv_str_tokenizer.NumTokens();  // upper bound on number of kv pairs
     if (cnt > kMaxKeyValuePairs)
     {
-      cnt = kMaxKeyValuePairs;
+      // trace state should be discarded if count exceeds
+      return GetDefault();
     }
 
     nostd::shared_ptr<TraceState> ts(new TraceState(cnt));

--- a/api/test/common/string_util_test.cc
+++ b/api/test/common/string_util_test.cc
@@ -35,9 +35,15 @@ TEST(StringUtilTest, TrimString)
                    {"k1=v1,k2=v2, k3=v3", "k1=v1,k2=v2, k3=v3"},
                    {"   k1=v1", "k1=v1"},
                    {"k1=v1   ", "k1=v1"},
+                   {"k1=v1\t", "k1=v1"},
+                   {"\t k1=v1 \t", "k1=v1"},
+                   {"\t\t k1=v1\t  ", "k1=v1"},
+                   {"\t\t k1=v1\t  ,k2=v2", "k1=v1\t  ,k2=v2"},
                    {"   k1=v1 ", "k1=v1"},
                    {" ", ""},
-                   {"", ""}};
+                   {"", ""},
+                   {"\n_some string_\t", "_some string_"}};
+
   for (auto &testcase : testcases)
   {
     EXPECT_EQ(StringUtil::Trim(testcase.input), testcase.expected);

--- a/api/test/trace/propagation/detail/BUILD
+++ b/api/test/trace/propagation/detail/BUILD
@@ -18,3 +18,19 @@ cc_test(
         "@com_google_googletest//:gtest_main",
     ],
 )
+
+cc_test(
+    name = "string_test",
+    srcs = [
+        "string_test.cc",
+    ],
+    tags = [
+        "api",
+        "test",
+        "trace",
+    ],
+    deps = [
+        "//api",
+        "@com_google_googletest//:gtest_main",
+    ],
+)

--- a/api/test/trace/propagation/detail/CMakeLists.txt
+++ b/api/test/trace/propagation/detail/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright The OpenTelemetry Authors
 # SPDX-License-Identifier: Apache-2.0
 
-foreach(testname hex_test)
+foreach(testname hex_test string_test)
   add_executable(${testname} "${testname}.cc")
   target_link_libraries(${testname} ${GTEST_BOTH_LIBRARIES}
                         ${CMAKE_THREAD_LIBS_INIT} opentelemetry_api)

--- a/api/test/trace/propagation/detail/string_test.cc
+++ b/api/test/trace/propagation/detail/string_test.cc
@@ -8,84 +8,57 @@
 #include "opentelemetry/nostd/string_view.h"
 
 using namespace opentelemetry;
-//
-// struct SplitStringTestData
-//{
-//   opentelemetry::nostd::string_view input;
-//   char separator;
-//   size_t max_count;
-//   std::vector<opentelemetry::nostd::string_view> splits;
-//   size_t expected_number_strings;
-// };
-//
-// const SplitStringTestData split_string_test_cases[] = {
-//     {"foo,bar,baz", ',', 4, std::vector<opentelemetry::nostd::string_view>{"foo", "bar", "baz"},
-//     3},
-//     {"foo,bar,baz,foobar", ',', 4,
-//      std::vector<opentelemetry::nostd::string_view>{"foo", "bar", "baz", "foobar"}, 4},
-//     {"foo,bar,baz,foobar", '.', 4,
-//      std::vector<opentelemetry::nostd::string_view>{"foo,bar,baz,foobar"}, 1},
-//     {"foo,bar,baz,", ',', 4,
-//      std::vector<opentelemetry::nostd::string_view>{"foo", "bar", "baz", ""}, 4},
-//     {"foo,bar,baz,", ',', 2, std::vector<opentelemetry::nostd::string_view>{"foo", "bar"}, 2},
-//     {"foo ,bar, baz ", ',', 4,
-//      std::vector<opentelemetry::nostd::string_view>{"foo ", "bar", " baz "}, 3},
-//     {"foo ,bar, baz ", ',', 4,
-//      std::vector<opentelemetry::nostd::string_view>{"foo ", "bar", " baz "}, 3},
-//     {"00-0af7651916cd43dd8448eb211c80319c-00f067aa0ba902b7-01", '-', 4,
-//      std::vector<opentelemetry::nostd::string_view>{"00", "0af7651916cd43dd8448eb211c80319c",
-//                                                     "00f067aa0ba902b7", "01"},
-//      4},
-// };
 
-TEST(StringTest, SplitStringTest)
+namespace
 {
-  struct
-  {
-    opentelemetry::nostd::string_view input;
-    char separator;
-    size_t max_count;
-    std::vector<opentelemetry::nostd::string_view> splits;
-    size_t expected_number_strings;
-  } test_cases[] = {
-      {"foo,bar,baz", ',', 4, std::vector<opentelemetry::nostd::string_view>{"foo", "bar", "baz"},
-       3},
-//      {"foo,bar,baz,foobar", ',', 4,
-//       std::vector<opentelemetry::nostd::string_view>{"foo", "bar", "baz", "foobar"}, 4},
-//      {"foo,bar,baz,foobar", '.', 4,
-//       std::vector<opentelemetry::nostd::string_view>{"foo,bar,baz,foobar"}, 1},
-//      {"foo,bar,baz,", ',', 4,
-//       std::vector<opentelemetry::nostd::string_view>{"foo", "bar", "baz", ""}, 4},
-//      {"foo,bar,baz,", ',', 2, std::vector<opentelemetry::nostd::string_view>{"foo", "bar"}, 2},
-//      {"foo ,bar, baz ", ',', 4,
-//       std::vector<opentelemetry::nostd::string_view>{"foo ", "bar", " baz "}, 3},
-//      {"foo ,bar, baz ", ',', 4,
-//       std::vector<opentelemetry::nostd::string_view>{"foo ", "bar", " baz "}, 3},
-//      {"00-0af7651916cd43dd8448eb211c80319c-00f067aa0ba902b7-01", '-', 4,
-//       std::vector<opentelemetry::nostd::string_view>{"00", "0af7651916cd43dd8448eb211c80319c",
-//                                                      "00f067aa0ba902b7", "01"},4}
-  };
-  for (auto &test_param : test_cases)
-  {
-    std::vector<opentelemetry::nostd::string_view> fields{};
-    fields.reserve(test_param.expected_number_strings);
-    size_t got_splits_num = opentelemetry::trace::propagation::detail::SplitString(
-        test_param.input, test_param.separator, fields.data(), test_param.max_count);
 
-    // Assert on the output
-    EXPECT_EQ(got_splits_num, test_param.expected_number_strings);
-    for (size_t i = 0; i < got_splits_num; i++)
-    {
-      // Checks for resulting strings in-order
-      EXPECT_EQ(fields[i], test_param.splits[i]);
-    }
+struct SplitStringTestData
+{
+  opentelemetry::nostd::string_view input;
+  char separator;
+  size_t max_count;
+  size_t expected_number_strings;
+
+  // When googletest registers parameterized tests, it uses this method to format the parameters.
+  // The default implementation prints hex dump of all bytes in the object. If there is any padding
+  // in these bytes, valgrind reports this as a warning - "Use of uninitialized bytes".
+  // See https://github.com/google/googletest/issues/3805.
+  friend void PrintTo(const SplitStringTestData &data, std::ostream *os)
+  {
+    std::stringstream ss;
+    *os << "(" << data.input << "," << data.separator << "," << data.max_count << ","
+        << data.expected_number_strings << ")";
   }
+};
+
+const SplitStringTestData split_string_test_cases[] = {
+    {"foo,bar,baz", ',', 4, 3},
+    {"foo,bar,baz,foobar", ',', 4, 4},
+    {"foo,bar,baz,foobar", '.', 4, 1},
+    {"foo,bar,baz,", ',', 4, 4},
+    {"foo,bar,baz,", ',', 2, 2},
+    {"foo ,bar, baz ", ',', 4, 3},
+    {"foo ,bar, baz ", ',', 4, 3},
+    {"00-0af7651916cd43dd8448eb211c80319c-00f067aa0ba902b7-01", '-', 4, 4},
+};
+}  // namespace
+
+// Test fixture
+class SplitStringTestFixture : public ::testing::TestWithParam<SplitStringTestData>
+{};
+
+TEST_P(SplitStringTestFixture, SplitsAsExpected)
+{
+  const SplitStringTestData test_param = GetParam();
+  std::vector<opentelemetry::nostd::string_view> fields{};
+  fields.reserve(test_param.expected_number_strings);
+  size_t got_splits_num = opentelemetry::trace::propagation::detail::SplitString(
+      test_param.input, test_param.separator, fields.data(), test_param.max_count);
+
+  // Assert on the output
+  EXPECT_EQ(got_splits_num, test_param.expected_number_strings);
 }
 
-TEST(StringTest, SimpleTest)
-{
-  nostd::string_view input = "foo,bar,baz";
-  std::array<nostd::string_view, 4> fields{};
-  size_t got_splits = ::trace::propagation::detail::SplitString(input, ',', fields.data(), 4);
-  EXPECT_EQ(3, got_splits);
-}
+INSTANTIATE_TEST_SUITE_P(SplitStringTestCases,
+                         SplitStringTestFixture,
+                         ::testing::ValuesIn(split_string_test_cases));

--- a/api/test/trace/propagation/detail/string_test.cc
+++ b/api/test/trace/propagation/detail/string_test.cc
@@ -1,0 +1,13 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+#include <gtest/gtest.h>
+#include <stdint.h>
+#include <string>
+
+#include "opentelemetry/nostd/string_view.h"
+
+TEST(StringTest, TrimStrings)
+{
+  //TODO(psx95): Add tests
+}

--- a/api/test/trace/propagation/detail/string_test.cc
+++ b/api/test/trace/propagation/detail/string_test.cc
@@ -2,12 +2,57 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include <gtest/gtest.h>
-#include <stdint.h>
+#include <opentelemetry/trace/propagation/b3_propagator.h>
 #include <string>
 
 #include "opentelemetry/nostd/string_view.h"
 
-TEST(StringTest, SplitString)
+struct SplitStringTestData
 {
-  // TODO(psx95): Add tests
+  opentelemetry::nostd::string_view input;
+  char separator;
+  size_t max_count;
+  std::vector<opentelemetry::nostd::string_view> splits;
+  size_t expected_number_strings;
+};
+
+const SplitStringTestData split_string_test_cases[] = {
+    {"foo,bar,baz", ',', 4,
+    std::vector<opentelemetry::nostd::string_view>{"foo", "bar", "baz"}, 3},
+    {"foo,bar,baz,foobar", ',', 4,
+     std::vector<opentelemetry::nostd::string_view>{"foo", "bar", "baz", "foobar"}, 4},
+    {"foo,bar,baz,foobar", '.', 4,
+     std::vector<opentelemetry::nostd::string_view>{"foo,bar,baz,foobar"}, 1},
+    {"foo,bar,baz,", ',', 4,
+     std::vector<opentelemetry::nostd::string_view>{"foo","bar","baz",""}, 4},
+    {"foo,bar,baz,", ',', 2,
+     std::vector<opentelemetry::nostd::string_view>{"foo","bar"}, 2},
+    {"foo ,bar, baz ", ',', 4,
+     std::vector<opentelemetry::nostd::string_view>{"foo ","bar"," baz "}, 3},
+    {"foo ,bar, baz ", ',', 4,
+     std::vector<opentelemetry::nostd::string_view>{"foo ","bar"," baz "}, 3},
+    {"00-0af7651916cd43dd8448eb211c80319c-00f067aa0ba902b7-01", '-', 4,
+     std::vector<opentelemetry::nostd::string_view>{"00","0af7651916cd43dd8448eb211c80319c","00f067aa0ba902b7", "01"}, 4},
+};
+
+// Test fixture
+class SplitStringTestFixture : public ::testing::TestWithParam<SplitStringTestData> {};
+
+TEST_P(SplitStringTestFixture, SplitsAsExpected)
+{
+  SplitStringTestData test_param = GetParam();
+  std::vector<opentelemetry::nostd::string_view> fields{};
+  fields.reserve(test_param.expected_number_strings);
+  size_t got_splits_num =  opentelemetry::trace::propagation::detail::SplitString(test_param.input, test_param.separator, fields.data(), test_param.max_count);
+
+
+  // Assert on the output
+  EXPECT_EQ(got_splits_num, test_param.expected_number_strings);
+  for (size_t i = 0; i < got_splits_num; i++)
+  {
+    // Checks for resulting strings in-order
+    EXPECT_EQ(fields[i], test_param.splits[i]);
+  }
 }
+
+INSTANTIATE_TEST_SUITE_P(SplitStringTestCases, SplitStringTestFixture, ::testing::ValuesIn(split_string_test_cases));

--- a/api/test/trace/propagation/detail/string_test.cc
+++ b/api/test/trace/propagation/detail/string_test.cc
@@ -25,7 +25,6 @@ struct SplitStringTestData
   // See https://github.com/google/googletest/issues/3805.
   friend void PrintTo(const SplitStringTestData &data, std::ostream *os)
   {
-    std::stringstream ss;
     *os << "(" << data.input << "," << data.separator << "," << data.max_count << ","
         << data.expected_number_strings << ")";
   }
@@ -50,8 +49,7 @@ class SplitStringTestFixture : public ::testing::TestWithParam<SplitStringTestDa
 TEST_P(SplitStringTestFixture, SplitsAsExpected)
 {
   const SplitStringTestData test_param = GetParam();
-  std::vector<opentelemetry::nostd::string_view> fields{};
-  fields.reserve(test_param.expected_number_strings);
+  std::vector<opentelemetry::nostd::string_view> fields(test_param.expected_number_strings);
   size_t got_splits_num = opentelemetry::trace::propagation::detail::SplitString(
       test_param.input, test_param.separator, fields.data(), test_param.max_count);
 

--- a/api/test/trace/propagation/detail/string_test.cc
+++ b/api/test/trace/propagation/detail/string_test.cc
@@ -8,7 +8,7 @@
 #include "opentelemetry/nostd/string_view.h"
 
 using namespace opentelemetry;
-
+//
 // struct SplitStringTestData
 //{
 //   opentelemetry::nostd::string_view input;
@@ -37,25 +37,50 @@ using namespace opentelemetry;
 //                                                     "00f067aa0ba902b7", "01"},
 //      4},
 // };
-//
-//
-// TEST(StringTest, SplitStringTest)
-//{
-//   for (auto &test_param : split_string_test_cases) {
-//     std::vector<opentelemetry::nostd::string_view> fields{};
-//     fields.reserve(test_param.expected_number_strings);
-//     size_t got_splits_num = opentelemetry::trace::propagation::detail::SplitString(
-//         test_param.input, test_param.separator, fields.data(), test_param.max_count);
-//
-//     // Assert on the output
-//     EXPECT_EQ(got_splits_num, test_param.expected_number_strings);
-//     for (size_t i = 0; i < got_splits_num; i++)
-//     {
-//       // Checks for resulting strings in-order
-//       EXPECT_EQ(fields[i], test_param.splits[i]);
-//     }
-//   }
-// }
+
+TEST(StringTest, SplitStringTest)
+{
+  struct
+  {
+    opentelemetry::nostd::string_view input;
+    char separator;
+    size_t max_count;
+    std::vector<opentelemetry::nostd::string_view> splits;
+    size_t expected_number_strings;
+  } test_cases[] = {
+      {"foo,bar,baz", ',', 4, std::vector<opentelemetry::nostd::string_view>{"foo", "bar", "baz"},
+       3},
+//      {"foo,bar,baz,foobar", ',', 4,
+//       std::vector<opentelemetry::nostd::string_view>{"foo", "bar", "baz", "foobar"}, 4},
+//      {"foo,bar,baz,foobar", '.', 4,
+//       std::vector<opentelemetry::nostd::string_view>{"foo,bar,baz,foobar"}, 1},
+//      {"foo,bar,baz,", ',', 4,
+//       std::vector<opentelemetry::nostd::string_view>{"foo", "bar", "baz", ""}, 4},
+//      {"foo,bar,baz,", ',', 2, std::vector<opentelemetry::nostd::string_view>{"foo", "bar"}, 2},
+//      {"foo ,bar, baz ", ',', 4,
+//       std::vector<opentelemetry::nostd::string_view>{"foo ", "bar", " baz "}, 3},
+//      {"foo ,bar, baz ", ',', 4,
+//       std::vector<opentelemetry::nostd::string_view>{"foo ", "bar", " baz "}, 3},
+//      {"00-0af7651916cd43dd8448eb211c80319c-00f067aa0ba902b7-01", '-', 4,
+//       std::vector<opentelemetry::nostd::string_view>{"00", "0af7651916cd43dd8448eb211c80319c",
+//                                                      "00f067aa0ba902b7", "01"},4}
+  };
+  for (auto &test_param : test_cases)
+  {
+    std::vector<opentelemetry::nostd::string_view> fields{};
+    fields.reserve(test_param.expected_number_strings);
+    size_t got_splits_num = opentelemetry::trace::propagation::detail::SplitString(
+        test_param.input, test_param.separator, fields.data(), test_param.max_count);
+
+    // Assert on the output
+    EXPECT_EQ(got_splits_num, test_param.expected_number_strings);
+    for (size_t i = 0; i < got_splits_num; i++)
+    {
+      // Checks for resulting strings in-order
+      EXPECT_EQ(fields[i], test_param.splits[i]);
+    }
+  }
+}
 
 TEST(StringTest, SimpleTest)
 {

--- a/api/test/trace/propagation/detail/string_test.cc
+++ b/api/test/trace/propagation/detail/string_test.cc
@@ -14,6 +14,21 @@ struct SplitStringTestData
   size_t max_count;
   std::vector<opentelemetry::nostd::string_view> splits;
   size_t expected_number_strings;
+
+  // When googletest registers parameterized tests, it uses this method to format the parameters.
+  // The default implementation prints hex dump of all bytes in the object. If there is any padding
+  // in these bytes, valgrind reports this as a warning - "Use of uninitialized bytes".
+  // See https://github.com/google/googletest/issues/3805.
+  friend void PrintTo(const SplitStringTestData& data, std::ostream* os) {
+    std::stringstream ss;
+    for (auto it = data.splits.begin(); it != data.splits.end(); it++) {
+      if (it != data.splits.begin()) {
+        ss << ",";
+      }
+      ss << *it;
+    }
+    *os << "(" << data.input << "," << data.separator << "," << data.max_count << "," << ss.str() << "," << data.expected_number_strings << ")";
+  }
 };
 
 const SplitStringTestData split_string_test_cases[] = {

--- a/api/test/trace/propagation/detail/string_test.cc
+++ b/api/test/trace/propagation/detail/string_test.cc
@@ -7,70 +7,60 @@
 
 #include "opentelemetry/nostd/string_view.h"
 
-struct SplitStringTestData
+using namespace opentelemetry;
+
+// struct SplitStringTestData
+//{
+//   opentelemetry::nostd::string_view input;
+//   char separator;
+//   size_t max_count;
+//   std::vector<opentelemetry::nostd::string_view> splits;
+//   size_t expected_number_strings;
+// };
+//
+// const SplitStringTestData split_string_test_cases[] = {
+//     {"foo,bar,baz", ',', 4, std::vector<opentelemetry::nostd::string_view>{"foo", "bar", "baz"},
+//     3},
+//     {"foo,bar,baz,foobar", ',', 4,
+//      std::vector<opentelemetry::nostd::string_view>{"foo", "bar", "baz", "foobar"}, 4},
+//     {"foo,bar,baz,foobar", '.', 4,
+//      std::vector<opentelemetry::nostd::string_view>{"foo,bar,baz,foobar"}, 1},
+//     {"foo,bar,baz,", ',', 4,
+//      std::vector<opentelemetry::nostd::string_view>{"foo", "bar", "baz", ""}, 4},
+//     {"foo,bar,baz,", ',', 2, std::vector<opentelemetry::nostd::string_view>{"foo", "bar"}, 2},
+//     {"foo ,bar, baz ", ',', 4,
+//      std::vector<opentelemetry::nostd::string_view>{"foo ", "bar", " baz "}, 3},
+//     {"foo ,bar, baz ", ',', 4,
+//      std::vector<opentelemetry::nostd::string_view>{"foo ", "bar", " baz "}, 3},
+//     {"00-0af7651916cd43dd8448eb211c80319c-00f067aa0ba902b7-01", '-', 4,
+//      std::vector<opentelemetry::nostd::string_view>{"00", "0af7651916cd43dd8448eb211c80319c",
+//                                                     "00f067aa0ba902b7", "01"},
+//      4},
+// };
+//
+//
+// TEST(StringTest, SplitStringTest)
+//{
+//   for (auto &test_param : split_string_test_cases) {
+//     std::vector<opentelemetry::nostd::string_view> fields{};
+//     fields.reserve(test_param.expected_number_strings);
+//     size_t got_splits_num = opentelemetry::trace::propagation::detail::SplitString(
+//         test_param.input, test_param.separator, fields.data(), test_param.max_count);
+//
+//     // Assert on the output
+//     EXPECT_EQ(got_splits_num, test_param.expected_number_strings);
+//     for (size_t i = 0; i < got_splits_num; i++)
+//     {
+//       // Checks for resulting strings in-order
+//       EXPECT_EQ(fields[i], test_param.splits[i]);
+//     }
+//   }
+// }
+
+TEST(StringTest, SimpleTest)
 {
-  opentelemetry::nostd::string_view input;
-  char separator;
-  size_t max_count;
-  std::vector<opentelemetry::nostd::string_view> splits;
-  size_t expected_number_strings;
-
-  // When googletest registers parameterized tests, it uses this method to format the parameters.
-  // The default implementation prints hex dump of all bytes in the object. If there is any padding
-  // in these bytes, valgrind reports this as a warning - "Use of uninitialized bytes".
-  // See https://github.com/google/googletest/issues/3805.
-  friend void PrintTo(const SplitStringTestData& data, std::ostream* os) {
-    std::stringstream ss;
-    for (auto it = data.splits.begin(); it != data.splits.end(); it++) {
-      if (it != data.splits.begin()) {
-        ss << ",";
-      }
-      ss << *it;
-    }
-    *os << "(" << data.input << "," << data.separator << "," << data.max_count << "," << ss.str() << "," << data.expected_number_strings << ")";
-  }
-};
-
-const SplitStringTestData split_string_test_cases[] = {
-    {"foo,bar,baz", ',', 4, std::vector<opentelemetry::nostd::string_view>{"foo", "bar", "baz"}, 3},
-    {"foo,bar,baz,foobar", ',', 4,
-     std::vector<opentelemetry::nostd::string_view>{"foo", "bar", "baz", "foobar"}, 4},
-    {"foo,bar,baz,foobar", '.', 4,
-     std::vector<opentelemetry::nostd::string_view>{"foo,bar,baz,foobar"}, 1},
-    {"foo,bar,baz,", ',', 4,
-     std::vector<opentelemetry::nostd::string_view>{"foo", "bar", "baz", ""}, 4},
-    {"foo,bar,baz,", ',', 2, std::vector<opentelemetry::nostd::string_view>{"foo", "bar"}, 2},
-    {"foo ,bar, baz ", ',', 4,
-     std::vector<opentelemetry::nostd::string_view>{"foo ", "bar", " baz "}, 3},
-    {"foo ,bar, baz ", ',', 4,
-     std::vector<opentelemetry::nostd::string_view>{"foo ", "bar", " baz "}, 3},
-    {"00-0af7651916cd43dd8448eb211c80319c-00f067aa0ba902b7-01", '-', 4,
-     std::vector<opentelemetry::nostd::string_view>{"00", "0af7651916cd43dd8448eb211c80319c",
-                                                    "00f067aa0ba902b7", "01"},
-     4},
-};
-
-// Test fixture
-class SplitStringTestFixture : public ::testing::TestWithParam<SplitStringTestData>
-{};
-
-TEST_P(SplitStringTestFixture, SplitsAsExpected)
-{
-  SplitStringTestData test_param = GetParam();
-  std::vector<opentelemetry::nostd::string_view> fields{};
-  fields.reserve(test_param.expected_number_strings);
-  size_t got_splits_num = opentelemetry::trace::propagation::detail::SplitString(
-      test_param.input, test_param.separator, fields.data(), test_param.max_count);
-
-  // Assert on the output
-  EXPECT_EQ(got_splits_num, test_param.expected_number_strings);
-  for (size_t i = 0; i < got_splits_num; i++)
-  {
-    // Checks for resulting strings in-order
-    EXPECT_EQ(fields[i], test_param.splits[i]);
-  }
+  nostd::string_view input = "foo,bar,baz";
+  std::array<nostd::string_view, 4> fields{};
+  size_t got_splits = ::trace::propagation::detail::SplitString(input, ',', fields.data(), 4);
+  EXPECT_EQ(3, got_splits);
 }
-
-INSTANTIATE_TEST_SUITE_P(SplitStringTestCases,
-                         SplitStringTestFixture,
-                         ::testing::ValuesIn(split_string_test_cases));

--- a/api/test/trace/propagation/detail/string_test.cc
+++ b/api/test/trace/propagation/detail/string_test.cc
@@ -7,7 +7,7 @@
 
 #include "opentelemetry/nostd/string_view.h"
 
-TEST(StringTest, TrimStrings)
+TEST(StringTest, SplitString)
 {
   //TODO(psx95): Add tests
 }

--- a/api/test/trace/propagation/detail/string_test.cc
+++ b/api/test/trace/propagation/detail/string_test.cc
@@ -9,5 +9,5 @@
 
 TEST(StringTest, SplitString)
 {
-  //TODO(psx95): Add tests
+  // TODO(psx95): Add tests
 }

--- a/api/test/trace/propagation/detail/string_test.cc
+++ b/api/test/trace/propagation/detail/string_test.cc
@@ -17,34 +17,35 @@ struct SplitStringTestData
 };
 
 const SplitStringTestData split_string_test_cases[] = {
-    {"foo,bar,baz", ',', 4,
-    std::vector<opentelemetry::nostd::string_view>{"foo", "bar", "baz"}, 3},
+    {"foo,bar,baz", ',', 4, std::vector<opentelemetry::nostd::string_view>{"foo", "bar", "baz"}, 3},
     {"foo,bar,baz,foobar", ',', 4,
      std::vector<opentelemetry::nostd::string_view>{"foo", "bar", "baz", "foobar"}, 4},
     {"foo,bar,baz,foobar", '.', 4,
      std::vector<opentelemetry::nostd::string_view>{"foo,bar,baz,foobar"}, 1},
     {"foo,bar,baz,", ',', 4,
-     std::vector<opentelemetry::nostd::string_view>{"foo","bar","baz",""}, 4},
-    {"foo,bar,baz,", ',', 2,
-     std::vector<opentelemetry::nostd::string_view>{"foo","bar"}, 2},
+     std::vector<opentelemetry::nostd::string_view>{"foo", "bar", "baz", ""}, 4},
+    {"foo,bar,baz,", ',', 2, std::vector<opentelemetry::nostd::string_view>{"foo", "bar"}, 2},
     {"foo ,bar, baz ", ',', 4,
-     std::vector<opentelemetry::nostd::string_view>{"foo ","bar"," baz "}, 3},
+     std::vector<opentelemetry::nostd::string_view>{"foo ", "bar", " baz "}, 3},
     {"foo ,bar, baz ", ',', 4,
-     std::vector<opentelemetry::nostd::string_view>{"foo ","bar"," baz "}, 3},
+     std::vector<opentelemetry::nostd::string_view>{"foo ", "bar", " baz "}, 3},
     {"00-0af7651916cd43dd8448eb211c80319c-00f067aa0ba902b7-01", '-', 4,
-     std::vector<opentelemetry::nostd::string_view>{"00","0af7651916cd43dd8448eb211c80319c","00f067aa0ba902b7", "01"}, 4},
+     std::vector<opentelemetry::nostd::string_view>{"00", "0af7651916cd43dd8448eb211c80319c",
+                                                    "00f067aa0ba902b7", "01"},
+     4},
 };
 
 // Test fixture
-class SplitStringTestFixture : public ::testing::TestWithParam<SplitStringTestData> {};
+class SplitStringTestFixture : public ::testing::TestWithParam<SplitStringTestData>
+{};
 
 TEST_P(SplitStringTestFixture, SplitsAsExpected)
 {
   SplitStringTestData test_param = GetParam();
   std::vector<opentelemetry::nostd::string_view> fields{};
   fields.reserve(test_param.expected_number_strings);
-  size_t got_splits_num =  opentelemetry::trace::propagation::detail::SplitString(test_param.input, test_param.separator, fields.data(), test_param.max_count);
-
+  size_t got_splits_num = opentelemetry::trace::propagation::detail::SplitString(
+      test_param.input, test_param.separator, fields.data(), test_param.max_count);
 
   // Assert on the output
   EXPECT_EQ(got_splits_num, test_param.expected_number_strings);
@@ -55,4 +56,6 @@ TEST_P(SplitStringTestFixture, SplitsAsExpected)
   }
 }
 
-INSTANTIATE_TEST_SUITE_P(SplitStringTestCases, SplitStringTestFixture, ::testing::ValuesIn(split_string_test_cases));
+INSTANTIATE_TEST_SUITE_P(SplitStringTestCases,
+                         SplitStringTestFixture,
+                         ::testing::ValuesIn(split_string_test_cases));

--- a/ci/do_ci.sh
+++ b/ci/do_ci.sh
@@ -402,9 +402,6 @@ elif [[ "$1" == "cmake.w3c.trace-context.build-server" ]]; then
           -DCMAKE_CXX_STANDARD=${CXX_STANDARD} \
           "${SRC_DIR}"
   eval "$MAKE_COMMAND"
-  echo "currently at $(pwd)"
-  echo "${BUILD_DIR}"
-  ls -lah "${BUILD_DIR}/ext/test/w3c_tracecontext_test"
   exit 0
 elif [[ "$1" == "cmake.do_not_install.test" ]]; then
   cd "${BUILD_DIR}"

--- a/ci/do_ci.sh
+++ b/ci/do_ci.sh
@@ -393,6 +393,19 @@ elif [[ "$1" == "cmake.exporter.otprotocol.with_async_export.test" ]]; then
   make -j $(nproc)
   cd exporters/otlp && make test
   exit 0
+elif [[ "$1" == "cmake.w3c.trace-context.build-server" ]]; then
+  echo "Building w3c trace context test server"
+  cd "${BUILD_DIR}"
+  rm -rf *
+  cmake "${CMAKE_OPTIONS[@]}"  \
+          -DBUILD_W3CTRACECONTEXT_TEST=ON \
+          -DCMAKE_CXX_STANDARD=${CXX_STANDARD} \
+          "${SRC_DIR}"
+  eval "$MAKE_COMMAND"
+  echo "currently at $(pwd)"
+  echo "${BUILD_DIR}"
+  ls -lah "${BUILD_DIR}/ext/test/w3c_tracecontext_test"
+  exit 0
 elif [[ "$1" == "cmake.do_not_install.test" ]]; then
   cd "${BUILD_DIR}"
   rm -rf *

--- a/ext/include/opentelemetry/ext/http/server/http_server.h
+++ b/ext/include/opentelemetry/ext/http/server/http_server.h
@@ -650,8 +650,10 @@ protected:
       }
       if (!conn.request.headers[name].empty())
       {
-        conn.request.headers[name] = conn.request.headers[name].append(",").append(std::string(begin, ptr));
-      } else
+        conn.request.headers[name] =
+            conn.request.headers[name].append(",").append(std::string(begin, ptr));
+      }
+      else
       {
         conn.request.headers[name] = std::string(begin, ptr);
       }

--- a/ext/include/opentelemetry/ext/http/server/http_server.h
+++ b/ext/include/opentelemetry/ext/http/server/http_server.h
@@ -648,7 +648,13 @@ protected:
       {
         ptr++;
       }
-      conn.request.headers[name] = std::string(begin, ptr);
+      if (!conn.request.headers[name].empty() && equalsLowercased(name, "tracestate"))
+      {
+        conn.request.headers[name] = conn.request.headers[name].append(",").append(std::string(begin, ptr));
+      } else
+      {
+        conn.request.headers[name] = std::string(begin, ptr);
+      }
       if (*ptr == '\r')
       {
         ptr++;

--- a/ext/include/opentelemetry/ext/http/server/http_server.h
+++ b/ext/include/opentelemetry/ext/http/server/http_server.h
@@ -648,7 +648,7 @@ protected:
       {
         ptr++;
       }
-      if (!conn.request.headers[name].empty() && equalsLowercased(name, "tracestate"))
+      if (!conn.request.headers[name].empty())
       {
         conn.request.headers[name] = conn.request.headers[name].append(",").append(std::string(begin, ptr));
       } else

--- a/ext/test/w3c_tracecontext_test/README.md
+++ b/ext/test/w3c_tracecontext_test/README.md
@@ -3,7 +3,7 @@
 This test application is intended to be used as a test service for the [W3C
 Distributed Tracing Validation
 Service](https://github.com/w3c/trace-context/tree/master/test). It is
-implemented according to [this
+implemented according to [these
 instructions](https://github.com/w3c/trace-context/tree/master/test#implement-test-service).
 
 ## Usage
@@ -47,4 +47,9 @@ docker run --network host w3c_driver http://localhost:31339/test
 3: The validation service will run the test suite and print detailed test
 results.
 
-4: Stop the test service by pressing enter.
+4: Stop the test service by invoking `/stop`. Make sure to use the correct port number.
+
+```sh
+# Assuming the service is currently running at port 30000
+curl http://localhost:30000/stop
+```

--- a/ext/test/w3c_tracecontext_test/main.cc
+++ b/ext/test/w3c_tracecontext_test/main.cc
@@ -3,8 +3,6 @@
 
 #include <stdint.h>
 #include <stdlib.h>
-#include <algorithm>
-#include <initializer_list>
 #include <iostream>
 #include <map>
 #include <nlohmann/json.hpp>
@@ -12,19 +10,16 @@
 #include <utility>
 #include <vector>
 
-#include "opentelemetry/context/context_value.h"
 #include "opentelemetry/context/propagation/text_map_propagator.h"
 #include "opentelemetry/context/runtime_context.h"
 #include "opentelemetry/exporters/ostream/span_exporter.h"
 #include "opentelemetry/ext/http/client/curl/http_client_curl.h"
-#include "opentelemetry/ext/http/client/curl/http_operation_curl.h"
 #include "opentelemetry/ext/http/client/http_client.h"
 #include "opentelemetry/ext/http/server/http_server.h"
 #include "opentelemetry/nostd/shared_ptr.h"
 #include "opentelemetry/nostd/string_view.h"
 #include "opentelemetry/sdk/trace/exporter.h"
 #include "opentelemetry/sdk/trace/processor.h"
-#include "opentelemetry/sdk/trace/recordable.h"
 #include "opentelemetry/sdk/trace/simple_processor.h"
 #include "opentelemetry/sdk/trace/tracer_context.h"
 #include "opentelemetry/sdk/trace/tracer_provider.h"
@@ -243,14 +238,11 @@ int main(int argc, char *argv[])
   std::cout << "Listening at http://" << default_host << ":" << port << "/test\n";
 
   // Wait for signal to stop server
-  std::thread server_check([&stop_server, &server]() {
-    while (!stop_server.load())
-    {
-      // keep running the thread
-    }
-    // received signal to stop server
-    std::cout << "stopping server \n";
-    server.stop();
-  });
-  server_check.join();
+  while (!stop_server.load())
+  {
+    std::this_thread::sleep_for(std::chrono::seconds(1));
+  }
+  // received signal to stop server
+  std::cout << "Stopping server \n";
+  server.stop();
 }

--- a/ext/test/w3c_tracecontext_test/main.cc
+++ b/ext/test/w3c_tracecontext_test/main.cc
@@ -51,7 +51,7 @@ public:
   TextMapCarrierTest(std::map<std::string, std::string> &headers) : headers_(headers) {}
   nostd::string_view Get(nostd::string_view key) const noexcept override
   {
-    for(const auto& elem : headers_)
+    for (const auto &elem : headers_)
     {
       if (equalsIgnoreCase(elem.first, std::string(key)))
       {

--- a/ext/test/w3c_tracecontext_test/main.cc
+++ b/ext/test/w3c_tracecontext_test/main.cc
@@ -51,16 +51,34 @@ public:
   TextMapCarrierTest(std::map<std::string, std::string> &headers) : headers_(headers) {}
   nostd::string_view Get(nostd::string_view key) const noexcept override
   {
-    auto it = headers_.find(std::string(key));
-    if (it != headers_.end())
+    for(const auto& elem : headers_)
     {
-      return nostd::string_view(it->second);
+      if (equalsIgnoreCase(elem.first, std::string(key)))
+      {
+        return nostd::string_view(elem.second);
+      }
     }
     return "";
   }
   void Set(nostd::string_view key, nostd::string_view value) noexcept override
   {
     headers_[std::string(key)] = std::string(value);
+  }
+
+  static bool equalsIgnoreCase(const std::string &str1, const std::string &str2)
+  {
+    if (str1.length() != str2.length())
+    {
+      return false;
+    }
+    for (int i = 0; i < str1.length(); i++)
+    {
+      if (tolower(str1[i]) != tolower(str2[i]))
+      {
+        return false;
+      }
+    }
+    return true;
   }
 
   std::map<std::string, std::string> &headers_;

--- a/ext/test/w3c_tracecontext_test/main.cc
+++ b/ext/test/w3c_tracecontext_test/main.cc
@@ -40,6 +40,22 @@ namespace
 {
 static trace_api::propagation::HttpTraceContext propagator_format;
 
+static bool equalsIgnoreCase(const std::string &str1, const std::string &str2)
+{
+  if (str1.length() != str2.length())
+  {
+    return false;
+  }
+  for (size_t i = 0; i < str1.length(); i++)
+  {
+    if (tolower(str1[i]) != tolower(str2[i]))
+    {
+      return false;
+    }
+  }
+  return true;
+}
+
 class TextMapCarrierTest : public context::propagation::TextMapCarrier
 {
 public:
@@ -58,22 +74,6 @@ public:
   void Set(nostd::string_view key, nostd::string_view value) noexcept override
   {
     headers_[std::string(key)] = std::string(value);
-  }
-
-  static bool equalsIgnoreCase(const std::string &str1, const std::string &str2)
-  {
-    if (str1.length() != str2.length())
-    {
-      return false;
-    }
-    for (size_t i = 0; i < str1.length(); i++)
-    {
-      if (tolower(str1[i]) != tolower(str2[i]))
-      {
-        return false;
-      }
-    }
-    return true;
   }
 
   std::map<std::string, std::string> &headers_;

--- a/ext/test/w3c_tracecontext_test/main.cc
+++ b/ext/test/w3c_tracecontext_test/main.cc
@@ -71,7 +71,7 @@ public:
     {
       return false;
     }
-    for (int i = 0; i < str1.length(); i++)
+    for (size_t i = 0; i < str1.length(); i++)
     {
       if (tolower(str1[i]) != tolower(str2[i]))
       {


### PR DESCRIPTION
Fixes #74 

## Changes
 - Fixes the listed failures in w3c trace-context compliance test suite. 
 - Adds a CI check which runs the w3c trace context tests for `SPEC_LEVEL=1`. 
     - Test suites run are `TraceContextTest` & `AdvancedTest`.

### Details

*The following lists shows all the failing tests. Checked box indicates that the changes in this PR have fixed the test.*
#### Currently failing tests from TraceContextTest suite
 - [x] test_traceparent_header_name_valid_casing 
 - [x] test_traceparent_included_tracestate_missing 
 - [x] test_traceparent_ows_handling 
 - [x] test_traceparent_version_0xcc 
 - [x] test_tracestate_all_allowed_characters 
 - [x] test_tracestate_duplicated_keys 
 - [x] test_tracestate_empty_header 
 - [x] test_tracestate_header_name_valid_casing 
 - [x] test_tracestate_included_traceparent_included 
 - [x] test_tracestate_key_length_limit 
 - [x] test_tracestate_member_count_limit 
 - [x] test_tracestate_multiple_headers_different_keys 
 - [x] test_tracestate_ows_handling 

#### Currently failing tests from AdvancedTest suite
 - [x] test_multiple_requests_with_valid_traceparent

**NOTE:** The tests above were part of test suites `TraceContextTest` & `AdvancedTest`. These test suites Trace Context Level 1 support.

### Current Status

All tests now passing. Test suites ran - `TraceContextTest` & `AdvancedTest`.

### Additional Tasks  

For significant contributions please make sure you have completed the following items:

* [x] `CHANGELOG.md` updated for non-trivial changes
* [x] Unit tests have been added
* [ ] Changes in public API reviewed