### PR TITLE
drop rules_foreign_cc as a dependency

### DIFF
--- a/bazel/extra_deps.bzl
+++ b/bazel/extra_deps.bzl
@@ -5,9 +5,7 @@
 
 load("@bazel_skylib//:workspace.bzl", "bazel_skylib_workspace")
 load("@com_github_jupp0r_prometheus_cpp//bazel:repositories.bzl", "prometheus_cpp_repositories")
-load("@rules_foreign_cc//foreign_cc:repositories.bzl", "rules_foreign_cc_dependencies")
 
 def opentelemetry_extra_deps():
     prometheus_cpp_repositories()
     bazel_skylib_workspace()
-    rules_foreign_cc_dependencies()

--- a/bazel/repository.bzl
+++ b/bazel/repository.bzl
@@ -141,15 +141,6 @@ def opentelemetry_cpp_deps():
         ],
     )
 
-    # rules foreign cc
-    maybe(
-        http_archive,
-        name = "rules_foreign_cc",
-        sha256 = "69023642d5781c68911beda769f91fcbc8ca48711db935a75da7f6536b65047f",
-        strip_prefix = "rules_foreign_cc-0.6.0",
-        url = "https://github.com/bazelbuild/rules_foreign_cc/archive/0.6.0.tar.gz",
-    )
-
     # bazel skylib
     maybe(
         http_archive,


### PR DESCRIPTION
It does not appear that the Bazel build of this repo makes any use of `rules_foreign_cc`, so we here remove its default definition.

Fixes #3600

## Changes

We here drop a default definition of `rules_foreign_cc` from the WORKSPACE-based setup for building this repo under Bazel.

For significant contributions please make sure you have completed the following items:

* [ ] `CHANGELOG.md` updated for non-trivial changes
* [ ] Unit tests have been added
* [ ] Changes in public API reviewed