### PR TITLE
[CMAKE] Address the vcpkg opentelemetry-cpp port CMake patches

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -497,6 +497,14 @@ if((NOT WITH_API_ONLY) AND USE_NLOHMANN_JSON)
   include("${opentelemetry-cpp_SOURCE_DIR}/cmake/nlohmann-json.cmake")
 endif()
 
+#
+# Do we need OpenTracing ?
+#
+
+if(WITH_OPENTRACING)
+  include("${opentelemetry-cpp_SOURCE_DIR}/cmake/opentracing-cpp.cmake")
+endif()
+
 if(OTELCPP_MAINTAINER_MODE)
   if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
     message(STATUS "Building with gcc in maintainer mode.")
@@ -701,6 +709,10 @@ endif()
 if(prometheus-cpp_FOUND)
   message(STATUS "prometheus-cpp: ${prometheus-cpp_VERSION}")
 endif()
+if(WITH_OPENTRACING)
+  message(
+    STATUS "opentracing-cpp: ${OpenTracing_VERSION} (${OpenTracing_PROVIDER})")
+endif()
 message(STATUS "---------------------------------------------")
 
 include("${opentelemetry-cpp_SOURCE_DIR}/cmake/otel-install-functions.cmake")
@@ -724,30 +736,6 @@ endif()
 add_subdirectory(api)
 
 if(WITH_OPENTRACING)
-  find_package(OpenTracing CONFIG QUIET)
-  if(NOT OpenTracing_FOUND)
-    set(OPENTRACING_DIR "third_party/opentracing-cpp")
-    message(STATUS "Trying to use local ${OPENTRACING_DIR} from submodule")
-    if(EXISTS "${PROJECT_SOURCE_DIR}/${OPENTRACING_DIR}/.git")
-      set(SAVED_BUILD_TESTING ${BUILD_TESTING})
-      set(BUILD_TESTING OFF)
-      set(SAVED_CMAKE_CXX_INCLUDE_WHAT_YOU_USE
-          ${CMAKE_CXX_INCLUDE_WHAT_YOU_USE})
-      set(CMAKE_CXX_INCLUDE_WHAT_YOU_USE "")
-      add_subdirectory(${OPENTRACING_DIR})
-      set(BUILD_TESTING ${SAVED_BUILD_TESTING})
-      set(CMAKE_CXX_INCLUDE_WHAT_YOU_USE
-          ${SAVED_CMAKE_CXX_INCLUDE_WHAT_YOU_USE})
-    else()
-      message(
-        FATAL_ERROR
-          "\nopentracing-cpp package was not found. Please either provide it manually or clone with submodules. "
-          "To initialize, fetch and checkout any nested submodules, you can use the following command:\n"
-          "git submodule update --init --recursive")
-    endif()
-  else()
-    message(STATUS "Using external opentracing-cpp")
-  endif()
   add_subdirectory(opentracing-shim)
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,11 +36,6 @@ project(opentelemetry-cpp)
 # Mark variables as used so cmake doesn't complain about them
 mark_as_advanced(CMAKE_TOOLCHAIN_FILE)
 
-# Note: CMAKE_FIND_PACKAGE_PREFER_CONFIG requires cmake 3.15. Prefer cmake
-# CONFIG search mode to find dependencies. This is important to properly find
-# protobuf versions 3.22.0 and above due to the abseil-cpp dependency.
-set(CMAKE_FIND_PACKAGE_PREFER_CONFIG TRUE)
-
 # Don't use customized cmake modules if vcpkg is used to resolve dependence.
 if(NOT DEFINED CMAKE_TOOLCHAIN_FILE)
   list(APPEND CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/cmake/modules/")
@@ -77,10 +72,6 @@ if(DEFINED ENV{VCPKG_ROOT} AND NOT DEFINED CMAKE_TOOLCHAIN_FILE)
   set(CMAKE_TOOLCHAIN_FILE
       "$ENV{VCPKG_ROOT}/scripts/buildsystems/vcpkg.cmake"
       CACHE STRING "")
-endif()
-
-if(VCPKG_CHAINLOAD_TOOLCHAIN_FILE)
-  include("${VCPKG_CHAINLOAD_TOOLCHAIN_FILE}")
 endif()
 
 option(WITH_ABI_VERSION_1 "ABI version 1" ON)

--- a/cmake/opentracing-cpp.cmake
+++ b/cmake/opentracing-cpp.cmake
@@ -34,7 +34,7 @@ if(NOT OpenTracing_FOUND)
   if(DEFINED _SAVED_BUILD_TESTING)
     set(BUILD_TESTING ${_SAVED_BUILD_TESTING} CACHE BOOL "" FORCE)
   else()
-    unset(BUILD_TESTING)
+    unset(BUILD_TESTING CACHE)
   endif()
 
   # Patch the opentracing targets to set missing includes, add namespaced alias targets, disable iwyu and clang-tidy.

--- a/cmake/opentracing-cpp.cmake
+++ b/cmake/opentracing-cpp.cmake
@@ -1,0 +1,65 @@
+# Copyright The OpenTelemetry Authors
+# SPDX-License-Identifier: Apache-2.0
+
+find_package(OpenTracing CONFIG QUIET)
+set(OpenTracing_PROVIDER "find_package")
+
+if(NOT OpenTracing_FOUND)
+  set(_OPENTRACING_SUBMODULE_DIR "${opentelemetry-cpp_SOURCE_DIR}/third_party/opentracing-cpp")
+  if(EXISTS "${_OPENTRACING_SUBMODULE_DIR}/.git")
+    FetchContent_Declare(
+       "opentracing"
+       SOURCE_DIR "${_OPENTRACING_SUBMODULE_DIR}"
+       )
+    set(OpenTracing_PROVIDER "fetch_source")
+  else()
+    FetchContent_Declare(
+      "opentracing"
+      GIT_REPOSITORY  "https://github.com/opentracing/opentracing-cpp.git"
+      GIT_TAG "${opentracing-cpp_GIT_TAG}"
+      )
+    set(OpenTracing_PROVIDER "fetch_repository")
+  endif()
+
+  # OpenTracing uses the BUILD_TESTING variable directly and we must force the cached value to OFF.
+  # save the current state of BUILD_TESTING
+  if(DEFINED BUILD_TESTING)
+    set(_SAVED_BUILD_TESTING ${BUILD_TESTING})
+  endif()
+
+  set(BUILD_TESTING OFF CACHE BOOL "" FORCE)
+  FetchContent_MakeAvailable(opentracing)
+
+  # Restore the saved state of BUILD_TESTING
+  if(DEFINED _SAVED_BUILD_TESTING)
+    set(BUILD_TESTING ${_SAVED_BUILD_TESTING} CACHE BOOL "" FORCE)
+  else()
+    unset(BUILD_TESTING)
+  endif()
+
+  # Patch the opentracing targets to set missing includes, add namespaced alias targets, disable iwyu and clang-tidy.
+  foreach(_target opentracing opentracing-static)
+    if(TARGET ${_target})
+      # Add missing include directories
+      target_include_directories(${_target} PUBLIC
+        "$<BUILD_INTERFACE:${opentracing_SOURCE_DIR}/include>"
+        "$<BUILD_INTERFACE:${opentracing_SOURCE_DIR}/3rd_party/include>"
+        "$<BUILD_INTERFACE:${opentracing_BINARY_DIR}/include>"
+        )
+      # Disable CXX_INCLUDE_WHAT_YOU_USE and CXX_CLANG_TIDY
+      set_target_properties(${_target}
+                          PROPERTIES CXX_INCLUDE_WHAT_YOU_USE "" CXX_CLANG_TIDY "")
+      # Create alias targets
+      if(NOT TARGET OpenTracing::${_target})
+        add_library(OpenTracing::${_target} ALIAS ${_target})
+      endif()
+    endif()
+  endforeach()
+
+  # Set the OpenTracing_VERSION variable from the git tag.
+  string(REGEX REPLACE "^v([0-9]+\\.[0-9]+\\.[0-9]+)$" "\\1" OpenTracing_VERSION "${opentracing-cpp_GIT_TAG}")
+endif(NOT OpenTracing_FOUND)
+
+if(NOT TARGET OpenTracing::opentracing AND NOT TARGET OpenTracing::opentracing-static)
+  message(FATAL_ERROR "No OpenTracing targets (OpenTracing::opentracing or OpenTracing::opentracing-static) were imported")
+endif()

--- a/install/conan/conanfile_latest.txt
+++ b/install/conan/conanfile_latest.txt
@@ -25,7 +25,7 @@ protobuf/*:shared=False
 abseil/*:fPIC=True
 abseil/*:shared=False
 opentracing-cpp/*:fPIC=True
-opentracing-cpp/*:shared=True
+opentracing-cpp/*:shared=False
 pcre2/*:with_bzip2=False
 
 [test_requires]

--- a/opentracing-shim/CMakeLists.txt
+++ b/opentracing-shim/CMakeLists.txt
@@ -1,37 +1,36 @@
 # Copyright The OpenTelemetry Authors
 # SPDX-License-Identifier: Apache-2.0
 
-set(this_target opentelemetry_opentracing_shim)
+add_library(
+  opentelemetry_opentracing_shim src/shim_utils.cc src/span_shim.cc
+                                 src/span_context_shim.cc src/tracer_shim.cc)
 
-add_library(${this_target} src/shim_utils.cc src/span_shim.cc
-                           src/span_context_shim.cc src/tracer_shim.cc)
-
-set_target_properties(${this_target} PROPERTIES EXPORT_NAME opentracing_shim)
-set_target_version(${this_target})
+set_target_properties(opentelemetry_opentracing_shim
+                      PROPERTIES EXPORT_NAME opentracing_shim)
+set_target_version(opentelemetry_opentracing_shim)
 
 target_include_directories(
-  ${this_target} PUBLIC "$<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}/include>"
-                        "$<INSTALL_INTERFACE:include>")
+  opentelemetry_opentracing_shim
+  PUBLIC "$<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}/include>"
+         "$<INSTALL_INTERFACE:include>")
 
-if(OPENTRACING_DIR)
-  target_include_directories(
-    ${this_target}
-    PUBLIC
-      "$<BUILD_INTERFACE:${PROJECT_BINARY_DIR}/${OPENTRACING_DIR}/include>"
-      "$<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/${OPENTRACING_DIR}/include>"
-      "$<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/${OPENTRACING_DIR}/3rd_party/include>"
-  )
-  target_link_libraries(${this_target} opentelemetry_api opentracing)
+target_link_libraries(opentelemetry_opentracing_shim PUBLIC opentelemetry_api)
+
+# link to the shared library target (OpenTracing::opentracing) if it exists
+# otherwise use the static library target.
+if(TARGET OpenTracing::opentracing)
+  target_link_libraries(opentelemetry_opentracing_shim
+                        PUBLIC OpenTracing::opentracing)
 else()
-  target_link_libraries(${this_target} opentelemetry_api
-                        OpenTracing::opentracing)
+  target_link_libraries(opentelemetry_opentracing_shim
+                        PUBLIC OpenTracing::opentracing-static)
 endif()
 
 otel_add_component(
   COMPONENT
   shims_opentracing
   TARGETS
-  ${this_target}
+  opentelemetry_opentracing_shim
   FILES_DIRECTORY
   "include/opentelemetry/opentracingshim"
   FILES_DESTINATION
@@ -43,20 +42,10 @@ otel_add_component(
 if(BUILD_TESTING)
   foreach(testname propagation_test shim_utils_test span_shim_test
                    span_context_shim_test tracer_shim_test)
-
     add_executable(${testname} "test/${testname}.cc")
-
-    if(OPENTRACING_DIR)
-      target_link_libraries(
-        ${testname} ${GTEST_BOTH_LIBRARIES} ${CMAKE_THREAD_LIBS_INIT}
-        opentelemetry_api opentelemetry_opentracing_shim opentracing)
-    else()
-      target_link_libraries(
-        ${testname} ${GTEST_BOTH_LIBRARIES} ${CMAKE_THREAD_LIBS_INIT}
-        opentelemetry_api opentelemetry_opentracing_shim
-        OpenTracing::opentracing)
-    endif()
-
+    target_link_libraries(
+      ${testname} PRIVATE ${GTEST_BOTH_LIBRARIES} Threads::Threads
+                          opentelemetry_opentracing_shim)
     gtest_add_tests(
       TARGET ${testname}
       TEST_PREFIX opentracing_shim.


### PR DESCRIPTION
Fixes #3401

Fix CMake issues requiring patches to the vcpkg opentelemetry-cpp port. 

## Changes

- Support finding or fetching OpenTracing
- Support linking to OpenTracing shared library or static library targets
- Don't set `CMAKE_FIND_PACKAGE_PREFER_CONFIG`
- Don't include `VCPKG_CHAINLOAD_TOOLCHAIN_FILE`

For significant contributions please make sure you have completed the following items:

* [ ] `CHANGELOG.md` updated for non-trivial changes
* [ ] Unit tests have been added
* [ ] Changes in public API reviewed