### PR TITLE
Test building opentelemetry-cpp as shared libraries against shared protobuf and grpc libraries

### DIFF
--- a/.github/workflows/cmake_install.yml
+++ b/.github/workflows/cmake_install.yml
@@ -270,7 +270,7 @@ jobs:
         run: ./ci/do_ci.sh cmake.opentracing_shim.install.test
 
   ubuntu_2404_conan_latest:
-    name: Ubuntu 24.04 conan latest versions cxx17 (static libs)
+    name: Ubuntu 24.04 conan latest versions cxx17 (static libs - shared libs)
     runs-on: ubuntu-24.04
     env:
       INSTALL_TEST_DIR: '/home/runner/install_test'
@@ -305,6 +305,44 @@ jobs:
         run: |
           export PKG_CONFIG_PATH=$INSTALL_TEST_DIR/lib/pkgconfig:$PKG_CONFIG_PATH
           ./ci/verify_packages.sh
+      - name: Run Tests (shared libs)
+        env:
+          BUILD_SHARED_LIBS: 'ON'
+        run: ./ci/do_ci.sh cmake.install.test
+
+  ubuntu_2404_conan_latest_shared_deps:
+    name: Ubuntu 24.04 conan latest w/shared protobuf and grpc (shared libs)
+    runs-on: ubuntu-24.04
+    env:
+      INSTALL_TEST_DIR: '/home/runner/install_test'
+      # Set to the latest version of cmake 3.x
+      CMAKE_VERSION: '3.31.6'
+      CXX_STANDARD: '17'
+      CMAKE_TOOLCHAIN_FILE: /home/runner/conan/build/Debug/generators/conan_toolchain.cmake
+      BUILD_TYPE: 'Debug'
+    steps:
+      - name: Harden the runner (Audit all outbound calls)
+        uses: step-security/harden-runner@0634a2670c59f64b4a01f0f96f84700a4088b9f0 # v2.12.0
+        with:
+          egress-policy: audit
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          submodules: 'recursive'
+      - name: Install Conan
+        run: |
+          python3 -m pip install pip==25.0.1
+          pip install "conan==2.15.1"
+          conan profile detect --force
+      - name: Install or build all dependencies with Conan
+        run: |
+          sudo -E ./ci/setup_cmake.sh
+          conan install install/conan/conanfile_latest.txt --build=missing -of /home/runner/conan -s build_type=${BUILD_TYPE} -s compiler.cppstd=${CXX_STANDARD} -o protobuf/*:shared=True -o grpc/*:shared=True
+      - name: Run Tests (shared libs)
+        env:
+          BUILD_SHARED_LIBS: 'ON'
+        run: |
+          source /home/runner/conan/build/Debug/generators/conanrun.sh
+          ./ci/do_ci.sh cmake.install.test
 
   macos_14_conan_stable:
     name: macOS 14 conan stable versions cxx17 (static libs)


### PR DESCRIPTION
Test for #3405 - This draft PR is just to demonstrate the current state of building opentelemetry-cpp shared libraries against newer versions of protobuf and grpc. 

## Changes

- adds cmake install tests for 
   - Building shared otel-cpp libs against static protobuf v5.27 and grpc v1.67 libs - This is known to fail tests and the otlp cmake targets do not function as expected (either segfault or just fail to export data)
   - Building shared otel-cpp libs against shared protobuf v5.27 and grpc v1.67 libs - The otlp grpc tests fail to build, but the otlp grpc cmake targets can be used in an application and work as expected. 

For significant contributions please make sure you have completed the following items:

* [ ] `CHANGELOG.md` updated for non-trivial changes
* [ ] Unit tests have been added
* [ ] Changes in public API reviewed