### PR TITLE
pin cmake in ci and devcontainer

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -648,6 +648,7 @@ jobs:
     - name: setup
       run: |
         sudo ./ci/setup_ci_environment.sh
+        sudo ./ci/setup_cmake.sh
         sudo ./ci/install_bazelisk.sh
     - name: run tests
       run: ./ci/do_ci.sh bazel.no_bzlmod.test
@@ -669,6 +670,7 @@ jobs:
     - name: setup
       run: |
         sudo ./ci/setup_ci_environment.sh
+        sudo ./ci/setup_cmake.sh
         sudo ./ci/install_bazelisk.sh
     - name: run tests
       run: ./ci/do_ci.sh bazel.with_async_export.test
@@ -690,6 +692,7 @@ jobs:
     - name: setup
       run: |
         sudo ./ci/setup_ci_environment.sh
+        sudo ./ci/setup_cmake.sh
         sudo ./ci/install_bazelisk.sh
     - name: run tests
       run: ./ci/do_ci.sh bazel.valgrind
@@ -711,6 +714,7 @@ jobs:
     - name: setup
       run: |
         sudo ./ci/setup_ci_environment.sh
+        sudo ./ci/setup_cmake.sh
         sudo ./ci/install_bazelisk.sh
     - name: run tests
       run: ./ci/do_ci.sh bazel.noexcept
@@ -732,6 +736,7 @@ jobs:
     - name: setup
       run: |
         sudo ./ci/setup_ci_environment.sh
+        sudo ./ci/setup_cmake.sh
         sudo ./ci/install_bazelisk.sh
     - name: run tests
       run: ./ci/do_ci.sh bazel.nortti
@@ -753,6 +758,7 @@ jobs:
     - name: setup
       run: |
         sudo ./ci/setup_ci_environment.sh
+        sudo ./ci/setup_cmake.sh
         sudo ./ci/install_bazelisk.sh
     - name: run tests
       run: ./ci/do_ci.sh bazel.asan
@@ -774,6 +780,7 @@ jobs:
     - name: setup
       run: |
         sudo ./ci/setup_ci_environment.sh
+        sudo ./ci/setup_cmake.sh
         sudo ./ci/install_bazelisk.sh
     - name: run tests
       run: ./ci/do_ci.sh bazel.tsan

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,8 +25,8 @@ jobs:
 #        CXX: /usr/bin/g++-10
 #      run: |
 #        sudo -E ./ci/setup_gcc10.sh
-#        sudo -E ./ci/setup_cmake.sh
 #        sudo -E ./ci/setup_ci_environment.sh
+#        sudo -E ./ci/setup_cmake.sh
 #        sudo -E ./ci/setup_googletest.sh
 #        sudo -E ./ci/install_abseil.sh
 #        sudo -E ./ci/install_protobuf.sh
@@ -51,8 +51,9 @@ jobs:
         submodules: 'recursive'
     - name: setup
       run: |
-        sudo -E ./ci/setup_googletest.sh
         sudo -E ./ci/setup_ci_environment.sh
+        sudo -E ./ci/setup_cmake.sh
+        sudo -E ./ci/setup_googletest.sh
     - name: run cmake tests
       run: |
         ./ci/do_ci.sh cmake.test
@@ -71,8 +72,9 @@ jobs:
         PROTOBUF_VERSION: 21.12
       run: |
         sudo apt remove needrestart #refer: https://github.com/actions/runner-images/issues/9937
-        sudo -E ./ci/setup_googletest.sh
         sudo -E ./ci/setup_ci_environment.sh
+        sudo -E ./ci/setup_cmake.sh
+        sudo -E ./ci/setup_googletest.sh
         sudo -E ./ci/install_protobuf.sh
     - name: setup grpc
       run: |
@@ -107,8 +109,9 @@ jobs:
         PROTOBUF_VERSION: 21.12
       run: |
         sudo apt remove needrestart #refer: https://github.com/actions/runner-images/issues/9937
-        sudo -E ./ci/setup_googletest.sh
         sudo -E ./ci/setup_ci_environment.sh
+        sudo -E ./ci/setup_cmake.sh
+        sudo -E ./ci/setup_googletest.sh
         sudo -E ./ci/install_protobuf.sh
     - name: setup grpc
       run: |
@@ -143,8 +146,9 @@ jobs:
         PROTOBUF_VERSION: 21.12
       run: |
         sudo apt remove needrestart #refer: https://github.com/actions/runner-images/issues/9937
-        sudo -E ./ci/setup_googletest.sh
         sudo -E ./ci/setup_ci_environment.sh
+        sudo -E ./ci/setup_cmake.sh
+        sudo -E ./ci/setup_googletest.sh
         sudo -E ./ci/install_protobuf.sh
     - name: setup grpc
       run: |
@@ -181,6 +185,7 @@ jobs:
         sudo apt remove needrestart #refer: https://github.com/actions/runner-images/issues/9937
         sudo -E ./ci/setup_googletest.sh
         sudo -E ./ci/setup_ci_environment.sh
+        sudo -E ./ci/setup_cmake.sh
         sudo -E ./ci/install_protobuf.sh
     - name: setup grpc
       run: |
@@ -215,8 +220,9 @@ jobs:
         PROTOBUF_VERSION: 21.12
       run: |
         sudo apt remove needrestart #refer: https://github.com/actions/runner-images/issues/9937
-        sudo -E ./ci/setup_googletest.sh
         sudo -E ./ci/setup_ci_environment.sh
+        sudo -E ./ci/setup_cmake.sh
+        sudo -E ./ci/setup_googletest.sh
         sudo -E ./ci/install_protobuf.sh
     - name: setup grpc
       run: |
@@ -292,8 +298,9 @@ jobs:
         CC: /usr/bin/gcc-12
         CXX: /usr/bin/g++-12
       run: |
-        sudo -E ./ci/setup_googletest.sh
         sudo -E ./ci/setup_ci_environment.sh
+        sudo -E ./ci/setup_cmake.sh
+        sudo -E ./ci/setup_googletest.sh
     - name: run cmake tests (without otlp-exporter)
       env:
         CC: /usr/bin/gcc-12
@@ -310,8 +317,10 @@ jobs:
 #        submodules: 'recursive'
 #    - name: setup
 #      run: |
-#        sudo -E ./ci/setup_googletest.sh
+
 #        sudo -E ./ci/setup_ci_environment.sh
+#        sudo -E ./ci/setup_cmake.sh
+#        sudo -E ./ci/setup_googletest.sh
 #    - name: run cmake tests (enable abseil-cpp)
 #      run: |
 #        sudo ./ci/install_abseil.sh
@@ -326,8 +335,9 @@ jobs:
         submodules: 'recursive'
     - name: setup
       run: |
-        sudo -E ./ci/setup_googletest.sh
         sudo -E ./ci/setup_ci_environment.sh
+        sudo -E ./ci/setup_cmake.sh
+        sudo -E ./ci/setup_googletest.sh
     - name: run cmake tests (enable opentracing-shim)
       run: ./ci/do_ci.sh cmake.opentracing_shim.test
 
@@ -341,6 +351,7 @@ jobs:
     - name: setup
       run: |
         sudo -E ./ci/setup_ci_environment.sh
+        sudo -E ./ci/setup_cmake.sh
         sudo -E ./ci/setup_googletest.sh
     - name: run tests (enable stl)
       env:
@@ -357,6 +368,7 @@ jobs:
     - name: setup
       run: |
         sudo -E ./ci/setup_ci_environment.sh
+        sudo -E ./ci/setup_cmake.sh
         sudo -E ./ci/setup_googletest.sh
     - name: run tests (enable stl)
       env:
@@ -373,6 +385,7 @@ jobs:
     - name: setup
       run: |
         sudo -E ./ci/setup_ci_environment.sh
+        sudo -E ./ci/setup_cmake.sh
         sudo -E ./ci/setup_googletest.sh
     - name: run tests
       env:
@@ -397,6 +410,7 @@ jobs:
         CXXFLAGS: "-stdlib=libc++"
       run: |
         sudo -E ./ci/setup_ci_environment.sh
+        sudo -E ./ci/setup_cmake.sh
         sudo -E ./ci/setup_googletest.sh
     - name: run tests
       env:
@@ -423,6 +437,7 @@ jobs:
     - name: setup
       run: |
         sudo -E ./ci/setup_ci_environment.sh
+        sudo -E ./ci/setup_cmake.sh
         sudo -E ./ci/setup_googletest.sh
     - name: run tests
       env:
@@ -447,6 +462,7 @@ jobs:
         CXXFLAGS: "-stdlib=libc++"
       run: |
         sudo -E ./ci/setup_ci_environment.sh
+        sudo -E ./ci/setup_cmake.sh
         sudo -E ./ci/setup_googletest.sh
     - name: run tests
       env:
@@ -472,8 +488,9 @@ jobs:
         submodules: 'recursive'
     - name: setup
       run: |
-        sudo -E ./ci/setup_googletest.sh
         sudo -E ./ci/setup_ci_environment.sh
+        sudo -E ./ci/setup_cmake.sh
+        sudo -E ./ci/setup_googletest.sh
     - name: run otlp exporter tests
       run: |
         sudo ./ci/setup_grpc.sh
@@ -501,8 +518,9 @@ jobs:
         ABSEIL_CPP_VERSION: '20230125.3'
         CXX_STANDARD: '14'
       run: |
-        sudo ./ci/setup_googletest.sh
-        sudo ./ci/setup_ci_environment.sh
+        sudo -E ./ci/setup_ci_environment.sh
+        sudo -E ./ci/setup_cmake.sh
+        sudo -E ./ci/setup_googletest.sh
         sudo -E ./ci/install_abseil.sh
         sudo -E ./ci/install_protobuf.sh
     - name: run otlp exporter tests
@@ -522,8 +540,9 @@ jobs:
         submodules: 'recursive'
     - name: setup
       run: |
-        sudo -E ./ci/setup_googletest.sh
         sudo -E ./ci/setup_ci_environment.sh
+        sudo -E ./ci/setup_cmake.sh
+        sudo -E ./ci/setup_googletest.sh
     - name: run otlp exporter tests
       run: |
         sudo ./ci/setup_grpc.sh
@@ -538,8 +557,9 @@ jobs:
         submodules: 'recursive'
     - name: setup
       run: |
-        sudo -E ./ci/setup_googletest.sh
         sudo -E ./ci/setup_ci_environment.sh
+        sudo -E ./ci/setup_cmake.sh
+        sudo -E ./ci/setup_googletest.sh
     - name: run otlp exporter tests
       run: |
         sudo ./ci/setup_grpc.sh -T
@@ -554,8 +574,9 @@ jobs:
 #        submodules: 'recursive'
 #    - name: setup
 #      run: |
-#        sudo -E ./ci/setup_googletest.sh
 #        sudo -E ./ci/setup_ci_environment.sh
+#        sudo -E ./ci/setup_cmake.sh
+#        sudo -E ./ci/setup_googletest.sh
 #    - name: run cmake install (with abseil)
 #      run: |
 #        sudo ./ci/install_abseil.sh
@@ -576,8 +597,9 @@ jobs:
         CC: /usr/bin/gcc-12
         CXX: /usr/bin/g++-12
       run: |
-        sudo -E ./ci/setup_googletest.sh
         sudo -E ./ci/setup_ci_environment.sh
+        sudo -E ./ci/setup_cmake.sh
+        sudo -E ./ci/setup_googletest.sh
     - name: run tests
       env:
         CC: /usr/bin/gcc-12
@@ -903,8 +925,9 @@ jobs:
         CC: /usr/bin/gcc-10
         CXX: /usr/bin/g++-10
       run: |
-        sudo -E ./ci/setup_googletest.sh
         sudo -E ./ci/setup_ci_environment.sh
+        sudo -E ./ci/setup_cmake.sh
+        sudo -E ./ci/setup_googletest.sh
     - name: run tests and generate report
       env:
         CC: /usr/bin/gcc-10
@@ -974,8 +997,9 @@ jobs:
           CC: /usr/bin/gcc-12
           CXX: /usr/bin/g++-12
         run: |
-          sudo -E ./ci/setup_googletest.sh
           sudo -E ./ci/setup_ci_environment.sh
+          sudo -E ./ci/setup_cmake.sh
+          sudo -E ./ci/setup_googletest.sh
       - name: run w3c trace-context test server (background)
         env:
           CXX_STANDARD: '14'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -183,9 +183,9 @@ jobs:
         PROTOBUF_VERSION: 21.12
       run: |
         sudo apt remove needrestart #refer: https://github.com/actions/runner-images/issues/9937
-        sudo -E ./ci/setup_googletest.sh
         sudo -E ./ci/setup_ci_environment.sh
         sudo -E ./ci/setup_cmake.sh
+        sudo -E ./ci/setup_googletest.sh
         sudo -E ./ci/install_protobuf.sh
     - name: setup grpc
       run: |
@@ -252,6 +252,7 @@ jobs:
         submodules: 'recursive'
     - name: setup
       run: |
+        ./ci/setup_cmake.ps1
         ./ci/setup_windows_ci_environment.ps1
     - name: run tests
       run: ./ci/do_ci.ps1 cmake.maintainer.test
@@ -265,6 +266,7 @@ jobs:
         submodules: 'recursive'
     - name: setup
       run: |
+        ./ci/setup_cmake.ps1
         ./ci/setup_windows_ci_environment.ps1
     - name: run tests
       env:
@@ -280,6 +282,7 @@ jobs:
         submodules: 'recursive'
     - name: setup
       run: |
+        ./ci/setup_cmake.ps1
         ./ci/setup_windows_ci_environment.ps1
     - name: run tests
       env:
@@ -623,6 +626,7 @@ jobs:
     - name: setup
       run: |
         sudo ./ci/setup_ci_environment.sh
+        sudo ./ci/setup_cmake.sh
         sudo ./ci/install_bazelisk.sh
     - name: run tests
       run: ./ci/do_ci.sh bazel.test
@@ -846,6 +850,7 @@ jobs:
         submodules: 'recursive'
     - name: setup
       run: |
+        ./ci/setup_cmake.ps1
         ./ci/setup_windows_ci_environment.ps1
         ./ci/install_windows_protobuf.ps1
     - name: run cmake test
@@ -862,6 +867,7 @@ jobs:
         submodules: 'recursive'
     - name: setup
       run: |
+        ./ci/setup_cmake.ps1
         ./ci/setup_windows_ci_environment.ps1
         ./ci/install_windows_protobuf.ps1
     - name: run cmake test (DLL build)
@@ -880,6 +886,7 @@ jobs:
         submodules: 'recursive'
     - name: setup
       run: |
+        ./ci/setup_cmake.ps1
         ./ci/setup_windows_ci_environment.ps1
         ./ci/install_windows_protobuf.ps1
     - name: run cmake test
@@ -909,6 +916,7 @@ jobs:
         submodules: 'recursive'
     - name: setup
       run: |
+        ./ci/setup_cmake.ps1
         ./ci/setup_windows_ci_environment.ps1
     - name: run tests
       run: ./ci/do_ci.ps1 cmake.test_example_plugin

--- a/.github/workflows/iwyu.yml
+++ b/.github/workflows/iwyu.yml
@@ -21,7 +21,6 @@ jobs:
           sudo apt install -y --no-install-recommends --no-install-suggests \
             build-essential \
             iwyu \
-            cmake \
             ninja-build \
             libssl-dev \
             libcurl4-openssl-dev \
@@ -30,6 +29,8 @@ jobs:
             libgmock-dev \
             libgtest-dev \
             libbenchmark-dev
+          sudo ./ci/setup_cmake.sh
+
 
       - name: setup grpc
         run: |

--- a/ci/setup_cmake.ps1
+++ b/ci/setup_cmake.ps1
@@ -7,9 +7,9 @@ trap { $host.SetShouldExit(1) }
 if (-not $env:CMAKE_VERSION) { $env:CMAKE_VERSION = "3.31.6" }
 $CMAKE_VERSION = $env:CMAKE_VERSION
 
-choco uninstall cmake -y
+choco uninstall cmake cmake.install -y --remove-dependencies --skip-autouninstaller --force --no-progress
 
 Write-Host "Installing CMake version $CMAKE_VERSION ..."
-choco install cmake --version=$CMAKE_VERSION -y
+choco install cmake --version=$CMAKE_VERSION --allow-downgrade -y --force --no-progress
 
 cmake --version

--- a/ci/setup_cmake.ps1
+++ b/ci/setup_cmake.ps1
@@ -1,0 +1,15 @@
+# Copyright The OpenTelemetry Authors
+# SPDX-License-Identifier: Apache-2.0
+
+$ErrorActionPreference = "Stop"
+trap { $host.SetShouldExit(1) }
+
+if (-not $env:CMAKE_VERSION) { $env:CMAKE_VERSION = "3.31.6" }
+$CMAKE_VERSION = $env:CMAKE_VERSION
+
+choco uninstall cmake -y
+
+Write-Host "Installing CMake version $CMAKE_VERSION ..."
+choco install cmake --version=$CMAKE_VERSION -y
+
+cmake --version

--- a/ci/setup_cmake.sh
+++ b/ci/setup_cmake.sh
@@ -4,6 +4,30 @@
 # SPDX-License-Identifier: Apache-2.0
 
 set -e
-apt-get update
-apt-get install --no-install-recommends --no-install-suggests -y \
-                cmake
+
+# Use CMAKE_VERSION env var if set, else default to 3.31.6
+CMAKE_VERSION=${CMAKE_VERSION:-3.31.6}
+CMAKE_DIR="cmake-$CMAKE_VERSION-linux-x86_64"
+CMAKE_TAR="$CMAKE_DIR.tar.gz"
+CMAKE_URL="https://github.com/Kitware/CMake/releases/download/v$CMAKE_VERSION/$CMAKE_TAR"
+
+echo "Installing CMake version: $CMAKE_VERSION"
+
+apt-get update && apt-get remove --purge -y cmake || true
+
+apt-get install -y wget tar
+
+wget "$CMAKE_URL"
+
+tar -xzf "$CMAKE_TAR"
+
+mkdir -p /opt/cmake
+mv "$CMAKE_DIR" /opt/cmake/cmake
+
+for file in /opt/cmake/cmake/bin/*; do
+    ln -sf "$file" /usr/local/bin/$(basename "$file")
+done
+
+rm -f "$CMAKE_TAR"
+
+cmake --version


### PR DESCRIPTION
Pin cmake to version 3.31.6 in ci

## Changes
- changes the `setup_cmake.sh` script to remove the system installed cmake and install a specific version from env var CMAKE_VERSION that defaults to 3.31.6
- adds a `setup_cmake.ps1` script for windows that does the same
- call the scripts in the ci workflow where needed

For significant contributions please make sure you have completed the following items:

* [ ] `CHANGELOG.md` updated for non-trivial changes
* [ ] Unit tests have been added
* [ ] Changes in public API reviewed