### PR TITLE
[TEST] Shared otel-cpp libs linked to latest static protobuf and grpc

### DIFF
--- a/.github/workflows/cmake_install.yml
+++ b/.github/workflows/cmake_install.yml
@@ -112,6 +112,10 @@ jobs:
       env:
         BUILD_SHARED_LIBS: 'OFF'
       run: ./ci/do_ci.sh cmake.install.test
+    - name: Run Tests (shared libs)
+      env:
+        BUILD_SHARED_LIBS: 'ON'
+      run: ./ci/do_ci.sh cmake.install.test
 
   ubuntu_2204_stable:
     name: Ubuntu 22.04 stable versions cxx17 (static libs - shared libs)

--- a/.github/workflows/cmake_install.yml
+++ b/.github/workflows/cmake_install.yml
@@ -88,7 +88,7 @@ jobs:
       run: ./ci/do_ci.sh cmake.install.test
 
   ubuntu_2404_latest:
-    name: Ubuntu 24.04 latest versions cxx20 (static libs)
+    name: Ubuntu 24.04 latest versions cxx20 (static libs - shared libs)
     runs-on: ubuntu-24.04
     env:
       INSTALL_TEST_DIR: '/home/runner/install_test'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,9 @@ Increment the:
 
 ## [Unreleased]
 
+* [TEST] Shared otel-cpp libs linked to latest static protobuf and grpc
+  [#3544](https://github.com/open-telemetry/opentelemetry-cpp/pull/3544)
+
 ## [1.22 2025-07-11]
 
 * [DOC] Udpate link to membership document


### PR DESCRIPTION
Follow up to https://github.com/open-telemetry/opentelemetry-cpp/pull/3435

## Changes

- add test step to the CMake install ci workflow that builds shared otel-cpp libs linked to the latest static protobuf and grpc libs.

For significant contributions please make sure you have completed the following items:

* [x] `CHANGELOG.md` updated for non-trivial changes
* [ ] Unit tests have been added
* [ ] Changes in public API reviewed