### PR TITLE
[CI] Add cppcheck in the build

### DIFF
--- a/.github/workflows/cppcheck.yml
+++ b/.github/workflows/cppcheck.yml
@@ -40,7 +40,6 @@ jobs:
         run: |
           cppcheck \
             --force \
-            --quiet \
             --enable=warning,performance,portability \
             --inline-suppr \
             --suppress=unknownMacro:exporters/etw/include/opentelemetry/exporters/etw/TraceLoggingDynamic.h \

--- a/.github/workflows/cppcheck.yml
+++ b/.github/workflows/cppcheck.yml
@@ -1,0 +1,77 @@
+
+name: cppcheck
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  cppcheck:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: 'recursive'
+
+      - name: Set up dependencies
+        run: |
+          sudo apt update -y
+          sudo apt install -y --no-install-recommends --no-install-suggests \
+            build-essential \
+            cppcheck \
+            cmake \
+            ninja-build \
+            libssl-dev \
+            libcurl4-openssl-dev \
+            libprotobuf-dev \
+            protobuf-compiler \
+            libgmock-dev \
+            libgtest-dev \
+            libbenchmark-dev
+
+      - name: Prepare CMake
+        run: |
+          mkdir build && cd build
+          CC="clang" CXX="clang++" cmake ..
+
+      - name: Run cppcheck
+        run: |
+          cppcheck \
+            --force \
+            --quiet \
+            --enable=warning,performance,portability \
+            --inline-suppr \
+            --suppress=unknownMacro:exporters/etw/include/opentelemetry/exporters/etw/TraceLoggingDynamic.h \
+            --language=c++ \
+            --std=c++14 \
+            -I api/include \
+            -I exporters/elasticsearch/include \
+            -I exporters/etw/include \
+            -I exporters/memory/include \
+            -I exporters/ostream/include \
+            -I exporters/otlp/include \
+            -I exporters/prometheus/include \
+            -I exporters/zipkin/include \
+            -I ext/include \
+            -I opentracing-shim/include \
+            -I sdk/include \
+            -i build \
+            -i test \
+            -i third_party \
+            -j $(nproc) \
+            . 2>&1 | tee cppcheck.log
+
+      - uses: actions/upload-artifact@v4
+        if: success() || failure()
+        with:
+          name: Logs (cppcheck)
+          path: ./cppcheck.log
+
+      - name: Count warnings
+        run: |
+          set +e
+          COUNT=`grep -c -E "\[.+\]" cppcheck.log`
+          echo "cppcheck reported ${COUNT} warning(s)"
+          if [ $COUNT -ne 0 ] ; then exit 1 ; fi

--- a/.github/workflows/cppcheck.yml
+++ b/.github/workflows/cppcheck.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   cppcheck:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
         with:
@@ -18,26 +18,11 @@ jobs:
       - name: Set up dependencies
         run: |
           sudo apt update -y
-          sudo apt install -y --no-install-recommends --no-install-suggests \
-            build-essential \
-            cppcheck \
-            cmake \
-            ninja-build \
-            libssl-dev \
-            libcurl4-openssl-dev \
-            libprotobuf-dev \
-            protobuf-compiler \
-            libgmock-dev \
-            libgtest-dev \
-            libbenchmark-dev
-
-      - name: Prepare CMake
-        run: |
-          mkdir build && cd build
-          CC="clang" CXX="clang++" cmake ..
+          sudo apt install -y cppcheck
 
       - name: Run cppcheck
         run: |
+          cppcheck --version | tee cppcheck.log
           cppcheck \
             --force \
             --enable=warning,performance,portability \
@@ -60,7 +45,7 @@ jobs:
             -i test \
             -i third_party \
             -j $(nproc) \
-            . 2>&1 | tee cppcheck.log
+            . 2>&1 | tee --append cppcheck.log
 
       - uses: actions/upload-artifact@v4
         if: success() || failure()
@@ -73,4 +58,5 @@ jobs:
           set +e
           COUNT=`grep -c -E "\[.+\]" cppcheck.log`
           echo "cppcheck reported ${COUNT} warning(s)"
-          if [ $COUNT -ne 0 ] ; then exit 1 ; fi
+          # TODO: uncomment to enforce failing the build
+          # if [ $COUNT -ne 0 ] ; then exit 1 ; fi


### PR DESCRIPTION
Fixes #2297

## Changes

- Added CI job for cppcheck. For now, it does not fail the build

For significant contributions please make sure you have completed the following items:

* [ ] `CHANGELOG.md` updated for non-trivial changes
* [ ] Unit tests have been added
* [ ] Changes in public API reviewed