### PR TITLE
[BUILD] Add OTLP/file exporter for dll and examples

### DIFF
--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -3,7 +3,9 @@
 
 add_subdirectory(common)
 include_directories(common)
-if(WITH_OTLP_GRPC OR WITH_OTLP_HTTP)
+if(WITH_OTLP_GRPC
+   OR WITH_OTLP_HTTP
+   OR WITH_OTLP_FILE)
   add_subdirectory(otlp)
 endif()
 if(WITH_OTLP_GRPC)

--- a/ext/src/dll/CMakeLists.txt
+++ b/ext/src/dll/CMakeLists.txt
@@ -22,6 +22,12 @@ if(WITH_OTLP_HTTP)
                         PRIVATE opentelemetry_exporter_otlp_http)
 endif()
 
+if(WITH_OTLP_FILE)
+  add_compile_definitions(WITH_OTLP_FILE)
+  target_link_libraries(opentelemetry_cpp
+                        PRIVATE opentelemetry_exporter_otlp_file)
+endif()
+
 target_link_libraries(
   opentelemetry_cpp PRIVATE opentelemetry_metrics
                             opentelemetry_exporter_ostream_metrics)
@@ -36,6 +42,11 @@ if(WITH_OTLP_HTTP)
                         PRIVATE opentelemetry_exporter_otlp_http_metric)
 endif()
 
+if(WITH_OTLP_FILE)
+  target_link_libraries(opentelemetry_cpp
+                        PRIVATE opentelemetry_exporter_otlp_file_metric)
+endif()
+
 target_link_libraries(
   opentelemetry_cpp PRIVATE opentelemetry_logs
                             opentelemetry_exporter_ostream_logs)
@@ -48,6 +59,11 @@ endif()
 if(WITH_OTLP_HTTP)
   target_link_libraries(opentelemetry_cpp
                         PRIVATE opentelemetry_exporter_otlp_http_log)
+endif()
+
+if(WITH_OTLP_FILE)
+  target_link_libraries(opentelemetry_cpp
+                        PRIVATE opentelemetry_exporter_otlp_file_log)
 endif()
 
 find_program(


### PR DESCRIPTION
Fixes #3225

## Changes

+ Add otlp for examples when include OTLP/file exporters only
+ Link OTLP/file exporters into standardalone dll.

For significant contributions please make sure you have completed the following items:

* [ ] `CHANGELOG.md` updated for non-trivial changes
* [ ] Unit tests have been added
* [ ] Changes in public API reviewed