### PR TITLE
[BUILD] Remove gRPC header including in `OtlpGrpcClientFactory`.

### DIFF
--- a/exporters/otlp/include/opentelemetry/exporters/otlp/otlp_grpc_client_factory.h
+++ b/exporters/otlp/include/opentelemetry/exporters/otlp/otlp_grpc_client_factory.h
@@ -5,6 +5,7 @@
 
 #include <memory>
 
+// IWYU pragma: no_include "opentelemetry/exporters/otlp/otlp_grpc_client.h"
 #include "opentelemetry/exporters/otlp/otlp_grpc_client_options.h"
 #include "opentelemetry/version.h"
 
@@ -14,8 +15,8 @@ namespace exporter
 namespace otlp
 {
 
-class OtlpGrpcClient;
-class OtlpGrpcClientReferenceGuard;
+class OtlpGrpcClient;                // IWYU pragma: keep
+class OtlpGrpcClientReferenceGuard;  // IWYU pragma: keep
 
 /**
  * Factory class for OtlpGrpcClient.

--- a/exporters/otlp/include/opentelemetry/exporters/otlp/otlp_grpc_client_factory.h
+++ b/exporters/otlp/include/opentelemetry/exporters/otlp/otlp_grpc_client_factory.h
@@ -5,7 +5,6 @@
 
 #include <memory>
 
-#include "opentelemetry/exporters/otlp/otlp_grpc_client.h"
 #include "opentelemetry/exporters/otlp/otlp_grpc_client_options.h"
 #include "opentelemetry/version.h"
 
@@ -14,6 +13,9 @@ namespace exporter
 {
 namespace otlp
 {
+
+class OtlpGrpcClient;
+class OtlpGrpcClientReferenceGuard;
 
 /**
  * Factory class for OtlpGrpcClient.

--- a/exporters/otlp/test/otlp_grpc_exporter_factory_test.cc
+++ b/exporters/otlp/test/otlp_grpc_exporter_factory_test.cc
@@ -18,6 +18,15 @@
   Implementation, this requires protobuf.
 */
 #include "opentelemetry/exporters/otlp/otlp_grpc_client_factory.h"
+
+/*
+  Make sure OtlpGrpcClientFactory does not require,
+  even indirectly, gRPC headers.
+*/
+#if defined(GRPC_CPP_VERSION_MAJOR) || defined(GRPC_CPP_VERSION_STRING)
+#  error "gRPC should not be included"
+#endif
+
 #include "opentelemetry/exporters/otlp/otlp_grpc_exporter.h"
 
 OPENTELEMETRY_BEGIN_NAMESPACE

--- a/exporters/otlp/test/otlp_grpc_log_record_exporter_factory_test.cc
+++ b/exporters/otlp/test/otlp_grpc_log_record_exporter_factory_test.cc
@@ -18,6 +18,15 @@
   Implementation, this requires protobuf.
 */
 #include "opentelemetry/exporters/otlp/otlp_grpc_client_factory.h"
+
+/*
+  Make sure OtlpGrpcClientFactory does not require,
+  even indirectly, gRPC headers.
+*/
+#if defined(GRPC_CPP_VERSION_MAJOR) || defined(GRPC_CPP_VERSION_STRING)
+#  error "gRPC should not be included"
+#endif
+
 #include "opentelemetry/exporters/otlp/otlp_grpc_log_record_exporter.h"
 
 OPENTELEMETRY_BEGIN_NAMESPACE

--- a/exporters/otlp/test/otlp_grpc_metric_exporter_factory_test.cc
+++ b/exporters/otlp/test/otlp_grpc_metric_exporter_factory_test.cc
@@ -18,6 +18,15 @@
   Implementation, this requires protobuf.
 */
 #include "opentelemetry/exporters/otlp/otlp_grpc_client_factory.h"
+
+/*
+  Make sure OtlpGrpcClientFactory does not require,
+  even indirectly, gRPC headers.
+*/
+#if defined(GRPC_CPP_VERSION_MAJOR) || defined(GRPC_CPP_VERSION_STRING)
+#  error "gRPC should not be included"
+#endif
+
 #include "opentelemetry/exporters/otlp/otlp_grpc_metric_exporter.h"
 
 OPENTELEMETRY_BEGIN_NAMESPACE


### PR DESCRIPTION
Fixes #3320 

## Changes

+ Remove the gRPC header dependency of `OtlpGrpcClientFactory`

For significant contributions please make sure you have completed the following items:

* [ ] `CHANGELOG.md` updated for non-trivial changes
* [x] Unit tests have been added
* [x] Changes in public API reviewed