### PR TITLE
[TEST] Change `is_called_` and `got_response_` to use atomic

### DIFF
--- a/ext/test/http/curl_http_test.cc
+++ b/ext/test/http/curl_http_test.cc
@@ -33,7 +33,7 @@ class CustomEventHandler : public http_client::EventHandler
 public:
   void OnResponse(http_client::Response & /* response */) noexcept override
   {
-    got_response_ = true;
+    got_response_.store(true, std::memory_order_release);
   }
   void OnEvent(http_client::SessionState state, nostd::string_view /* reason */) noexcept override
   {
@@ -41,16 +41,20 @@ public:
     {
       case http_client::SessionState::ConnectFailed:
       case http_client::SessionState::SendFailed: {
-        is_called_ = true;
+        is_called_.store(true, std::memory_order_release);
         break;
       }
       default:
         break;
     }
   }
+
+  CustomEventHandler() : is_called_(false), got_response_(false) {}
+
   ~CustomEventHandler() override = default;
-  bool is_called_                = false;
-  bool got_response_             = false;
+
+  std::atomic<bool> is_called_;
+  std::atomic<bool> got_response_;
 };
 
 class GetEventHandler : public CustomEventHandler
@@ -59,8 +63,8 @@ class GetEventHandler : public CustomEventHandler
   {
     ASSERT_EQ(200, response.GetStatusCode());
     ASSERT_EQ(response.GetBody().size(), 0);
-    is_called_    = true;
-    got_response_ = true;
+    is_called_.store(true, std::memory_order_release);
+    got_response_.store(true, std::memory_order_release);
   }
 };
 
@@ -71,8 +75,8 @@ class PostEventHandler : public CustomEventHandler
     ASSERT_EQ(200, response.GetStatusCode());
     std::string body(response.GetBody().begin(), response.GetBody().end());
     ASSERT_EQ(body, "{'k1':'v1', 'k2':'v2', 'k3':'v3'}");
-    is_called_    = true;
-    got_response_ = true;
+    is_called_.store(true, std::memory_order_release);
+    got_response_.store(true, std::memory_order_release);
   }
 };
 
@@ -87,8 +91,8 @@ public:
   {
     ASSERT_EQ(200, response.GetStatusCode());
     ASSERT_EQ(response.GetBody().size(), 0);
-    is_called_    = true;
-    got_response_ = true;
+    is_called_.store(true, std::memory_order_release);
+    got_response_.store(true, std::memory_order_release);
 
     if (session_)
     {
@@ -249,8 +253,8 @@ TEST_F(BasicCurlHttpTests, SendGetRequest)
   session->SendRequest(handler);
   ASSERT_TRUE(waitForRequests(30, 1));
   session->FinishSession();
-  ASSERT_TRUE(handler->is_called_);
-  ASSERT_TRUE(handler->got_response_);
+  ASSERT_TRUE(handler->is_called_.load(std::memory_order_acquire));
+  ASSERT_TRUE(handler->got_response_.load(std::memory_order_acquire));
 }
 
 TEST_F(BasicCurlHttpTests, SendPostRequest)
@@ -272,8 +276,8 @@ TEST_F(BasicCurlHttpTests, SendPostRequest)
   session->SendRequest(handler);
   ASSERT_TRUE(waitForRequests(30, 1));
   session->FinishSession();
-  ASSERT_TRUE(handler->is_called_);
-  ASSERT_TRUE(handler->got_response_);
+  ASSERT_TRUE(handler->is_called_.load(std::memory_order_acquire));
+  ASSERT_TRUE(handler->got_response_.load(std::memory_order_acquire));
 
   session_manager->CancelAllSessions();
   session_manager->FinishAllSessions();
@@ -291,8 +295,8 @@ TEST_F(BasicCurlHttpTests, RequestTimeout)
   auto handler = std::make_shared<GetEventHandler>();
   session->SendRequest(handler);
   session->FinishSession();
-  ASSERT_TRUE(handler->is_called_);
-  ASSERT_FALSE(handler->got_response_);
+  ASSERT_TRUE(handler->is_called_.load(std::memory_order_acquire));
+  ASSERT_FALSE(handler->got_response_.load(std::memory_order_acquire));
 }
 
 TEST_F(BasicCurlHttpTests, CurlHttpOperations)
@@ -408,8 +412,8 @@ TEST_F(BasicCurlHttpTests, SendGetRequestAsync)
       sessions[i]->FinishSession();
       ASSERT_FALSE(sessions[i]->IsSessionActive());
 
-      ASSERT_TRUE(handlers[i]->is_called_);
-      ASSERT_TRUE(handlers[i]->got_response_);
+      ASSERT_TRUE(handlers[i]->is_called_.load(std::memory_order_acquire));
+      ASSERT_TRUE(handlers[i]->got_response_.load(std::memory_order_acquire));
     }
 
     http_client.WaitBackgroundThreadExit();
@@ -437,7 +441,8 @@ TEST_F(BasicCurlHttpTests, SendGetRequestAsyncTimeout)
     // Lock mtx_requests to prevent response, we will check IsSessionActive() in the end
     std::unique_lock<std::mutex> lock_requests(mtx_requests);
     sessions[i]->SendRequest(handlers[i]);
-    ASSERT_TRUE(sessions[i]->IsSessionActive() || handlers[i]->is_called_);
+    ASSERT_TRUE(sessions[i]->IsSessionActive() ||
+                handlers[i]->is_called_.load(std::memory_order_acquire));
   }
 
   for (unsigned i = 0; i < batch_count; ++i)
@@ -445,8 +450,8 @@ TEST_F(BasicCurlHttpTests, SendGetRequestAsyncTimeout)
     sessions[i]->FinishSession();
     ASSERT_FALSE(sessions[i]->IsSessionActive());
 
-    ASSERT_TRUE(handlers[i]->is_called_);
-    ASSERT_FALSE(handlers[i]->got_response_);
+    ASSERT_TRUE(handlers[i]->is_called_.load(std::memory_order_acquire));
+    ASSERT_FALSE(handlers[i]->got_response_.load(std::memory_order_acquire));
   }
 }
 
@@ -482,8 +487,8 @@ TEST_F(BasicCurlHttpTests, SendPostRequestAsync)
       ASSERT_FALSE(session->IsSessionActive());
     }
 
-    ASSERT_TRUE(handler->is_called_);
-    ASSERT_TRUE(handler->got_response_);
+    ASSERT_TRUE(handler->is_called_.load(std::memory_order_acquire));
+    ASSERT_TRUE(handler->got_response_.load(std::memory_order_acquire));
 
     http_client.WaitBackgroundThreadExit();
   }
@@ -521,8 +526,8 @@ TEST_F(BasicCurlHttpTests, FinishInAsyncCallback)
     {
       ASSERT_FALSE(sessions[i]->IsSessionActive());
 
-      ASSERT_TRUE(handlers[i]->is_called_);
-      ASSERT_TRUE(handlers[i]->got_response_);
+      ASSERT_TRUE(handlers[i]->is_called_.load(std::memory_order_acquire));
+      ASSERT_TRUE(handlers[i]->got_response_.load(std::memory_order_acquire));
     }
   }
 }


### PR DESCRIPTION
Fixes #3172

## Changes

+ Change `is_called_` and `got_response_` to use atomic

Not sure if it can solve the problems, we can reopen it if it still exists.

For significant contributions please make sure you have completed the following items:

* [ ] `CHANGELOG.md` updated for non-trivial changes
* [ ] Unit tests have been added
* [ ] Changes in public API reviewed