### PR TITLE
[EXPORTER] Support exporting event_name using OTLP Exporter

### DIFF
--- a/exporters/otlp/include/opentelemetry/exporters/otlp/otlp_log_recordable.h
+++ b/exporters/otlp/include/opentelemetry/exporters/otlp/otlp_log_recordable.h
@@ -76,10 +76,7 @@ public:
    * @param id the event Id to set
    * @param name  the event name to set
    */
-  void SetEventId(int64_t /* id */, nostd::string_view /* name */) noexcept override
-  {
-    // TODO: export Event Id to OTLP
-  }
+  void SetEventId(int64_t /* id */, nostd::string_view event_name) noexcept override;
 
   /**
    * Set the trace id for this log.

--- a/exporters/otlp/src/otlp_log_recordable.cc
+++ b/exporters/otlp/src/otlp_log_recordable.cc
@@ -197,6 +197,11 @@ void OtlpLogRecordable::SetBody(const opentelemetry::common::AttributeValue &mes
   OtlpPopulateAttributeUtils::PopulateAnyValue(proto_record_.mutable_body(), message);
 }
 
+void OtlpLogRecordable::SetEventId(int64_t /* id */, nostd::string_view event_name) noexcept
+{
+  proto_record_.set_event_name(event_name.data(), event_name.size());
+}
+
 void OtlpLogRecordable::SetTraceId(const opentelemetry::trace::TraceId &trace_id) noexcept
 {
   if (trace_id.IsValid())

--- a/exporters/otlp/test/otlp_log_recordable_test.cc
+++ b/exporters/otlp/test/otlp_log_recordable_test.cc
@@ -174,6 +174,16 @@ TEST(OtlpLogRecordable, SetInstrumentationScope)
   EXPECT_EQ(&rec.GetInstrumentationScope(), inst_lib.get());
 }
 
+TEST(OtlpLogRecordable, SetEventName)
+{
+  OtlpLogRecordable rec;
+
+  nostd::string_view event_name = "Test Event";
+  rec.SetEventId(0, event_name);
+
+  EXPECT_EQ(rec.log_record().event_name(), event_name);
+}
+
 /**
  * AttributeValue can contain different int types, such as int, int64_t,
  * unsigned int, and uint64_t. To avoid writing test cases for each, we can


### PR DESCRIPTION
Fixes #3201 

## Changes

OtlpLogRecordable now supports exporting EventId::name

For significant contributions please make sure you have completed the following items:

* [ ] `CHANGELOG.md` updated for non-trivial changes
* [ ] Unit tests have been added
* [ ] Changes in public API reviewed