### PR TITLE
fix fetching nlohmann_json when cmake version is less than 3.19

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,6 +58,7 @@ jobs:
     runs-on: ubuntu-24.04
     env:
       CXX_STANDARD: '17'
+      CMAKE_VERSION: '3.14.0'
       BUILD_TYPE: 'Debug'
     steps:
     - name: Harden the runner (Audit all outbound calls)
@@ -70,6 +71,7 @@ jobs:
     - name: setup
       run: |
         sudo -E ./ci/setup_ci_environment.sh
+        sudo -E ./ci/setup_cmake.sh
     - name: install dependencies
       run: |
         sudo -E apt-get update

--- a/cmake/nlohmann-json.cmake
+++ b/cmake/nlohmann-json.cmake
@@ -35,8 +35,9 @@ if(NOT nlohmann_json_FOUND)
   # Set the nlohmann_json_VERSION variable from the git tag.
   string(REGEX REPLACE "^v([0-9]+\\.[0-9]+\\.[0-9]+)$" "\\1" nlohmann_json_VERSION "${nlohmann-json_GIT_TAG}")
 
-  #Disable iwyu and clang-tidy
-  if(TARGET nlohmann_json)
+  # Disable iwyu and clang-tidy only if the CMake version is greater or equal to 3.19.
+  # CMake 3.19+ is needed to set the iwyu and clang-tidy properties on the INTERFACE target
+  if(TARGET nlohmann_json AND CMAKE_VERSION VERSION_GREATER_EQUAL "3.19")
     set_target_properties(nlohmann_json PROPERTIES CXX_INCLUDE_WHAT_YOU_USE ""
                                                      CXX_CLANG_TIDY "")
   endif()


### PR DESCRIPTION
Fixes #3560

`nlohmann_json` is an INTERFACE target and CMake <3.19 does not support setting the iwyu and clang-tidy properties on interface targets. 

## Changes

- check if the CMake version is >= 3.19 before setting the iwyu and clang-tidy properties on the nlohmann-json target
- Update the fetch content test in the CI workflow to verify fetching nlohmann-json (and the other fetchable dependencies) with the minimum supported CMake version (3.14).  

For significant contributions please make sure you have completed the following items:

* [ ] `CHANGELOG.md` updated for non-trivial changes
* [ ] Unit tests have been added
* [ ] Changes in public API reviewed