### PR TITLE
[CI] Add GRPC in maintainer CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,6 +78,9 @@ jobs:
         sudo -E ./ci/setup_googletest.sh
         sudo -E ./ci/setup_ci_environment.sh
         sudo -E ./ci/install_protobuf.sh
+    - name: setup grpc
+      run: |
+        sudo ./ci/setup_grpc.sh
     - name: run cmake gcc (maintainer mode, sync)
       env:
         CC: /usr/bin/gcc-14
@@ -111,6 +114,9 @@ jobs:
         sudo -E ./ci/setup_googletest.sh
         sudo -E ./ci/setup_ci_environment.sh
         sudo -E ./ci/install_protobuf.sh
+    - name: setup grpc
+      run: |
+        sudo ./ci/setup_grpc.sh
     - name: run cmake gcc (maintainer mode, async)
       env:
         CC: /usr/bin/gcc-14
@@ -144,6 +150,9 @@ jobs:
         sudo -E ./ci/setup_googletest.sh
         sudo -E ./ci/setup_ci_environment.sh
         sudo -E ./ci/install_protobuf.sh
+    - name: setup grpc
+      run: |
+        sudo ./ci/setup_grpc.sh
     - name: run cmake clang (maintainer mode, sync)
       env:
         CC: /usr/bin/clang-18
@@ -177,6 +186,9 @@ jobs:
         sudo -E ./ci/setup_googletest.sh
         sudo -E ./ci/setup_ci_environment.sh
         sudo -E ./ci/install_protobuf.sh
+    - name: setup grpc
+      run: |
+        sudo ./ci/setup_grpc.sh
     - name: run cmake clang (maintainer mode, async)
       env:
         CC: /usr/bin/clang-18
@@ -210,6 +222,9 @@ jobs:
         sudo -E ./ci/setup_googletest.sh
         sudo -E ./ci/setup_ci_environment.sh
         sudo -E ./ci/install_protobuf.sh
+    - name: setup grpc
+      run: |
+        sudo ./ci/setup_grpc.sh
     - name: run cmake clang (maintainer mode, abiv2)
       env:
         CC: /usr/bin/clang-18

--- a/ci/do_ci.sh
+++ b/ci/do_ci.sh
@@ -108,6 +108,7 @@ elif [[ "$1" == "cmake.maintainer.sync.test" ]]; then
   rm -rf *
   cmake "${CMAKE_OPTIONS[@]}"  \
         -DWITH_OTLP_HTTP=ON \
+        -DWITH_OTLP_GRPC=ON \
         -DWITH_OTLP_FILE=ON \
         -DWITH_PROMETHEUS=ON \
         -DWITH_EXAMPLES=ON \
@@ -131,6 +132,7 @@ elif [[ "$1" == "cmake.maintainer.async.test" ]]; then
   rm -rf *
   cmake "${CMAKE_OPTIONS[@]}"  \
         -DWITH_OTLP_HTTP=ON \
+        -DWITH_OTLP_GRPC=ON \
         -DWITH_OTLP_FILE=ON \
         -DWITH_PROMETHEUS=ON \
         -DWITH_EXAMPLES=ON \
@@ -178,6 +180,7 @@ elif [[ "$1" == "cmake.maintainer.abiv2.test" ]]; then
   rm -rf *
   cmake "${CMAKE_OPTIONS[@]}"  \
         -DWITH_OTLP_HTTP=ON \
+        -DWITH_OTLP_GRPC=ON \
         -DWITH_OTLP_FILE=ON \
         -DWITH_PROMETHEUS=ON \
         -DWITH_EXAMPLES=ON \

--- a/exporters/otlp/src/otlp_grpc_metric_exporter.cc
+++ b/exporters/otlp/src/otlp_grpc_metric_exporter.cc
@@ -50,10 +50,10 @@ OtlpGrpcMetricExporter::OtlpGrpcMetricExporter(
 OtlpGrpcMetricExporter::OtlpGrpcMetricExporter(const OtlpGrpcMetricExporterOptions &options,
                                                const std::shared_ptr<OtlpGrpcClient> &client)
     : options_(options),
-      aggregation_temporality_selector_{
-          OtlpMetricUtils::ChooseTemporalitySelector(options_.aggregation_temporality)},
       client_(client),
-      client_reference_guard_(OtlpGrpcClientFactory::CreateReferenceGuard())
+      client_reference_guard_(OtlpGrpcClientFactory::CreateReferenceGuard()),
+      aggregation_temporality_selector_{
+          OtlpMetricUtils::ChooseTemporalitySelector(options_.aggregation_temporality)}
 {
   client_->AddReference(*client_reference_guard_, options_);
 
@@ -64,10 +64,10 @@ OtlpGrpcMetricExporter::OtlpGrpcMetricExporter(
     std::unique_ptr<proto::collector::metrics::v1::MetricsService::StubInterface> stub,
     const std::shared_ptr<OtlpGrpcClient> &client)
     : options_(OtlpGrpcMetricExporterOptions()),
-      aggregation_temporality_selector_{
-          OtlpMetricUtils::ChooseTemporalitySelector(options_.aggregation_temporality)},
       client_(client),
       client_reference_guard_(OtlpGrpcClientFactory::CreateReferenceGuard()),
+      aggregation_temporality_selector_{
+          OtlpMetricUtils::ChooseTemporalitySelector(options_.aggregation_temporality)},
       metrics_service_stub_(std::move(stub))
 {
   client_->AddReference(*client_reference_guard_, options_);

--- a/exporters/otlp/test/otlp_grpc_exporter_test.cc
+++ b/exporters/otlp/test/otlp_grpc_exporter_test.cc
@@ -103,7 +103,7 @@ public:
     OtlpMockTraceServiceStub *stub_;
   };
 
-  async_interface_base *async() { return &async_interface_; }
+  async_interface_base *async() override { return &async_interface_; }
   async_interface_base *experimental_async() { return &async_interface_; }
 
   ::grpc::Status GetLastAsyncStatus() const noexcept { return last_async_status_; }

--- a/exporters/otlp/test/otlp_grpc_exporter_test.cc
+++ b/exporters/otlp/test/otlp_grpc_exporter_test.cc
@@ -68,7 +68,7 @@ public:
   public:
     async_interface(OtlpMockTraceServiceStub *owner) : stub_(owner) {}
 
-    virtual ~async_interface() {}
+    virtual ~async_interface() override = default;
 
     void Export(
         ::grpc::ClientContext *context,

--- a/exporters/otlp/test/otlp_grpc_log_record_exporter_test.cc
+++ b/exporters/otlp/test/otlp_grpc_log_record_exporter_test.cc
@@ -69,7 +69,7 @@ public:
   public:
     async_interface(OtlpMockTraceServiceStub *owner) : stub_(owner) {}
 
-    virtual ~async_interface() {}
+    virtual ~async_interface() override = default;
 
     void Export(
         ::grpc::ClientContext *context,
@@ -132,7 +132,7 @@ public:
   public:
     async_interface(OtlpMockLogsServiceStub *owner) : stub_(owner) {}
 
-    virtual ~async_interface() {}
+    virtual ~async_interface() override = default;
 
     void Export(
         ::grpc::ClientContext *context,

--- a/exporters/otlp/test/otlp_grpc_log_record_exporter_test.cc
+++ b/exporters/otlp/test/otlp_grpc_log_record_exporter_test.cc
@@ -103,7 +103,7 @@ public:
     OtlpMockTraceServiceStub *stub_;
   };
 
-  async_interface_base *async() { return &async_interface_; }
+  async_interface_base *async() override { return &async_interface_; }
   async_interface_base *experimental_async() { return &async_interface_; }
 
   ::grpc::Status GetLastAsyncStatus() const noexcept { return last_async_status_; }
@@ -166,7 +166,7 @@ public:
     OtlpMockLogsServiceStub *stub_;
   };
 
-  async_interface_base *async() { return &async_interface_; }
+  async_interface_base *async() override { return &async_interface_; }
   async_interface_base *experimental_async() { return &async_interface_; }
 
   ::grpc::Status GetLastAsyncStatus() const noexcept { return last_async_status_; }

--- a/sdk/include/opentelemetry/sdk/common/global_log_handler.h
+++ b/sdk/include/opentelemetry/sdk/common/global_log_handler.h
@@ -5,7 +5,6 @@
 
 #include <sstream>  // IWYU pragma: keep
 #include <string>
-#include <utility>
 
 #include "opentelemetry/nostd/shared_ptr.h"
 #include "opentelemetry/sdk/common/attribute_utils.h"

--- a/sdk/include/opentelemetry/sdk/resource/resource_detector.h
+++ b/sdk/include/opentelemetry/sdk/resource/resource_detector.h
@@ -3,6 +3,8 @@
 
 #pragma once
 
+#include <string>
+
 #include "opentelemetry/sdk/resource/resource.h"
 #include "opentelemetry/version.h"
 

--- a/sdk/test/common/global_log_handle_singleton_lifetime_test.cc
+++ b/sdk/test/common/global_log_handle_singleton_lifetime_test.cc
@@ -3,8 +3,8 @@
 
 #include <gtest/gtest.h>
 #include <cstdlib>
-#include <cstring>
 #include <iostream>
+#include <string>
 
 #include "opentelemetry/nostd/shared_ptr.h"
 #include "opentelemetry/sdk/common/attribute_utils.h"

--- a/sdk/test/resource/resource_test.cc
+++ b/sdk/test/resource/resource_test.cc
@@ -10,6 +10,7 @@
 #include <utility>
 
 #include "opentelemetry/nostd/variant.h"
+#include "opentelemetry/sdk/common/attribute_utils.h"
 #include "opentelemetry/sdk/resource/resource.h"
 #include "opentelemetry/sdk/resource/resource_detector.h"
 #include "opentelemetry/sdk/version/version.h"


### PR DESCRIPTION
Fixes # (issue)

## Changes

Please provide a brief description of the changes here.

* Use grpc in maintainer CI : `WITH_OTLP_GRPC=ON`
* Fixed build warnings in grpc exporter
* Fixed remaining include-what-you-use warnings

For significant contributions please make sure you have completed the following items:

* [ ] `CHANGELOG.md` updated for non-trivial changes
* [ ] Unit tests have been added
* [ ] Changes in public API reviewed