### PR TITLE
[SDK] Implement env var configuration for PeriodicExportingMetricReader

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,12 @@ Increment the:
 
 ## [Unreleased]
 
+* [TEST] Shared otel-cpp libs linked to latest static protobuf and grpc
+  [#3544](https://github.com/open-telemetry/opentelemetry-cpp/pull/3544)
+
+* [SDK] Implement env var configuration for PeriodicExportingMetricReader
+  [#3549](https://github.com/open-telemetry/opentelemetry-cpp/pull/3549)
+
 ## [1.22 2025-07-11]
 
 * [DOC] Udpate link to membership document
@@ -1404,7 +1410,7 @@ Important changes:
 * [ETW EXPORTER] Remove namespace using in ETW exporter which affects global
   namespace
   [#2531](https://github.com/open-telemetry/opentelemetry-cpp/pull/2531)
-* [BUILD] Don't invoke vcpkg from this repo with CMAKE_TOOLCHAIN_FILE set
+* [BUILD] Don't invoke vcpkg from this repo with CMAKE_TOOLCHAIN_FILE set
   [#2527](https://github.com/open-telemetry/opentelemetry-cpp/pull/2527)
 * [EXPORTER] Async exporting for otlp grpc
   [#2407](https://github.com/open-telemetry/opentelemetry-cpp/pull/2407)

--- a/ext/src/dll/input.src
+++ b/ext/src/dll/input.src
@@ -16,6 +16,7 @@ ForceFlush@LoggerProvider@logs@sdk@v1@opentelemetry
 OStreamLogRecordExporter@logs@exporter@v1@opentelemetry
 Create@OStreamMetricExporterFactory@metrics@exporter@v1@opentelemetry
 Create@PeriodicExportingMetricReaderFactory@metrics@sdk@v1@opentelemetry
+PeriodicExportingMetricReaderOptions@metrics@sdk@v1@opentelemetry
 Create@MeterProviderFactory@metrics@sdk@v1@opentelemetry
 Create@MeterContextFactory@metrics@sdk@v1@opentelemetry
 Create@ViewFactory@metrics@sdk@v1@opentelemetry

--- a/sdk/include/opentelemetry/sdk/metrics/export/periodic_exporting_metric_reader_options.h
+++ b/sdk/include/opentelemetry/sdk/metrics/export/periodic_exporting_metric_reader_options.h
@@ -5,7 +5,6 @@
 
 #include <chrono>
 
-#include "opentelemetry/nostd/string_view.h"
 #include "opentelemetry/version.h"
 
 OPENTELEMETRY_BEGIN_NAMESPACE
@@ -17,14 +16,11 @@ namespace metrics
 constexpr std::chrono::milliseconds kExportIntervalMillis = std::chrono::milliseconds(60000);
 constexpr std::chrono::milliseconds kExportTimeOutMillis  = std::chrono::milliseconds(30000);
 
-std::chrono::milliseconds GetEnvDuration(nostd::string_view env_var_name,
-                                         std::chrono::milliseconds default_value);
-
 /**
  * Struct to hold PeriodicExortingMetricReader options.
  */
 
-struct PeriodicExportingMetricReaderOptions
+struct OPENTELEMETRY_EXPORT PeriodicExportingMetricReaderOptions
 {
   /* The time interval between two consecutive exports. */
   std::chrono::milliseconds export_interval_millis;

--- a/sdk/include/opentelemetry/sdk/metrics/export/periodic_exporting_metric_reader_options.h
+++ b/sdk/include/opentelemetry/sdk/metrics/export/periodic_exporting_metric_reader_options.h
@@ -3,9 +3,10 @@
 
 #pragma once
 
-#include "opentelemetry/version.h"
-
 #include <chrono>
+
+#include "opentelemetry/nostd/string_view.h"
+#include "opentelemetry/version.h"
 
 OPENTELEMETRY_BEGIN_NAMESPACE
 namespace sdk
@@ -16,6 +17,9 @@ namespace metrics
 constexpr std::chrono::milliseconds kExportIntervalMillis = std::chrono::milliseconds(60000);
 constexpr std::chrono::milliseconds kExportTimeOutMillis  = std::chrono::milliseconds(30000);
 
+std::chrono::milliseconds GetEnvDuration(nostd::string_view env_var_name,
+                                         std::chrono::milliseconds default_value);
+
 /**
  * Struct to hold PeriodicExortingMetricReader options.
  */
@@ -23,11 +27,12 @@ constexpr std::chrono::milliseconds kExportTimeOutMillis  = std::chrono::millise
 struct PeriodicExportingMetricReaderOptions
 {
   /* The time interval between two consecutive exports. */
-  std::chrono::milliseconds export_interval_millis =
-      std::chrono::milliseconds(kExportIntervalMillis);
+  std::chrono::milliseconds export_interval_millis;
 
   /*  how long the export can run before it is cancelled. */
-  std::chrono::milliseconds export_timeout_millis = std::chrono::milliseconds(kExportTimeOutMillis);
+  std::chrono::milliseconds export_timeout_millis;
+
+  PeriodicExportingMetricReaderOptions();
 };
 
 }  // namespace metrics

--- a/sdk/src/metrics/CMakeLists.txt
+++ b/sdk/src/metrics/CMakeLists.txt
@@ -15,6 +15,7 @@ add_library(
   instrument_metadata_validator.cc
   export/periodic_exporting_metric_reader.cc
   export/periodic_exporting_metric_reader_factory.cc
+  export/periodic_exporting_metric_reader_options.cc
   state/filtered_ordered_attribute_map.cc
   state/metric_collector.cc
   state/observable_registry.cc

--- a/sdk/src/metrics/export/periodic_exporting_metric_reader_options.cc
+++ b/sdk/src/metrics/export/periodic_exporting_metric_reader_options.cc
@@ -24,10 +24,12 @@ std::chrono::milliseconds GetEnvDuration(nostd::string_view env_var_name,
   }
   return default_value;
 }
+
 PeriodicExportingMetricReaderOptions::PeriodicExportingMetricReaderOptions()
     : export_interval_millis(GetEnvDuration("OTEL_METRIC_EXPORT_INTERVAL", kExportIntervalMillis)),
       export_timeout_millis(GetEnvDuration("OTEL_METRIC_EXPORT_TIMEOUT", kExportTimeOutMillis))
 {}
+
 }  // namespace metrics
 }  // namespace sdk
 OPENTELEMETRY_END_NAMESPACE

--- a/sdk/src/metrics/export/periodic_exporting_metric_reader_options.cc
+++ b/sdk/src/metrics/export/periodic_exporting_metric_reader_options.cc
@@ -1,0 +1,33 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+#include <chrono>
+
+#include "opentelemetry/nostd/string_view.h"
+#include "opentelemetry/sdk/common/env_variables.h"
+#include "opentelemetry/sdk/metrics/export/periodic_exporting_metric_reader_options.h"
+#include "opentelemetry/version.h"
+
+OPENTELEMETRY_BEGIN_NAMESPACE
+namespace sdk
+{
+namespace metrics
+{
+
+std::chrono::milliseconds GetEnvDuration(nostd::string_view env_var_name,
+                                         std::chrono::milliseconds default_value)
+{
+  std::chrono::system_clock::duration duration;
+  if (common::GetDurationEnvironmentVariable(env_var_name.data(), duration))
+  {
+    return std::chrono::duration_cast<std::chrono::milliseconds>(duration);
+  }
+  return default_value;
+}
+PeriodicExportingMetricReaderOptions::PeriodicExportingMetricReaderOptions()
+    : export_interval_millis(GetEnvDuration("OTEL_METRIC_EXPORT_INTERVAL", kExportIntervalMillis)),
+      export_timeout_millis(GetEnvDuration("OTEL_METRIC_EXPORT_TIMEOUT", kExportTimeOutMillis))
+{}
+}  // namespace metrics
+}  // namespace sdk
+OPENTELEMETRY_END_NAMESPACE

--- a/sdk/test/metrics/periodic_exporting_metric_reader_test.cc
+++ b/sdk/test/metrics/periodic_exporting_metric_reader_test.cc
@@ -4,7 +4,9 @@
 #include <gtest/gtest.h>
 #include <stddef.h>
 #include <chrono>
+#include <cstdlib>
 #include <memory>
+#include <ratio>
 #include <thread>
 #include <utility>
 #include <vector>
@@ -18,8 +20,9 @@
 #include "opentelemetry/sdk/metrics/push_metric_exporter.h"
 
 #if defined(_MSC_VER)
-using opentelemetry::common::setenv;
-using opentelemetry::common::unsetenv;
+#  include "opentelemetry/sdk/common/env_variables.h"
+using opentelemetry::sdk::common::setenv;
+using opentelemetry::sdk::common::unsetenv;
 #endif
 
 using namespace opentelemetry;
@@ -112,41 +115,6 @@ TEST(PeriodicExportingMetricReader, Timeout)
   reader->SetMetricProducer(&producer);
   std::this_thread::sleep_for(std::chrono::milliseconds(1000));
   reader->Shutdown();
-}
-
-TEST(GetEnvDurationTest, Absent)
-{
-  const char *env = "OTEL_TEST";
-  unsetenv(env);
-  EXPECT_EQ(GetEnvDuration(env, std::chrono::milliseconds(42)), std::chrono::milliseconds(42));
-}
-
-TEST(GetEnvDurationTest, NotSet)
-{
-  const char *env = "OTEL_TEST";
-  setenv(env, "", 1);
-  EXPECT_EQ(GetEnvDuration(env, std::chrono::milliseconds(42)), std::chrono::milliseconds(42));
-  unsetenv(env);
-}
-
-TEST(GetEnvDurationTest, Valid)
-{
-  const char *env = "OTEL_TEST";
-  setenv(env, "1243ms", 1);
-  EXPECT_EQ(GetEnvDuration(env, std::chrono::milliseconds(42)), std::chrono::milliseconds(1243));
-
-  setenv(env, "3s", 1);
-  EXPECT_EQ(GetEnvDuration(env, std::chrono::milliseconds(42)), std::chrono::milliseconds(3000));
-
-  unsetenv(env);
-}
-
-TEST(GetEnvDurationTest, Invalid)
-{
-  const char *env = "OTEL_TEST";
-  setenv(env, "not_a_duration", 1);
-  EXPECT_EQ(GetEnvDuration(env, std::chrono::milliseconds(42)), std::chrono::milliseconds(42));
-  unsetenv(env);
 }
 
 TEST(PeriodicExportingMetricReaderOptions, UsesEnvVars)


### PR DESCRIPTION
Fixes #3515 

## Changes

Implements the configuration of `PeriodicExportingMetricReader` via environment variables with default values.

It introduces support for:
*   `OTEL_METRIC_EXPORT_INTERVAL` (Duration)
*   `OTEL_METRIC_EXPORT_TIMEOUT` (Timeout)

**Known Limitation / Discussion Point:**

During implementation, I identified that the existing utility function `common::GetDurationEnvironmentVariable` is not fully compliant with the specification for `Timeout` types.

*   **Specification:** A `Timeout` value of `0` SHOULD be interpreted as "infinite".
*   **Current Implementation:** The underlying parser (`GetTimeoutFromString`) explicitly rejects a value of `0` as invalid.

To keep the scope of this PR focused on the `PeriodicExportingMetricReaderOptions`, I have used the existing utility for both environment variables. This means that `OTEL_METRIC_EXPORT_TIMEOUT=0` is currently not handled as an infinite timeout but will instead fall back to the default value.

I believe fixing the common utility function should be addressed in a separate issue/PR to ensure it doesn't introduce unintended side effects elsewhere.

For significant contributions please make sure you have completed the following items:

* [x] `CHANGELOG.md` updated for non-trivial changes
* [x] Unit tests have been added
* [ ] Changes in public API reviewed