### PR TITLE
[BUILD] Fix misssing exported definition for OTLP file exporter and forceflush

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,9 @@ Increment the:
 
 ## [Unreleased]
 
+* [BUILD] Fix misssing exported definition for OTLP file exporter and forceflush
+  [#3319](https://github.com/open-telemetry/opentelemetry-cpp/pull/3319)
+
 * [SDK] Add tracer scope configurator
   [#3137](https://github.com/open-telemetry/opentelemetry-cpp/pull/3137)
 

--- a/ext/src/dll/input.src
+++ b/ext/src/dll/input.src
@@ -10,7 +10,9 @@ Create@BatchLogRecordProcessorFactory@logs@sdk@v1@opentelemetry
 Create@SimpleLogRecordProcessorFactory@logs@sdk@v1@opentelemetry
 Create@MultiLogRecordProcessorFactory@logs@sdk@v1@opentelemetry
 TracerProvider@trace@sdk@v1@opentelemetry
+ForceFlush@TracerProvider@trace@sdk@v1@opentelemetry
 LoggerProvider@logs@sdk@v1@opentelemetry
+ForceFlush@LoggerProvider@logs@sdk@v1@opentelemetry
 OStreamLogRecordExporter@logs@exporter@v1@opentelemetry
 Create@OStreamMetricExporterFactory@metrics@exporter@v1@opentelemetry
 Create@PeriodicExportingMetricReaderFactory@metrics@sdk@v1@opentelemetry
@@ -68,4 +70,14 @@ GetOtlpDefaultHttpTracesEndpoint@otlp@exporter@v1@opentelemetry
 GetOtlpDefaultHttpMetricsEndpoint@otlp@exporter@v1@opentelemetry
 GetOtlpDefaultHttpLogsEndpoint@otlp@exporter@v1@opentelemetry
 #endif  // defined(WITH_OTLP_HTTP)
+
+#if defined(WITH_OTLP_FILE)
+Create@OtlpFileExporterFactory@otlp@exporter@v1@opentelemetry
+Create@OtlpFileLogRecordExporterFactory@otlp@exporter@v1@opentelemetry
+Create@OtlpFileMetricExporterFactory@otlp@exporter@v1@opentelemetry
+OtlpFileExporterOptions@otlp@exporter@v1@opentelemetry
+OtlpFileLogRecordExporterOptions@otlp@exporter@v1@opentelemetry
+OtlpFileMetricExporterOptions@otlp@exporter@v1@opentelemetry
+#endif  // defined(WITH_OTLP_FILE)
+
 // clang-format on


### PR DESCRIPTION
## Changes

Add the missing exported definition for DLL build.

For significant contributions please make sure you have completed the following items:

* [ ] `CHANGELOG.md` updated for non-trivial changes
* [ ] Unit tests have been added
* [ ] Changes in public API reviewed