### PR TITLE
[CMAKE] Fix CMake 4.x build error on MacOS runner and when building opentracing 

### DIFF
--- a/.github/workflows/cmake_install.yml
+++ b/.github/workflows/cmake_install.yml
@@ -204,8 +204,9 @@ jobs:
           pip install "conan==2.15.1"
           conan profile detect --force
       - name: Install or build all dependencies with Conan
+        # CMAKE_POLICY_VERSION_MINIMUM: '3.5' is required to build opentracing with CMake 4.x
         run: |
-          conan install install/conan/conanfile_stable.txt --build=missing -of /home/runner/conan -s build_type=${BUILD_TYPE} -s compiler.cppstd=${CXX_STANDARD}
+          conan install install/conan/conanfile_stable.txt --build=missing -of /home/runner/conan -s build_type=${BUILD_TYPE} -s compiler.cppstd=${CXX_STANDARD} -c "tools.cmake.cmaketoolchain:extra_variables={'CMAKE_POLICY_VERSION_MINIMUM': '3.5'}"
           conan cache clean --source --build
       - name: Run Tests (static libs)
         env:
@@ -241,8 +242,9 @@ jobs:
           pip install "conan==2.15.1"
           conan profile detect --force
       - name: Install or build all dependencies with Conan
+        # CMAKE_POLICY_VERSION_MINIMUM: '3.5' is required to build opentracing with CMake 4.x
         run: |
-          conan install install/conan/conanfile_latest.txt --build=missing -of /home/runner/conan -s build_type=${BUILD_TYPE} -s compiler.cppstd=${CXX_STANDARD}
+          conan install install/conan/conanfile_latest.txt --build=missing -of /home/runner/conan -s build_type=${BUILD_TYPE} -s compiler.cppstd=${CXX_STANDARD} -c "tools.cmake.cmaketoolchain:extra_variables={'CMAKE_POLICY_VERSION_MINIMUM': '3.5'}"
           conan cache clean --source --build
       - name: Run Tests (static libs)
         env:
@@ -277,8 +279,9 @@ jobs:
         brew install conan autoconf automake libtool coreutils
         conan profile detect --force
     - name: Install or build all dependencies with Conan
+      # CMAKE_POLICY_VERSION_MINIMUM: '3.5' is required to build opentracing with CMake 4.x
       run: |
-        conan install install/conan/conanfile_stable.txt --build=missing -of /Users/runner/conan -s build_type=${BUILD_TYPE} -s compiler.cppstd=${CXX_STANDARD}
+        conan install install/conan/conanfile_stable.txt --build=missing -of /Users/runner/conan -s build_type=${BUILD_TYPE} -s compiler.cppstd=${CXX_STANDARD} -c "tools.cmake.cmaketoolchain:extra_variables={'CMAKE_POLICY_VERSION_MINIMUM': '3.5'}"
         conan cache clean --source --build
     - name: Run Tests (static libs)
       env:

--- a/.github/workflows/cmake_install.yml
+++ b/.github/workflows/cmake_install.yml
@@ -275,7 +275,7 @@ jobs:
         submodules: 'recursive'
     - name: Install CMake
       run: |
-        sudo -E ./ci/setup_cmake_macos.sh
+        ./ci/setup_cmake_macos.sh
     - name: Install Conan and tools
       run: |
         brew install conan autoconf automake libtool coreutils

--- a/.github/workflows/cmake_install.yml
+++ b/.github/workflows/cmake_install.yml
@@ -204,9 +204,8 @@ jobs:
           pip install "conan==2.15.1"
           conan profile detect --force
       - name: Install or build all dependencies with Conan
-        # CMAKE_POLICY_VERSION_MINIMUM: '3.5' is required to build opentracing with CMake 4.x
         run: |
-          conan install install/conan/conanfile_stable.txt --build=missing -of /home/runner/conan -s build_type=${BUILD_TYPE} -s compiler.cppstd=${CXX_STANDARD} -c "tools.cmake.cmaketoolchain:extra_variables={'CMAKE_POLICY_VERSION_MINIMUM': '3.5'}"
+          conan install install/conan/conanfile_stable.txt --build=missing -of /home/runner/conan -s build_type=${BUILD_TYPE} -s compiler.cppstd=${CXX_STANDARD}
           conan cache clean --source --build
       - name: Run Tests (static libs)
         env:
@@ -242,9 +241,8 @@ jobs:
           pip install "conan==2.15.1"
           conan profile detect --force
       - name: Install or build all dependencies with Conan
-        # CMAKE_POLICY_VERSION_MINIMUM: '3.5' is required to build opentracing with CMake 4.x
         run: |
-          conan install install/conan/conanfile_latest.txt --build=missing -of /home/runner/conan -s build_type=${BUILD_TYPE} -s compiler.cppstd=${CXX_STANDARD} -c "tools.cmake.cmaketoolchain:extra_variables={'CMAKE_POLICY_VERSION_MINIMUM': '3.5'}"
+          conan install install/conan/conanfile_latest.txt --build=missing -of /home/runner/conan -s build_type=${BUILD_TYPE} -s compiler.cppstd=${CXX_STANDARD}
           conan cache clean --source --build
       - name: Run Tests (static libs)
         env:
@@ -264,6 +262,7 @@ jobs:
       INSTALL_TEST_DIR: '/Users/runner/install_test'
       CXX_STANDARD: '17'
       CMAKE_TOOLCHAIN_FILE: '/Users/runner/conan/build/Debug/generators/conan_toolchain.cmake'
+      CMAKE_VERSION: 3.31.0 # building the conan "stable" versions requires CMake 3.x
       BUILD_TYPE: 'Debug'
     steps:
     - name: Harden the runner (Audit all outbound calls)
@@ -274,14 +273,16 @@ jobs:
     - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
       with:
         submodules: 'recursive'
+    - name: Install CMake
+      run: |
+        sudo -E ./ci/setup_cmake_macos.sh
     - name: Install Conan and tools
       run: |
         brew install conan autoconf automake libtool coreutils
         conan profile detect --force
     - name: Install or build all dependencies with Conan
-      # CMAKE_POLICY_VERSION_MINIMUM: '3.5' is required to build opentracing with CMake 4.x
       run: |
-        conan install install/conan/conanfile_stable.txt --build=missing -of /Users/runner/conan -s build_type=${BUILD_TYPE} -s compiler.cppstd=${CXX_STANDARD} -c "tools.cmake.cmaketoolchain:extra_variables={'CMAKE_POLICY_VERSION_MINIMUM': '3.5'}"
+        conan install install/conan/conanfile_stable.txt --build=missing -of /Users/runner/conan -s build_type=${BUILD_TYPE} -s compiler.cppstd=${CXX_STANDARD}
         conan cache clean --source --build
     - name: Run Tests (static libs)
       env:

--- a/cmake/opentracing-cpp.cmake
+++ b/cmake/opentracing-cpp.cmake
@@ -27,9 +27,14 @@ if(NOT OpenTracing_FOUND)
     set(_SAVED_BUILD_TESTING ${BUILD_TESTING})
   endif()
 
+  if(DEFINED CMAKE_POLICY_VERSION_MINIMUM)
+    set(_SAVED_CMAKE_POLICY_VERSION_MINIMUM ${CMAKE_POLICY_VERSION_MINIMUM})
+  endif()
+
   # Set the cache variables for the opentracing build
   set(BUILD_TESTING OFF CACHE BOOL "" FORCE)
   set(BUILD_MOCKTRACER OFF CACHE BOOL "" FORCE)
+  set(CMAKE_POLICY_VERSION_MINIMUM "3.5" CACHE STRING "" FORCE)
 
   FetchContent_MakeAvailable(opentracing)
 
@@ -38,6 +43,13 @@ if(NOT OpenTracing_FOUND)
     set(BUILD_TESTING ${_SAVED_BUILD_TESTING} CACHE BOOL "" FORCE)
   else()
     unset(BUILD_TESTING CACHE)
+  endif()
+
+  # Restore the saved state of CMAKE_POLICY_VERSION_MINIMUM
+  if(DEFINED _SAVED_CMAKE_POLICY_VERSION_MINIMUM)
+    set(CMAKE_POLICY_VERSION_MINIMUM ${_SAVED_CMAKE_POLICY_VERSION_MINIMUM} CACHE STRING "" FORCE)
+  else()
+    unset(CMAKE_POLICY_VERSION_MINIMUM CACHE)
   endif()
 
   # Patch the opentracing targets to set missing includes, add namespaced alias targets, disable iwyu and clang-tidy.


### PR DESCRIPTION
Fixes #3648 

CMake 4.x removed compatibility with versions older than 3.5. 
https://cmake.org/cmake/help/latest/release/4.0.html#deprecated-and-removed-features

OpenTracing is no longer being updated and sets the minimum CMake version required to 3.1. This creates a CMake configure error when using CMake 4.x. 

Older versions of many dependencies depend on minimum versions of CMake < 3.5 (those in the `install/cmake/third_party_<minimum,stable>` and `install/conan/conanfile_stable.txt`). 

## Changes

- Set `CMAKE_POLICY_VERSION_MINIMUM=3.5` when building opentracing-cpp from source using FetchContent
- Install CMake 3.31 in the MacOS CMake install test with `conanfile_stable.txt` dependency versions. 

For significant contributions please make sure you have completed the following items:

* [ ] `CHANGELOG.md` updated for non-trivial changes
* [ ] Unit tests have been added
* [ ] Changes in public API reviewed