### PR TITLE
[CONFIGURATION] File configuration - spec version 1.0.0-rc1

### DIFF
--- a/sdk/include/opentelemetry/sdk/configuration/extension_metric_producer_configuration.h
+++ b/sdk/include/opentelemetry/sdk/configuration/extension_metric_producer_configuration.h
@@ -1,0 +1,34 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <memory>
+#include <string>
+
+#include "opentelemetry/sdk/configuration/document_node.h"
+#include "opentelemetry/sdk/configuration/metric_producer_configuration.h"
+#include "opentelemetry/sdk/configuration/metric_producer_configuration_visitor.h"
+#include "opentelemetry/version.h"
+
+OPENTELEMETRY_BEGIN_NAMESPACE
+namespace sdk
+{
+namespace configuration
+{
+
+class ExtensionMetricProducerConfiguration : public MetricProducerConfiguration
+{
+public:
+  void Accept(MetricProducerConfigurationVisitor *visitor) const override
+  {
+    visitor->VisitExtension(this);
+  }
+
+  std::string name;
+  std::unique_ptr<DocumentNode> node;
+};
+
+}  // namespace configuration
+}  // namespace sdk
+OPENTELEMETRY_END_NAMESPACE

--- a/sdk/include/opentelemetry/sdk/configuration/metric_producer_configuration_visitor.h
+++ b/sdk/include/opentelemetry/sdk/configuration/metric_producer_configuration_visitor.h
@@ -1,0 +1,34 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "opentelemetry/version.h"
+
+OPENTELEMETRY_BEGIN_NAMESPACE
+namespace sdk
+{
+namespace configuration
+{
+
+class OpenCensusMetricProducerConfiguration;
+class ExtensionMetricProducerConfiguration;
+
+class MetricProducerConfigurationVisitor
+{
+public:
+  MetricProducerConfigurationVisitor()                                                 = default;
+  MetricProducerConfigurationVisitor(MetricProducerConfigurationVisitor &&)            = default;
+  MetricProducerConfigurationVisitor(const MetricProducerConfigurationVisitor &)       = default;
+  MetricProducerConfigurationVisitor &operator=(MetricProducerConfigurationVisitor &&) = default;
+  MetricProducerConfigurationVisitor &operator=(const MetricProducerConfigurationVisitor &other) =
+      default;
+  virtual ~MetricProducerConfigurationVisitor() = default;
+
+  virtual void VisitOpenCensus(const OpenCensusMetricProducerConfiguration *model) = 0;
+  virtual void VisitExtension(const ExtensionMetricProducerConfiguration *model)   = 0;
+};
+
+}  // namespace configuration
+}  // namespace sdk
+OPENTELEMETRY_END_NAMESPACE

--- a/sdk/include/opentelemetry/sdk/configuration/open_census_metric_producer_configuration.h
+++ b/sdk/include/opentelemetry/sdk/configuration/open_census_metric_producer_configuration.h
@@ -1,0 +1,31 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <string>
+
+#include "opentelemetry/sdk/configuration/metric_producer_configuration.h"
+#include "opentelemetry/sdk/configuration/metric_producer_configuration_visitor.h"
+#include "opentelemetry/version.h"
+
+OPENTELEMETRY_BEGIN_NAMESPACE
+namespace sdk
+{
+namespace configuration
+{
+
+// YAML-SCHEMA: schema/meter_provider.json
+// YAML-NODE: OpenCensusMetricProducer
+class OpenCensusMetricProducerConfiguration : public MetricProducerConfiguration
+{
+public:
+  void Accept(MetricProducerConfigurationVisitor *visitor) const override
+  {
+    visitor->VisitOpenCensus(this);
+  }
+};
+
+}  // namespace configuration
+}  // namespace sdk
+OPENTELEMETRY_END_NAMESPACE

--- a/sdk/include/opentelemetry/sdk/configuration/propagator_configuration.h
+++ b/sdk/include/opentelemetry/sdk/configuration/propagator_configuration.h
@@ -20,6 +20,7 @@ class PropagatorConfiguration
 {
 public:
   std::vector<std::string> composite;
+  std::string composite_list;
 };
 
 }  // namespace configuration

--- a/sdk/src/configuration/configuration_parser.cc
+++ b/sdk/src/configuration/configuration_parser.cc
@@ -37,6 +37,7 @@
 #include "opentelemetry/sdk/configuration/explicit_bucket_histogram_aggregation_configuration.h"
 #include "opentelemetry/sdk/configuration/extension_log_record_exporter_configuration.h"
 #include "opentelemetry/sdk/configuration/extension_log_record_processor_configuration.h"
+#include "opentelemetry/sdk/configuration/extension_metric_producer_configuration.h"
 #include "opentelemetry/sdk/configuration/extension_pull_metric_exporter_configuration.h"
 #include "opentelemetry/sdk/configuration/extension_push_metric_exporter_configuration.h"
 #include "opentelemetry/sdk/configuration/extension_sampler_configuration.h"
@@ -55,7 +56,9 @@
 #include "opentelemetry/sdk/configuration/log_record_processor_configuration.h"
 #include "opentelemetry/sdk/configuration/logger_provider_configuration.h"
 #include "opentelemetry/sdk/configuration/meter_provider_configuration.h"
+#include "opentelemetry/sdk/configuration/metric_producer_configuration.h"
 #include "opentelemetry/sdk/configuration/metric_reader_configuration.h"
+#include "opentelemetry/sdk/configuration/open_census_metric_producer_configuration.h"
 #include "opentelemetry/sdk/configuration/otlp_file_log_record_exporter_configuration.h"
 #include "opentelemetry/sdk/configuration/otlp_file_push_metric_exporter_configuration.h"
 #include "opentelemetry/sdk/configuration/otlp_file_span_exporter_configuration.h"
@@ -691,13 +694,68 @@ static std::unique_ptr<PullMetricExporterConfiguration> ParsePullMetricExporterC
     throw InvalidSchemaException(message);
   }
 
-  if (name == "prometheus")
+  if (name == "prometheus/development")
   {
     model = ParsePrometheusPullMetricExporterConfiguration(child);
   }
   else
   {
     model = ParsePullMetricExporterExtensionConfiguration(name, std::move(child));
+  }
+
+  return model;
+}
+
+static std::unique_ptr<OpenCensusMetricProducerConfiguration>
+ParseOpenCensusMetricProducerConfiguration(const std::unique_ptr<DocumentNode> & /* node */)
+{
+  auto model = std::make_unique<OpenCensusMetricProducerConfiguration>();
+
+  return model;
+}
+
+static std::unique_ptr<ExtensionMetricProducerConfiguration>
+ParseExtensionMetricProducerConfiguration(const std::string &name,
+                                          std::unique_ptr<DocumentNode> node)
+{
+  auto model = std::make_unique<ExtensionMetricProducerConfiguration>();
+
+  model->name = name;
+  model->node = std::move(node);
+
+  return model;
+}
+
+static std::unique_ptr<MetricProducerConfiguration> ParseMetricProducerConfiguration(
+    const std::unique_ptr<DocumentNode> &node)
+{
+  std::unique_ptr<MetricProducerConfiguration> model;
+
+  std::string name;
+  std::unique_ptr<DocumentNode> child;
+  size_t count = 0;
+
+  for (auto it = node->begin_properties(); it != node->end_properties(); ++it)
+  {
+    name  = it.Name();
+    child = it.Value();
+    count++;
+  }
+
+  if (count != 1)
+  {
+    std::string message("Illegal metric producer, properties count: ");
+    message.append(std::to_string(count));
+    throw InvalidSchemaException(message);
+  }
+
+  if (name == "opencensus")
+  {
+    model = ParseOpenCensusMetricProducerConfiguration(child);
+  }
+  else
+  {
+    model = ParseExtensionMetricProducerConfiguration(name, std::move(child));
   }
 
   return model;
@@ -715,6 +773,16 @@ static std::unique_ptr<PeriodicMetricReaderConfiguration> ParsePeriodicMetricRea
   child           = node->GetRequiredChildNode("exporter");
   model->exporter = ParsePushMetricExporterConfiguration(child);
 
+  child = node->GetChildNode("producers");
+
+  if (child)
+  {
+    for (auto it = child->begin(); it != child->end(); ++it)
+    {
+      model->producers.push_back(ParseMetricProducerConfiguration(*it));
+    }
+  }
+
   return model;
 }
 
@@ -726,6 +794,16 @@ static std::unique_ptr<PullMetricReaderConfiguration> ParsePullMetricReaderConfi
 
   child           = node->GetRequiredChildNode("exporter");
   model->exporter = ParsePullMetricExporterConfiguration(child);
+
+  child = node->GetChildNode("producers");
+
+  if (child)
+  {
+    for (auto it = child->begin(); it != child->end(); ++it)
+    {
+      model->producers.push_back(ParseMetricProducerConfiguration(*it));
+    }
+  }
 
   return model;
 }
@@ -1031,16 +1109,40 @@ static std::unique_ptr<PropagatorConfiguration> ParsePropagatorConfiguration(
   auto model = std::make_unique<PropagatorConfiguration>();
 
   std::unique_ptr<DocumentNode> child;
-  child = node->GetRequiredChildNode("composite");
+  child = node->GetChildNode("composite");
+  std::string name;
+  int num_child = 0;
 
-  for (auto it = child->begin(); it != child->end(); ++it)
+  if (child)
   {
-    std::unique_ptr<DocumentNode> element(*it);
+    for (auto it = child->begin(); it != child->end(); ++it)
+    {
+      // This is an entry in the composite array
+      std::unique_ptr<DocumentNode> element(*it);
+      num_child++;
+      int count = 0;
 
-    std::string name = element->AsString();
+      // Find out its name, we expect an object with a unique property.
+      for (auto it2 = element->begin_properties(); it2 != element->end_properties(); ++it2)
+      {
+        name = it2.Name();
+        count++;
+      }
 
-    model->composite.push_back(name);
+      if (count != 1)
+      {
+        std::string message("Illegal composite child ");
+        message.append(std::to_string(num_child));
+        message.append(", properties count: ");
+        message.append(std::to_string(count));
+        throw InvalidSchemaException(message);
+      }
+
+      model->composite.push_back(name);
+    }
   }
+
+  model->composite_list = node->GetString("composite_list", "");
 
   return model;
 }

--- a/sdk/src/configuration/sdk_builder.cc
+++ b/sdk/src/configuration/sdk_builder.cc
@@ -1061,21 +1061,87 @@ SdkBuilder::CreateTextMapPropagator(const std::string &name) const
   throw UnsupportedException(die);
 }
 
+static bool IsDuplicate(const std::vector<std::string> &propagator_seen, const std::string &name)
+{
+  bool duplicate = false;
+  for (const auto &seen : propagator_seen)
+  {
+    if (name == seen)
+    {
+      duplicate = true;
+    }
+  }
+
+  return duplicate;
+}
+
 std::unique_ptr<opentelemetry::context::propagation::TextMapPropagator>
 SdkBuilder::CreatePropagator(
     const std::unique_ptr<opentelemetry::sdk::configuration::PropagatorConfiguration> &model) const
 {
+  std::unique_ptr<opentelemetry::context::propagation::CompositePropagator> sdk;
   std::vector<std::unique_ptr<opentelemetry::context::propagation::TextMapPropagator>> propagators;
   std::unique_ptr<opentelemetry::context::propagation::TextMapPropagator> propagator;
+  std::vector<std::string> propagator_seen;
+  bool duplicate;
+
+  /*
+   * Note that the spec only requires to check duplicates between
+   * composite and composite_list.
+   * Here we check for duplicates globally, for ease of use.
+   */
 
   for (const auto &name : model->composite)
   {
-    propagator = CreateTextMapPropagator(name);
-    propagators.push_back(std::move(propagator));
+    duplicate = IsDuplicate(propagator_seen, name);
+
+    if (!duplicate)
+    {
+      propagator = CreateTextMapPropagator(name);
+      propagators.push_back(std::move(propagator));
+      propagator_seen.push_back(name);
+    }
   }
 
-  auto sdk = std::make_unique<opentelemetry::context::propagation::CompositePropagator>(
-      std::move(propagators));
+  if (model->composite_list.size() > 0)
+  {
+    std::string str_list = model->composite_list;
+    size_t start_pos     = 0;
+    size_t end_pos       = 0;
+    char separator       = ',';
+    std::string name;
+
+    while ((end_pos = str_list.find(separator, start_pos)) != std::string::npos)
+    {
+      name = str_list.substr(start_pos, end_pos - start_pos);
+
+      duplicate = IsDuplicate(propagator_seen, name);
+
+      if (!duplicate)
+      {
+        propagator = CreateTextMapPropagator(name);
+        propagators.push_back(std::move(propagator));
+        propagator_seen.push_back(name);
+      }
+      start_pos = end_pos + 1;
+    }
+
+    name = str_list.substr(start_pos);
+
+    duplicate = IsDuplicate(propagator_seen, name);
+
+    if (!duplicate)
+    {
+      propagator = CreateTextMapPropagator(name);
+      propagators.push_back(std::move(propagator));
+    }
+  }
+
+  if (propagators.size() > 0)
+  {
+    sdk = std::make_unique<opentelemetry::context::propagation::CompositePropagator>(
+        std::move(propagators));
+  }
 
   return sdk;
 }
@@ -1293,6 +1359,11 @@ std::unique_ptr<opentelemetry::sdk::metrics::MetricReader> SdkBuilder::CreatePer
 
   auto exporter_sdk = CreatePushMetricExporter(model->exporter);
 
+  if (model->producers.size() > 0)
+  {
+    OTEL_INTERNAL_LOG_WARN("metric producer not supported, ignoring");
+  }
+
   sdk = opentelemetry::sdk::metrics::PeriodicExportingMetricReaderFactory::Create(
       std::move(exporter_sdk), options);
 
@@ -1305,6 +1376,11 @@ std::unique_ptr<opentelemetry::sdk::metrics::MetricReader> SdkBuilder::CreatePul
   std::unique_ptr<opentelemetry::sdk::metrics::MetricReader> sdk;
 
   sdk = CreatePullMetricExporter(model->exporter);
+
+  if (model->producers.size() > 0)
+  {
+    OTEL_INTERNAL_LOG_WARN("metric producer not supported, ignoring");
+  }
 
   return sdk;
 }

--- a/sdk/src/configuration/sdk_builder.cc
+++ b/sdk/src/configuration/sdk_builder.cc
@@ -1083,7 +1083,7 @@ SdkBuilder::CreatePropagator(
   std::vector<std::unique_ptr<opentelemetry::context::propagation::TextMapPropagator>> propagators;
   std::unique_ptr<opentelemetry::context::propagation::TextMapPropagator> propagator;
   std::vector<std::string> propagator_seen;
-  bool duplicate;
+  bool duplicate = false;
 
   /*
    * Note that the spec only requires to check duplicates between

--- a/sdk/test/configuration/yaml_metrics_test.cc
+++ b/sdk/test/configuration/yaml_metrics_test.cc
@@ -144,7 +144,7 @@ meter_provider:
   readers:
     - pull:
         exporter:
-          prometheus:
+          prometheus/development:
 )";
 
   auto config = DoParse(yaml);
@@ -519,7 +519,7 @@ meter_provider:
   readers:
     - pull:
         exporter:
-          prometheus:
+          prometheus/development:
 )";
 
   auto config = DoParse(yaml);
@@ -550,7 +550,7 @@ meter_provider:
   readers:
     - pull:
         exporter:
-          prometheus:
+          prometheus/development:
             host: "prometheus"
             port: 1234
             without_units: true

--- a/sdk/test/configuration/yaml_propagator_test.cc
+++ b/sdk/test/configuration/yaml_propagator_test.cc
@@ -1,0 +1,172 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+#include <gtest/gtest.h>
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "opentelemetry/sdk/configuration/configuration.h"
+#include "opentelemetry/sdk/configuration/propagator_configuration.h"
+#include "opentelemetry/sdk/configuration/yaml_configuration_parser.h"
+
+static std::unique_ptr<opentelemetry::sdk::configuration::Configuration> DoParse(
+    const std::string &yaml)
+{
+  static const std::string source("test");
+  return opentelemetry::sdk::configuration::YamlConfigurationParser::ParseString(source, yaml);
+}
+
+TEST(YamlPropagator, empty_propagator)
+{
+  std::string yaml = R"(
+file_format: xx.yy
+propagator:
+)";
+
+  auto config = DoParse(yaml);
+  ASSERT_NE(config, nullptr);
+  ASSERT_NE(config->propagator, nullptr);
+  ASSERT_EQ(config->propagator->composite.size(), 0);
+  ASSERT_EQ(config->propagator->composite_list, "");
+}
+
+TEST(YamlPropagator, empty_composite)
+{
+  std::string yaml = R"(
+file_format: xx.yy
+propagator:
+  composite:
+)";
+
+  auto config = DoParse(yaml);
+  ASSERT_NE(config, nullptr);
+  ASSERT_NE(config->propagator, nullptr);
+  ASSERT_EQ(config->propagator->composite.size(), 0);
+  ASSERT_EQ(config->propagator->composite_list, "");
+}
+
+TEST(YamlPropagator, old_propagator_1)
+{
+  // This is the old format, must fail
+  std::string yaml = R"(
+file_format: xx.yy
+propagator:
+  composite:
+    - foo
+    - bar
+)";
+
+  auto config = DoParse(yaml);
+  ASSERT_EQ(config, nullptr);
+}
+
+TEST(YamlPropagator, old_propagator_2)
+{
+  // This is the old format, must fail
+  std::string yaml = R"(
+file_format: xx.yy
+propagator:
+  composite: [foo, bar]
+)";
+
+  auto config = DoParse(yaml);
+  ASSERT_EQ(config, nullptr);
+}
+
+TEST(YamlPropagator, propagator_array_ok)
+{
+  std::string yaml = R"(
+file_format: xx.yy
+propagator:
+  composite:
+    - foo:
+    - bar:
+    - baz:
+)";
+
+  auto config = DoParse(yaml);
+  ASSERT_NE(config, nullptr);
+  ASSERT_NE(config->propagator, nullptr);
+  ASSERT_EQ(config->propagator->composite.size(), 3);
+  ASSERT_EQ(config->propagator->composite[0], "foo");
+  ASSERT_EQ(config->propagator->composite[1], "bar");
+  ASSERT_EQ(config->propagator->composite[2], "baz");
+  ASSERT_EQ(config->propagator->composite_list, "");
+}
+
+TEST(YamlPropagator, propagator_array_broken)
+{
+  std::string yaml = R"(
+file_format: xx.yy
+propagator:
+  composite:
+    - foo:
+    - bar:
+      baz:
+)";
+
+  auto config = DoParse(yaml);
+  ASSERT_EQ(config, nullptr);
+}
+
+TEST(YamlPropagator, propagator_composite_list)
+{
+  std::string yaml = R"(
+file_format: xx.yy
+propagator:
+  composite_list: "foo,bar,baz"
+)";
+
+  auto config = DoParse(yaml);
+  ASSERT_NE(config, nullptr);
+  ASSERT_NE(config->propagator, nullptr);
+  ASSERT_EQ(config->propagator->composite.size(), 0);
+  ASSERT_EQ(config->propagator->composite_list, "foo,bar,baz");
+}
+
+TEST(YamlPropagator, propagator_both)
+{
+  std::string yaml = R"(
+file_format: xx.yy
+propagator:
+  composite:
+    - aaa:
+    - bbb:
+    - ccc:
+  composite_list: "ddd,eee,fff"
+)";
+
+  auto config = DoParse(yaml);
+  ASSERT_NE(config, nullptr);
+  ASSERT_NE(config->propagator, nullptr);
+  ASSERT_EQ(config->propagator->composite.size(), 3);
+  ASSERT_EQ(config->propagator->composite[0], "aaa");
+  ASSERT_EQ(config->propagator->composite[1], "bbb");
+  ASSERT_EQ(config->propagator->composite[2], "ccc");
+  ASSERT_EQ(config->propagator->composite_list, "ddd,eee,fff");
+}
+
+TEST(YamlPropagator, propagator_duplicates)
+{
+  std::string yaml = R"(
+file_format: xx.yy
+propagator:
+  composite:
+    - aaa:
+    - bbb:
+    - bbb:
+    - ccc:
+  composite_list: "aaa,eee,eee,fff,ccc"
+)";
+
+  auto config = DoParse(yaml);
+  ASSERT_NE(config, nullptr);
+  ASSERT_NE(config->propagator, nullptr);
+  ASSERT_EQ(config->propagator->composite.size(), 4);
+  ASSERT_EQ(config->propagator->composite[0], "aaa");
+  ASSERT_EQ(config->propagator->composite[1], "bbb");
+  ASSERT_EQ(config->propagator->composite[2], "bbb");
+  ASSERT_EQ(config->propagator->composite[3], "ccc");
+  ASSERT_EQ(config->propagator->composite_list, "aaa,eee,eee,fff,ccc");
+}


### PR DESCRIPTION
Contributes to #2481

This is a partial fix, to align on the declarative configuration specs version 1.0.0-rc1

## Changes

Please provide a brief description of the changes here.

Adjusted the implementation to recent spec changes:

* https://github.com/open-telemetry/opentelemetry-configuration/pull/187
  * Changed the composite propagator from an array of strings to an array of objects
  * Added composite_list
  * Adjusted the yaml parser accordingly
  * Added unit tests
  * Adjusted the SDK builder accordingly
* https://github.com/open-telemetry/opentelemetry-configuration/pull/180
  * Adjusted the yaml parser accordingly
  * Adjusted unit tests
* https://github.com/open-telemetry/opentelemetry-configuration/pull/90
  * The support for MetricProducer was incomplete
  * Added supporting configuration classes
  * Adjusted the yaml parser accordingly

For significant contributions please make sure you have completed the following items:

* [ ] `CHANGELOG.md` updated for non-trivial changes
* [ ] Unit tests have been added
* [ ] Changes in public API reviewed