### PR TITLE
[BUILD] Fix cross-compilation with protoc

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -429,7 +429,6 @@ if(WITH_OTLP_GRPC
   # Latest Protobuf imported targets and without legacy module support
   if(TARGET protobuf::protoc)
     if(CMAKE_CROSSCOMPILING AND Protobuf_PROTOC_EXECUTABLE)
-      # Some versions of FindProtobuf.cmake uses mixed case instead of uppercase
       set(PROTOBUF_PROTOC_EXECUTABLE ${Protobuf_PROTOC_EXECUTABLE})
     else()
       project_build_tools_get_imported_location(PROTOBUF_PROTOC_EXECUTABLE
@@ -440,6 +439,9 @@ if(WITH_OTLP_GRPC
         set(PROTOBUF_PROTOC_EXECUTABLE protobuf::protoc)
       endif()
     endif()
+  elseif(Protobuf_PROTOC_EXECUTABLE)
+    # Some versions of FindProtobuf.cmake uses mixed case instead of uppercase
+    set(PROTOBUF_PROTOC_EXECUTABLE ${Protobuf_PROTOC_EXECUTABLE})
   endif()
   include(CMakeDependentOption)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -428,16 +428,18 @@ if(WITH_OTLP_GRPC
   endif()
   # Latest Protobuf imported targets and without legacy module support
   if(TARGET protobuf::protoc)
-    project_build_tools_get_imported_location(PROTOBUF_PROTOC_EXECUTABLE
-                                              protobuf::protoc)
-    # If protobuf::protoc is not a imported target, then we use the target
-    # directly for fallback
-    if(NOT PROTOBUF_PROTOC_EXECUTABLE)
-      set(PROTOBUF_PROTOC_EXECUTABLE protobuf::protoc)
+    if(CMAKE_CROSSCOMPILING AND Protobuf_PROTOC_EXECUTABLE)
+      # Some versions of FindProtobuf.cmake uses mixed case instead of uppercase
+      set(PROTOBUF_PROTOC_EXECUTABLE ${Protobuf_PROTOC_EXECUTABLE})
+    else()
+      project_build_tools_get_imported_location(PROTOBUF_PROTOC_EXECUTABLE
+                                                protobuf::protoc)
+      # If protobuf::protoc is not a imported target, then we use the target
+      # directly for fallback
+      if(NOT PROTOBUF_PROTOC_EXECUTABLE)
+        set(PROTOBUF_PROTOC_EXECUTABLE protobuf::protoc)
+      endif()
     endif()
-  elseif(Protobuf_PROTOC_EXECUTABLE)
-    # Some versions of FindProtobuf.cmake uses mixed case instead of uppercase
-    set(PROTOBUF_PROTOC_EXECUTABLE ${Protobuf_PROTOC_EXECUTABLE})
   endif()
   include(CMakeDependentOption)
 


### PR DESCRIPTION
Change-Id: I931ff0ad1951473acd56ae3f5778ac11f7499caa

## Changes

When cross-compiling, the `protoc` found through `find_package(Protobuf)` is not a binary that can be executed on the host and cannot be run. In the case of cross-compilation, it is necessary to specify the executable protoc program on the host.