### PR TITLE
Update to actions/upload-artifact@v4 action

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -35,7 +35,7 @@ jobs:
           mv api-benchmark_result.json benchmarks
           mv sdk-benchmark_result.json benchmarks
           mv exporters-benchmark_result.json benchmarks
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: benchmark_results
           path: benchmarks

--- a/.github/workflows/dependencies_image.yml
+++ b/.github/workflows/dependencies_image.yml
@@ -39,7 +39,7 @@ jobs:
         docker save -o /opt/otel-cpp-deps-debian.tar otel-cpp-deps
     -
       name: Upload Image
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: otel-cpp-deps
         path: /opt/otel-cpp-deps-debian.tar


### PR DESCRIPTION
No Jira card

## Changes

Update GHA workflows to use actions/upload-artifact@v4 action.

# Email from GitHub

> **Artifacts v3 Upcoming Deprecation Notice**
> Artifact actions v3 will be deprecated by December 5, 2024. You are receiving this email because you have GitHub Actions workflows using v3 of actions/upload-artifact or actions/download-artifact. After this date using v3 of these actions will result in a workflow failure. Artifacts within their retention period will remain accessible from the UI or REST API regardless of the version used to upload.
>
> To raise awareness of the upcoming removal, we will temporarily fail jobs using v3 of [actions/upload-artifact](https://app.github.media/e/er?s=88570519&lid=6648&elqTrackId=d2da2b8a2e2546f6bbbefc4362a25248&elq=1c2dae0486164a808b27db759ebea8e1&elqaid=4245&elqat=1&elqak=8AF5A79567D1D842C6394C4E2A26BD2485A9150BB891EA7FA0E70F84951E98807287) or [actions/download-artifact](https://app.github.media/e/er?s=88570519&lid=6647&elqTrackId=a0c373a95cb941a69247c326aef08dfe&elq=1c2dae0486164a808b27db759ebea8e1&elqaid=4245&elqat=1&elqak=8AF5A416F3461CA0C91DF8AF94CEC73EC20A150BB891EA7FA0E70F84951E98807287). Builds that are scheduled to run during the brownout periods will fail. The brownouts are scheduled for the following dates and times:
>
>    November 14, 12pm - 1pm EST
>    November 21, 9am - 5pm EST
>
> **What you need to do**
> Update workflows to begin using v4 of the artifact actions as soon as possible. While v4 improves upload and download speeds by up to 98% and includes several new features, there are key differences from previous versions that may require updates to your workflows. Please see the documentation in the project repositories for guidance on how to migrate your workflows.
