### PR TITLE
[BUILD] Fix error ‘uint8_t’ does not name a type with gcc-15

### DIFF
--- a/api/include/opentelemetry/logs/severity.h
+++ b/api/include/opentelemetry/logs/severity.h
@@ -3,6 +3,8 @@
 
 #pragma once
 
+#include <cstdint>
+
 #include "opentelemetry/nostd/string_view.h"
 #include "opentelemetry/version.h"
 


### PR DESCRIPTION
Fixes #3239

## Changes

Added missing `cstdint` header for `uint8_t` type in `api/include/opentelemetry/logs/severity.h`.

For significant contributions please make sure you have completed the following items:

* [ ] `CHANGELOG.md` updated for non-trivial changes
* [ ] Unit tests have been added
* [X] Changes in public API reviewed