### PR TITLE
[CMAKE] Switch opentelemetry-proto to use FetchContent

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -683,6 +683,12 @@ endif()
 if(absl_FOUND)
   message(STATUS "Abseil: ${absl_VERSION}")
 endif()
+if(opentelemetry-proto_VERSION)
+  message(
+    STATUS
+      "opentelemetry-proto: ${opentelemetry-proto_VERSION} (${opentelemetry-proto_PROVIDER})"
+  )
+endif()
 if(Protobuf_FOUND)
   message(STATUS "Protobuf: ${Protobuf_VERSION}")
 endif()

--- a/cmake/opentelemetry-proto.cmake
+++ b/cmake/opentelemetry-proto.cmake
@@ -2,26 +2,17 @@
 # SPDX-License-Identifier: Apache-2.0
 
 #
-# The dependency on opentelemetry-proto can be provided different ways. By order
+# The dependency on opentelemetry-proto can be provided by order
 # of decreasing priority, options are:
 #
-# 1 - Use a provided package
+# 1 - Fetch from local source directory defined by the OTELCPP_PROTO_PATH variable
 #
-# This is useful to build opentelemetry-cpp as part of a super project.
+# 2 - Fetch from the opentelemetry-proto git submodule (opentelemetry-cpp/third_party/opentelemetry-proto)
 #
-# The super project provides the path to the opentelemetry-proto source code
-# using variable ${OTELCPP_PROTO_PATH}
+# 3 - Fetch from github using the git tag set in opentelemetry-cpp/third_party_release
 #
-# 2 - Search for a opentelemetry-proto git submodule
-#
-# When git submodule is used, the opentelemetry-proto code is located in:
-# third_party/opentelemetry-proto
-#
-# 3 - Download opentelemetry-proto from github
-#
-# Code from the required version is used, unless a specific release tag is
-# provided in variable ${opentelemetry-proto}
-#
+
+set(OPENTELEMETRY_PROTO_SUBMODULE "${opentelemetry-cpp_SOURCE_DIR}/third_party/opentelemetry-proto")
 
 if(OTELCPP_PROTO_PATH)
   if(NOT EXISTS
@@ -30,48 +21,34 @@ if(OTELCPP_PROTO_PATH)
       FATAL_ERROR
         "OTELCPP_PROTO_PATH does not point to a opentelemetry-proto repository")
   endif()
-  message(STATUS "opentelemetry-proto dependency satisfied by: external path")
-  set(PROTO_PATH ${OTELCPP_PROTO_PATH})
-  set(needs_proto_download FALSE)
+  message(STATUS "fetching opentelemetry-proto from OTELCPP_PROTO_PATH=${OTELCPP_PROTO_PATH}")
+  FetchContent_Declare(
+      opentelemetry-proto
+      SOURCE_DIR ${OTELCPP_PROTO_PATH}
+  )
+  set(opentelemetry-proto_PROVIDER "fetch_source")
+  # If the opentelemetry-proto directory is a general directory then we don't have a good way to determine the version. Set it as unknown.
+  set(opentelemetry-proto_VERSION "unknown")
+elseif(EXISTS ${OPENTELEMETRY_PROTO_SUBMODULE}/.git)
+   message(STATUS "fetching opentelemetry-proto from git submodule")
+   FetchContent_Declare(
+      opentelemetry-proto
+      SOURCE_DIR ${OPENTELEMETRY_PROTO_SUBMODULE}
+  )
+  set(opentelemetry-proto_PROVIDER "fetch_source")
+  string(REGEX REPLACE "^v([0-9]+\\.[0-9]+\\.[0-9]+)$" "\\1" opentelemetry-proto_VERSION "${opentelemetry-proto_GIT_TAG}")
 else()
-  if(EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/third_party/opentelemetry-proto/.git)
-    message(STATUS "opentelemetry-proto dependency satisfied by: git submodule")
-    set(PROTO_PATH
-        "${CMAKE_CURRENT_SOURCE_DIR}/third_party/opentelemetry-proto")
-    set(needs_proto_download FALSE)
-  else()
-    message(
-      STATUS "opentelemetry-proto dependency satisfied by: github download")
-    if("${opentelemetry-proto}" STREQUAL "")
-      file(READ "${CMAKE_CURRENT_LIST_DIR}/../third_party_release"
-           OTELCPP_THIRD_PARTY_RELEASE_CONTENT)
-      if(OTELCPP_THIRD_PARTY_RELEASE_CONTENT MATCHES
-         "opentelemetry-proto=[ \\t]*([A-Za-z0-9_\\.\\-]+)")
-        set(opentelemetry-proto "${CMAKE_MATCH_1}")
-      else()
-        set(opentelemetry-proto "v1.7.0")
-      endif()
-      unset(OTELCPP_THIRD_PARTY_RELEASE_CONTENT)
-    endif()
-    include(ExternalProject)
-    ExternalProject_Add(
+  FetchContent_Declare(
       opentelemetry-proto
       GIT_REPOSITORY https://github.com/open-telemetry/opentelemetry-proto.git
-      GIT_TAG "${opentelemetry-proto_GIT_TAG}"
-      UPDATE_COMMAND ""
-      BUILD_COMMAND ""
-      INSTALL_COMMAND ""
-      CONFIGURE_COMMAND ""
-      TEST_AFTER_INSTALL 0
-      DOWNLOAD_NO_PROGRESS 1
-      LOG_CONFIGURE 1
-      LOG_BUILD 1
-      LOG_INSTALL 1)
-    ExternalProject_Get_Property(opentelemetry-proto INSTALL_DIR)
-    set(PROTO_PATH "${INSTALL_DIR}/src/opentelemetry-proto")
-    set(needs_proto_download TRUE)
-  endif()
+      GIT_TAG "${opentelemetry-proto_GIT_TAG}")
+  set(opentelemetry-proto_PROVIDER "fetch_repository")
+  string(REGEX REPLACE "^v([0-9]+\\.[0-9]+\\.[0-9]+)$" "\\1" opentelemetry-proto_VERSION "${opentelemetry-proto_GIT_TAG}")
 endif()
+
+FetchContent_MakeAvailable(opentelemetry-proto)
+
+set(PROTO_PATH "${opentelemetry-proto_SOURCE_DIR}")
 
 set(COMMON_PROTO "${PROTO_PATH}/opentelemetry/proto/common/v1/common.proto")
 set(RESOURCE_PROTO
@@ -387,9 +364,6 @@ if(WITH_OTLP_GRPC)
   endif()
 endif()
 
-if(needs_proto_download)
-  add_dependencies(opentelemetry_proto opentelemetry-proto)
-endif()
 set_target_properties(opentelemetry_proto PROPERTIES EXPORT_NAME proto)
 patch_protobuf_targets(opentelemetry_proto)
 


### PR DESCRIPTION
Fixes # (issue)

## Changes

- Switch opentelemetry-proto to use the FetchContent module instead of the ExternalProject module. 
- Set and log the opentelemetry-proto_VERSION and opentelemetry-proto_PROVIDER variables.

For significant contributions please make sure you have completed the following items:

* [ ] `CHANGELOG.md` updated for non-trivial changes
* [ ] Unit tests have been added
* [ ] Changes in public API reviewed