### PR TITLE
[BUILD] remove unused WITH_CURL build flag

### DIFF
--- a/examples/http/BUILD
+++ b/examples/http/BUILD
@@ -7,9 +7,6 @@ cc_binary(
         "client.cc",
         "tracer_common.h",
     ],
-    copts = [
-        "-DWITH_CURL",
-    ],
     linkopts = select({
         "//bazel:windows": [
             "-DEFAULTLIB:advapi32.lib",

--- a/ext/src/http/client/curl/BUILD
+++ b/ext/src/http/client/curl/BUILD
@@ -10,9 +10,6 @@ cc_library(
         "http_client_factory_curl.cc",
         "http_operation_curl.cc",
     ],
-    copts = [
-        "-DWITH_CURL",
-    ],
     include_prefix = "src/http/client/curl",
     linkopts = select({
         "//bazel:windows": [

--- a/ext/test/http/CMakeLists.txt
+++ b/ext/test/http/CMakeLists.txt
@@ -3,7 +3,6 @@
 
 if(WITH_HTTP_CLIENT_CURL)
   set(FILENAME curl_http_test)
-  add_compile_definitions(WITH_CURL)
   add_executable(${FILENAME} ${FILENAME}.cc)
   target_link_libraries(${FILENAME} ${GMOCK_LIB} ${GTEST_BOTH_LIBRARIES}
                         ${CMAKE_THREAD_LIBS_INIT})


### PR DESCRIPTION
Fixes # (issue)

## Changes

Removed the `WITH_CURL` build flag from the code base, it is set but never used.

For significant contributions please make sure you have completed the following items:

* [ ] `CHANGELOG.md` updated for non-trivial changes
* [ ] Unit tests have been added
* [ ] Changes in public API reviewed