### PR TITLE
[Metrics SDK] Use nostd::function_ref in AttributesHashMap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,9 @@ Increment the:
 
 ## [Unreleased]
 
+* [Metrics SDK] Use nostd::function_ref in AttributesHashMap
+  [#3393](https://github.com/open-telemetry/opentelemetry-cpp/pull/3393)
+
 * [SDK] Base2 exponential histogram aggregation
   [#3175](https://github.com/open-telemetry/opentelemetry-cpp/pull/3346)
 

--- a/sdk/include/opentelemetry/sdk/metrics/state/attributes_hashmap.h
+++ b/sdk/include/opentelemetry/sdk/metrics/state/attributes_hashmap.h
@@ -74,9 +74,10 @@ public:
    * If not present, it uses the provided callback to generate
    * value and store in the hash
    */
-  Aggregation *GetOrSetDefault(const opentelemetry::common::KeyValueIterable &attributes,
-                               const AttributesProcessor *attributes_processor,
-                               std::function<std::unique_ptr<Aggregation>()> aggregation_callback)
+  Aggregation *GetOrSetDefault(
+      const opentelemetry::common::KeyValueIterable &attributes,
+      const AttributesProcessor *attributes_processor,
+      nostd::function_ref<std::unique_ptr<Aggregation>()> aggregation_callback)
   {
     // TODO: avoid constructing MetricAttributes from KeyValueIterable for
     // hash_map_.find which is a heavy operation
@@ -97,8 +98,9 @@ public:
     return result.first->second.get();
   }
 
-  Aggregation *GetOrSetDefault(const MetricAttributes &attributes,
-                               std::function<std::unique_ptr<Aggregation>()> aggregation_callback)
+  Aggregation *GetOrSetDefault(
+      const MetricAttributes &attributes,
+      nostd::function_ref<std::unique_ptr<Aggregation>()> aggregation_callback)
   {
     auto it = hash_map_.find(attributes);
     if (it != hash_map_.end())
@@ -115,8 +117,9 @@ public:
     return hash_map_[attributes].get();
   }
 
-  Aggregation *GetOrSetDefault(MetricAttributes &&attributes,
-                               std::function<std::unique_ptr<Aggregation>()> aggregation_callback)
+  Aggregation *GetOrSetDefault(
+      MetricAttributes &&attributes,
+      nostd::function_ref<std::unique_ptr<Aggregation>()> aggregation_callback)
   {
     auto it = hash_map_.find(attributes);
     if (it != hash_map_.end())
@@ -207,7 +210,7 @@ private:
   size_t attributes_limit_;
 
   Aggregation *GetOrSetOveflowAttributes(
-      std::function<std::unique_ptr<Aggregation>()> aggregation_callback)
+      nostd::function_ref<std::unique_ptr<Aggregation>()> aggregation_callback)
   {
     auto agg = aggregation_callback();
     return GetOrSetOveflowAttributes(std::move(agg));

--- a/sdk/test/metrics/attributes_hashmap_benchmark.cc
+++ b/sdk/test/metrics/attributes_hashmap_benchmark.cc
@@ -11,6 +11,7 @@
 #include <thread>
 #include <vector>
 
+#include "opentelemetry/nostd/function_ref.h"
 #include "opentelemetry/sdk/metrics/aggregation/aggregation.h"
 #include "opentelemetry/sdk/metrics/aggregation/drop_aggregation.h"
 #include "opentelemetry/sdk/metrics/state/attributes_hashmap.h"


### PR DESCRIPTION
## Changes

Use nostd::function_ref in AttributesHashMap for `aggregation_callback`.

A benchmark at https://github.com/grpc/grpc/blob/507a5de9483c9b8675e626977a51d9286f4104f0/test/cpp/microbenchmarks/bm_stats_plugin.cc#L81. shows time go down from 200+ns to ~20ns.

Additionally, with the benchmarks run by @psx95 on BM_AttributseHashMap -

Current HEAD ([merged PR#3383](https://github.com/open-telemetry/opentelemetry-cpp/actions/runs/14851261737/job/41708957121?pr=3383)):

```
"benchmarks": [
    {
      "name": "BM_AttributseHashMap",
      "family_index": 0,
      "per_family_instance_index": 0,
      "run_name": "BM_AttributseHashMap",
      "run_type": "iteration",
      "repetitions": 1,
      "repetition_index": 0,
      "threads": 1,
      "iterations": 7,
      "real_time": 3.8004398345947266e+07,
      "cpu_time": 2.0847316142857142e+07,
      "time_unit": "ns"
    }
  ]
```
This PR's [CI](https://github.com/open-telemetry/opentelemetry-cpp/actions/runs/14879093619/job/41782702404):
```
"benchmarks": [
    {
      "name": "BM_AttributseHashMap",
      "family_index": 0,
      "per_family_instance_index": 0,
      "run_name": "BM_AttributseHashMap",
      "run_type": "iteration",
      "repetitions": 1,
      "repetition_index": 0,
      "threads": 1,
      "iterations": 8,
      "real_time": 2.9205620288848877e+07,
      "cpu_time": 2.0728138000000000e+07,
      "time_unit": "ns"
    }
  ]
```
Looking at the implementation, we don't need to make a copy of the passed in callable, so it seems desirable to do this.

For significant contributions please make sure you have completed the following items:

* [x] `CHANGELOG.md` updated for non-trivial changes
* [ ] Unit tests have been added
* [ ] Changes in public API reviewed