### PR TITLE
Fix compilation with Regex being disabled

### DIFF
--- a/sdk/src/metrics/instrument_metadata_validator.cc
+++ b/sdk/src/metrics/instrument_metadata_validator.cc
@@ -1,6 +1,7 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
+#include <algorithm>
 #include <string>
 
 #include "opentelemetry/nostd/string_view.h"
@@ -16,11 +17,13 @@ namespace sdk
 {
 namespace metrics
 {
+#if OPENTELEMETRY_HAVE_WORKING_REGEX
 // instrument-name = ALPHA 0*254 ("_" / "." / "-" / "/" / ALPHA / DIGIT)
 const std::string kInstrumentNamePattern = "[a-zA-Z][-_./a-zA-Z0-9]{0,254}";
 //
 const std::string kInstrumentUnitPattern = "[\x01-\x7F]{0,63}";
 // instrument-unit = It can have a maximum length of 63 ASCII chars
+#endif
 
 InstrumentMetaDataValidator::InstrumentMetaDataValidator()
 #if OPENTELEMETRY_HAVE_WORKING_REGEX

--- a/sdk/src/metrics/instrument_metadata_validator.cc
+++ b/sdk/src/metrics/instrument_metadata_validator.cc
@@ -1,9 +1,6 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-#if OPENTELEMETRY_HAVE_WORKING_REGEX
-#include <algorithm>
-#endif
 #include <string>
 
 #include "opentelemetry/nostd/string_view.h"
@@ -12,6 +9,8 @@
 
 #if OPENTELEMETRY_HAVE_WORKING_REGEX
 #  include <regex>
+#else
+#  include <algorithm>
 #endif
 
 OPENTELEMETRY_BEGIN_NAMESPACE

--- a/sdk/src/metrics/instrument_metadata_validator.cc
+++ b/sdk/src/metrics/instrument_metadata_validator.cc
@@ -1,7 +1,9 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
+#if OPENTELEMETRY_HAVE_WORKING_REGEX
 #include <algorithm>
+#endif
 #include <string>
 
 #include "opentelemetry/nostd/string_view.h"


### PR DESCRIPTION
## Changes

Fix compilation with Regex disabled:
* It was missing an include for std::any_of
* Avoid declaring unused constants (at least my LLVM errors out)

## Testing

I compiled it locally, and it works - but I assume either not-regex isn't covered by testing, our my use of LLVM 19 in my own code base means it was being more strict.
