### PR TITLE
Set up for opentelemetry_proto_grpc_lib_type being shared

### DIFF
--- a/cmake/opentelemetry-proto.cmake
+++ b/cmake/opentelemetry-proto.cmake
@@ -348,7 +348,8 @@ if(WITH_OTLP_GRPC)
   target_link_libraries(opentelemetry_proto_grpc PUBLIC opentelemetry_proto)
 
   get_target_property(grpc_lib_type gRPC::grpc++ TYPE)
-  if(grpc_lib_type STREQUAL "SHARED_LIBRARY")
+  get_target_property(opentelemetry_proto_grpc_lib_type opentelemetry_proto_grpc TYPE)
+  if ((grpc_lib_type STREQUAL "SHARED_LIBRARY") OR (opentelemetry_proto_grpc_lib_type STREQUAL "SHARED_LIBRARY"))
     target_link_libraries(opentelemetry_proto_grpc PUBLIC gRPC::grpc++)
   endif()
   set_target_properties(opentelemetry_proto_grpc PROPERTIES EXPORT_NAME


### PR DESCRIPTION
Caution, this patch may cause one of the tests to go into a loop

Fixes #3126
Buildability for AIX
## Changes
cmake/opentelemetry-proto.cmake to make opentelemetry_proto_grpc library link with gRPC::grpc++ if building shared

This PR split off from #3127

* [ ] `CHANGELOG.md` updated for non-trivial changes
* [ ] Unit tests have been added
* [ ] Changes in public API reviewed