### PR TITLE
[TEST] Use collector v0.115.1 in functional tests

### DIFF
--- a/functional/otlp/Dockerfile
+++ b/functional/otlp/Dockerfile
@@ -1,7 +1,7 @@
 # Copyright The OpenTelemetry Authors
 # SPDX-License-Identifier: Apache-2.0
 
-FROM otel/opentelemetry-collector
+FROM otel/opentelemetry-collector:0.115.1
 COPY . .
 CMD ["--config", "/otel-cpp/otel-config.yaml"]
 EXPOSE 4318


### PR DESCRIPTION
Fixes # (issue)

## Changes

Please provide a brief description of the changes here.

* Use opentelemetry-collector 0.115.1 in functional tests, as 0.116.0 fails.

For significant contributions please make sure you have completed the following items:

* [ ] `CHANGELOG.md` updated for non-trivial changes
* [ ] Unit tests have been added
* [ ] Changes in public API reviewed