### PR TITLE
fix: BatchLogRecordProcessor::ForceFlush is not waking up bg thread

### DIFF
--- a/sdk/src/logs/batch_log_record_processor.cc
+++ b/sdk/src/logs/batch_log_record_processor.cc
@@ -136,6 +136,7 @@ bool BatchLogRecordProcessor::ForceFlush(std::chrono::microseconds timeout) noex
     if (synchronization_data_->force_flush_pending_sequence.load(std::memory_order_acquire) >
         synchronization_data_->force_flush_notified_sequence.load(std::memory_order_acquire))
     {
+      synchronization_data_->is_force_wakeup_background_worker.store(true, std::memory_order_release);
       synchronization_data_->cv.notify_all();
     }
 


### PR DESCRIPTION
Calling `BatchLogRecordProcessor::ForceFlush` was not waking up the background to actually perform the flush. So, this was simply sleeping on the condvar for the entire timeout, and then returning `false` without ever flushing anything.

I probably should put together a test for this - I'll try and find some time early next week to do that.