### PR TITLE
Fix `type_traits.h` to address compiler warnings around using deprecated methods

### DIFF
--- a/api/include/opentelemetry/nostd/type_traits.h
+++ b/api/include/opentelemetry/nostd/type_traits.h
@@ -142,7 +142,8 @@ using std::is_trivially_move_constructible;
 template <typename T>
 struct is_trivially_copy_constructible
 {
-  static constexpr bool value = std::is_copy_constructible<T>::value && __has_trivial_copy(T);
+  static constexpr bool value = std::is_copy_constructible<T>::value
+      && __is_trivially_assignable(T&, const T&);
 };
 
 template <typename T>
@@ -154,7 +155,8 @@ struct is_trivially_move_constructible
 template <typename T>
 struct is_trivially_copy_assignable
 {
-  static constexpr bool value = std::is_copy_assignable<T>::value && __has_trivial_assign(T);
+  static constexpr bool value = std::is_copy_assignable<T>::value
+      && __is_trivially_assignable(T&, const T&);
 };
 
 template <typename T>


### PR DESCRIPTION
## Description

`__has_trivial_copy` has been deprecated in favor of `__is_trivially_assignable`. This is causing issues while bumping up the Open Telemetry dependency in Envoy from v1.29 => v1.20 [[See This](https://github.com/envoyproxy/envoy/pull/39182)].

## Changes

We have created a patch in Envoy and are trying to upstream the fixes to get a clean patch-free build.