### PR TITLE
[CONFIGURATION] File configuration - sdk resource

### DIFF
--- a/sdk/include/opentelemetry/sdk/logs/batch_log_record_processor_options.h
+++ b/sdk/include/opentelemetry/sdk/logs/batch_log_record_processor_options.h
@@ -16,7 +16,7 @@ namespace logs
 {
 
 /**
- * Struct to hold batch SpanProcessor options.
+ * Struct to hold batch LogRecordProcessor options.
  */
 struct BatchLogRecordProcessorOptions
 {

--- a/sdk/include/opentelemetry/sdk/resource/resource.h
+++ b/sdk/include/opentelemetry/sdk/resource/resource.h
@@ -19,7 +19,14 @@ using ResourceAttributes = opentelemetry::sdk::common::AttributeMap;
 class Resource
 {
 public:
-  Resource(const Resource &) = default;
+  Resource() noexcept;
+
+  Resource(const ResourceAttributes &attributes) noexcept;
+
+  Resource(const ResourceAttributes &attributes, const std::string &schema_url) noexcept;
+
+  Resource(const Resource &)            = default;
+  Resource &operator=(const Resource &) = default;
 
   const ResourceAttributes &GetAttributes() const noexcept;
   const std::string &GetSchemaURL() const noexcept;
@@ -61,21 +68,9 @@ public:
 
   static Resource &GetDefault();
 
-protected:
-  /**
-   * The constructor is protected and only for use internally by the class and
-   * inside ResourceDetector class.
-   * Users should use the Create factory method to obtain a Resource
-   * instance.
-   */
-  Resource(const ResourceAttributes &attributes = ResourceAttributes(),
-           const std::string &schema_url        = std::string{}) noexcept;
-
 private:
   ResourceAttributes attributes_;
   std::string schema_url_;
-
-  friend class ResourceDetector;
 };
 
 }  // namespace resource

--- a/sdk/src/resource/resource.cc
+++ b/sdk/src/resource/resource.cc
@@ -20,6 +20,12 @@ namespace sdk
 namespace resource
 {
 
+Resource::Resource() noexcept : attributes_(), schema_url_() {}
+
+Resource::Resource(const ResourceAttributes &attributes) noexcept
+    : attributes_(attributes), schema_url_()
+{}
+
 Resource::Resource(const ResourceAttributes &attributes, const std::string &schema_url) noexcept
     : attributes_(attributes), schema_url_(schema_url)
 {}


### PR DESCRIPTION
Contributes to #2481

Remove restrictions on resource creation.

## Changes

Please provide a brief description of the changes here.

* Remove restrictions on resource creation in the SDK.
* With declarative configuration, resources can be created after parsing a `config.yaml` file, calling a resource detector is no longer the only way to build a resource.

For significant contributions please make sure you have completed the following items:

* [ ] `CHANGELOG.md` updated for non-trivial changes
* [ ] Unit tests have been added
* [ ] Changes in public API reviewed