### PR TITLE
[CMAKE] remove global include_directories usage and rely on target properties

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,9 @@ Increment the:
 * [CMAKE] Add generated protobuf headers to the opentelemetry_proto target
   [#3400](https://github.com/open-telemetry/opentelemetry-cpp/pull/3400)
 
+* [CMAKE] Remove include_directories usage and rely on target properties
+  [#3426](https://github.com/open-telemetry/opentelemetry-cpp/pull/3426)
+
 ## [1.20 2025-04-01]
 
 * [BUILD] Update opentelemetry-proto version

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -859,8 +859,6 @@ if(DEFINED OPENTELEMETRY_BUILD_DLL)
   add_definitions(-DOPENTELEMETRY_BUILD_EXPORT_DLL)
 endif()
 
-include_directories(api/include)
-
 add_subdirectory(api)
 
 if(WITH_OPENTRACING)
@@ -893,9 +891,6 @@ endif()
 
 if(NOT WITH_API_ONLY)
   set(BUILD_TESTING ${BUILD_TESTING})
-  include_directories(sdk/include)
-  include_directories(sdk)
-  include_directories(ext/include)
 
   add_subdirectory(sdk)
   add_subdirectory(ext)

--- a/examples/common/foo_library/foo_library.cc
+++ b/examples/common/foo_library/foo_library.cc
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "opentelemetry/nostd/shared_ptr.h"
-#include "opentelemetry/sdk/version/version.h"
 #include "opentelemetry/trace/provider.h"
 #include "opentelemetry/trace/scope.h"
 #include "opentelemetry/trace/tracer.h"
@@ -16,7 +15,7 @@ namespace
 nostd::shared_ptr<trace::Tracer> get_tracer()
 {
   auto provider = trace::Provider::GetTracerProvider();
-  return provider->GetTracer("foo_library", OPENTELEMETRY_SDK_VERSION);
+  return provider->GetTracer("foo_library");
 }
 
 void f1()

--- a/examples/common/logs_foo_library/foo_library.cc
+++ b/examples/common/logs_foo_library/foo_library.cc
@@ -5,7 +5,6 @@
 #include "opentelemetry/logs/logger_provider.h"
 #include "opentelemetry/logs/provider.h"
 #include "opentelemetry/nostd/shared_ptr.h"
-#include "opentelemetry/sdk/version/version.h"
 #include "opentelemetry/trace/provider.h"
 #include "opentelemetry/trace/scope.h"
 #include "opentelemetry/trace/span.h"
@@ -21,7 +20,7 @@ namespace
 opentelemetry::nostd::shared_ptr<trace::Tracer> get_tracer()
 {
   auto provider = trace::Provider::GetTracerProvider();
-  return provider->GetTracer("foo_library", OPENTELEMETRY_SDK_VERSION);
+  return provider->GetTracer("foo_library");
 }
 
 opentelemetry::nostd::shared_ptr<logs::Logger> get_logger()

--- a/exporters/prometheus/CMakeLists.txt
+++ b/exporters/prometheus/CMakeLists.txt
@@ -1,7 +1,6 @@
 # Copyright The OpenTelemetry Authors
 # SPDX-License-Identifier: Apache-2.0
 
-include_directories(include)
 if(NOT TARGET prometheus-cpp::core)
   find_package(prometheus-cpp CONFIG REQUIRED)
 endif()

--- a/exporters/zipkin/CMakeLists.txt
+++ b/exporters/zipkin/CMakeLists.txt
@@ -1,8 +1,6 @@
 # Copyright The OpenTelemetry Authors
 # SPDX-License-Identifier: Apache-2.0
 
-include_directories(include)
-add_definitions(-DWITH_CURL)
 add_library(
   opentelemetry_exporter_zipkin_trace
   src/zipkin_exporter.cc src/zipkin_exporter_factory.cc src/recordable.cc)

--- a/ext/test/http/CMakeLists.txt
+++ b/ext/test/http/CMakeLists.txt
@@ -22,7 +22,7 @@ if(WITH_HTTP_CLIENT_CURL)
     target_link_libraries(${FILENAME} opentelemetry_http_client_curl
                           opentelemetry_common ${CURL_IMPORTED_TARGET_NAME})
   else()
-    include_directories(${CURL_INCLUDE_DIRS})
+    target_include_directories(${FILENAME} PRIVATE ${CURL_INCLUDE_DIRS})
     target_link_libraries(${FILENAME} ${CURL_LIBRARIES}
                           opentelemetry_http_client_curl opentelemetry_common)
   endif()
@@ -35,7 +35,7 @@ endif()
 
 set(URL_PARSER_FILENAME url_parser_test)
 add_executable(${URL_PARSER_FILENAME} ${URL_PARSER_FILENAME}.cc)
-target_link_libraries(${URL_PARSER_FILENAME} opentelemetry_api ${GMOCK_LIB}
+target_link_libraries(${URL_PARSER_FILENAME} opentelemetry_ext ${GMOCK_LIB}
                       ${GTEST_BOTH_LIBRARIES} ${CMAKE_THREAD_LIBS_INIT})
 gtest_add_tests(
   TARGET ${URL_PARSER_FILENAME}

--- a/ext/test/w3c_tracecontext_http_test_server/CMakeLists.txt
+++ b/ext/test/w3c_tracecontext_http_test_server/CMakeLists.txt
@@ -1,8 +1,6 @@
 # Copyright The OpenTelemetry Authors
 # SPDX-License-Identifier: Apache-2.0
 
-include_directories(${CMAKE_SOURCE_DIR}/exporters/ostream/include)
-
 add_executable(w3c_tracecontext_http_test_server main.cc)
 target_link_libraries(
   w3c_tracecontext_http_test_server

--- a/functional/otlp/CMakeLists.txt
+++ b/functional/otlp/CMakeLists.txt
@@ -1,8 +1,6 @@
 # Copyright The OpenTelemetry Authors
 # SPDX-License-Identifier: Apache-2.0
 
-include_directories(${CMAKE_SOURCE_DIR}/exporters/otlp/include)
-
 if(WITH_OTLP_GRPC)
   add_executable(func_otlp_grpc func_grpc_main.cc)
   target_link_libraries(func_otlp_grpc ${CMAKE_THREAD_LIBS_INIT}

--- a/sdk/CMakeLists.txt
+++ b/sdk/CMakeLists.txt
@@ -9,6 +9,9 @@ target_include_directories(
 
 set_target_properties(opentelemetry_sdk PROPERTIES EXPORT_NAME sdk)
 
+target_link_libraries(opentelemetry_sdk INTERFACE opentelemetry_api)
+
+set(OTEL_SDK_DIR ${CMAKE_CURRENT_SOURCE_DIR})
 add_subdirectory(src)
 
 otel_add_component(

--- a/sdk/src/common/CMakeLists.txt
+++ b/sdk/src/common/CMakeLists.txt
@@ -14,6 +14,9 @@ add_library(opentelemetry_common ${COMMON_SRCS})
 set_target_properties(opentelemetry_common PROPERTIES EXPORT_NAME common)
 set_target_version(opentelemetry_common)
 
+target_include_directories(opentelemetry_common
+                           PUBLIC "$<BUILD_INTERFACE:${OTEL_SDK_DIR}>")
+
 target_link_libraries(
   opentelemetry_common PUBLIC opentelemetry_api opentelemetry_sdk
                               Threads::Threads)

--- a/sdk/src/resource/CMakeLists.txt
+++ b/sdk/src/resource/CMakeLists.txt
@@ -6,7 +6,7 @@ add_library(opentelemetry_resources resource.cc resource_detector.cc)
 set_target_properties(opentelemetry_resources PROPERTIES EXPORT_NAME resources)
 set_target_version(opentelemetry_resources)
 
-target_link_libraries(opentelemetry_resources opentelemetry_common)
+target_link_libraries(opentelemetry_resources PUBLIC opentelemetry_common)
 
 target_include_directories(
   opentelemetry_resources

--- a/sdk/test/common/CMakeLists.txt
+++ b/sdk/test/common/CMakeLists.txt
@@ -47,7 +47,7 @@ if(WITH_BENCHMARK)
 
   add_executable(circular_buffer_benchmark circular_buffer_benchmark.cc)
   target_link_libraries(circular_buffer_benchmark benchmark::benchmark
-                        ${CMAKE_THREAD_LIBS_INIT} opentelemetry_api)
+                        ${CMAKE_THREAD_LIBS_INIT} opentelemetry_common)
 
   add_executable(attributemap_hash_benchmark attributemap_hash_benchmark.cc)
   target_link_libraries(attributemap_hash_benchmark benchmark::benchmark

--- a/sdk/test/instrumentationscope/CMakeLists.txt
+++ b/sdk/test/instrumentationscope/CMakeLists.txt
@@ -6,7 +6,7 @@ include(GoogleTest)
 foreach(testname instrumentationscope_test)
   add_executable(${testname} "${testname}.cc")
   target_link_libraries(${testname} ${GTEST_BOTH_LIBRARIES}
-                        ${CMAKE_THREAD_LIBS_INIT} opentelemetry_api)
+                        ${CMAKE_THREAD_LIBS_INIT} opentelemetry_sdk)
   gtest_add_tests(
     TARGET ${testname}
     TEST_PREFIX instrumentationscope.


### PR DESCRIPTION
More cmake cleanup. 

## Changes
- Remove more global `include_directories` calls in favor of `target_include_directories`. Make sure the targets relying on these global includes link/include what they need. 
- Make the api target an interface link to the sdk target
- Remove usage of the sdk headers in the `foo_*` example libraries (These example libraries should link to the api only)

For significant contributions please make sure you have completed the following items:

* [x] `CHANGELOG.md` updated for non-trivial changes
* [ ] Unit tests have been added
* [ ] Changes in public API reviewed