### PR TITLE
update links to openmetrics to reference the v1.0.0 release

### DIFF
--- a/api/include/opentelemetry/semconv/incubating/hw_metrics.h
+++ b/api/include/opentelemetry/semconv/incubating/hw_metrics.h
@@ -132,7 +132,7 @@ static inline nostd::shared_ptr<metrics::ObservableInstrument> CreateAsyncDouble
  * states <p>
  * @code hw.status @endcode is currently specified as an <em>UpDownCounter</em> but would ideally be
  * represented using a <a
- * href="https://github.com/OpenObservability/OpenMetrics/blob/main/specification/OpenMetrics.md#stateset"><em>StateSet</em>
+ * href="https://github.com/prometheus/OpenMetrics/blob/v1.0.0/specification/OpenMetrics.md#stateset"><em>StateSet</em>
  * as defined in OpenMetrics</a>. This semantic convention will be updated once <em>StateSet</em> is
  * specified in OpenTelemetry. This planned change is not expected to have any consequence on the
  * way users query their timeseries backend to retrieve the values of @code hw.status @endcode over


### PR DESCRIPTION
Related to https://github.com/prometheus/OpenMetrics/issues/287

The OM 2.0 effort is kicked off, and will start developing on main. This updates the links to OpenMetrics to reference the 1.0 release. The OM project has also been moved into the prometheus github org.