### PR TITLE
[BUILD] Build break with CURL 7.29.0

### DIFF
--- a/.iwyu.imp
+++ b/.iwyu.imp
@@ -24,5 +24,8 @@
   # We prefer to include <gmock/gmock.h> for simplicity
   { "include": ["<gmock/gmock-function-mocker.h>", "private", "<gmock/gmock.h>", "public"] },
   { "include": ["<gmock/gmock-spec-builders.h>", "private", "<gmock/gmock.h>", "public"] },
+
+  # We prefer to include <curl/curl.h> for simplicity
+  { "include": ["<curl/system.h>", "private", "<curl/curl.h>", "public"] },
 ]
 

--- a/ext/src/http/client/curl/http_operation_curl.cc
+++ b/ext/src/http/client/curl/http_operation_curl.cc
@@ -3,7 +3,6 @@
 
 #include <curl/curl.h>
 #include <curl/curlver.h>
-#include <curl/system.h>
 
 #ifdef ENABLE_OTLP_RETRY_PREVIEW
 #  include <array>


### PR DESCRIPTION
Fixes #3252

## Changes

Please provide a brief description of the changes here.

* Indicate to include-what-you-use to not include header curl/system.h
* This fixes the build with CURL 7.29.0, where this header does not exist.

For significant contributions please make sure you have completed the following items:

* [ ] `CHANGELOG.md` updated for non-trivial changes
* [ ] Unit tests have been added
* [ ] Changes in public API reviewed