### PR TITLE
[CodeHealth] Fix clang-tidy warnings part 5

### DIFF
--- a/exporters/otlp/include/opentelemetry/exporters/otlp/otlp_file_client.h
+++ b/exporters/otlp/include/opentelemetry/exporters/otlp/otlp_file_client.h
@@ -40,6 +40,10 @@ public:
                           OtlpFileClientRuntimeOptions &&runtime_options);
 
   ~OtlpFileClient();
+  OtlpFileClient(const OtlpFileClient &)            = delete;
+  OtlpFileClient &operator=(const OtlpFileClient &) = delete;
+  OtlpFileClient(OtlpFileClient &&)                 = delete;
+  OtlpFileClient &operator=(OtlpFileClient &&)      = delete;
 
   /**
    * Sync export

--- a/exporters/otlp/include/opentelemetry/exporters/otlp/otlp_file_client_options.h
+++ b/exporters/otlp/include/opentelemetry/exporters/otlp/otlp_file_client_options.h
@@ -68,7 +68,7 @@ struct OtlpFileClientFileSystemOptions
   // Maximum file count
   std::size_t rotate_size = 3;
 
-  inline OtlpFileClientFileSystemOptions() noexcept {}
+  OtlpFileClientFileSystemOptions() = default;
 };
 
 /**
@@ -77,7 +77,12 @@ struct OtlpFileClientFileSystemOptions
 class OtlpFileAppender
 {
 public:
-  virtual ~OtlpFileAppender() = default;
+  OtlpFileAppender()                                    = default;
+  virtual ~OtlpFileAppender()                           = default;
+  OtlpFileAppender(const OtlpFileAppender &)            = default;
+  OtlpFileAppender &operator=(const OtlpFileAppender &) = default;
+  OtlpFileAppender(OtlpFileAppender &&)                 = default;
+  OtlpFileAppender &operator=(OtlpFileAppender &&)      = default;
 
   virtual void Export(opentelemetry::nostd::string_view data, std::size_t record_count) = 0;
 
@@ -96,12 +101,17 @@ using OtlpFileClientBackendOptions =
  */
 struct OtlpFileClientOptions
 {
+  OtlpFileClientOptions()                                         = default;
+  virtual ~OtlpFileClientOptions()                                = default;
+  OtlpFileClientOptions(const OtlpFileClientOptions &)            = default;
+  OtlpFileClientOptions &operator=(const OtlpFileClientOptions &) = default;
+  OtlpFileClientOptions(OtlpFileClientOptions &&)                 = default;
+  OtlpFileClientOptions &operator=(OtlpFileClientOptions &&)      = default;
+
   // Whether to print the status of the FILE client in the console
   bool console_debug = false;
 
   OtlpFileClientBackendOptions backend_options;
-
-  inline OtlpFileClientOptions() noexcept {}
 };
 }  // namespace otlp
 }  // namespace exporter

--- a/exporters/otlp/include/opentelemetry/exporters/otlp/otlp_file_client_runtime_options.h
+++ b/exporters/otlp/include/opentelemetry/exporters/otlp/otlp_file_client_runtime_options.h
@@ -19,6 +19,13 @@ namespace otlp
  */
 struct OtlpFileClientRuntimeOptions
 {
+  OtlpFileClientRuntimeOptions()                                                = default;
+  virtual ~OtlpFileClientRuntimeOptions()                                       = default;
+  OtlpFileClientRuntimeOptions(const OtlpFileClientRuntimeOptions &)            = default;
+  OtlpFileClientRuntimeOptions &operator=(const OtlpFileClientRuntimeOptions &) = default;
+  OtlpFileClientRuntimeOptions(OtlpFileClientRuntimeOptions &&)                 = default;
+  OtlpFileClientRuntimeOptions &operator=(OtlpFileClientRuntimeOptions &&)      = default;
+
   std::shared_ptr<sdk::common::ThreadInstrumentation> thread_instrumentation =
       std::shared_ptr<sdk::common::ThreadInstrumentation>(nullptr);
 };

--- a/exporters/otlp/include/opentelemetry/exporters/otlp/otlp_file_exporter.h
+++ b/exporters/otlp/include/opentelemetry/exporters/otlp/otlp_file_exporter.h
@@ -76,9 +76,9 @@ public:
 
 private:
   // The configuration options associated with this exporter.
-  const OtlpFileExporterOptions options_;
+  OtlpFileExporterOptions options_;
   // The runtime options associated with this exporter.
-  const OtlpFileExporterRuntimeOptions runtime_options_;
+  OtlpFileExporterRuntimeOptions runtime_options_;
 
   // Object that stores the file context.
   std::unique_ptr<OtlpFileClient> file_client_;

--- a/exporters/otlp/include/opentelemetry/exporters/otlp/otlp_file_exporter_options.h
+++ b/exporters/otlp/include/opentelemetry/exporters/otlp/otlp_file_exporter_options.h
@@ -22,7 +22,6 @@ namespace otlp
 struct OPENTELEMETRY_EXPORT OtlpFileExporterOptions : public OtlpFileClientOptions
 {
   OtlpFileExporterOptions();
-  ~OtlpFileExporterOptions();
 };
 
 }  // namespace otlp

--- a/exporters/otlp/include/opentelemetry/exporters/otlp/otlp_file_exporter_runtime_options.h
+++ b/exporters/otlp/include/opentelemetry/exporters/otlp/otlp_file_exporter_runtime_options.h
@@ -18,8 +18,7 @@ namespace otlp
  */
 struct OPENTELEMETRY_EXPORT OtlpFileExporterRuntimeOptions : public OtlpFileClientRuntimeOptions
 {
-  OtlpFileExporterRuntimeOptions()  = default;
-  ~OtlpFileExporterRuntimeOptions() = default;
+  OtlpFileExporterRuntimeOptions() = default;
 };
 
 }  // namespace otlp

--- a/exporters/otlp/include/opentelemetry/exporters/otlp/otlp_file_log_record_exporter.h
+++ b/exporters/otlp/include/opentelemetry/exporters/otlp/otlp_file_log_record_exporter.h
@@ -77,9 +77,9 @@ public:
 
 private:
   // Configuration options for the exporter
-  const OtlpFileLogRecordExporterOptions options_;
+  OtlpFileLogRecordExporterOptions options_;
   // Runtime options for the exporter
-  const OtlpFileLogRecordExporterRuntimeOptions runtime_options_;
+  OtlpFileLogRecordExporterRuntimeOptions runtime_options_;
 
   // Object that stores the file context.
   std::unique_ptr<OtlpFileClient> file_client_;

--- a/exporters/otlp/include/opentelemetry/exporters/otlp/otlp_file_log_record_exporter_options.h
+++ b/exporters/otlp/include/opentelemetry/exporters/otlp/otlp_file_log_record_exporter_options.h
@@ -22,7 +22,6 @@ namespace otlp
 struct OPENTELEMETRY_EXPORT OtlpFileLogRecordExporterOptions : public OtlpFileClientOptions
 {
   OtlpFileLogRecordExporterOptions();
-  ~OtlpFileLogRecordExporterOptions();
 };
 
 }  // namespace otlp

--- a/exporters/otlp/include/opentelemetry/exporters/otlp/otlp_file_log_record_exporter_runtime_options.h
+++ b/exporters/otlp/include/opentelemetry/exporters/otlp/otlp_file_log_record_exporter_runtime_options.h
@@ -18,8 +18,7 @@ namespace otlp
 struct OPENTELEMETRY_EXPORT OtlpFileLogRecordExporterRuntimeOptions
     : public OtlpFileClientRuntimeOptions
 {
-  OtlpFileLogRecordExporterRuntimeOptions()  = default;
-  ~OtlpFileLogRecordExporterRuntimeOptions() = default;
+  OtlpFileLogRecordExporterRuntimeOptions() = default;
 };
 
 }  // namespace otlp

--- a/exporters/otlp/include/opentelemetry/exporters/otlp/otlp_file_metric_exporter.h
+++ b/exporters/otlp/include/opentelemetry/exporters/otlp/otlp_file_metric_exporter.h
@@ -69,12 +69,12 @@ private:
   friend class OtlpFileMetricExporterTestPeer;
 
   // Configuration options for the exporter
-  const OtlpFileMetricExporterOptions options_;
+  OtlpFileMetricExporterOptions options_;
   // Runtime options for the exporter
-  const OtlpFileMetricExporterRuntimeOptions runtime_options_;
+  OtlpFileMetricExporterRuntimeOptions runtime_options_;
 
   // Aggregation Temporality Selector
-  const sdk::metrics::AggregationTemporalitySelector aggregation_temporality_selector_;
+  sdk::metrics::AggregationTemporalitySelector aggregation_temporality_selector_;
 
   // Object that stores the file context.
   std::unique_ptr<OtlpFileClient> file_client_;

--- a/exporters/otlp/include/opentelemetry/exporters/otlp/otlp_file_metric_exporter_options.h
+++ b/exporters/otlp/include/opentelemetry/exporters/otlp/otlp_file_metric_exporter_options.h
@@ -23,7 +23,6 @@ namespace otlp
 struct OPENTELEMETRY_EXPORT OtlpFileMetricExporterOptions : public OtlpFileClientOptions
 {
   OtlpFileMetricExporterOptions();
-  ~OtlpFileMetricExporterOptions();
 
   PreferredAggregationTemporality aggregation_temporality;
 };

--- a/exporters/otlp/include/opentelemetry/exporters/otlp/otlp_file_metric_exporter_runtime_options.h
+++ b/exporters/otlp/include/opentelemetry/exporters/otlp/otlp_file_metric_exporter_runtime_options.h
@@ -18,8 +18,7 @@ namespace otlp
 struct OPENTELEMETRY_EXPORT OtlpFileMetricExporterRuntimeOptions
     : public OtlpFileClientRuntimeOptions
 {
-  OtlpFileMetricExporterRuntimeOptions()  = default;
-  ~OtlpFileMetricExporterRuntimeOptions() = default;
+  OtlpFileMetricExporterRuntimeOptions() = default;
 };
 
 }  // namespace otlp

--- a/exporters/otlp/src/otlp_file_exporter_options.cc
+++ b/exporters/otlp/src/otlp_file_exporter_options.cc
@@ -27,8 +27,6 @@ OtlpFileExporterOptions::OtlpFileExporterOptions()
   backend_options = fs_options;
 }
 
-OtlpFileExporterOptions::~OtlpFileExporterOptions() {}
-
 }  // namespace otlp
 }  // namespace exporter
 OPENTELEMETRY_END_NAMESPACE

--- a/exporters/otlp/src/otlp_file_log_record_exporter_options.cc
+++ b/exporters/otlp/src/otlp_file_log_record_exporter_options.cc
@@ -27,8 +27,6 @@ OtlpFileLogRecordExporterOptions::OtlpFileLogRecordExporterOptions()
   backend_options = fs_options;
 }
 
-OtlpFileLogRecordExporterOptions::~OtlpFileLogRecordExporterOptions() {}
-
 }  // namespace otlp
 }  // namespace exporter
 OPENTELEMETRY_END_NAMESPACE

--- a/exporters/otlp/src/otlp_file_metric_exporter.cc
+++ b/exporters/otlp/src/otlp_file_metric_exporter.cc
@@ -49,8 +49,9 @@ OtlpFileMetricExporter::OtlpFileMetricExporter(
       runtime_options_(runtime_options),
       aggregation_temporality_selector_{
           OtlpMetricUtils::ChooseTemporalitySelector(options_.aggregation_temporality)},
-      file_client_(new OtlpFileClient(OtlpFileClientOptions(options),
-                                      OtlpFileClientRuntimeOptions(runtime_options)))
+      file_client_(new OtlpFileClient(
+          OtlpFileClientOptions(static_cast<const OtlpFileClientOptions &>(options)),
+          OtlpFileClientRuntimeOptions(runtime_options)))
 {}
 
 // ----------------------------- Exporter methods ------------------------------

--- a/exporters/otlp/src/otlp_file_metric_exporter_options.cc
+++ b/exporters/otlp/src/otlp_file_metric_exporter_options.cc
@@ -28,8 +28,6 @@ OtlpFileMetricExporterOptions::OtlpFileMetricExporterOptions()
   backend_options = fs_options;
 }
 
-OtlpFileMetricExporterOptions::~OtlpFileMetricExporterOptions() {}
-
 }  // namespace otlp
 }  // namespace exporter
 OPENTELEMETRY_END_NAMESPACE


### PR DESCRIPTION
Contributes to https://github.com/open-telemetry/opentelemetry-cpp/issues/2053

## Changes

Fixes clang-tidy warnings with the OTLP File component
- cppcoreguidelines-slicing
- cppcoreguidelines-avoid-const-or-ref-data-members
- cppcoreguidelines-special-member-functions

For significant contributions please make sure you have completed the following items:

* [ ] `CHANGELOG.md` updated for non-trivial changes
* [ ] Unit tests have been added
* [ ] Changes in public API reviewed