### PR TITLE
Fix lifetime for sdk::ReadWriteLogRecord

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,13 +63,15 @@ Important changes:
 * [SDK] Fix lifetime for sdk::ReadWriteLogRecord
   [#3147](https://github.com/open-telemetry/opentelemetry-cpp/pull/3245)
 
-  * With ABI version 2, `opentelemetry::sdk::logs::ReadableLogRecord::GetAttributes()`
+  * `opentelemetry::sdk::logs::ReadableLogRecord::GetAttributes()`
     will returns a `std::unordered_map<std::string, opentelemetry::sdk::common::OwnedAttributeValue>`
     instead of a `std::unordered_map<std::string, opentelemetry::common::AttributeValue>`
     to keep the same type as the `opentelemetry::sdk::trace::SpanData`. And
     `opentelemetry::sdk::logs::ReadableLogRecord::GetBody()` will returns a
     `const opentelemetry::sdk::common::OwnedAttributeValue &` instead of a
-    `const opentelemetry::common::AttributeValue &`.
+    `const opentelemetry::common::AttributeValue &` now, we switch to the old
+    APIs by add `-DWITH_DEPRECATED_SDK_LOG_RECORD=ON` for cmake or add
+    `--copt -DOPENTELEMETRY_DEPRECATED_SDK_LOG_RECORD` for bazel.
 
 ## [1.20 2025-04-01]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,22 @@ Increment the:
 * [CMAKE] Add generated protobuf headers to the opentelemetry_proto target
   [#3400](https://github.com/open-telemetry/opentelemetry-cpp/pull/3400)
 
+* [SDK] Fix lifetime for sdk::ReadWriteLogRecord
+  [#3147](https://github.com/open-telemetry/opentelemetry-cpp/pull/3245)
+
+Important changes:
+
+* [SDK] Fix lifetime for sdk::ReadWriteLogRecord
+  [#3147](https://github.com/open-telemetry/opentelemetry-cpp/pull/3245)
+
+  * With ABI version 2, `opentelemetry::sdk::logs::ReadableLogRecord::GetAttributes()`
+    will returns a `std::unordered_map<std::string, opentelemetry::sdk::common::OwnedAttributeValue>`
+    instead of a `std::unordered_map<std::string, opentelemetry::common::AttributeValue>`
+    to keep the same type as the `opentelemetry::sdk::trace::SpanData`. And
+    `opentelemetry::sdk::logs::ReadableLogRecord::GetBody()` will returns a
+    `const opentelemetry::sdk::common::OwnedAttributeValue &` instead of a
+    `const opentelemetry::common::AttributeValue &`.
+
 ## [1.20 2025-04-01]
 
 * [BUILD] Update opentelemetry-proto version
@@ -198,6 +214,9 @@ Important changes:
     `Provider` classes, to benefit from this feature.
 
   * All the example code has been updated to reflect the new usage.
+
+* [SDK] Implement spec: MetricFilter
+  [#3235](https://github.com/open-telemetry/opentelemetry-cpp/pull/3235)
 
 ## [1.19 2025-01-22]
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -121,8 +121,10 @@ if(VCPKG_CHAINLOAD_TOOLCHAIN_FILE)
   include("${VCPKG_CHAINLOAD_TOOLCHAIN_FILE}")
 endif()
 
-option(WITH_ABI_VERSION_1 "ABI version 1" ON)
+include(CMakeDependentOption)
 option(WITH_ABI_VERSION_2 "EXPERIMENTAL: ABI version 2 preview" OFF)
+cmake_dependent_option(WITH_ABI_VERSION_1 "ABI version 1" ON
+                       "NOT WITH_ABI_VERSION_2" OFF)
 
 file(READ "${CMAKE_CURRENT_LIST_DIR}/api/include/opentelemetry/version.h"
      OPENTELEMETRY_CPP_HEADER_VERSION_H)
@@ -490,7 +492,6 @@ if(WITH_OTLP_GRPC
     # Some versions of FindProtobuf.cmake uses mixed case instead of uppercase
     set(PROTOBUF_PROTOC_EXECUTABLE ${Protobuf_PROTOC_EXECUTABLE})
   endif()
-  include(CMakeDependentOption)
 
   message(STATUS "PROTOBUF_PROTOC_EXECUTABLE=${PROTOBUF_PROTOC_EXECUTABLE}")
   set(SAVED_CMAKE_CXX_CLANG_TIDY ${CMAKE_CXX_CLANG_TIDY})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -185,6 +185,13 @@ message(STATUS "OPENTELEMETRY_VERSION=${OPENTELEMETRY_VERSION}")
 
 option(WITH_NO_DEPRECATED_CODE "Do not include deprecated code" OFF)
 
+option(WITH_DEPRECATED_SDK_LOG_RECORD "Use deprecated SDK log record" OFF)
+
+if(WITH_DEPRECATED_SDK_LOG_RECORD)
+  message(
+    WARNING "WITH_DEPRECATED_SDK_LOG_RECORD=ON is temporary and deprecated")
+endif()
+
 set(WITH_STL
     "OFF"
     CACHE STRING "Which version of the Standard Library for C++ to use")

--- a/ci/do_ci.ps1
+++ b/ci/do_ci.ps1
@@ -67,6 +67,7 @@ switch ($action) {
     cmake $SRC_DIR `
       -DVCPKG_TARGET_TRIPLET=x64-windows `
       -DOPENTELEMETRY_BUILD_DLL=1 `
+      -DWITH_DEPRECATED_SDK_LOG_RECORD=ON `
      "-DCMAKE_TOOLCHAIN_FILE=$VCPKG_DIR/scripts/buildsystems/vcpkg.cmake"
     $exit = $LASTEXITCODE
     if ($exit -ne 0) {
@@ -221,6 +222,7 @@ switch ($action) {
     cmake $SRC_DIR `
       -DVCPKG_TARGET_TRIPLET=x64-windows `
       -DWITH_ASYNC_EXPORT_PREVIEW=ON `
+      -DWITH_DEPRECATED_SDK_LOG_RECORD=ON `
       "-DCMAKE_TOOLCHAIN_FILE=$VCPKG_DIR/scripts/buildsystems/vcpkg.cmake"
     $exit = $LASTEXITCODE
     if ($exit -ne 0) {

--- a/ci/do_ci.sh
+++ b/ci/do_ci.sh
@@ -228,6 +228,7 @@ elif [[ "$1" == "cmake.with_async_export.test" ]]; then
         -DWITH_METRICS_EXEMPLAR_PREVIEW=ON \
         -DCMAKE_CXX_FLAGS="-Werror $CXXFLAGS" \
         -DWITH_ASYNC_EXPORT_PREVIEW=ON \
+        -DWITH_DEPRECATED_SDK_LOG_RECORD=ON \
         "${SRC_DIR}"
   make -j $(nproc)
   make test
@@ -281,6 +282,7 @@ elif [[ "$1" == "cmake.c++20.test" ]]; then
         -DCMAKE_CXX_FLAGS="-Werror $CXXFLAGS" \
         -DWITH_ASYNC_EXPORT_PREVIEW=ON \
         -DWITH_STL=CXX20 \
+        -DWITH_DEPRECATED_SDK_LOG_RECORD=ON \
         "${SRC_DIR}"
   eval "$MAKE_COMMAND"
   make test
@@ -292,6 +294,7 @@ elif [[ "$1" == "cmake.c++23.test" ]]; then
         -DCMAKE_CXX_FLAGS="-Werror $CXXFLAGS" \
         -DWITH_ASYNC_EXPORT_PREVIEW=ON \
         -DWITH_STL=CXX23 \
+        -DWITH_DEPRECATED_SDK_LOG_RECORD=ON \
         "${SRC_DIR}"
   eval "$MAKE_COMMAND"
   make test
@@ -304,6 +307,7 @@ elif [[ "$1" == "cmake.c++14.stl.test" ]]; then
         -DCMAKE_CXX_FLAGS="-Werror $CXXFLAGS" \
         -DWITH_ASYNC_EXPORT_PREVIEW=ON \
         -DWITH_STL=CXX14 \
+        -DWITH_DEPRECATED_SDK_LOG_RECORD=ON \
         "${SRC_DIR}"
   eval "$MAKE_COMMAND"
   make test
@@ -316,6 +320,7 @@ elif [[ "$1" == "cmake.c++17.stl.test" ]]; then
         -DCMAKE_CXX_FLAGS="-Werror $CXXFLAGS" \
         -DWITH_ASYNC_EXPORT_PREVIEW=ON \
         -DWITH_STL=CXX17 \
+        -DWITH_DEPRECATED_SDK_LOG_RECORD=ON \
         "${SRC_DIR}"
   eval "$MAKE_COMMAND"
   make test

--- a/exporters/ostream/src/log_record_exporter.cc
+++ b/exporters/ostream/src/log_record_exporter.cc
@@ -22,7 +22,7 @@
 #include "opentelemetry/sdk/common/exporter_utils.h"
 #include "opentelemetry/sdk/common/global_log_handler.h"
 #include "opentelemetry/sdk/instrumentationscope/instrumentation_scope.h"
-#include "opentelemetry/sdk/logs/read_write_log_record.h"
+#include "opentelemetry/sdk/logs/log_record_data.h"
 #include "opentelemetry/sdk/logs/recordable.h"
 #include "opentelemetry/sdk/resource/resource.h"
 #include "opentelemetry/trace/span_id.h"
@@ -47,7 +47,7 @@ OStreamLogRecordExporter::OStreamLogRecordExporter(std::ostream &sout) noexcept 
 
 std::unique_ptr<sdklogs::Recordable> OStreamLogRecordExporter::MakeRecordable() noexcept
 {
-  return std::unique_ptr<sdklogs::Recordable>(new sdklogs::ReadWriteLogRecord());
+  return std::unique_ptr<sdklogs::Recordable>(new sdklogs::LogRecordData());
 }
 
 sdk::common::ExportResult OStreamLogRecordExporter::Export(
@@ -62,8 +62,8 @@ sdk::common::ExportResult OStreamLogRecordExporter::Export(
 
   for (auto &record : records)
   {
-    auto log_record = std::unique_ptr<sdklogs::ReadWriteLogRecord>(
-        static_cast<sdklogs::ReadWriteLogRecord *>(record.release()));
+    auto log_record = std::unique_ptr<sdklogs::LogRecordData>(
+        static_cast<sdklogs::LogRecordData *>(record.release()));
 
     if (log_record == nullptr)
     {

--- a/exporters/ostream/test/ostream_log_test.cc
+++ b/exporters/ostream/test/ostream_log_test.cc
@@ -27,10 +27,10 @@
 #include "opentelemetry/nostd/utility.h"
 #include "opentelemetry/sdk/instrumentationscope/instrumentation_scope.h"
 #include "opentelemetry/sdk/logs/exporter.h"
+#include "opentelemetry/sdk/logs/log_record_data.h"
 #include "opentelemetry/sdk/logs/logger_provider.h"
 #include "opentelemetry/sdk/logs/processor.h"
 #include "opentelemetry/sdk/logs/provider.h"
-#include "opentelemetry/sdk/logs/read_write_log_record.h"
 #include "opentelemetry/sdk/logs/readable_log_record.h"
 #include "opentelemetry/sdk/logs/recordable.h"
 #include "opentelemetry/sdk/logs/simple_log_record_processor.h"
@@ -82,7 +82,7 @@ TEST(OStreamLogRecordExporter, Shutdown)
 
   // After processor/exporter is shutdown, no logs should be sent to stream
   auto record = exporter->MakeRecordable();
-  static_cast<sdklogs::ReadWriteLogRecord *>(record.get())->SetBody("Log record not empty");
+  static_cast<sdklogs::LogRecordData *>(record.get())->SetBody("Log record not empty");
   exporter->Export(nostd::span<std::unique_ptr<sdklogs::Recordable>>(&record, 1));
 
   // Restore original stringstream buffer
@@ -171,12 +171,12 @@ TEST(OStreamLogRecordExporter, SimpleLogToCout)
   // Create a log record and manually timestamp, severity, name, message
   common::SystemTimestamp now(std::chrono::system_clock::now());
 
-  auto record = std::unique_ptr<sdklogs::Recordable>(new sdklogs::ReadWriteLogRecord());
-  static_cast<sdklogs::ReadWriteLogRecord *>(record.get())->SetTimestamp(now);
-  static_cast<sdklogs::ReadWriteLogRecord *>(record.get())->SetObservedTimestamp(now);
-  static_cast<sdklogs::ReadWriteLogRecord *>(record.get())
+  auto record = std::unique_ptr<sdklogs::Recordable>(new sdklogs::LogRecordData());
+  static_cast<sdklogs::LogRecordData *>(record.get())->SetTimestamp(now);
+  static_cast<sdklogs::LogRecordData *>(record.get())->SetObservedTimestamp(now);
+  static_cast<sdklogs::LogRecordData *>(record.get())
       ->SetSeverity(logs_api::Severity::kTrace);  // kTrace has enum value of 1
-  static_cast<sdklogs::ReadWriteLogRecord *>(record.get())->SetBody("Message");
+  static_cast<sdklogs::LogRecordData *>(record.get())->SetBody("Message");
 
   opentelemetry::sdk::instrumentationscope::InstrumentationScope instrumentation_scope =
       GetTestInstrumentationScope();
@@ -248,10 +248,10 @@ TEST(OStreamLogRecordExporter, LogWithStringAttributesToCerr)
 
   // Set resources for this log record only of type <string, string>
   auto resource = opentelemetry::sdk::resource::Resource::Create({{"key1", "val1"}});
-  static_cast<sdklogs::ReadWriteLogRecord *>(record.get())->SetResource(resource);
+  static_cast<sdklogs::LogRecordData *>(record.get())->SetResource(resource);
 
   // Set attributes to this log record of type <string, AttributeValue>
-  static_cast<sdklogs::ReadWriteLogRecord *>(record.get())->SetAttribute("a", true);
+  static_cast<sdklogs::LogRecordData *>(record.get())->SetAttribute("a", true);
 
   opentelemetry::sdk::instrumentationscope::InstrumentationScope instrumentation_scope =
       GetTestInstrumentationScope();
@@ -326,12 +326,12 @@ TEST(OStreamLogRecordExporter, LogWithVariantTypesToClog)
   nostd::span<int> data1{array1.data(), array1.size()};
 
   auto resource = opentelemetry::sdk::resource::Resource::Create({{"res1", data1}});
-  static_cast<sdklogs::ReadWriteLogRecord *>(record.get())->SetResource(resource);
+  static_cast<sdklogs::LogRecordData *>(record.get())->SetResource(resource);
 
   // Set resources for this log record of bool types as the value
   // e.g. key/value is a par of type <string, array of bools>
   std::array<bool, 3> array = {false, true, false};
-  static_cast<sdklogs::ReadWriteLogRecord *>(record.get())
+  static_cast<sdklogs::LogRecordData *>(record.get())
       ->SetAttribute("attr1", nostd::span<bool>{array.data(), array.size()});
 
   opentelemetry::sdk::instrumentationscope::InstrumentationScope instrumentation_scope =

--- a/sdk/include/opentelemetry/sdk/logs/exporter.h
+++ b/sdk/include/opentelemetry/sdk/logs/exporter.h
@@ -28,8 +28,8 @@ public:
   /**
    * Create a log recordable. This object will be used to record log data and
    * will subsequently be passed to LogRecordExporter::Export. Vendors can implement
-   * custom recordables or use the default ReadWriteLogRecord recordable provided by the
-   * SDK.
+   * custom recordables or use the default ReadWriteLogRecord/LogRecordData recordable provided by
+   * the SDK.
    * @return a newly initialized Recordable object
    *
    * Note: This method must be callable from multiple threads.

--- a/sdk/include/opentelemetry/sdk/logs/log_record_data.h
+++ b/sdk/include/opentelemetry/sdk/logs/log_record_data.h
@@ -30,11 +30,11 @@ namespace logs
  *
  * This class is thread-compatible.
  */
-class ReadWriteLogRecord final : public ReadableLogRecord
+class LogRecordData final : public ReadableLogRecord
 {
 public:
-  ReadWriteLogRecord();
-  ~ReadWriteLogRecord() override;
+  LogRecordData();
+  ~LogRecordData() override;
 
   /**
    * Set the timestamp for this log.
@@ -78,9 +78,9 @@ public:
    */
   void SetBody(const opentelemetry::common::AttributeValue &message) noexcept override;
 
-  /**
-   * Get body field of this log.
-   * @return the body field for this log.
+  /**                                     \
+   * Get body field of this log.          \
+   * @return the body field for this log. \
    */
 #if OPENTELEMETRY_ABI_VERSION_NO >= 2
   const common::OwnedAttributeValue &
@@ -202,9 +202,9 @@ private:
   common::OwnedAttributeValue body_;
   common::AttributeConverter attribute_converter_;
 #else
-  std::unordered_map<std::string, opentelemetry::common::AttributeValue> attributes_map_;
+  common::MixedAttributeMap attributes_map_;
   // We resue the same utility functions of MixedAttributeMap with key="" for the body field
-  opentelemetry::common::AttributeValue body_;
+  common::MixedAttributeMap body_;
 #endif
   opentelemetry::common::SystemTimestamp timestamp_;
   opentelemetry::common::SystemTimestamp observed_timestamp_;

--- a/sdk/include/opentelemetry/sdk/logs/log_record_data.h
+++ b/sdk/include/opentelemetry/sdk/logs/log_record_data.h
@@ -82,7 +82,7 @@ public:
    * Get body field of this log.          \
    * @return the body field for this log. \
    */
-#if OPENTELEMETRY_ABI_VERSION_NO >= 2
+#if !defined(OPENTELEMETRY_DEPRECATED_SDK_LOG_RECORD)
   const common::OwnedAttributeValue &
 #else
   const opentelemetry::common::AttributeValue &
@@ -156,7 +156,7 @@ public:
    * Get attributes of this log.
    * @return the body field of this log
    */
-#if OPENTELEMETRY_ABI_VERSION_NO >= 2
+#if !defined(OPENTELEMETRY_DEPRECATED_SDK_LOG_RECORD)
   const std::unordered_map<std::string, common::OwnedAttributeValue> &
 #else
   const std::unordered_map<std::string, opentelemetry::common::AttributeValue> &
@@ -196,7 +196,7 @@ private:
   const opentelemetry::sdk::resource::Resource *resource_;
   const opentelemetry::sdk::instrumentationscope::InstrumentationScope *instrumentation_scope_;
 
-#if OPENTELEMETRY_ABI_VERSION_NO >= 2
+#if !defined(OPENTELEMETRY_DEPRECATED_SDK_LOG_RECORD)
   common::AttributeMap attributes_map_;
   // We resue the same utility functions of MixedAttributeMap with key="" for the body field
   common::OwnedAttributeValue body_;

--- a/sdk/include/opentelemetry/sdk/logs/read_write_log_record.h
+++ b/sdk/include/opentelemetry/sdk/logs/read_write_log_record.h
@@ -82,7 +82,7 @@ public:
    * Get body field of this log.
    * @return the body field for this log.
    */
-#if OPENTELEMETRY_ABI_VERSION_NO >= 2
+#if !defined(OPENTELEMETRY_DEPRECATED_SDK_LOG_RECORD)
   const common::OwnedAttributeValue &
 #else
   const opentelemetry::common::AttributeValue &
@@ -156,7 +156,7 @@ public:
    * Get attributes of this log.
    * @return the body field of this log
    */
-#if OPENTELEMETRY_ABI_VERSION_NO >= 2
+#if !defined(OPENTELEMETRY_DEPRECATED_SDK_LOG_RECORD)
   const std::unordered_map<std::string, common::OwnedAttributeValue> &
 #else
   const std::unordered_map<std::string, opentelemetry::common::AttributeValue> &
@@ -196,7 +196,7 @@ private:
   const opentelemetry::sdk::resource::Resource *resource_;
   const opentelemetry::sdk::instrumentationscope::InstrumentationScope *instrumentation_scope_;
 
-#if OPENTELEMETRY_ABI_VERSION_NO >= 2
+#if !defined(OPENTELEMETRY_DEPRECATED_SDK_LOG_RECORD)
   common::AttributeMap attributes_map_;
   // We resue the same utility functions of MixedAttributeMap with key="" for the body field
   common::OwnedAttributeValue body_;

--- a/sdk/include/opentelemetry/sdk/logs/readable_log_record.h
+++ b/sdk/include/opentelemetry/sdk/logs/readable_log_record.h
@@ -75,7 +75,12 @@ public:
    * Get body field of this log.
    * @return the body field for this log.
    */
-  virtual const opentelemetry::common::AttributeValue &GetBody() const noexcept = 0;
+#if OPENTELEMETRY_ABI_VERSION_NO >= 2
+  virtual const common::OwnedAttributeValue &
+#else
+  virtual const opentelemetry::common::AttributeValue &
+#endif
+  GetBody() const noexcept = 0;
 
   /**
    * Get the Event id.
@@ -111,7 +116,11 @@ public:
    * Get attributes of this log.
    * @return the body field of this log
    */
+#if OPENTELEMETRY_ABI_VERSION_NO >= 2
+  virtual const std::unordered_map<std::string, common::OwnedAttributeValue> &
+#else
   virtual const std::unordered_map<std::string, opentelemetry::common::AttributeValue> &
+#endif
   GetAttributes() const noexcept = 0;
 
   /**

--- a/sdk/include/opentelemetry/sdk/logs/readable_log_record.h
+++ b/sdk/include/opentelemetry/sdk/logs/readable_log_record.h
@@ -75,7 +75,7 @@ public:
    * Get body field of this log.
    * @return the body field for this log.
    */
-#if OPENTELEMETRY_ABI_VERSION_NO >= 2
+#if !defined(OPENTELEMETRY_DEPRECATED_SDK_LOG_RECORD)
   virtual const common::OwnedAttributeValue &
 #else
   virtual const opentelemetry::common::AttributeValue &
@@ -116,7 +116,7 @@ public:
    * Get attributes of this log.
    * @return the body field of this log
    */
-#if OPENTELEMETRY_ABI_VERSION_NO >= 2
+#if !defined(OPENTELEMETRY_DEPRECATED_SDK_LOG_RECORD)
   virtual const std::unordered_map<std::string, common::OwnedAttributeValue> &
 #else
   virtual const std::unordered_map<std::string, opentelemetry::common::AttributeValue> &

--- a/sdk/src/logs/CMakeLists.txt
+++ b/sdk/src/logs/CMakeLists.txt
@@ -18,6 +18,7 @@ add_library(
   logger_config.cc
   logger_context.cc
   logger_context_factory.cc
+  log_record_data.cc
   multi_log_record_processor.cc
   multi_log_record_processor_factory.cc
   multi_recordable.cc

--- a/sdk/src/logs/CMakeLists.txt
+++ b/sdk/src/logs/CMakeLists.txt
@@ -31,6 +31,11 @@ target_link_libraries(opentelemetry_logs PUBLIC opentelemetry_resources
                                                 opentelemetry_common)
 set_target_version(opentelemetry_logs)
 
+if(NOT WITH_NO_DEPRECATED_CODE AND WITH_DEPRECATED_SDK_LOG_RECORD)
+  target_compile_definitions(opentelemetry_logs
+                             PUBLIC OPENTELEMETRY_DEPRECATED_SDK_LOG_RECORD)
+endif()
+
 target_include_directories(
   opentelemetry_logs
   PUBLIC "$<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/sdk/include>")

--- a/sdk/src/logs/log_record_data.cc
+++ b/sdk/src/logs/log_record_data.cc
@@ -31,14 +31,14 @@ LogRecordData::LogRecordData()
     : severity_(opentelemetry::logs::Severity::kInvalid),
       resource_(nullptr),
       instrumentation_scope_(nullptr),
+#if !defined(OPENTELEMETRY_DEPRECATED_SDK_LOG_RECORD)
+      body_(std::string()),
+#endif
       observed_timestamp_(std::chrono::system_clock::now()),
       event_id_(0),
       event_name_("")
 {
-
-#if !defined(OPENTELEMETRY_DEPRECATED_SDK_LOG_RECORD)
-  body_ = std::string();
-#else
+#if defined(OPENTELEMETRY_DEPRECATED_SDK_LOG_RECORD)
   body_.SetAttribute("", nostd::string_view());
 #endif
 }

--- a/sdk/src/logs/log_record_data.cc
+++ b/sdk/src/logs/log_record_data.cc
@@ -6,12 +6,12 @@
 #include <memory>
 #include <string>
 #include <unordered_map>
-#include <utility>
 
 #include "opentelemetry/common/attribute_value.h"
 #include "opentelemetry/common/timestamp.h"
 #include "opentelemetry/logs/severity.h"
 #include "opentelemetry/nostd/string_view.h"
+#include "opentelemetry/nostd/variant.h"
 #include "opentelemetry/sdk/common/attribute_utils.h"
 #include "opentelemetry/sdk/instrumentationscope/instrumentation_scope.h"
 #include "opentelemetry/sdk/logs/log_record_data.h"

--- a/sdk/src/logs/log_record_data.cc
+++ b/sdk/src/logs/log_record_data.cc
@@ -36,7 +36,7 @@ LogRecordData::LogRecordData()
       event_name_("")
 {
 
-#if OPENTELEMETRY_ABI_VERSION_NO >= 2
+#if !defined(OPENTELEMETRY_DEPRECATED_SDK_LOG_RECORD)
   body_ = std::string();
 #else
   body_.SetAttribute("", nostd::string_view());
@@ -77,21 +77,21 @@ opentelemetry::logs::Severity LogRecordData::GetSeverity() const noexcept
 
 void LogRecordData::SetBody(const opentelemetry::common::AttributeValue &message) noexcept
 {
-#if OPENTELEMETRY_ABI_VERSION_NO >= 2
+#if !defined(OPENTELEMETRY_DEPRECATED_SDK_LOG_RECORD)
   body_ = nostd::visit(attribute_converter_, message);
 #else
   body_.SetAttribute("", message);
 #endif
 }
 
-#if OPENTELEMETRY_ABI_VERSION_NO >= 2
+#if !defined(OPENTELEMETRY_DEPRECATED_SDK_LOG_RECORD)
 const common::OwnedAttributeValue &
 #else
 const opentelemetry::common::AttributeValue &
 #endif
 LogRecordData::GetBody() const noexcept
 {
-#if OPENTELEMETRY_ABI_VERSION_NO >= 2
+#if !defined(OPENTELEMETRY_DEPRECATED_SDK_LOG_RECORD)
   return body_;
 #else
   return body_.GetAttributes().begin()->second;
@@ -183,7 +183,7 @@ void LogRecordData::SetAttribute(nostd::string_view key,
   attributes_map_.SetAttribute(key, value);
 }
 
-#if OPENTELEMETRY_ABI_VERSION_NO >= 2
+#if !defined(OPENTELEMETRY_DEPRECATED_SDK_LOG_RECORD)
 const std::unordered_map<std::string, opentelemetry::sdk::common::OwnedAttributeValue> &
 #else
 const std::unordered_map<std::string, opentelemetry::common::AttributeValue> &

--- a/sdk/src/logs/read_write_log_record.cc
+++ b/sdk/src/logs/read_write_log_record.cc
@@ -12,6 +12,7 @@
 #include "opentelemetry/logs/severity.h"
 #include "opentelemetry/nostd/string_view.h"
 #include "opentelemetry/nostd/variant.h"
+#include "opentelemetry/sdk/common/attribute_utils.h"
 #include "opentelemetry/sdk/instrumentationscope/instrumentation_scope.h"
 #include "opentelemetry/sdk/logs/read_write_log_record.h"
 #include "opentelemetry/sdk/resource/resource.h"

--- a/sdk/src/logs/read_write_log_record.cc
+++ b/sdk/src/logs/read_write_log_record.cc
@@ -30,7 +30,7 @@ ReadWriteLogRecord::ReadWriteLogRecord()
     : severity_(opentelemetry::logs::Severity::kInvalid),
       resource_(nullptr),
       instrumentation_scope_(nullptr),
-#if OPENTELEMETRY_ABI_VERSION_NO >= 2
+#if !defined(OPENTELEMETRY_DEPRECATED_SDK_LOG_RECORD)
       body_(std::string()),
 #else
       body_(nostd::string_view()),
@@ -75,14 +75,14 @@ opentelemetry::logs::Severity ReadWriteLogRecord::GetSeverity() const noexcept
 
 void ReadWriteLogRecord::SetBody(const opentelemetry::common::AttributeValue &message) noexcept
 {
-#if OPENTELEMETRY_ABI_VERSION_NO >= 2
+#if !defined(OPENTELEMETRY_DEPRECATED_SDK_LOG_RECORD)
   body_ = nostd::visit(attribute_converter_, message);
 #else
   body_ = message;
 #endif
 }
 
-#if OPENTELEMETRY_ABI_VERSION_NO >= 2
+#if !defined(OPENTELEMETRY_DEPRECATED_SDK_LOG_RECORD)
 const common::OwnedAttributeValue &
 #else
 const opentelemetry::common::AttributeValue &
@@ -174,21 +174,21 @@ const opentelemetry::trace::TraceFlags &ReadWriteLogRecord::GetTraceFlags() cons
 void ReadWriteLogRecord::SetAttribute(nostd::string_view key,
                                       const opentelemetry::common::AttributeValue &value) noexcept
 {
-#if OPENTELEMETRY_ABI_VERSION_NO >= 2
+#if !defined(OPENTELEMETRY_DEPRECATED_SDK_LOG_RECORD)
   attributes_map_.SetAttribute(key, value);
 #else
   attributes_map_[std::string(key)] = value;
 #endif
 }
 
-#if OPENTELEMETRY_ABI_VERSION_NO >= 2
+#if !defined(OPENTELEMETRY_DEPRECATED_SDK_LOG_RECORD)
 const std::unordered_map<std::string, opentelemetry::sdk::common::OwnedAttributeValue> &
 #else
 const std::unordered_map<std::string, opentelemetry::common::AttributeValue> &
 #endif
 ReadWriteLogRecord::GetAttributes() const noexcept
 {
-#if OPENTELEMETRY_ABI_VERSION_NO >= 2
+#if !defined(OPENTELEMETRY_DEPRECATED_SDK_LOG_RECORD)
   return attributes_map_.GetAttributes();
 #else
   return attributes_map_;

--- a/sdk/test/common/attribute_utils_test.cc
+++ b/sdk/test/common/attribute_utils_test.cc
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include <gtest/gtest.h>
+#include <stddef.h>
 #include <stdint.h>
 #include <array>
 #include <initializer_list>
@@ -13,9 +14,87 @@
 
 #include "opentelemetry/common/attribute_value.h"
 #include "opentelemetry/common/key_value_iterable_view.h"
+#include "opentelemetry/nostd/span.h"
 #include "opentelemetry/nostd/string_view.h"
+#include "opentelemetry/nostd/utility.h"
 #include "opentelemetry/nostd/variant.h"
 #include "opentelemetry/sdk/common/attribute_utils.h"
+
+namespace
+{
+
+template <class DataType>
+static void CheckExceptOneValue(const opentelemetry::sdk::common::MixedAttributeMap &data,
+                                opentelemetry::nostd::string_view key,
+                                DataType value)
+{
+  auto iter1 = data.GetAttributes().find(std::string(key));
+  EXPECT_TRUE(iter1 != data.GetAttributes().end());
+
+  auto iter2 = data.GetOwnedAttributes().find(std::string(key));
+  EXPECT_TRUE(iter2 != data.GetOwnedAttributes().end());
+
+  EXPECT_EQ(opentelemetry::nostd::get<DataType>(iter1->second), value);
+  EXPECT_EQ(opentelemetry::nostd::get<DataType>(iter2->second), value);
+}
+
+template <class DataType>
+static void CheckExceptOneStringView(const opentelemetry::sdk::common::MixedAttributeMap &data,
+                                     opentelemetry::nostd::string_view key,
+                                     opentelemetry::nostd::string_view value)
+{
+  auto iter1 = data.GetAttributes().find(std::string(key));
+  EXPECT_TRUE(iter1 != data.GetAttributes().end());
+
+  auto iter2 = data.GetOwnedAttributes().find(std::string(key));
+  EXPECT_TRUE(iter2 != data.GetOwnedAttributes().end());
+
+  EXPECT_EQ(opentelemetry::nostd::get<DataType>(iter1->second), value);
+  EXPECT_EQ(opentelemetry::nostd::get<std::string>(iter2->second), value);
+}
+
+template <class DataType, size_t DataSize>
+static void CheckExceptArrayValue(const opentelemetry::sdk::common::MixedAttributeMap &data,
+                                  opentelemetry::nostd::string_view key,
+                                  DataType (&value)[DataSize])
+{
+  auto iter1 = data.GetAttributes().find(std::string(key));
+  EXPECT_TRUE(iter1 != data.GetAttributes().end());
+
+  auto iter2 = data.GetOwnedAttributes().find(std::string(key));
+  EXPECT_TRUE(iter2 != data.GetOwnedAttributes().end());
+
+  for (size_t i = 0; i < DataSize; ++i)
+  {
+    EXPECT_EQ(
+        opentelemetry::nostd::get<opentelemetry::nostd::span<const DataType>>(iter1->second)[i],
+        value[i]);
+    EXPECT_EQ(opentelemetry::nostd::get<std::vector<DataType>>(iter2->second)[i], value[i]);
+  }
+}
+
+template <size_t DataSize>
+static void CheckExceptArrayString(const opentelemetry::sdk::common::MixedAttributeMap &data,
+                                   opentelemetry::nostd::string_view key,
+                                   opentelemetry::nostd::string_view (&value)[DataSize])
+{
+  auto iter1 = data.GetAttributes().find(std::string(key));
+  EXPECT_TRUE(iter1 != data.GetAttributes().end());
+
+  auto iter2 = data.GetOwnedAttributes().find(std::string(key));
+  EXPECT_TRUE(iter2 != data.GetOwnedAttributes().end());
+
+  for (size_t i = 0; i < DataSize; ++i)
+  {
+    EXPECT_EQ(
+        opentelemetry::nostd::get<
+            opentelemetry::nostd::span<const opentelemetry::nostd::string_view>>(iter1->second)[i],
+        value[i]);
+    EXPECT_EQ(opentelemetry::nostd::get<std::vector<std::string>>(iter2->second)[i], value[i]);
+  }
+}
+
+}  // namespace
 
 TEST(AttributeMapTest, DefaultConstruction)
 {
@@ -61,6 +140,66 @@ TEST(OrderedAttributeMapTest, AttributesConstruction)
   {
     EXPECT_EQ(opentelemetry::nostd::get<int>(attribute_map.GetAttributes().at(keys[i])), values[i]);
   }
+}
+
+TEST(MixedAttributeMapTest, SetterAndGetter)
+{
+  opentelemetry::sdk::common::MixedAttributeMap attribute_map;
+  attribute_map.Reserve(16);
+  EXPECT_TRUE(attribute_map.Empty());
+
+  attribute_map.SetAttribute("bool", true);
+  attribute_map.SetAttribute("int32_t", static_cast<int32_t>(42));
+  attribute_map.SetAttribute("int64_t", static_cast<int64_t>(43));
+  attribute_map.SetAttribute("uint32_t", static_cast<uint32_t>(44));
+  attribute_map.SetAttribute("double", static_cast<double>(45.0));
+  attribute_map.SetAttribute("uint64_t", static_cast<uint64_t>(46));
+  attribute_map.SetAttribute("const char *", "const char *");
+  attribute_map.SetAttribute("string_view", opentelemetry::nostd::string_view("string_view"));
+
+  bool array_bool[]       = {true, false, true};
+  uint8_t array_uint8[]   = {47, 48};
+  int32_t array_int32[]   = {48, 49};
+  int64_t array_int64[]   = {49, 50};
+  uint32_t array_uint32[] = {50, 51};
+  double array_double[]   = {51.0, 52.0};
+  uint64_t array_uint64[] = {52, 53};
+
+  attribute_map.SetAttribute("sbool", opentelemetry::nostd::span<const bool>(array_bool));
+  attribute_map.SetAttribute("suint8_t", opentelemetry::nostd::span<const uint8_t>(array_uint8));
+  attribute_map.SetAttribute("sint32_t", opentelemetry::nostd::span<const int32_t>(array_int32));
+  attribute_map.SetAttribute("sint64_t", opentelemetry::nostd::span<const int64_t>(array_int64));
+  attribute_map.SetAttribute("suint32_t", opentelemetry::nostd::span<const uint32_t>(array_uint32));
+  attribute_map.SetAttribute("sdouble", opentelemetry::nostd::span<const double>(array_double));
+  attribute_map.SetAttribute("suint64_t", opentelemetry::nostd::span<const uint64_t>(array_uint64));
+
+  opentelemetry::nostd::string_view array_string_view[] = {"string_view1", "string_view2"};
+  attribute_map.SetAttribute(
+      "sstring_view",
+      opentelemetry::nostd::span<const opentelemetry::nostd::string_view>(array_string_view));
+
+  EXPECT_FALSE(attribute_map.Empty());
+  EXPECT_EQ(attribute_map.Size(), 16);
+
+  CheckExceptOneValue<bool>(attribute_map, "bool", true);
+  CheckExceptOneValue<int32_t>(attribute_map, "int32_t", static_cast<int32_t>(42));
+  CheckExceptOneValue<int64_t>(attribute_map, "int64_t", static_cast<int64_t>(43));
+  CheckExceptOneValue<uint32_t>(attribute_map, "uint32_t", static_cast<uint32_t>(44));
+  CheckExceptOneValue<double>(attribute_map, "double", static_cast<double>(45.0));
+  CheckExceptOneValue<uint64_t>(attribute_map, "uint64_t", static_cast<uint64_t>(46));
+
+  CheckExceptOneStringView<const char *>(attribute_map, "const char *", "const char *");
+  CheckExceptOneStringView<opentelemetry::nostd::string_view>(attribute_map, "string_view",
+                                                              "string_view");
+
+  CheckExceptArrayValue(attribute_map, "sbool", array_bool);
+  CheckExceptArrayValue(attribute_map, "suint8_t", array_uint8);
+  CheckExceptArrayValue(attribute_map, "sint32_t", array_int32);
+  CheckExceptArrayValue(attribute_map, "sint64_t", array_int64);
+  CheckExceptArrayValue(attribute_map, "suint32_t", array_uint32);
+  CheckExceptArrayValue(attribute_map, "sdouble", array_double);
+  CheckExceptArrayValue(attribute_map, "suint64_t", array_uint64);
+  CheckExceptArrayString(attribute_map, "sstring_view", array_string_view);
 }
 
 TEST(AttributeEqualToVisitorTest, AttributeValueEqualTo)

--- a/sdk/test/logs/log_record_test.cc
+++ b/sdk/test/logs/log_record_test.cc
@@ -74,7 +74,7 @@ TEST(ReadWriteLogRecord, SetAndGet)
 
   // Test that all fields match what was set
   ASSERT_EQ(record.GetSeverity(), logs_api::Severity::kInvalid);
-#if OPENTELEMETRY_ABI_VERSION_NO >= 2
+#if !defined(OPENTELEMETRY_DEPRECATED_SDK_LOG_RECORD)
   if (nostd::holds_alternative<std::string>(record.GetBody()))
   {
     ASSERT_EQ(nostd::get<std::string>(record.GetBody()), "Message");
@@ -119,7 +119,7 @@ public:
     }
   }
 
-#if OPENTELEMETRY_ABI_VERSION_NO >= 2
+#if !defined(OPENTELEMETRY_DEPRECATED_SDK_LOG_RECORD)
   const opentelemetry::sdk::common::OwnedAttributeValue &
 #else
   const opentelemetry::common::AttributeValue &
@@ -135,7 +135,7 @@ public:
   }
 
 private:
-#if OPENTELEMETRY_ABI_VERSION_NO >= 2
+#if !defined(OPENTELEMETRY_DEPRECATED_SDK_LOG_RECORD)
   opentelemetry::sdk::common::OwnedAttributeValue empty_ = std::string();
 #else
   opentelemetry::common::AttributeValue empty_ = nostd::string_view();
@@ -198,7 +198,7 @@ TEST(ReadWriteLogRecord, BodyConversation)
               0.0001);
 
   real_logger->EmitLogRecord(opentelemetry::logs::Severity::kInfo, "128");
-#if OPENTELEMETRY_ABI_VERSION_NO >= 2
+#if !defined(OPENTELEMETRY_DEPRECATED_SDK_LOG_RECORD)
   ASSERT_TRUE(
       opentelemetry::nostd::holds_alternative<std::string>(real_logger->GetLastLogRecord()));
   if (opentelemetry::nostd::holds_alternative<std::string>(real_logger->GetLastLogRecord()))
@@ -259,7 +259,7 @@ TEST(ReadWriteLogRecord, BodyConversation)
 #endif
 
   {
-#if OPENTELEMETRY_ABI_VERSION_NO >= 2
+#if !defined(OPENTELEMETRY_DEPRECATED_SDK_LOG_RECORD)
     using value_type = std::vector<int32_t>;
 #else
     using value_type = nostd::span<const int32_t>;
@@ -282,7 +282,7 @@ TEST(ReadWriteLogRecord, BodyConversation)
   }
 
   {
-#if OPENTELEMETRY_ABI_VERSION_NO >= 2
+#if !defined(OPENTELEMETRY_DEPRECATED_SDK_LOG_RECORD)
     using value_type = std::vector<uint32_t>;
 #else
     using value_type = nostd::span<const uint32_t>;
@@ -305,7 +305,7 @@ TEST(ReadWriteLogRecord, BodyConversation)
   }
 
   {
-#if OPENTELEMETRY_ABI_VERSION_NO >= 2
+#if !defined(OPENTELEMETRY_DEPRECATED_SDK_LOG_RECORD)
     using value_type = std::vector<int64_t>;
 #else
     using value_type = nostd::span<const int64_t>;
@@ -328,7 +328,7 @@ TEST(ReadWriteLogRecord, BodyConversation)
   }
 
   {
-#if OPENTELEMETRY_ABI_VERSION_NO >= 2
+#if !defined(OPENTELEMETRY_DEPRECATED_SDK_LOG_RECORD)
     using value_type = std::vector<uint64_t>;
 #else
     using value_type = nostd::span<const uint64_t>;
@@ -351,7 +351,7 @@ TEST(ReadWriteLogRecord, BodyConversation)
   }
 
   {
-#if OPENTELEMETRY_ABI_VERSION_NO >= 2
+#if !defined(OPENTELEMETRY_DEPRECATED_SDK_LOG_RECORD)
     using value_type = std::vector<uint8_t>;
 #else
     using value_type = nostd::span<const uint8_t>;
@@ -374,7 +374,7 @@ TEST(ReadWriteLogRecord, BodyConversation)
   }
 
   {
-#if OPENTELEMETRY_ABI_VERSION_NO >= 2
+#if !defined(OPENTELEMETRY_DEPRECATED_SDK_LOG_RECORD)
     using value_type = std::vector<double>;
 #else
     using value_type = nostd::span<const double>;
@@ -397,7 +397,7 @@ TEST(ReadWriteLogRecord, BodyConversation)
   }
 
   {
-#if OPENTELEMETRY_ABI_VERSION_NO >= 2
+#if !defined(OPENTELEMETRY_DEPRECATED_SDK_LOG_RECORD)
     using value_type = std::vector<std::string>;
 #else
     using value_type = nostd::span<const nostd::string_view>;
@@ -460,7 +460,7 @@ TEST(LogRecordData, SetAndGet)
 
   // Test that all fields match what was set
   ASSERT_EQ(record.GetSeverity(), logs_api::Severity::kInvalid);
-#if OPENTELEMETRY_ABI_VERSION_NO >= 2
+#if !defined(OPENTELEMETRY_DEPRECATED_SDK_LOG_RECORD)
   if (nostd::holds_alternative<std::string>(record.GetBody()))
   {
     ASSERT_EQ(nostd::get<std::string>(record.GetBody()), "Message");
@@ -520,7 +520,7 @@ TEST(LogRecordData, BodyConversation)
               0.0001);
 
   real_logger->EmitLogRecord(opentelemetry::logs::Severity::kInfo, "128");
-#if OPENTELEMETRY_ABI_VERSION_NO >= 2
+#if !defined(OPENTELEMETRY_DEPRECATED_SDK_LOG_RECORD)
   ASSERT_TRUE(
       opentelemetry::nostd::holds_alternative<std::string>(real_logger->GetLastLogRecord()));
   if (opentelemetry::nostd::holds_alternative<std::string>(real_logger->GetLastLogRecord()))
@@ -581,7 +581,7 @@ TEST(LogRecordData, BodyConversation)
 #endif
 
   {
-#if OPENTELEMETRY_ABI_VERSION_NO >= 2
+#if !defined(OPENTELEMETRY_DEPRECATED_SDK_LOG_RECORD)
     using value_type = std::vector<int32_t>;
 #else
     using value_type = nostd::span<const int32_t>;
@@ -604,7 +604,7 @@ TEST(LogRecordData, BodyConversation)
   }
 
   {
-#if OPENTELEMETRY_ABI_VERSION_NO >= 2
+#if !defined(OPENTELEMETRY_DEPRECATED_SDK_LOG_RECORD)
     using value_type = std::vector<uint32_t>;
 #else
     using value_type = nostd::span<const uint32_t>;
@@ -627,7 +627,7 @@ TEST(LogRecordData, BodyConversation)
   }
 
   {
-#if OPENTELEMETRY_ABI_VERSION_NO >= 2
+#if !defined(OPENTELEMETRY_DEPRECATED_SDK_LOG_RECORD)
     using value_type = std::vector<int64_t>;
 #else
     using value_type = nostd::span<const int64_t>;
@@ -650,7 +650,7 @@ TEST(LogRecordData, BodyConversation)
   }
 
   {
-#if OPENTELEMETRY_ABI_VERSION_NO >= 2
+#if !defined(OPENTELEMETRY_DEPRECATED_SDK_LOG_RECORD)
     using value_type = std::vector<uint64_t>;
 #else
     using value_type = nostd::span<const uint64_t>;
@@ -673,7 +673,7 @@ TEST(LogRecordData, BodyConversation)
   }
 
   {
-#if OPENTELEMETRY_ABI_VERSION_NO >= 2
+#if !defined(OPENTELEMETRY_DEPRECATED_SDK_LOG_RECORD)
     using value_type = std::vector<uint8_t>;
 #else
     using value_type = nostd::span<const uint8_t>;
@@ -696,7 +696,7 @@ TEST(LogRecordData, BodyConversation)
   }
 
   {
-#if OPENTELEMETRY_ABI_VERSION_NO >= 2
+#if !defined(OPENTELEMETRY_DEPRECATED_SDK_LOG_RECORD)
     using value_type = std::vector<double>;
 #else
     using value_type = nostd::span<const double>;
@@ -719,7 +719,7 @@ TEST(LogRecordData, BodyConversation)
   }
 
   {
-#if OPENTELEMETRY_ABI_VERSION_NO >= 2
+#if !defined(OPENTELEMETRY_DEPRECATED_SDK_LOG_RECORD)
     using value_type = std::vector<std::string>;
 #else
     using value_type = nostd::span<const nostd::string_view>;

--- a/sdk/test/logs/log_record_test.cc
+++ b/sdk/test/logs/log_record_test.cc
@@ -9,8 +9,8 @@
 #include <string>
 #include <unordered_map>
 #include <utility>
+#include <vector>
 
-#include "opentelemetry/common/attribute_value.h"
 #include "opentelemetry/common/key_value_iterable.h"
 #include "opentelemetry/common/timestamp.h"
 #include "opentelemetry/logs/log_record.h"
@@ -22,6 +22,7 @@
 #include "opentelemetry/nostd/string_view.h"
 #include "opentelemetry/nostd/unique_ptr.h"
 #include "opentelemetry/nostd/variant.h"
+#include "opentelemetry/sdk/common/attribute_utils.h"
 #include "opentelemetry/sdk/logs/log_record_data.h"
 #include "opentelemetry/sdk/logs/read_write_log_record.h"
 #include "opentelemetry/sdk/resource/resource.h"

--- a/sdk/test/logs/log_record_test.cc
+++ b/sdk/test/logs/log_record_test.cc
@@ -22,12 +22,14 @@
 #include "opentelemetry/nostd/string_view.h"
 #include "opentelemetry/nostd/unique_ptr.h"
 #include "opentelemetry/nostd/variant.h"
+#include "opentelemetry/sdk/logs/log_record_data.h"
 #include "opentelemetry/sdk/logs/read_write_log_record.h"
 #include "opentelemetry/sdk/resource/resource.h"
 #include "opentelemetry/trace/span_id.h"
 #include "opentelemetry/trace/trace_flags.h"
 #include "opentelemetry/trace/trace_id.h"
 
+using opentelemetry::sdk::logs::LogRecordData;
 using opentelemetry::sdk::logs::ReadWriteLogRecord;
 namespace trace_api = opentelemetry::trace;
 namespace logs_api  = opentelemetry::logs;
@@ -72,6 +74,12 @@ TEST(ReadWriteLogRecord, SetAndGet)
 
   // Test that all fields match what was set
   ASSERT_EQ(record.GetSeverity(), logs_api::Severity::kInvalid);
+#if OPENTELEMETRY_ABI_VERSION_NO >= 2
+  if (nostd::holds_alternative<std::string>(record.GetBody()))
+  {
+    ASSERT_EQ(nostd::get<std::string>(record.GetBody()), "Message");
+  }
+#else
   if (nostd::holds_alternative<const char *>(record.GetBody()))
   {
     ASSERT_EQ(std::string(nostd::get<const char *>(record.GetBody())), "Message");
@@ -80,6 +88,7 @@ TEST(ReadWriteLogRecord, SetAndGet)
   {
     ASSERT_TRUE(nostd::get<nostd::string_view>(record.GetBody()) == "Message");
   }
+#endif
   ASSERT_TRUE(nostd::get<bool>(record.GetResource().GetAttributes().at("res1")));
   ASSERT_EQ(nostd::get<int64_t>(record.GetAttributes().at("attr1")), 314159);
   ASSERT_EQ(record.GetTraceId(), trace_id);
@@ -89,6 +98,7 @@ TEST(ReadWriteLogRecord, SetAndGet)
 }
 
 // Define a basic Logger class
+template <class BackendLogger>
 class TestBodyLogger : public opentelemetry::logs::Logger
 {
 public:
@@ -96,7 +106,7 @@ public:
 
   nostd::unique_ptr<opentelemetry::logs::LogRecord> CreateLogRecord() noexcept override
   {
-    return nostd::unique_ptr<opentelemetry::logs::LogRecord>(new ReadWriteLogRecord());
+    return nostd::unique_ptr<opentelemetry::logs::LogRecord>(new BackendLogger());
   }
 
   using opentelemetry::logs::Logger::EmitLogRecord;
@@ -105,20 +115,36 @@ public:
   {
     if (record)
     {
-      last_body_ = static_cast<ReadWriteLogRecord *>(record.get())->GetBody();
+      last_body_.reset(static_cast<BackendLogger *>(record.release()));
     }
   }
 
-  const opentelemetry::common::AttributeValue &GetLastLogRecord() const noexcept
+#if OPENTELEMETRY_ABI_VERSION_NO >= 2
+  const opentelemetry::sdk::common::OwnedAttributeValue &
+#else
+  const opentelemetry::common::AttributeValue &
+#endif
+  GetLastLogRecord() const noexcept
   {
-    return last_body_;
+    if (last_body_)
+    {
+      return last_body_->GetBody();
+    }
+
+    return empty_;
   }
 
 private:
-  opentelemetry::common::AttributeValue last_body_;
+#if OPENTELEMETRY_ABI_VERSION_NO >= 2
+  opentelemetry::sdk::common::OwnedAttributeValue empty_ = std::string();
+#else
+  opentelemetry::common::AttributeValue empty_ = nostd::string_view();
+#endif
+  nostd::unique_ptr<BackendLogger> last_body_;
 };
 
 // Define a basic LoggerProvider class that returns an instance of the logger class defined above
+template <class BackendLogger>
 class TestBodyProvider : public opentelemetry::logs::LoggerProvider
 {
 public:
@@ -131,20 +157,20 @@ public:
       nostd::string_view /* schema_url */,
       const opentelemetry::common::KeyValueIterable & /* attributes */) override
   {
-    return nostd::shared_ptr<opentelemetry::logs::Logger>(new TestBodyLogger());
+    return nostd::shared_ptr<opentelemetry::logs::Logger>(new TestBodyLogger<BackendLogger>());
   }
 };
 
-TEST(LogBody, BodyConversation)
+TEST(ReadWriteLogRecord, BodyConversation)
 {
   // Push the new loggerprovider class into the global singleton
-  TestBodyProvider lp;
+  TestBodyProvider<ReadWriteLogRecord> lp;
 
   // Check that the implementation was pushed by calling TestLogger's GetName()
   nostd::string_view schema_url{"https://opentelemetry.io/schemas/1.11.0"};
   auto logger = lp.GetLogger("TestBodyProvider", "opentelelemtry_library", "", schema_url, {});
 
-  auto real_logger = static_cast<TestBodyLogger *>(logger.get());
+  auto real_logger = static_cast<TestBodyLogger<ReadWriteLogRecord> *>(logger.get());
 
   real_logger->EmitLogRecord(opentelemetry::logs::Severity::kInfo, true);
   ASSERT_TRUE(opentelemetry::nostd::holds_alternative<bool>(real_logger->GetLastLogRecord()));
@@ -172,13 +198,40 @@ TEST(LogBody, BodyConversation)
               0.0001);
 
   real_logger->EmitLogRecord(opentelemetry::logs::Severity::kInfo, "128");
+#if OPENTELEMETRY_ABI_VERSION_NO >= 2
+  ASSERT_TRUE(
+      opentelemetry::nostd::holds_alternative<std::string>(real_logger->GetLastLogRecord()));
+  if (opentelemetry::nostd::holds_alternative<std::string>(real_logger->GetLastLogRecord()))
+  {
+    ASSERT_EQ(std::string{"128"},
+              opentelemetry::nostd::get<std::string>(real_logger->GetLastLogRecord()));
+  }
+
+  {
+    bool data[]                       = {true, false, true};
+    nostd::span<const bool> data_span = data;
+    real_logger->EmitLogRecord(opentelemetry::logs::Severity::kInfo, data_span);
+    ASSERT_TRUE(opentelemetry::nostd::holds_alternative<std::vector<bool>>(
+        real_logger->GetLastLogRecord()));
+
+    const std::vector<bool> &output =
+        opentelemetry::nostd::get<std::vector<bool>>(real_logger->GetLastLogRecord());
+
+    ASSERT_EQ(data_span.size(), output.size());
+
+    for (size_t i = 0; i < data_span.size(); ++i)
+    {
+      ASSERT_TRUE(data_span[i] == output[i]);
+    }
+  }
+#else
   ASSERT_TRUE(
       opentelemetry::nostd::holds_alternative<const char *>(real_logger->GetLastLogRecord()) ||
       opentelemetry::nostd::holds_alternative<nostd::string_view>(real_logger->GetLastLogRecord()));
   if (opentelemetry::nostd::holds_alternative<const char *>(real_logger->GetLastLogRecord()))
   {
-    ASSERT_EQ(nostd::string_view{"128"},
-              opentelemetry::nostd::get<const char *>(real_logger->GetLastLogRecord()));
+    ASSERT_EQ(nostd::string_view{"128"}, nostd::string_view{opentelemetry::nostd::get<const char *>(
+                                             real_logger->GetLastLogRecord())});
   }
   else
   {
@@ -200,109 +253,140 @@ TEST(LogBody, BodyConversation)
 
     for (size_t i = 0; i < data_span.size(); ++i)
     {
-      ASSERT_EQ(data_span[i], output[i]);
+      ASSERT_TRUE(data_span[i] == output[i]);
     }
   }
+#endif
 
   {
+#if OPENTELEMETRY_ABI_VERSION_NO >= 2
+    using value_type = std::vector<int32_t>;
+#else
+    using value_type = nostd::span<const int32_t>;
+#endif
     int32_t data[]                       = {221, 222, 223};
     nostd::span<const int32_t> data_span = data;
     real_logger->EmitLogRecord(opentelemetry::logs::Severity::kInfo, data_span);
-    ASSERT_TRUE(opentelemetry::nostd::holds_alternative<nostd::span<const int32_t>>(
-        real_logger->GetLastLogRecord()));
+    ASSERT_TRUE(
+        opentelemetry::nostd::holds_alternative<value_type>(real_logger->GetLastLogRecord()));
 
-    nostd::span<const int32_t> output =
-        opentelemetry::nostd::get<nostd::span<const int32_t>>(real_logger->GetLastLogRecord());
+    const value_type &output =
+        opentelemetry::nostd::get<value_type>(real_logger->GetLastLogRecord());
 
     ASSERT_EQ(data_span.size(), output.size());
 
     for (size_t i = 0; i < data_span.size(); ++i)
     {
-      ASSERT_EQ(data_span[i], output[i]);
+      EXPECT_EQ(data_span[i], output[i]);
     }
   }
 
   {
+#if OPENTELEMETRY_ABI_VERSION_NO >= 2
+    using value_type = std::vector<uint32_t>;
+#else
+    using value_type = nostd::span<const uint32_t>;
+#endif
     uint32_t data[]                       = {231, 232, 233};
     nostd::span<const uint32_t> data_span = data;
     real_logger->EmitLogRecord(opentelemetry::logs::Severity::kInfo, data_span);
-    ASSERT_TRUE(opentelemetry::nostd::holds_alternative<nostd::span<const uint32_t>>(
-        real_logger->GetLastLogRecord()));
+    ASSERT_TRUE(
+        opentelemetry::nostd::holds_alternative<value_type>(real_logger->GetLastLogRecord()));
 
-    nostd::span<const uint32_t> output =
-        opentelemetry::nostd::get<nostd::span<const uint32_t>>(real_logger->GetLastLogRecord());
+    const value_type &output =
+        opentelemetry::nostd::get<value_type>(real_logger->GetLastLogRecord());
 
     ASSERT_EQ(data_span.size(), output.size());
 
     for (size_t i = 0; i < data_span.size(); ++i)
     {
-      ASSERT_EQ(data_span[i], output[i]);
+      EXPECT_EQ(data_span[i], output[i]);
     }
   }
 
   {
+#if OPENTELEMETRY_ABI_VERSION_NO >= 2
+    using value_type = std::vector<int64_t>;
+#else
+    using value_type = nostd::span<const int64_t>;
+#endif
     int64_t data[]                       = {241, 242, 243};
     nostd::span<const int64_t> data_span = data;
     real_logger->EmitLogRecord(opentelemetry::logs::Severity::kInfo, data_span);
-    ASSERT_TRUE(opentelemetry::nostd::holds_alternative<nostd::span<const int64_t>>(
-        real_logger->GetLastLogRecord()));
+    ASSERT_TRUE(
+        opentelemetry::nostd::holds_alternative<value_type>(real_logger->GetLastLogRecord()));
 
-    nostd::span<const int64_t> output =
-        opentelemetry::nostd::get<nostd::span<const int64_t>>(real_logger->GetLastLogRecord());
+    const value_type &output =
+        opentelemetry::nostd::get<value_type>(real_logger->GetLastLogRecord());
 
     ASSERT_EQ(data_span.size(), output.size());
 
     for (size_t i = 0; i < data_span.size(); ++i)
     {
-      ASSERT_EQ(data_span[i], output[i]);
+      EXPECT_EQ(data_span[i], output[i]);
     }
   }
 
   {
+#if OPENTELEMETRY_ABI_VERSION_NO >= 2
+    using value_type = std::vector<uint64_t>;
+#else
+    using value_type = nostd::span<const uint64_t>;
+#endif
     uint64_t data[]                       = {251, 252, 253};
     nostd::span<const uint64_t> data_span = data;
     real_logger->EmitLogRecord(opentelemetry::logs::Severity::kInfo, data_span);
-    ASSERT_TRUE(opentelemetry::nostd::holds_alternative<nostd::span<const uint64_t>>(
-        real_logger->GetLastLogRecord()));
+    ASSERT_TRUE(
+        opentelemetry::nostd::holds_alternative<value_type>(real_logger->GetLastLogRecord()));
 
-    nostd::span<const uint64_t> output =
-        opentelemetry::nostd::get<nostd::span<const uint64_t>>(real_logger->GetLastLogRecord());
+    const value_type &output =
+        opentelemetry::nostd::get<value_type>(real_logger->GetLastLogRecord());
 
     ASSERT_EQ(data_span.size(), output.size());
 
     for (size_t i = 0; i < data_span.size(); ++i)
     {
-      ASSERT_EQ(data_span[i], output[i]);
+      EXPECT_EQ(data_span[i], output[i]);
     }
   }
 
   {
+#if OPENTELEMETRY_ABI_VERSION_NO >= 2
+    using value_type = std::vector<uint8_t>;
+#else
+    using value_type = nostd::span<const uint8_t>;
+#endif
     uint8_t data[]                       = {161, 162, 163};
     nostd::span<const uint8_t> data_span = data;
     real_logger->EmitLogRecord(opentelemetry::logs::Severity::kInfo, data_span);
-    ASSERT_TRUE(opentelemetry::nostd::holds_alternative<nostd::span<const uint8_t>>(
-        real_logger->GetLastLogRecord()));
+    ASSERT_TRUE(
+        opentelemetry::nostd::holds_alternative<value_type>(real_logger->GetLastLogRecord()));
 
-    nostd::span<const uint8_t> output =
-        opentelemetry::nostd::get<nostd::span<const uint8_t>>(real_logger->GetLastLogRecord());
+    const value_type &output =
+        opentelemetry::nostd::get<value_type>(real_logger->GetLastLogRecord());
 
     ASSERT_EQ(data_span.size(), output.size());
 
     for (size_t i = 0; i < data_span.size(); ++i)
     {
-      ASSERT_EQ(data_span[i], output[i]);
+      EXPECT_EQ(data_span[i], output[i]);
     }
   }
 
   {
+#if OPENTELEMETRY_ABI_VERSION_NO >= 2
+    using value_type = std::vector<double>;
+#else
+    using value_type = nostd::span<const double>;
+#endif
     double data[]                       = {271.0, 272.0, 273.0};
     nostd::span<const double> data_span = data;
     real_logger->EmitLogRecord(opentelemetry::logs::Severity::kInfo, data_span);
-    ASSERT_TRUE(opentelemetry::nostd::holds_alternative<nostd::span<const double>>(
-        real_logger->GetLastLogRecord()));
+    ASSERT_TRUE(
+        opentelemetry::nostd::holds_alternative<value_type>(real_logger->GetLastLogRecord()));
 
-    nostd::span<const double> output =
-        opentelemetry::nostd::get<nostd::span<const double>>(real_logger->GetLastLogRecord());
+    const value_type &output =
+        opentelemetry::nostd::get<value_type>(real_logger->GetLastLogRecord());
 
     ASSERT_EQ(data_span.size(), output.size());
 
@@ -313,22 +397,348 @@ TEST(LogBody, BodyConversation)
   }
 
   {
+#if OPENTELEMETRY_ABI_VERSION_NO >= 2
+    using value_type = std::vector<std::string>;
+#else
+    using value_type = nostd::span<const nostd::string_view>;
+#endif
     std::string data_origin[] = {"281", "282", "283"};
     nostd::string_view data[] = {data_origin[0], data_origin[1], data_origin[2]};
     nostd::span<const nostd::string_view> data_span = data;
     real_logger->EmitLogRecord(opentelemetry::logs::Severity::kInfo, data_span);
-    ASSERT_TRUE(opentelemetry::nostd::holds_alternative<nostd::span<const nostd::string_view>>(
-        real_logger->GetLastLogRecord()));
+    ASSERT_TRUE(
+        opentelemetry::nostd::holds_alternative<value_type>(real_logger->GetLastLogRecord()));
 
-    nostd::span<const nostd::string_view> output =
-        opentelemetry::nostd::get<nostd::span<const nostd::string_view>>(
-            real_logger->GetLastLogRecord());
+    const value_type &output =
+        opentelemetry::nostd::get<value_type>(real_logger->GetLastLogRecord());
 
     ASSERT_EQ(data_span.size(), output.size());
 
     for (size_t i = 0; i < data_span.size(); ++i)
     {
-      ASSERT_EQ(data_span[i], output[i]);
+      EXPECT_EQ(data_span[i], output[i]);
+    }
+  }
+}
+
+// Test what a default LogRecordData with no fields set holds
+TEST(LogRecordData, GetDefaultValues)
+{
+  trace_api::TraceId zero_trace_id;
+  trace_api::SpanId zero_span_id;
+  trace_api::TraceFlags zero_trace_flags;
+  LogRecordData record;
+
+  ASSERT_EQ(record.GetSeverity(), logs_api::Severity::kInvalid);
+  ASSERT_NE(record.GetResource().GetAttributes().size(), 0);
+  ASSERT_EQ(record.GetAttributes().size(), 0);
+  ASSERT_EQ(record.GetTraceId(), zero_trace_id);
+  ASSERT_EQ(record.GetSpanId(), zero_span_id);
+  ASSERT_EQ(record.GetTraceFlags(), zero_trace_flags);
+  ASSERT_EQ(record.GetTimestamp().time_since_epoch(), std::chrono::nanoseconds(0));
+}
+
+// Test LogRecordData fields are properly set and get
+TEST(LogRecordData, SetAndGet)
+{
+  trace_api::TraceId trace_id;
+  trace_api::SpanId span_id;
+  trace_api::TraceFlags trace_flags;
+  opentelemetry::common::SystemTimestamp now(std::chrono::system_clock::now());
+
+  // Set most fields of the LogRecordData
+  LogRecordData record;
+  auto resource = opentelemetry::sdk::resource::Resource::Create({{"res1", true}});
+  record.SetSeverity(logs_api::Severity::kInvalid);
+  record.SetBody("Message");
+  record.SetResource(resource);
+  record.SetAttribute("attr1", static_cast<int64_t>(314159));
+  record.SetTraceId(trace_id);
+  record.SetSpanId(span_id);
+  record.SetTraceFlags(trace_flags);
+  record.SetTimestamp(now);
+
+  // Test that all fields match what was set
+  ASSERT_EQ(record.GetSeverity(), logs_api::Severity::kInvalid);
+#if OPENTELEMETRY_ABI_VERSION_NO >= 2
+  if (nostd::holds_alternative<std::string>(record.GetBody()))
+  {
+    ASSERT_EQ(nostd::get<std::string>(record.GetBody()), "Message");
+  }
+#else
+  if (nostd::holds_alternative<const char *>(record.GetBody()))
+  {
+    ASSERT_EQ(std::string(nostd::get<const char *>(record.GetBody())), "Message");
+  }
+  else if (nostd::holds_alternative<nostd::string_view>(record.GetBody()))
+  {
+    ASSERT_TRUE(nostd::get<nostd::string_view>(record.GetBody()) == "Message");
+  }
+#endif
+  ASSERT_TRUE(nostd::get<bool>(record.GetResource().GetAttributes().at("res1")));
+  ASSERT_EQ(nostd::get<int64_t>(record.GetAttributes().at("attr1")), 314159);
+  ASSERT_EQ(record.GetTraceId(), trace_id);
+  ASSERT_EQ(record.GetSpanId(), span_id);
+  ASSERT_EQ(record.GetTraceFlags(), trace_flags);
+  ASSERT_EQ(record.GetTimestamp().time_since_epoch(), now.time_since_epoch());
+}
+
+TEST(LogRecordData, BodyConversation)
+{
+  // Push the new loggerprovider class into the global singleton
+  TestBodyProvider<LogRecordData> lp;
+
+  // Check that the implementation was pushed by calling TestLogger's GetName()
+  nostd::string_view schema_url{"https://opentelemetry.io/schemas/1.11.0"};
+  auto logger = lp.GetLogger("TestBodyProvider", "opentelelemtry_library", "", schema_url, {});
+
+  auto real_logger = static_cast<TestBodyLogger<LogRecordData> *>(logger.get());
+
+  real_logger->EmitLogRecord(opentelemetry::logs::Severity::kInfo, true);
+  ASSERT_TRUE(opentelemetry::nostd::holds_alternative<bool>(real_logger->GetLastLogRecord()));
+  ASSERT_TRUE(opentelemetry::nostd::get<bool>(real_logger->GetLastLogRecord()));
+
+  real_logger->EmitLogRecord(opentelemetry::logs::Severity::kInfo, static_cast<int32_t>(123));
+  ASSERT_TRUE(opentelemetry::nostd::holds_alternative<int32_t>(real_logger->GetLastLogRecord()));
+  ASSERT_EQ(123, opentelemetry::nostd::get<int32_t>(real_logger->GetLastLogRecord()));
+
+  real_logger->EmitLogRecord(opentelemetry::logs::Severity::kInfo, static_cast<uint32_t>(124));
+  ASSERT_TRUE(opentelemetry::nostd::holds_alternative<uint32_t>(real_logger->GetLastLogRecord()));
+  ASSERT_EQ(124, opentelemetry::nostd::get<uint32_t>(real_logger->GetLastLogRecord()));
+
+  real_logger->EmitLogRecord(opentelemetry::logs::Severity::kInfo, static_cast<int64_t>(125));
+  ASSERT_TRUE(opentelemetry::nostd::holds_alternative<int64_t>(real_logger->GetLastLogRecord()));
+  ASSERT_EQ(125, opentelemetry::nostd::get<int64_t>(real_logger->GetLastLogRecord()));
+
+  real_logger->EmitLogRecord(opentelemetry::logs::Severity::kInfo, static_cast<uint64_t>(126));
+  ASSERT_TRUE(opentelemetry::nostd::holds_alternative<uint64_t>(real_logger->GetLastLogRecord()));
+  ASSERT_EQ(126, opentelemetry::nostd::get<uint64_t>(real_logger->GetLastLogRecord()));
+
+  real_logger->EmitLogRecord(opentelemetry::logs::Severity::kInfo, static_cast<double>(127.0));
+  ASSERT_TRUE(opentelemetry::nostd::holds_alternative<double>(real_logger->GetLastLogRecord()));
+  ASSERT_TRUE(std::abs(127.0 - opentelemetry::nostd::get<double>(real_logger->GetLastLogRecord())) <
+              0.0001);
+
+  real_logger->EmitLogRecord(opentelemetry::logs::Severity::kInfo, "128");
+#if OPENTELEMETRY_ABI_VERSION_NO >= 2
+  ASSERT_TRUE(
+      opentelemetry::nostd::holds_alternative<std::string>(real_logger->GetLastLogRecord()));
+  if (opentelemetry::nostd::holds_alternative<std::string>(real_logger->GetLastLogRecord()))
+  {
+    ASSERT_EQ(std::string{"128"},
+              opentelemetry::nostd::get<std::string>(real_logger->GetLastLogRecord()));
+  }
+
+  {
+    bool data[]                       = {true, false, true};
+    nostd::span<const bool> data_span = data;
+    real_logger->EmitLogRecord(opentelemetry::logs::Severity::kInfo, data_span);
+    ASSERT_TRUE(opentelemetry::nostd::holds_alternative<std::vector<bool>>(
+        real_logger->GetLastLogRecord()));
+
+    const std::vector<bool> &output =
+        opentelemetry::nostd::get<std::vector<bool>>(real_logger->GetLastLogRecord());
+
+    ASSERT_EQ(data_span.size(), output.size());
+
+    for (size_t i = 0; i < data_span.size(); ++i)
+    {
+      ASSERT_TRUE(data_span[i] == output[i]);
+    }
+  }
+#else
+  ASSERT_TRUE(
+      opentelemetry::nostd::holds_alternative<const char *>(real_logger->GetLastLogRecord()) ||
+      opentelemetry::nostd::holds_alternative<nostd::string_view>(real_logger->GetLastLogRecord()));
+  if (opentelemetry::nostd::holds_alternative<const char *>(real_logger->GetLastLogRecord()))
+  {
+    ASSERT_EQ(nostd::string_view{"128"}, nostd::string_view{opentelemetry::nostd::get<const char *>(
+                                             real_logger->GetLastLogRecord())});
+  }
+  else
+  {
+    ASSERT_EQ(nostd::string_view{"128"},
+              opentelemetry::nostd::get<nostd::string_view>(real_logger->GetLastLogRecord()));
+  }
+
+  {
+    bool data[]                       = {true, false, true};
+    nostd::span<const bool> data_span = data;
+    real_logger->EmitLogRecord(opentelemetry::logs::Severity::kInfo, data_span);
+    ASSERT_TRUE(opentelemetry::nostd::holds_alternative<nostd::span<const bool>>(
+        real_logger->GetLastLogRecord()));
+
+    nostd::span<const bool> output =
+        opentelemetry::nostd::get<nostd::span<const bool>>(real_logger->GetLastLogRecord());
+
+    ASSERT_EQ(data_span.size(), output.size());
+
+    for (size_t i = 0; i < data_span.size(); ++i)
+    {
+      ASSERT_TRUE(data_span[i] == output[i]);
+    }
+  }
+#endif
+
+  {
+#if OPENTELEMETRY_ABI_VERSION_NO >= 2
+    using value_type = std::vector<int32_t>;
+#else
+    using value_type = nostd::span<const int32_t>;
+#endif
+    int32_t data[]                       = {221, 222, 223};
+    nostd::span<const int32_t> data_span = data;
+    real_logger->EmitLogRecord(opentelemetry::logs::Severity::kInfo, data_span);
+    ASSERT_TRUE(
+        opentelemetry::nostd::holds_alternative<value_type>(real_logger->GetLastLogRecord()));
+
+    const value_type &output =
+        opentelemetry::nostd::get<value_type>(real_logger->GetLastLogRecord());
+
+    ASSERT_EQ(data_span.size(), output.size());
+
+    for (size_t i = 0; i < data_span.size(); ++i)
+    {
+      EXPECT_EQ(data_span[i], output[i]);
+    }
+  }
+
+  {
+#if OPENTELEMETRY_ABI_VERSION_NO >= 2
+    using value_type = std::vector<uint32_t>;
+#else
+    using value_type = nostd::span<const uint32_t>;
+#endif
+    uint32_t data[]                       = {231, 232, 233};
+    nostd::span<const uint32_t> data_span = data;
+    real_logger->EmitLogRecord(opentelemetry::logs::Severity::kInfo, data_span);
+    ASSERT_TRUE(
+        opentelemetry::nostd::holds_alternative<value_type>(real_logger->GetLastLogRecord()));
+
+    const value_type &output =
+        opentelemetry::nostd::get<value_type>(real_logger->GetLastLogRecord());
+
+    ASSERT_EQ(data_span.size(), output.size());
+
+    for (size_t i = 0; i < data_span.size(); ++i)
+    {
+      EXPECT_EQ(data_span[i], output[i]);
+    }
+  }
+
+  {
+#if OPENTELEMETRY_ABI_VERSION_NO >= 2
+    using value_type = std::vector<int64_t>;
+#else
+    using value_type = nostd::span<const int64_t>;
+#endif
+    int64_t data[]                       = {241, 242, 243};
+    nostd::span<const int64_t> data_span = data;
+    real_logger->EmitLogRecord(opentelemetry::logs::Severity::kInfo, data_span);
+    ASSERT_TRUE(
+        opentelemetry::nostd::holds_alternative<value_type>(real_logger->GetLastLogRecord()));
+
+    const value_type &output =
+        opentelemetry::nostd::get<value_type>(real_logger->GetLastLogRecord());
+
+    ASSERT_EQ(data_span.size(), output.size());
+
+    for (size_t i = 0; i < data_span.size(); ++i)
+    {
+      EXPECT_EQ(data_span[i], output[i]);
+    }
+  }
+
+  {
+#if OPENTELEMETRY_ABI_VERSION_NO >= 2
+    using value_type = std::vector<uint64_t>;
+#else
+    using value_type = nostd::span<const uint64_t>;
+#endif
+    uint64_t data[]                       = {251, 252, 253};
+    nostd::span<const uint64_t> data_span = data;
+    real_logger->EmitLogRecord(opentelemetry::logs::Severity::kInfo, data_span);
+    ASSERT_TRUE(
+        opentelemetry::nostd::holds_alternative<value_type>(real_logger->GetLastLogRecord()));
+
+    const value_type &output =
+        opentelemetry::nostd::get<value_type>(real_logger->GetLastLogRecord());
+
+    ASSERT_EQ(data_span.size(), output.size());
+
+    for (size_t i = 0; i < data_span.size(); ++i)
+    {
+      EXPECT_EQ(data_span[i], output[i]);
+    }
+  }
+
+  {
+#if OPENTELEMETRY_ABI_VERSION_NO >= 2
+    using value_type = std::vector<uint8_t>;
+#else
+    using value_type = nostd::span<const uint8_t>;
+#endif
+    uint8_t data[]                       = {161, 162, 163};
+    nostd::span<const uint8_t> data_span = data;
+    real_logger->EmitLogRecord(opentelemetry::logs::Severity::kInfo, data_span);
+    ASSERT_TRUE(
+        opentelemetry::nostd::holds_alternative<value_type>(real_logger->GetLastLogRecord()));
+
+    const value_type &output =
+        opentelemetry::nostd::get<value_type>(real_logger->GetLastLogRecord());
+
+    ASSERT_EQ(data_span.size(), output.size());
+
+    for (size_t i = 0; i < data_span.size(); ++i)
+    {
+      EXPECT_EQ(data_span[i], output[i]);
+    }
+  }
+
+  {
+#if OPENTELEMETRY_ABI_VERSION_NO >= 2
+    using value_type = std::vector<double>;
+#else
+    using value_type = nostd::span<const double>;
+#endif
+    double data[]                       = {271.0, 272.0, 273.0};
+    nostd::span<const double> data_span = data;
+    real_logger->EmitLogRecord(opentelemetry::logs::Severity::kInfo, data_span);
+    ASSERT_TRUE(
+        opentelemetry::nostd::holds_alternative<value_type>(real_logger->GetLastLogRecord()));
+
+    const value_type &output =
+        opentelemetry::nostd::get<value_type>(real_logger->GetLastLogRecord());
+
+    ASSERT_EQ(data_span.size(), output.size());
+
+    for (size_t i = 0; i < data_span.size(); ++i)
+    {
+      ASSERT_TRUE(std::abs(data_span[i] - output[i]) < 0.0001);
+    }
+  }
+
+  {
+#if OPENTELEMETRY_ABI_VERSION_NO >= 2
+    using value_type = std::vector<std::string>;
+#else
+    using value_type = nostd::span<const nostd::string_view>;
+#endif
+    std::string data_origin[] = {"281", "282", "283"};
+    nostd::string_view data[] = {data_origin[0], data_origin[1], data_origin[2]};
+    nostd::span<const nostd::string_view> data_span = data;
+    real_logger->EmitLogRecord(opentelemetry::logs::Severity::kInfo, data_span);
+    ASSERT_TRUE(
+        opentelemetry::nostd::holds_alternative<value_type>(real_logger->GetLastLogRecord()));
+
+    const value_type &output =
+        opentelemetry::nostd::get<value_type>(real_logger->GetLastLogRecord());
+
+    ASSERT_EQ(data_span.size(), output.size());
+
+    for (size_t i = 0; i < data_span.size(); ++i)
+    {
+      EXPECT_EQ(data_span[i], output[i]);
     }
   }
 }


### PR DESCRIPTION
Fixes #3135 
Fixes #2651

## Changes

+ Add `MixedAttributeMap` to store both `std::unordered_map<std::string, opentelemetry::common::AttributeValue>` and `AttributeMap`
+ Copy both `OwnedAttributeValue`, `std::vector<nostd::string_view>` and `bool` array for `ReadWriteLogRecord`.

For significant contributions please make sure you have completed the following items:

* [ ] `CHANGELOG.md` updated for non-trivial changes
* [x] Unit tests have been added
* [ ] Changes in public API reviewed