### PR TITLE
[CI] disable bzip2 in conan builds

### DIFF
--- a/install/conan/conanfile_latest.txt
+++ b/install/conan/conanfile_latest.txt
@@ -26,6 +26,7 @@ abseil/*:fPIC=True
 abseil/*:shared=False
 opentracing-cpp/*:fPIC=True
 opentracing-cpp/*:shared=True
+pcre2/*:with_bzip2=False
 
 [test_requires]
 gtest/1.16.0

--- a/install/conan/conanfile_stable.txt
+++ b/install/conan/conanfile_stable.txt
@@ -26,6 +26,7 @@ abseil/*:fPIC=True
 abseil/*:shared=False
 opentracing-cpp/*:fPIC=True
 opentracing-cpp/*:shared=True
+pcre2/*:with_bzip2=False
 
 [test_requires]
 gtest/1.14.0


### PR DESCRIPTION
the cmake install tests based on conan are failing due to the bzip2 server being down. Remove bzip2 from the build it is not needed. 

## Changes
- remove bzip2 from the install/conan/conanfile* files

For significant contributions please make sure you have completed the following items:

* [ ] `CHANGELOG.md` updated for non-trivial changes
* [ ] Unit tests have been added
* [ ] Changes in public API reviewed