### PR TITLE
[BUILD] Enable old behavior of CMP0092

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,8 +20,8 @@ if(POLICY CMP0091)
 endif()
 
 if(POLICY CMP0092)
-  # https://cmake.org/cmake/help/latest/policy/CMP0092.html#policy:CMP0092
-  # Make sure the /W3 is not removed from CMAKE_CXX_FLAGS since CMake 3.15
+  # https://cmake.org/cmake/help/latest/policy/CMP0092.html#policy:CMP0092 Make
+  # sure the /W3 is not removed from CMAKE_CXX_FLAGS since CMake 3.15
   cmake_policy(SET CMP0092 OLD)
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,6 +19,12 @@ if(POLICY CMP0091)
   cmake_policy(SET CMP0091 NEW)
 endif()
 
+if(POLICY CMP0092)
+  # https://cmake.org/cmake/help/latest/policy/CMP0092.html#policy:CMP0092
+  # Make sure the /W3 is not removed from CMAKE_CXX_FLAGS since CMake 3.15
+  cmake_policy(SET CMP0092 OLD)
+endif()
+
 # MSVC RTTI flag /GR should not be not added to CMAKE_CXX_FLAGS by default. @see
 # https://cmake.org/cmake/help/latest/policy/CMP0117.html
 if(CMAKE_VERSION VERSION_GREATER_EQUAL "3.20.0")


### PR DESCRIPTION
## Changes

Based on below doc, CMake 3.15 introduced policy CMP0092 which removes `/W3` option by default for MSVC. This change restores the old behavior of CMP0092 to keep `/W3` for MSVC, before we set the warning level explicitly for the project.
[CMakeLists](https://cmake.org/cmake/help/latest/policy/CMP0092.html#policy:CMP0092)



For significant contributions please make sure you have completed the following items:

* [ ] `CHANGELOG.md` updated for non-trivial changes
* [ ] Unit tests have been added
* [ ] Changes in public API reviewed