### PR TITLE
[SDK] Tracer provider shutdown blocks in-definitively

### DIFF
--- a/exporters/memory/include/opentelemetry/exporters/memory/in_memory_span_exporter.h
+++ b/exporters/memory/include/opentelemetry/exporters/memory/in_memory_span_exporter.h
@@ -75,6 +75,11 @@ public:
     return sdk::common::ExportResult::kSuccess;
   }
 
+  virtual bool ForceFlush(std::chrono::microseconds /* timeout */) noexcept override
+  {
+    return true;
+  }
+
   /**
    * @param timeout an optional value containing the timeout of the exporter
    * note: passing custom timeout values is not currently supported for this exporter

--- a/sdk/include/opentelemetry/sdk/logs/exporter.h
+++ b/sdk/include/opentelemetry/sdk/logs/exporter.h
@@ -51,7 +51,7 @@ public:
    * Force flush the log records pushed into this log exporter.
    */
   virtual bool ForceFlush(
-      std::chrono::microseconds timeout = (std::chrono::microseconds::max)()) noexcept;
+      std::chrono::microseconds timeout = (std::chrono::microseconds::max)()) noexcept = 0;
 
   /**
    * Marks the exporter as ShutDown and cleans up any resources as required.

--- a/sdk/include/opentelemetry/sdk/logs/logger_provider.h
+++ b/sdk/include/opentelemetry/sdk/logs/logger_provider.h
@@ -93,7 +93,7 @@ public:
   /**
    * Shutdown the log processor associated with this log provider.
    */
-  bool Shutdown() noexcept;
+  bool Shutdown(std::chrono::microseconds timeout = (std::chrono::microseconds::max)()) noexcept;
 
   /**
    * Force flush the log processor associated with this log provider.

--- a/sdk/include/opentelemetry/sdk/metrics/meter_context.h
+++ b/sdk/include/opentelemetry/sdk/metrics/meter_context.h
@@ -147,7 +147,7 @@ public:
   /**
    * Shutdown the Collectors associated with this meter provider.
    */
-  bool Shutdown() noexcept;
+  bool Shutdown(std::chrono::microseconds timeout = (std::chrono::microseconds::max)()) noexcept;
 
 private:
   opentelemetry::sdk::resource::Resource resource_;

--- a/sdk/include/opentelemetry/sdk/metrics/meter_provider.h
+++ b/sdk/include/opentelemetry/sdk/metrics/meter_provider.h
@@ -110,7 +110,7 @@ public:
   /**
    * Shutdown the meter provider.
    */
-  bool Shutdown() noexcept;
+  bool Shutdown(std::chrono::microseconds timeout = (std::chrono::microseconds::max)()) noexcept;
 
   /**
    * Force flush the meter provider.

--- a/sdk/include/opentelemetry/sdk/metrics/push_metric_exporter.h
+++ b/sdk/include/opentelemetry/sdk/metrics/push_metric_exporter.h
@@ -53,7 +53,7 @@ public:
    * @return return the status of the operation.
    */
   virtual bool Shutdown(
-      std::chrono::microseconds timeout = std::chrono::microseconds(0)) noexcept = 0;
+      std::chrono::microseconds timeout = (std::chrono::microseconds::max)()) noexcept = 0;
 };
 }  // namespace metrics
 }  // namespace sdk

--- a/sdk/include/opentelemetry/sdk/trace/exporter.h
+++ b/sdk/include/opentelemetry/sdk/trace/exporter.h
@@ -48,12 +48,12 @@ public:
 
   /**
    * Export all spans that have been exported.
-   * @param timeout an optional timeout, the default timeout of 0 means that no
+   * @param timeout an optional timeout, the default timeout means that no
    * timeout is applied.
    * @return return true when all data are exported, and false when timeout
    */
   virtual bool ForceFlush(
-      std::chrono::microseconds timeout = (std::chrono::microseconds::max)()) noexcept;
+      std::chrono::microseconds timeout = (std::chrono::microseconds::max)()) noexcept = 0;
 
   /**
    * Shut down the exporter.

--- a/sdk/include/opentelemetry/sdk/trace/processor.h
+++ b/sdk/include/opentelemetry/sdk/trace/processor.h
@@ -56,7 +56,7 @@ public:
 
   /**
    * Export all ended spans that have not yet been exported.
-   * @param timeout an optional timeout, the default timeout of 0 means that no
+   * @param timeout an optional timeout, the default timeout means that no
    * timeout is applied.
    */
   virtual bool ForceFlush(
@@ -67,7 +67,7 @@ public:
    * exported before shutdown. After the call to Shutdown, subsequent calls to
    * OnStart, OnEnd, ForceFlush or Shutdown will return immediately without
    * doing anything.
-   * @param timeout an optional timeout, the default timeout of 0 means that no
+   * @param timeout an optional timeout, the default timeout means that no
    * timeout is applied.
    */
   virtual bool Shutdown(

--- a/sdk/include/opentelemetry/sdk/trace/tracer_provider.h
+++ b/sdk/include/opentelemetry/sdk/trace/tracer_provider.h
@@ -101,7 +101,7 @@ public:
   /**
    * Shutdown the span processor associated with this tracer provider.
    */
-  bool Shutdown() noexcept;
+  bool Shutdown(std::chrono::microseconds timeout = (std::chrono::microseconds::max)()) noexcept;
 
   /**
    * Force flush the span processor associated with this tracer provider.

--- a/sdk/src/logs/logger_provider.cc
+++ b/sdk/src/logs/logger_provider.cc
@@ -118,9 +118,9 @@ const opentelemetry::sdk::resource::Resource &LoggerProvider::GetResource() cons
   return context_->GetResource();
 }
 
-bool LoggerProvider::Shutdown() noexcept
+bool LoggerProvider::Shutdown(std::chrono::microseconds timeout) noexcept
 {
-  return context_->Shutdown();
+  return context_->Shutdown(timeout);
 }
 
 bool LoggerProvider::ForceFlush(std::chrono::microseconds timeout) noexcept

--- a/sdk/src/metrics/meter_context.cc
+++ b/sdk/src/metrics/meter_context.cc
@@ -138,16 +138,15 @@ void MeterContext::RemoveMeter(nostd::string_view name,
   meters_.swap(filtered_meters);
 }
 
-bool MeterContext::Shutdown() noexcept
+bool MeterContext::Shutdown(std::chrono::microseconds timeout) noexcept
 {
   bool result = true;
   // Shutdown only once.
   if (!shutdown_latch_.test_and_set(std::memory_order_acquire))
   {
-
     for (auto &collector : collectors_)
     {
-      bool status = std::static_pointer_cast<MetricCollector>(collector)->Shutdown();
+      bool status = std::static_pointer_cast<MetricCollector>(collector)->Shutdown(timeout);
       result      = result && status;
     }
     if (!result)

--- a/sdk/src/metrics/meter_provider.cc
+++ b/sdk/src/metrics/meter_provider.cc
@@ -132,9 +132,9 @@ void MeterProvider::SetExemplarFilter(metrics::ExemplarFilterType exemplar_filte
 /**
  * Shutdown the meter provider.
  */
-bool MeterProvider::Shutdown() noexcept
+bool MeterProvider::Shutdown(std::chrono::microseconds timeout) noexcept
 {
-  return context_->Shutdown();
+  return context_->Shutdown(timeout);
 }
 
 /**

--- a/sdk/src/trace/tracer_provider.cc
+++ b/sdk/src/trace/tracer_provider.cc
@@ -125,9 +125,9 @@ const resource::Resource &TracerProvider::GetResource() const noexcept
   return context_->GetResource();
 }
 
-bool TracerProvider::Shutdown() noexcept
+bool TracerProvider::Shutdown(std::chrono::microseconds timeout) noexcept
 {
-  return context_->Shutdown();
+  return context_->Shutdown(timeout);
 }
 
 bool TracerProvider::ForceFlush(std::chrono::microseconds timeout) noexcept


### PR DESCRIPTION
Fixes #3187

## Changes

Please provide a brief description of the changes here.

* Fixed several `::Shutdown()` methods, where the timeout parameter was missing
* Fixed implementation to forward the timeout parameter downstream, from providers to processors to exporters

For significant contributions please make sure you have completed the following items:

* [ ] `CHANGELOG.md` updated for non-trivial changes
* [ ] Unit tests have been added
* [ ] Changes in public API reviewed