### PR TITLE
[ETW] Add configuration to export 64-bit integer as timestamp

### DIFF
--- a/exporters/etw/include/opentelemetry/exporters/etw/etw_config.h
+++ b/exporters/etw/include/opentelemetry/exporters/etw/etw_config.h
@@ -4,6 +4,10 @@
 #pragma once
 #include <map>
 
+#if defined(OPENTELEMETRY_ATTRIBUTE_TIMESTAMP_PREVIEW)
+#include <set>
+#endif  // defined(OPENTELEMETRY_ATTRIBUTE_TIMESTAMP_PREVIEW)
+
 #include "opentelemetry/nostd/shared_ptr.h"
 #include "opentelemetry/nostd/string_view.h"
 #include "opentelemetry/nostd/unique_ptr.h"
@@ -23,9 +27,18 @@ namespace etw
 /**
  * @brief TelemetryProvider Options passed via SDK API.
  */
+
+#if defined(OPENTELEMETRY_ATTRIBUTE_TIMESTAMP_PREVIEW)
+using TelemetryProviderOptions = std::map<
+    std::string,
+    nostd::variant<std::string, uint64_t, float, bool, std::map<std::string, std::string>, std::set<std::string>>>;
+
+#else
 using TelemetryProviderOptions = std::map<
     std::string,
     nostd::variant<std::string, uint64_t, float, bool, std::map<std::string, std::string>>>;
+
+#endif  // defined(OPENTELEMETRY_ATTRIBUTE_TIMESTAMP_PREVIEW)
 
 /**
  * @brief TelemetryProvider runtime configuration class. Internal representation
@@ -45,6 +58,13 @@ typedef struct
   bool enableTableNameMappings;  // Map instrumentation scope name to table name with
                                  // `tableNameMappings`
   std::map<std::string, std::string> tableNameMappings;
+
+#if defined(OPENTELEMETRY_ATTRIBUTE_TIMESTAMP_PREVIEW)
+
+  std::set<std::string> timestampAttributes;  // Attributes to use as timestamp
+
+#endif  // defined(OPENTELEMETRY_ATTRIBUTE_TIMESTAMP_PREVIEW)
+
 } TelemetryProviderConfiguration;
 
 /**

--- a/exporters/etw/include/opentelemetry/exporters/etw/etw_config.h
+++ b/exporters/etw/include/opentelemetry/exporters/etw/etw_config.h
@@ -5,7 +5,7 @@
 #include <map>
 
 #if defined(OPENTELEMETRY_ATTRIBUTE_TIMESTAMP_PREVIEW)
-#include <set>
+#  include <set>
 #endif  // defined(OPENTELEMETRY_ATTRIBUTE_TIMESTAMP_PREVIEW)
 
 #include "opentelemetry/nostd/shared_ptr.h"
@@ -29,9 +29,13 @@ namespace etw
  */
 
 #if defined(OPENTELEMETRY_ATTRIBUTE_TIMESTAMP_PREVIEW)
-using TelemetryProviderOptions = std::map<
-    std::string,
-    nostd::variant<std::string, uint64_t, float, bool, std::map<std::string, std::string>, std::set<std::string>>>;
+using TelemetryProviderOptions = std::map<std::string,
+                                          nostd::variant<std::string,
+                                                         uint64_t,
+                                                         float,
+                                                         bool,
+                                                         std::map<std::string, std::string>,
+                                                         std::set<std::string>>>;
 
 #else
 using TelemetryProviderOptions = std::map<

--- a/exporters/etw/include/opentelemetry/exporters/etw/etw_logger.h
+++ b/exporters/etw/include/opentelemetry/exporters/etw/etw_logger.h
@@ -338,12 +338,14 @@ public:
           continue;
         }
         int64_t filetime = value_index == exporter_etw::PropertyType::kTypeUInt64
-                        ? nostd::get<uint64_t>(it->second)
-                        : nostd::get<int64_t>(it->second);
-        constexpr int64_t FILETIME_EPOCH_DIFF = 11644473600LL; // Seconds from 1601 to 1970
+                               ? nostd::get<uint64_t>(it->second)
+                               : nostd::get<int64_t>(it->second);
+        constexpr int64_t FILETIME_EPOCH_DIFF = 11644473600LL;  // Seconds from 1601 to 1970
         constexpr int64_t HUNDRED_NANOSECONDS_PER_SECOND = 10000000LL;
-        int64_t unix_time_seconds = (filetime / HUNDRED_NANOSECONDS_PER_SECOND) - FILETIME_EPOCH_DIFF;
-        int64_t unix_time_nanos = unix_time_seconds * 1'000'000'000 + (filetime % HUNDRED_NANOSECONDS_PER_SECOND) * 100;
+        int64_t unix_time_seconds =
+            (filetime / HUNDRED_NANOSECONDS_PER_SECOND) - FILETIME_EPOCH_DIFF;
+        int64_t unix_time_nanos =
+            unix_time_seconds * 1'000'000'000 + (filetime % HUNDRED_NANOSECONDS_PER_SECOND) * 100;
         it->second = utils::formatUtcTimestampNsAsISO8601(unix_time_nanos);
       }
     }

--- a/exporters/etw/test/etw_logger_test.cc
+++ b/exporters/etw/test/etw_logger_test.cc
@@ -169,7 +169,7 @@ TEST(ETWLogger, LoggerCheckWithTableNameMappings)
  *   "Timestamp": "2021-09-30T22:04:15.066411500Z",
  *   "TraceId": "00000000000000000000000000000000",
  *   "_name": "table1",
- *   "attrib1": 1,
+ *   "tiemstamp1": "2025-02-20T19:18:11.048166700Z",
  *   "attrib2": "value2",
  *   "body": "This is a debug log body",
  *   "severityNumber": 5,
@@ -182,14 +182,14 @@ TEST(ETWLogger, LoggerCheckWithTableNameMappings)
 TEST(ETWLogger, LoggerCheckWithTimestampAttributes)
 {
   std::string providerName = kGlobalProviderName;  // supply unique instrumentation name here
-  std::set<std::string> timestampAttributes = {{"attrib1"}};
+  std::set<std::string> timestampAttributes = {{"timestamp1"}};
   exporter::etw::TelemetryProviderOptions options = {{"timestampAttributes", timestampAttributes}};
   exporter::etw::LoggerProvider lp{options};
 
   auto logger = lp.GetLogger(providerName, "name1");
 
   // Log attributes
-  Properties attribs = {{"attrib1", 133845526910481667ULL}, {"attrib2", "value2"}};
+  Properties attribs = {{"timestamp1", 133845526910481667ULL}, {"attrib2", "value2"}};
 
   EXPECT_NO_THROW(
       logger->Debug("This is a debug log body", opentelemetry::common::MakeAttributes(attribs)));

--- a/exporters/etw/test/etw_logger_test.cc
+++ b/exporters/etw/test/etw_logger_test.cc
@@ -182,7 +182,7 @@ TEST(ETWLogger, LoggerCheckWithTableNameMappings)
 TEST(ETWLogger, LoggerCheckWithTimestampAttributes)
 {
   std::string providerName = kGlobalProviderName;  // supply unique instrumentation name here
-  std::set<std::string> timestampAttributes = {{"timestamp1"}};
+  std::set<std::string> timestampAttributes       = {{"timestamp1"}};
   exporter::etw::TelemetryProviderOptions options = {{"timestampAttributes", timestampAttributes}};
   exporter::etw::LoggerProvider lp{options};
 

--- a/exporters/etw/test/etw_logger_test.cc
+++ b/exporters/etw/test/etw_logger_test.cc
@@ -5,7 +5,10 @@
 
 #  include <gtest/gtest.h>
 #  include <map>
+#  include <set>
 #  include <string>
+
+#  define OPENTELEMETRY_ATTRIBUTE_TIMESTAMP_PREVIEW
 
 #  include "opentelemetry/exporters/etw/etw_logger_exporter.h"
 #  include "opentelemetry/sdk/trace/simple_processor.h"
@@ -141,6 +144,52 @@ TEST(ETWLogger, LoggerCheckWithTableNameMappings)
 
   // Log attributes
   Properties attribs = {{"attrib1", 1}, {"attrib2", "value2"}};
+
+  EXPECT_NO_THROW(
+      logger->Debug("This is a debug log body", opentelemetry::common::MakeAttributes(attribs)));
+}
+
+/**
+ * @brief Logger Test with structured attributes
+ *
+ * Example Event for below test:
+ * {
+ *  "Timestamp": "2024-06-02T15:04:15.4227815-07:00",
+ *  "ProviderName": "OpenTelemetry-ETW-TLD",
+ *  "Id": 1,
+ *  "Message": null,
+ *  "ProcessId": 37696,
+ *  "Level": "Always",
+ *  "Keywords": "0x0000000000000000",
+ *  "EventName": "table1",
+ *  "ActivityID": null,
+ *  "RelatedActivityID": null,
+ *  "Payload": {
+ *   "SpanId": "0000000000000000",
+ *   "Timestamp": "2021-09-30T22:04:15.066411500Z",
+ *   "TraceId": "00000000000000000000000000000000",
+ *   "_name": "table1",
+ *   "attrib1": 1,
+ *   "attrib2": "value2",
+ *   "body": "This is a debug log body",
+ *   "severityNumber": 5,
+ *   "severityText": "DEBUG"
+ *  }
+ * }
+ *
+ */
+
+TEST(ETWLogger, LoggerCheckWithTimestampAttributes)
+{
+  std::string providerName = kGlobalProviderName;  // supply unique instrumentation name here
+  std::set<std::string> timestampAttributes = {{"attrib1"}};
+  exporter::etw::TelemetryProviderOptions options = {{"timestampAttributes", timestampAttributes}};
+  exporter::etw::LoggerProvider lp{options};
+
+  auto logger = lp.GetLogger(providerName, "name1");
+
+  // Log attributes
+  Properties attribs = {{"attrib1", 133845526910481667ULL}, {"attrib2", "value2"}};
 
   EXPECT_NO_THROW(
       logger->Debug("This is a debug log body", opentelemetry::common::MakeAttributes(attribs)));


### PR DESCRIPTION
## Changes

Add macro `OPENTELEMETRY_ATTRIBUTE_TIMESTAMP_PREVIEW` to ETW exporter to support exporting a given 64-bit integer as timestamp type, because timestamp is not supported in the attribute type.

For significant contributions please make sure you have completed the following items:

* [ ] `CHANGELOG.md` updated for non-trivial changes
* [ ] Unit tests have been added
* [ ] Changes in public API reviewed