### PR TITLE
fix: buffer overrun in the gRPC sample project

### DIFF
--- a/examples/grpc/tracer_common.h
+++ b/examples/grpc/tracer_common.h
@@ -59,7 +59,7 @@ public:
     auto it = context_->client_metadata().find({key.data(), key.size()});
     if (it != context_->client_metadata().end())
     {
-      return it->second.data();
+      return opentelemetry::nostd::string_view(it->second.data(), it->second.size());
     }
     return "";
   }


### PR DESCRIPTION
Building the sample on Windows, the gRPC sample server/client app fails to function correctly. The propagated trace context is corrupted, containing garbage characters after the trace parent string.

The string buffer from gRPC cannot be safely treated as a null-terminated C-string. To ensure safe copying, we must use its length property instead.
