### PR TITLE
[CMAKE] Unify third party dependency management

### DIFF
--- a/.github/workflows/cmake_install.yml
+++ b/.github/workflows/cmake_install.yml
@@ -19,6 +19,7 @@ jobs:
       CMAKE_VERSION: '3.31.6'
       # cxx17 is the default for windows-2022
       CXX_STANDARD: '17'
+      CMAKE_EXTRA_ARGS: "-DWITH_STL=CXX17 -DOTELCPP_REQUIRE_LOCAL_DEPENDENCIES=ON"
     steps:
       - name: Harden the runner (Audit all outbound calls)
         uses: step-security/harden-runner@0634a2670c59f64b4a01f0f96f84700a4088b9f0 # v2.12.0
@@ -45,6 +46,7 @@ jobs:
       CMAKE_VERSION: '3.15.0'
       # cxx14 is the default for windows-2019
       CXX_STANDARD: '14'
+      CMAKE_EXTRA_ARGS: "-DWITH_GSL=ON -DOTELCPP_REQUIRE_LOCAL_DEPENDENCIES=ON"
     steps:
       - name: Harden the runner (Audit all outbound calls)
         uses: step-security/harden-runner@0634a2670c59f64b4a01f0f96f84700a4088b9f0 # v2.12.0
@@ -70,6 +72,7 @@ jobs:
       CMAKE_VERSION: '3.28.3'
       # cxx17 is the default for Ubuntu 24.04
       CXX_STANDARD: '17'
+      CMAKE_EXTRA_ARGS: "-DOTELCPP_REQUIRE_LOCAL_DEPENDENCIES=ON"
       BUILD_TYPE: 'Debug'
     steps:
     - name: Harden the runner (Audit all outbound calls)
@@ -80,15 +83,14 @@ jobs:
     - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       with:
         submodules: 'recursive'
-    - name: Install libcurl, zlib, nlohmann-json with apt
+    - name: Setup CI Environment
       run: |
         sudo -E ./ci/setup_ci_environment.sh
         sudo -E ./ci/setup_cmake.sh
-        sudo -E ./ci/setup_googletest.sh
-    - name: Install abseil, protobuf, and grpc with apt
+    - name: Install Dependencies
       run: |
         sudo -E apt-get update
-        sudo -E apt-get install -y libabsl-dev libprotobuf-dev libgrpc++-dev protobuf-compiler protobuf-compiler-grpc
+        sudo -E apt-get install -y libabsl-dev libcurl4-openssl-dev zlib1g-dev nlohmann-json3-dev libprotobuf-dev libgrpc++-dev protobuf-compiler protobuf-compiler-grpc
     - name: Run Tests (static libs)
       env:
         BUILD_SHARED_LIBS: 'OFF'
@@ -97,6 +99,41 @@ jobs:
       env:
         BUILD_SHARED_LIBS: 'ON'
       run: ./ci/do_ci.sh cmake.install.test
+
+  ubuntu_2404_all_fetch:
+    name: Ubuntu 24.04 fetch all dependencies (static libs - shared libs - opentracing shim)
+    runs-on: ubuntu-24.04
+    env:
+      INSTALL_TEST_DIR: '/home/runner/install_test'
+      # CMake 3.28 is apt package version for Ubuntu 24.04
+      CMAKE_VERSION: '3.28.3'
+      # The default cxx standard for Ubuntu 24.04
+      CXX_STANDARD: '17'
+      CMAKE_EXTRA_ARGS: "-DOTELCPP_FORCE_FETCH_DEPENDENCIES=ON"
+      BUILD_TYPE: 'Debug'
+    steps:
+    - name: Harden the runner (Audit all outbound calls)
+      uses: step-security/harden-runner@0634a2670c59f64b4a01f0f96f84700a4088b9f0 # v2.12.0
+      with:
+        egress-policy: audit
+    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      with:
+        # Don't checkout the submodules.
+        submodules: false
+    - name: Setup CI Environment
+      run: |
+        sudo -E ./ci/setup_ci_environment.sh
+        sudo -E ./ci/setup_cmake.sh
+    - name: Run Tests (static libs)
+      env:
+        BUILD_SHARED_LIBS: 'OFF'
+      run: ./ci/do_ci.sh cmake.install.test
+    - name: Run Tests (shared libs)
+      env:
+        BUILD_SHARED_LIBS: 'ON'
+      run: ./ci/do_ci.sh cmake.install.test
+    - name: Run OpenTracing Shim Test
+      run: ./ci/do_ci.sh cmake.opentracing_shim.install.test
 
   ubuntu_2404_latest:
     name: Ubuntu 24.04 latest versions cxx20 (static libs)
@@ -107,6 +144,7 @@ jobs:
       CMAKE_VERSION: '3.31.6'
       # Set to the latest cxx standard supported by opentelemetry-cpp
       CXX_STANDARD: '20'
+      CMAKE_EXTRA_ARGS: "-DWITH_STL=CXX20"
       # Versions below set to the latest version available
       # The abseil and protobuf versions are taken from
       # the grpc submodules at the GRPC_VERSION tag
@@ -124,14 +162,14 @@ jobs:
     - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       with:
         submodules: 'recursive'
-    - name: Install gtest, libcurl, zlib, nlohmann-json with apt
+    - name: Setup CI Environment
       run: |
         sudo -E ./ci/setup_ci_environment.sh
         sudo -E ./ci/setup_cmake.sh
-        sudo -E ./ci/setup_googletest.sh
-    - name: Build abseil, protobuf, and grpc with ci scripts
+    - name: Install Dependencies
       run: |
         sudo -E ./ci/install_abseil.sh
+        sudo -E ./ci/setup_googletest.sh
         sudo -E ./ci/install_protobuf.sh
         sudo -E ./ci/setup_grpc.sh -r $GRPC_VERSION -s $CXX_STANDARD -p protobuf -p abseil-cpp
     - name: Run Tests (static libs)
@@ -147,6 +185,7 @@ jobs:
       # CMake 3.22 is the apt package version for Ubuntu 22.04
       CMAKE_VERSION: '3.22.0'
       CXX_STANDARD: '17'
+      CMAKE_EXTRA_ARGS: "-DWITH_STL=CXX17"
       # These are stable versions tested in the main ci workflow
       # and defaults in the devcontainer
       GOOGLETEST_VERSION: '1.14.0'
@@ -163,14 +202,14 @@ jobs:
     - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       with:
         submodules: 'recursive'
-    - name: Install gtest, libcurl, zlib, nlohmann-json with apt
+    - name: Setup CI Environment
       run: |
         sudo -E ./ci/setup_ci_environment.sh
         sudo -E ./ci/setup_cmake.sh
-        sudo -E ./ci/setup_googletest.sh
-    - name: Build abseil, protobuf, and grpc with ci scripts
+    - name: Install Dependencies
       run: |
         sudo -E ./ci/install_abseil.sh
+        sudo -E ./ci/setup_googletest.sh
         sudo -E ./ci/install_protobuf.sh
         sudo -E ./ci/setup_grpc.sh -r $GRPC_VERSION -s $CXX_STANDARD -p protobuf -p abseil-cpp
     - name: Run Tests (static libs)
@@ -191,6 +230,7 @@ jobs:
       CMAKE_VERSION: '3.14.0'
       # cxx14 is the default for Ubuntu 22.04
       CXX_STANDARD: '14'
+      CMAKE_EXTRA_ARGS: "-DWITH_GSL=ON"
       # This is the apt package version of googletest for Ubuntu 22.04
       GOOGLETEST_VERSION: '1.11.0'
       # These are minimum versions tested in the main ci workflow
@@ -207,14 +247,15 @@ jobs:
     - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       with:
         submodules: 'recursive'
-    - name: Install gtest, libcurl, zlib, nlohmann-json with apt
+    - name: Setup CI Environment
       run: |
         sudo -E ./ci/setup_ci_environment.sh
         sudo -E ./ci/setup_cmake.sh
-        sudo -E ./ci/setup_googletest.sh
-    - name: Build abseil, protobuf, and grpc with ci scripts
+    - name: Install Dependencies
       run: |
+        sudo -E apt-get install -y libcurl4-openssl-dev zlib1g-dev nlohmann-json3-dev
         sudo -E ./ci/install_abseil.sh
+        sudo -E ./ci/setup_googletest.sh
         sudo -E ./ci/install_protobuf.sh
         sudo -E ./ci/setup_grpc.sh -r $GRPC_VERSION -s $CXX_STANDARD -p protobuf -p abseil-cpp
     - name: Run Tests (static libs)
@@ -234,6 +275,7 @@ jobs:
        # CMake 3.28 is apt package version for Ubuntu 24.04
       CMAKE_VERSION: '3.28.3'
       CXX_STANDARD: '17'
+      CMAKE_EXTRA_ARGS: "-DOTELCPP_REQUIRE_LOCAL_DEPENDENCIES=ON"
       CMAKE_TOOLCHAIN_FILE: /home/runner/conan/build/Debug/generators/conan_toolchain.cmake
       BUILD_TYPE: 'Debug'
     steps:
@@ -244,7 +286,10 @@ jobs:
 
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
-          submodules: 'recursive'
+          submodules: false
+      - name: Get required submodules
+        run: |
+          git submodule update --init --depth 1 third_party/opentelemetry-proto
       - name: Install Conan
         run: |
           python3 -m pip install pip==25.0.1
@@ -270,13 +315,14 @@ jobs:
         run: ./ci/do_ci.sh cmake.opentracing_shim.install.test
 
   ubuntu_2404_conan_latest:
-    name: Ubuntu 24.04 conan latest versions cxx17 (static libs)
+    name: Ubuntu 24.04 conan latest versions cxx17 (static libs - opentracing shim)
     runs-on: ubuntu-24.04
     env:
       INSTALL_TEST_DIR: '/home/runner/install_test'
       # Set to the latest version of cmake 3.x
       CMAKE_VERSION: '3.31.6'
       CXX_STANDARD: '17'
+      CMAKE_EXTRA_ARGS: "-DOTELCPP_REQUIRE_LOCAL_DEPENDENCIES=ON"
       CMAKE_TOOLCHAIN_FILE: /home/runner/conan/build/Debug/generators/conan_toolchain.cmake
       BUILD_TYPE: 'Debug'
     steps:
@@ -287,7 +333,10 @@ jobs:
 
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
-          submodules: 'recursive'
+          submodules: false
+      - name: Get required submodules
+        run: |
+          git submodule update --init --depth 1 third_party/opentelemetry-proto
       - name: Install Conan
         run: |
           python3 -m pip install pip==25.0.1
@@ -305,6 +354,8 @@ jobs:
         run: |
           export PKG_CONFIG_PATH=$INSTALL_TEST_DIR/lib/pkgconfig:$PKG_CONFIG_PATH
           ./ci/verify_packages.sh
+      - name: Run OpenTracing Shim Test
+        run: ./ci/do_ci.sh cmake.opentracing_shim.install.test
 
   macos_14_conan_stable:
     name: macOS 14 conan stable versions cxx17 (static libs)
@@ -313,6 +364,7 @@ jobs:
       INSTALL_TEST_DIR: '/Users/runner/install_test'
       CMAKE_VERSION: '3.28.3'
       CXX_STANDARD: '17'
+      CMAKE_EXTRA_ARGS: "-DOTELCPP_REQUIRE_LOCAL_DEPENDENCIES=ON"
       CMAKE_TOOLCHAIN_FILE: '/Users/runner/conan/build/Debug/generators/conan_toolchain.cmake'
       BUILD_TYPE: 'Debug'
     steps:
@@ -323,7 +375,10 @@ jobs:
 
     - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       with:
-        submodules: 'recursive'
+        submodules: false
+    - name: Get required submodules
+      run: |
+        git submodule update --init --depth 1 third_party/opentelemetry-proto
     - name: Install Conan and tools
       run: |
         brew install conan autoconf automake libtool coreutils
@@ -344,6 +399,7 @@ jobs:
       # Set to the latest version of cmake 3.x
       CMAKE_VERSION: '3.31.6'
       CXX_STANDARD: '17'
+      CMAKE_EXTRA_ARGS: "-DOTELCPP_REQUIRE_LOCAL_DEPENDENCIES=ON"
       BUILD_TYPE: 'Debug'
     steps:
     - name: Harden the runner (Audit all outbound calls)
@@ -353,7 +409,10 @@ jobs:
 
     - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       with:
-        submodules: 'recursive'
+        submodules: false
+    - name: Get required submodules
+      run: |
+        git submodule update --init --depth 1 third_party/opentelemetry-proto
     - name: Install Dependencies with Homebrew
       run: |
         ./ci/setup_cmake_macos.sh

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,89 +36,22 @@ project(opentelemetry-cpp)
 # Mark variables as used so cmake doesn't complain about them
 mark_as_advanced(CMAKE_TOOLCHAIN_FILE)
 
-# Note: CMAKE_FIND_PACKAGE_PREFER_CONFIG requires cmake 3.15. Prefer cmake
-# CONFIG search mode to find dependencies. This is important to properly find
-# protobuf versions 3.22.0 and above due to the abseil-cpp dependency.
-set(CMAKE_FIND_PACKAGE_PREFER_CONFIG TRUE)
-
-# Don't use customized cmake modules if vcpkg is used to resolve dependence.
-if(NOT DEFINED CMAKE_TOOLCHAIN_FILE)
-  list(APPEND CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/cmake/modules/")
-endif()
-
+# Set the third-party dependency versions expected
 if(EXISTS "${CMAKE_SOURCE_DIR}/third_party_release")
   file(STRINGS "${CMAKE_SOURCE_DIR}/third_party_release" third_party_tags)
   foreach(third_party ${third_party_tags})
     string(REGEX REPLACE "^[ ]+" "" third_party ${third_party})
     string(REGEX MATCH "^[^=]+" third_party_name ${third_party})
     string(REPLACE "${third_party_name}=" "" third_party_tag ${third_party})
-    set(${third_party_name} "${third_party_tag}")
+    set(${third_party_name}_GIT_TAG "${third_party_tag}")
   endforeach()
 endif()
-
-if(DEFINED ENV{ARCH})
-  # Architecture may be specified via ARCH environment variable
-  set(ARCH $ENV{ARCH})
-else()
-  # Autodetection logic that populates ARCH variable
-  if(CMAKE_SYSTEM_PROCESSOR MATCHES "amd64.*|x86_64.*|AMD64.*")
-    # Windows may report AMD64 even if target is 32-bit
-    if(CMAKE_SIZEOF_VOID_P EQUAL 8)
-      set(ARCH x64)
-    elseif(CMAKE_SIZEOF_VOID_P EQUAL 4)
-      set(ARCH x86)
-    endif()
-  elseif(CMAKE_SYSTEM_PROCESSOR MATCHES "i686.*|i386.*|x86.*")
-    # Windows may report x86 even if target is 64-bit
-    if(CMAKE_SIZEOF_VOID_P EQUAL 8)
-      set(ARCH x64)
-    elseif(CMAKE_SIZEOF_VOID_P EQUAL 4)
-      set(ARCH x86)
-    endif()
-  elseif(CMAKE_SYSTEM_PROCESSOR MATCHES "powerpc")
-    # AIX will report the processor as 'powerpc' even if building in 64-bit mode
-    if(CMAKE_SIZEOF_VOID_P EQUAL 8)
-      set(ARCH ppc64)
-    else()
-      set(ARCH ppc32)
-    endif()
-  elseif(CMAKE_SYSTEM_PROCESSOR MATCHES
-         "^(aarch64.*|AARCH64.*|arm64.*|ARM64.*)")
-    set(ARCH arm64)
-  elseif(CMAKE_SYSTEM_PROCESSOR MATCHES "^(arm.*|ARM.*)")
-    set(ARCH arm)
-  elseif(CMAKE_SYSTEM_PROCESSOR MATCHES "^(powerpc|ppc)64le")
-    set(ARCH ppc64le)
-  elseif(CMAKE_SYSTEM_PROCESSOR MATCHES "^(powerpc|ppc)64")
-    set(ARCH ppc64)
-  elseif(CMAKE_SYSTEM_PROCESSOR MATCHES "^(mips.*|MIPS.*)")
-    set(ARCH mips)
-  elseif(CMAKE_SYSTEM_PROCESSOR MATCHES "^(riscv.*|RISCV.*)")
-    set(ARCH riscv)
-  elseif(CMAKE_SYSTEM_PROCESSOR MATCHES "^(s390x.*|S390X.*)")
-    set(ARCH s390x)
-  elseif(CMAKE_SYSTEM_PROCESSOR MATCHES "^(sparc.*|SPARC.*)")
-    set(ARCH sparc)
-  elseif(CMAKE_SYSTEM_PROCESSOR MATCHES "^(loongarch.*|LOONGARCH.*)")
-    set(ARCH loongarch)
-  else()
-    message(
-      FATAL_ERROR
-        "opentelemetry-cpp: unrecognized target processor ${CMAKE_SYSTEM_PROCESSOR} configuration!"
-    )
-  endif()
-endif()
-message(STATUS "Building for architecture ARCH=${ARCH}")
 
 # Autodetect vcpkg toolchain
 if(DEFINED ENV{VCPKG_ROOT} AND NOT DEFINED CMAKE_TOOLCHAIN_FILE)
   set(CMAKE_TOOLCHAIN_FILE
       "$ENV{VCPKG_ROOT}/scripts/buildsystems/vcpkg.cmake"
       CACHE STRING "")
-endif()
-
-if(VCPKG_CHAINLOAD_TOOLCHAIN_FILE)
-  include("${VCPKG_CHAINLOAD_TOOLCHAIN_FILE}")
 endif()
 
 option(WITH_ABI_VERSION_1 "ABI version 1" ON)
@@ -167,8 +100,6 @@ else()
   endif()
 endif()
 
-message(STATUS "OPENTELEMETRY_ABI_VERSION_NO=${OPENTELEMETRY_ABI_VERSION_NO}")
-
 if(OPENTELEMETRY_CPP_HEADER_VERSION_H MATCHES
    "OPENTELEMETRY_VERSION[ \t\r\n]+\"?([^\"]+)\"?")
   set(OPENTELEMETRY_VERSION ${CMAKE_MATCH_1})
@@ -178,8 +109,6 @@ else()
       "OPENTELEMETRY_VERSION not found on ${CMAKE_CURRENT_LIST_DIR}/api/include/opentelemetry/version.h"
   )
 endif()
-
-message(STATUS "OPENTELEMETRY_VERSION=${OPENTELEMETRY_VERSION}")
 
 option(WITH_NO_DEPRECATED_CODE "Do not include deprecated code" OFF)
 
@@ -197,7 +126,7 @@ endif()
 option(OPENTELEMETRY_INSTALL "Whether to install opentelemetry targets"
        ${OPENTELEMETRY_INSTALL_default})
 
-include("${PROJECT_SOURCE_DIR}/cmake/tools.cmake")
+include("${opentelemetry-cpp_SOURCE_DIR}/cmake/tools.cmake")
 
 if(NOT WITH_STL STREQUAL "OFF")
   # These definitions are needed for test projects that do not link against
@@ -317,44 +246,31 @@ option(OPENTELEMETRY_SKIP_DYNAMIC_LOADING_TESTS
        "Whether to build test libraries that are always linked as shared libs"
        OFF)
 
+option(
+  OTELCPP_FORCE_FETCH_DEPENDENCIES
+  "Whether to force fetching dependencies from submodules or git repositories"
+  OFF)
+
+option(
+  OTELCPP_REQUIRE_LOCAL_DEPENDENCIES
+  "Whether to require finding dependencies as a locally installed package or submodules"
+  OFF)
+
 #
 # Verify options dependencies
 #
-
+if(OTELCPP_FORCE_FETCH_DEPENDENCIES AND OTELCPP_REQUIRE_LOCAL_DEPENDENCIES)
+  message(
+    FATAL_ERROR
+      "OTELCPP_FORCE_FETCH_DEPENDENCIES and "
+      "OTELCPP_REQUIRE_LOCAL_DEPENDENCIES are mutually "
+      "exclusive options. Both can be OFF but only one can be ON.")
+endif()
 if(WITH_EXAMPLES_HTTP AND NOT WITH_EXAMPLES)
   message(FATAL_ERROR "WITH_EXAMPLES_HTTP=ON requires WITH_EXAMPLES=ON")
 endif()
 
 find_package(Threads)
-
-function(install_windows_deps)
-  # Bootstrap vcpkg from CMake and auto-install deps in case if we are missing
-  # deps on Windows. Respect the target architecture variable.
-  set(VCPKG_TARGET_ARCHITECTURE
-      ${ARCH}
-      PARENT_SCOPE)
-  message(STATUS "Installing build tools and dependencies...")
-  set(ENV{ARCH} ${ARCH})
-  execute_process(
-    COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/tools/setup-buildtools.cmd)
-  set(CMAKE_TOOLCHAIN_FILE
-      ${CMAKE_CURRENT_SOURCE_DIR}/tools/vcpkg/scripts/buildsystems/vcpkg.cmake
-      CACHE FILEPATH "")
-  message(
-    STATUS
-      "Make sure that vcpkg.cmake is set as the CMAKE_TOOLCHAIN_FILE at the START of the cmake build process!
-    Can be command-line arg (cmake -DCMAKE_TOOLCHAIN_FILE=...) or set in your editor of choice."
-  )
-
-endfunction()
-
-function(set_target_version target_name)
-  if(OTELCPP_VERSIONED_LIBS)
-    set_target_properties(
-      ${target_name} PROPERTIES VERSION ${OPENTELEMETRY_VERSION}
-                                SOVERSION ${OPENTELEMETRY_ABI_VERSION_NO})
-  endif()
-endfunction()
 
 if(MSVC)
   # Options for Visual C++ compiler: /Zc:__cplusplus - report an updated value
@@ -366,137 +282,20 @@ if(MSVC)
   endif()
 endif()
 
-# include GNUInstallDirs before include cmake/opentelemetry-proto.cmake because
-# opentelemetry-proto installs targets to the location variables defined in
-# GNUInstallDirs.
-include(GNUInstallDirs)
-
-if(WITH_PROMETHEUS)
-  find_package(prometheus-cpp CONFIG QUIET)
-  if(NOT prometheus-cpp_FOUND)
-    message(STATUS "Trying to use local prometheus-cpp from submodule")
-    if(EXISTS ${PROJECT_SOURCE_DIR}/third_party/prometheus-cpp/.git)
-      set(SAVED_ENABLE_TESTING ${ENABLE_TESTING})
-      set(SAVED_CMAKE_CXX_CLANG_TIDY ${CMAKE_CXX_CLANG_TIDY})
-      set(SAVED_CMAKE_CXX_INCLUDE_WHAT_YOU_USE
-          ${CMAKE_CXX_INCLUDE_WHAT_YOU_USE})
-      set(ENABLE_TESTING OFF)
-      set(CMAKE_CXX_CLANG_TIDY "")
-      set(CMAKE_CXX_INCLUDE_WHAT_YOU_USE "")
-      add_subdirectory(third_party/prometheus-cpp)
-      set(ENABLE_TESTING ${SAVED_ENABLE_TESTING})
-      set(CMAKE_CXX_CLANG_TIDY ${SAVED_CMAKE_CXX_CLANG_TIDY})
-      set(CMAKE_CXX_INCLUDE_WHAT_YOU_USE
-          ${SAVED_CMAKE_CXX_INCLUDE_WHAT_YOU_USE})
-
-      # Get the version of the prometheus-cpp submodule
-      find_package(Git QUIET)
-      if(Git_FOUND)
-        execute_process(
-          COMMAND ${GIT_EXECUTABLE} describe --tags --always
-          WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}/third_party/prometheus-cpp
-          OUTPUT_VARIABLE prometheus-cpp_VERSION
-          OUTPUT_STRIP_TRAILING_WHITESPACE)
-        string(REGEX REPLACE "^v" "" prometheus-cpp_VERSION
-                             "${prometheus-cpp_VERSION}")
-      endif()
-
-      message(
-        STATUS
-          "Using local prometheus-cpp from submodule. Version = ${prometheus-cpp_VERSION}"
-      )
-    else()
-      message(
-        FATAL_ERROR
-          "\nprometheus-cpp package was not found. Please either provide it manually or clone with submodules. "
-          "To initialize, fetch and checkout any nested submodules, you can use the following command:\n"
-          "git submodule update --init --recursive")
-    endif()
-  else()
-    message(STATUS "Using external prometheus-cpp")
-  endif()
+if(WITH_GSL)
+  include("${opentelemetry-cpp_SOURCE_DIR}/cmake/ms-gsl.cmake")
 endif()
 
 if(WITH_OTLP_GRPC
    OR WITH_OTLP_HTTP
    OR WITH_OTLP_FILE)
 
-  # Including the CMakeFindDependencyMacro resolves an error from
-  # gRPCConfig.cmake on some grpc versions. See
-  # https://github.com/grpc/grpc/pull/33361 for more details.
-  include(CMakeFindDependencyMacro)
-
-  # Protobuf 3.22+ depends on abseil-cpp and must be found using the cmake
-  # find_package CONFIG search mode. The following attempts to find Protobuf
-  # using the CONFIG mode first, and if not found, falls back to the MODULE
-  # mode. See https://gitlab.kitware.com/cmake/cmake/-/issues/24321 for more
-  # details.
-  find_package(Protobuf CONFIG)
-  if(NOT Protobuf_FOUND)
-    find_package(Protobuf MODULE)
-    if(Protobuf_FOUND AND Protobuf_VERSION VERSION_GREATER_EQUAL "3.22.0")
-      message(
-        WARNING
-          "Found Protobuf version ${Protobuf_VERSION} using MODULE mode. "
-          "Linking errors may occur. Protobuf 3.22+ depends on abseil-cpp "
-          "and should be found using the CONFIG mode.")
-    endif()
-  endif()
-
   if(WITH_OTLP_GRPC)
-    find_package(gRPC CONFIG)
+    include("${opentelemetry-cpp_SOURCE_DIR}/cmake/grpc.cmake")
   endif()
-  if((NOT Protobuf_FOUND) OR (WITH_OTLP_GRPC AND NOT gRPC_FOUND))
-    if(WIN32 AND (NOT DEFINED CMAKE_TOOLCHAIN_FILE))
-      install_windows_deps()
-    endif()
 
-    if(WIN32 AND (NOT DEFINED CMAKE_TOOLCHAIN_FILE))
-      message(FATAL_ERROR "Windows dependency installation failed!")
-    endif()
-    if(WIN32)
-      include(${CMAKE_TOOLCHAIN_FILE})
-    endif()
-
-    if(NOT Protobuf_FOUND)
-      find_package(Protobuf CONFIG REQUIRED)
-    endif()
-    if(NOT gRPC_FOUND AND WITH_OTLP_GRPC)
-      find_package(gRPC CONFIG)
-    endif()
-    if(WIN32)
-      # Always use x64 protoc.exe
-      if(NOT EXISTS "${Protobuf_PROTOC_EXECUTABLE}")
-        set(Protobuf_PROTOC_EXECUTABLE
-            ${CMAKE_CURRENT_SOURCE_DIR}/tools/vcpkg/packages/protobuf_x64-windows/tools/protobuf/protoc.exe
-        )
-      endif()
-    endif()
-  endif()
-  # Latest Protobuf imported targets and without legacy module support
-  if(TARGET protobuf::protoc)
-    if(CMAKE_CROSSCOMPILING AND Protobuf_PROTOC_EXECUTABLE)
-      set(PROTOBUF_PROTOC_EXECUTABLE ${Protobuf_PROTOC_EXECUTABLE})
-    else()
-      project_build_tools_get_imported_location(PROTOBUF_PROTOC_EXECUTABLE
-                                                protobuf::protoc)
-      # If protobuf::protoc is not a imported target, then we use the target
-      # directly for fallback
-      if(NOT PROTOBUF_PROTOC_EXECUTABLE)
-        set(PROTOBUF_PROTOC_EXECUTABLE protobuf::protoc)
-      endif()
-    endif()
-  elseif(Protobuf_PROTOC_EXECUTABLE)
-    # Some versions of FindProtobuf.cmake uses mixed case instead of uppercase
-    set(PROTOBUF_PROTOC_EXECUTABLE ${Protobuf_PROTOC_EXECUTABLE})
-  endif()
-  include(CMakeDependentOption)
-
-  message(STATUS "PROTOBUF_PROTOC_EXECUTABLE=${PROTOBUF_PROTOC_EXECUTABLE}")
-  set(SAVED_CMAKE_CXX_CLANG_TIDY ${CMAKE_CXX_CLANG_TIDY})
-  set(CMAKE_CXX_CLANG_TIDY "")
-  include(cmake/opentelemetry-proto.cmake)
-  set(CMAKE_CXX_CLANG_TIDY ${SAVED_CMAKE_CXX_CLANG_TIDY})
+  include("${opentelemetry-cpp_SOURCE_DIR}/cmake/protobuf.cmake")
+  include("${opentelemetry-cpp_SOURCE_DIR}/cmake/opentelemetry-proto.cmake")
 endif()
 
 #
@@ -519,12 +318,7 @@ endif()
 
 if((NOT WITH_API_ONLY) AND WITH_HTTP_CLIENT_CURL)
   # No specific version required.
-  find_package(CURL REQUIRED)
-  # Set the CURL_VERSION from the legacy CURL_VERSION_STRING Required for CMake
-  # versions below 4.0
-  if(NOT DEFINED CURL_VERSION AND DEFINED CURL_VERSION_STRING)
-    set(CURL_VERSION ${CURL_VERSION_STRING})
-  endif()
+  include("${opentelemetry-cpp_SOURCE_DIR}/cmake/curl.cmake")
 endif()
 
 #
@@ -535,12 +329,7 @@ if((NOT WITH_API_ONLY)
    AND WITH_HTTP_CLIENT_CURL
    AND WITH_OTLP_HTTP_COMPRESSION)
   # No specific version required.
-  find_package(ZLIB REQUIRED)
-  # Set the ZLIB_VERSION from the legacy ZLIB_VERSION_STRING Required for CMake
-  # versions below 3.26
-  if(NOT DEFINED ZLIB_VERSION AND DEFINED ZLIB_VERSION_STRING)
-    set(ZLIB_VERSION ${ZLIB_VERSION_STRING})
-  endif()
+  include("${opentelemetry-cpp_SOURCE_DIR}/cmake/zlib.cmake")
 endif()
 
 #
@@ -559,7 +348,15 @@ else()
 endif()
 
 if((NOT WITH_API_ONLY) AND USE_NLOHMANN_JSON)
-  include(cmake/nlohmann-json.cmake)
+  include("${opentelemetry-cpp_SOURCE_DIR}/cmake/nlohmann-json.cmake")
+endif()
+
+if(WITH_PROMETHEUS)
+  include("${opentelemetry-cpp_SOURCE_DIR}/cmake/prometheus-cpp.cmake")
+endif()
+
+if(WITH_OPENTRACING)
+  include("${opentelemetry-cpp_SOURCE_DIR}/cmake/opentracing-cpp.cmake")
 endif()
 
 if(OTELCPP_MAINTAINER_MODE)
@@ -655,193 +452,20 @@ endif(OTELCPP_MAINTAINER_MODE)
 
 list(APPEND CMAKE_PREFIX_PATH "${CMAKE_BINARY_DIR}")
 
-include(CTest)
 if(BUILD_TESTING)
-  if(EXISTS ${CMAKE_BINARY_DIR}/lib/libgtest.a)
-    # Prefer GTest from build tree. GTest is not always working with
-    # CMAKE_PREFIX_PATH
-    set(GTEST_INCLUDE_DIRS
-        ${CMAKE_CURRENT_SOURCE_DIR}/third_party/googletest/googletest/include
-        ${CMAKE_CURRENT_SOURCE_DIR}/third_party/googletest/googlemock/include)
-    if(TARGET gtest)
-      set(GTEST_BOTH_LIBRARIES gtest gtest_main)
-    else()
-      set(GTEST_BOTH_LIBRARIES ${CMAKE_BINARY_DIR}/lib/libgtest.a
-                               ${CMAKE_BINARY_DIR}/lib/libgtest_main.a)
-    endif()
-  elseif(WIN32)
-    # Make sure we are always bootsrapped with vcpkg on Windows
-    find_package(GTest)
-    if(NOT (GTEST_FOUND OR GTest_FOUND))
-      if(DEFINED CMAKE_TOOLCHAIN_FILE)
-        message(
-          FATAL_ERROR
-            "Pleaes install GTest with the CMAKE_TOOLCHAIN_FILE at ${CMAKE_TOOLCHAIN_FILE}"
-        )
-      else()
-        install_windows_deps()
-        include(${CMAKE_TOOLCHAIN_FILE})
-        find_package(GTest REQUIRED)
-      endif()
-    endif()
-  else()
-    # Prefer GTest installed by OS distro, brew or vcpkg package manager
-    find_package(GTest REQUIRED)
-  endif()
-  if(NOT GTEST_BOTH_LIBRARIES)
-    # New GTest package names
-    if(TARGET GTest::gtest)
-      set(GTEST_BOTH_LIBRARIES GTest::gtest GTest::gtest_main)
-    elseif(TARGET GTest::GTest)
-      set(GTEST_BOTH_LIBRARIES GTest::GTest GTest::Main)
-    endif()
-  endif()
-  if(GTEST_INCLUDE_DIRS)
-    include_directories(SYSTEM ${GTEST_INCLUDE_DIRS})
-  endif()
-  message(STATUS "GTEST_INCLUDE_DIRS   = ${GTEST_INCLUDE_DIRS}")
-  message(STATUS "GTEST_BOTH_LIBRARIES = ${GTEST_BOTH_LIBRARIES}")
-
-  # Try to find gmock
-  if(NOT GMOCK_LIB AND TARGET GTest::gmock)
-    set(GMOCK_LIB GTest::gmock)
-  elseif(MSVC)
-    # Explicitly specify that we consume GTest from shared library. The rest of
-    # code logic below determines whether we link Release or Debug flavor of the
-    # library. These flavors have different prefix on Windows, gmock and gmockd
-    # respectively.
-    add_definitions(-DGTEST_LINKED_AS_SHARED_LIBRARY=1)
-    if(GMOCK_LIB)
-      # unset GMOCK_LIB to force find_library to redo the lookup, as the cached
-      # entry could cause linking to incorrect flavor of gmock and leading to
-      # runtime error.
-      unset(GMOCK_LIB CACHE)
-    endif()
-  endif()
-  if(NOT GMOCK_LIB)
-    if(MSVC AND CMAKE_BUILD_TYPE STREQUAL "Debug")
-      find_library(GMOCK_LIB gmockd PATH_SUFFIXES lib)
-    else()
-      find_library(GMOCK_LIB gmock PATH_SUFFIXES lib)
-    endif()
-    # Reset GMOCK_LIB if it was not found, or some target may link
-    # GMOCK_LIB-NOTFOUND
-    if(NOT GMOCK_LIB)
-      unset(GMOCK_LIB)
-      unset(GMOCK_LIB CACHE)
-    endif()
-  endif()
-
+  include(CTest)
+  include(GoogleTest)
+  include("${opentelemetry-cpp_SOURCE_DIR}/cmake/googletest.cmake")
   enable_testing()
+
   if(WITH_BENCHMARK)
-    # Benchmark respects the CMAKE_PREFIX_PATH
-    find_package(benchmark CONFIG REQUIRED)
+    include("${opentelemetry-cpp_SOURCE_DIR}/cmake/benchmark.cmake")
   endif()
 endif()
 
-# Record build config and versions
-message(STATUS "---------------------------------------------")
-message(STATUS "build settings")
-message(STATUS "---------------------------------------------")
-message(STATUS "OpenTelemetry: ${OPENTELEMETRY_VERSION}")
-message(STATUS "OpenTelemetry ABI: ${OPENTELEMETRY_ABI_VERSION_NO}")
-message(STATUS "ARCH: ${ARCH}")
-message(STATUS "CXX: ${CMAKE_CXX_COMPILER_ID} ${CMAKE_CXX_COMPILER_VERSION}")
-message(STATUS "CMAKE_BUILD_TYPE: ${CMAKE_BUILD_TYPE}")
-message(STATUS "CXXFLAGS: ${CMAKE_CXX_FLAGS}")
-message(STATUS "CMAKE_CXX_STANDARD: ${CMAKE_CXX_STANDARD}")
-message(STATUS "CMAKE_TOOLCHAIN_FILE: ${CMAKE_TOOLCHAIN_FILE}")
-message(STATUS "BUILD_SHARED_LIBS: ${BUILD_SHARED_LIBS}")
+include("${opentelemetry-cpp_SOURCE_DIR}/cmake/otel-install-functions.cmake")
 
-message(STATUS "---------------------------------------------")
-message(STATUS "opentelemetry-cpp build options")
-message(STATUS "---------------------------------------------")
-message(STATUS "WITH_API_ONLY: ${WITH_API_ONLY}")
-message(STATUS "WITH_NO_DEPRECATED_CODE: ${WITH_NO_DEPRECATED_CODE}")
-message(STATUS "WITH_ABI_VERSION_1: ${WITH_ABI_VERSION_1}")
-message(STATUS "WITH_ABI_VERSION_2: ${WITH_ABI_VERSION_2}")
-message(STATUS "OTELCPP_VERSIONED_LIBS: ${OTELCPP_VERSIONED_LIBS}")
-message(STATUS "OTELCPP_MAINTAINER_MODE: ${OTELCPP_MAINTAINER_MODE}")
-message(STATUS "WITH_STL: ${WITH_STL}")
-message(STATUS "WITH_GSL: ${WITH_GSL}")
-message(STATUS "WITH_NO_GETENV: ${WITH_NO_GETENV}")
-
-message(STATUS "---------------------------------------------")
-message(STATUS "opentelemetry-cpp cmake component options")
-message(STATUS "---------------------------------------------")
-message(STATUS "WITH_OTLP_GRPC: ${WITH_OTLP_GRPC}")
-message(STATUS "WITH_OTLP_HTTP: ${WITH_OTLP_HTTP}")
-message(STATUS "WITH_OTLP_FILE: ${WITH_OTLP_FILE}")
-message(STATUS "WITH_HTTP_CLIENT_CURL: ${WITH_HTTP_CLIENT_CURL}")
-message(STATUS "WITH_ZIPKIN: ${WITH_ZIPKIN}")
-message(STATUS "WITH_PROMETHEUS: ${WITH_PROMETHEUS}")
-message(STATUS "WITH_ELASTICSEARCH: ${WITH_ELASTICSEARCH}")
-message(STATUS "WITH_OPENTRACING: ${WITH_OPENTRACING}")
-message(STATUS "WITH_ETW: ${WITH_ETW}")
-message(STATUS "OPENTELEMETRY_BUILD_DLL: ${OPENTELEMETRY_BUILD_DLL}")
-
-message(STATUS "---------------------------------------------")
-message(STATUS "feature preview options")
-message(STATUS "---------------------------------------------")
-message(STATUS "WITH_ASYNC_EXPORT_PREVIEW: ${WITH_ASYNC_EXPORT_PREVIEW}")
-message(
-  STATUS
-    "WITH_THREAD_INSTRUMENTATION_PREVIEW: ${WITH_THREAD_INSTRUMENTATION_PREVIEW}"
-)
-message(
-  STATUS "WITH_METRICS_EXEMPLAR_PREVIEW: ${WITH_METRICS_EXEMPLAR_PREVIEW}")
-message(STATUS "WITH_REMOVE_METER_PREVIEW: ${WITH_REMOVE_METER_PREVIEW}")
-message(
-  STATUS "WITH_OTLP_GRPC_SSL_MTLS_PREVIEW: ${WITH_OTLP_GRPC_SSL_MTLS_PREVIEW}")
-message(STATUS "WITH_OTLP_RETRY_PREVIEW: ${WITH_OTLP_RETRY_PREVIEW}")
-message(STATUS "---------------------------------------------")
-message(STATUS "third-party options")
-message(STATUS "---------------------------------------------")
-message(STATUS "WITH_NLOHMANN_JSON: ${USE_NLOHMANN_JSON}")
-message(STATUS "WITH_CURL_LOGGING: ${WITH_CURL_LOGGING}")
-message(STATUS "WITH_OTLP_HTTP_COMPRESSION: ${WITH_OTLP_HTTP_COMPRESSION}")
-message(STATUS "---------------------------------------------")
-message(STATUS "examples and test options")
-message(STATUS "---------------------------------------------")
-message(STATUS "WITH_BENCHMARK: ${WITH_BENCHMARK}")
-message(STATUS "WITH_EXAMPLES: ${WITH_EXAMPLES}")
-message(STATUS "WITH_EXAMPLES_HTTP: ${WITH_EXAMPLES_HTTP}")
-message(STATUS "WITH_FUNC_TESTS: ${WITH_FUNC_TESTS}")
-message(STATUS "BUILD_W3CTRACECONTEXT_TEST: ${BUILD_W3CTRACECONTEXT_TEST}")
-message(STATUS "BUILD_TESTING: ${BUILD_TESTING}")
-message(STATUS "---------------------------------------------")
-message(STATUS "versions")
-message(STATUS "---------------------------------------------")
-message(STATUS "CMake: ${CMAKE_VERSION}")
-message(STATUS "GTest: ${GTest_VERSION}")
-message(STATUS "benchmark: ${benchmark_VERSION}")
-if(WITH_GSL)
-  message(STATUS "GSL: ${GSL_VERSION}")
-endif()
-if(absl_FOUND)
-  message(STATUS "Abseil: ${absl_VERSION}")
-endif()
-if(Protobuf_FOUND)
-  message(STATUS "Protobuf: ${Protobuf_VERSION}")
-endif()
-if(gRPC_FOUND)
-  message(STATUS "gRPC: ${gRPC_VERSION}")
-endif()
-if(CURL_FOUND)
-  message(STATUS "CURL: ${CURL_VERSION}")
-endif()
-if(ZLIB_FOUND)
-  message(STATUS "ZLIB: ${ZLIB_VERSION}")
-endif()
-if(USE_NLOHMANN_JSON)
-  message(STATUS "nlohmann-json: ${nlohmann_json_VERSION}")
-endif()
-if(prometheus-cpp_FOUND)
-  message(STATUS "prometheus-cpp: ${prometheus-cpp_VERSION}")
-endif()
-message(STATUS "---------------------------------------------")
-
-include("${PROJECT_SOURCE_DIR}/cmake/otel-install-functions.cmake")
+otel_print_build_config()
 
 include(CMakePackageConfigHelpers)
 
@@ -861,37 +485,10 @@ endif()
 
 add_subdirectory(api)
 
-if(WITH_OPENTRACING)
-  find_package(OpenTracing CONFIG QUIET)
-  if(NOT OpenTracing_FOUND)
-    set(OPENTRACING_DIR "third_party/opentracing-cpp")
-    message(STATUS "Trying to use local ${OPENTRACING_DIR} from submodule")
-    if(EXISTS "${PROJECT_SOURCE_DIR}/${OPENTRACING_DIR}/.git")
-      set(SAVED_BUILD_TESTING ${BUILD_TESTING})
-      set(BUILD_TESTING OFF)
-      set(SAVED_CMAKE_CXX_INCLUDE_WHAT_YOU_USE
-          ${CMAKE_CXX_INCLUDE_WHAT_YOU_USE})
-      set(CMAKE_CXX_INCLUDE_WHAT_YOU_USE "")
-      add_subdirectory(${OPENTRACING_DIR})
-      set(BUILD_TESTING ${SAVED_BUILD_TESTING})
-      set(CMAKE_CXX_INCLUDE_WHAT_YOU_USE
-          ${SAVED_CMAKE_CXX_INCLUDE_WHAT_YOU_USE})
-    else()
-      message(
-        FATAL_ERROR
-          "\nopentracing-cpp package was not found. Please either provide it manually or clone with submodules. "
-          "To initialize, fetch and checkout any nested submodules, you can use the following command:\n"
-          "git submodule update --init --recursive")
-    endif()
-  else()
-    message(STATUS "Using external opentracing-cpp")
-  endif()
-  add_subdirectory(opentracing-shim)
-endif()
-
 if(NOT WITH_API_ONLY)
-  set(BUILD_TESTING ${BUILD_TESTING})
-
+  if(WITH_OPENTRACING)
+    add_subdirectory(opentracing-shim)
+  endif()
   add_subdirectory(sdk)
   add_subdirectory(ext)
   add_subdirectory(exporters)
@@ -907,8 +504,10 @@ if(NOT WITH_API_ONLY)
   endif()
 endif()
 
-include(cmake/opentelemetry-build-external-component.cmake)
-include(cmake/patch-imported-config.cmake)
+include(
+  "${opentelemetry-cpp_SOURCE_DIR}/cmake/opentelemetry-build-external-component.cmake"
+)
+include("${opentelemetry-cpp_SOURCE_DIR}/cmake/patch-imported-config.cmake")
 
 if(OPENTELEMETRY_INSTALL)
   # Install the cmake config and version files
@@ -921,7 +520,7 @@ if(OPENTELEMETRY_INSTALL)
   otel_install_thirdparty_definitions()
 
   if(BUILD_PACKAGE)
-    include(cmake/package.cmake)
+    include("${opentelemetry-cpp_SOURCE_DIR}/cmake/package.cmake")
     include(CPack)
   endif()
 endif()

--- a/api/CMakeLists.txt
+++ b/api/CMakeLists.txt
@@ -9,22 +9,7 @@ target_include_directories(
 
 set_target_properties(opentelemetry_api PROPERTIES EXPORT_NAME api)
 
-otel_add_component(
-  COMPONENT
-  api
-  TARGETS
-  opentelemetry_api
-  FILES_DIRECTORY
-  "include/opentelemetry"
-  FILES_DESTINATION
-  "include"
-  FILES_MATCHING
-  PATTERN
-  "*.h")
-
-if(OPENTELEMETRY_INSTALL)
-  unset(TARGET_DEPS)
-endif()
+unset(TARGET_DEPS)
 
 if(BUILD_TESTING)
   add_subdirectory(test)
@@ -69,18 +54,8 @@ endif()
 
 if(WITH_GSL)
   target_compile_definitions(opentelemetry_api INTERFACE HAVE_GSL)
-
-  # Guidelines Support Library path. Used if we are not on not get C++20.
-  #
-  find_package(Microsoft.GSL QUIET)
-  if(TARGET Microsoft.GSL::GSL)
-    target_link_libraries(opentelemetry_api INTERFACE Microsoft.GSL::GSL)
-    list(APPEND TARGET_DEPS "gsl")
-  else()
-    set(GSL_DIR third_party/ms-gsl)
-    target_include_directories(
-      opentelemetry_api INTERFACE "$<BUILD_INTERFACE:${GSL_DIR}/include>")
-  endif()
+  target_link_libraries(opentelemetry_api INTERFACE Microsoft.GSL::GSL)
+  list(APPEND TARGET_DEPS "gsl")
 endif()
 
 if(WITH_NO_GETENV)
@@ -129,6 +104,19 @@ endif()
 if(APPLE)
   target_link_libraries(opentelemetry_api INTERFACE "-framework CoreFoundation")
 endif()
+
+otel_add_component(
+  COMPONENT
+  api
+  TARGETS
+  opentelemetry_api
+  FILES_DIRECTORY
+  "include/opentelemetry"
+  FILES_DESTINATION
+  "include"
+  FILES_MATCHING
+  PATTERN
+  "*.h")
 
 include(${PROJECT_SOURCE_DIR}/cmake/pkgconfig.cmake)
 

--- a/ci/do_ci.ps1
+++ b/ci/do_ci.ps1
@@ -359,6 +359,17 @@ switch ($action) {
         $CXX_STANDARD = 14
     }
     Write-Host "Using CXX_STANDARD: $CXX_STANDARD"
+
+    if (Test-Path Env:\CMAKE_EXTRA_ARGS) {
+        # Split on any run of whitespace; filter out any empty tokens
+        $CMAKE_EXTRA_ARGS = $Env:CMAKE_EXTRA_ARGS -split '\s+' |
+                          Where-Object { -not [string]::IsNullOrWhiteSpace($_) }
+    }
+    else {
+        $CMAKE_EXTRA_ARGS = @()
+    }
+
+    Write-Host "CMAKE_EXTRA_ARGS is: $CMAKE_EXTRA_ARGS"
       
     $CMAKE_OPTIONS = @(
     "-DCMAKE_CXX_STANDARD=$CXX_STANDARD",
@@ -390,7 +401,8 @@ switch ($action) {
       -DWITH_EXAMPLES=ON `
       -DWITH_EXAMPLES_HTTP=ON `
       -DBUILD_W3CTRACECONTEXT_TEST=ON `
-      -DOPENTELEMETRY_INSTALL=ON
+      -DOPENTELEMETRY_INSTALL=ON `
+      @CMAKE_EXTRA_ARGS
 
     $exit = $LASTEXITCODE
     if ($exit -ne 0) {

--- a/ci/do_ci.sh
+++ b/ci/do_ci.sh
@@ -454,7 +454,8 @@ elif [[ "$1" == "cmake.install.test" ]]; then
     echo "BUILD_SHARED_LIBS is set to: OFF"
   fi
   CMAKE_OPTIONS+=("-DCMAKE_POSITION_INDEPENDENT_CODE=ON")
-
+  read -r -a CMAKE_EXTRA_ARGS <<< "$CMAKE_EXTRA_ARGS"
+  echo "CMAKE_EXTRA_ARGS is set to: ${CMAKE_EXTRA_ARGS[*]}"
   cd "${BUILD_DIR}"
   rm -rf *
   rm -rf ${INSTALL_TEST_DIR}/*
@@ -480,6 +481,7 @@ elif [[ "$1" == "cmake.install.test" ]]; then
         -DWITH_EXAMPLES_HTTP=ON \
         -DBUILD_W3CTRACECONTEXT_TEST=ON \
         -DOPENTELEMETRY_INSTALL=ON \
+        "${CMAKE_EXTRA_ARGS[@]}" \
         "${SRC_DIR}"
 
   make -j $(nproc)

--- a/ci/install_abseil.sh
+++ b/ci/install_abseil.sh
@@ -15,9 +15,10 @@ pushd $BUILD_DIR
 git clone --depth=1 -b ${ABSEIL_CPP_VERSION} https://github.com/abseil/abseil-cpp.git
 cd abseil-cpp
 ABSEIL_CPP_BUILD_OPTIONS=(
-    "-DBUILD_TESTING=OFF"
+    "-DABSL_BUILD_TESTING=OFF"
     "-DCMAKE_POSITION_INDEPENDENT_CODE=ON"
     "-DCMAKE_INSTALL_PREFIX=$INSTALL_DIR"
+    "-DABSL_ENABLE_INSTALL=ON"
 )
 
 if [ ! -z "${CXX_STANDARD}" ]; then

--- a/ci/setup_ci_environment.sh
+++ b/ci/setup_ci_environment.sh
@@ -13,4 +13,5 @@ apt-get install --no-install-recommends --no-install-suggests -y \
                 valgrind \
                 lcov \
                 iwyu \
-                pkg-config
+                pkg-config \
+                sudo \

--- a/ci/setup_googletest.sh
+++ b/ci/setup_googletest.sh
@@ -13,6 +13,26 @@ if [ -z "${GOOGLETEST_VERSION}" ]; then
   export GOOGLETEST_VERSION=1.14.0
 fi
 
+INSTALL_DIR=/usr/local/
+
+GOOGLETEST_BUILD_OPTIONS=(
+    "-DBUILD_SHARED_LIBS=ON"
+    "-DBUILD_GMOCK=ON"
+    "-DCMAKE_POSITION_INDEPENDENT_CODE=ON"
+    "-DINSTALL_GTEST=ON"
+    "-DCMAKE_INSTALL_PREFIX=$INSTALL_DIR"
+)
+
+if [ ! -z "${CXX_STANDARD}" ]; then
+    GOOGLETEST_BUILD_OPTIONS+=("-DCMAKE_CXX_STANDARD=${CXX_STANDARD}")
+    GOOGLETEST_BUILD_OPTIONS+=("-DCMAKE_CXX_STANDARD_REQUIRED=ON")
+    GOOGLETEST_BUILD_OPTIONS+=("-DCMAKE_CXX_EXTENSIONS=OFF")
+fi
+
+if [ ! -z "${GTEST_HAS_ABSL}" ]; then
+    GOOGLETEST_BUILD_OPTIONS+=("-DGTEST_HAS_ABSL=${GTEST_HAS_ABSL}")
+fi
+
 OLD_GOOGLETEST_VERSION_REGEXP="^1\.([0-9]|10|11|12)(\..*)?$"
 
 if [[ ${GOOGLETEST_VERSION} =~ ${OLD_GOOGLETEST_VERSION_REGEXP} ]]; then
@@ -27,30 +47,21 @@ fi
 
 googletest_install()
 {
-  # Follows these instructions
-  # https://gist.github.com/dlime/313f74fd23e4267c4a915086b84c7d3d
   tmp_dir=$(mktemp -d)
   pushd $tmp_dir
   wget https://github.com/google/googletest/archive/${GOOGLETEST_VERSION_PATH}.tar.gz
   tar -xf ${GOOGLETEST_VERSION_PATH}.tar.gz
   cd ${GOOGLETEST_FOLDER_PATH}/
   mkdir build && cd build
-  cmake .. -DBUILD_SHARED_LIBS=ON -DINSTALL_GTEST=ON -DCMAKE_INSTALL_PREFIX:PATH=/usr
+
+  echo "Installing googletest version: ${GOOGLETEST_VERSION}..."
+  echo "Using build options:" "${GOOGLETEST_BUILD_OPTIONS[@]}"
+
+  cmake "${GOOGLETEST_BUILD_OPTIONS[@]}" ..
   make -j $(nproc)
   make install
   ldconfig
   popd
 }
-
-set +e
-echo	\
-      libbenchmark-dev \
-      zlib1g-dev \
-      sudo \
-      libcurl4-openssl-dev \
-      nlohmann-json-dev \
-      nlohmann-json3 \
-      nlohmann-json3-dev | xargs -n 1 apt-get install --ignore-missing --no-install-recommends --no-install-suggests -y
-set -e
 
 googletest_install

--- a/cmake/benchmark.cmake
+++ b/cmake/benchmark.cmake
@@ -1,0 +1,16 @@
+# Copyright The OpenTelemetry Authors
+# SPDX-License-Identifier: Apache-2.0
+
+otel_add_thirdparty_package(
+  PACKAGE_NAME "benchmark"
+  PACKAGE_SEARCH_MODES "CONFIG"
+  FETCH_GIT_REPOSITORY "https://github.com/google/benchmark.git"
+  FETCH_GIT_TAG ${benchmark_GIT_TAG}
+  FETCH_SOURCE_DIR "${PROJECT_SOURCE_DIR}/third_party/benchmark"
+  FETCH_CMAKE_ARGS
+    BENCHMARK_ENABLE_TESTING=OFF
+    BENCHMARK_ENABLE_INSTALL=${OPENTELEMETRY_INSTALL}
+  REQUIRED_TARGETS "benchmark::benchmark"
+  VERSION_REGEX "project.*\\([^\\)]*VERSION[ \t]*([0-9]+(\\.[0-9]+)*(\\.[0-9]+)*)"
+  VERSION_FILE "\${benchmark_SOURCE_DIR}/CMakeLists.txt"
+)

--- a/cmake/curl.cmake
+++ b/cmake/curl.cmake
@@ -1,0 +1,44 @@
+# Copyright The OpenTelemetry Authors
+# SPDX-License-Identifier: Apache-2.0
+
+if(OPENTELEMETRY_INSTALL)
+  set(_CURL_DISABLE_INSTALL OFF)
+else()
+  set(_CURL_DISABLE_INSTALL ON)
+endif()
+
+set(_OTEL_BUILD_SHARED_LIBS ${BUILD_SHARED_LIBS})
+
+otel_add_thirdparty_package(
+  PACKAGE_NAME "CURL"
+  PACKAGE_SEARCH_MODES "MODULE" "CONFIG"
+  FETCH_NAME "curl"
+  FETCH_GIT_REPOSITORY "https://github.com/curl/curl.git"
+  FETCH_GIT_TAG "${curl_GIT_TAG}"
+  FETCH_CMAKE_ARGS
+    CURL_DISABLE_INSTALL=${_CURL_DISABLE_INSTALL}
+    CURL_USE_LIBPSL=OFF
+    BUILD_CURL_EXE=OFF
+    BUILD_LIBCURL_DOCS=OFF
+    BUILD_MISC_DOCS=OFF
+    ENABLE_CURL_MANUAL=OFF
+    BUILD_SHARED_LIBS=ON
+  VERSION_REGEX "#define[ \t]+LIBCURL_VERSION[ \t]+\"([0-9]+\\.[0-9]+\\.[0-9]+(-[A-Za-z0-9]+)?)\""
+  VERSION_FILE "\${curl_SOURCE_DIR}/include/curl/curlver.h"
+)
+
+set(BUILD_SHARED_LIBS ${_OTEL_BUILD_SHARED_LIBS} CACHE BOOL "" FORCE)
+unset(_OTEL_BUILD_SHARED_LIBS)
+unset(_CURL_DISABLE_INSTALL)
+
+if(NOT TARGET CURL::libcurl)
+  if(TARGET libcurl_shared)
+    add_library(CURL::libcurl ALIAS libcurl_shared)
+  elseif(TARGET libcurl_static)
+    add_library(CURL::libcurl ALIAS libcurl_static)
+  endif()
+endif()
+
+if(NOT TARGET CURL::libcurl)
+  message(FATAL_ERROR "CURL::libcurl imported target not found.")
+endif()

--- a/cmake/googletest.cmake
+++ b/cmake/googletest.cmake
@@ -1,0 +1,25 @@
+# Copyright The OpenTelemetry Authors
+# SPDX-License-Identifier: Apache-2.0
+
+otel_add_thirdparty_package(
+  PACKAGE_NAME "GTest"
+  PACKAGE_SEARCH_MODES "CONFIG"
+  FETCH_NAME googletest
+  FETCH_GIT_REPOSITORY "https://github.com/google/googletest.git"
+  FETCH_GIT_TAG "${googletest_GIT_TAG}"
+  FETCH_SOURCE_DIR "${PROJECT_SOURCE_DIR}/third_party/googletest"
+  FETCH_CMAKE_ARGS
+    INSTALL_GTEST=${OPENTELEMETRY_INSTALL}
+    BUILD_GMOCK=ON
+  REQUIRED_TARGETS "GTest::gtest;GTest::gtest_main;GTest::gmock"
+  VERSION_REGEX "set\\s*\\(\\s*GOOGLETEST_VERSION[ \t]+([0-9]+(\\.[0-9]+)*)([ \t]|\\))"
+  VERSION_FILE "\${googletest_SOURCE_DIR}/CMakeLists.txt"
+)
+
+if(NOT GTEST_BOTH_LIBRARIES)
+  set(GTEST_BOTH_LIBRARIES GTest::gtest GTest::gtest_main)
+endif()
+
+if(NOT GMOCK_LIB)
+  set(GMOCK_LIB GTest::gmock)
+endif()

--- a/cmake/grpc.cmake
+++ b/cmake/grpc.cmake
@@ -1,0 +1,57 @@
+# Copyright The OpenTelemetry Authors
+# SPDX-License-Identifier: Apache-2.0
+
+# Including the CMakeFindDependencyMacro resolves an error from
+# gRPCConfig.cmake on some grpc versions. See
+# https://github.com/grpc/grpc/pull/33361 for more details.
+include(CMakeFindDependencyMacro)
+
+otel_add_thirdparty_package(
+  PACKAGE_NAME "gRPC"
+  PACKAGE_SEARCH_MODES "CONFIG"
+  FETCH_NAME "grpc"
+  FETCH_GIT_REPOSITORY "https://github.com/grpc/grpc.git"
+  FETCH_GIT_TAG "${grpc_GIT_TAG}"
+  FETCH_CMAKE_ARGS
+    gRPC_INSTALL=${OPENTELEMETRY_INSTALL}
+    gRPC_BUILD_TESTS=OFF
+    gRPC_BUILD_GRPC_CPP_PLUGIN=ON
+    gRPC_BUILD_GRPC_CSHARP_PLUGIN=OFF
+    gRPC_BUILD_GRPC_OBJECTIVE_C_PLUGIN=OFF
+    gRPC_BUILD_GRPC_PHP_PLUGIN=OFF
+    gRPC_BUILD_GRPC_NODE_PLUGIN=OFF
+    gRPC_BUILD_GRPC_PYTHON_PLUGIN=OFF
+    gRPC_BUILD_GRPC_RUBY_PLUGIN=OFF
+    gRPC_BUILD_GRPCPP_OTEL_PLUGIN=OFF
+    RE2_BUILD_TESTING=OFF
+    gRPC_ZLIB_PROVIDER=module
+    gRPC_PROTOBUF_PROVIDER=module
+)
+
+if(TARGET grpc++)
+  set_target_properties(grpc++ PROPERTIES POSITION_INDEPENDENT_CODE ON
+                        CXX_INCLUDE_WHAT_YOU_USE "" CXX_CLANG_TIDY "")
+endif()
+
+if(TARGET grpc++ AND NOT TARGET gRPC::grpc++)
+  add_library(gRPC::grpc++ ALIAS grpc++)
+endif()
+
+if(TARGET grpc_cpp_plugin AND NOT TARGET gRPC::grpc_cpp_plugin)
+  add_executable(gRPC::grpc_cpp_plugin ALIAS grpc_cpp_plugin)
+endif()
+
+if(NOT TARGET gRPC::grpc++)
+  message(FATAL_ERROR "A required gRPC target (grpc++) was not found")
+endif()
+
+if(CMAKE_CROSSCOMPILING)
+  find_program(gRPC_CPP_PLUGIN_EXECUTABLE grpc_cpp_plugin)
+else()
+  if(NOT TARGET gRPC::grpc_cpp_plugin)
+    message(FATAL_ERROR "A required gRPC target (grpc_cpp_plugin) was not found")
+  endif()
+  set(gRPC_CPP_PLUGIN_EXECUTABLE "$<TARGET_FILE:gRPC::grpc_cpp_plugin>")
+endif()
+
+message(STATUS "gRPC_CPP_PLUGIN_EXECUTABLE=${gRPC_CPP_PLUGIN_EXECUTABLE}")

--- a/cmake/ms-gsl.cmake
+++ b/cmake/ms-gsl.cmake
@@ -1,0 +1,14 @@
+# Copyright The OpenTelemetry Authors
+# SPDX-License-Identifier: Apache-2.0
+
+otel_add_thirdparty_package(
+  PACKAGE_NAME "Microsoft.GSL"
+  PACKAGE_SEARCH_MODES "CONFIG"
+  FETCH_NAME "gsl"
+  FETCH_GIT_REPOSITORY "https://github.com/microsoft/GSL.git"
+  FETCH_GIT_TAG "${ms-gsl_GIT_TAG}"
+  FETCH_SOURCE_DIR "${PROJECT_SOURCE_DIR}/third_party/ms-gsl"
+  REQUIRED_TARGETS "Microsoft.GSL::GSL"
+  VERSION_REGEX "project\\([^\\)]*VERSION[ \t]*([0-9]+(\\.[0-9]+)*(\\.[0-9]+)*)"
+  VERSION_FILE "\${GSL_SOURCE_DIR}/CMakeLists.txt"
+)

--- a/cmake/nlohmann-json.cmake
+++ b/cmake/nlohmann-json.cmake
@@ -1,94 +1,16 @@
 # Copyright The OpenTelemetry Authors
 # SPDX-License-Identifier: Apache-2.0
 
-#
-# The dependency on nlohmann_json can be provided different ways. By order of
-# decreasing priority, options are:
-#
-# 1 - Search for a nlohmann_json package
-#
-# Packages installed on the local machine are used if found.
-#
-# The nlohmann_json dependency is not installed, as it already is.
-#
-# 2 - Search for a nlohmann_json git submodule
-#
-# When git submodule is used, the nlohmann_json code is located in:
-# third_party/nlohmann-json
-#
-# The nlohmann_json dependency is installed, by building the sub directory with
-# JSON_Install=ON
-#
-# 3 - Download nlohmann_json from github
-#
-# Code from the development branch is used, unless a specific release tag is
-# provided in variable ${nlohmann-json}
-#
-# The nlohmann_json dependency is installed, by building the downloaded code
-# with JSON_Install=ON
-#
-
-# nlohmann_json package is required for most SDK build configurations
-find_package(nlohmann_json QUIET)
-set(nlohmann_json_clone FALSE)
-if(nlohmann_json_FOUND)
-  message(STATUS "nlohmann::json dependency satisfied by: package")
-elseif(TARGET nlohmann_json)
-  message(STATUS "nlohmann::json is already added as a CMake target!")
-elseif(EXISTS ${PROJECT_SOURCE_DIR}/.git
-       AND EXISTS
-           ${PROJECT_SOURCE_DIR}/third_party/nlohmann-json/CMakeLists.txt)
-  message(STATUS "nlohmann::json dependency satisfied by: git submodule")
-  set(JSON_BuildTests
-      OFF
-      CACHE INTERNAL "")
-  set(JSON_Install
-      ON
-      CACHE INTERNAL "")
-  # This option allows to link nlohmann_json::nlohmann_json target
-  add_subdirectory(${PROJECT_SOURCE_DIR}/third_party/nlohmann-json)
-  # This option allows to add header to include directories
-  include_directories(
-    ${PROJECT_SOURCE_DIR}/third_party/nlohmann-json/single_include)
-else()
-  if("${nlohmann-json}" STREQUAL "")
-    set(nlohmann-json "develop")
-  endif()
-  message(STATUS "nlohmann::json dependency satisfied by: github download")
-  set(nlohmann_json_clone TRUE)
-  include(ExternalProject)
-  ExternalProject_Add(
-    nlohmann_json_download
-    PREFIX third_party
-    GIT_REPOSITORY https://github.com/nlohmann/json.git
-    GIT_TAG "${nlohmann-json}"
-    UPDATE_COMMAND ""
-    CMAKE_ARGS -DCMAKE_INSTALL_PREFIX=${CMAKE_INSTALL_PREFIX}
-               -DJSON_BuildTests=OFF -DJSON_Install=ON
-               -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}
-    TEST_AFTER_INSTALL 0
-    DOWNLOAD_NO_PROGRESS 1
-    LOG_CONFIGURE 1
-    LOG_BUILD 1
-    LOG_INSTALL 1)
-
-  ExternalProject_Get_Property(nlohmann_json_download INSTALL_DIR)
-  set(NLOHMANN_JSON_INCLUDE_DIR
-      ${INSTALL_DIR}/src/nlohmann_json_download/single_include)
-  add_library(nlohmann_json_ INTERFACE)
-  target_include_directories(
-    nlohmann_json_ INTERFACE "$<BUILD_INTERFACE:${NLOHMANN_JSON_INCLUDE_DIR}>"
-                             "$<INSTALL_INTERFACE:include>")
-  add_dependencies(nlohmann_json_ nlohmann_json_download)
-  add_library(nlohmann_json::nlohmann_json ALIAS nlohmann_json_)
-
-  if(OPENTELEMETRY_INSTALL)
-    install(
-      TARGETS nlohmann_json_
-      EXPORT "${PROJECT_NAME}-third_party_nlohmann_json_target"
-      RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
-      LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
-      ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
-      COMPONENT third_party_nlohmann_json)
-  endif()
-endif()
+otel_add_thirdparty_package(
+  PACKAGE_NAME "nlohmann_json"
+  PACKAGE_SEARCH_MODES "CONFIG"
+  FETCH_GIT_REPOSITORY "https://github.com/nlohmann/json.git"
+  FETCH_GIT_TAG "${nlohmann-json_GIT_TAG}"
+  FETCH_SOURCE_DIR "${PROJECT_SOURCE_DIR}/third_party/nlohmann-json"
+  FETCH_CMAKE_ARGS
+    JSON_BuildTests=OFF
+    JSON_Install=${OPENTELEMETRY_INSTALL}
+  REQUIRED_TARGETS "nlohmann_json::nlohmann_json"
+  VERSION_REGEX "project\\([^\\)]*VERSION[ \t]*([0-9]+(\\.[0-9]+)*(\\.[0-9]+)*)"
+  VERSION_FILE "\${nlohmann_json_SOURCE_DIR}/CMakeLists.txt"
+)

--- a/cmake/opentelemetry-proto.cmake
+++ b/cmake/opentelemetry-proto.cmake
@@ -20,7 +20,7 @@
 # 3 - Download opentelemetry-proto from github
 #
 # Code from the required version is used, unless a specific release tag is
-# provided in variable ${opentelemetry-proto}
+# provided in variable ${opentelemetry-proto_GIT_TAG}
 #
 
 if(OTELCPP_PROTO_PATH)
@@ -32,44 +32,27 @@ if(OTELCPP_PROTO_PATH)
   endif()
   message(STATUS "opentelemetry-proto dependency satisfied by: external path")
   set(PROTO_PATH ${OTELCPP_PROTO_PATH})
-  set(needs_proto_download FALSE)
-else()
-  if(EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/third_party/opentelemetry-proto/.git)
+elseif(EXISTS ${PROJECT_SOURCE_DIR}/third_party/opentelemetry-proto/.git)
     message(STATUS "opentelemetry-proto dependency satisfied by: git submodule")
     set(PROTO_PATH
-        "${CMAKE_CURRENT_SOURCE_DIR}/third_party/opentelemetry-proto")
-    set(needs_proto_download FALSE)
+        "${PROJECT_SOURCE_DIR}/third_party/opentelemetry-proto")
+endif()
+
+otel_add_thirdparty_package(
+  PACKAGE_NAME "opentelemetry-proto"
+  FETCH_GIT_REPOSITORY "https://github.com/open-telemetry/opentelemetry-proto.git"
+  FETCH_GIT_TAG "${opentelemetry-proto_GIT_TAG}"
+  FETCH_SOURCE_DIR "${PROTO_PATH}"
+)
+
+if(NOT DEFINED PROTO_PATH)
+  if(EXISTS ${opentelemetry-proto_SOURCE_DIR})
+    set(PROTO_PATH ${opentelemetry-proto_SOURCE_DIR})
   else()
     message(
-      STATUS "opentelemetry-proto dependency satisfied by: github download")
-    if("${opentelemetry-proto}" STREQUAL "")
-      file(READ "${CMAKE_CURRENT_LIST_DIR}/../third_party_release"
-           OTELCPP_THIRD_PARTY_RELEASE_CONTENT)
-      if(OTELCPP_THIRD_PARTY_RELEASE_CONTENT MATCHES
-         "opentelemetry-proto=[ \\t]*([A-Za-z0-9_\\.\\-]+)")
-        set(opentelemetry-proto "${CMAKE_MATCH_1}")
-      else()
-        set(opentelemetry-proto "v1.6.0")
-      endif()
-      unset(OTELCPP_THIRD_PARTY_RELEASE_CONTENT)
-    endif()
-    include(ExternalProject)
-    ExternalProject_Add(
-      opentelemetry-proto
-      GIT_REPOSITORY https://github.com/open-telemetry/opentelemetry-proto.git
-      GIT_TAG "${opentelemetry-proto}"
-      UPDATE_COMMAND ""
-      BUILD_COMMAND ""
-      INSTALL_COMMAND ""
-      CONFIGURE_COMMAND ""
-      TEST_AFTER_INSTALL 0
-      DOWNLOAD_NO_PROGRESS 1
-      LOG_CONFIGURE 1
-      LOG_BUILD 1
-      LOG_INSTALL 1)
-    ExternalProject_Get_Property(opentelemetry-proto INSTALL_DIR)
-    set(PROTO_PATH "${INSTALL_DIR}/src/opentelemetry-proto")
-    set(needs_proto_download TRUE)
+      FATAL_ERROR
+        "opentelemetry-proto src directory has not been fetched. Please set the OTELCPP_PROTO_PATH to the path of the opentelemetry-proto source code."
+    )
   endif()
 endif()
 
@@ -197,20 +180,6 @@ foreach(IMPORT_DIR ${PROTOBUF_IMPORT_DIRS})
   list(APPEND PROTOBUF_INCLUDE_FLAGS "-I${IMPORT_DIR}")
 endforeach()
 
-if(WITH_OTLP_GRPC)
-  if(CMAKE_CROSSCOMPILING)
-    find_program(gRPC_CPP_PLUGIN_EXECUTABLE grpc_cpp_plugin)
-  else()
-    if(TARGET gRPC::grpc_cpp_plugin)
-      project_build_tools_get_imported_location(gRPC_CPP_PLUGIN_EXECUTABLE
-                                                gRPC::grpc_cpp_plugin)
-    else()
-      find_program(gRPC_CPP_PLUGIN_EXECUTABLE grpc_cpp_plugin)
-    endif()
-  endif()
-  message(STATUS "gRPC_CPP_PLUGIN_EXECUTABLE=${gRPC_CPP_PLUGIN_EXECUTABLE}")
-endif()
-
 set(PROTOBUF_COMMON_FLAGS "--proto_path=${PROTO_PATH}"
                           "--cpp_out=${GENERATED_PROTOBUF_PATH}")
 # --experimental_allow_proto3_optional is available from 3.13 and be stable and
@@ -243,7 +212,11 @@ set(PROTOBUF_GENERATED_FILES
     ${PROFILES_SERVICE_PB_H_FILE}
     ${PROFILES_SERVICE_PB_CPP_FILE})
 
+
+set(PROTOBUF_GENERATE_DEPENDS ${PROTOBUF_PROTOC_EXECUTABLE})
+
 if(WITH_OTLP_GRPC)
+  list(APPEND PROTOBUF_GENERATE_DEPENDS ${gRPC_CPP_PLUGIN_EXECUTABLE})
   list(APPEND PROTOBUF_COMMON_FLAGS
        "--grpc_out=generate_mock_code=true:${GENERATED_PROTOBUF_PATH}"
        --plugin=protoc-gen-grpc="${gRPC_CPP_PLUGIN_EXECUTABLE}")
@@ -288,7 +261,7 @@ add_custom_command(
     ${LOGS_PROTO} ${METRICS_PROTO} ${TRACE_SERVICE_PROTO} ${LOGS_SERVICE_PROTO}
     ${METRICS_SERVICE_PROTO} ${PROFILES_PROTO} ${PROFILES_SERVICE_PROTO}
   COMMENT "[Run]: ${PROTOBUF_RUN_PROTOC_COMMAND}"
-  DEPENDS ${PROTOBUF_PROTOC_EXECUTABLE})
+  DEPENDS ${PROTOBUF_GENERATE_DEPENDS})
 
 unset(OTELCPP_PROTO_TARGET_OPTIONS)
 if(CMAKE_SYSTEM_NAME MATCHES "Windows|MinGW|WindowsStore")
@@ -319,8 +292,8 @@ target_include_directories(
          "$<INSTALL_INTERFACE:include>")
 
 # Disable include-what-you-use on generated code.
-set_target_properties(opentelemetry_proto PROPERTIES CXX_INCLUDE_WHAT_YOU_USE
-                                                     "")
+set_target_properties(opentelemetry_proto PROPERTIES CXX_INCLUDE_WHAT_YOU_USE ""
+                                                          CXX_CLANG_TIDY "")
 if(NOT Protobuf_INCLUDE_DIRS AND TARGET protobuf::libprotobuf)
   get_target_property(Protobuf_INCLUDE_DIRS protobuf::libprotobuf
                       INTERFACE_INCLUDE_DIRECTORIES)
@@ -340,7 +313,7 @@ if(WITH_OTLP_GRPC)
 
   # Disable include-what-you-use on generated code.
   set_target_properties(opentelemetry_proto_grpc
-                        PROPERTIES CXX_INCLUDE_WHAT_YOU_USE "")
+                        PROPERTIES CXX_INCLUDE_WHAT_YOU_USE "" CXX_CLANG_TIDY "")
 
   list(APPEND OPENTELEMETRY_PROTO_TARGETS opentelemetry_proto_grpc)
   target_link_libraries(opentelemetry_proto_grpc PUBLIC opentelemetry_proto)
@@ -361,9 +334,6 @@ if(WITH_OTLP_GRPC)
   endif()
 endif()
 
-if(needs_proto_download)
-  add_dependencies(opentelemetry_proto opentelemetry-proto)
-endif()
 set_target_properties(opentelemetry_proto PROPERTIES EXPORT_NAME proto)
 patch_protobuf_targets(opentelemetry_proto)
 

--- a/cmake/opentracing-cpp.cmake
+++ b/cmake/opentracing-cpp.cmake
@@ -1,0 +1,50 @@
+# Copyright The OpenTelemetry Authors
+# SPDX-License-Identifier: Apache-2.0
+
+set(_OTEL_BUILD_TESTING ${BUILD_TESTING})
+
+otel_add_thirdparty_package(
+  PACKAGE_NAME "OpenTracing"
+  PACKAGE_SEARCH_MODES "CONFIG"
+  FETCH_NAME "opentracing"
+  FETCH_GIT_REPOSITORY "https://github.com/opentracing/opentracing-cpp.git"
+  FETCH_GIT_TAG "${opentracing-cpp_GIT_TAG}"
+  FETCH_SOURCE_DIR "${PROJECT_SOURCE_DIR}/third_party/opentracing-cpp"
+  FETCH_CMAKE_ARGS
+    BUILD_TESTING=OFF
+  VERSION_REGEX "#define[ \t]+OPENTRACING_VERSION[ \t]+\"([0-9]+(\\.[0-9]+)*)\""
+  VERSION_FILE "\${opentracing_BINARY_DIR}/include/opentracing/version.h"
+)
+
+set(BUILD_TESTING ${_OTEL_BUILD_TESTING} CACHE BOOL "" FORCE)
+unset(_OTEL_BUILD_TESTING)
+
+if(NOT ${OpenTracing_PROVIDER} STREQUAL "package")
+  if(TARGET opentracing AND NOT TARGET OpenTracing::opentracing)
+    target_include_directories(opentracing PUBLIC
+      "$<BUILD_INTERFACE:${opentracing_SOURCE_DIR}/include>"
+      "$<BUILD_INTERFACE:${opentracing_SOURCE_DIR}/3rd_party/include>"
+      "$<BUILD_INTERFACE:${opentracing_BINARY_DIR}/include>"
+      )
+    set_target_properties(opentracing
+                        PROPERTIES CXX_INCLUDE_WHAT_YOU_USE "" CXX_CLANG_TIDY "")
+    add_library(OpenTracing::opentracing ALIAS opentracing)
+  endif()
+
+  if(TARGET opentracing-static AND NOT TARGET OpenTracing::opentracing-static)
+    target_include_directories(opentracing-static PUBLIC
+      "$<BUILD_INTERFACE:${opentracing_SOURCE_DIR}/include>"
+      "$<BUILD_INTERFACE:${opentracing_SOURCE_DIR}/3rd_party/include>"
+      "$<BUILD_INTERFACE:${opentracing_BINARY_DIR}/include>"
+      )
+    set_target_properties(opentracing-static PROPERTIES
+                        POSITION_INDEPENDENT_CODE ON
+                        CXX_INCLUDE_WHAT_YOU_USE "" CXX_CLANG_TIDY "")
+
+    add_library(OpenTracing::opentracing-static ALIAS opentracing-static)
+  endif()
+endif()
+
+if(NOT TARGET OpenTracing::opentracing AND NOT TARGET OpenTracing::opentracing-static)
+  message(FATAL_ERROR "A required OpenTracing target (opentracing or opentracing-static) was not found")
+endif()

--- a/cmake/otel-install-functions.cmake
+++ b/cmake/otel-install-functions.cmake
@@ -1,6 +1,8 @@
 # Copyright The OpenTelemetry Authors
 # SPDX-License-Identifier: Apache-2.0
+
 include("${PROJECT_SOURCE_DIR}/cmake/thirdparty-dependency-config.cmake")
+include(GNUInstallDirs)
 
 ########################################################################
 # INTERNAL FUNCTIONS - do not call directly. Use the otel_* "Main" functions
@@ -503,4 +505,102 @@ function(otel_install_cmake_config)
       "${CMAKE_CURRENT_LIST_DIR}/cmake/find-package-support-functions.cmake"
     DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME}"
     COMPONENT cmake-config)
+endfunction()
+
+#-----------------------------------------------------------------------
+#  otel_print_build_config
+#   Prints the build configuration and options used to build opentelemetry-cpp.
+function(otel_print_build_config)
+    # Record build config and versions
+    message(STATUS "---------------------------------------------")
+    message(STATUS "build settings")
+    message(STATUS "---------------------------------------------")
+    message(STATUS "OpenTelemetry: ${OPENTELEMETRY_VERSION}")
+    message(STATUS "OpenTelemetry ABI: ${OPENTELEMETRY_ABI_VERSION_NO}")
+    message(STATUS "CMAKE_SYSTEM_PROCESSOR: ${CMAKE_SYSTEM_PROCESSOR}")
+    message(STATUS "CXX: ${CMAKE_CXX_COMPILER_ID} ${CMAKE_CXX_COMPILER_VERSION}")
+    message(STATUS "CMAKE_BUILD_TYPE: ${CMAKE_BUILD_TYPE}")
+    message(STATUS "CXXFLAGS: ${CMAKE_CXX_FLAGS}")
+    message(STATUS "CMAKE_CXX_STANDARD: ${CMAKE_CXX_STANDARD}")
+    message(STATUS "CMAKE_TOOLCHAIN_FILE: ${CMAKE_TOOLCHAIN_FILE}")
+    message(STATUS "BUILD_SHARED_LIBS: ${BUILD_SHARED_LIBS}")
+
+    message(STATUS "---------------------------------------------")
+    message(STATUS "opentelemetry-cpp build options")
+    message(STATUS "---------------------------------------------")
+    message(STATUS "WITH_API_ONLY: ${WITH_API_ONLY}")
+    message(STATUS "WITH_NO_DEPRECATED_CODE: ${WITH_NO_DEPRECATED_CODE}")
+    message(STATUS "WITH_ABI_VERSION_1: ${WITH_ABI_VERSION_1}")
+    message(STATUS "WITH_ABI_VERSION_2: ${WITH_ABI_VERSION_2}")
+    message(STATUS "OTELCPP_VERSIONED_LIBS: ${OTELCPP_VERSIONED_LIBS}")
+    message(STATUS "OTELCPP_MAINTAINER_MODE: ${OTELCPP_MAINTAINER_MODE}")
+    message(STATUS "WITH_STL: ${WITH_STL}")
+    message(STATUS "WITH_GSL: ${WITH_GSL}")
+    message(STATUS "WITH_NO_GETENV: ${WITH_NO_GETENV}")
+    message(STATUS "OTELCPP_FORCE_FETCH_DEPENDENCIES: ${OTELCPP_FORCE_FETCH_DEPENDENCIES}")
+    message(STATUS "OTELCPP_REQUIRE_LOCAL_DEPENDENCIES: ${OTELCPP_REQUIRE_LOCAL_DEPENDENCIES}")
+
+    message(STATUS "---------------------------------------------")
+    message(STATUS "opentelemetry-cpp cmake component options")
+    message(STATUS "---------------------------------------------")
+    message(STATUS "WITH_OTLP_GRPC: ${WITH_OTLP_GRPC}")
+    message(STATUS "WITH_OTLP_HTTP: ${WITH_OTLP_HTTP}")
+    message(STATUS "WITH_OTLP_FILE: ${WITH_OTLP_FILE}")
+    message(STATUS "WITH_HTTP_CLIENT_CURL: ${WITH_HTTP_CLIENT_CURL}")
+    message(STATUS "WITH_ZIPKIN: ${WITH_ZIPKIN}")
+    message(STATUS "WITH_PROMETHEUS: ${WITH_PROMETHEUS}")
+    message(STATUS "WITH_ELASTICSEARCH: ${WITH_ELASTICSEARCH}")
+    message(STATUS "WITH_OPENTRACING: ${WITH_OPENTRACING}")
+    message(STATUS "WITH_ETW: ${WITH_ETW}")
+    message(STATUS "OPENTELEMETRY_BUILD_DLL: ${OPENTELEMETRY_BUILD_DLL}")
+
+    message(STATUS "---------------------------------------------")
+    message(STATUS "feature preview options")
+    message(STATUS "---------------------------------------------")
+    message(STATUS "WITH_ASYNC_EXPORT_PREVIEW: ${WITH_ASYNC_EXPORT_PREVIEW}")
+    message(
+      STATUS
+        "WITH_THREAD_INSTRUMENTATION_PREVIEW: ${WITH_THREAD_INSTRUMENTATION_PREVIEW}"
+    )
+    message(
+      STATUS "WITH_METRICS_EXEMPLAR_PREVIEW: ${WITH_METRICS_EXEMPLAR_PREVIEW}")
+    message(STATUS "WITH_REMOVE_METER_PREVIEW: ${WITH_REMOVE_METER_PREVIEW}")
+    message(
+      STATUS "WITH_OTLP_GRPC_SSL_MTLS_PREVIEW: ${WITH_OTLP_GRPC_SSL_MTLS_PREVIEW}")
+    message(STATUS "WITH_OTLP_RETRY_PREVIEW: ${WITH_OTLP_RETRY_PREVIEW}")
+    message(STATUS "---------------------------------------------")
+    message(STATUS "third-party options")
+    message(STATUS "---------------------------------------------")
+    message(STATUS "WITH_NLOHMANN_JSON: ${USE_NLOHMANN_JSON}")
+    message(STATUS "WITH_CURL_LOGGING: ${WITH_CURL_LOGGING}")
+    message(STATUS "WITH_OTLP_HTTP_COMPRESSION: ${WITH_OTLP_HTTP_COMPRESSION}")
+    message(STATUS "---------------------------------------------")
+    message(STATUS "examples and test options")
+    message(STATUS "---------------------------------------------")
+    message(STATUS "WITH_BENCHMARK: ${WITH_BENCHMARK}")
+    message(STATUS "WITH_EXAMPLES: ${WITH_EXAMPLES}")
+    message(STATUS "WITH_EXAMPLES_HTTP: ${WITH_EXAMPLES_HTTP}")
+    message(STATUS "WITH_FUNC_TESTS: ${WITH_FUNC_TESTS}")
+    message(STATUS "BUILD_W3CTRACECONTEXT_TEST: ${BUILD_W3CTRACECONTEXT_TEST}")
+    message(STATUS "BUILD_TESTING: ${BUILD_TESTING}")
+    message(STATUS "---------------------------------------------")
+    message(STATUS "versions")
+    message(STATUS "---------------------------------------------")
+    message(STATUS "CMake: ${CMAKE_VERSION}")
+    if(BUILD_TESTING)
+      message(STATUS "GTest: ${GTest_VERSION} (${GTest_PROVIDER})")
+      message(STATUS "benchmark: ${benchmark_VERSION} (${benchmark_PROVIDER})")
+    endif()
+
+    foreach(_dependency ${OTEL_THIRDPARTY_DEPENDENCIES_SUPPORTED})
+        if(DEFINED ${_dependency}_VERSION)
+            if(DEFINED ${_dependency}_PROVIDER)
+              set(_provider ${${_dependency}_PROVIDER})
+            else()
+              set(_provider "package")
+            endif()
+            message(STATUS "${_dependency}: ${${_dependency}_VERSION} (${_provider})")
+        endif()
+    endforeach()
+    message(STATUS "---------------------------------------------")
 endfunction()

--- a/cmake/prometheus-cpp.cmake
+++ b/cmake/prometheus-cpp.cmake
@@ -1,0 +1,28 @@
+# Copyright The OpenTelemetry Authors
+# SPDX-License-Identifier: Apache-2.0
+
+otel_add_thirdparty_package(
+  PACKAGE_NAME "prometheus-cpp"
+  PACKAGE_SEARCH_MODES "CONFIG"
+  FETCH_GIT_REPOSITORY "https://github.com/jupp0r/prometheus-cpp.git"
+  FETCH_GIT_TAG "${prometheus-cpp_GIT_TAG}"
+  FETCH_SOURCE_DIR "${PROJECT_SOURCE_DIR}/third_party/prometheus-cpp"
+  FETCH_CMAKE_ARGS
+    ENABLE_TESTING=OFF
+    ENABLE_PUSH=OFF
+  REQUIRED_TARGETS "prometheus-cpp::core;prometheus-cpp::pull"
+  VERSION_REGEX "project\\([^\\)]*VERSION[ \t]*([0-9]+(\\.[0-9]+)*(\\.[0-9]+)*)"
+  VERSION_FILE "\${prometheus-cpp_SOURCE_DIR}/CMakeLists.txt"
+)
+
+if(TARGET core)
+  set_target_properties(core PROPERTIES
+        CXX_INCLUDE_WHAT_YOU_USE ""
+        CXX_CLANG_TIDY "")
+endif()
+
+if(TARGET pull)
+  set_target_properties(pull PROPERTIES
+        CXX_INCLUDE_WHAT_YOU_USE ""
+        CXX_CLANG_TIDY "")
+endif()

--- a/cmake/protobuf.cmake
+++ b/cmake/protobuf.cmake
@@ -1,0 +1,52 @@
+# Copyright The OpenTelemetry Authors
+# SPDX-License-Identifier: Apache-2.0
+
+if(DEFINED gRPC_PROVIDER AND NOT gRPC_PROVIDER STREQUAL "package" AND TARGET libprotobuf)
+  # gRPC was fetched and built protobuf as a submodule
+  set(Protobuf_PROVIDER "grpc_submodule")
+  otel_add_thirdparty_package(
+    PACKAGE_NAME "Protobuf"
+    VERSION_REGEX "\"cpp\"[ \t]*:[ \t]*\"([0-9]+\\.[0-9]+(\\.[0-9]+)?)\""
+    VERSION_FILE "\${grpc_SOURCE_DIR}/third_party/protobuf/version.json"
+  )
+else()
+  # Protobuf 3.22+ depends on abseil-cpp and must be found using the cmake
+  # find_package CONFIG search mode. The following attempts to find Protobuf
+  # using the CONFIG mode first, and if not found, falls back to the MODULE
+  # mode. See https://gitlab.kitware.com/cmake/cmake/-/issues/24321 for more
+  # details.
+
+  otel_add_thirdparty_package(
+    PACKAGE_NAME "Protobuf"
+    PACKAGE_SEARCH_MODES "CONFIG" "MODULE"
+    FETCH_NAME "protobuf"
+    FETCH_GIT_REPOSITORY "https://github.com/protocolbuffers/protobuf.git"
+    FETCH_GIT_TAG "${protobuf_GIT_TAG}"
+    FETCH_CMAKE_ARGS
+      protobuf_INSTALL=${OPENTELEMETRY_INSTALL}
+      protobuf_BUILD_TESTS=OFF
+      protobuf_BUILD_EXAMPLES=OFF
+      protobuf_WITH_ZLIB=OFF
+    VERSION_REGEX "\"cpp\"[ \t]*:[ \t]*\"([0-9]+\\.[0-9]+(\\.[0-9]+)?)\""
+    VERSION_FILE "\${protobuf_SOURCE_DIR}/version.json"
+  )
+endif()
+
+if(TARGET libprotobuf)
+  set_target_properties(libprotobuf PROPERTIES POSITION_INDEPENDENT_CODE ON CXX_CLANG_TIDY "" CXX_INCLUDE_WHAT_YOU_USE "")
+endif()
+
+if(NOT TARGET protobuf::libprotobuf)
+  message(FATAL_ERROR "A required protobuf target (protobuf::libprotobuf) was not found")
+endif()
+
+if(CMAKE_CROSSCOMPILING)
+  find_program(PROTOBUF_PROTOC_EXECUTABLE protoc)
+else()
+  if(NOT TARGET protobuf::protoc)
+    message(FATAL_ERROR "A required protobuf target (protobuf::protoc) was not found")
+  endif()
+  set(PROTOBUF_PROTOC_EXECUTABLE "$<TARGET_FILE:protobuf::protoc>")
+endif()
+
+message(STATUS "PROTOBUF_PROTOC_EXECUTABLE=${PROTOBUF_PROTOC_EXECUTABLE}")

--- a/cmake/thirdparty-dependency-config.cmake
+++ b/cmake/thirdparty-dependency-config.cmake
@@ -15,6 +15,8 @@ set(OTEL_THIRDPARTY_DEPENDENCIES_SUPPORTED
      gRPC
      prometheus-cpp
      OpenTracing
+     opentelemetry-proto
+     Microsoft.GSL
 )
 
 #-----------------------------------------------------------------------
@@ -35,6 +37,8 @@ set(OTEL_nlohmann_json_SEARCH_MODE "CONFIG")
 set(OTEL_gRPC_SEARCH_MODE "CONFIG")
 set(OTEL_prometheus-cpp_SEARCH_MODE "CONFIG")
 set(OTEL_OpenTracing_SEARCH_MODE "CONFIG")
+set(OTEL_opentelemetry-proto_SEARCH_MODE "")
+set(OTEL_Microsoft.GSL_SEARCH_MODE "CONFIG")
 
 # The search mode is set to "CONFIG" for Protobuf versions >= 3.22.0
 # to find Protobuf's abseil dependency properly until the FindProtobuf module is updated support the upstream protobuf-config.cmake.

--- a/cmake/tools.cmake
+++ b/cmake/tools.cmake
@@ -220,3 +220,176 @@ function(project_build_tools_patch_default_imported_config)
     endif()
   endforeach()
 endfunction()
+
+#-------------------------------------------------------------------------------
+# Set the target version for a given target
+function(set_target_version target_name)
+  if(OTELCPP_VERSIONED_LIBS)
+    set_target_properties(
+      ${target_name} PROPERTIES VERSION ${OPENTELEMETRY_VERSION}
+                                SOVERSION ${OPENTELEMETRY_ABI_VERSION_NO})
+  endif()
+endfunction()
+
+#-------------------------------------------------------------------------------
+# otel_add_thirdparty_package
+# Add a third party package to the project using CMake's find_package or FetchContent.
+# By default the dependencies are found/fetched in the following order:
+#   Step 1. Search for installed packages by calling find_package using the provided search modes.
+#   Step 2. Use FetchContent on the provided source directory (used for git submodules)
+#   Step 3. Use FetchContent to fetch the package from a git repository if not found in the previous steps.
+# Arguments:
+#   PACKAGE_NAME: The name of the package to find or fetch
+#   PACKAGE_SEARCH_MODES: The cmake find_package search modes. Multiple search modes can be provided
+#            (ie: SEARCH_MODES "MODULE" "CONFIG" will search first using the MODULE mode, then CONFIG mode).
+#   FETCH_NAME: The name of the package to fetch if not found
+#   FETCH_SOURCE_DIR: The directory to fetch the package into
+#   FETCH_GIT_REPOSITORY: The git repository URL to fetch the package from
+#   FETCH_GIT_TAG: The git tag to checkout
+#   FETCH_CMAKE_ARGS: The cmake arguments used to build the package
+#   REQUIRED_TARGETS: The targets to check for existence
+#   VERSION_REGEX: The regex to parse the package version if fetched from source or git repository. Defaults to parsing the version from the third_party_release file.
+#   VERSION_FILE: The file to read the version from when using VERSION_REGEX. Defaults to "opentelemetry-cpp/third_party_release".
+
+# Output variables set at the parent scope:
+#   <package>_SOURCE_DIR: Set if the package was fetched
+#   <package>_BINARY_DIR: Set if the package was fetched
+#   <package>_VERSION: The version of the package found or fetched
+#   <package>_PROVIDER: The provider of the package (package, fetch_source, fetch_respository)
+function(otel_add_thirdparty_package)
+
+  set(optionArgs )
+  set(oneValueArgs PACKAGE_NAME FETCH_NAME FETCH_GIT_REPOSITORY FETCH_GIT_TAG FETCH_SOURCE_DIR VERSION_REGEX VERSION_FILE)
+  set(multiValueArgs PACKAGE_SEARCH_MODES FETCH_CMAKE_ARGS REQUIRED_TARGETS )
+  cmake_parse_arguments(_THIRDPARTY "${optionArgs}" "${oneValueArgs}" "${multiValueArgs}" "${ARGN}")
+
+  if(NOT _THIRDPARTY_PACKAGE_NAME)
+    message(FATAL_ERROR "PACKAGE_NAME is required")
+  endif()
+
+  if(DEFINED _THIRDPARTY_UNPARSED_ARGUMENTS)
+    message(FATAL_ERROR "Unparsed arguments detected: ${_THIRDPARTY_UNPARSED_ARGUMENTS}")
+  endif()
+
+  if(NOT _THIRDPARTY_FETCH_NAME)
+    set(_THIRDPARTY_FETCH_NAME ${_THIRDPARTY_PACKAGE_NAME})
+  endif()
+
+  if(NOT _THIRDPARTY_VERSION_FILE)
+    set(_THIRDPARTY_VERSION_FILE "${PROJECT_SOURCE_DIR}/third_party_release")
+  endif()
+
+  if(NOT _THIRDPARTY_VERSION_REGEX)
+    set(_THIRDPARTY_VERSION_REGEX "${_THIRDPARTY_FETCH_NAME}=[ \\t]*v?([0-9]+(\\.[0-9]+)*)")
+  endif()
+
+  if(DEFINED _THIRDPARTY_FETCH_GIT_REPOSITORY AND NOT _THIRDPARTY_FETCH_GIT_TAG)
+    message(FATAL_ERROR "FETCH_GIT_TAG is required if FETCH_GIT_REPOSITORY is defined")
+  endif()
+
+  message(STATUS "Adding third party package ${_THIRDPARTY_PACKAGE_NAME}")
+  message(DEBUG "  Search modes: ${_THIRDPARTY_PACKAGE_SEARCH_MODES}")
+  message(DEBUG "  Fetch name: ${_THIRDPARTY_FETCH_NAME}")
+  message(DEBUG "  Source dir: ${_THIRDPARTY_FETCH_SOURCE_DIR}")
+  message(DEBUG "  Git repository: ${_THIRDPARTY_FETCH_GIT_REPOSITORY}")
+  message(DEBUG "  Git tag: ${_THIRDPARTY_FETCH_GIT_TAG}")
+  message(DEBUG "  CMake args: ${_THIRDPARTY_FETCH_CMAKE_ARGS}")
+  message(DEBUG "  Required targets: ${_THIRDPARTY_REQUIRED_TARGETS}")
+  message(DEBUG "  Version regex: ${_THIRDPARTY_VERSION_REGEX}")
+  message(DEBUG "  Version file: ${_THIRDPARTY_VERSION_FILE}")
+
+  if(NOT OTELCPP_FORCE_FETCH_DEPENDENCIES)
+    foreach(_search_mode IN LISTS _THIRDPARTY_PACKAGE_SEARCH_MODES)
+      message(STATUS "  Searching for ${_THIRDPARTY_PACKAGE_NAME} with search mode ${_search_mode}")
+      find_package(${_THIRDPARTY_PACKAGE_NAME} ${_search_mode} QUIET)
+      if(${_THIRDPARTY_PACKAGE_NAME}_FOUND)
+        # ZLIB and CURL have a version string in older versions of cmake. Set <package>_VERSION from <package>_VERSION_STRING
+        if(DEFINED ${_THIRDPARTY_PACKAGE_NAME}_VERSION_STRING AND NOT DEFINED ${_THIRDPARTY_PACKAGE_NAME}_VERSION)
+          set(${_THIRDPARTY_PACKAGE_NAME}_VERSION ${${_THIRDPARTY_PACKAGE_NAME}_VERSION_STRING})
+        endif()
+        message(STATUS "  Found ${_THIRDPARTY_PACKAGE_NAME} with search mode ${_search_mode}")
+        break()
+      endif()
+    endforeach()
+  endif()
+
+  if(${_THIRDPARTY_PACKAGE_NAME}_FOUND)
+    set("${_THIRDPARTY_PACKAGE_NAME}_PROVIDER" "package")
+  elseif(DEFINED _THIRDPARTY_FETCH_SOURCE_DIR OR DEFINED _THIRDPARTY_FETCH_GIT_REPOSITORY)
+    # Use FetchContent to fetch the package if not found
+    include(FetchContent)
+
+    if(DEFINED _THIRDPARTY_FETCH_SOURCE_DIR AND EXISTS "${_THIRDPARTY_FETCH_SOURCE_DIR}/.git")
+      message(STATUS "  Fetching ${_THIRDPARTY_FETCH_PACKAGE_NAME} from local source at ${_THIRDPARTY_FETCH_SOURCE_DIR}")
+      FetchContent_Declare(
+          ${_THIRDPARTY_FETCH_NAME}
+          SOURCE_DIR ${_THIRDPARTY_FETCH_SOURCE_DIR}
+      )
+      set("${_THIRDPARTY_PACKAGE_NAME}_PROVIDER" "fetch_source")
+    elseif( NOT OTELCPP_REQUIRE_LOCAL_DEPENDENCIES AND DEFINED _THIRDPARTY_FETCH_GIT_REPOSITORY AND DEFINED _THIRDPARTY_FETCH_GIT_TAG)
+      message(STATUS "  Fetching ${_THIRDPARTY_PACKAGE_NAME} from ${_THIRDPARTY_FETCH_GIT_REPOSITORY} at tag ${_THIRDPARTY_FETCH_GIT_TAG}")
+      FetchContent_Declare(
+          ${_THIRDPARTY_FETCH_NAME}
+          GIT_REPOSITORY
+          ${_THIRDPARTY_FETCH_GIT_REPOSITORY}
+          GIT_TAG
+          ${_THIRDPARTY_FETCH_GIT_TAG}
+          GIT_SHALLOW ON
+      )
+      set("${_THIRDPARTY_PACKAGE_NAME}_PROVIDER" "fetch_respository")
+    else()
+      message(FATAL_ERROR "No valid source found for ${_THIRDPARTY_PACKAGE_NAME}")
+    endif()
+
+    # Set the CMake arguments (KEY=VALUE) for the third party package
+    foreach(_arg IN LISTS _THIRDPARTY_FETCH_CMAKE_ARGS)
+      if(_arg MATCHES "^([^=]+)=(.*)$")
+        set(_key   "${CMAKE_MATCH_1}")
+        set(_value "${CMAKE_MATCH_2}")
+        message(DEBUG "  Setting ${_key}=${_value}")
+        set(${_key} "${_value}" CACHE STRING "" FORCE)
+      else()
+        message(WARNING "  ignoring malformed CMAKE_ARG: ${_arg}")
+      endif()
+    endforeach()
+
+    FetchContent_MakeAvailable(${_THIRDPARTY_FETCH_NAME})
+
+    set(${_THIRDPARTY_FETCH_NAME}_SOURCE_DIR ${${_THIRDPARTY_FETCH_NAME}_SOURCE_DIR} PARENT_SCOPE)
+    set(${_THIRDPARTY_FETCH_NAME}_BINARY_DIR ${${_THIRDPARTY_FETCH_NAME}_BINARY_DIR} PARENT_SCOPE)
+  endif()
+
+  # Check for required targets
+  foreach(_target ${_THIRDPARTY_REQUIRED_TARGETS})
+    if(NOT TARGET ${_target})
+      message(FATAL_ERROR "Required target ${_target} not found")
+    endif()
+  endforeach()
+
+  # Determine the package version if not already defined
+  if(NOT DEFINED ${_THIRDPARTY_PACKAGE_NAME}_VERSION AND NOT ${_THIRDPARTY_PACKAGE_NAME}_PROVIDER STREQUAL "package")
+    if(DEFINED _THIRDPARTY_VERSION_REGEX AND DEFINED _THIRDPARTY_VERSION_FILE)
+      string(CONFIGURE "${_THIRDPARTY_VERSION_FILE}" THIRDPARTY_VERSION_FILE)
+      if(NOT EXISTS "${THIRDPARTY_VERSION_FILE}")
+        message(WARNING "Version file ${THIRDPARTY_VERSION_FILE} does not exist")
+      else()
+        file(READ "${THIRDPARTY_VERSION_FILE}" _file_contents)
+        string(REGEX MATCH
+              "${_THIRDPARTY_VERSION_REGEX}"
+              _version_match
+              "${_file_contents}")
+        if(_version_match)
+          set("${_THIRDPARTY_PACKAGE_NAME}_VERSION" "${CMAKE_MATCH_1}")
+        else()
+          message(WARNING "Failed to parse version from ${_THIRDPARTY_VERSION_FILE} using regex ${_THIRDPARTY_VERSION_REGEX}")
+        endif()
+      endif()
+    endif()
+  endif()
+
+  message(STATUS "${_THIRDPARTY_PACKAGE_NAME} version: ${${_THIRDPARTY_PACKAGE_NAME}_VERSION}")
+  message(STATUS "${_THIRDPARTY_PACKAGE_NAME} provider: ${${_THIRDPARTY_PACKAGE_NAME}_PROVIDER}")
+
+  set(${_THIRDPARTY_PACKAGE_NAME}_VERSION ${${_THIRDPARTY_PACKAGE_NAME}_VERSION} PARENT_SCOPE)
+  set(${_THIRDPARTY_PACKAGE_NAME}_PROVIDER ${${_THIRDPARTY_PACKAGE_NAME}_PROVIDER} PARENT_SCOPE)
+endfunction()

--- a/cmake/zlib.cmake
+++ b/cmake/zlib.cmake
@@ -1,0 +1,94 @@
+# Copyright The OpenTelemetry Authors
+# SPDX-License-Identifier: Apache-2.0
+
+if(DEFINED gRPC_PROVIDER AND NOT gRPC_PROVIDER STREQUAL "package" AND (TARGET zlib OR TARGET zlibstatic))
+  # zlib was built as a submodule of gRPC
+  set(ZLIB_PROVIDER "grpc_submodule")
+  otel_add_thirdparty_package(
+    PACKAGE_NAME "ZLIB"
+    VERSION_REGEX "set\\([ \t]*VERSION[ \t]+\"([0-9]+\\.[0-9]+\\.[0-9]+(\\.[0-9]+)?)\"\\)"
+    VERSION_FILE "\${grpc_SOURCE_DIR}/third_party/zlib/CMakeLists.txt"
+  )
+else()
+  if(${OPENTELEMETRY_INSTALL})
+    set(_SKIP_ZLIB_INSTALL OFF)
+  else()
+    set(_SKIP_ZLIB_INSTALL ON)
+  endif()
+
+  otel_add_thirdparty_package(
+    PACKAGE_NAME "ZLIB"
+    PACKAGE_SEARCH_MODES "MODULE" "CONFIG"
+    FETCH_NAME "zlib"
+    FETCH_GIT_REPOSITORY "https://github.com/madler/zlib.git"
+    FETCH_GIT_TAG "${zlib_GIT_TAG}"
+    FETCH_CMAKE_ARGS
+      ZLIB_BUILD_EXAMPLES=OFF
+      ZLIB_INSTALL=${OPENTELEMETRY_INSTALL}
+      SKIP_INSTALL_ALL=${_SKIP_ZLIB_INSTALL}
+      SKIP_INSTALL_LIBRARIES=${_SKIP_ZLIB_INSTALL}
+    VERSION_REGEX "set\\([ \t]*VERSION[ \t]+\"([0-9]+\\.[0-9]+\\.[0-9]+(\\.[0-9]+)?)\"\\)"
+    VERSION_FILE "\${zlib_SOURCE_DIR}/CMakeLists.txt"
+  )
+  unset(_SKIP_ZLIB_INSTALL)
+endif()
+
+if(TARGET zlib OR TARGET zlibstatic)
+  # ZLIB_USE_STATIC_LIBS is added to FindZLIB with CMake 3.24 and defaults to OFF
+  if(NOT DEFINED ZLIB_USE_STATIC_LIBS)
+    set(ZLIB_USE_STATIC_LIBS OFF)
+  endif()
+
+  set(_ZLIB_TARGETS)
+  if(TARGET zlib)
+    set_target_properties(zlib PROPERTIES INTERFACE_INCLUDE_DIRECTORIES "")
+    set_target_properties(zlib PROPERTIES EXPORT_NAME ZLIB)
+    target_include_directories(zlib INTERFACE
+      $<BUILD_INTERFACE:${zlib_SOURCE_DIR}>
+      $<BUILD_INTERFACE:${zlib_BINARY_DIR}>
+      $<INSTALL_INTERFACE:include>)
+    list(APPEND _ZLIB_TARGETS zlib)
+  endif()
+
+  if(TARGET zlibstatic)
+    set_target_properties(zlibstatic PROPERTIES INTERFACE_INCLUDE_DIRECTORIES "")
+    set_target_properties(zlibstatic PROPERTIES EXPORT_NAME ZLIBSTATIC)
+    target_include_directories(zlibstatic INTERFACE
+      $<BUILD_INTERFACE:${zlib_SOURCE_DIR}>
+      $<BUILD_INTERFACE:${zlib_BINARY_DIR}>
+      $<INSTALL_INTERFACE:include>)
+    list(APPEND _ZLIB_TARGETS zlibstatic)
+  endif()
+
+  # Create an alias target for ZLIB::ZLIB
+  if(NOT TARGET ZLIB::ZLIB)
+    if(TARGET zlib AND NOT ZLIB_USE_STATIC_LIBS)
+      add_library(ZLIB::ZLIB ALIAS zlib)
+    elseif(TARGET zlibstatic AND ZLIB_USE_STATIC_LIBS)
+      add_library(ZLIB::ZLIB ALIAS zlibstatic)
+    endif()
+  endif()
+
+  if(OPENTELEMETRY_INSTALL)
+    # ZLIB doesn't install its targets to an export set. This causes errors when trying to install opentelemetry-cpp targets that link to zlib.
+    # Create an export set here for the zlib targets to be installed.
+    # A config.cmake file is not created as we will still rely on the FindZLIB module to find zlib after install.
+    install(
+      TARGETS ${_ZLIB_TARGETS}
+      EXPORT "zlib-target"
+      RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+      LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+      ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR} COMPONENT "zlib")
+
+    install(
+      EXPORT "zlib-target"
+      FILE "zlib-target.cmake"
+      NAMESPACE "ZLIB::"
+      DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/ZLIB"
+      COMPONENT "zlib")
+  endif()
+endif()
+
+if(NOT TARGET ZLIB::ZLIB)
+  message(FATAL_ERROR "A required zlib target (ZLIB::ZLIB) was not found")
+endif()

--- a/examples/http/CMakeLists.txt
+++ b/examples/http/CMakeLists.txt
@@ -7,7 +7,7 @@ add_executable(http_server server.cc)
 target_link_libraries(
   http_client
   PRIVATE opentelemetry-cpp::trace opentelemetry-cpp::http_client_curl
-          opentelemetry-cpp::ostream_span_exporter ${CURL_LIBRARIES})
+          opentelemetry-cpp::ostream_span_exporter CURL::libcurl)
 
 target_link_libraries(
   http_server

--- a/exporters/etw/CMakeLists.txt
+++ b/exporters/etw/CMakeLists.txt
@@ -15,9 +15,6 @@ target_link_libraries(
   opentelemetry_exporter_etw INTERFACE opentelemetry_api opentelemetry_trace
                                        nlohmann_json::nlohmann_json)
 target_link_libraries(opentelemetry_exporter_etw INTERFACE opentelemetry_logs)
-if(nlohmann_json_clone)
-  add_dependencies(opentelemetry_exporter_etw nlohmann_json::nlohmann_json)
-endif()
 
 otel_add_component(
   COMPONENT

--- a/exporters/otlp/CMakeLists.txt
+++ b/exporters/otlp/CMakeLists.txt
@@ -22,7 +22,6 @@ target_link_libraries(opentelemetry_otlp_recordable
                       PUBLIC opentelemetry_metrics)
 
 if(WITH_OTLP_GRPC)
-  find_package(gRPC REQUIRED)
   add_library(
     opentelemetry_exporter_otlp_grpc_client
     src/otlp_grpc_client.cc src/otlp_grpc_client_factory.cc
@@ -127,10 +126,6 @@ if(WITH_OTLP_HTTP)
             "$<BUILD_INTERFACE:nlohmann_json::nlohmann_json>"
             "$<INSTALL_INTERFACE:opentelemetry_http_client_curl>")
 
-  if(nlohmann_json_clone)
-    add_dependencies(opentelemetry_exporter_otlp_http_client
-                     nlohmann_json::nlohmann_json)
-  endif()
   target_include_directories(
     opentelemetry_exporter_otlp_http_client
     PUBLIC "$<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}/include>"
@@ -202,10 +197,6 @@ if(WITH_OTLP_FILE)
     PUBLIC opentelemetry_sdk opentelemetry_common
     PRIVATE opentelemetry_proto $<BUILD_INTERFACE:nlohmann_json::nlohmann_json>)
 
-  if(nlohmann_json_clone)
-    add_dependencies(opentelemetry_exporter_otlp_file_client
-                     nlohmann_json::nlohmann_json)
-  endif()
   target_include_directories(
     opentelemetry_exporter_otlp_file_client
     PUBLIC "$<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}/include>"

--- a/exporters/prometheus/CMakeLists.txt
+++ b/exporters/prometheus/CMakeLists.txt
@@ -1,10 +1,6 @@
 # Copyright The OpenTelemetry Authors
 # SPDX-License-Identifier: Apache-2.0
 
-if(NOT TARGET prometheus-cpp::core)
-  find_package(prometheus-cpp CONFIG REQUIRED)
-endif()
-
 add_library(
   opentelemetry_exporter_prometheus
   src/exporter.cc src/exporter_options.cc src/exporter_factory.cc
@@ -19,22 +15,10 @@ target_include_directories(
   PUBLIC "$<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}/include>"
          "$<INSTALL_INTERFACE:include>")
 
-set(PROMETHEUS_EXPORTER_TARGETS opentelemetry_exporter_prometheus)
-if(TARGET pull)
-  list(APPEND PROMETHEUS_EXPORTER_TARGETS pull)
-endif()
-if(TARGET core)
-  list(APPEND PROMETHEUS_EXPORTER_TARGETS core)
-endif()
-if(TARGET util)
-  list(APPEND PROMETHEUS_EXPORTER_TARGETS util)
-endif()
-set(PROMETHEUS_CPP_TARGETS prometheus-cpp::pull prometheus-cpp::core)
-if(TARGET prometheus-cpp::util)
-  list(APPEND PROMETHEUS_CPP_TARGETS prometheus-cpp::util)
-endif()
-target_link_libraries(opentelemetry_exporter_prometheus
-                      PUBLIC opentelemetry_metrics ${PROMETHEUS_CPP_TARGETS})
+target_link_libraries(
+  opentelemetry_exporter_prometheus
+  PUBLIC opentelemetry_metrics prometheus-cpp::core
+  PRIVATE prometheus-cpp::pull)
 
 otel_add_component(
   COMPONENT

--- a/exporters/zipkin/CMakeLists.txt
+++ b/exporters/zipkin/CMakeLists.txt
@@ -59,7 +59,7 @@ if(BUILD_TESTING)
     ${GMOCK_LIB}
     opentelemetry_exporter_zipkin_trace
     opentelemetry_resources
-    ${CURL_LIBRARIES})
+    CURL::libcurl)
 
   gtest_add_tests(
     TARGET zipkin_exporter_test

--- a/ext/src/http/client/curl/CMakeLists.txt
+++ b/ext/src/http/client/curl/CMakeLists.txt
@@ -11,39 +11,19 @@ set_target_version(opentelemetry_http_client_curl)
 target_link_libraries(opentelemetry_http_client_curl
                       PUBLIC opentelemetry_common)
 
-unset(CURL_IMPORTED_TARGET_NAME)
+target_link_libraries(
+  opentelemetry_http_client_curl
+  PUBLIC opentelemetry_ext
+  PRIVATE CURL::libcurl)
 
-foreach(FIND_CURL_IMPORTED_TARGET CURL::libcurl CURL::libcurl_shared
-                                  CURL::libcurl_static)
-  if(TARGET ${FIND_CURL_IMPORTED_TARGET})
-    set(CURL_IMPORTED_TARGET_NAME ${FIND_CURL_IMPORTED_TARGET})
-    break()
-  endif()
-endforeach()
+# Some versions of libcurl do not export the link directories, which may cause
+# link errors
+project_build_tools_get_imported_location(CURL_LIB_FILE_PATH CURL::libcurl)
+get_filename_component(CURL_LIB_DIR_PATH "${CURL_LIB_FILE_PATH}" DIRECTORY)
 
-if(TARGET ${CURL_IMPORTED_TARGET_NAME})
-  target_link_libraries(
-    opentelemetry_http_client_curl
-    PUBLIC opentelemetry_ext
-    PRIVATE ${CURL_IMPORTED_TARGET_NAME})
-
-  # Some versions of libcurl do not export the link directories, which may cause
-  # link errors
-  project_build_tools_get_imported_location(CURL_LIB_FILE_PATH
-                                            ${CURL_IMPORTED_TARGET_NAME})
-  get_filename_component(CURL_LIB_DIR_PATH "${CURL_LIB_FILE_PATH}" DIRECTORY)
-
-  if(CURL_LIB_DIR_PATH)
-    target_link_directories(opentelemetry_http_client_curl PUBLIC
-                            "$<BUILD_INTERFACE:${CURL_LIB_DIR_PATH}>")
-  endif()
-else()
-  target_include_directories(opentelemetry_http_client_curl
-                             INTERFACE "${CURL_INCLUDE_DIRS}")
-  target_link_libraries(
-    opentelemetry_http_client_curl
-    PUBLIC opentelemetry_ext
-    PRIVATE ${CURL_LIBRARIES})
+if(CURL_LIB_DIR_PATH)
+  target_link_directories(opentelemetry_http_client_curl PUBLIC
+                          "$<BUILD_INTERFACE:${CURL_LIB_DIR_PATH}>")
 endif()
 
 if(WITH_CURL_LOGGING)
@@ -52,19 +32,10 @@ if(WITH_CURL_LOGGING)
 endif()
 
 if(WITH_OTLP_HTTP_COMPRESSION)
-  if(TARGET ZLIB::ZLIB)
-    target_link_libraries(
-      opentelemetry_http_client_curl
-      PUBLIC opentelemetry_ext
-      PRIVATE ZLIB::ZLIB)
-  else()
-    target_include_directories(opentelemetry_http_client_curl
-                               INTERFACE "${ZLIB_INCLUDE_DIRS}")
-    target_link_libraries(
-      opentelemetry_http_client_curl
-      PUBLIC opentelemetry_ext
-      PRIVATE ${ZLIB_LIBRARIES})
-  endif()
+  target_link_libraries(
+    opentelemetry_http_client_curl
+    PUBLIC opentelemetry_ext
+    PRIVATE ZLIB::ZLIB)
 endif()
 
 otel_add_component(COMPONENT ext_http_curl TARGETS

--- a/ext/test/http/CMakeLists.txt
+++ b/ext/test/http/CMakeLists.txt
@@ -4,28 +4,10 @@
 if(WITH_HTTP_CLIENT_CURL)
   set(FILENAME curl_http_test)
   add_executable(${FILENAME} ${FILENAME}.cc)
-  target_link_libraries(${FILENAME} ${GMOCK_LIB} ${GTEST_BOTH_LIBRARIES}
-                        ${CMAKE_THREAD_LIBS_INIT})
-
-  unset(CURL_IMPORTED_TARGET_NAME)
-
-  foreach(FIND_CURL_IMPORTED_TARGET CURL::libcurl CURL::libcurl_shared
-                                    CURL::libcurl_static)
-    if(TARGET ${FIND_CURL_IMPORTED_TARGET})
-      set(CURL_IMPORTED_TARGET_NAME ${FIND_CURL_IMPORTED_TARGET})
-      break()
-    endif()
-  endforeach()
-
-  if(TARGET ${CURL_IMPORTED_TARGET_NAME})
-    target_link_libraries(${FILENAME} opentelemetry_http_client_curl
-                          opentelemetry_common ${CURL_IMPORTED_TARGET_NAME})
-  else()
-    target_include_directories(${FILENAME} PRIVATE ${CURL_INCLUDE_DIRS})
-    target_link_libraries(${FILENAME} ${CURL_LIBRARIES}
-                          opentelemetry_http_client_curl opentelemetry_common)
-  endif()
-
+  target_link_libraries(
+    ${FILENAME}
+    PRIVATE ${GMOCK_LIB} ${GTEST_BOTH_LIBRARIES} opentelemetry_http_client_curl
+            opentelemetry_common CURL::libcurl)
   gtest_add_tests(
     TARGET ${FILENAME}
     TEST_PREFIX ext.http.curl.

--- a/ext/test/w3c_tracecontext_http_test_server/CMakeLists.txt
+++ b/ext/test/w3c_tracecontext_http_test_server/CMakeLists.txt
@@ -6,8 +6,4 @@ target_link_libraries(
   w3c_tracecontext_http_test_server
   PRIVATE ${CMAKE_THREAD_LIBS_INIT} opentelemetry_trace
           opentelemetry_http_client_curl opentelemetry_exporter_ostream_span
-          ${CURL_LIBRARIES} nlohmann_json::nlohmann_json)
-if(nlohmann_json_clone)
-  add_dependencies(w3c_tracecontext_http_test_server
-                   nlohmann_json::nlohmann_json)
-endif()
+          CURL::libcurl nlohmann_json::nlohmann_json)

--- a/install/conan/conanfile_latest.txt
+++ b/install/conan/conanfile_latest.txt
@@ -25,7 +25,7 @@ protobuf/*:shared=False
 abseil/*:fPIC=True
 abseil/*:shared=False
 opentracing-cpp/*:fPIC=True
-opentracing-cpp/*:shared=True
+opentracing-cpp/*:shared=False
 pcre2/*:with_bzip2=False
 
 [test_requires]

--- a/install/test/cmake/component_tests/shims_opentracing/CMakeLists.txt
+++ b/install/test/cmake/component_tests/shims_opentracing/CMakeLists.txt
@@ -6,8 +6,12 @@ project(opentelemetry-cpp-shims_opentracing-install-test LANGUAGES CXX)
 
 find_package(opentelemetry-cpp REQUIRED COMPONENTS shims_opentracing)
 
-if(NOT TARGET OpenTracing::opentracing)
-  message(FATAL_ERROR "OpenTracing::opentracing target not found")
+if(NOT TARGET OpenTracing::opentracing AND NOT TARGET
+                                           OpenTracing::opentracing-static)
+  message(
+    FATAL_ERROR
+      "OpenTracing::opentracing or OpenTracing::opentracing-static was not found"
+  )
 endif()
 
 find_package(GTest CONFIG REQUIRED)

--- a/opentracing-shim/CMakeLists.txt
+++ b/opentracing-shim/CMakeLists.txt
@@ -1,37 +1,34 @@
 # Copyright The OpenTelemetry Authors
 # SPDX-License-Identifier: Apache-2.0
 
-set(this_target opentelemetry_opentracing_shim)
+add_library(
+  opentelemetry_opentracing_shim src/shim_utils.cc src/span_shim.cc
+                                 src/span_context_shim.cc src/tracer_shim.cc)
 
-add_library(${this_target} src/shim_utils.cc src/span_shim.cc
-                           src/span_context_shim.cc src/tracer_shim.cc)
-
-set_target_properties(${this_target} PROPERTIES EXPORT_NAME opentracing_shim)
-set_target_version(${this_target})
+set_target_properties(opentelemetry_opentracing_shim
+                      PROPERTIES EXPORT_NAME opentracing_shim)
+set_target_version(opentelemetry_opentracing_shim)
 
 target_include_directories(
-  ${this_target} PUBLIC "$<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}/include>"
-                        "$<INSTALL_INTERFACE:include>")
+  opentelemetry_opentracing_shim
+  PUBLIC "$<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}/include>"
+         "$<INSTALL_INTERFACE:include>")
 
-if(OPENTRACING_DIR)
-  target_include_directories(
-    ${this_target}
-    PUBLIC
-      "$<BUILD_INTERFACE:${PROJECT_BINARY_DIR}/${OPENTRACING_DIR}/include>"
-      "$<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/${OPENTRACING_DIR}/include>"
-      "$<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/${OPENTRACING_DIR}/3rd_party/include>"
-  )
-  target_link_libraries(${this_target} opentelemetry_api opentracing)
+target_link_libraries(opentelemetry_opentracing_shim PUBLIC opentelemetry_api)
+
+if(TARGET OpenTracing::opentracing)
+  target_link_libraries(opentelemetry_opentracing_shim
+                        PUBLIC OpenTracing::opentracing)
 else()
-  target_link_libraries(${this_target} opentelemetry_api
-                        OpenTracing::opentracing)
+  target_link_libraries(opentelemetry_opentracing_shim
+                        PUBLIC OpenTracing::opentracing-static)
 endif()
 
 otel_add_component(
   COMPONENT
   shims_opentracing
   TARGETS
-  ${this_target}
+  opentelemetry_opentracing_shim
   FILES_DIRECTORY
   "include/opentelemetry/opentracingshim"
   FILES_DESTINATION
@@ -43,20 +40,10 @@ otel_add_component(
 if(BUILD_TESTING)
   foreach(testname propagation_test shim_utils_test span_shim_test
                    span_context_shim_test tracer_shim_test)
-
     add_executable(${testname} "test/${testname}.cc")
-
-    if(OPENTRACING_DIR)
-      target_link_libraries(
-        ${testname} ${GTEST_BOTH_LIBRARIES} ${CMAKE_THREAD_LIBS_INIT}
-        opentelemetry_api opentelemetry_opentracing_shim opentracing)
-    else()
-      target_link_libraries(
-        ${testname} ${GTEST_BOTH_LIBRARIES} ${CMAKE_THREAD_LIBS_INIT}
-        opentelemetry_api opentelemetry_opentracing_shim
-        OpenTracing::opentracing)
-    endif()
-
+    target_link_libraries(
+      ${testname} PRIVATE ${GTEST_BOTH_LIBRARIES} Threads::Threads
+                          opentelemetry_opentracing_shim)
     gtest_add_tests(
       TARGET ${testname}
       TEST_PREFIX opentracing_shim.

--- a/sdk/test/metrics/CMakeLists.txt
+++ b/sdk/test/metrics/CMakeLists.txt
@@ -38,7 +38,7 @@ foreach(
   instrument_descriptor_test)
   add_executable(${testname} "${testname}.cc")
   target_link_libraries(
-    ${testname} ${GTEST_BOTH_LIBRARIES} ${CMAKE_THREAD_LIBS_INIT}
+    ${testname} ${GTEST_BOTH_LIBRARIES} ${GMOCK_LIB} ${CMAKE_THREAD_LIBS_INIT}
     metrics_common_test_utils opentelemetry_resources)
   target_compile_definitions(${testname} PRIVATE UNIT_TESTING)
   gtest_add_tests(

--- a/third_party_release
+++ b/third_party_release
@@ -13,11 +13,13 @@
 #   git submodule status
 #
 
-gRPC=v1.49.2
-abseil=20240116.1
+protobuf=v3.21.6
+grpc=v1.49.2
 benchmark=v1.8.3
-googletest=1.14.0
-ms-gsl=v3.1.0-67-g6f45293
+googletest=v1.14.0
+ms-gsl=v3.1.0
+curl=curl-8_12_0
+zlib=v1.3.1
 nlohmann-json=v3.12.0
 opentelemetry-proto=v1.6.0
 opentracing-cpp=v1.6.0


### PR DESCRIPTION
Update third party dependency management in CMake. 

## Changes
- Add an `otel_add_external_project` function unify how third party dependencies are found/fetched. 
  - Create a cmake script file for each dependency to ensure all required targets are imported/installed
  - Enable fetching from submodules or git repo with the version tags in the `third_party_release file`. 
- Remove the `install_windows_deps` CMake function and ARCH detection
   - This seems intended to support bootstrapping vcpkg windows packages within the otel-cpp CMake file. 
   - This extra logic seems untested in ci and not required since vcpkg users can set the CMAKE_TOOLCHAIN_FILE as expected
   - The bootstrapping use case is addressed through fetching all dependencies with standard CMake FetchContent from github. 
- Clean up cmake dependency linking
   - Use the standard `CURL::libcurl` target
   - Use the explicit `prometheus-cpp` `pull` and `core` targets
   - Use either the shared or static `opentracing-cpp` target 
- Add cmake options to force fetch dependencies or to require all local dependencies (following the model used by Protobuf)
   - If only local dependencies should be used then set `OTELCPP_REQUIRE_LOCAL_DEPENDENCIES=ON` to prevent fetching from github
   - If only fetching from github is desired then set `OTELCPP_FORCE_FETCH_DEPENDENCIES=ON`
- Update github ci workflow to test fetching all dependencies from github (no git submodules).
  -  Clean up the googletest install script to build with the selected cxx standard and no longer install curl, zlib,and nlohmann-json. 
- Add the ms-gsl dependency to the api component if `WITH_GSL=ON` and test in ci

For significant contributions please make sure you have completed the following items:

* [ ] `CHANGELOG.md` updated for non-trivial changes
* [ ] Unit tests have been added
* [ ] Changes in public API reviewed