### PR TITLE
[BUILD] Fixes compatibility of type_traits

### DIFF
--- a/api/include/opentelemetry/nostd/type_traits.h
+++ b/api/include/opentelemetry/nostd/type_traits.h
@@ -17,6 +17,7 @@
 #  include "opentelemetry/config.h"
 #  include "opentelemetry/nostd/detail/void.h"  // IWYU pragma: export
 #  include "opentelemetry/version.h"
+#endif
 
 OPENTELEMETRY_BEGIN_NAMESPACE
 namespace nostd
@@ -70,6 +71,10 @@ struct remove_all_extents<std::array<T, N>> : remove_all_extents<T>
 template <typename T>
 using remove_all_extents_t = typename remove_all_extents<T>::type;
 
+#if defined(OPENTELEMETRY_STL_VERSION) && OPENTELEMETRY_STL_VERSION >= 2017
+using std::is_nothrow_swappable;
+using std::is_swappable;
+#else
 /**
  * Back port of std::is_swappable
  */
@@ -119,6 +124,7 @@ struct is_nothrow_swappable<false, T> : std::false_type
 }  // namespace detail
 template <typename T>
 using is_nothrow_swappable = detail::swappable::is_nothrow_swappable<is_swappable<T>::value, T>;
+#endif
 
 /**
  * Back port of
@@ -127,12 +133,12 @@ using is_nothrow_swappable = detail::swappable::is_nothrow_swappable<is_swappabl
  *  std::is_trivialy_copy_assignable
  *  std::is_trivialy_move_assignable
  */
-#  ifdef OPENTELEMETRY_TRIVIALITY_TYPE_TRAITS
+#ifdef OPENTELEMETRY_TRIVIALITY_TYPE_TRAITS
 using std::is_trivially_copy_assignable;
 using std::is_trivially_copy_constructible;
 using std::is_trivially_move_assignable;
 using std::is_trivially_move_constructible;
-#  else
+#else
 template <typename T>
 struct is_trivially_copy_constructible
 {
@@ -156,7 +162,6 @@ struct is_trivially_move_assignable
 {
   static constexpr bool value = __is_trivial(T);
 };
-#  endif
+#endif
 }  // namespace nostd
 OPENTELEMETRY_END_NAMESPACE
-#endif /* OPENTELEMETRY_HAVE_STD_TYPE_TRAITS */

--- a/api/include/opentelemetry/std/type_traits.h
+++ b/api/include/opentelemetry/std/type_traits.h
@@ -5,18 +5,6 @@
 
 // IWYU pragma: private, include "opentelemetry/nostd/type_traits.h"
 
-#include <type_traits>
+#include <type_traits>  // IWYU pragma: keep
 
-#include "opentelemetry/version.h"
-
-OPENTELEMETRY_BEGIN_NAMESPACE
-// Standard Type aliases in nostd namespace
-namespace nostd
-{
-
-// nostd::enable_if_t<...>
-template <bool B, class T = void>
-using enable_if_t = typename std::enable_if<B, T>::type;
-
-}  // namespace nostd
-OPENTELEMETRY_END_NAMESPACE
+#include "opentelemetry/version.h"  // IWYU pragma: keep

--- a/exporters/elasticsearch/src/es_log_recordable.cc
+++ b/exporters/elasticsearch/src/es_log_recordable.cc
@@ -23,12 +23,25 @@
 
 namespace nlohmann
 {
+template <class T>
+struct json_assign_visitor
+{
+  T *j_;
+  json_assign_visitor(T &j) : j_(&j) {}
+
+  template <class U>
+  void operator()(const U &u)
+  {
+    *j_ = u;
+  }
+};
+
 template <>
 struct adl_serializer<opentelemetry::sdk::common::OwnedAttributeValue>
 {
   static void to_json(json &j, const opentelemetry::sdk::common::OwnedAttributeValue &v)
   {
-    opentelemetry::nostd::visit([&j](const auto &value) { j = value; }, v);
+    opentelemetry::nostd::visit(json_assign_visitor<json>(j), v);
   }
 };
 
@@ -37,7 +50,7 @@ struct adl_serializer<opentelemetry::common::AttributeValue>
 {
   static void to_json(json &j, const opentelemetry::common::AttributeValue &v)
   {
-    opentelemetry::nostd::visit([&j](const auto &value) { j = value; }, v);
+    opentelemetry::nostd::visit(json_assign_visitor<json>(j), v);
   }
 };
 }  // namespace nlohmann

--- a/ext/src/http/client/curl/http_client_curl.cc
+++ b/ext/src/http/client/curl/http_client_curl.cc
@@ -15,7 +15,6 @@
 #include <mutex>
 #include <string>
 #include <thread>
-#include <type_traits>
 #include <unordered_map>
 #include <unordered_set>
 #include <utility>

--- a/ext/src/http/client/curl/http_client_curl.cc
+++ b/ext/src/http/client/curl/http_client_curl.cc
@@ -26,6 +26,7 @@
 #include "opentelemetry/ext/http/common/url_parser.h"
 #include "opentelemetry/nostd/shared_ptr.h"
 #include "opentelemetry/nostd/string_view.h"
+#include "opentelemetry/nostd/type_traits.h"
 #include "opentelemetry/sdk/common/thread_instrumentation.h"
 #include "opentelemetry/version.h"
 
@@ -116,7 +117,7 @@ int deflateInPlace(z_stream *strm, unsigned char *buf, uint32_t len, uint32_t *m
   // now empty input buffer (this will only occur for long incompressible streams, more than ~20 MB
   // for the default deflate memLevel of 8, or when *max_len is too small and less than the length
   // of the header plus one byte)
-  auto hold = static_cast<std::remove_const_t<decltype(z_stream::next_in)>>(
+  auto hold = static_cast<nostd::remove_const_t<decltype(z_stream::next_in)>>(
       strm->zalloc(strm->opaque, strm->avail_in, 1));  // allocated buffer to hold input data
   if (hold == Z_NULL)
   {


### PR DESCRIPTION
Fixes #3273 

## Changes

+ Make type traits the same when `OPENTELEMETRY_STL_VERSION>=2011` or not
+ Do not use auto as parameter of lambda to support legacy toolchain.

For significant contributions please make sure you have completed the following items:

* [ ] `CHANGELOG.md` updated for non-trivial changes
* [x] Unit tests have been added
* [x] Changes in public API reviewed