### PR TITLE
[API] Add Enabled method to Tracer

### DIFF
--- a/api/include/opentelemetry/plugin/tracer.h
+++ b/api/include/opentelemetry/plugin/tracer.h
@@ -104,6 +104,13 @@ public:
     return nostd::shared_ptr<trace::Span>{new (std::nothrow) Span{this->shared_from_this(), span}};
   }
 
+#if OPENTELEMETRY_ABI_VERSION_NO >= 2
+  bool Enabled() noexcept override
+  {
+    return true;
+  }
+#endif
+
 #if OPENTELEMETRY_ABI_VERSION_NO == 1
 
   void ForceFlushWithMicroseconds(uint64_t timeout) noexcept override

--- a/api/include/opentelemetry/plugin/tracer.h
+++ b/api/include/opentelemetry/plugin/tracer.h
@@ -105,10 +105,7 @@ public:
   }
 
 #if OPENTELEMETRY_ABI_VERSION_NO >= 2
-  bool Enabled() noexcept override
-  {
-    return true;
-  }
+  bool Enabled() noexcept override { return true; }
 #endif
 
 #if OPENTELEMETRY_ABI_VERSION_NO == 1

--- a/api/include/opentelemetry/trace/noop.h
+++ b/api/include/opentelemetry/trace/noop.h
@@ -108,6 +108,13 @@ public:
     return noop_span;
   }
 
+#if OPENTELEMETRY_ABI_VERSION_NO >= 2
+  bool Enabled() noexcept override
+  {
+    return false;
+  }
+#endif
+
 #if OPENTELEMETRY_ABI_VERSION_NO == 1
 
   void ForceFlushWithMicroseconds(uint64_t /*timeout*/) noexcept override {}

--- a/api/include/opentelemetry/trace/noop.h
+++ b/api/include/opentelemetry/trace/noop.h
@@ -109,10 +109,7 @@ public:
   }
 
 #if OPENTELEMETRY_ABI_VERSION_NO >= 2
-  bool Enabled() noexcept override
-  {
-    return false;
-  }
+  bool Enabled() noexcept override { return false; }
 #endif
 
 #if OPENTELEMETRY_ABI_VERSION_NO == 1

--- a/api/include/opentelemetry/trace/tracer.h
+++ b/api/include/opentelemetry/trace/tracer.h
@@ -163,6 +163,19 @@ public:
     }
   }
 
+#if OPENTELEMETRY_ABI_VERSION_NO >= 2
+  /**
+   * Reports if the tracer is enabled or not. A disabled tracer will not create spans.
+   *
+   * The returned value can change over time so the instrumentation authors must call this method
+   * every time before creating a span to potentially avoid performing computationally expensive
+   * operations.
+   *
+   * @since ABI_VERSION 2
+   */
+  virtual bool Enabled() noexcept = 0;
+#endif
+
 #if OPENTELEMETRY_ABI_VERSION_NO == 1
 
   /*

--- a/api/include/opentelemetry/trace/tracer.h
+++ b/api/include/opentelemetry/trace/tracer.h
@@ -66,7 +66,7 @@ public:
   template <class T,
             class U,
             nostd::enable_if_t<common::detail::is_key_value_iterable<T>::value> * = nullptr,
-            nostd::enable_if_t<detail::is_span_context_kv_iterable<U>::value>   * = nullptr>
+            nostd::enable_if_t<detail::is_span_context_kv_iterable<U>::value> *   = nullptr>
   nostd::shared_ptr<Span> StartSpan(nostd::string_view name,
                                     const T &attributes,
                                     const U &links,

--- a/api/test/singleton/singleton_test.cc
+++ b/api/test/singleton/singleton_test.cc
@@ -287,10 +287,7 @@ public:
 
 #if OPENTELEMETRY_ABI_VERSION_NO >= 2
 
-  bool Enabled() noexcept override
-  {
-    return true;
-  }
+  bool Enabled() noexcept override { return true; }
 
 #endif
 

--- a/api/test/singleton/singleton_test.cc
+++ b/api/test/singleton/singleton_test.cc
@@ -285,6 +285,15 @@ public:
     return result;
   }
 
+#if OPENTELEMETRY_ABI_VERSION_NO >= 2
+
+  bool Enabled() noexcept override
+  {
+    return true;
+  }
+
+#endif
+
 #if OPENTELEMETRY_ABI_VERSION_NO == 1
 
   void ForceFlushWithMicroseconds(uint64_t /* timeout */) noexcept override {}

--- a/examples/plugin/plugin/tracer.cc
+++ b/examples/plugin/plugin/tracer.cc
@@ -91,3 +91,10 @@ nostd::shared_ptr<trace::Span> Tracer::StartSpan(nostd::string_view name,
   return nostd::shared_ptr<trace::Span>{
       new (std::nothrow) Span{this->shared_from_this(), name, attributes, links, options}};
 }
+
+#if OPENTELEMETRY_ABI_VERSION_NO >= 2
+bool Tracer::Enabled() noexcept
+{
+  return true;
+}
+#endif

--- a/examples/plugin/plugin/tracer.h
+++ b/examples/plugin/plugin/tracer.h
@@ -26,6 +26,12 @@ public:
       const opentelemetry::trace::SpanContextKeyValueIterable & /*links*/,
       const opentelemetry::trace::StartSpanOptions & /*options */) noexcept override;
 
+#if OPENTELEMETRY_ABI_VERSION_NO >= 2
+
+  bool Enabled() noexcept override;
+
+#endif
+
 #if OPENTELEMETRY_ABI_VERSION_NO == 1
 
   void ForceFlushWithMicroseconds(uint64_t /*timeout*/) noexcept override {}

--- a/sdk/include/opentelemetry/sdk/trace/tracer.h
+++ b/sdk/include/opentelemetry/sdk/trace/tracer.h
@@ -71,6 +71,8 @@ public:
   }
 
   void CloseWithMicroseconds(uint64_t timeout) noexcept;
+
+  bool Enabled() noexcept override;
 #else
   /* Exposed in the API in ABI version 1, but does not belong to the API */
   void ForceFlushWithMicroseconds(uint64_t timeout) noexcept override;

--- a/sdk/src/trace/tracer.cc
+++ b/sdk/src/trace/tracer.cc
@@ -163,6 +163,13 @@ nostd::shared_ptr<opentelemetry::trace::Span> Tracer::StartSpan(
   }
 }
 
+#if OPENTELEMETRY_ABI_VERSION_NO >= 2
+bool Tracer::Enabled() noexcept
+{
+  return tracer_config_.IsEnabled();
+}
+#endif
+
 void Tracer::ForceFlushWithMicroseconds(uint64_t timeout) noexcept
 {
   if (context_)


### PR DESCRIPTION
Fixes #3149 

## Changes

Adds a method to Tracer (ABI version >= 2) that allows the user to check if the tracer is enabled or not. A disabled tracer does not produce spans.

This change enhances [tracer spec-compatibility](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/api.md#tracer).

For significant contributions please make sure you have completed the following items:

* [ ] `CHANGELOG.md` updated for non-trivial changes
* [ ] Unit tests have been added
* [ ] Changes in public API reviewed