### PR TITLE
[EXPORTER] fix clang-tidy warnings in UrlParser

### DIFF
--- a/ext/include/opentelemetry/ext/http/common/url_parser.h
+++ b/ext/include/opentelemetry/ext/http/common/url_parser.h
@@ -51,8 +51,7 @@ public:
     }
     else
     {
-      scheme_ = std::string(url_.begin() + static_cast<std::string::difference_type>(cpos),
-                            url_.begin() + static_cast<std::string::difference_type>(pos));
+      scheme_ = url_.substr(cpos, pos - cpos);
       cpos    = pos + 3;
     }
 
@@ -74,16 +73,19 @@ public:
     {
       // port missing. Used default 80 / 443
       if (scheme_ == "http")
+      {
         port_ = 80;
-      if (scheme_ == "https")
+      }
+      else if (scheme_ == "https")
+      {
         port_ = 443;
+      }
     }
     else
     {
       // port present
       is_port = true;
-      host_   = std::string(url_.begin() + static_cast<std::string::difference_type>(cpos),
-                            url_.begin() + static_cast<std::string::difference_type>(pos));
+      host_   = url_.substr(cpos, pos - cpos);
       cpos    = pos + 1;
     }
     pos = url_.find_first_of("/?", cpos);
@@ -92,30 +94,23 @@ public:
       path_ = std::string("/");  // use default path
       if (is_port)
       {
-        std::string port_str(
-            url_.begin() + static_cast<std::string::difference_type>(cpos),
-            url_.begin() + static_cast<std::string::difference_type>(url_.length()));
-
-        port_ = GetPort(port_str);
+        auto port_str = url_.substr(cpos, url_.length());
+        port_         = GetPort(port_str);
       }
       else
       {
-        host_ =
-            std::string(url_.begin() + static_cast<std::string::difference_type>(cpos),
-                        url_.begin() + static_cast<std::string::difference_type>(url_.length()));
+        host_ = url_.substr(cpos, url_.length());
       }
       return;
     }
     if (is_port)
     {
-      std::string port_str(url_.begin() + static_cast<std::string::difference_type>(cpos),
-                           url_.begin() + static_cast<std::string::difference_type>(pos));
-      port_ = GetPort(port_str);
+      auto port_str = url_.substr(cpos, pos - cpos);
+      port_         = GetPort(port_str);
     }
     else
     {
-      host_ = std::string(url_.begin() + static_cast<std::string::difference_type>(cpos),
-                          url_.begin() + static_cast<std::string::difference_type>(pos));
+      host_ = url_.substr(cpos, pos - cpos);
     }
     cpos = pos;
 
@@ -124,27 +119,21 @@ public:
       pos = url_.find('?', cpos);
       if (pos == std::string::npos)
       {
-        path_ =
-            std::string(url_.begin() + static_cast<std::string::difference_type>(cpos),
-                        url_.begin() + static_cast<std::string::difference_type>(url_.length()));
+        path_  = url_.substr(cpos, url_.length());
         query_ = "";
       }
       else
       {
-        path_ = std::string(url_.begin() + static_cast<std::string::difference_type>(cpos),
-                            url_.begin() + static_cast<std::string::difference_type>(pos));
-        cpos  = pos + 1;
-        query_ =
-            std::string(url_.begin() + static_cast<std::string::difference_type>(cpos),
-                        url_.begin() + static_cast<std::string::difference_type>(url_.length()));
+        path_  = url_.substr(cpos, pos - cpos);
+        cpos   = pos + 1;
+        query_ = url_.substr(cpos, url_.length());
       }
       return;
     }
     path_ = std::string("/");
     if (url_[cpos] == '?')
     {
-      query_ = std::string(url_.begin() + static_cast<std::string::difference_type>(cpos),
-                           url_.begin() + static_cast<std::string::difference_type>(url_.length()));
+      query_ = url_.substr(cpos, url_.length());
     }
   }
 

--- a/ext/include/opentelemetry/ext/http/common/url_parser.h
+++ b/ext/include/opentelemetry/ext/http/common/url_parser.h
@@ -94,12 +94,12 @@ public:
       path_ = std::string("/");  // use default path
       if (is_port)
       {
-        auto port_str = url_.substr(cpos, url_.length());
+        auto port_str = url_.substr(cpos);
         port_         = GetPort(port_str);
       }
       else
       {
-        host_ = url_.substr(cpos, url_.length());
+        host_ = url_.substr(cpos);
       }
       return;
     }
@@ -119,21 +119,20 @@ public:
       pos = url_.find('?', cpos);
       if (pos == std::string::npos)
       {
-        path_  = url_.substr(cpos, url_.length());
-        query_ = "";
+        path_ = url_.substr(cpos);
       }
       else
       {
         path_  = url_.substr(cpos, pos - cpos);
         cpos   = pos + 1;
-        query_ = url_.substr(cpos, url_.length());
+        query_ = url_.substr(cpos);
       }
       return;
     }
     path_ = std::string("/");
     if (url_[cpos] == '?')
     {
-      query_ = url_.substr(cpos, url_.length());
+      query_ = url_.substr(cpos);
     }
   }
 
@@ -207,16 +206,23 @@ public:
     for (size_t pos = 0; pos < encoded.size(); pos++)
     {
       auto c = encoded[pos];
-      if (c == '%' && pos + 2 < encoded.size())
+      if (c == '%')
       {
+        if (pos + 2 >= encoded.size())
+        {
+          return encoded;
+        }
+
         int hi = hex_to_int(encoded[pos + 1]);
         int lo = hex_to_int(encoded[pos + 2]);
 
-        if (hi != -1 && lo != -1)
+        if (hi == -1 || lo == -1)
         {
-          c = static_cast<char>((hi << 4) | lo);
-          pos += 2;
+          return encoded;
         }
+
+        c = static_cast<char>((hi << 4) | lo);
+        pos += 2;
       }
 
       result.push_back(c);

--- a/ext/include/opentelemetry/ext/http/common/url_parser.h
+++ b/ext/include/opentelemetry/ext/http/common/url_parser.h
@@ -194,36 +194,32 @@ public:
     std::string result;
     result.reserve(encoded.size());
 
+    auto hex_to_int = [](int ch) -> int {
+      if (ch >= '0' && ch <= '9')
+        return ch - '0';
+      if (ch >= 'a' && ch <= 'f')
+        return ch - 'a' + 10;
+      if (ch >= 'A' && ch <= 'F')
+        return ch - 'A' + 10;
+      return -1;
+    };
+
     for (size_t pos = 0; pos < encoded.size(); pos++)
     {
-      if (encoded[pos] == '%')
+      auto c = encoded[pos];
+      if (c == '%' && pos + 2 < encoded.size())
       {
+        int hi = hex_to_int(encoded[pos + 1]);
+        int lo = hex_to_int(encoded[pos + 2]);
 
-        // Invalid input: less than two characters left after '%'
-        if (encoded.size() < pos + 3)
+        if (hi != -1 && lo != -1)
         {
-          return encoded;
+          c = static_cast<char>((hi << 4) | lo);
+          pos += 2;
         }
-
-        char hex[3] = {0};
-        hex[0]      = encoded[++pos];
-        hex[1]      = encoded[++pos];
-
-        char *endptr;
-        int value = static_cast<int>(std::strtol(hex, &endptr, 16));
-
-        // Invalid input: no valid hex characters after '%'
-        if (endptr != &hex[2])
-        {
-          return encoded;
-        }
-
-        result.push_back(static_cast<char>(value));
       }
-      else
-      {
-        result.push_back(encoded[pos]);
-      }
+
+      result.push_back(c);
     }
 
     return result;

--- a/ext/test/http/url_parser_test.cc
+++ b/ext/test/http/url_parser_test.cc
@@ -238,7 +238,8 @@ TEST(UrlDecoderTests, BasicTests)
       {"%2x", "%2x"},
       {"%20", " "},
       {"text%2", "text%2"},
-  };
+      {"%20test%zztest", "%20test%zztest"},
+      {"%20test%2", "%20test%2"}};
 
   for (auto &testsample : testdata)
   {


### PR DESCRIPTION
## Changes

This PR fixes issues found by `clang-tidy` in UrlParser.

Please provide a brief description of the changes here.

For significant contributions please make sure you have completed the following items:

* [ ] `CHANGELOG.md` updated for non-trivial changes
* [ ] Unit tests have been added
* [ ] Changes in public API reviewed