### PR TITLE
Increase code coverage of iwyu and clang-tidy ci jobs

### DIFF
--- a/.github/workflows/clang-tidy.yaml
+++ b/.github/workflows/clang-tidy.yaml
@@ -32,10 +32,15 @@ jobs:
           sudo apt install -y --no-install-recommends --no-install-suggests \
           build-essential \
           cmake \
+          zlib1g-dev \
           libssl-dev \
           libcurl4-openssl-dev \
+          nlohmann-json3-dev \
+          libabsl-dev \
           libprotobuf-dev \
+          libgrpc++-dev \
           protobuf-compiler \
+          protobuf-compiler-grpc \
           libgmock-dev \
           libgtest-dev \
           libbenchmark-dev
@@ -57,6 +62,14 @@ jobs:
           cmake -B build \
             -DCMAKE_CXX_STANDARD=14 \
             -DWITH_STL=CXX14 \
+            -DWITH_ABI_VERSION_1=OFF \
+            -DWITH_ABI_VERSION_2=ON \
+            -DWITH_HTTP_CLIENT_CURL=ON \
+            -DWITH_THREAD_INSTRUMENTATION_PREVIEW=ON \
+            -DWITH_OTLP_GRPC_SSL_MTLS_PREVIEW=ON \
+            -DWITH_OTLP_GRPC_CREDENTIAL_PREVIEW=ON \
+            -DWITH_OTLP_RETRY_PREVIEW=ON \
+            -DWITH_OTLP_GRPC=ON \
             -DWITH_OTLP_HTTP=ON \
             -DWITH_OTLP_FILE=ON \
             -DWITH_PROMETHEUS=ON \
@@ -85,4 +98,3 @@ jobs:
           COUNT=$(grep -c "warning:" clang-tidy.log)
           echo "clang-tidy reported ${COUNT} warning(s)"
 
-# TODO: include WITH_OTLP_GRPC flags.

--- a/.github/workflows/iwyu.yml
+++ b/.github/workflows/iwyu.yml
@@ -62,9 +62,18 @@ jobs:
             -DWITH_OTLP_FILE=ON \
             -DWITH_OPENTRACING=ON \
             -DWITH_OTLP_HTTP_COMPRESSION=ON \
-            -DWITH_THREAD_INSTRUMENTATION=ON \
             -DWITH_ZIPKIN=ON \
             -DWITH_PROMETHEUS=ON \
+            -DWITH_ELASTICSEARCH=ON \
+            -DWITH_HTTP_CLIENT_CURL=ON \
+            -DWITH_ABI_VERSION_1=OFF \
+            -DWITH_ABI_VERSION_2=ON \
+            -DWITH_METRICS_EXEMPLAR_PREVIEW=ON \
+            -DWITH_ASYNC_EXPORT_PREVIEW=ON \
+            -DWITH_THREAD_INSTRUMENTATION_PREVIEW=ON \
+            -DWITH_OTLP_GRPC_SSL_MTLS_PREVIEW=ON \
+            -DWITH_OTLP_GRPC_CREDENTIAL_PREVIEW=ON \
+            -DWITH_OTLP_RETRY_PREVIEW=ON \
             ..
 
       - name: iwyu_tool


### PR DESCRIPTION

## Changes

- Turns on abiv2 and all exporter options for iwyu and clang-tidy

For significant contributions please make sure you have completed the following items:

* [ ] `CHANGELOG.md` updated for non-trivial changes
* [ ] Unit tests have been added
* [ ] Changes in public API reviewed