### PR TITLE
[CMAKE] update cmake files in examples directory

### DIFF
--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 add_subdirectory(common)
-include_directories(common)
+
 if(WITH_OTLP_GRPC
    OR WITH_OTLP_HTTP
    OR WITH_OTLP_FILE)

--- a/examples/batch/CMakeLists.txt
+++ b/examples/batch/CMakeLists.txt
@@ -1,9 +1,7 @@
 # Copyright The OpenTelemetry Authors
 # SPDX-License-Identifier: Apache-2.0
-
-include_directories(${CMAKE_SOURCE_DIR}/exporters/ostream/include)
-
 add_executable(batch_span_processor_example main.cc)
 
-target_link_libraries(batch_span_processor_example ${CMAKE_THREAD_LIBS_INIT}
-                      opentelemetry_exporter_ostream_span opentelemetry_trace)
+target_link_libraries(
+  batch_span_processor_example PRIVATE opentelemetry-cpp::ostream_span_exporter
+                                       opentelemetry-cpp::trace)

--- a/examples/common/CMakeLists.txt
+++ b/examples/common/CMakeLists.txt
@@ -1,6 +1,7 @@
 # Copyright The OpenTelemetry Authors
 # SPDX-License-Identifier: Apache-2.0
 
+set(EXAMPLES_COMMON_DIR ${CMAKE_CURRENT_SOURCE_DIR})
 add_subdirectory(foo_library)
 add_subdirectory(logs_foo_library)
 add_subdirectory(metrics_foo_library)

--- a/examples/common/foo_library/CMakeLists.txt
+++ b/examples/common/foo_library/CMakeLists.txt
@@ -1,12 +1,15 @@
 # Copyright The OpenTelemetry Authors
 # SPDX-License-Identifier: Apache-2.0
 
-if(DEFINED OPENTELEMETRY_BUILD_DLL)
-  add_definitions(-DOPENTELEMETRY_BUILD_IMPORT_DLL)
-endif()
-
 add_library(common_foo_library foo_library.h foo_library.cc)
+
 set_target_version(common_foo_library)
 
-target_link_libraries(common_foo_library PUBLIC ${CMAKE_THREAD_LIBS_INIT}
-                                                opentelemetry_api)
+if(DEFINED OPENTELEMETRY_BUILD_DLL)
+  target_compile_definitions(common_foo_library
+                             PRIVATE OPENTELEMETRY_BUILD_IMPORT_DLL)
+endif()
+
+target_include_directories(common_foo_library
+                           PUBLIC "$<BUILD_INTERFACE:${EXAMPLES_COMMON_DIR}>")
+target_link_libraries(common_foo_library PRIVATE opentelemetry-cpp::api)

--- a/examples/common/logs_foo_library/CMakeLists.txt
+++ b/examples/common/logs_foo_library/CMakeLists.txt
@@ -1,12 +1,16 @@
 # Copyright The OpenTelemetry Authors
 # SPDX-License-Identifier: Apache-2.0
 
-if(DEFINED OPENTELEMETRY_BUILD_DLL)
-  add_definitions(-DOPENTELEMETRY_BUILD_IMPORT_DLL)
-endif()
-
 add_library(common_logs_foo_library foo_library.h foo_library.cc)
+
 set_target_version(common_logs_foo_library)
 
-target_link_libraries(common_logs_foo_library PUBLIC ${CMAKE_THREAD_LIBS_INIT}
-                                                     opentelemetry_api)
+if(DEFINED OPENTELEMETRY_BUILD_DLL)
+  target_compile_definitions(common_logs_foo_library
+                             PRIVATE OPENTELEMETRY_BUILD_IMPORT_DLL)
+endif()
+
+target_include_directories(common_logs_foo_library
+                           PUBLIC $<BUILD_INTERFACE:${EXAMPLES_COMMON_DIR}>)
+
+target_link_libraries(common_logs_foo_library PRIVATE opentelemetry-cpp::api)

--- a/examples/common/metrics_foo_library/CMakeLists.txt
+++ b/examples/common/metrics_foo_library/CMakeLists.txt
@@ -1,12 +1,16 @@
 # Copyright The OpenTelemetry Authors
 # SPDX-License-Identifier: Apache-2.0
 
-if(DEFINED OPENTELEMETRY_BUILD_DLL)
-  add_definitions(-DOPENTELEMETRY_BUILD_IMPORT_DLL)
-endif()
-
 add_library(common_metrics_foo_library foo_library.h foo_library.cc)
+
 set_target_version(common_metrics_foo_library)
 
-target_link_libraries(common_metrics_foo_library
-                      PUBLIC ${CMAKE_THREAD_LIBS_INIT} opentelemetry_api)
+if(DEFINED OPENTELEMETRY_BUILD_DLL)
+  target_compile_definitions(common_metrics_foo_library
+                             PRIVATE OPENTELEMETRY_BUILD_IMPORT_DLL)
+endif()
+
+target_include_directories(common_metrics_foo_library
+                           PUBLIC $<BUILD_INTERFACE:${EXAMPLES_COMMON_DIR}>)
+
+target_link_libraries(common_metrics_foo_library PRIVATE opentelemetry-cpp::api)

--- a/examples/etw_threads/CMakeLists.txt
+++ b/examples/etw_threads/CMakeLists.txt
@@ -5,5 +5,6 @@ project(etw_threadpool)
 
 add_executable(etw_threadpool main.cc)
 
-target_link_libraries(etw_threadpool ${CMAKE_THREAD_LIBS_INIT}
-                      opentelemetry_api opentelemetry_exporter_etw)
+target_link_libraries(
+  etw_threadpool PRIVATE Threads::Threads opentelemetry-cpp::api
+                         opentelemetry-cpp::etw_exporter)

--- a/examples/grpc/CMakeLists.txt
+++ b/examples/grpc/CMakeLists.txt
@@ -28,11 +28,8 @@ patch_protobuf_targets(example_grpc_proto)
 # Disable include-what-you-use on generated code.
 set_target_properties(example_grpc_proto PROPERTIES CXX_INCLUDE_WHAT_YOU_USE "")
 
-include_directories(
-  ${CMAKE_SOURCE_DIR}/exporters/ostream/include ${CMAKE_SOURCE_DIR}/ext/include
-  ${CMAKE_SOURCE_DIR}/api/include/ ${CMAKE_SOURCE_DIR/})
-
-include_directories(${CMAKE_CURRENT_BINARY_DIR})
+target_include_directories(
+  example_grpc_proto PUBLIC "$<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}>")
 
 if(TARGET protobuf::libprotobuf)
   target_link_libraries(example_grpc_proto PUBLIC gRPC::grpc++
@@ -45,7 +42,8 @@ endif()
 
 foreach(_target client server)
   add_executable(${_target} "${_target}.cc")
-  target_link_libraries(${_target} example_grpc_proto opentelemetry_trace
-                        opentelemetry_exporter_ostream_span)
+  target_link_libraries(
+    ${_target} PRIVATE example_grpc_proto
+                       opentelemetry-cpp::ostream_span_exporter)
   patch_protobuf_targets(${_target})
 endforeach()

--- a/examples/http/CMakeLists.txt
+++ b/examples/http/CMakeLists.txt
@@ -1,17 +1,15 @@
 # Copyright The OpenTelemetry Authors
 # SPDX-License-Identifier: Apache-2.0
 
-include_directories(${CMAKE_SOURCE_DIR}/exporters/ostream/include
-                    ${CMAKE_SOURCE_DIR}/ext/include ${CMAKE_SOURCE_DIR/})
-
 add_executable(http_client client.cc)
 add_executable(http_server server.cc)
 
 target_link_libraries(
-  http_client ${CMAKE_THREAD_LIBS_INIT} opentelemetry_trace
-  opentelemetry_http_client_curl opentelemetry_exporter_ostream_span
-  ${CURL_LIBRARIES})
+  http_client
+  PRIVATE opentelemetry-cpp::trace opentelemetry-cpp::http_client_curl
+          opentelemetry-cpp::ostream_span_exporter ${CURL_LIBRARIES})
 
 target_link_libraries(
-  http_server ${CMAKE_THREAD_LIBS_INIT} opentelemetry_trace
-  opentelemetry_http_client_curl opentelemetry_exporter_ostream_span)
+  http_server
+  PRIVATE opentelemetry-cpp::trace opentelemetry-cpp::http_client_curl
+          opentelemetry-cpp::ostream_span_exporter)

--- a/examples/logs_simple/CMakeLists.txt
+++ b/examples/logs_simple/CMakeLists.txt
@@ -1,20 +1,18 @@
 # Copyright The OpenTelemetry Authors
 # SPDX-License-Identifier: Apache-2.0
 
-if(DEFINED OPENTELEMETRY_BUILD_DLL)
-  add_definitions(-DOPENTELEMETRY_BUILD_IMPORT_DLL)
-endif()
-
-include_directories(${CMAKE_SOURCE_DIR}/exporters/ostream/include)
-
 add_executable(example_logs_simple main.cc)
-target_link_libraries(example_logs_simple ${CMAKE_THREAD_LIBS_INIT}
-                      common_logs_foo_library)
+target_link_libraries(example_logs_simple PRIVATE common_logs_foo_library)
 
 if(DEFINED OPENTELEMETRY_BUILD_DLL)
-  target_link_libraries(example_logs_simple opentelemetry_cpp)
+  target_compile_definitions(example_logs_simple
+                             PRIVATE OPENTELEMETRY_BUILD_IMPORT_DLL)
+  target_link_libraries(example_logs_simple
+                        PRIVATE opentelemetry-cpp::opentelemetry_cpp)
 else()
   target_link_libraries(
-    example_logs_simple opentelemetry_trace opentelemetry_logs
-    opentelemetry_exporter_ostream_span opentelemetry_exporter_ostream_logs)
+    example_logs_simple
+    PRIVATE opentelemetry-cpp::trace opentelemetry-cpp::logs
+            opentelemetry-cpp::ostream_span_exporter
+            opentelemetry-cpp::ostream_log_record_exporter)
 endif()

--- a/examples/metrics_simple/CMakeLists.txt
+++ b/examples/metrics_simple/CMakeLists.txt
@@ -1,20 +1,18 @@
 # Copyright The OpenTelemetry Authors
 # SPDX-License-Identifier: Apache-2.0
 
-if(DEFINED OPENTELEMETRY_BUILD_DLL)
-  add_definitions(-DOPENTELEMETRY_BUILD_IMPORT_DLL)
-endif()
-
-include_directories(${CMAKE_SOURCE_DIR}/exporters/ostream/include)
-
 add_executable(metrics_ostream_example metrics_ostream.cc)
-target_link_libraries(metrics_ostream_example ${CMAKE_THREAD_LIBS_INIT}
-                      common_metrics_foo_library)
+
+target_link_libraries(metrics_ostream_example
+                      PRIVATE common_metrics_foo_library)
 
 if(DEFINED OPENTELEMETRY_BUILD_DLL)
-  target_link_libraries(metrics_ostream_example opentelemetry_cpp)
+  target_compile_definitions(metrics_ostream_example
+                             PRIVATE OPENTELEMETRY_BUILD_IMPORT_DLL)
+  target_link_libraries(metrics_ostream_example
+                        PRIVATE opentelemetry-cpp::opentelemetry_cpp)
 else()
   target_link_libraries(
-    metrics_ostream_example opentelemetry_metrics
-    opentelemetry_exporter_ostream_metrics opentelemetry_resources)
+    metrics_ostream_example PRIVATE opentelemetry-cpp::metrics
+                                    opentelemetry-cpp::ostream_metrics_exporter)
 endif()

--- a/examples/multi_processor/CMakeLists.txt
+++ b/examples/multi_processor/CMakeLists.txt
@@ -1,11 +1,9 @@
 # Copyright The OpenTelemetry Authors
 # SPDX-License-Identifier: Apache-2.0
 
-include_directories(${CMAKE_SOURCE_DIR}/exporters/ostream/include
-                    ${CMAKE_SOURCE_DIR}/exporters/memory/include)
-
 add_executable(example_multi_processor main.cc)
 target_link_libraries(
-  example_multi_processor ${CMAKE_THREAD_LIBS_INIT} common_foo_library
-  opentelemetry_trace opentelemetry_exporter_ostream_span
-  opentelemetry_exporter_in_memory)
+  example_multi_processor
+  PRIVATE common_foo_library opentelemetry-cpp::trace
+          opentelemetry-cpp::ostream_span_exporter
+          opentelemetry-cpp::in_memory_span_exporter)

--- a/examples/multithreaded/CMakeLists.txt
+++ b/examples/multithreaded/CMakeLists.txt
@@ -1,8 +1,7 @@
 # Copyright The OpenTelemetry Authors
 # SPDX-License-Identifier: Apache-2.0
 
-include_directories(${CMAKE_SOURCE_DIR}/exporters/ostream/include)
-
 add_executable(example_multithreaded main.cc)
-target_link_libraries(example_multithreaded ${CMAKE_THREAD_LIBS_INIT}
-                      opentelemetry_trace opentelemetry_exporter_ostream_span)
+target_link_libraries(
+  example_multithreaded PRIVATE opentelemetry-cpp::trace
+                                opentelemetry-cpp::ostream_span_exporter)

--- a/examples/otlp/CMakeLists.txt
+++ b/examples/otlp/CMakeLists.txt
@@ -1,55 +1,55 @@
 # Copyright The OpenTelemetry Authors
 # SPDX-License-Identifier: Apache-2.0
 
-if(DEFINED OPENTELEMETRY_BUILD_DLL)
-  add_definitions(-DOPENTELEMETRY_BUILD_IMPORT_DLL)
-endif()
-
-include_directories(
-  ${CMAKE_BINARY_DIR}/generated/third_party/opentelemetry-proto
-  ${CMAKE_SOURCE_DIR}/exporters/otlp/include)
-
 if(WITH_OTLP_GRPC)
   # TRACE
 
   add_executable(example_otlp_grpc grpc_main.cc)
 
-  target_link_libraries(example_otlp_grpc ${CMAKE_THREAD_LIBS_INIT}
-                        common_foo_library)
+  target_link_libraries(example_otlp_grpc PRIVATE common_foo_library)
 
   if(DEFINED OPENTELEMETRY_BUILD_DLL)
-    target_link_libraries(example_otlp_grpc opentelemetry_cpp)
+    target_compile_definitions(example_otlp_grpc
+                               PRIVATE OPENTELEMETRY_BUILD_IMPORT_DLL)
+    target_link_libraries(example_otlp_grpc
+                          PRIVATE opentelemetry-cpp::opentelemetry_cpp)
   else()
-    target_link_libraries(example_otlp_grpc opentelemetry_trace
-                          opentelemetry_exporter_otlp_grpc)
+    target_link_libraries(example_otlp_grpc
+                          PRIVATE opentelemetry-cpp::otlp_grpc_exporter)
   endif()
 
   # METRIC
 
   add_executable(example_otlp_grpc_metric grpc_metric_main.cc)
 
-  target_link_libraries(example_otlp_grpc_metric ${CMAKE_THREAD_LIBS_INIT}
-                        common_metrics_foo_library)
+  target_link_libraries(example_otlp_grpc_metric
+                        PRIVATE common_metrics_foo_library)
 
   if(DEFINED OPENTELEMETRY_BUILD_DLL)
-    target_link_libraries(example_otlp_grpc_metric opentelemetry_cpp)
+    target_compile_definitions(example_otlp_grpc_metric
+                               PRIVATE OPENTELEMETRY_BUILD_IMPORT_DLL)
+    target_link_libraries(example_otlp_grpc_metric
+                          PRIVATE opentelemetry-cpp::opentelemetry_cpp)
   else()
-    target_link_libraries(example_otlp_grpc_metric opentelemetry_metrics
-                          opentelemetry_exporter_otlp_grpc_metrics)
+    target_link_libraries(example_otlp_grpc_metric
+                          PRIVATE opentelemetry-cpp::otlp_grpc_metrics_exporter)
   endif()
 
   # LOG
 
   add_executable(example_otlp_grpc_log grpc_log_main.cc)
 
-  target_link_libraries(example_otlp_grpc_log ${CMAKE_THREAD_LIBS_INIT}
-                        common_logs_foo_library)
+  target_link_libraries(example_otlp_grpc_log PRIVATE common_logs_foo_library)
   if(DEFINED OPENTELEMETRY_BUILD_DLL)
-    target_link_libraries(example_otlp_grpc_log opentelemetry_cpp)
+    target_compile_definitions(example_otlp_grpc_log
+                               PRIVATE OPENTELEMETRY_BUILD_IMPORT_DLL)
+    target_link_libraries(example_otlp_grpc_log
+                          PRIVATE opentelemetry-cpp::opentelemetry_cpp)
   else()
     target_link_libraries(
-      example_otlp_grpc_log opentelemetry_trace opentelemetry_logs
-      opentelemetry_exporter_otlp_grpc opentelemetry_exporter_otlp_grpc_log)
+      example_otlp_grpc_log
+      PRIVATE opentelemetry-cpp::otlp_grpc_exporter
+              opentelemetry-cpp::otlp_grpc_log_record_exporter)
   endif()
 endif()
 
@@ -58,45 +58,48 @@ if(WITH_OTLP_HTTP)
 
   add_executable(example_otlp_http http_main.cc)
 
-  target_link_libraries(example_otlp_http ${CMAKE_THREAD_LIBS_INIT}
-                        common_foo_library)
+  target_link_libraries(example_otlp_http PRIVATE common_foo_library)
   if(DEFINED OPENTELEMETRY_BUILD_DLL)
-    target_link_libraries(example_otlp_http opentelemetry_cpp
-                          opentelemetry_common)
+    target_compile_definitions(example_otlp_http
+                               PRIVATE OPENTELEMETRY_BUILD_IMPORT_DLL)
+    target_link_libraries(example_otlp_http
+                          PRIVATE opentelemetry-cpp::opentelemetry_cpp)
   else()
-    target_link_libraries(example_otlp_http opentelemetry_trace
-                          opentelemetry_exporter_otlp_http)
+    target_link_libraries(example_otlp_http
+                          PRIVATE opentelemetry-cpp::otlp_http_exporter)
   endif()
 
   # METRIC
 
   add_executable(example_otlp_http_metric http_metric_main.cc)
-  target_link_libraries(example_otlp_http_metric ${CMAKE_THREAD_LIBS_INIT}
-                        common_metrics_foo_library)
+  target_link_libraries(example_otlp_http_metric
+                        PRIVATE common_metrics_foo_library)
 
   if(DEFINED OPENTELEMETRY_BUILD_DLL)
-    target_link_libraries(example_otlp_http_metric opentelemetry_cpp
-                          opentelemetry_common)
+    target_compile_definitions(example_otlp_http_metric
+                               PRIVATE OPENTELEMETRY_BUILD_IMPORT_DLL)
+    target_link_libraries(example_otlp_http_metric
+                          PRIVATE opentelemetry-cpp::opentelemetry_cpp)
   else()
-    target_link_libraries(
-      example_otlp_http_metric common_metrics_foo_library opentelemetry_metrics
-      opentelemetry_exporter_otlp_http_metric)
+    target_link_libraries(example_otlp_http_metric
+                          PRIVATE opentelemetry-cpp::otlp_http_metric_exporter)
   endif()
 
   # LOG
 
   add_executable(example_otlp_http_log http_log_main.cc)
-  target_link_libraries(example_otlp_http_log ${CMAKE_THREAD_LIBS_INIT}
-                        common_logs_foo_library)
+  target_link_libraries(example_otlp_http_log PRIVATE common_logs_foo_library)
 
   if(DEFINED OPENTELEMETRY_BUILD_DLL)
-    target_link_libraries(example_otlp_http_log opentelemetry_cpp
-                          opentelemetry_common)
+    target_compile_definitions(example_otlp_http_log
+                               PRIVATE OPENTELEMETRY_BUILD_IMPORT_DLL)
+    target_link_libraries(example_otlp_http_log
+                          PRIVATE opentelemetry-cpp::opentelemetry_cpp)
   else()
     target_link_libraries(
-      example_otlp_http_log common_logs_foo_library opentelemetry_trace
-      opentelemetry_logs opentelemetry_exporter_otlp_http
-      opentelemetry_exporter_otlp_http_log)
+      example_otlp_http_log
+      PRIVATE opentelemetry-cpp::otlp_http_exporter
+              opentelemetry-cpp::otlp_http_log_record_exporter)
   endif()
 
   # ALL, instrumented
@@ -105,21 +108,20 @@ if(WITH_OTLP_HTTP)
 
   # Note: common_logs_foo_library provide traces and logs
   target_link_libraries(
-    example_otlp_instrumented_http ${CMAKE_THREAD_LIBS_INIT}
-    common_metrics_foo_library common_logs_foo_library)
+    example_otlp_instrumented_http PRIVATE common_metrics_foo_library
+                                           common_logs_foo_library)
 
   if(DEFINED OPENTELEMETRY_BUILD_DLL)
-    target_link_libraries(example_otlp_instrumented_http opentelemetry_cpp
-                          opentelemetry_common)
+    target_compile_definitions(example_otlp_instrumented_http
+                               PRIVATE OPENTELEMETRY_BUILD_IMPORT_DLL)
+    target_link_libraries(example_otlp_instrumented_http
+                          opentelemetry-cpp::opentelemetry_cpp)
   else()
     target_link_libraries(
       example_otlp_instrumented_http
-      opentelemetry_trace
-      opentelemetry_metrics
-      opentelemetry_logs
-      opentelemetry_exporter_otlp_http
-      opentelemetry_exporter_otlp_http_metric
-      opentelemetry_exporter_otlp_http_log)
+      PRIVATE opentelemetry-cpp::otlp_http_exporter
+              opentelemetry-cpp::otlp_http_metric_exporter
+              opentelemetry-cpp::otlp_http_log_record_exporter)
   endif()
 
 endif()
@@ -129,41 +131,49 @@ if(WITH_OTLP_FILE)
 
   add_executable(example_otlp_file file_main.cc)
 
-  target_link_libraries(example_otlp_file ${CMAKE_THREAD_LIBS_INIT}
-                        common_foo_library)
+  target_link_libraries(example_otlp_file PRIVATE common_foo_library)
 
   if(DEFINED OPENTELEMETRY_BUILD_DLL)
-    target_link_libraries(example_otlp_file opentelemetry_cpp)
+    target_compile_definitions(example_otlp_file
+                               PRIVATE OPENTELEMETRY_BUILD_IMPORT_DLL)
+    target_link_libraries(example_otlp_file
+                          PRIVATE opentelemetry-cpp::opentelemetry_cpp)
   else()
-    target_link_libraries(example_otlp_file opentelemetry_trace
-                          opentelemetry_exporter_otlp_file)
+    target_link_libraries(example_otlp_file
+                          PRIVATE opentelemetry-cpp::otlp_file_exporter)
   endif()
 
   # METRIC
 
   add_executable(example_otlp_file_metric file_metric_main.cc)
 
-  target_link_libraries(example_otlp_file_metric ${CMAKE_THREAD_LIBS_INIT}
-                        common_metrics_foo_library)
+  target_link_libraries(example_otlp_file_metric
+                        PRIVATE common_metrics_foo_library)
 
   if(DEFINED OPENTELEMETRY_BUILD_DLL)
-    target_link_libraries(example_otlp_file_metric opentelemetry_cpp)
+    target_compile_definitions(example_otlp_file_metric
+                               PRIVATE OPENTELEMETRY_BUILD_IMPORT_DLL)
+    target_link_libraries(example_otlp_file_metric
+                          PRIVATE opentelemetry-cpp::opentelemetry_cpp)
   else()
-    target_link_libraries(example_otlp_file_metric opentelemetry_metrics
-                          opentelemetry_exporter_otlp_file_metric)
+    target_link_libraries(example_otlp_file_metric
+                          PRIVATE opentelemetry-cpp::otlp_file_metric_exporter)
   endif()
 
   # LOG
 
   add_executable(example_otlp_file_log file_log_main.cc)
 
-  target_link_libraries(example_otlp_file_log ${CMAKE_THREAD_LIBS_INIT}
-                        common_logs_foo_library)
+  target_link_libraries(example_otlp_file_log PRIVATE common_logs_foo_library)
   if(DEFINED OPENTELEMETRY_BUILD_DLL)
-    target_link_libraries(example_otlp_file_log opentelemetry_cpp)
+    target_compile_definitions(example_otlp_file_log
+                               PRIVATE OPENTELEMETRY_BUILD_IMPORT_DLL)
+    target_link_libraries(example_otlp_file_log
+                          PRIVATE opentelemetry-cpp::opentelemetry_cpp)
   else()
     target_link_libraries(
-      example_otlp_file_log opentelemetry_trace opentelemetry_logs
-      opentelemetry_exporter_otlp_file opentelemetry_exporter_otlp_file_log)
+      example_otlp_file_log
+      PRIVATE opentelemetry-cpp::otlp_file_exporter
+              opentelemetry-cpp::otlp_file_log_record_exporter)
   endif()
 endif()

--- a/examples/plugin/load/CMakeLists.txt
+++ b/examples/plugin/load/CMakeLists.txt
@@ -2,4 +2,5 @@
 # SPDX-License-Identifier: Apache-2.0
 
 add_executable(load_plugin_example main.cc)
-target_link_libraries(load_plugin_example opentelemetry_api ${CMAKE_DL_LIBS})
+target_link_libraries(load_plugin_example PRIVATE opentelemetry-cpp::api
+                                                  ${CMAKE_DL_LIBS})

--- a/examples/plugin/plugin/CMakeLists.txt
+++ b/examples/plugin/plugin/CMakeLists.txt
@@ -2,4 +2,4 @@
 # SPDX-License-Identifier: Apache-2.0
 
 add_library(example_plugin SHARED tracer.cc factory_impl.cc)
-target_link_libraries(example_plugin opentelemetry_api)
+target_link_libraries(example_plugin PUBLIC opentelemetry-cpp::api)

--- a/examples/prometheus/CMakeLists.txt
+++ b/examples/prometheus/CMakeLists.txt
@@ -1,9 +1,7 @@
 # Copyright The OpenTelemetry Authors
 # SPDX-License-Identifier: Apache-2.0
 
-include_directories(${CMAKE_SOURCE_DIR}/exporters/prometheus/include)
 add_executable(prometheus_example main.cc)
 target_link_libraries(
-  prometheus_example ${CMAKE_THREAD_LIBS_INIT} opentelemetry_metrics
-  opentelemetry_exporter_prometheus opentelemetry_resources
-  common_metrics_foo_library)
+  prometheus_example PRIVATE opentelemetry-cpp::prometheus_exporter
+                             common_metrics_foo_library)

--- a/examples/simple/CMakeLists.txt
+++ b/examples/simple/CMakeLists.txt
@@ -1,19 +1,16 @@
 # Copyright The OpenTelemetry Authors
 # SPDX-License-Identifier: Apache-2.0
 
-if(DEFINED OPENTELEMETRY_BUILD_DLL)
-  add_definitions(-DOPENTELEMETRY_BUILD_IMPORT_DLL)
-endif()
-
-include_directories(${CMAKE_SOURCE_DIR}/exporters/ostream/include)
-
 add_executable(example_simple main.cc)
-target_link_libraries(example_simple ${CMAKE_THREAD_LIBS_INIT}
-                      common_foo_library)
+target_link_libraries(example_simple PRIVATE common_foo_library)
 
 if(DEFINED OPENTELEMETRY_BUILD_DLL)
-  target_link_libraries(example_simple opentelemetry_cpp)
+  target_compile_definitions(example_simple
+                             PRIVATE OPENTELEMETRY_BUILD_IMPORT_DLL)
+  target_link_libraries(example_simple
+                        PRIVATE opentelemetry-cpp::opentelemetry_cpp)
 else()
-  target_link_libraries(example_simple opentelemetry_trace
-                        opentelemetry_exporter_ostream_span)
+  target_link_libraries(
+    example_simple PRIVATE opentelemetry-cpp::trace
+                           opentelemetry-cpp::ostream_span_exporter)
 endif()

--- a/examples/zipkin/CMakeLists.txt
+++ b/examples/zipkin/CMakeLists.txt
@@ -1,9 +1,7 @@
 # Copyright The OpenTelemetry Authors
 # SPDX-License-Identifier: Apache-2.0
 
-include_directories(${CMAKE_SOURCE_DIR}/exporters/zipkin/include)
-
 add_executable(example_zipkin main.cc)
 target_link_libraries(
-  example_zipkin ${CMAKE_THREAD_LIBS_INIT} common_foo_library
-  opentelemetry_trace opentelemetry_exporter_zipkin_trace)
+  example_zipkin PRIVATE common_foo_library
+                         opentelemetry-cpp::zipkin_trace_exporter)

--- a/ext/src/dll/CMakeLists.txt
+++ b/ext/src/dll/CMakeLists.txt
@@ -13,60 +13,124 @@ target_link_libraries(
   opentelemetry_cpp PRIVATE opentelemetry_trace
                             opentelemetry_exporter_ostream_span)
 
+target_include_directories(
+  opentelemetry_cpp
+  PUBLIC
+    $<TARGET_PROPERTY:opentelemetry_trace,INTERFACE_INCLUDE_DIRECTORIES>
+    $<TARGET_PROPERTY:opentelemetry_exporter_ostream_span,INTERFACE_INCLUDE_DIRECTORIES>
+)
+
 if(WITH_OTLP_GRPC)
-  add_compile_definitions(WITH_OTLP_GRPC)
+  target_compile_definitions(opentelemetry_cpp PRIVATE WITH_OTLP_GRPC)
   target_link_libraries(opentelemetry_cpp
                         PRIVATE opentelemetry_exporter_otlp_grpc)
+  target_include_directories(
+    opentelemetry_cpp
+    PUBLIC
+      $<TARGET_PROPERTY:opentelemetry_exporter_otlp_grpc,INTERFACE_INCLUDE_DIRECTORIES>
+  )
 endif()
 
 if(WITH_OTLP_HTTP)
-  add_compile_definitions(WITH_OTLP_HTTP)
+  target_compile_definitions(opentelemetry_cpp PRIVATE WITH_OTLP_HTTP)
   target_link_libraries(opentelemetry_cpp
                         PRIVATE opentelemetry_exporter_otlp_http)
+  target_include_directories(
+    opentelemetry_cpp
+    PUBLIC
+      $<TARGET_PROPERTY:opentelemetry_exporter_otlp_http,INTERFACE_INCLUDE_DIRECTORIES>
+  )
 endif()
 
 if(WITH_OTLP_FILE)
-  add_compile_definitions(WITH_OTLP_FILE)
+  target_compile_definitions(opentelemetry_cpp PRIVATE WITH_OTLP_FILE)
   target_link_libraries(opentelemetry_cpp
                         PRIVATE opentelemetry_exporter_otlp_file)
+  target_include_directories(
+    opentelemetry_cpp
+    PUBLIC
+      $<TARGET_PROPERTY:opentelemetry_exporter_otlp_file,INTERFACE_INCLUDE_DIRECTORIES>
+  )
 endif()
 
 target_link_libraries(
   opentelemetry_cpp PRIVATE opentelemetry_metrics
                             opentelemetry_exporter_ostream_metrics)
+target_include_directories(
+  opentelemetry_cpp
+  PUBLIC
+    $<TARGET_PROPERTY:opentelemetry_metrics,INTERFACE_INCLUDE_DIRECTORIES>
+    $<TARGET_PROPERTY:opentelemetry_exporter_ostream_metrics,INTERFACE_INCLUDE_DIRECTORIES>
+)
 
 if(WITH_OTLP_GRPC)
   target_link_libraries(opentelemetry_cpp
                         PRIVATE opentelemetry_exporter_otlp_grpc_metrics)
+  target_include_directories(
+    opentelemetry_cpp
+    PUBLIC
+      $<TARGET_PROPERTY:opentelemetry_exporter_otlp_grpc_metrics,INTERFACE_INCLUDE_DIRECTORIES>
+  )
 endif()
 
 if(WITH_OTLP_HTTP)
   target_link_libraries(opentelemetry_cpp
                         PRIVATE opentelemetry_exporter_otlp_http_metric)
+  target_include_directories(
+    opentelemetry_cpp
+    PUBLIC
+      $<TARGET_PROPERTY:opentelemetry_exporter_otlp_http_metric,INTERFACE_INCLUDE_DIRECTORIES>
+  )
 endif()
 
 if(WITH_OTLP_FILE)
   target_link_libraries(opentelemetry_cpp
                         PRIVATE opentelemetry_exporter_otlp_file_metric)
+  target_include_directories(
+    opentelemetry_cpp
+    PUBLIC
+      $<TARGET_PROPERTY:opentelemetry_exporter_otlp_file_metric,INTERFACE_INCLUDE_DIRECTORIES>
+  )
 endif()
 
 target_link_libraries(
   opentelemetry_cpp PRIVATE opentelemetry_logs
                             opentelemetry_exporter_ostream_logs)
+target_include_directories(
+  opentelemetry_cpp
+  PUBLIC
+    $<TARGET_PROPERTY:opentelemetry_logs,INTERFACE_INCLUDE_DIRECTORIES>
+    $<TARGET_PROPERTY:opentelemetry_exporter_ostream_logs,INTERFACE_INCLUDE_DIRECTORIES>
+)
 
 if(WITH_OTLP_GRPC)
   target_link_libraries(opentelemetry_cpp
                         PRIVATE opentelemetry_exporter_otlp_grpc_log)
+  target_include_directories(
+    opentelemetry_cpp
+    PUBLIC
+      $<TARGET_PROPERTY:opentelemetry_exporter_otlp_grpc_log,INTERFACE_INCLUDE_DIRECTORIES>
+  )
 endif()
 
 if(WITH_OTLP_HTTP)
   target_link_libraries(opentelemetry_cpp
                         PRIVATE opentelemetry_exporter_otlp_http_log)
+  target_include_directories(
+    opentelemetry_cpp
+    PUBLIC
+      $<TARGET_PROPERTY:opentelemetry_exporter_otlp_http_log,INTERFACE_INCLUDE_DIRECTORIES>
+  )
 endif()
 
 if(WITH_OTLP_FILE)
   target_link_libraries(opentelemetry_cpp
                         PRIVATE opentelemetry_exporter_otlp_file_log)
+  target_include_directories(
+    opentelemetry_cpp
+    PUBLIC
+      $<TARGET_PROPERTY:opentelemetry_exporter_otlp_file_log,INTERFACE_INCLUDE_DIRECTORIES>
+  )
 endif()
 
 find_program(

--- a/install/test/cmake/component_tests/ext_dll/CMakeLists.txt
+++ b/install/test/cmake/component_tests/ext_dll/CMakeLists.txt
@@ -4,17 +4,14 @@
 cmake_minimum_required(VERSION 3.14)
 project(opentelemetry-cpp-ext_dll-install-test LANGUAGES CXX)
 
-find_package(opentelemetry-cpp REQUIRED COMPONENTS ext_dll)
-
-add_definitions(-DOPENTELEMETRY_BUILD_IMPORT_DLL)
+find_package(opentelemetry-cpp REQUIRED COMPONENTS ext_dll exporters_ostream)
 
 find_package(GTest CONFIG REQUIRED)
 include(GoogleTest)
 
 add_executable(ext_dll_test ${INSTALL_TEST_SRC_DIR}/test_ext_dll.cc)
 
-target_include_directories(ext_dll_test
-                           PRIVATE ${OPENTELEMETRY_CPP_INCLUDE_DIRS})
+target_compile_definitions(ext_dll_test PRIVATE OPENTELEMETRY_BUILD_IMPORT_DLL)
 
 target_link_libraries(ext_dll_test PRIVATE opentelemetry-cpp::opentelemetry_cpp
                                            GTest::gtest GTest::gtest_main)


### PR DESCRIPTION
Fixes #3399

Updates the examples' cmake files to use the read-only ALIAS targets of `opentelemetry-cpp` added by https://github.com/open-telemetry/opentelemetry-cpp/pull/3368 and to use explicitly scoped target properties. 

## Changes
- Use public read-only `opentelemetry-cpp` ALIAS targets (ie: `opentelemetry-cpp::api` in place of `opentelemetry_api`)
- Use `target_compile_definitions` in place of `add_definitions` 
- Use `target_include_directories` in place of `include_directories`
- Add explicit scope keywords (ie: `PRIVATE`, `PUBLIC`) to `target_link_libraries`
- Remove some redundant target linking and includes
  - Rely on the transitive `PUBLIC` target properties (definitions, linked libraries, include directories) 
-  Replace `CMAKE_THREAD_LIBS_INIT` with the `Threads::Threads` target where needed, otherwise remove it and rely on the `opentelemetry-cpp::common` target's public transitive link to Threads.  
- Update the dll target (`opentelemetry-cpp::opentelemetry_cpp`) to include the directories for headers it depends on. Update the `ext_dll` component install test to verify.

For significant contributions please make sure you have completed the following items:

* [ ] `CHANGELOG.md` updated for non-trivial changes
* [ ] Unit tests have been added
* [ ] Changes in public API reviewed