### PR TITLE
[Metrics] New Attribute Processor for Exclude list

### DIFF
--- a/sdk/test/metrics/attributes_processor_test.cc
+++ b/sdk/test/metrics/attributes_processor_test.cc
@@ -51,3 +51,40 @@ TEST(AttributesProcessor, FilteringAllAttributesProcessor)
   auto filtered_attributes = attributes_processor.process(iterable);
   EXPECT_EQ(filter.size(), kNumFilterAttributes);
 }
+
+TEST(AttributesProcessor, FilteringExcludeAttributesProcessor)
+{
+  const int kNumFilterAttributes               = 3;
+  std::unordered_map<std::string, bool> filter = {
+      {"attr2", true}, {"attr4", true}, {"attr6", true}};
+  const int kNumAttributes              = 6;
+  std::string keys[kNumAttributes]      = {"attr1", "attr2", "attr3", "attr4", "attr5", "attr6"};
+  int values[kNumAttributes]            = {10, 20, 30, 40, 50, 60};
+  std::map<std::string, int> attributes = {{keys[0], values[0]}, {keys[1], values[1]},
+                                           {keys[2], values[2]}, {keys[3], values[3]},
+                                           {keys[4], values[4]}, {keys[5], values[5]}};
+  FilteringExcludeAttributesProcessor attributes_processor(filter);
+  opentelemetry::common::KeyValueIterableView<std::map<std::string, int>> iterable(attributes);
+  auto filtered_attributes = attributes_processor.process(iterable);
+  for (auto &e : filtered_attributes)
+  {
+    EXPECT_TRUE(filter.find(e.first) == filter.end());
+  }
+  EXPECT_EQ(filter.size(), kNumFilterAttributes);
+}
+
+TEST(AttributesProcessor, FilteringExcludeAllAtrributesProcessor)
+{
+  const int kNumFilterAttributes               = 0;
+  std::unordered_map<std::string, bool> filter = {};
+  const int kNumAttributes                     = 6;
+  std::string keys[kNumAttributes]      = {"attr1", "attr2", "attr3", "attr4", "attr5", "attr6"};
+  int values[kNumAttributes]            = {10, 20, 30, 40, 50, 60};
+  std::map<std::string, int> attributes = {{keys[0], values[0]}, {keys[1], values[1]},
+                                           {keys[2], values[2]}, {keys[3], values[3]},
+                                           {keys[4], values[4]}, {keys[5], values[5]}};
+  FilteringExcludeAttributesProcessor attributes_processor(filter);
+  opentelemetry::common::KeyValueIterableView<std::map<std::string, int>> iterable(attributes);
+  auto filtered_attributes = attributes_processor.process(iterable);
+  EXPECT_EQ(filter.size(), kNumFilterAttributes);
+}


### PR DESCRIPTION
Fixes # ([issue](https://github.com/open-telemetry/opentelemetry-cpp/issues/3546#issue-3237554269))

## Changes

Created a new Attribute processor for exclude list as filter only partially exists for allowed list

This is the doc of spec - https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/metrics/sdk.md#stream-configuration

Please provide a brief description of the changes here.

For significant contributions please make sure you have completed the following items:

* [ ] `CHANGELOG.md` updated for non-trivial changes
* [ ] Unit tests have been added
* [ ] Changes in public API reviewed