### PR TITLE
[CMAKE] Add CMake script to find or fetch prometheus-cpp

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -310,49 +310,7 @@ endif()
 include(GNUInstallDirs)
 
 if(WITH_PROMETHEUS)
-  find_package(prometheus-cpp CONFIG QUIET)
-  if(NOT prometheus-cpp_FOUND)
-    message(STATUS "Trying to use local prometheus-cpp from submodule")
-    if(EXISTS ${PROJECT_SOURCE_DIR}/third_party/prometheus-cpp/.git)
-      set(SAVED_ENABLE_TESTING ${ENABLE_TESTING})
-      set(SAVED_CMAKE_CXX_CLANG_TIDY ${CMAKE_CXX_CLANG_TIDY})
-      set(SAVED_CMAKE_CXX_INCLUDE_WHAT_YOU_USE
-          ${CMAKE_CXX_INCLUDE_WHAT_YOU_USE})
-      set(ENABLE_TESTING OFF)
-      set(CMAKE_CXX_CLANG_TIDY "")
-      set(CMAKE_CXX_INCLUDE_WHAT_YOU_USE "")
-      add_subdirectory(third_party/prometheus-cpp)
-      set(ENABLE_TESTING ${SAVED_ENABLE_TESTING})
-      set(CMAKE_CXX_CLANG_TIDY ${SAVED_CMAKE_CXX_CLANG_TIDY})
-      set(CMAKE_CXX_INCLUDE_WHAT_YOU_USE
-          ${SAVED_CMAKE_CXX_INCLUDE_WHAT_YOU_USE})
-
-      # Get the version of the prometheus-cpp submodule
-      find_package(Git QUIET)
-      if(Git_FOUND)
-        execute_process(
-          COMMAND ${GIT_EXECUTABLE} describe --tags --always
-          WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}/third_party/prometheus-cpp
-          OUTPUT_VARIABLE prometheus-cpp_VERSION
-          OUTPUT_STRIP_TRAILING_WHITESPACE)
-        string(REGEX REPLACE "^v" "" prometheus-cpp_VERSION
-                             "${prometheus-cpp_VERSION}")
-      endif()
-
-      message(
-        STATUS
-          "Using local prometheus-cpp from submodule. Version = ${prometheus-cpp_VERSION}"
-      )
-    else()
-      message(
-        FATAL_ERROR
-          "\nprometheus-cpp package was not found. Please either provide it manually or clone with submodules. "
-          "To initialize, fetch and checkout any nested submodules, you can use the following command:\n"
-          "git submodule update --init --recursive")
-    endif()
-  else()
-    message(STATUS "Using external prometheus-cpp")
-  endif()
+  include("${opentelemetry-cpp_SOURCE_DIR}/cmake/prometheus-cpp.cmake")
 endif()
 
 if(WITH_OTLP_GRPC
@@ -698,8 +656,10 @@ endif()
 if(USE_NLOHMANN_JSON)
   message(STATUS "nlohmann-json: ${nlohmann_json_VERSION}")
 endif()
-if(prometheus-cpp_FOUND)
-  message(STATUS "prometheus-cpp: ${prometheus-cpp_VERSION}")
+if(WITH_PROMETHEUS)
+  message(
+    STATUS
+      "prometheus-cpp: ${prometheus-cpp_VERSION} (${prometheus-cpp_PROVIDER})")
 endif()
 message(STATUS "---------------------------------------------")
 

--- a/cmake/prometheus-cpp.cmake
+++ b/cmake/prometheus-cpp.cmake
@@ -1,0 +1,53 @@
+# Copyright The OpenTelemetry Authors
+# SPDX-License-Identifier: Apache-2.0
+
+# Import prometheus-cpp targets (prometheus-cpp::core and prometheus-cpp::pull)
+# 1. Find an installed prometheus-cpp package
+# 2. Use FetchContent to build prometheus-cpp from a git submodule
+# 3. Use FetchContent to fetch and build prometheus-cpp from GitHub
+
+find_package(prometheus-cpp CONFIG QUIET)
+set(prometheus-cpp_PROVIDER "find_package")
+
+if(NOT prometheus-cpp_FOUND)
+  set(_PROMETHEUS_SUBMODULE_DIR "${opentelemetry-cpp_SOURCE_DIR}/third_party/prometheus-cpp")
+  if(EXISTS "${_PROMETHEUS_SUBMODULE_DIR}/.git")
+    FetchContent_Declare(
+       "prometheus-cpp"
+       SOURCE_DIR "${_PROMETHEUS_SUBMODULE_DIR}"
+       )
+    set(prometheus-cpp_PROVIDER "fetch_source")
+  else()
+    FetchContent_Declare(
+      "prometheus-cpp"
+      GIT_REPOSITORY  "https://github.com/jupp0r/prometheus-cpp.git"
+      GIT_TAG "${prometheus-cpp_GIT_TAG}"
+      GIT_SUBMODULES "3rdparty/civetweb"
+      )
+    set(prometheus-cpp_PROVIDER "fetch_repository")
+  endif()
+
+  if(DEFINED ENABLE_TESTING)
+    set(_SAVED_ENABLE_TESTING ${ENABLE_TESTING})
+  endif()
+
+  set(ENABLE_TESTING OFF CACHE BOOL "" FORCE)
+  set(ENABLE_PUSH OFF CACHE BOOL "" FORCE)
+  set(USE_THIRDPARTY_LIBRARIES ON CACHE BOOL "" FORCE)
+
+  FetchContent_MakeAvailable(prometheus-cpp)
+
+  if(DEFINED _SAVED_ENABLE_TESTING)
+    set(ENABLE_TESTING ${_SAVED_ENABLE_TESTING} CACHE BOOL "" FORCE)
+  else()
+    unset(ENABLE_TESTING CACHE)
+  endif()
+
+  # Set the prometheus-cpp_VERSION variable from the git tag.
+  string(REGEX REPLACE "^v([0-9]+\\.[0-9]+\\.[0-9]+)$" "\\1" prometheus-cpp_VERSION "${prometheus-cpp_GIT_TAG}")
+endif()
+
+if(NOT TARGET prometheus-cpp::core OR
+   NOT TARGET prometheus-cpp::pull)
+  message(FATAL_ERROR "A required prometheus-cpp target (prometheus-cpp::core or prometheus-cpp::pull) was not imported")
+endif()

--- a/exporters/prometheus/CMakeLists.txt
+++ b/exporters/prometheus/CMakeLists.txt
@@ -1,10 +1,6 @@
 # Copyright The OpenTelemetry Authors
 # SPDX-License-Identifier: Apache-2.0
 
-if(NOT TARGET prometheus-cpp::core)
-  find_package(prometheus-cpp CONFIG REQUIRED)
-endif()
-
 add_library(
   opentelemetry_exporter_prometheus
   src/exporter.cc src/exporter_options.cc src/exporter_factory.cc
@@ -19,22 +15,10 @@ target_include_directories(
   PUBLIC "$<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}/include>"
          "$<INSTALL_INTERFACE:include>")
 
-set(PROMETHEUS_EXPORTER_TARGETS opentelemetry_exporter_prometheus)
-if(TARGET pull)
-  list(APPEND PROMETHEUS_EXPORTER_TARGETS pull)
-endif()
-if(TARGET core)
-  list(APPEND PROMETHEUS_EXPORTER_TARGETS core)
-endif()
-if(TARGET util)
-  list(APPEND PROMETHEUS_EXPORTER_TARGETS util)
-endif()
-set(PROMETHEUS_CPP_TARGETS prometheus-cpp::pull prometheus-cpp::core)
-if(TARGET prometheus-cpp::util)
-  list(APPEND PROMETHEUS_CPP_TARGETS prometheus-cpp::util)
-endif()
-target_link_libraries(opentelemetry_exporter_prometheus
-                      PUBLIC opentelemetry_metrics ${PROMETHEUS_CPP_TARGETS})
+target_link_libraries(
+  opentelemetry_exporter_prometheus
+  PUBLIC opentelemetry_metrics prometheus-cpp::core
+  PRIVATE prometheus-cpp::pull)
 
 otel_add_component(
   COMPONENT


### PR DESCRIPTION
Fixes # (issue)

## Changes

- Adds CMake script to find or fetch prometheus-cpp
- Explicitly link to the core and pull targets from the prometheus exporter.

For significant contributions please make sure you have completed the following items:

* [ ] `CHANGELOG.md` updated for non-trivial changes
* [ ] Unit tests have been added
* [ ] Changes in public API reviewed