### PR TITLE
[CONFIGURATION] File configuration - otlp exporter builders

### DIFF
--- a/exporters/otlp/include/opentelemetry/exporters/otlp/otlp_builder_utils.h
+++ b/exporters/otlp/include/opentelemetry/exporters/otlp/otlp_builder_utils.h
@@ -1,0 +1,38 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <string>
+
+#include "opentelemetry/exporters/otlp/otlp_environment.h"  // For OtlpHeaders
+#include "opentelemetry/exporters/otlp/otlp_http.h"
+#include "opentelemetry/exporters/otlp/otlp_preferred_temporality.h"
+#include "opentelemetry/sdk/configuration/headers_configuration.h"
+#include "opentelemetry/sdk/configuration/otlp_http_encoding.h"
+#include "opentelemetry/sdk/configuration/temporality_preference.h"
+#include "opentelemetry/version.h"
+
+OPENTELEMETRY_BEGIN_NAMESPACE
+namespace exporter
+{
+namespace otlp
+{
+
+class OtlpBuilderUtils
+{
+public:
+  static HttpRequestContentType ConvertOtlpHttpEncoding(
+      opentelemetry::sdk::configuration::OtlpHttpEncoding model);
+
+  static OtlpHeaders ConvertHeadersConfigurationModel(
+      const opentelemetry::sdk::configuration::HeadersConfiguration *model,
+      const std::string &headers_list);
+
+  static PreferredAggregationTemporality ConvertTemporalityPreference(
+      opentelemetry::sdk::configuration::TemporalityPreference model);
+};
+
+}  // namespace otlp
+}  // namespace exporter
+OPENTELEMETRY_END_NAMESPACE

--- a/exporters/otlp/include/opentelemetry/exporters/otlp/otlp_file_log_record_builder.h
+++ b/exporters/otlp/include/opentelemetry/exporters/otlp/otlp_file_log_record_builder.h
@@ -1,0 +1,36 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <memory>
+
+#include "opentelemetry/sdk/configuration/otlp_file_log_record_exporter_builder.h"
+#include "opentelemetry/sdk/configuration/otlp_file_log_record_exporter_configuration.h"
+#include "opentelemetry/sdk/configuration/registry.h"
+#include "opentelemetry/sdk/logs/exporter.h"
+#include "opentelemetry/version.h"
+
+OPENTELEMETRY_BEGIN_NAMESPACE
+namespace exporter
+{
+namespace otlp
+{
+
+class OPENTELEMETRY_EXPORT OtlpFileLogRecordBuilder
+    : public opentelemetry::sdk::configuration::OtlpFileLogRecordExporterBuilder
+{
+public:
+  static void Register(opentelemetry::sdk::configuration::Registry *registry);
+
+  OtlpFileLogRecordBuilder()           = default;
+  ~OtlpFileLogRecordBuilder() override = default;
+
+  std::unique_ptr<opentelemetry::sdk::logs::LogRecordExporter> Build(
+      const opentelemetry::sdk::configuration::OtlpFileLogRecordExporterConfiguration *model)
+      const override;
+};
+
+}  // namespace otlp
+}  // namespace exporter
+OPENTELEMETRY_END_NAMESPACE

--- a/exporters/otlp/include/opentelemetry/exporters/otlp/otlp_file_log_record_builder.h
+++ b/exporters/otlp/include/opentelemetry/exporters/otlp/otlp_file_log_record_builder.h
@@ -23,9 +23,6 @@ class OPENTELEMETRY_EXPORT OtlpFileLogRecordBuilder
 public:
   static void Register(opentelemetry::sdk::configuration::Registry *registry);
 
-  OtlpFileLogRecordBuilder()           = default;
-  ~OtlpFileLogRecordBuilder() override = default;
-
   std::unique_ptr<opentelemetry::sdk::logs::LogRecordExporter> Build(
       const opentelemetry::sdk::configuration::OtlpFileLogRecordExporterConfiguration *model)
       const override;

--- a/exporters/otlp/include/opentelemetry/exporters/otlp/otlp_file_push_metric_builder.h
+++ b/exporters/otlp/include/opentelemetry/exporters/otlp/otlp_file_push_metric_builder.h
@@ -23,9 +23,6 @@ class OPENTELEMETRY_EXPORT OtlpFilePushMetricBuilder
 public:
   static void Register(opentelemetry::sdk::configuration::Registry *registry);
 
-  OtlpFilePushMetricBuilder()           = default;
-  ~OtlpFilePushMetricBuilder() override = default;
-
   std::unique_ptr<opentelemetry::sdk::metrics::PushMetricExporter> Build(
       const opentelemetry::sdk::configuration::OtlpFilePushMetricExporterConfiguration *model)
       const override;

--- a/exporters/otlp/include/opentelemetry/exporters/otlp/otlp_file_push_metric_builder.h
+++ b/exporters/otlp/include/opentelemetry/exporters/otlp/otlp_file_push_metric_builder.h
@@ -1,0 +1,36 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <memory>
+
+#include "opentelemetry/sdk/configuration/otlp_file_push_metric_exporter_builder.h"
+#include "opentelemetry/sdk/configuration/otlp_file_push_metric_exporter_configuration.h"
+#include "opentelemetry/sdk/configuration/registry.h"
+#include "opentelemetry/sdk/metrics/push_metric_exporter.h"
+#include "opentelemetry/version.h"
+
+OPENTELEMETRY_BEGIN_NAMESPACE
+namespace exporter
+{
+namespace otlp
+{
+
+class OPENTELEMETRY_EXPORT OtlpFilePushMetricBuilder
+    : public opentelemetry::sdk::configuration::OtlpFilePushMetricExporterBuilder
+{
+public:
+  static void Register(opentelemetry::sdk::configuration::Registry *registry);
+
+  OtlpFilePushMetricBuilder()           = default;
+  ~OtlpFilePushMetricBuilder() override = default;
+
+  std::unique_ptr<opentelemetry::sdk::metrics::PushMetricExporter> Build(
+      const opentelemetry::sdk::configuration::OtlpFilePushMetricExporterConfiguration *model)
+      const override;
+};
+
+}  // namespace otlp
+}  // namespace exporter
+OPENTELEMETRY_END_NAMESPACE

--- a/exporters/otlp/include/opentelemetry/exporters/otlp/otlp_file_span_builder.h
+++ b/exporters/otlp/include/opentelemetry/exporters/otlp/otlp_file_span_builder.h
@@ -1,0 +1,36 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <memory>
+
+#include "opentelemetry/sdk/configuration/otlp_file_span_exporter_builder.h"
+#include "opentelemetry/sdk/configuration/otlp_file_span_exporter_configuration.h"
+#include "opentelemetry/sdk/configuration/registry.h"
+#include "opentelemetry/sdk/trace/exporter.h"
+#include "opentelemetry/version.h"
+
+OPENTELEMETRY_BEGIN_NAMESPACE
+namespace exporter
+{
+namespace otlp
+{
+
+class OPENTELEMETRY_EXPORT OtlpFileSpanBuilder
+    : public opentelemetry::sdk::configuration::OtlpFileSpanExporterBuilder
+{
+public:
+  static void Register(opentelemetry::sdk::configuration::Registry *registry);
+
+  OtlpFileSpanBuilder()           = default;
+  ~OtlpFileSpanBuilder() override = default;
+
+  std::unique_ptr<opentelemetry::sdk::trace::SpanExporter> Build(
+      const opentelemetry::sdk::configuration::OtlpFileSpanExporterConfiguration *model)
+      const override;
+};
+
+}  // namespace otlp
+}  // namespace exporter
+OPENTELEMETRY_END_NAMESPACE

--- a/exporters/otlp/include/opentelemetry/exporters/otlp/otlp_file_span_builder.h
+++ b/exporters/otlp/include/opentelemetry/exporters/otlp/otlp_file_span_builder.h
@@ -23,9 +23,6 @@ class OPENTELEMETRY_EXPORT OtlpFileSpanBuilder
 public:
   static void Register(opentelemetry::sdk::configuration::Registry *registry);
 
-  OtlpFileSpanBuilder()           = default;
-  ~OtlpFileSpanBuilder() override = default;
-
   std::unique_ptr<opentelemetry::sdk::trace::SpanExporter> Build(
       const opentelemetry::sdk::configuration::OtlpFileSpanExporterConfiguration *model)
       const override;

--- a/exporters/otlp/include/opentelemetry/exporters/otlp/otlp_grpc_exporter_options.h
+++ b/exporters/otlp/include/opentelemetry/exporters/otlp/otlp_grpc_exporter_options.h
@@ -23,7 +23,10 @@ namespace otlp
  */
 struct OPENTELEMETRY_EXPORT OtlpGrpcExporterOptions : public OtlpGrpcClientOptions
 {
+  /** Lookup environment variables. */
   OtlpGrpcExporterOptions();
+  /** No defaults. */
+  OtlpGrpcExporterOptions(void *);
   OtlpGrpcExporterOptions(const OtlpGrpcExporterOptions &)            = default;
   OtlpGrpcExporterOptions(OtlpGrpcExporterOptions &&)                 = default;
   OtlpGrpcExporterOptions &operator=(const OtlpGrpcExporterOptions &) = default;

--- a/exporters/otlp/include/opentelemetry/exporters/otlp/otlp_grpc_log_record_builder.h
+++ b/exporters/otlp/include/opentelemetry/exporters/otlp/otlp_grpc_log_record_builder.h
@@ -1,0 +1,36 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <memory>
+
+#include "opentelemetry/sdk/configuration/otlp_grpc_log_record_exporter_builder.h"
+#include "opentelemetry/sdk/configuration/otlp_grpc_log_record_exporter_configuration.h"
+#include "opentelemetry/sdk/configuration/registry.h"
+#include "opentelemetry/sdk/logs/exporter.h"
+#include "opentelemetry/version.h"
+
+OPENTELEMETRY_BEGIN_NAMESPACE
+namespace exporter
+{
+namespace otlp
+{
+
+class OPENTELEMETRY_EXPORT OtlpGrpcLogRecordBuilder
+    : public opentelemetry::sdk::configuration::OtlpGrpcLogRecordExporterBuilder
+{
+public:
+  static void Register(opentelemetry::sdk::configuration::Registry *registry);
+
+  OtlpGrpcLogRecordBuilder()           = default;
+  ~OtlpGrpcLogRecordBuilder() override = default;
+
+  std::unique_ptr<opentelemetry::sdk::logs::LogRecordExporter> Build(
+      const opentelemetry::sdk::configuration::OtlpGrpcLogRecordExporterConfiguration *model)
+      const override;
+};
+
+}  // namespace otlp
+}  // namespace exporter
+OPENTELEMETRY_END_NAMESPACE

--- a/exporters/otlp/include/opentelemetry/exporters/otlp/otlp_grpc_log_record_builder.h
+++ b/exporters/otlp/include/opentelemetry/exporters/otlp/otlp_grpc_log_record_builder.h
@@ -23,9 +23,6 @@ class OPENTELEMETRY_EXPORT OtlpGrpcLogRecordBuilder
 public:
   static void Register(opentelemetry::sdk::configuration::Registry *registry);
 
-  OtlpGrpcLogRecordBuilder()           = default;
-  ~OtlpGrpcLogRecordBuilder() override = default;
-
   std::unique_ptr<opentelemetry::sdk::logs::LogRecordExporter> Build(
       const opentelemetry::sdk::configuration::OtlpGrpcLogRecordExporterConfiguration *model)
       const override;

--- a/exporters/otlp/include/opentelemetry/exporters/otlp/otlp_grpc_log_record_exporter_options.h
+++ b/exporters/otlp/include/opentelemetry/exporters/otlp/otlp_grpc_log_record_exporter_options.h
@@ -23,7 +23,10 @@ namespace otlp
  */
 struct OPENTELEMETRY_EXPORT OtlpGrpcLogRecordExporterOptions : public OtlpGrpcClientOptions
 {
+  /** Lookup environment variables. */
   OtlpGrpcLogRecordExporterOptions();
+  /** No defaults. */
+  OtlpGrpcLogRecordExporterOptions(void *);
   OtlpGrpcLogRecordExporterOptions(const OtlpGrpcLogRecordExporterOptions &)            = default;
   OtlpGrpcLogRecordExporterOptions(OtlpGrpcLogRecordExporterOptions &&)                 = default;
   OtlpGrpcLogRecordExporterOptions &operator=(const OtlpGrpcLogRecordExporterOptions &) = default;

--- a/exporters/otlp/include/opentelemetry/exporters/otlp/otlp_grpc_metric_exporter_options.h
+++ b/exporters/otlp/include/opentelemetry/exporters/otlp/otlp_grpc_metric_exporter_options.h
@@ -24,7 +24,10 @@ namespace otlp
  */
 struct OPENTELEMETRY_EXPORT OtlpGrpcMetricExporterOptions : public OtlpGrpcClientOptions
 {
+  /** Lookup environment variables. */
   OtlpGrpcMetricExporterOptions();
+  /** No defaults. */
+  OtlpGrpcMetricExporterOptions(void *);
   OtlpGrpcMetricExporterOptions(const OtlpGrpcMetricExporterOptions &)            = default;
   OtlpGrpcMetricExporterOptions(OtlpGrpcMetricExporterOptions &&)                 = default;
   OtlpGrpcMetricExporterOptions &operator=(const OtlpGrpcMetricExporterOptions &) = default;

--- a/exporters/otlp/include/opentelemetry/exporters/otlp/otlp_grpc_push_metric_builder.h
+++ b/exporters/otlp/include/opentelemetry/exporters/otlp/otlp_grpc_push_metric_builder.h
@@ -23,9 +23,6 @@ class OPENTELEMETRY_EXPORT OtlpGrpcPushMetricBuilder
 public:
   static void Register(opentelemetry::sdk::configuration::Registry *registry);
 
-  OtlpGrpcPushMetricBuilder()           = default;
-  ~OtlpGrpcPushMetricBuilder() override = default;
-
   std::unique_ptr<opentelemetry::sdk::metrics::PushMetricExporter> Build(
       const opentelemetry::sdk::configuration::OtlpGrpcPushMetricExporterConfiguration *model)
       const override;

--- a/exporters/otlp/include/opentelemetry/exporters/otlp/otlp_grpc_push_metric_builder.h
+++ b/exporters/otlp/include/opentelemetry/exporters/otlp/otlp_grpc_push_metric_builder.h
@@ -1,0 +1,36 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <memory>
+
+#include "opentelemetry/sdk/configuration/otlp_grpc_push_metric_exporter_builder.h"
+#include "opentelemetry/sdk/configuration/otlp_grpc_push_metric_exporter_configuration.h"
+#include "opentelemetry/sdk/configuration/registry.h"
+#include "opentelemetry/sdk/metrics/push_metric_exporter.h"
+#include "opentelemetry/version.h"
+
+OPENTELEMETRY_BEGIN_NAMESPACE
+namespace exporter
+{
+namespace otlp
+{
+
+class OPENTELEMETRY_EXPORT OtlpGrpcPushMetricBuilder
+    : public opentelemetry::sdk::configuration::OtlpGrpcPushMetricExporterBuilder
+{
+public:
+  static void Register(opentelemetry::sdk::configuration::Registry *registry);
+
+  OtlpGrpcPushMetricBuilder()           = default;
+  ~OtlpGrpcPushMetricBuilder() override = default;
+
+  std::unique_ptr<opentelemetry::sdk::metrics::PushMetricExporter> Build(
+      const opentelemetry::sdk::configuration::OtlpGrpcPushMetricExporterConfiguration *model)
+      const override;
+};
+
+}  // namespace otlp
+}  // namespace exporter
+OPENTELEMETRY_END_NAMESPACE

--- a/exporters/otlp/include/opentelemetry/exporters/otlp/otlp_grpc_span_builder.h
+++ b/exporters/otlp/include/opentelemetry/exporters/otlp/otlp_grpc_span_builder.h
@@ -23,9 +23,6 @@ class OPENTELEMETRY_EXPORT OtlpGrpcSpanBuilder
 public:
   static void Register(opentelemetry::sdk::configuration::Registry *registry);
 
-  OtlpGrpcSpanBuilder()           = default;
-  ~OtlpGrpcSpanBuilder() override = default;
-
   std::unique_ptr<opentelemetry::sdk::trace::SpanExporter> Build(
       const opentelemetry::sdk::configuration::OtlpGrpcSpanExporterConfiguration *model)
       const override;

--- a/exporters/otlp/include/opentelemetry/exporters/otlp/otlp_grpc_span_builder.h
+++ b/exporters/otlp/include/opentelemetry/exporters/otlp/otlp_grpc_span_builder.h
@@ -1,0 +1,36 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <memory>
+
+#include "opentelemetry/sdk/configuration/otlp_grpc_span_exporter_builder.h"
+#include "opentelemetry/sdk/configuration/otlp_grpc_span_exporter_configuration.h"
+#include "opentelemetry/sdk/configuration/registry.h"
+#include "opentelemetry/sdk/trace/exporter.h"
+#include "opentelemetry/version.h"
+
+OPENTELEMETRY_BEGIN_NAMESPACE
+namespace exporter
+{
+namespace otlp
+{
+
+class OPENTELEMETRY_EXPORT OtlpGrpcSpanBuilder
+    : public opentelemetry::sdk::configuration::OtlpGrpcSpanExporterBuilder
+{
+public:
+  static void Register(opentelemetry::sdk::configuration::Registry *registry);
+
+  OtlpGrpcSpanBuilder()           = default;
+  ~OtlpGrpcSpanBuilder() override = default;
+
+  std::unique_ptr<opentelemetry::sdk::trace::SpanExporter> Build(
+      const opentelemetry::sdk::configuration::OtlpGrpcSpanExporterConfiguration *model)
+      const override;
+};
+
+}  // namespace otlp
+}  // namespace exporter
+OPENTELEMETRY_END_NAMESPACE

--- a/exporters/otlp/include/opentelemetry/exporters/otlp/otlp_http_exporter_options.h
+++ b/exporters/otlp/include/opentelemetry/exporters/otlp/otlp_http_exporter_options.h
@@ -32,7 +32,10 @@ namespace otlp
  */
 struct OPENTELEMETRY_EXPORT OtlpHttpExporterOptions
 {
+  /** Lookup environment variables. */
   OtlpHttpExporterOptions();
+  /** No defaults. */
+  OtlpHttpExporterOptions(void *);
   OtlpHttpExporterOptions(const OtlpHttpExporterOptions &)            = default;
   OtlpHttpExporterOptions(OtlpHttpExporterOptions &&)                 = default;
   OtlpHttpExporterOptions &operator=(const OtlpHttpExporterOptions &) = default;

--- a/exporters/otlp/include/opentelemetry/exporters/otlp/otlp_http_log_record_builder.h
+++ b/exporters/otlp/include/opentelemetry/exporters/otlp/otlp_http_log_record_builder.h
@@ -23,9 +23,6 @@ class OPENTELEMETRY_EXPORT OtlpHttpLogRecordBuilder
 public:
   static void Register(opentelemetry::sdk::configuration::Registry *registry);
 
-  OtlpHttpLogRecordBuilder()           = default;
-  ~OtlpHttpLogRecordBuilder() override = default;
-
   std::unique_ptr<opentelemetry::sdk::logs::LogRecordExporter> Build(
       const opentelemetry::sdk::configuration::OtlpHttpLogRecordExporterConfiguration *model)
       const override;

--- a/exporters/otlp/include/opentelemetry/exporters/otlp/otlp_http_log_record_builder.h
+++ b/exporters/otlp/include/opentelemetry/exporters/otlp/otlp_http_log_record_builder.h
@@ -1,0 +1,36 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <memory>
+
+#include "opentelemetry/sdk/configuration/otlp_http_log_record_exporter_builder.h"
+#include "opentelemetry/sdk/configuration/otlp_http_log_record_exporter_configuration.h"
+#include "opentelemetry/sdk/configuration/registry.h"
+#include "opentelemetry/sdk/logs/exporter.h"
+#include "opentelemetry/version.h"
+
+OPENTELEMETRY_BEGIN_NAMESPACE
+namespace exporter
+{
+namespace otlp
+{
+
+class OPENTELEMETRY_EXPORT OtlpHttpLogRecordBuilder
+    : public opentelemetry::sdk::configuration::OtlpHttpLogRecordExporterBuilder
+{
+public:
+  static void Register(opentelemetry::sdk::configuration::Registry *registry);
+
+  OtlpHttpLogRecordBuilder()           = default;
+  ~OtlpHttpLogRecordBuilder() override = default;
+
+  std::unique_ptr<opentelemetry::sdk::logs::LogRecordExporter> Build(
+      const opentelemetry::sdk::configuration::OtlpHttpLogRecordExporterConfiguration *model)
+      const override;
+};
+
+}  // namespace otlp
+}  // namespace exporter
+OPENTELEMETRY_END_NAMESPACE

--- a/exporters/otlp/include/opentelemetry/exporters/otlp/otlp_http_log_record_exporter_options.h
+++ b/exporters/otlp/include/opentelemetry/exporters/otlp/otlp_http_log_record_exporter_options.h
@@ -32,7 +32,10 @@ namespace otlp
  */
 struct OPENTELEMETRY_EXPORT OtlpHttpLogRecordExporterOptions
 {
+  /** Lookup environment variables. */
   OtlpHttpLogRecordExporterOptions();
+  /** No defaults. */
+  OtlpHttpLogRecordExporterOptions(void *);
   OtlpHttpLogRecordExporterOptions(const OtlpHttpLogRecordExporterOptions &)            = default;
   OtlpHttpLogRecordExporterOptions(OtlpHttpLogRecordExporterOptions &&)                 = default;
   OtlpHttpLogRecordExporterOptions &operator=(const OtlpHttpLogRecordExporterOptions &) = default;

--- a/exporters/otlp/include/opentelemetry/exporters/otlp/otlp_http_metric_exporter_options.h
+++ b/exporters/otlp/include/opentelemetry/exporters/otlp/otlp_http_metric_exporter_options.h
@@ -33,7 +33,10 @@ namespace otlp
  */
 struct OPENTELEMETRY_EXPORT OtlpHttpMetricExporterOptions
 {
+  /** Lookup environment variables. */
   OtlpHttpMetricExporterOptions();
+  /** No defaults. */
+  OtlpHttpMetricExporterOptions(void *);
   OtlpHttpMetricExporterOptions(const OtlpHttpMetricExporterOptions &)            = default;
   OtlpHttpMetricExporterOptions(OtlpHttpMetricExporterOptions &&)                 = default;
   OtlpHttpMetricExporterOptions &operator=(const OtlpHttpMetricExporterOptions &) = default;

--- a/exporters/otlp/include/opentelemetry/exporters/otlp/otlp_http_push_metric_builder.h
+++ b/exporters/otlp/include/opentelemetry/exporters/otlp/otlp_http_push_metric_builder.h
@@ -1,0 +1,36 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <memory>
+
+#include "opentelemetry/sdk/configuration/otlp_http_push_metric_exporter_builder.h"
+#include "opentelemetry/sdk/configuration/otlp_http_push_metric_exporter_configuration.h"
+#include "opentelemetry/sdk/configuration/registry.h"
+#include "opentelemetry/sdk/metrics/push_metric_exporter.h"
+#include "opentelemetry/version.h"
+
+OPENTELEMETRY_BEGIN_NAMESPACE
+namespace exporter
+{
+namespace otlp
+{
+
+class OPENTELEMETRY_EXPORT OtlpHttpPushMetricBuilder
+    : public opentelemetry::sdk::configuration::OtlpHttpPushMetricExporterBuilder
+{
+public:
+  static void Register(opentelemetry::sdk::configuration::Registry *registry);
+
+  OtlpHttpPushMetricBuilder()           = default;
+  ~OtlpHttpPushMetricBuilder() override = default;
+
+  std::unique_ptr<opentelemetry::sdk::metrics::PushMetricExporter> Build(
+      const opentelemetry::sdk::configuration::OtlpHttpPushMetricExporterConfiguration *model)
+      const override;
+};
+
+}  // namespace otlp
+}  // namespace exporter
+OPENTELEMETRY_END_NAMESPACE

--- a/exporters/otlp/include/opentelemetry/exporters/otlp/otlp_http_push_metric_builder.h
+++ b/exporters/otlp/include/opentelemetry/exporters/otlp/otlp_http_push_metric_builder.h
@@ -23,9 +23,6 @@ class OPENTELEMETRY_EXPORT OtlpHttpPushMetricBuilder
 public:
   static void Register(opentelemetry::sdk::configuration::Registry *registry);
 
-  OtlpHttpPushMetricBuilder()           = default;
-  ~OtlpHttpPushMetricBuilder() override = default;
-
   std::unique_ptr<opentelemetry::sdk::metrics::PushMetricExporter> Build(
       const opentelemetry::sdk::configuration::OtlpHttpPushMetricExporterConfiguration *model)
       const override;

--- a/exporters/otlp/include/opentelemetry/exporters/otlp/otlp_http_span_builder.h
+++ b/exporters/otlp/include/opentelemetry/exporters/otlp/otlp_http_span_builder.h
@@ -23,9 +23,6 @@ class OPENTELEMETRY_EXPORT OtlpHttpSpanBuilder
 public:
   static void Register(opentelemetry::sdk::configuration::Registry *registry);
 
-  OtlpHttpSpanBuilder()           = default;
-  ~OtlpHttpSpanBuilder() override = default;
-
   std::unique_ptr<opentelemetry::sdk::trace::SpanExporter> Build(
       const opentelemetry::sdk::configuration::OtlpHttpSpanExporterConfiguration *model)
       const override;

--- a/exporters/otlp/include/opentelemetry/exporters/otlp/otlp_http_span_builder.h
+++ b/exporters/otlp/include/opentelemetry/exporters/otlp/otlp_http_span_builder.h
@@ -1,0 +1,36 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <memory>
+
+#include "opentelemetry/sdk/configuration/otlp_http_span_exporter_builder.h"
+#include "opentelemetry/sdk/configuration/otlp_http_span_exporter_configuration.h"
+#include "opentelemetry/sdk/configuration/registry.h"
+#include "opentelemetry/sdk/trace/exporter.h"
+#include "opentelemetry/version.h"
+
+OPENTELEMETRY_BEGIN_NAMESPACE
+namespace exporter
+{
+namespace otlp
+{
+
+class OPENTELEMETRY_EXPORT OtlpHttpSpanBuilder
+    : public opentelemetry::sdk::configuration::OtlpHttpSpanExporterBuilder
+{
+public:
+  static void Register(opentelemetry::sdk::configuration::Registry *registry);
+
+  OtlpHttpSpanBuilder()           = default;
+  ~OtlpHttpSpanBuilder() override = default;
+
+  std::unique_ptr<opentelemetry::sdk::trace::SpanExporter> Build(
+      const opentelemetry::sdk::configuration::OtlpHttpSpanExporterConfiguration *model)
+      const override;
+};
+
+}  // namespace otlp
+}  // namespace exporter
+OPENTELEMETRY_END_NAMESPACE

--- a/exporters/otlp/src/otlp_builder_utils.cc
+++ b/exporters/otlp/src/otlp_builder_utils.cc
@@ -2,12 +2,19 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include <map>
+#include <string>
 #include <utility>
 
 #include "opentelemetry/common/kv_properties.h"
 #include "opentelemetry/exporters/otlp/otlp_builder_utils.h"
+#include "opentelemetry/exporters/otlp/otlp_environment.h"
+#include "opentelemetry/exporters/otlp/otlp_http.h"
+#include "opentelemetry/exporters/otlp/otlp_preferred_temporality.h"
 #include "opentelemetry/nostd/string_view.h"
 #include "opentelemetry/sdk/common/global_log_handler.h"
+#include "opentelemetry/sdk/configuration/headers_configuration.h"
+#include "opentelemetry/sdk/configuration/otlp_http_encoding.h"
+#include "opentelemetry/sdk/configuration/temporality_preference.h"
 #include "opentelemetry/version.h"
 
 OPENTELEMETRY_BEGIN_NAMESPACE

--- a/exporters/otlp/src/otlp_builder_utils.cc
+++ b/exporters/otlp/src/otlp_builder_utils.cc
@@ -1,0 +1,113 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+#include <map>
+#include <utility>
+
+#include "opentelemetry/common/kv_properties.h"
+#include "opentelemetry/exporters/otlp/otlp_builder_utils.h"
+#include "opentelemetry/nostd/string_view.h"
+#include "opentelemetry/sdk/common/global_log_handler.h"
+#include "opentelemetry/version.h"
+
+OPENTELEMETRY_BEGIN_NAMESPACE
+namespace exporter
+{
+namespace otlp
+{
+
+HttpRequestContentType OtlpBuilderUtils::ConvertOtlpHttpEncoding(
+    opentelemetry::sdk::configuration::OtlpHttpEncoding model)
+{
+  auto result = exporter::otlp::HttpRequestContentType::kBinary;
+
+  switch (model)
+  {
+    case opentelemetry::sdk::configuration::OtlpHttpEncoding::protobuf:
+      result = exporter::otlp::HttpRequestContentType::kBinary;
+      break;
+    case opentelemetry::sdk::configuration::OtlpHttpEncoding::json:
+      result = exporter::otlp::HttpRequestContentType::kJson;
+      break;
+  }
+
+  return result;
+}
+
+OtlpHeaders OtlpBuilderUtils::ConvertHeadersConfigurationModel(
+    const opentelemetry::sdk::configuration::HeadersConfiguration *model,
+    const std::string &headers_list)
+{
+  OtlpHeaders headers;
+
+  // First, scan headers_list, which has low priority.
+  if (headers_list.size() > 0)
+  {
+    opentelemetry::common::KeyValueStringTokenizer tokenizer{headers_list};
+
+    opentelemetry::nostd::string_view header_key;
+    opentelemetry::nostd::string_view header_value;
+    bool header_valid = true;
+
+    while (tokenizer.next(header_valid, header_key, header_value))
+    {
+      if (header_valid)
+      {
+        std::string key(header_key);
+        std::string value(header_value);
+
+        if (headers.find(key) == headers.end())
+        {
+          headers.emplace(std::make_pair(std::move(key), std::move(value)));
+        }
+        else
+        {
+          OTEL_INTERNAL_LOG_WARN("Found duplicate key in headers_list");
+        }
+      }
+      else
+      {
+        OTEL_INTERNAL_LOG_WARN("Found invalid key/value pair in headers_list");
+      }
+    }
+  }
+
+  // Second, scan headers, which has high priority.
+  for (const auto &kv : model->kv_map)
+  {
+    const auto &search = headers.find(kv.first);
+    if (search != headers.end())
+    {
+      headers.erase(search);
+    }
+
+    headers.emplace(std::make_pair(kv.first, kv.second));
+  }
+
+  return headers;
+}
+
+PreferredAggregationTemporality OtlpBuilderUtils::ConvertTemporalityPreference(
+    opentelemetry::sdk::configuration::TemporalityPreference model)
+{
+  auto result = exporter::otlp::PreferredAggregationTemporality::kCumulative;
+
+  switch (model)
+  {
+    case opentelemetry::sdk::configuration::TemporalityPreference::cumulative:
+      result = exporter::otlp::PreferredAggregationTemporality::kCumulative;
+      break;
+    case opentelemetry::sdk::configuration::TemporalityPreference::delta:
+      result = exporter::otlp::PreferredAggregationTemporality::kDelta;
+      break;
+    case opentelemetry::sdk::configuration::TemporalityPreference::low_memory:
+      result = exporter::otlp::PreferredAggregationTemporality::kLowMemory;
+      break;
+  }
+
+  return result;
+}
+
+}  // namespace otlp
+}  // namespace exporter
+OPENTELEMETRY_END_NAMESPACE

--- a/exporters/otlp/src/otlp_file_log_record_builder.cc
+++ b/exporters/otlp/src/otlp_file_log_record_builder.cc
@@ -1,0 +1,41 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+#include <memory>
+#include <utility>
+
+#include "opentelemetry/exporters/otlp/otlp_file_log_record_builder.h"
+#include "opentelemetry/exporters/otlp/otlp_file_log_record_exporter_factory.h"
+#include "opentelemetry/exporters/otlp/otlp_file_log_record_exporter_options.h"
+#include "opentelemetry/sdk/configuration/otlp_file_log_record_exporter_builder.h"
+#include "opentelemetry/sdk/configuration/otlp_file_log_record_exporter_configuration.h"
+#include "opentelemetry/sdk/configuration/registry.h"
+#include "opentelemetry/sdk/logs/exporter.h"
+#include "opentelemetry/version.h"
+
+OPENTELEMETRY_BEGIN_NAMESPACE
+namespace exporter
+{
+namespace otlp
+{
+
+void OtlpFileLogRecordBuilder::Register(opentelemetry::sdk::configuration::Registry *registry)
+{
+  auto builder = std::make_unique<OtlpFileLogRecordBuilder>();
+  registry->SetOtlpFileLogRecordBuilder(std::move(builder));
+}
+
+std::unique_ptr<opentelemetry::sdk::logs::LogRecordExporter> OtlpFileLogRecordBuilder::Build(
+    const opentelemetry::sdk::configuration::OtlpFileLogRecordExporterConfiguration * /* model */)
+    const
+{
+  OtlpFileLogRecordExporterOptions options;
+
+  // FIXME: unclear how to map model->output_stream to a OtlpFileClientBackendOptions
+
+  return OtlpFileLogRecordExporterFactory::Create(options);
+}
+
+}  // namespace otlp
+}  // namespace exporter
+OPENTELEMETRY_END_NAMESPACE

--- a/exporters/otlp/src/otlp_file_push_metric_builder.cc
+++ b/exporters/otlp/src/otlp_file_push_metric_builder.cc
@@ -1,0 +1,44 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+#include <memory>
+#include <utility>
+
+#include "opentelemetry/exporters/otlp/otlp_builder_utils.h"
+#include "opentelemetry/exporters/otlp/otlp_file_metric_exporter_factory.h"
+#include "opentelemetry/exporters/otlp/otlp_file_metric_exporter_options.h"
+#include "opentelemetry/exporters/otlp/otlp_file_push_metric_builder.h"
+#include "opentelemetry/sdk/configuration/otlp_file_push_metric_exporter_builder.h"
+#include "opentelemetry/sdk/configuration/otlp_file_push_metric_exporter_configuration.h"
+#include "opentelemetry/sdk/configuration/registry.h"
+#include "opentelemetry/sdk/metrics/push_metric_exporter.h"
+#include "opentelemetry/version.h"
+
+OPENTELEMETRY_BEGIN_NAMESPACE
+namespace exporter
+{
+namespace otlp
+{
+
+void OtlpFilePushMetricBuilder::Register(opentelemetry::sdk::configuration::Registry *registry)
+{
+  auto builder = std::make_unique<OtlpFilePushMetricBuilder>();
+  registry->SetOtlpFilePushMetricExporterBuilder(std::move(builder));
+}
+
+std::unique_ptr<opentelemetry::sdk::metrics::PushMetricExporter> OtlpFilePushMetricBuilder::Build(
+    const opentelemetry::sdk::configuration::OtlpFilePushMetricExporterConfiguration *model) const
+{
+  OtlpFileMetricExporterOptions options;
+
+  // FIXME: unclear how to map model->output_stream to a OtlpFileClientBackendOptions
+
+  options.aggregation_temporality =
+      OtlpBuilderUtils::ConvertTemporalityPreference(model->temporality_preference);
+
+  return OtlpFileMetricExporterFactory::Create(options);
+}
+
+}  // namespace otlp
+}  // namespace exporter
+OPENTELEMETRY_END_NAMESPACE

--- a/exporters/otlp/src/otlp_file_span_builder.cc
+++ b/exporters/otlp/src/otlp_file_span_builder.cc
@@ -1,0 +1,40 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+#include <memory>
+#include <utility>
+
+#include "opentelemetry/exporters/otlp/otlp_file_exporter_factory.h"
+#include "opentelemetry/exporters/otlp/otlp_file_exporter_options.h"
+#include "opentelemetry/exporters/otlp/otlp_file_span_builder.h"
+#include "opentelemetry/sdk/configuration/otlp_file_span_exporter_builder.h"
+#include "opentelemetry/sdk/configuration/otlp_file_span_exporter_configuration.h"
+#include "opentelemetry/sdk/configuration/registry.h"
+#include "opentelemetry/sdk/trace/exporter.h"
+#include "opentelemetry/version.h"
+
+OPENTELEMETRY_BEGIN_NAMESPACE
+namespace exporter
+{
+namespace otlp
+{
+
+void OtlpFileSpanBuilder::Register(opentelemetry::sdk::configuration::Registry *registry)
+{
+  auto builder = std::make_unique<OtlpFileSpanBuilder>();
+  registry->SetOtlpFileSpanBuilder(std::move(builder));
+}
+
+std::unique_ptr<opentelemetry::sdk::trace::SpanExporter> OtlpFileSpanBuilder::Build(
+    const opentelemetry::sdk::configuration::OtlpFileSpanExporterConfiguration * /* model */) const
+{
+  OtlpFileExporterOptions options;
+
+  // FIXME: unclear how to map model->output_stream to a OtlpFileClientBackendOptions
+
+  return OtlpFileExporterFactory::Create(options);
+}
+
+}  // namespace otlp
+}  // namespace exporter
+OPENTELEMETRY_END_NAMESPACE

--- a/exporters/otlp/src/otlp_grpc_exporter_options.cc
+++ b/exporters/otlp/src/otlp_grpc_exporter_options.cc
@@ -45,6 +45,16 @@ OtlpGrpcExporterOptions::OtlpGrpcExporterOptions()
   retry_policy_backoff_multiplier = GetOtlpDefaultTracesRetryBackoffMultiplier();
 }
 
+OtlpGrpcExporterOptions::OtlpGrpcExporterOptions(void *)
+{
+  use_ssl_credentials = true;
+  max_threads         = 0;
+
+#ifdef ENABLE_ASYNC_EXPORT
+  max_concurrent_requests = 64;
+#endif
+}
+
 OtlpGrpcExporterOptions::~OtlpGrpcExporterOptions() {}
 
 }  // namespace otlp

--- a/exporters/otlp/src/otlp_grpc_log_record_builder.cc
+++ b/exporters/otlp/src/otlp_grpc_log_record_builder.cc
@@ -1,0 +1,56 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+#include <chrono>
+#include <memory>
+#include <string>
+#include <utility>
+
+#include "opentelemetry/exporters/otlp/otlp_builder_utils.h"
+#include "opentelemetry/exporters/otlp/otlp_grpc_log_record_builder.h"
+#include "opentelemetry/exporters/otlp/otlp_grpc_log_record_exporter_factory.h"
+#include "opentelemetry/exporters/otlp/otlp_grpc_log_record_exporter_options.h"
+#include "opentelemetry/sdk/configuration/otlp_grpc_log_record_exporter_builder.h"
+#include "opentelemetry/sdk/configuration/otlp_grpc_log_record_exporter_configuration.h"
+#include "opentelemetry/sdk/configuration/registry.h"
+#include "opentelemetry/sdk/logs/exporter.h"
+#include "opentelemetry/version.h"
+
+OPENTELEMETRY_BEGIN_NAMESPACE
+namespace exporter
+{
+namespace otlp
+{
+
+void OtlpGrpcLogRecordBuilder::Register(opentelemetry::sdk::configuration::Registry *registry)
+{
+  auto builder = std::make_unique<OtlpGrpcLogRecordBuilder>();
+  registry->SetOtlpGrpcLogRecordBuilder(std::move(builder));
+}
+
+std::unique_ptr<opentelemetry::sdk::logs::LogRecordExporter> OtlpGrpcLogRecordBuilder::Build(
+    const opentelemetry::sdk::configuration::OtlpGrpcLogRecordExporterConfiguration *model) const
+{
+  OtlpGrpcLogRecordExporterOptions options(nullptr);
+
+  options.endpoint            = model->endpoint;
+  options.use_ssl_credentials = !model->insecure;
+
+  options.ssl_credentials_cacert_path = model->certificate_file;
+#ifdef ENABLE_OTLP_GRPC_SSL_MTLS_PREVIEW
+  options.ssl_client_key_path  = model->client_key_file;
+  options.ssl_client_cert_path = model->client_certificate_file;
+#endif
+
+  options.timeout = std::chrono::duration_cast<std::chrono::system_clock::duration>(
+      std::chrono::seconds{model->timeout});
+  options.metadata =
+      OtlpBuilderUtils::ConvertHeadersConfigurationModel(model->headers.get(), model->headers_list);
+  options.compression = model->compression;
+
+  return OtlpGrpcLogRecordExporterFactory::Create(options);
+}
+
+}  // namespace otlp
+}  // namespace exporter
+OPENTELEMETRY_END_NAMESPACE

--- a/exporters/otlp/src/otlp_grpc_log_record_exporter_options.cc
+++ b/exporters/otlp/src/otlp_grpc_log_record_exporter_options.cc
@@ -45,6 +45,16 @@ OtlpGrpcLogRecordExporterOptions::OtlpGrpcLogRecordExporterOptions()
   retry_policy_backoff_multiplier = GetOtlpDefaultLogsRetryBackoffMultiplier();
 }
 
+OtlpGrpcLogRecordExporterOptions::OtlpGrpcLogRecordExporterOptions(void *)
+{
+  use_ssl_credentials = true;
+  max_threads         = 0;
+
+#ifdef ENABLE_ASYNC_EXPORT
+  max_concurrent_requests = 64;
+#endif
+}
+
 OtlpGrpcLogRecordExporterOptions::~OtlpGrpcLogRecordExporterOptions() {}
 
 }  // namespace otlp

--- a/exporters/otlp/src/otlp_grpc_metric_exporter_options.cc
+++ b/exporters/otlp/src/otlp_grpc_metric_exporter_options.cc
@@ -47,6 +47,17 @@ OtlpGrpcMetricExporterOptions::OtlpGrpcMetricExporterOptions()
   retry_policy_backoff_multiplier = GetOtlpDefaultMetricsRetryBackoffMultiplier();
 }
 
+OtlpGrpcMetricExporterOptions::OtlpGrpcMetricExporterOptions(void *)
+    : aggregation_temporality(PreferredAggregationTemporality::kCumulative)
+{
+  use_ssl_credentials = true;
+  max_threads         = 0;
+
+#ifdef ENABLE_ASYNC_EXPORT
+  max_concurrent_requests = 64;
+#endif
+}
+
 OtlpGrpcMetricExporterOptions::~OtlpGrpcMetricExporterOptions() {}
 
 }  // namespace otlp

--- a/exporters/otlp/src/otlp_grpc_push_metric_builder.cc
+++ b/exporters/otlp/src/otlp_grpc_push_metric_builder.cc
@@ -1,0 +1,59 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+#include <chrono>
+#include <memory>
+#include <string>
+#include <utility>
+
+#include "opentelemetry/exporters/otlp/otlp_builder_utils.h"
+#include "opentelemetry/exporters/otlp/otlp_grpc_metric_exporter_factory.h"
+#include "opentelemetry/exporters/otlp/otlp_grpc_metric_exporter_options.h"
+#include "opentelemetry/exporters/otlp/otlp_grpc_push_metric_builder.h"
+#include "opentelemetry/sdk/configuration/otlp_grpc_push_metric_exporter_builder.h"
+#include "opentelemetry/sdk/configuration/otlp_grpc_push_metric_exporter_configuration.h"
+#include "opentelemetry/sdk/configuration/registry.h"
+#include "opentelemetry/sdk/metrics/push_metric_exporter.h"
+#include "opentelemetry/version.h"
+
+OPENTELEMETRY_BEGIN_NAMESPACE
+namespace exporter
+{
+namespace otlp
+{
+
+void OtlpGrpcPushMetricBuilder::Register(opentelemetry::sdk::configuration::Registry *registry)
+{
+  auto builder = std::make_unique<OtlpGrpcPushMetricBuilder>();
+  registry->SetOtlpGrpcPushMetricExporterBuilder(std::move(builder));
+}
+
+std::unique_ptr<opentelemetry::sdk::metrics::PushMetricExporter> OtlpGrpcPushMetricBuilder::Build(
+    const opentelemetry::sdk::configuration::OtlpGrpcPushMetricExporterConfiguration *model) const
+{
+  OtlpGrpcMetricExporterOptions options(nullptr);
+
+  options.endpoint            = model->endpoint;
+  options.use_ssl_credentials = !model->insecure;
+
+  options.ssl_credentials_cacert_path = model->certificate_file;
+#ifdef ENABLE_OTLP_GRPC_SSL_MTLS_PREVIEW
+  options.ssl_client_key_path  = model->client_key_file;
+  options.ssl_client_cert_path = model->client_certificate_file;
+#endif
+
+  options.timeout = std::chrono::duration_cast<std::chrono::system_clock::duration>(
+      std::chrono::seconds{model->timeout});
+  options.metadata =
+      OtlpBuilderUtils::ConvertHeadersConfigurationModel(model->headers.get(), model->headers_list);
+  options.compression = model->compression;
+
+  options.aggregation_temporality =
+      OtlpBuilderUtils::ConvertTemporalityPreference(model->temporality_preference);
+
+  return OtlpGrpcMetricExporterFactory::Create(options);
+}
+
+}  // namespace otlp
+}  // namespace exporter
+OPENTELEMETRY_END_NAMESPACE

--- a/exporters/otlp/src/otlp_grpc_span_builder.cc
+++ b/exporters/otlp/src/otlp_grpc_span_builder.cc
@@ -1,0 +1,56 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+#include <chrono>
+#include <memory>
+#include <string>
+#include <utility>
+
+#include "opentelemetry/exporters/otlp/otlp_builder_utils.h"
+#include "opentelemetry/exporters/otlp/otlp_grpc_exporter_factory.h"
+#include "opentelemetry/exporters/otlp/otlp_grpc_exporter_options.h"
+#include "opentelemetry/exporters/otlp/otlp_grpc_span_builder.h"
+#include "opentelemetry/sdk/configuration/otlp_grpc_span_exporter_builder.h"
+#include "opentelemetry/sdk/configuration/otlp_grpc_span_exporter_configuration.h"
+#include "opentelemetry/sdk/configuration/registry.h"
+#include "opentelemetry/sdk/trace/exporter.h"
+#include "opentelemetry/version.h"
+
+OPENTELEMETRY_BEGIN_NAMESPACE
+namespace exporter
+{
+namespace otlp
+{
+
+void OtlpGrpcSpanBuilder::Register(opentelemetry::sdk::configuration::Registry *registry)
+{
+  auto builder = std::make_unique<OtlpGrpcSpanBuilder>();
+  registry->SetOtlpGrpcSpanBuilder(std::move(builder));
+}
+
+std::unique_ptr<opentelemetry::sdk::trace::SpanExporter> OtlpGrpcSpanBuilder::Build(
+    const opentelemetry::sdk::configuration::OtlpGrpcSpanExporterConfiguration *model) const
+{
+  OtlpGrpcExporterOptions options(nullptr);
+
+  options.endpoint            = model->endpoint;
+  options.use_ssl_credentials = !model->insecure;
+
+  options.ssl_credentials_cacert_path = model->certificate_file;
+#ifdef ENABLE_OTLP_GRPC_SSL_MTLS_PREVIEW
+  options.ssl_client_key_path  = model->client_key_file;
+  options.ssl_client_cert_path = model->client_certificate_file;
+#endif
+
+  options.timeout = std::chrono::duration_cast<std::chrono::system_clock::duration>(
+      std::chrono::seconds{model->timeout});
+  options.metadata =
+      OtlpBuilderUtils::ConvertHeadersConfigurationModel(model->headers.get(), model->headers_list);
+  options.compression = model->compression;
+
+  return OtlpGrpcExporterFactory::Create(options);
+}
+
+}  // namespace otlp
+}  // namespace exporter
+OPENTELEMETRY_END_NAMESPACE

--- a/exporters/otlp/src/otlp_http_exporter_options.cc
+++ b/exporters/otlp/src/otlp_http_exporter_options.cc
@@ -43,6 +43,32 @@ OtlpHttpExporterOptions::OtlpHttpExporterOptions()
       retry_policy_backoff_multiplier(GetOtlpDefaultTracesRetryBackoffMultiplier())
 {}
 
+OtlpHttpExporterOptions::OtlpHttpExporterOptions(void *)
+    : url(),
+      content_type(HttpRequestContentType::kBinary),
+      json_bytes_mapping(JsonBytesMappingKind::kHexId),
+      use_json_name(false),
+      console_debug(false),
+      timeout(0),
+      http_headers(),
+#ifdef ENABLE_ASYNC_EXPORT
+      max_concurrent_requests{64},
+      max_requests_per_connection{8},
+#endif
+      ssl_insecure_skip_verify(false),
+      ssl_ca_cert_path(),
+      ssl_ca_cert_string(),
+      ssl_client_key_path(),
+      ssl_client_key_string(),
+      ssl_client_cert_path(),
+      ssl_client_cert_string(),
+      ssl_min_tls(),
+      ssl_max_tls(),
+      ssl_cipher(),
+      ssl_cipher_suite(),
+      compression()
+{}
+
 OtlpHttpExporterOptions::~OtlpHttpExporterOptions() {}
 
 }  // namespace otlp

--- a/exporters/otlp/src/otlp_http_exporter_options.cc
+++ b/exporters/otlp/src/otlp_http_exporter_options.cc
@@ -49,24 +49,11 @@ OtlpHttpExporterOptions::OtlpHttpExporterOptions(void *)
       json_bytes_mapping(JsonBytesMappingKind::kHexId),
       use_json_name(false),
       console_debug(false),
-      timeout(0),
-      http_headers(),
 #ifdef ENABLE_ASYNC_EXPORT
       max_concurrent_requests{64},
       max_requests_per_connection{8},
 #endif
-      ssl_insecure_skip_verify(false),
-      ssl_ca_cert_path(),
-      ssl_ca_cert_string(),
-      ssl_client_key_path(),
-      ssl_client_key_string(),
-      ssl_client_cert_path(),
-      ssl_client_cert_string(),
-      ssl_min_tls(),
-      ssl_max_tls(),
-      ssl_cipher(),
-      ssl_cipher_suite(),
-      compression()
+      ssl_insecure_skip_verify(false)
 {}
 
 OtlpHttpExporterOptions::~OtlpHttpExporterOptions() {}

--- a/exporters/otlp/src/otlp_http_log_record_builder.cc
+++ b/exporters/otlp/src/otlp_http_log_record_builder.cc
@@ -1,0 +1,57 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+#include <chrono>
+#include <memory>
+#include <string>
+#include <utility>
+
+#include "opentelemetry/exporters/otlp/otlp_builder_utils.h"
+#include "opentelemetry/exporters/otlp/otlp_http.h"
+#include "opentelemetry/exporters/otlp/otlp_http_log_record_builder.h"
+#include "opentelemetry/exporters/otlp/otlp_http_log_record_exporter_factory.h"
+#include "opentelemetry/exporters/otlp/otlp_http_log_record_exporter_options.h"
+#include "opentelemetry/sdk/configuration/otlp_http_log_record_exporter_builder.h"
+#include "opentelemetry/sdk/configuration/otlp_http_log_record_exporter_configuration.h"
+#include "opentelemetry/sdk/configuration/registry.h"
+#include "opentelemetry/sdk/logs/exporter.h"
+#include "opentelemetry/version.h"
+
+OPENTELEMETRY_BEGIN_NAMESPACE
+namespace exporter
+{
+namespace otlp
+{
+
+void OtlpHttpLogRecordBuilder::Register(opentelemetry::sdk::configuration::Registry *registry)
+{
+  auto builder = std::make_unique<OtlpHttpLogRecordBuilder>();
+  registry->SetOtlpHttpLogRecordBuilder(std::move(builder));
+}
+
+std::unique_ptr<opentelemetry::sdk::logs::LogRecordExporter> OtlpHttpLogRecordBuilder::Build(
+    const opentelemetry::sdk::configuration::OtlpHttpLogRecordExporterConfiguration *model) const
+{
+  OtlpHttpLogRecordExporterOptions options(nullptr);
+
+  options.url                = model->endpoint;
+  options.content_type       = OtlpBuilderUtils::ConvertOtlpHttpEncoding(model->encoding);
+  options.json_bytes_mapping = JsonBytesMappingKind::kHexId;
+  options.use_json_name      = false;
+  options.console_debug      = false;
+  options.timeout            = std::chrono::duration_cast<std::chrono::system_clock::duration>(
+      std::chrono::seconds{model->timeout});
+  options.http_headers =
+      OtlpBuilderUtils::ConvertHeadersConfigurationModel(model->headers.get(), model->headers_list);
+  options.ssl_insecure_skip_verify = false;
+  options.ssl_ca_cert_path         = model->certificate_file;
+  options.ssl_client_key_path      = model->client_key_file;
+  options.ssl_client_cert_path     = model->client_certificate_file;
+  options.compression              = model->compression;
+
+  return OtlpHttpLogRecordExporterFactory::Create(options);
+}
+
+}  // namespace otlp
+}  // namespace exporter
+OPENTELEMETRY_END_NAMESPACE

--- a/exporters/otlp/src/otlp_http_log_record_exporter_options.cc
+++ b/exporters/otlp/src/otlp_http_log_record_exporter_options.cc
@@ -43,6 +43,19 @@ OtlpHttpLogRecordExporterOptions::OtlpHttpLogRecordExporterOptions()
       retry_policy_backoff_multiplier(GetOtlpDefaultLogsRetryBackoffMultiplier())
 {}
 
+OtlpHttpLogRecordExporterOptions::OtlpHttpLogRecordExporterOptions(void *)
+    : url(),
+      content_type(exporter::otlp::HttpRequestContentType::kBinary),
+      json_bytes_mapping(JsonBytesMappingKind::kHexId),
+      use_json_name(false),
+      console_debug(false),
+#ifdef ENABLE_ASYNC_EXPORT
+      max_concurrent_requests{64},
+      max_requests_per_connection{8},
+#endif
+      ssl_insecure_skip_verify(false)
+{}
+
 OtlpHttpLogRecordExporterOptions::~OtlpHttpLogRecordExporterOptions() {}
 
 }  // namespace otlp

--- a/exporters/otlp/src/otlp_http_metric_exporter_options.cc
+++ b/exporters/otlp/src/otlp_http_metric_exporter_options.cc
@@ -45,6 +45,20 @@ OtlpHttpMetricExporterOptions::OtlpHttpMetricExporterOptions()
       retry_policy_backoff_multiplier(GetOtlpDefaultMetricsRetryBackoffMultiplier())
 {}
 
+OtlpHttpMetricExporterOptions::OtlpHttpMetricExporterOptions(void *)
+    : url(),
+      content_type(exporter::otlp::HttpRequestContentType::kBinary),
+      json_bytes_mapping(JsonBytesMappingKind::kHexId),
+      use_json_name(false),
+      console_debug(false),
+      aggregation_temporality(PreferredAggregationTemporality::kCumulative),
+#ifdef ENABLE_ASYNC_EXPORT
+      max_concurrent_requests{64},
+      max_requests_per_connection{8},
+#endif
+      ssl_insecure_skip_verify(false)
+{}
+
 OtlpHttpMetricExporterOptions::~OtlpHttpMetricExporterOptions() {}
 
 }  // namespace otlp

--- a/exporters/otlp/src/otlp_http_push_metric_builder.cc
+++ b/exporters/otlp/src/otlp_http_push_metric_builder.cc
@@ -1,0 +1,59 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+#include <chrono>
+#include <memory>
+#include <string>
+#include <utility>
+
+#include "opentelemetry/exporters/otlp/otlp_builder_utils.h"
+#include "opentelemetry/exporters/otlp/otlp_http.h"
+#include "opentelemetry/exporters/otlp/otlp_http_metric_exporter_factory.h"
+#include "opentelemetry/exporters/otlp/otlp_http_metric_exporter_options.h"
+#include "opentelemetry/exporters/otlp/otlp_http_push_metric_builder.h"
+#include "opentelemetry/sdk/configuration/otlp_http_push_metric_exporter_builder.h"
+#include "opentelemetry/sdk/configuration/otlp_http_push_metric_exporter_configuration.h"
+#include "opentelemetry/sdk/configuration/registry.h"
+#include "opentelemetry/sdk/metrics/push_metric_exporter.h"
+#include "opentelemetry/version.h"
+
+OPENTELEMETRY_BEGIN_NAMESPACE
+namespace exporter
+{
+namespace otlp
+{
+
+void OtlpHttpPushMetricBuilder::Register(opentelemetry::sdk::configuration::Registry *registry)
+{
+  auto builder = std::make_unique<OtlpHttpPushMetricBuilder>();
+  registry->SetOtlpHttpPushMetricExporterBuilder(std::move(builder));
+}
+
+std::unique_ptr<opentelemetry::sdk::metrics::PushMetricExporter> OtlpHttpPushMetricBuilder::Build(
+    const opentelemetry::sdk::configuration::OtlpHttpPushMetricExporterConfiguration *model) const
+{
+  OtlpHttpMetricExporterOptions options(nullptr);
+
+  options.url                = model->endpoint;
+  options.content_type       = OtlpBuilderUtils::ConvertOtlpHttpEncoding(model->encoding);
+  options.json_bytes_mapping = JsonBytesMappingKind::kHexId;
+  options.use_json_name      = false;
+  options.console_debug      = false;
+  options.timeout            = std::chrono::duration_cast<std::chrono::system_clock::duration>(
+      std::chrono::seconds{model->timeout});
+  options.http_headers =
+      OtlpBuilderUtils::ConvertHeadersConfigurationModel(model->headers.get(), model->headers_list);
+  options.aggregation_temporality =
+      OtlpBuilderUtils::ConvertTemporalityPreference(model->temporality_preference);
+  options.ssl_insecure_skip_verify = false;
+  options.ssl_ca_cert_path         = model->certificate_file;
+  options.ssl_client_key_path      = model->client_key_file;
+  options.ssl_client_cert_path     = model->client_certificate_file;
+  options.compression              = model->compression;
+
+  return OtlpHttpMetricExporterFactory::Create(options);
+}
+
+}  // namespace otlp
+}  // namespace exporter
+OPENTELEMETRY_END_NAMESPACE

--- a/exporters/otlp/src/otlp_http_span_builder.cc
+++ b/exporters/otlp/src/otlp_http_span_builder.cc
@@ -1,0 +1,57 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+#include <chrono>
+#include <memory>
+#include <string>
+#include <utility>
+
+#include "opentelemetry/exporters/otlp/otlp_builder_utils.h"
+#include "opentelemetry/exporters/otlp/otlp_http.h"
+#include "opentelemetry/exporters/otlp/otlp_http_exporter_factory.h"
+#include "opentelemetry/exporters/otlp/otlp_http_exporter_options.h"
+#include "opentelemetry/exporters/otlp/otlp_http_span_builder.h"
+#include "opentelemetry/sdk/configuration/otlp_http_span_exporter_builder.h"
+#include "opentelemetry/sdk/configuration/otlp_http_span_exporter_configuration.h"
+#include "opentelemetry/sdk/configuration/registry.h"
+#include "opentelemetry/sdk/trace/exporter.h"
+#include "opentelemetry/version.h"
+
+OPENTELEMETRY_BEGIN_NAMESPACE
+namespace exporter
+{
+namespace otlp
+{
+
+void OtlpHttpSpanBuilder::Register(opentelemetry::sdk::configuration::Registry *registry)
+{
+  auto builder = std::make_unique<OtlpHttpSpanBuilder>();
+  registry->SetOtlpHttpSpanBuilder(std::move(builder));
+}
+
+std::unique_ptr<opentelemetry::sdk::trace::SpanExporter> OtlpHttpSpanBuilder::Build(
+    const opentelemetry::sdk::configuration::OtlpHttpSpanExporterConfiguration *model) const
+{
+  OtlpHttpExporterOptions options(nullptr);
+
+  options.url                = model->endpoint;
+  options.content_type       = OtlpBuilderUtils::ConvertOtlpHttpEncoding(model->encoding);
+  options.json_bytes_mapping = JsonBytesMappingKind::kHexId;
+  options.use_json_name      = false;
+  options.console_debug      = false;
+  options.timeout            = std::chrono::duration_cast<std::chrono::system_clock::duration>(
+      std::chrono::seconds{model->timeout});
+  options.http_headers =
+      OtlpBuilderUtils::ConvertHeadersConfigurationModel(model->headers.get(), model->headers_list);
+  options.ssl_insecure_skip_verify = false;
+  options.ssl_ca_cert_path         = model->certificate_file;
+  options.ssl_client_key_path      = model->client_key_file;
+  options.ssl_client_cert_path     = model->client_certificate_file;
+  options.compression              = model->compression;
+
+  return OtlpHttpExporterFactory::Create(options);
+}
+
+}  // namespace otlp
+}  // namespace exporter
+OPENTELEMETRY_END_NAMESPACE


### PR DESCRIPTION
Contributes to #2481

This is a partial fix, to implement otlp exporter builders.

## Changes

Please provide a brief description of the changes here.

* Add a new option constructor, that ignores environment variables
* Implement the otlp exporter builders

For significant contributions please make sure you have completed the following items:

* [ ] `CHANGELOG.md` updated for non-trivial changes
* [ ] Unit tests have been added
* [ ] Changes in public API reviewed