### PR TITLE
[BUILD] allow building with -DWITH_OTLP_HTTP_COMPRESSION=OFF without zlib

### DIFF
--- a/ext/src/http/client/curl/http_client_curl.cc
+++ b/ext/src/http/client/curl/http_client_curl.cc
@@ -3,7 +3,6 @@
 
 #include <curl/curl.h>
 #include <curl/curlver.h>
-#include <zconf.h>
 #include <atomic>
 #include <chrono>
 #include <cstddef>
@@ -25,6 +24,7 @@
 #include "opentelemetry/version.h"
 
 #ifdef ENABLE_OTLP_COMPRESSION_PREVIEW
+#  include <zconf.h>
 #  include <zlib.h>
 #else
 #  include "opentelemetry/sdk/common/global_log_handler.h"


### PR DESCRIPTION
## Issue
Currently, when building `-DWITH_OTLP_HTTP_COMPRESSION=OFF`, and not providing the libz dependency, we get this error:

```
...\opentelemetry-cpp\ext\src\http\client\curl\http_
client_curl.cc(6,10): error C1083: Cannot open include file: 'zconf.h': No such file or directory [...opentelemetry-cpp\build\ext\src\http\client\curl\opentelemetry_http_cli
ent_curl.vcxproj]
```

## Changes

This fixes the issue by moving the `#include <zconf.h>` inside the corresponding #ifdef block, letting the build pass.

Do I need to do any of these? LMK, happy to :)

> * [ ] `CHANGELOG.md` updated for non-trivial changes
> * [ ] Unit tests have been added
> * [ ] Changes in public API reviewed