### PR TITLE
3267 cmake googletest

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
 #        sudo -E ./ci/setup_gcc10.sh
 #        sudo -E ./ci/setup_cmake.sh
 #        sudo -E ./ci/setup_ci_environment.sh
-#        sudo -E ./ci/setup_googletest.sh
+#        git submodule update --init third_party/googletest
 #        sudo -E ./ci/install_abseil.sh
 #        sudo -E ./ci/install_protobuf.sh
 #    - name: run otlp exporter tests
@@ -52,8 +52,8 @@ jobs:
         CC: /usr/bin/gcc-12
         CXX: /usr/bin/g++-12
       run: |
-        sudo -E ./ci/setup_googletest.sh
         sudo -E ./ci/setup_ci_environment.sh
+        git submodule update --init third_party/googletest
     - name: run cmake tests (without otlp-exporter)
       env:
         CC: /usr/bin/gcc-12
@@ -75,8 +75,8 @@ jobs:
         PROTOBUF_VERSION: 21.12
       run: |
         sudo apt remove needrestart #refer: https://github.com/actions/runner-images/issues/9937
-        sudo -E ./ci/setup_googletest.sh
         sudo -E ./ci/setup_ci_environment.sh
+        git submodule update --init third_party/googletest
         sudo -E ./ci/install_protobuf.sh
     - name: setup grpc
       run: |
@@ -111,8 +111,8 @@ jobs:
         PROTOBUF_VERSION: 21.12
       run: |
         sudo apt remove needrestart #refer: https://github.com/actions/runner-images/issues/9937
-        sudo -E ./ci/setup_googletest.sh
         sudo -E ./ci/setup_ci_environment.sh
+        git submodule update --init third_party/googletest
         sudo -E ./ci/install_protobuf.sh
     - name: setup grpc
       run: |
@@ -147,8 +147,8 @@ jobs:
         PROTOBUF_VERSION: 21.12
       run: |
         sudo apt remove needrestart #refer: https://github.com/actions/runner-images/issues/9937
-        sudo -E ./ci/setup_googletest.sh
         sudo -E ./ci/setup_ci_environment.sh
+        git submodule update --init third_party/googletest
         sudo -E ./ci/install_protobuf.sh
     - name: setup grpc
       run: |
@@ -183,8 +183,8 @@ jobs:
         PROTOBUF_VERSION: 21.12
       run: |
         sudo apt remove needrestart #refer: https://github.com/actions/runner-images/issues/9937
-        sudo -E ./ci/setup_googletest.sh
         sudo -E ./ci/setup_ci_environment.sh
+        git submodule update --init third_party/googletest
         sudo -E ./ci/install_protobuf.sh
     - name: setup grpc
       run: |
@@ -219,8 +219,8 @@ jobs:
         PROTOBUF_VERSION: 21.12
       run: |
         sudo apt remove needrestart #refer: https://github.com/actions/runner-images/issues/9937
-        sudo -E ./ci/setup_googletest.sh
         sudo -E ./ci/setup_ci_environment.sh
+        git submodule update --init third_party/googletest
         sudo -E ./ci/install_protobuf.sh
     - name: setup grpc
       run: |
@@ -296,8 +296,8 @@ jobs:
         CC: /usr/bin/gcc-12
         CXX: /usr/bin/g++-12
       run: |
-        sudo -E ./ci/setup_googletest.sh
         sudo -E ./ci/setup_ci_environment.sh
+        git submodule update --init third_party/googletest
     - name: run cmake tests (without otlp-exporter)
       env:
         CC: /usr/bin/gcc-12
@@ -314,8 +314,8 @@ jobs:
         submodules: 'recursive'
     - name: setup
       run: |
-        sudo -E ./ci/setup_googletest.sh
         sudo -E ./ci/setup_ci_environment.sh
+        git submodule update --init third_party/googletest
     - name: run cmake tests (enable abseil-cpp)
       run: |
         sudo ./ci/install_abseil.sh
@@ -330,8 +330,8 @@ jobs:
         submodules: 'recursive'
     - name: setup
       run: |
-        sudo -E ./ci/setup_googletest.sh
         sudo -E ./ci/setup_ci_environment.sh
+        git submodule update --init third_party/googletest
     - name: run cmake tests (enable opentracing-shim)
       run: ./ci/do_ci.sh cmake.opentracing_shim.test
 
@@ -345,7 +345,7 @@ jobs:
     - name: setup
       run: |
         sudo -E ./ci/setup_ci_environment.sh
-        sudo -E ./ci/setup_googletest.sh
+        git submodule update --init third_party/googletest
     - name: run tests (enable stl)
       env:
         CXX_STANDARD: '14'
@@ -361,7 +361,7 @@ jobs:
     - name: setup
       run: |
         sudo -E ./ci/setup_ci_environment.sh
-        sudo -E ./ci/setup_googletest.sh
+        git submodule update --init third_party/googletest
     - name: run tests (enable stl)
       env:
         CXX_STANDARD: '17'
@@ -377,7 +377,7 @@ jobs:
     - name: setup
       run: |
         sudo -E ./ci/setup_ci_environment.sh
-        sudo -E ./ci/setup_googletest.sh
+        git submodule update --init third_party/googletest
     - name: run tests
       env:
         CXX_STANDARD: '20'
@@ -401,7 +401,7 @@ jobs:
         CXXFLAGS: "-stdlib=libc++"
       run: |
         sudo -E ./ci/setup_ci_environment.sh
-        sudo -E ./ci/setup_googletest.sh
+        git submodule update --init third_party/googletest
     - name: run tests
       env:
         CC: /usr/bin/clang
@@ -427,7 +427,7 @@ jobs:
     - name: setup
       run: |
         sudo -E ./ci/setup_ci_environment.sh
-        sudo -E ./ci/setup_googletest.sh
+        git submodule update --init third_party/googletest
     - name: run tests
       env:
         CXX_STANDARD: '23'
@@ -451,7 +451,7 @@ jobs:
         CXXFLAGS: "-stdlib=libc++"
       run: |
         sudo -E ./ci/setup_ci_environment.sh
-        sudo -E ./ci/setup_googletest.sh
+        git submodule update --init third_party/googletest
     - name: run tests
       env:
         CC: /usr/bin/clang
@@ -476,8 +476,8 @@ jobs:
         submodules: 'recursive'
     - name: setup
       run: |
-        sudo -E ./ci/setup_googletest.sh
         sudo -E ./ci/setup_ci_environment.sh
+        git submodule update --init third_party/googletest
     - name: run otlp exporter tests
       run: |
         sudo ./ci/setup_grpc.sh
@@ -505,8 +505,8 @@ jobs:
         ABSEIL_CPP_VERSION: '20230125.3'
         CXX_STANDARD: '14'
       run: |
-        sudo ./ci/setup_googletest.sh
         sudo ./ci/setup_ci_environment.sh
+        git submodule update --init third_party/googletest
         sudo -E ./ci/install_abseil.sh
         sudo -E ./ci/install_protobuf.sh
     - name: run otlp exporter tests
@@ -526,8 +526,8 @@ jobs:
         submodules: 'recursive'
     - name: setup
       run: |
-        sudo -E ./ci/setup_googletest.sh
         sudo -E ./ci/setup_ci_environment.sh
+        git submodule update --init third_party/googletest
     - name: run otlp exporter tests
       run: |
         sudo ./ci/setup_grpc.sh
@@ -542,8 +542,8 @@ jobs:
         submodules: 'recursive'
     - name: setup
       run: |
-        sudo -E ./ci/setup_googletest.sh
         sudo -E ./ci/setup_ci_environment.sh
+        git submodule update --init third_party/googletest
     - name: run otlp exporter tests
       run: |
         sudo ./ci/setup_grpc.sh -T
@@ -558,8 +558,8 @@ jobs:
         submodules: 'recursive'
     - name: setup
       run: |
-        sudo -E ./ci/setup_googletest.sh
         sudo -E ./ci/setup_ci_environment.sh
+        git submodule update --init third_party/googletest
     - name: run cmake install (with abseil)
       run: |
         sudo ./ci/install_abseil.sh
@@ -580,8 +580,8 @@ jobs:
         CC: /usr/bin/gcc-12
         CXX: /usr/bin/g++-12
       run: |
-        sudo -E ./ci/setup_googletest.sh
         sudo -E ./ci/setup_ci_environment.sh
+        git submodule update --init third_party/googletest
     - name: run tests
       env:
         CC: /usr/bin/gcc-12
@@ -907,8 +907,8 @@ jobs:
         CC: /usr/bin/gcc-10
         CXX: /usr/bin/g++-10
       run: |
-        sudo -E ./ci/setup_googletest.sh
         sudo -E ./ci/setup_ci_environment.sh
+        git submodule update --init third_party/googletest
     - name: run tests and generate report
       env:
         CC: /usr/bin/gcc-10
@@ -978,8 +978,8 @@ jobs:
           CC: /usr/bin/gcc-12
           CXX: /usr/bin/g++-12
         run: |
-          sudo -E ./ci/setup_googletest.sh
           sudo -E ./ci/setup_ci_environment.sh
+          git submodule update --init third_party/googletest
       - name: run w3c trace-context test server (background)
         env:
           CXX_STANDARD: '14'

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -620,19 +620,8 @@ list(APPEND CMAKE_PREFIX_PATH "${CMAKE_BINARY_DIR}")
 
 include(CTest)
 if(BUILD_TESTING)
-  if(EXISTS ${CMAKE_BINARY_DIR}/lib/libgtest.a)
-    # Prefer GTest from build tree. GTest is not always working with
-    # CMAKE_PREFIX_PATH
-    set(GTEST_INCLUDE_DIRS
-        ${CMAKE_CURRENT_SOURCE_DIR}/third_party/googletest/googletest/include
-        ${CMAKE_CURRENT_SOURCE_DIR}/third_party/googletest/googlemock/include)
-    if(TARGET gtest)
-      set(GTEST_BOTH_LIBRARIES gtest gtest_main)
-    else()
-      set(GTEST_BOTH_LIBRARIES ${CMAKE_BINARY_DIR}/lib/libgtest.a
-                               ${CMAKE_BINARY_DIR}/lib/libgtest_main.a)
-    endif()
-  elseif(WIN32)
+
+  if(WIN32)
     # Make sure we are always bootsrapped with vcpkg on Windows
     find_package(GTest)
     if(NOT (GTEST_FOUND OR GTest_FOUND))
@@ -648,9 +637,81 @@ if(BUILD_TESTING)
       endif()
     endif()
   else()
-    # Prefer GTest installed by OS distro, brew or vcpkg package manager
-    find_package(GTest REQUIRED)
+    # Build googletest from sources. This is the preferred way.
+    set(GTEST_SRC_DIR_DEFAULT ${CMAKE_SOURCE_DIR}/third_party/googletest)
+    set(GTEST_SRC_DIR ${GTEST_SRC_DIR_DEFAULT} CACHE STRING "Location of gtest sources")
+    if(EXISTS ${GTEST_SRC_DIR}/googletest/src/gtest-all.cc)
+
+      include(ExternalProject)
+
+      # Build googletest/googletest from sources available as third party
+      ExternalProject_Add(
+        googletest
+        DOWNLOAD_COMMAND ""
+        SOURCE_DIR ${GTEST_SRC_DIR}/googletest
+        INSTALL_COMMAND ""
+        LOG_CONFIGURE ON
+        LOG_BUILD ON
+        CMAKE_ARGS  -DBUILD_SHARED_LIBS=ON
+                    -DCMAKE_POSITION_INDEPENDENT_CODE=ON
+                    #BUILD_BYPRODUCTS
+                    #${CMAKE_BINARY_DIR}/googletest-prefix/src/googletest-build/lib/libgtest.so
+                    #${CMAKE_BINARY_DIR}/googletest-prefix/src/googletest-build/lib/libgtest_main.so
+      )
+      message(STATUS "Building googletest from sources in ${GTEST_SRC_DIR}")
+
+      set(GTEST_LIBRARY_PATH ${CMAKE_BINARY_DIR}/googletest-prefix/src/googletest-build/lib/libgtest.so)
+      add_library(GTest::gtest SHARED IMPORTED)
+      set_target_properties(GTest::gtest PROPERTIES IMPORTED_LOCATION
+        ${GTEST_LIBRARY_PATH})
+      add_dependencies(GTest::gtest googletest)
+
+      set(GTEST_MAIN_LIBRARY_PATH  ${CMAKE_BINARY_DIR}/googletest-prefix/src/googletest-build/lib/libgtest_main.so)
+      add_library(GTest::gtest_main SHARED IMPORTED)
+      set_target_properties(GTest::gtest_main PROPERTIES IMPORTED_LOCATION
+        ${GTEST_MAIN_LIBRARY_PATH})
+      add_dependencies(GTest::gtest_main googletest)
+
+      ExternalProject_Get_Property(googletest source_dir)
+      set(GTEST_INCLUDE_DIR ${source_dir}/include)
+
+      # Build googletest/googlemock from sources available as third party
+      ExternalProject_Add(
+          googlemock
+          DOWNLOAD_COMMAND ""
+          SOURCE_DIR ${GTEST_SRC_DIR}/googlemock
+          INSTALL_COMMAND ""
+          LOG_CONFIGURE ON
+          LOG_BUILD ON
+          CMAKE_ARGS -DBUILD_SHARED_LIBS=ON
+                     -DCMAKE_POSITION_INDEPENDENT_CODE=ON
+      )
+      message(STATUS "Building googlemock from sources in ${GTEST_SRC_DIR}")
+
+      set(GMOCK_LIBRARY_PATH ${CMAKE_BINARY_DIR}/googlemock-prefix/src/googlemock-build/lib/libgmock.so)
+      add_library(GTest::gmock SHARED IMPORTED)
+      set_target_properties(GTest::gmock PROPERTIES IMPORTED_LOCATION
+        ${GMOCK_LIBRARY_PATH})
+      add_dependencies(GTest::gmock googlemock)
+
+      set(GMOCK_MAIN_LIBRARY_PATH  ${CMAKE_BINARY_DIR}/googlemock-prefix/src/googlemock-build/lib/libgmock_main.so)
+      add_library(GTest::gmock_main SHARED IMPORTED)
+      set_target_properties(GTest::gmock_main PROPERTIES IMPORTED_LOCATION
+        ${GMOCK_MAIN_LIBRARY_PATH})
+      add_dependencies(GTest::gtest_main googlemock)
+
+      set(GTEST_INCLUDE_DIRS
+          ${CMAKE_CURRENT_SOURCE_DIR}/third_party/googletest/googletest/include
+          ${CMAKE_CURRENT_SOURCE_DIR}/third_party/googletest/googlemock/include)
+
+      set(GTEST_BOTH_LIBRARIES GTest::gtest_main GTest::gtest)
+      set(GMOCK_LIB GTest::gmock)
+
+    else()
+      message(FATAL_ERROR "UNIT_TEST is set but unable to find gtest library source code")
+    endif()
   endif()
+
   if(NOT GTEST_BOTH_LIBRARIES)
     # New GTest package names
     if(TARGET GTest::gtest)
@@ -664,6 +725,11 @@ if(BUILD_TESTING)
   endif()
   message(STATUS "GTEST_INCLUDE_DIRS   = ${GTEST_INCLUDE_DIRS}")
   message(STATUS "GTEST_BOTH_LIBRARIES = ${GTEST_BOTH_LIBRARIES}")
+  message(STATUS "gtest library path ${GTEST_LIBRARY_PATH}")
+  message(STATUS "gtest main library path ${GTEST_MAIN_LIBRARY_PATH}")
+  message(STATUS "GMOCK_LIB = ${GMOCK_LIB}")
+  message(STATUS "gmock library path ${GMOCK_LIBRARY_PATH}")
+  message(STATUS "gmock main library path ${GMOCK_MAIN_LIBRARY_PATH}")
 
   # Try to find gmock
   if(NOT GMOCK_LIB AND TARGET GTest::gmock)

--- a/ci/setup_ci_environment.sh
+++ b/ci/setup_ci_environment.sh
@@ -13,4 +13,8 @@ apt-get install --no-install-recommends --no-install-suggests -y \
                 valgrind \
                 lcov \
                 iwyu \
-                pkg-config
+                pkg-config \
+                libbenchmark-dev \
+                zlib1g-dev \
+                libcurl4-openssl-dev \
+                nlohmann-json3-dev


### PR DESCRIPTION
Fixes # (3267)

## Changes

Build googletest from the source code along with opentelemetry-cpp, as it is recommended by googletest. Relying on precompiled shared libraries yields to some errors during testing. Using ExternalProject_add() (in favor of alternatives as FetchContent) since googletest is found as a third-party submodule, and it is easier to "integrate" in distros like debian, that ship googletest source code as a package.

I am not able to test how this builds on windows.

For significant contributions please make sure you have completed the following items:

* [ ] `CHANGELOG.md` updated for non-trivial changes -> I think these are trivial changes, but I can describe them in CHANGELOG.md, if you think that helps.
* [ ] Unit tests have been added -> N/A
* [ ] Changes in public API reviewed -> None