### PR TITLE
[BUILD] Fix elasticsearch exporter json compatibility

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,23 +41,19 @@ jobs:
 #        ./ci/do_ci.sh cmake.exporter.otprotocol.test
 
   cmake_test:
-    name: CMake test (without otlp-exporter)
-    runs-on: ubuntu-latest
+    name: CMake test (prometheus, elasticsearch, zipkin)
+    runs-on: ubuntu-22.04
+    env:
+      CXX_STANDARD: '17'
     steps:
     - uses: actions/checkout@v4
       with:
         submodules: 'recursive'
     - name: setup
-      env:
-        CC: /usr/bin/gcc-12
-        CXX: /usr/bin/g++-12
       run: |
         sudo -E ./ci/setup_googletest.sh
         sudo -E ./ci/setup_ci_environment.sh
-    - name: run cmake tests (without otlp-exporter)
-      env:
-        CC: /usr/bin/gcc-12
-        CXX: /usr/bin/g++-12
+    - name: run cmake tests
       run: |
         ./ci/do_ci.sh cmake.test
 

--- a/exporters/elasticsearch/src/es_log_recordable.cc
+++ b/exporters/elasticsearch/src/es_log_recordable.cc
@@ -23,19 +23,19 @@
 
 namespace nlohmann
 {
-template <typename T>
+template <class T>
 struct json_assign_visitor
 {
   T *j_;
   json_assign_visitor(T &j) : j_(&j) {}
 
-  template <typename U>
+  template <class U>
   void operator()(const U &u)
   {
     *j_ = u;
   }
 
-  template <typename U>
+  template <class U>
   void operator()(const opentelemetry::nostd::span<U> &span)
   {
     *j_ = nlohmann::json::array();

--- a/exporters/elasticsearch/src/es_log_recordable.cc
+++ b/exporters/elasticsearch/src/es_log_recordable.cc
@@ -23,16 +23,26 @@
 
 namespace nlohmann
 {
-template <class T>
+template <typename T>
 struct json_assign_visitor
 {
   T *j_;
   json_assign_visitor(T &j) : j_(&j) {}
 
-  template <class U>
+  template <typename U>
   void operator()(const U &u)
   {
     *j_ = u;
+  }
+
+  template <typename U>
+  void operator()(const opentelemetry::nostd::span<U> &span)
+  {
+    *j_ = nlohmann::json::array();
+    for (const auto &elem : span)
+    {
+      j_->push_back(elem);
+    }
   }
 };
 


### PR DESCRIPTION
Fixes #3312

The system package of nlohmann_json is version 3.10.5 on Ubuntu 22.04. 

## Changes
- Add a template specialization of the `json_assign_visitor` to handle `nostd::span` attribute values. 
- Switch one runner that builds the elastic search exporter (runs ./ci/do_ci.sh cmake.test) to Ubuntu 22.04 and CXX_STANDARD=17

For significant contributions please make sure you have completed the following items:

* [ ] `CHANGELOG.md` updated for non-trivial changes
* [ ] Unit tests have been added
* [ ] Changes in public API reviewed