### PR TITLE
[TEST] otlp grpc exporter retry test fix

### DIFF
--- a/exporters/otlp/test/otlp_grpc_exporter_test.cc
+++ b/exporters/otlp/test/otlp_grpc_exporter_test.cc
@@ -37,6 +37,7 @@
 
 #  include <grpcpp/grpcpp.h>
 #  include <gtest/gtest.h>
+#  include <future>
 
 #  if defined(_MSC_VER)
 #    include "opentelemetry/sdk/common/env_variables.h"
@@ -510,14 +511,20 @@ TEST_P(OtlpGrpcExporterRetryIntegrationTests, StatusCodes)
   TestTraceService service(status_codes);
   std::unique_ptr<grpc::Server> server;
 
-  std::thread server_thread([&server, &service]() {
+  std::promise<void> server_ready;
+  auto server_ready_future = server_ready.get_future();
+
+  std::thread server_thread([&server, &service, &server_ready]() {
     std::string address("localhost:4317");
     grpc::ServerBuilder builder;
     builder.RegisterService(&service);
     builder.AddListeningPort(address, grpc::InsecureServerCredentials());
     server = builder.BuildAndStart();
+    server_ready.set_value();
     server->Wait();
   });
+
+  server_ready_future.wait();
 
   otlp::OtlpGrpcExporterOptions opts{};
 


### PR DESCRIPTION
Fixes #3310 

## Changes

The main thread of the grpc retry test now waits on a future until the grpc server is ready. 

For significant contributions please make sure you have completed the following items:

* [ ] `CHANGELOG.md` updated for non-trivial changes
* [ ] Unit tests have been added
* [ ] Changes in public API reviewed