### PR TITLE
[SDK] Update default exemplar reservoir size for exponential histograms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,9 @@ Increment the:
 * [TEST] Shared otel-cpp libs linked to latest static protobuf and grpc
   [#3544](https://github.com/open-telemetry/opentelemetry-cpp/pull/3544)
 
+* [SDK] Set SimpleFixedSizeExemplarReservoir default size for exponential
+  histograms based on maximum bucket count
+
 ## [1.22 2025-07-11]
 
 * [DOC] Udpate link to membership document

--- a/sdk/include/opentelemetry/sdk/metrics/exemplar/reservoir_utils.h
+++ b/sdk/include/opentelemetry/sdk/metrics/exemplar/reservoir_utils.h
@@ -39,7 +39,8 @@ static inline size_t GetSimpleFixedReservoirDefaultSize(const AggregationType ag
   {
     const auto *histogram_agg_config =
         static_cast<const Base2ExponentialHistogramAggregationConfig *>(agg_config);
-    return std::min(kMaxBase2ExponentialHistogramReservoirSize, histogram_agg_config->max_buckets_);
+    return (std::min)(kMaxBase2ExponentialHistogramReservoirSize,
+                      histogram_agg_config->max_buckets_);
   }
 
   return SimpleFixedSizeExemplarReservoir::kDefaultSimpleReservoirSize;

--- a/sdk/include/opentelemetry/sdk/metrics/exemplar/reservoir_utils.h
+++ b/sdk/include/opentelemetry/sdk/metrics/exemplar/reservoir_utils.h
@@ -5,6 +5,8 @@
 
 #ifdef ENABLE_METRICS_EXEMPLAR_PREVIEW
 
+#  include <algorithm>
+
 #  include "opentelemetry/common/macros.h"
 #  include "opentelemetry/sdk/metrics/aggregation/aggregation_config.h"
 #  include "opentelemetry/sdk/metrics/exemplar/aligned_histogram_bucket_exemplar_reservoir.h"
@@ -25,6 +27,22 @@ static inline MapAndResetCellType GetMapAndResetCellMethod(
   }
 
   return &ReservoirCell::GetAndResetDouble;
+}
+
+static inline size_t GetSimpleFixedReservoirDefaultSize(const AggregationType agg_type,
+                                                        const AggregationConfig *const agg_config)
+
+{
+  constexpr size_t kMaxBase2ExponentialHistogramReservoirSize = 20;
+
+  if (agg_type == AggregationType::kBase2ExponentialHistogram)
+  {
+    const auto *histogram_agg_config =
+        static_cast<const Base2ExponentialHistogramAggregationConfig *>(agg_config);
+    return std::min(kMaxBase2ExponentialHistogramReservoirSize, histogram_agg_config->max_buckets_);
+  }
+
+  return SimpleFixedSizeExemplarReservoir::kDefaultSimpleReservoirSize;
 }
 
 static inline nostd::shared_ptr<ExemplarReservoir> GetExemplarReservoir(
@@ -52,7 +70,7 @@ static inline nostd::shared_ptr<ExemplarReservoir> GetExemplarReservoir(
   }
 
   return nostd::shared_ptr<ExemplarReservoir>(new SimpleFixedSizeExemplarReservoir(
-      SimpleFixedSizeExemplarReservoir::kDefaultSimpleReservoirSize,
+      GetSimpleFixedReservoirDefaultSize(agg_type, agg_config),
       SimpleFixedSizeExemplarReservoir::GetSimpleFixedSizeCellSelector(),
       GetMapAndResetCellMethod(instrument_descriptor)));
 }


### PR DESCRIPTION
## Changes

Set _SimpleFixedSizeExemplarReservoir_ default size for exponential histograms based on configured maximum bucket count as recommended in the spec:

https://github.com/open-telemetry/opentelemetry-specification/blob/v1.46.0/specification/metrics/sdk.md#exemplar-defaults

> Base2 Exponential Histogram Aggregation SHOULD use a SimpleFixedSizeExemplarReservoir with a reservoir equal to the smaller of the maximum number of buckets configured on the aggregation or twenty (e.g. min(20, max_buckets)).

For significant contributions please make sure you have completed the following items:

* [x] `CHANGELOG.md` updated for non-trivial changes
* [ ] Unit tests have been added
* [ ] Changes in public API reviewed

Note that I didn't update any tests (yet) - I couldn't find any existing tests for the fixed size reservoir? Thus wasn't sure if explicit tests are needed or if this is considered small / covered by other tests?