### PR TITLE
New circular buffer using faa instead of cas to optimize performance 

### DIFF
--- a/sdk/include/opentelemetry/sdk/common/circular_buffer_range.h
+++ b/sdk/include/opentelemetry/sdk/common/circular_buffer_range.h
@@ -75,7 +75,10 @@ public:
    */
   CircularBufferRange Take(size_t n) const noexcept
   {
-    assert(n <= size());
+    // assert(n <= size());
+    if (n >= size()) {
+      return CircularBufferRange{first_,second_};
+    }
     if (first_.size() >= n)
     {
       return CircularBufferRange{nostd::span<T>{first_.data(), n}};

--- a/sdk/test/common/CMakeLists.txt
+++ b/sdk/test/common/CMakeLists.txt
@@ -8,6 +8,7 @@ foreach(
   atomic_unique_ptr_test
   circular_buffer_range_test
   circular_buffer_test
+  optimize_circular_buffer_test
   attribute_utils_test
   attributemap_hash_test
   global_log_handle_test

--- a/sdk/test/common/baseline_circular_buffer.h
+++ b/sdk/test/common/baseline_circular_buffer.h
@@ -78,6 +78,11 @@ public:
     tail_ = head_;
   }
 
+  size_t size() noexcept {
+    std::lock_guard<std::mutex> lock_guard{mutex_};
+    return head_ - tail_;
+  }
+
 private:
   std::mutex mutex_;
   uint64_t head_{0};

--- a/sdk/test/common/optimize_circular_buffer_test.cc
+++ b/sdk/test/common/optimize_circular_buffer_test.cc
@@ -1,0 +1,171 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+#include <gtest/gtest.h>
+#include <stddef.h>
+#include <algorithm>
+#include <atomic>
+#include <cassert>
+#include <cstdint>
+#include <functional>
+#include <initializer_list>
+#include <memory>
+#include <random>
+#include <string>
+#include <thread>
+#include <vector>
+
+#include "opentelemetry/sdk/common/atomic_unique_ptr.h"
+#include "opentelemetry/sdk/common/circular_buffer.h"
+#include "test/common/optmize_circular_buffer.h"
+
+using opentelemetry::sdk::common::AtomicUniquePtr;
+using opentelemetry::sdk::common::CircularBufferRange;
+using opentelemetry::sdk::common::OptimizedCircularBuffer;
+
+static thread_local std::mt19937 RandomNumberGenerator{std::random_device{}()};
+
+static void GenerateRandomNumbers(OptimizedCircularBuffer<uint32_t> &buffer,
+                                  std::vector<uint32_t> &numbers,
+                                  int n)
+{
+  for (int i = 0; i < n; ++i)
+  {
+    auto value = static_cast<uint32_t>(RandomNumberGenerator());
+    std::unique_ptr<uint32_t> x{new uint32_t{value}};
+    if (buffer.Add(x))
+    {
+      numbers.push_back(value);
+    }
+  }
+}
+
+static void RunNumberProducers(OptimizedCircularBuffer<uint32_t> &buffer,
+                               std::vector<uint32_t> &numbers,
+                               int num_threads,
+                               int n)
+{
+  std::vector<std::vector<uint32_t>> thread_numbers(num_threads);
+  std::vector<std::thread> threads(num_threads);
+  for (int thread_index = 0; thread_index < num_threads; ++thread_index)
+  {
+    threads[thread_index] = std::thread{GenerateRandomNumbers, std::ref(buffer),
+                                        std::ref(thread_numbers[thread_index]), n};
+  }
+  for (auto &thread : threads)
+  {
+    thread.join();
+  }
+  for (int thread_index = 0; thread_index < num_threads; ++thread_index)
+  {
+    numbers.insert(numbers.end(), thread_numbers[thread_index].begin(),
+                   thread_numbers[thread_index].end());
+  }
+}
+
+void RunNumberConsumer(OptimizedCircularBuffer<uint32_t> &buffer,
+                       std::atomic<bool> &exit,
+                       std::vector<uint32_t> &numbers)
+{
+  while (true)
+  {
+    if (exit && buffer.Peek().empty())
+    {
+      return;
+    }
+    auto n = std::uniform_int_distribution<size_t>{0, buffer.Peek().size()}(RandomNumberGenerator);
+    buffer.Consume(n, [&](CircularBufferRange<AtomicUniquePtr<uint32_t>> range) noexcept {
+      assert(range.size() == n);
+      range.ForEach([&](AtomicUniquePtr<uint32_t> &ptr) noexcept {
+        assert(!ptr.IsNull());
+        numbers.push_back(*ptr);
+        ptr.Reset();
+        return true;
+      });
+    });
+  }
+}
+
+TEST(OptmizeCircularBufferTest, Add)
+{
+  OptimizedCircularBuffer<int> buffer{10};
+
+  std::unique_ptr<int> x{new int{11}};
+  EXPECT_TRUE(buffer.Add(x));
+  EXPECT_EQ(x, nullptr);
+  auto range = buffer.Peek();
+  EXPECT_EQ(range.size(), 1);
+  range.ForEach([](const AtomicUniquePtr<int> &y) {
+    EXPECT_EQ(*y, 11);
+    return true;
+  });
+}
+
+TEST(OptmizeCircularBufferTest, Clear)
+{
+  OptimizedCircularBuffer<int> buffer{10};
+
+  std::unique_ptr<int> x{new int{11}};
+  EXPECT_TRUE(buffer.Add(x));
+  EXPECT_EQ(x, nullptr);
+  buffer.Clear();
+  EXPECT_TRUE(buffer.empty());
+}
+
+TEST(OptmizeCircularBufferTest, AddOnFull)
+{
+  OptimizedCircularBuffer<int> buffer{10};
+  for (int i = 0; i < static_cast<int>(buffer.max_size()); ++i)
+  {
+    std::unique_ptr<int> x{new int{i}};
+    EXPECT_TRUE(buffer.Add(x));
+  }
+  std::unique_ptr<int> x{new int{33}};
+  EXPECT_FALSE(buffer.Add(x));
+  EXPECT_NE(x, nullptr);
+  EXPECT_EQ(*x, 33);
+}
+
+TEST(OptmizeCircularBufferTest, Consume)
+{
+  OptimizedCircularBuffer<int> buffer{10};
+  for (int i = 0; i < static_cast<int>(buffer.max_size()); ++i)
+  {
+    std::unique_ptr<int> x{new int{i}};
+    EXPECT_TRUE(buffer.Add(x));
+  }
+  int count = 0;
+  buffer.Consume(5, [&](CircularBufferRange<AtomicUniquePtr<int>> range) noexcept {
+    range.ForEach([&](AtomicUniquePtr<int> &ptr) {
+      EXPECT_EQ(*ptr, count++);
+      ptr.Reset();
+      return true;
+    });
+  });
+  EXPECT_EQ(count, 5);
+}
+
+TEST(OptmizeCircularBufferTest, Simulation)
+{
+  const int num_producer_threads = 4;
+  const int n                    = 25000;
+  for (size_t max_size : {1, 2, 10, 50, 100, 1000})
+  {
+    OptimizedCircularBuffer<uint32_t> buffer{max_size};
+    std::vector<uint32_t> producer_numbers;
+    std::vector<uint32_t> consumer_numbers;
+    auto producers = std::thread{RunNumberProducers, std::ref(buffer), std::ref(producer_numbers),
+                                 num_producer_threads, n};
+    std::atomic<bool> exit{false};
+    auto consumer = std::thread{RunNumberConsumer, std::ref(buffer), std::ref(exit),
+                                std::ref(consumer_numbers)};
+    producers.join();
+    exit = true;
+    consumer.join();
+    std::sort(producer_numbers.begin(), producer_numbers.end());
+    std::sort(consumer_numbers.begin(), consumer_numbers.end());
+
+    EXPECT_EQ(producer_numbers.size(), consumer_numbers.size());
+    EXPECT_EQ(producer_numbers, consumer_numbers);
+  }
+}

--- a/sdk/test/common/optmize_circular_buffer.h
+++ b/sdk/test/common/optmize_circular_buffer.h
@@ -14,6 +14,7 @@
 #include "opentelemetry/sdk/common/atomic_unique_ptr.h"
 #include "opentelemetry/sdk/common/circular_buffer_range.h"
 #include "opentelemetry/version.h"
+#include <iostream>
 
 OPENTELEMETRY_BEGIN_NAMESPACE
 namespace sdk
@@ -21,14 +22,14 @@ namespace sdk
 namespace common
 {
 /*
- * A lock-free circular buffer that supports multiple concurrent producers
- * and a single consumer.
+ * An optimized lock-free circular buffer that supports multiple concurrent producers
+ * and a single consumer. Uses FAA (Fetch-And-Add) for better performance.
  */
 template <class T>
-class CircularBuffer
+class OptimizedCircularBuffer
 {
 public:
-  explicit CircularBuffer(size_t max_size)
+  explicit OptimizedCircularBuffer(size_t max_size)
       : data_{new AtomicUniquePtr<T>[max_size + 1]}, capacity_{max_size + 1}
   {}
 
@@ -39,7 +40,7 @@ public:
    */
   CircularBufferRange<const AtomicUniquePtr<T>> Peek() const noexcept
   {
-    return const_cast<CircularBuffer *>(this)->PeekImpl();
+    return const_cast<OptimizedCircularBuffer *>(this)->PeekImpl();
   }
 
   /**
@@ -55,13 +56,15 @@ public:
   template <class Callback>
   void Consume(size_t n, Callback callback) noexcept
   {
-    assert(n <= static_cast<size_t>(head_ - tail_));
+    // comsume max(n, available) elements
     auto range = PeekImpl().Take(n);
     static_assert(noexcept(callback(range)), "callback not allowed to throw");
-    tail_ += n;
-    // why not call back after tail_ += n
+    // consume elements
     callback(range);
-    // tail_ += n;
+    // free elements to let producers add new elements
+    tail_ += range.size();
+    tail_ %= capacity_;
+    count_.fetch_sub(range.size(), std::memory_order_release);
   }
 
   /**
@@ -87,37 +90,24 @@ public:
    */
   bool Add(std::unique_ptr<T> &ptr) noexcept
   {
-    while (true)
+    uint64_t count = count_.fetch_add(1, std::memory_order_acquire);
+    if (count >= capacity_ - 1)
     {
-      uint64_t tail = tail_;
-      uint64_t head = head_;
-
-      // The circular buffer is full, so return false.
-      if (head - tail >= capacity_ - 1)
-      {
-        return false;
-      }
-
-      uint64_t head_index = head % capacity_;
-      if (data_[head_index].SwapIfNull(ptr))
-      {
-        auto new_head      = head + 1;
-        auto expected_head = head;
-        if (head_.compare_exchange_weak(expected_head, new_head, std::memory_order_release,
-                                        std::memory_order_relaxed))
-        {
-          // free the swapped out value
-          ptr.reset();
-
-          return true;
-        }
-
-        // If we reached this point (unlikely), it means that between the last
-        // iteration elements were added and then consumed from the circular
-        // buffer, so we undo the swap and attempt to add again.
-        data_[head_index].Swap(ptr);
-      }
+      // queue is full, rollback
+      count_.fetch_sub(1, std::memory_order_release);
+      return false;
     }
+
+    uint64_t head_pos = head_.fetch_add(1, std::memory_order_acquire);
+    uint64_t head_index = head_pos % capacity_;
+    // It should be a valid pos to add an element
+    assert(data_[head_index].Get() == nullptr);
+    
+    // set the element must be sucess
+    bool success = data_[head_index].SwapIfNull(ptr);
+    assert(success); 
+    ptr.reset();
+    return true;
   }
 
   bool Add(std::unique_ptr<T> &&ptr) noexcept
@@ -143,7 +133,7 @@ public:
   /**
    * @return true if the buffer is empty.
    */
-  bool empty() const noexcept { return head_ == tail_; }
+  bool empty() const noexcept { return count_.load(std::memory_order_relaxed) == 0; }
 
   /**
    * @return the number of bytes stored in the circular buffer.
@@ -153,10 +143,7 @@ public:
    */
   size_t size() const noexcept
   {
-    uint64_t tail = tail_;
-    uint64_t head = head_;
-    assert(tail <= head);
-    return head - tail;
+    return count_.load(std::memory_order_relaxed);
   }
 
   /**
@@ -172,26 +159,53 @@ public:
 private:
   std::unique_ptr<AtomicUniquePtr<T>[]> data_;
   size_t capacity_;
-  std::atomic<uint64_t> head_{0};
-  std::atomic<uint64_t> tail_{0};
+  std::atomic<uint64_t> count_{0};  
+  std::atomic<uint64_t> head_{0}; 
+  uint64_t tail_{0};
 
   CircularBufferRange<AtomicUniquePtr<T>> PeekImpl() noexcept
   {
-    uint64_t tail_index = tail_ % capacity_;
-    uint64_t head_index = head_ % capacity_;
-    if (head_index == tail_index)
+    uint64_t current_count = count_.load(std::memory_order_relaxed);
+    if (current_count == 0)
     {
       return {};
     }
+    
     auto data = data_.get();
-    if (tail_index < head_index)
+    uint64_t available_count = 0;
+    uint64_t max_check = std::min(current_count, capacity_);
+    
+    for (uint64_t i = 0; i < max_check; ++i)
+    {
+      uint64_t index = (tail_ + i) % capacity_;
+      if (data[index].Get() != nullptr)
+      {
+        available_count++;
+      }
+      else
+      {
+        // Find the first null pointer, it's a element currently being added by producer 
+        break;
+      }
+    }
+    
+    if (available_count == 0)
+    {
+      return {};
+    }
+
+    if (tail_ + available_count <= capacity_)
     {
       return CircularBufferRange<AtomicUniquePtr<T>>{nostd::span<AtomicUniquePtr<T>>{
-          data + tail_index, static_cast<std::size_t>(head_index - tail_index)}};
+          data + tail_, static_cast<std::size_t>(available_count)}};
+    } else {
+      // the elements are split into two parts
+      uint64_t first_part_size = capacity_ - tail_;
+      uint64_t second_part_size = available_count - first_part_size;
+      
+      return {nostd::span<AtomicUniquePtr<T>>{data + tail_, static_cast<std::size_t>(first_part_size)},
+              nostd::span<AtomicUniquePtr<T>>{data, static_cast<std::size_t>(second_part_size)}};
     }
-    return {nostd::span<AtomicUniquePtr<T>>{data + tail_index,
-                                            static_cast<std::size_t>(capacity_ - tail_index)},
-            nostd::span<AtomicUniquePtr<T>>{data, static_cast<std::size_t>(head_index)}};
   }
 };
 }  // namespace common


### PR DESCRIPTION
solve #3645

## Changes

I noticed that original circular buffer using by batch span processor use lock free MPSC queu based on CAS. When experiencing intense multithreading contention, Compare-And-Swap (CAS) exhibits poorer scalability compared to Fetch-And-Add (FAA). In reference of https://github.com/dbittman/waitfree-mpsc-queue, this pr attempt to implement a wait-free MPSC (Multiple Producer, Single Consumer) queue using FAA. Base on original benchmark, it indicate that this approach demonstrates better performance scalability.

```
Run on (48 X 2593.99 MHz CPU s)
CPU Caches:
  L1 Data 32 KiB (x24)
  L1 Instruction 32 KiB (x24)
  L2 Unified 256 KiB (x24)
  L3 Unified 30720 KiB (x2)
Load Average: 7.85, 5.70, 4.48
----------------------------------------------------------------
Benchmark                      Time             CPU   Iterations
----------------------------------------------------------------
BM_BaselineBuffer/1     10178537 ns        51528 ns         1000
BM_BaselineBuffer/2      7408646 ns        69828 ns         1000
BM_BaselineBuffer/4      7684772 ns       127549 ns         1000
BM_BaselineBuffer/8      7222459 ns       278660 ns         1000
BM_BaselineBuffer/16     6716972 ns       603712 ns         1215
BM_LockFreeBuffer/1      3915343 ns        53125 ns         1000
BM_LockFreeBuffer/2      4798406 ns        70581 ns         1000
BM_LockFreeBuffer/4      4562709 ns       128493 ns         1000
BM_LockFreeBuffer/8      4935221 ns       289996 ns         1000
BM_LockFreeBuffer/16     5187913 ns       618856 ns         1081
BM_OptimizedBuffer/1     4256507 ns        49970 ns         1000
BM_OptimizedBuffer/2     3398719 ns        67712 ns         1000
BM_OptimizedBuffer/4     3204749 ns       127378 ns         1000
BM_OptimizedBuffer/8     3230722 ns       296507 ns         1000
BM_OptimizedBuffer/16    3859005 ns       769220 ns         1000
```

I would like to refine this PR if it's acceptable.