### PR TITLE
[BUILD] Add missing CMake keyword for target_link_libraries

### DIFF
--- a/examples/otlp/CMakeLists.txt
+++ b/examples/otlp/CMakeLists.txt
@@ -115,7 +115,7 @@ if(WITH_OTLP_HTTP)
     target_compile_definitions(example_otlp_instrumented_http
                                PRIVATE OPENTELEMETRY_BUILD_IMPORT_DLL)
     target_link_libraries(example_otlp_instrumented_http
-                          opentelemetry-cpp::opentelemetry_cpp)
+                          PRIVATE opentelemetry-cpp::opentelemetry_cpp)
   else()
     target_link_libraries(
       example_otlp_instrumented_http


### PR DESCRIPTION
Since the same target was linked with `PRIVATE` keyboard (see below), it should have explicit keyword for all the dependencies. Or there will be CMake error like the following.

```cmake
  target_link_libraries(
    example_otlp_instrumented_http PRIVATE common_metrics_foo_library
```

> CMake Error at examples/otlp/CMakeLists.txt:117 (target_link_libraries):
 > The keyword signature for target_link_libraries has already been used with
 > the target "example_otlp_instrumented_http".  All uses of
 > target_link_libraries with a target must be either all-keyword or
 > all-plain.

## Changes

Please provide a brief description of the changes here.

For significant contributions please make sure you have completed the following items:

* [ ] `CHANGELOG.md` updated for non-trivial changes
* [ ] Unit tests have been added
* [ ] Changes in public API reviewed