### PR TITLE
Allow cross-compilation with protobuf

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -419,20 +419,21 @@ if(WITH_OTLP_GRPC
       endif()
     endif()
   endif()
-  # Latest Protobuf imported targets and without legacy module support
-  if(TARGET protobuf::protoc)
-    project_build_tools_get_imported_location(PROTOBUF_PROTOC_EXECUTABLE
-                                              protobuf::protoc)
-    # If protobuf::protoc is not a imported target, then we use the target
-    # directly for fallback
-    if(NOT PROTOBUF_PROTOC_EXECUTABLE)
-      set(PROTOBUF_PROTOC_EXECUTABLE protobuf::protoc)
+  if(NOT PROTOBUF_PROTOC_EXECUTABLE)
+    # Latest Protobuf imported targets and without legacy module support
+    if(TARGET protobuf::protoc)
+      project_build_tools_get_imported_location(PROTOBUF_PROTOC_EXECUTABLE
+                                                protobuf::protoc)
+      # If protobuf::protoc is not a imported target, then we use the target
+      # directly for fallback
+      if(NOT PROTOBUF_PROTOC_EXECUTABLE)
+        set(PROTOBUF_PROTOC_EXECUTABLE protobuf::protoc)
+      endif()
+    elseif(Protobuf_PROTOC_EXECUTABLE)
+      # Some versions of FindProtobuf.cmake uses mixed case instead of uppercase
+      set(PROTOBUF_PROTOC_EXECUTABLE ${Protobuf_PROTOC_EXECUTABLE})
     endif()
-  elseif(Protobuf_PROTOC_EXECUTABLE)
-    # Some versions of FindProtobuf.cmake uses mixed case instead of uppercase
-    set(PROTOBUF_PROTOC_EXECUTABLE ${Protobuf_PROTOC_EXECUTABLE})
   endif()
-  include(CMakeDependentOption)
 
   message(STATUS "PROTOBUF_PROTOC_EXECUTABLE=${PROTOBUF_PROTOC_EXECUTABLE}")
   set(SAVED_CMAKE_CXX_CLANG_TIDY ${CMAKE_CXX_CLANG_TIDY})


### PR DESCRIPTION
The upstream config module from protobuf always declares targets for the protobuf library and protoc of the same platform. This means one of the two is always wrong, as protoc needs to be run on the build machine, but the library must be linked for the "host" platform.

A small change in the CMake scaffold allows the user to pass `-DPROTOBUF_PROTOC_EXECUTABLE=<path/to/protoc>` to cmake when creating the build tree.

Fixes # (issue)

## Changes

Please provide a brief description of the changes here.

For significant contributions please make sure you have completed the following items:

* [ ] `CHANGELOG.md` updated for non-trivial changes
* [ ] Unit tests have been added
* [ ] Changes in public API reviewed