### PR TITLE
[CMAKE] upgrade cmake minimum version to 3.16

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,7 +58,7 @@ jobs:
     runs-on: ubuntu-24.04
     env:
       CXX_STANDARD: '17'
-      CMAKE_VERSION: '3.14.0'
+      CMAKE_VERSION: '3.16.0'
       BUILD_TYPE: 'Debug'
     steps:
     - name: Harden the runner (Audit all outbound calls)

--- a/.github/workflows/cmake_install.yml
+++ b/.github/workflows/cmake_install.yml
@@ -153,7 +153,7 @@ jobs:
     env:
       INSTALL_TEST_DIR: '/home/runner/install_test'
       # Set to the current minimum version of cmake
-      CMAKE_VERSION: '3.14.0'
+      CMAKE_VERSION: '3.16.0'
       # cxx14 is the default for Ubuntu 22.04
       CXX_STANDARD: '14'
       BUILD_TYPE: 'Debug'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,11 @@ Increment the:
 * [SDK] View should not have a unit
   [#3552](https://github.com/open-telemetry/opentelemetry-cpp/pull/3552)
 
+Important changes:
+
+* [CMAKE] Upgrade CMake minimum version to 3.16
+  [#3599](https://github.com/open-telemetry/opentelemetry-cpp/pull/3599)
+
 Breaking changes:
 
 * [SDK] View should not have a unit

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright The OpenTelemetry Authors
 # SPDX-License-Identifier: Apache-2.0
 
-cmake_minimum_required(VERSION 3.14)
+cmake_minimum_required(VERSION 3.16)
 
 # See https://cmake.org/cmake/help/latest/policy/CMP0074.html required by
 # certain version of zlib which CURL depends on.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,22 +3,6 @@
 
 cmake_minimum_required(VERSION 3.16)
 
-# See https://cmake.org/cmake/help/latest/policy/CMP0074.html required by
-# certain version of zlib which CURL depends on.
-if(${CMAKE_VERSION} VERSION_GREATER_EQUAL "3.12")
-  cmake_policy(SET CMP0074 NEW)
-endif()
-
-# Allow to use normal variable for option()
-if(${CMAKE_VERSION} VERSION_GREATER_EQUAL "3.13")
-  cmake_policy(SET CMP0077 NEW)
-endif()
-
-# Prefer CMAKE_MSVC_RUNTIME_LIBRARY if possible
-if(POLICY CMP0091)
-  cmake_policy(SET CMP0091 NEW)
-endif()
-
 if(POLICY CMP0092)
   # https://cmake.org/cmake/help/latest/policy/CMP0092.html#policy:CMP0092 Make
   # sure the /W3 is not removed from CMAKE_CXX_FLAGS since CMake 3.15

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -23,8 +23,7 @@ You can link OpenTelemetry C++ SDK with libraries provided in
   repository. To install Git, consult the [Set up
   Git](https://help.github.com/articles/set-up-git/) guide on GitHub.
 - [CMake](https://cmake.org/) for building opentelemetry-cpp API, SDK with their
-  unittests. The minimum CMake version is 3.14.
-  CMake 3.15+ is recommended on Windows due to known CI test failures with 3.14.
+  unittests. The minimum CMake version is 3.16.
   To install CMake,
   consult the [Installing CMake](https://cmake.org/install/) guide.
 - [GoogleTest](https://github.com/google/googletest) framework to build and run

--- a/install/cmake/CMakeLists.txt
+++ b/install/cmake/CMakeLists.txt
@@ -22,7 +22,7 @@
 # CMAKE_CXX_STANDARD: The C++ standard to use for all third-party packages.
 # Defaults to 14 if not set.
 
-cmake_minimum_required(VERSION 3.14)
+cmake_minimum_required(VERSION 3.16)
 project(opentelemetry-cpp-thirdparty-install LANGUAGES CXX)
 
 # Added in CMake 3.16. ExternalProject_Add() with GIT_SUBMODULES "" initializes

--- a/install/test/cmake/CMakeLists.txt
+++ b/install/test/cmake/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright The OpenTelemetry Authors
 # SPDX-License-Identifier: Apache-2.0
 
-cmake_minimum_required(VERSION 3.14)
+cmake_minimum_required(VERSION 3.16)
 project(opentelemetry-cpp-component-install-tests LANGUAGES CXX)
 
 if(NOT INSTALL_TEST_CMAKE_OPTIONS)

--- a/install/test/cmake/component_tests/api/CMakeLists.txt
+++ b/install/test/cmake/component_tests/api/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright The OpenTelemetry Authors
 # SPDX-License-Identifier: Apache-2.0
 
-cmake_minimum_required(VERSION 3.14)
+cmake_minimum_required(VERSION 3.16)
 
 project(opentelemetry-cpp-api-install-test LANGUAGES CXX)
 

--- a/install/test/cmake/component_tests/exporters_elasticsearch/CMakeLists.txt
+++ b/install/test/cmake/component_tests/exporters_elasticsearch/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright The OpenTelemetry Authors
 # SPDX-License-Identifier: Apache-2.0
 
-cmake_minimum_required(VERSION 3.14)
+cmake_minimum_required(VERSION 3.16)
 project(opentelemetry-cpp-exporters-elasticsearch-install-test LANGUAGES CXX)
 
 find_package(opentelemetry-cpp REQUIRED COMPONENTS exporters_elasticsearch)

--- a/install/test/cmake/component_tests/exporters_etw/CMakeLists.txt
+++ b/install/test/cmake/component_tests/exporters_etw/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright The OpenTelemetry Authors
 # SPDX-License-Identifier: Apache-2.0
 
-cmake_minimum_required(VERSION 3.14)
+cmake_minimum_required(VERSION 3.16)
 project(opentelemetry-cpp-exporters_etw-install-test LANGUAGES CXX)
 
 find_package(opentelemetry-cpp REQUIRED COMPONENTS exporters_etw)

--- a/install/test/cmake/component_tests/exporters_in_memory/CMakeLists.txt
+++ b/install/test/cmake/component_tests/exporters_in_memory/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright The OpenTelemetry Authors
 # SPDX-License-Identifier: Apache-2.0
 
-cmake_minimum_required(VERSION 3.14)
+cmake_minimum_required(VERSION 3.16)
 project(opentelemetry-cpp-exporters-in-memory-install-test LANGUAGES CXX)
 
 find_package(opentelemetry-cpp REQUIRED COMPONENTS exporters_in_memory)

--- a/install/test/cmake/component_tests/exporters_ostream/CMakeLists.txt
+++ b/install/test/cmake/component_tests/exporters_ostream/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright The OpenTelemetry Authors
 # SPDX-License-Identifier: Apache-2.0
 
-cmake_minimum_required(VERSION 3.14)
+cmake_minimum_required(VERSION 3.16)
 project(opentelemetry-cpp-exporters-ostream-install-test LANGUAGES CXX)
 
 find_package(opentelemetry-cpp REQUIRED COMPONENTS exporters_ostream)

--- a/install/test/cmake/component_tests/exporters_otlp_common/CMakeLists.txt
+++ b/install/test/cmake/component_tests/exporters_otlp_common/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright The OpenTelemetry Authors
 # SPDX-License-Identifier: Apache-2.0
 
-cmake_minimum_required(VERSION 3.14)
+cmake_minimum_required(VERSION 3.16)
 project(opentelemetry-cpp-exporters-otlp-common-install-test LANGUAGES CXX)
 
 find_package(opentelemetry-cpp REQUIRED COMPONENTS exporters_otlp_common)

--- a/install/test/cmake/component_tests/exporters_otlp_file/CMakeLists.txt
+++ b/install/test/cmake/component_tests/exporters_otlp_file/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright The OpenTelemetry Authors
 # SPDX-License-Identifier: Apache-2.0
 
-cmake_minimum_required(VERSION 3.14)
+cmake_minimum_required(VERSION 3.16)
 project(opentelemetry-cpp-exporters-otlp-file-install-test LANGUAGES CXX)
 
 find_package(opentelemetry-cpp REQUIRED COMPONENTS exporters_otlp_file)

--- a/install/test/cmake/component_tests/exporters_otlp_grpc/CMakeLists.txt
+++ b/install/test/cmake/component_tests/exporters_otlp_grpc/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright The OpenTelemetry Authors
 # SPDX-License-Identifier: Apache-2.0
 
-cmake_minimum_required(VERSION 3.14)
+cmake_minimum_required(VERSION 3.16)
 project(opentelemetry-cpp-exporters-otlp-grpc-install-test LANGUAGES CXX)
 
 find_package(opentelemetry-cpp REQUIRED COMPONENTS exporters_otlp_grpc)

--- a/install/test/cmake/component_tests/exporters_otlp_http/CMakeLists.txt
+++ b/install/test/cmake/component_tests/exporters_otlp_http/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright The OpenTelemetry Authors
 # SPDX-License-Identifier: Apache-2.0
 
-cmake_minimum_required(VERSION 3.14)
+cmake_minimum_required(VERSION 3.16)
 project(opentelemetry-cpp-exporters-otlp-http-install-test LANGUAGES CXX)
 
 find_package(opentelemetry-cpp REQUIRED COMPONENTS exporters_otlp_http)

--- a/install/test/cmake/component_tests/exporters_prometheus/CMakeLists.txt
+++ b/install/test/cmake/component_tests/exporters_prometheus/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright The OpenTelemetry Authors
 # SPDX-License-Identifier: Apache-2.0
 
-cmake_minimum_required(VERSION 3.14)
+cmake_minimum_required(VERSION 3.16)
 project(opentelemetry-cpp-exporters-prometheus-install-test LANGUAGES CXX)
 
 find_package(opentelemetry-cpp REQUIRED COMPONENTS exporters_prometheus)

--- a/install/test/cmake/component_tests/exporters_zipkin/CMakeLists.txt
+++ b/install/test/cmake/component_tests/exporters_zipkin/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright The OpenTelemetry Authors
 # SPDX-License-Identifier: Apache-2.0
 
-cmake_minimum_required(VERSION 3.14)
+cmake_minimum_required(VERSION 3.16)
 project(opentelemetry-cpp-exporters-zipkin-install-test LANGUAGES CXX)
 
 find_package(opentelemetry-cpp REQUIRED COMPONENTS exporters_zipkin)

--- a/install/test/cmake/component_tests/ext_common/CMakeLists.txt
+++ b/install/test/cmake/component_tests/ext_common/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright The OpenTelemetry Authors
 # SPDX-License-Identifier: Apache-2.0
 
-cmake_minimum_required(VERSION 3.14)
+cmake_minimum_required(VERSION 3.16)
 project(opentelemetry-cpp-ext_common-install-test LANGUAGES CXX)
 
 find_package(opentelemetry-cpp REQUIRED COMPONENTS ext_common)

--- a/install/test/cmake/component_tests/ext_dll/CMakeLists.txt
+++ b/install/test/cmake/component_tests/ext_dll/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright The OpenTelemetry Authors
 # SPDX-License-Identifier: Apache-2.0
 
-cmake_minimum_required(VERSION 3.14)
+cmake_minimum_required(VERSION 3.16)
 project(opentelemetry-cpp-ext_dll-install-test LANGUAGES CXX)
 
 find_package(opentelemetry-cpp REQUIRED COMPONENTS ext_dll exporters_ostream)

--- a/install/test/cmake/component_tests/ext_http_curl/CMakeLists.txt
+++ b/install/test/cmake/component_tests/ext_http_curl/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright The OpenTelemetry Authors
 # SPDX-License-Identifier: Apache-2.0
 
-cmake_minimum_required(VERSION 3.14)
+cmake_minimum_required(VERSION 3.16)
 project(opentelemetry-cpp-ext_http_curl-install-test LANGUAGES CXX)
 
 find_package(opentelemetry-cpp REQUIRED COMPONENTS ext_http_curl)

--- a/install/test/cmake/component_tests/sdk/CMakeLists.txt
+++ b/install/test/cmake/component_tests/sdk/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright The OpenTelemetry Authors
 # SPDX-License-Identifier: Apache-2.0
 
-cmake_minimum_required(VERSION 3.14)
+cmake_minimum_required(VERSION 3.16)
 project(opentelemetry-cpp-sdk-install-test LANGUAGES CXX)
 
 find_package(opentelemetry-cpp REQUIRED COMPONENTS sdk)

--- a/install/test/cmake/component_tests/shims_opentracing/CMakeLists.txt
+++ b/install/test/cmake/component_tests/shims_opentracing/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright The OpenTelemetry Authors
 # SPDX-License-Identifier: Apache-2.0
 
-cmake_minimum_required(VERSION 3.14)
+cmake_minimum_required(VERSION 3.16)
 project(opentelemetry-cpp-shims_opentracing-install-test LANGUAGES CXX)
 
 find_package(opentelemetry-cpp REQUIRED COMPONENTS shims_opentracing)

--- a/install/test/cmake/examples_test/CMakeLists.txt
+++ b/install/test/cmake/examples_test/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright The OpenTelemetry Authors
 # SPDX-License-Identifier: Apache-2.0
 
-cmake_minimum_required(VERSION 3.14)
+cmake_minimum_required(VERSION 3.16)
 
 project(opentelemetry-cpp-examples-test LANGUAGES CXX)
 

--- a/install/test/cmake/fetch_content_test/CMakeLists.txt
+++ b/install/test/cmake/fetch_content_test/CMakeLists.txt
@@ -4,7 +4,7 @@
 # This test uses CMake's FetchContent module to build opentelemetry-cpp from src
 # and make its targets available within an external project.
 
-cmake_minimum_required(VERSION 3.14)
+cmake_minimum_required(VERSION 3.16)
 
 project(opentelemetry-cpp-fetch-content-test LANGUAGES CXX)
 

--- a/install/test/cmake/package_test/CMakeLists.txt
+++ b/install/test/cmake/package_test/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright The OpenTelemetry Authors
 # SPDX-License-Identifier: Apache-2.0
 
-cmake_minimum_required(VERSION 3.14)
+cmake_minimum_required(VERSION 3.16)
 
 project(opentelemetry-cpp-full-package-install-test LANGUAGES CXX)
 

--- a/install/test/cmake/usage_tests/missing_components/CMakeLists.txt
+++ b/install/test/cmake/usage_tests/missing_components/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright The OpenTelemetry Authors
 # SPDX-License-Identifier: Apache-2.0
 
-cmake_minimum_required(VERSION 3.14)
+cmake_minimum_required(VERSION 3.16)
 
 project(opentelemetry-cpp-unsorted-components-install-test LANGUAGES CXX)
 

--- a/install/test/cmake/usage_tests/no_components/CMakeLists.txt
+++ b/install/test/cmake/usage_tests/no_components/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright The OpenTelemetry Authors
 # SPDX-License-Identifier: Apache-2.0
 
-cmake_minimum_required(VERSION 3.14)
+cmake_minimum_required(VERSION 3.16)
 
 project(opentelemetry-cpp-unsorted-components-install-test LANGUAGES CXX)
 

--- a/install/test/cmake/usage_tests/unsorted_components/CMakeLists.txt
+++ b/install/test/cmake/usage_tests/unsorted_components/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright The OpenTelemetry Authors
 # SPDX-License-Identifier: Apache-2.0
 
-cmake_minimum_required(VERSION 3.14)
+cmake_minimum_required(VERSION 3.16)
 
 project(opentelemetry-cpp-unsorted-components-install-test LANGUAGES CXX)
 

--- a/install/test/cmake/usage_tests/unsupported_components/CMakeLists.txt
+++ b/install/test/cmake/usage_tests/unsupported_components/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright The OpenTelemetry Authors
 # SPDX-License-Identifier: Apache-2.0
 
-cmake_minimum_required(VERSION 3.14)
+cmake_minimum_required(VERSION 3.16)
 
 project(opentelemetry-cpp-unsupported-components-install-test LANGUAGES CXX)
 


### PR DESCRIPTION
Fixes #3598 

## Changes
- upgrade cmake min version from 3.14 to 3.16
- test against 3.16 in CI

For significant contributions please make sure you have completed the following items:

* [x] `CHANGELOG.md` updated for non-trivial changes
* [ ] Unit tests have been added
* [ ] Changes in public API reviewed