### PR TITLE
[SDK] Fix BatchLogRecordProcessor to instrument shutdown

### DIFF
--- a/sdk/src/logs/batch_log_record_processor.cc
+++ b/sdk/src/logs/batch_log_record_processor.cc
@@ -218,7 +218,7 @@ void BatchLogRecordProcessor::DoBackgroundWork()
     if (synchronization_data_->is_shutdown.load() == true)
     {
       DrainQueue();
-      return;
+      break;
     }
 
     auto start = std::chrono::steady_clock::now();


### PR DESCRIPTION
Fixes #3261

## Changes

Please provide a brief description of the changes here.

* In BatchLogRecordProcessor, used the same coding pattern in BatchSpanProcessor, so that proper OnEnd() instrumentation is called on shutdown.

For significant contributions please make sure you have completed the following items:

* [ ] `CHANGELOG.md` updated for non-trivial changes
* [ ] Unit tests have been added
* [ ] Changes in public API reviewed