### PR TITLE
[DEVCONTAINER] fix grpc install

### DIFF
--- a/.devcontainer/Dockerfile.dev
+++ b/.devcontainer/Dockerfile.dev
@@ -30,7 +30,7 @@ RUN cd /opt/ci && bash setup_ci_environment.sh
 RUN cd /opt && bash ci/setup_googletest.sh \
     && bash ci/install_abseil.sh \
     && bash ci/install_protobuf.sh \
-    && bash ci/setup_grpc.sh -r $GRPC_VERSION -s $CXX_STANDARD -p protobuf -p abseil
+    && bash ci/setup_grpc.sh -r $GRPC_VERSION -s $CXX_STANDARD -p protobuf -p abseil-cpp
 
 ADD https://github.com/bazelbuild/bazelisk/releases/download/v1.22.1/bazelisk-linux-amd64 /usr/local/bin
 	

--- a/ci/install_abseil.sh
+++ b/ci/install_abseil.sh
@@ -21,7 +21,9 @@ ABSEIL_CPP_BUILD_OPTIONS=(
 )
 
 if [ ! -z "${CXX_STANDARD}" ]; then
-    ABSEIL_CPP_BUILD_OPTIONS=(${ABSEIL_CPP_BUILD_OPTIONS[@]} "-DCMAKE_CXX_STANDARD=${CXX_STANDARD}")
+    ABSEIL_CPP_BUILD_OPTIONS+=("-DCMAKE_CXX_STANDARD=${CXX_STANDARD}")
+    ABSEIL_CPP_BUILD_OPTIONS+=("-DCMAKE_CXX_STANDARD_REQUIRED=ON")
+    ABSEIL_CPP_BUILD_OPTIONS+=("-DCMAKE_CXX_EXTENSIONS=OFF")
 fi
 
 #
@@ -58,6 +60,9 @@ if [ "${ABSEIL_CPP_VERSION}" = "20240116.1" ] || [ "${ABSEIL_CPP_VERSION}" = "20
 else
   echo "Not patching abseil"
 fi
+
+echo "Building abseil ${ABSEIL_CPP_VERSION}"
+echo "CMake build options:" "${ABSEIL_CPP_BUILD_OPTIONS[@]}"
 
 mkdir build && pushd build
 cmake "${ABSEIL_CPP_BUILD_OPTIONS[@]}" ..

--- a/ci/install_protobuf.sh
+++ b/ci/install_protobuf.sh
@@ -38,7 +38,9 @@ CPP_PROTOBUF_BUILD_OPTIONS=(
 )
 
 if [ ! -z "${CXX_STANDARD}" ]; then
-    CPP_PROTOBUF_BUILD_OPTIONS=(${CPP_PROTOBUF_BUILD_OPTIONS[@]} "-DCMAKE_CXX_STANDARD=${CXX_STANDARD}")
+    CPP_PROTOBUF_BUILD_OPTIONS+=("-DCMAKE_CXX_STANDARD=${CXX_STANDARD}")
+    CPP_PROTOBUF_BUILD_OPTIONS+=("-DCMAKE_CXX_STANDARD_REQUIRED=ON")
+    CPP_PROTOBUF_BUILD_OPTIONS+=("-DCMAKE_CXX_EXTENSIONS=OFF")
 fi
 
 # After protobuf 22/4.22, protobuf depends on absl and we can use
@@ -58,6 +60,9 @@ fi
 cd /tmp
 wget https://github.com/google/protobuf/releases/download/v${PROTOBUF_VERSION}/${CPP_PROTOBUF_PACKAGE_NAME}.tar.gz
 tar zxf ${CPP_PROTOBUF_PACKAGE_NAME}.tar.gz --no-same-owner
+
+echo "Building protobuf ${CPP_PROTOBUF_VERSION}"
+echo "CMake build options:" "${CPP_PROTOBUF_BUILD_OPTIONS[@]}"
 
 mkdir protobuf-${CPP_PROTOBUF_VERSION}/build && pushd protobuf-${CPP_PROTOBUF_VERSION}/build
 if [ -e "../CMakeLists.txt" ]; then

--- a/ci/setup_grpc.sh
+++ b/ci/setup_grpc.sh
@@ -50,6 +50,9 @@ while getopts ":v:hi:mp:r:s:TH" o; do
             elif [ "${OPTARG}" == "abseil-cpp" ]; then
                 GRPC_BUILD_OPTIONS=(${GRPC_BUILD_OPTIONS[@]} "-DgRPC_ABSL_PROVIDER=package")
                 build_internal_abseil_cpp=0
+            else
+                usage
+                exit 1;
             fi
             ;;
         r)
@@ -101,6 +104,9 @@ if [[ $build_internal_abseil_cpp -ne 0 ]]; then
 
     ABSEIL_CPP_BUILD_OPTIONS=(
         -DCMAKE_BUILD_TYPE=Release
+        -DCMAKE_CXX_STANDARD=${std_version}
+        -DCMAKE_CXX_STANDARD_REQUIRED=ON
+        -DCMAKE_CXX_EXTENSIONS=OFF
         -DCMAKE_POSITION_INDEPENDENT_CODE=TRUE
         -DCMAKE_INSTALL_PREFIX=$INSTALL_DIR
     )
@@ -116,13 +122,26 @@ GRPC_BUILD_OPTIONS=(
     ${GRPC_BUILD_OPTIONS[@]}
     -DgRPC_INSTALL=ON
     -DCMAKE_CXX_STANDARD=${std_version}
+    -DCMAKE_CXX_STANDARD_REQUIRED=ON
+    -DCMAKE_CXX_EXTENSIONS=OFF
     -DgRPC_BUILD_TESTS=OFF
+    -DgRPC_BUILD_GRPC_CSHARP_PLUGIN=OFF
+    -DgRPC_BUILD_GRPC_OBJECTIVE_C_PLUGIN=OFF
+    -DgRPC_BUILD_GRPC_PHP_PLUGIN=OFF
+    -DgRPC_BUILD_GRPC_NODE_PLUGIN=OFF
+    -DgRPC_BUILD_GRPC_JAVA_PLUGIN=OFF
+    -DgRPC_BUILD_GRPC_PYTHON_PLUGIN=OFF
+    -DgRPC_BUILD_GRPC_RUBY_PLUGIN=OFF
+    -DgRPC_BUILD_GRPCPP_OTEL_PLUGIN=OFF
     -DCMAKE_INSTALL_PREFIX=$INSTALL_DIR
     -DCMAKE_PREFIX_PATH=$INSTALL_DIR
 )
 if [ ! -z "$build_shared_libs" ]; then
     GRPC_BUILD_OPTIONS=(${GRPC_BUILD_OPTIONS[@]} "-DBUILD_SHARED_LIBS=$build_shared_libs")
 fi
+
+echo "Building gRPC ${install_grpc_version}"
+echo "CMake build options:" "${GRPC_BUILD_OPTIONS[@]}"
 
 cmake "${GRPC_BUILD_OPTIONS[@]}" ..
 cmake --build . -j$(nproc)


### PR DESCRIPTION
Follow up fix to PR #3270

## Changes
- fixes typo in args to the setup_grpc.sh script in DockerFile.dev
- adds check for the arg in setup_grpc.sh
- adds cmake flag to the install scripts for abseil, protobuf, and grpc to require the cxx standard requested and not allow cxx extensions 
- remove unused plugins from the grpc build

For significant contributions please make sure you have completed the following items:

* [ ] `CHANGELOG.md` updated for non-trivial changes
* [ ] Unit tests have been added
* [ ] Changes in public API reviewed