### PR TITLE
[EXPORTER] fix throw in OtlpGrpcMetricExporter with shared grpc client

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,9 @@ Increment the:
 * [EXPORTER] Fix scope attributes missing from otlp traces metrics
   [#3185](https://github.com/open-telemetry/opentelemetry-cpp/pull/3185)
 
+* [EXPORTER] Fix throw in OtlpGrpcMetricExporter with shared grpc client
+  [#3243](https://github.com/open-telemetry/opentelemetry-cpp/pull/3243)
+
 ## [1.18 2024-11-25]
 
 * [EXPORTER] Fix crash in ElasticsearchLogRecordExporter

--- a/exporters/otlp/src/otlp_grpc_metric_exporter.cc
+++ b/exporters/otlp/src/otlp_grpc_metric_exporter.cc
@@ -50,6 +50,8 @@ OtlpGrpcMetricExporter::OtlpGrpcMetricExporter(
 OtlpGrpcMetricExporter::OtlpGrpcMetricExporter(const OtlpGrpcMetricExporterOptions &options,
                                                const std::shared_ptr<OtlpGrpcClient> &client)
     : options_(options),
+      aggregation_temporality_selector_{
+          OtlpMetricUtils::ChooseTemporalitySelector(options_.aggregation_temporality)},
       client_(client),
       client_reference_guard_(OtlpGrpcClientFactory::CreateReferenceGuard())
 {
@@ -62,6 +64,8 @@ OtlpGrpcMetricExporter::OtlpGrpcMetricExporter(
     std::unique_ptr<proto::collector::metrics::v1::MetricsService::StubInterface> stub,
     const std::shared_ptr<OtlpGrpcClient> &client)
     : options_(OtlpGrpcMetricExporterOptions()),
+      aggregation_temporality_selector_{
+          OtlpMetricUtils::ChooseTemporalitySelector(options_.aggregation_temporality)},
       client_(client),
       client_reference_guard_(OtlpGrpcClientFactory::CreateReferenceGuard()),
       metrics_service_stub_(std::move(stub))

--- a/exporters/otlp/test/otlp_grpc_metric_exporter_test.cc
+++ b/exporters/otlp/test/otlp_grpc_metric_exporter_test.cc
@@ -25,6 +25,9 @@
 
 #  include "opentelemetry/exporters/otlp/protobuf_include_suffix.h"
 
+#  include "opentelemetry/exporters/otlp/otlp_grpc_client.h"
+#  include "opentelemetry/exporters/otlp/otlp_grpc_client_factory.h"
+
 #  include "opentelemetry/sdk/trace/simple_processor.h"
 #  include "opentelemetry/sdk/trace/tracer_provider.h"
 #  include "opentelemetry/trace/provider.h"
@@ -50,10 +53,32 @@ class OtlpGrpcMetricExporterTestPeer : public ::testing::Test
 {
 public:
   std::unique_ptr<sdk::metrics::PushMetricExporter> GetExporter(
-      std::unique_ptr<proto::collector::metrics::v1::MetricsService::StubInterface> &stub_interface)
+      const OtlpGrpcMetricExporterOptions &options)
+  {
+    return std::unique_ptr<sdk::metrics::PushMetricExporter>(new OtlpGrpcMetricExporter(options));
+  }
+
+  std::unique_ptr<sdk::metrics::PushMetricExporter> GetExporter(
+      std::unique_ptr<proto::collector::metrics::v1::MetricsService::StubInterface> stub_interface)
   {
     return std::unique_ptr<sdk::metrics::PushMetricExporter>(
         new OtlpGrpcMetricExporter(std::move(stub_interface)));
+  }
+
+  std::unique_ptr<sdk::metrics::PushMetricExporter> GetExporter(
+      std::unique_ptr<proto::collector::metrics::v1::MetricsService::StubInterface> stub_interface,
+      std::shared_ptr<OtlpGrpcClient> client)
+  {
+    return std::unique_ptr<sdk::metrics::PushMetricExporter>(
+        new OtlpGrpcMetricExporter(std::move(stub_interface), std::move(client)));
+  }
+
+  std::unique_ptr<sdk::metrics::PushMetricExporter> GetExporter(
+      const OtlpGrpcMetricExporterOptions &options,
+      std::shared_ptr<OtlpGrpcClient> client)
+  {
+    return std::unique_ptr<sdk::metrics::PushMetricExporter>(
+        new OtlpGrpcMetricExporter(options, std::move(client)));
   }
 
   // Get the options associated with the given exporter.
@@ -203,6 +228,35 @@ TEST_F(OtlpGrpcMetricExporterTestPeer, ConfigUnknownInsecureFromEnv)
   unsetenv("OTEL_EXPORTER_OTLP_METRICS_INSECURE");
 }
 #  endif
+
+TEST_F(OtlpGrpcMetricExporterTestPeer, CheckGetAggregationTemporality)
+{
+  auto options                    = OtlpGrpcMetricExporterOptions();
+  options.aggregation_temporality = PreferredAggregationTemporality::kCumulative;
+
+  auto client = OtlpGrpcClientFactory::Create(options);
+
+  auto exporter0 = GetExporter(options);
+  auto exporter1 = GetExporter(client->MakeMetricsServiceStub());
+  auto exporter2 = GetExporter(options, client);
+  auto exporter3 = GetExporter(client->MakeMetricsServiceStub(), client);
+
+  EXPECT_EQ(
+      opentelemetry::sdk::metrics::AggregationTemporality::kCumulative,
+      exporter0->GetAggregationTemporality(opentelemetry::sdk::metrics::InstrumentType::kCounter));
+
+  EXPECT_EQ(
+      opentelemetry::sdk::metrics::AggregationTemporality::kCumulative,
+      exporter1->GetAggregationTemporality(opentelemetry::sdk::metrics::InstrumentType::kCounter));
+
+  EXPECT_EQ(
+      opentelemetry::sdk::metrics::AggregationTemporality::kCumulative,
+      exporter2->GetAggregationTemporality(opentelemetry::sdk::metrics::InstrumentType::kCounter));
+
+  EXPECT_EQ(
+      opentelemetry::sdk::metrics::AggregationTemporality::kCumulative,
+      exporter3->GetAggregationTemporality(opentelemetry::sdk::metrics::InstrumentType::kCounter));
+}
 
 }  // namespace otlp
 }  // namespace exporter


### PR DESCRIPTION
Fixes #3242

OtlpGrpcMetricExporter throws on export when constructed with a shared grpc client. 

## Changes
- Sets the `OtlpGrpcMetricExporter::aggregation_temporality_selector_` in the constructors that accept a shared grpc client 
- Adds test cases to cover `OtlpGrpcMetricExporter::GetAggregationTemporality`

For significant contributions please make sure you have completed the following items:

* [x] `CHANGELOG.md` updated for non-trivial changes
* [x] Unit tests have been added
* [x] Changes in public API reviewed