### PR TITLE
[TEST] fix test failure with elasticsearch exporter on cxx20

### DIFF
--- a/exporters/elasticsearch/src/es_log_recordable.cc
+++ b/exporters/elasticsearch/src/es_log_recordable.cc
@@ -88,12 +88,6 @@ void ElasticSearchRecordable::SetTimestamp(
 {
   const std::chrono::system_clock::time_point timePoint{timestamp};
 
-  // If built with with at least cpp 20 then use std::format
-  // Otherwise use the old style to format the timestamp in UTC
-  // @see https://en.cppreference.com/w/cpp/feature_test#cpp_lib_format
-#if defined(__cpp_lib_format) && __cpp_lib_format >= 201907
-  const std::string dateStr = std::format("{:%FT%T%Ez}", timePoint);
-#else
   std::time_t time = std::chrono::system_clock::to_time_t(timePoint);
   std::tm tm       = *std::gmtime(&time);
   auto microseconds =
@@ -108,7 +102,6 @@ void ElasticSearchRecordable::SetTimestamp(
                 static_cast<long>(microseconds.count()));
 
   const std::string dateStr(bufferDate);
-#endif
 
   json_["@timestamp"] = dateStr;
 }


### PR DESCRIPTION
Fixes #3278

## Changes

Removes the conditional that switches to std::format on cxx20 in es_log_recordable.cc. 

For significant contributions please make sure you have completed the following items:

* [ ] `CHANGELOG.md` updated for non-trivial changes
* [ ] Unit tests have been added
* [ ] Changes in public API reviewed