### PR TITLE
[CI] Upgrade CI to ubuntu 22.04

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -301,23 +301,21 @@ jobs:
       run: |
         ./ci/do_ci.sh cmake.with_async_export.test
 
-  cmake_abseil_stl_test:
-    name: CMake test (with abseil)
-    runs-on: ubuntu-22.04
-    env:
-      CXX_STANDARD: '14'
-    steps:
-    - uses: actions/checkout@v4
-      with:
-        submodules: 'recursive'
-    - name: setup
-      run: |
-        sudo -E ./ci/setup_googletest.sh
-        sudo -E ./ci/setup_ci_environment.sh
-    - name: run cmake tests (enable abseil-cpp)
-      run: |
-        sudo ./ci/install_abseil.sh
-        ./ci/do_ci.sh cmake.abseil.test
+#  cmake_abseil_stl_test:
+#    name: CMake test (with abseil)
+#    runs-on: ubuntu-20.04
+#    steps:
+#    - uses: actions/checkout@v4
+#      with:
+#        submodules: 'recursive'
+#    - name: setup
+#      run: |
+#        sudo -E ./ci/setup_googletest.sh
+#        sudo -E ./ci/setup_ci_environment.sh
+#    - name: run cmake tests (enable abseil-cpp)
+#      run: |
+#        sudo ./ci/install_abseil.sh
+#        ./ci/do_ci.sh cmake.abseil.test
 
   cmake_opentracing_shim_test:
     name: CMake test (with opentracing-shim)
@@ -547,26 +545,24 @@ jobs:
         sudo ./ci/setup_grpc.sh -T
         ./ci/do_ci.sh cmake.exporter.otprotocol.shared_libs.with_static_grpc.test
 
-  cmake_install_test:
-    name: CMake install test (with abseil)
-    runs-on: ubuntu-22.04
-    env:
-      CXX_STANDARD: '14'
-    steps:
-    - uses: actions/checkout@v4
-      with:
-        submodules: 'recursive'
-    - name: setup
-      run: |
-        sudo -E ./ci/setup_googletest.sh
-        sudo -E ./ci/setup_ci_environment.sh
-    - name: run cmake install (with abseil)
-      run: |
-        sudo ./ci/install_abseil.sh
-        ./ci/do_ci.sh cmake.install.test
-    - name: verify packages
-      run: |
-        ./ci/verify_packages.sh
+#  cmake_install_test:
+#    name: CMake install test (with abseil)
+#    runs-on: ubuntu-20.04
+#    steps:
+#    - uses: actions/checkout@v4
+#      with:
+#        submodules: 'recursive'
+#    - name: setup
+#      run: |
+#        sudo -E ./ci/setup_googletest.sh
+#        sudo -E ./ci/setup_ci_environment.sh
+#    - name: run cmake install (with abseil)
+#      run: |
+#        sudo ./ci/install_abseil.sh
+#        ./ci/do_ci.sh cmake.install.test
+#    - name: verify packages
+#      run: |
+#        ./ci/verify_packages.sh
 
   plugin_test:
     name: Plugin -> CMake

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -303,7 +303,7 @@ jobs:
 
   cmake_abseil_stl_test:
     name: CMake test (with abseil)
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
     - uses: actions/checkout@v4
       with:
@@ -333,7 +333,7 @@ jobs:
 
   cmake_test_cxx14_gcc:
     name: CMake C++14 test(GCC)
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
     - uses: actions/checkout@v4
       with:
@@ -349,7 +349,7 @@ jobs:
 
   cmake_test_cxx17_gcc:
     name: CMake C++17 test(GCC)
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
     - uses: actions/checkout@v4
       with:
@@ -365,7 +365,7 @@ jobs:
 
   cmake_test_cxx20_gcc:
     name: CMake C++20 test(GCC)
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
     - uses: actions/checkout@v4
       with:
@@ -465,7 +465,7 @@ jobs:
 
   cmake_otprotocol_test:
     name: CMake test (with otlp-exporter)
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
     - uses: actions/checkout@v4
       with:
@@ -515,7 +515,7 @@ jobs:
 
   cmake_do_not_install_test:
     name: CMake do not install test (with otlp-exporter)
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
     - uses: actions/checkout@v4
       with:
@@ -531,7 +531,7 @@ jobs:
 
   cmake_otprotocol_shared_libs_with_static_grpc_test:
     name: CMake test (build shared libraries with otlp-exporter and static gRPC)
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
     - uses: actions/checkout@v4
       with:
@@ -547,7 +547,7 @@ jobs:
 
   cmake_install_test:
     name: CMake install test (with abseil)
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
     - uses: actions/checkout@v4
       with:
@@ -809,7 +809,7 @@ jobs:
 
   copyright:
     name: Copyright
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
     - uses: actions/checkout@v4
     - name: check copyright

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -304,6 +304,8 @@ jobs:
   cmake_abseil_stl_test:
     name: CMake test (with abseil)
     runs-on: ubuntu-22.04
+    env:
+      CXX_STANDARD: '14'
     steps:
     - uses: actions/checkout@v4
       with:
@@ -548,6 +550,8 @@ jobs:
   cmake_install_test:
     name: CMake install test (with abseil)
     runs-on: ubuntu-22.04
+    env:
+      CXX_STANDARD: '14'
     steps:
     - uses: actions/checkout@v4
       with:


### PR DESCRIPTION
Fixes #3329

## Changes

Please provide a brief description of the changes here.

* Upgrade CI from ubuntu 20.04 to ubuntu 22.04
* Disable CI tests using abseil, to be revisited after PR #3318

For significant contributions please make sure you have completed the following items:

* [ ] `CHANGELOG.md` updated for non-trivial changes
* [ ] Unit tests have been added
* [ ] Changes in public API reviewed