### PR TITLE
[BUILD] Improve how to handle yield() in ARM.

### DIFF
--- a/api/include/opentelemetry/common/spin_lock_mutex.h
+++ b/api/include/opentelemetry/common/spin_lock_mutex.h
@@ -68,8 +68,10 @@ public:
 #  else
     __builtin_ia32_pause();
 #  endif
-#elif defined(__arm__)
-    __asm__ volatile("yield" ::: "memory");
+#elif defined(__armel__) || defined(__ARMEL__)
+    asm volatile("nop" ::: "memory");
+#elif defined(__arm__) || defined(__aarch64__)  // arm big endian / arm64
+    __asm__ __volatile__("yield" ::: "memory");
 #else
     // TODO: Issue PAGE/YIELD on other architectures.
 #endif

--- a/api/test/common/spinlock_benchmark.cc
+++ b/api/test/common/spinlock_benchmark.cc
@@ -102,8 +102,10 @@ static void BM_ProcYieldSpinLockThrashing(benchmark::State &s)
 #  else
           __builtin_ia32_pause();
 #  endif
-#elif defined(__arm__)
-          __asm__ volatile("yield" ::: "memory");
+#elif defined(__armel__) || defined(__ARMEL__)
+          asm volatile("nop" ::: "memory");
+#elif defined(__arm__) || defined(__aarch64__)  // arm big endian / arm64
+          __asm__ __volatile__("yield" ::: "memory");
 #endif
         }
       },


### PR DESCRIPTION
## Changes

The yield instruction was introduced in ARM processors more recent than armel. So building in armel ends up in "Error: selected processor does not support `yield' in ARM mode". Also, the __yield() intrinsic instruction is not understood for armel by g++. So let's do nothing for armel.

This armel build CI job has the patch applied: https://salsa.debian.org/science-team/opentelemetry-cpp/-/jobs/6543996

Ref: https://developer.arm.com/documentation/ddi0406/b/Application-Level-Architecture/Application-Level-Programmers--Model/Exceptions--debug-events-and-checks/The-Yield-instruction?lang=en

Fixes #3128 

P.S. Example of other project handling similar instructions in different architectures: https://github.com/geidav/spinlocks-bench/blob/master/os.hpp#L31