### PR TITLE
Fixes warnings of ciso646 in C++17

### DIFF
--- a/api/include/opentelemetry/nostd/internal/absl/base/options.h
+++ b/api/include/opentelemetry/nostd/internal/absl/base/options.h
@@ -69,8 +69,21 @@
 
 // Include a standard library header to allow configuration based on the
 // standard library in use.
-#ifdef __cplusplus
-#include <ciso646>
+// Using C++20 feature-test macros when possible, otherwise fall back to
+// ciso646/iso646.h.There are warnings when includeing ciso646 in C++17 mode
+#ifdef __has_include
+#  if __has_include(<version>)
+#    include <version>
+#  endif
+#elif defined(_MSC_VER) && \
+    ((defined(__cplusplus) && __cplusplus >= 202002L) || (defined(_MSVC_LANG) && _MSVC_LANG >= 202002L))
+#  if _MSC_VER >= 1922
+#    include <version>
+#  endif
+#elif defined(__cplusplus) && __cplusplus < 201703L
+#  include <ciso646>
+#else
+#  include <iso646.h>
 #endif
 
 // -----------------------------------------------------------------------------

--- a/api/include/opentelemetry/nostd/internal/absl/base/options.h
+++ b/api/include/opentelemetry/nostd/internal/absl/base/options.h
@@ -80,10 +80,20 @@
 #  if _MSC_VER >= 1922
 #    include <version>
 #  endif
-#elif defined(__cplusplus) && __cplusplus < 201703L
-#  include <ciso646>
 #else
-#  include <iso646.h>
+#  if defined(__GNUC__) && !defined(__clang__) && !defined(__apple_build_version__)
+#    pragma GCC diagnostic push
+#    pragma GCC diagnostic ignored "-Wcpp"
+#  elif defined(__clang__) || defined(__apple_build_version__)
+#    pragma clang diagnostic push
+#    pragma clang diagnostic ignored "-Wcpp"
+#  endif
+#  include <ciso646>
+#  if defined(__GNUC__) && !defined(__clang__) && !defined(__apple_build_version__)
+#      pragma GCC diagnostic pop
+#  elif defined(__clang__) || defined(__apple_build_version__)
+#    pragma clang diagnostic pop
+#  endif
 #endif
 
 // -----------------------------------------------------------------------------

--- a/api/include/opentelemetry/nostd/internal/absl/base/options.h
+++ b/api/include/opentelemetry/nostd/internal/absl/base/options.h
@@ -70,7 +70,7 @@
 // Include a standard library header to allow configuration based on the
 // standard library in use.
 // Using C++20 feature-test macros when possible, otherwise fall back to
-// ciso646/iso646.h.There are warnings when includeing ciso646 in C++17 mode
+// ciso646/iso646.h.There are warnings when including ciso646 in C++17 mode
 #ifdef __has_include
 #  if __has_include(<version>)
 #    include <version>


### PR DESCRIPTION
Fixes #3359 

There will be warning when using `-std=c++17` in the trunk version of GCC.
The issues were first reported in <https://github.com/open-telemetry/opentelemetry-cpp/issues/3121#issuecomment-2790880867> .

## Changes

+ Using `<version>`to import feature checking macros in C++20
+ Using `<iso646.h>` to avoid warnings in C++17

For significant contributions please make sure you have completed the following items:

* [ ] `CHANGELOG.md` updated for non-trivial changes
* [ ] Unit tests have been added
* [ ] Changes in public API reviewed