### PR TITLE
[BUILD] fix build of otlp_grpc_exporter_test with modern grpc

### DIFF
--- a/exporters/otlp/CMakeLists.txt
+++ b/exporters/otlp/CMakeLists.txt
@@ -321,7 +321,7 @@ if(BUILD_TESTING)
     add_executable(otlp_grpc_exporter_test test/otlp_grpc_exporter_test.cc)
     target_link_libraries(
       otlp_grpc_exporter_test ${GTEST_BOTH_LIBRARIES} ${CMAKE_THREAD_LIBS_INIT}
-      ${GMOCK_LIB} opentelemetry_exporter_otlp_grpc gRPC::grpc++)
+      ${GMOCK_LIB} opentelemetry_exporter_otlp_grpc)
     gtest_add_tests(
       TARGET otlp_grpc_exporter_test
       TEST_PREFIX exporter.otlp.

--- a/exporters/otlp/CMakeLists.txt
+++ b/exporters/otlp/CMakeLists.txt
@@ -38,18 +38,11 @@ if(WITH_OTLP_GRPC)
   # targets that depend on opentelemetry_proto_grpc.
   target_link_libraries(
     opentelemetry_exporter_otlp_grpc_client
-    PUBLIC opentelemetry_sdk opentelemetry_common opentelemetry_ext
+    PUBLIC opentelemetry_sdk opentelemetry_common
            # gRPC::grpc++ must be linked before opentelemetry_proto_grpc.
-           opentelemetry_proto_grpc
-    PRIVATE gRPC::grpc++)
+           opentelemetry_proto_grpc gRPC::grpc++
+    PRIVATE opentelemetry_ext)
 
-  get_target_property(GRPC_INCLUDE_DIRECTORY gRPC::grpc++
-                      INTERFACE_INCLUDE_DIRECTORIES)
-  if(GRPC_INCLUDE_DIRECTORY)
-    target_include_directories(
-      opentelemetry_exporter_otlp_grpc_client BEFORE
-      PUBLIC "$<BUILD_INTERFACE:${GRPC_INCLUDE_DIRECTORY}>")
-  endif()
   target_include_directories(
     opentelemetry_exporter_otlp_grpc_client
     PUBLIC "$<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}/include>"
@@ -290,9 +283,8 @@ endif()
 
 if(BUILD_TESTING)
   add_executable(otlp_recordable_test test/otlp_recordable_test.cc)
-  target_link_libraries(
-    otlp_recordable_test ${GTEST_BOTH_LIBRARIES} ${CMAKE_THREAD_LIBS_INIT}
-    opentelemetry_otlp_recordable protobuf::libprotobuf)
+  target_link_libraries(otlp_recordable_test ${GTEST_BOTH_LIBRARIES}
+                        ${CMAKE_THREAD_LIBS_INIT} opentelemetry_otlp_recordable)
   gtest_add_tests(
     TARGET otlp_recordable_test
     TEST_PREFIX exporter.otlp.
@@ -308,10 +300,8 @@ if(BUILD_TESTING)
 
   add_executable(otlp_metrics_serialization_test
                  test/otlp_metrics_serialization_test.cc)
-  target_link_libraries(
-    otlp_metrics_serialization_test ${GTEST_BOTH_LIBRARIES}
-    ${CMAKE_THREAD_LIBS_INIT} opentelemetry_otlp_recordable
-    protobuf::libprotobuf)
+  target_link_libraries(otlp_metrics_serialization_test ${GTEST_BOTH_LIBRARIES}
+                        ${CMAKE_THREAD_LIBS_INIT} opentelemetry_otlp_recordable)
   gtest_add_tests(
     TARGET otlp_metrics_serialization_test
     TEST_PREFIX exporter.otlp.
@@ -396,8 +386,7 @@ if(BUILD_TESTING)
       ${GMOCK_LIB}
       opentelemetry_exporter_otlp_http
       opentelemetry_http_client_nosend
-      nlohmann_json::nlohmann_json
-      protobuf::libprotobuf)
+      nlohmann_json::nlohmann_json)
     gtest_add_tests(
       TARGET otlp_http_exporter_test
       TEST_PREFIX exporter.otlp.
@@ -450,8 +439,7 @@ if(BUILD_TESTING)
       opentelemetry_exporter_otlp_http_metric
       opentelemetry_metrics
       opentelemetry_http_client_nosend
-      nlohmann_json::nlohmann_json
-      protobuf::libprotobuf)
+      nlohmann_json::nlohmann_json)
     gtest_add_tests(
       TARGET otlp_http_metric_exporter_test
       TEST_PREFIX exporter.otlp.
@@ -486,13 +474,9 @@ if(BUILD_TESTING)
 
     add_executable(otlp_file_exporter_test test/otlp_file_exporter_test.cc)
     target_link_libraries(
-      otlp_file_exporter_test
-      ${GTEST_BOTH_LIBRARIES}
-      ${CMAKE_THREAD_LIBS_INIT}
-      ${GMOCK_LIB}
-      opentelemetry_exporter_otlp_file
-      nlohmann_json::nlohmann_json
-      protobuf::libprotobuf)
+      otlp_file_exporter_test ${GTEST_BOTH_LIBRARIES} ${CMAKE_THREAD_LIBS_INIT}
+      ${GMOCK_LIB} opentelemetry_exporter_otlp_file
+      nlohmann_json::nlohmann_json)
     gtest_add_tests(
       TARGET otlp_file_exporter_test
       TEST_PREFIX exporter.otlp.
@@ -543,8 +527,7 @@ if(BUILD_TESTING)
       ${GMOCK_LIB}
       opentelemetry_exporter_otlp_file_metric
       opentelemetry_metrics
-      nlohmann_json::nlohmann_json
-      protobuf::libprotobuf)
+      nlohmann_json::nlohmann_json)
     gtest_add_tests(
       TARGET otlp_file_metric_exporter_test
       TEST_PREFIX exporter.otlp.

--- a/exporters/zipkin/CMakeLists.txt
+++ b/exporters/zipkin/CMakeLists.txt
@@ -52,8 +52,13 @@ if(BUILD_TESTING)
   add_executable(zipkin_exporter_test test/zipkin_exporter_test.cc)
 
   target_link_libraries(
-    zipkin_exporter_test ${GTEST_BOTH_LIBRARIES} ${CMAKE_THREAD_LIBS_INIT}
-    ${GMOCK_LIB} opentelemetry_exporter_zipkin_trace opentelemetry_resources)
+    zipkin_exporter_test
+    ${GTEST_BOTH_LIBRARIES}
+    ${CMAKE_THREAD_LIBS_INIT}
+    ${GMOCK_LIB}
+    opentelemetry_exporter_zipkin_trace
+    opentelemetry_resources
+    ${CURL_LIBRARIES})
 
   gtest_add_tests(
     TARGET zipkin_exporter_test


### PR DESCRIPTION
Fixes #3306

## Changes
- makes grpc link publicly to the grpc client 
- remove otlp_grpc_exporter_test's link to gRPC::grpc++
- removes extra protobuf links to tests 
- adds curl link to the zipkin test

For significant contributions please make sure you have completed the following items:

* [ ] `CHANGELOG.md` updated for non-trivial changes
* [ ] Unit tests have been added
* [ ] Changes in public API reviewed