### PR TITLE
[API] Change the param-pack unpacking order to start from left to right

### DIFF
--- a/api/include/opentelemetry/logs/logger.h
+++ b/api/include/opentelemetry/logs/logger.h
@@ -78,10 +78,17 @@ public:
     // attributes. The left to right unpack order could pass the more important
     // data to processors to avoid caching and memory allocating.
     //
-    IgnoreTraitResult(
-      (detail::LogRecordSetterTrait<typename std::decay<ArgumentType>::type>::Set(
-        log_record.get(),
-        std::forward<ArgumentType>(args)),...));
+#if __cplusplus <= 201402L
+    // C++14 does not support fold expressions for parameter pack expansion.
+    int dummy[] = {(detail::LogRecordSetterTrait<typename std::decay<ArgumentType>::type>::Set(
+                        log_record.get(), std::forward<ArgumentType>(args)),
+                    0)...};
+    IgnoreTraitResult(dummy);
+#else
+    IgnoreTraitResult((detail::LogRecordSetterTrait<typename std::decay<ArgumentType>::type>::Set(
+                           log_record.get(), std::forward<ArgumentType>(args)),
+                       ...));
+#endif
 
     EmitLogRecord(std::move(log_record));
   }

--- a/api/include/opentelemetry/logs/logger.h
+++ b/api/include/opentelemetry/logs/logger.h
@@ -72,8 +72,16 @@ public:
       return;
     }
 
-    IgnoreTraitResult(detail::LogRecordSetterTrait<typename std::decay<ArgumentType>::type>::Set(
-        log_record.get(), std::forward<ArgumentType>(args))...);
+    //
+    // Keep the parameter pack unpacking order from left to right because left
+    // ones are usually more important like severity and event_id than the
+    // attributes. The left to right unpack order could pass the more important
+    // data to processors to avoid caching and memory allocating.
+    //
+    IgnoreTraitResult(
+      (detail::LogRecordSetterTrait<typename std::decay<ArgumentType>::type>::Set(
+        log_record.get(),
+        std::forward<ArgumentType>(args)),...));
 
     EmitLogRecord(std::move(log_record));
   }


### PR DESCRIPTION
## Changes

The parameter pack sent to `EmitLogRecord` is unpacked from right to left, which are caused by passing them as function parameters to template function `IgnoreTraitResult`. This will send the rightmost `attributes` parameter to the processor and then pass it to the `Recordable`. It makes it a little hard to do serialization in the `Recordable` interface, because the serialization usually needs to encode the data like event name or severity before encoding the attributes.

This PR changes the unpack order to help do serialization in the `Recordable` interface in a straightforward way, without caching any attributes.

For significant contributions please make sure you have completed the following items:

* [ ] `CHANGELOG.md` updated for non-trivial changes
* [ ] Unit tests have been added
* [X] Changes in public API reviewed