### PR TITLE
[CMAKE] Only build and run the exemplar tests if the preview flag is set

### DIFF
--- a/sdk/test/metrics/CMakeLists.txt
+++ b/sdk/test/metrics/CMakeLists.txt
@@ -80,4 +80,6 @@ if(WITH_BENCHMARK)
     metrics_common_test_utils opentelemetry_common opentelemetry_resources)
 endif()
 
-add_subdirectory(exemplar)
+if(WITH_METRICS_EXEMPLAR_PREVIEW)
+  add_subdirectory(exemplar)
+endif()


### PR DESCRIPTION
Fixes an issue where setting WITH_METRICS_EXEMPLAR_PREVIEW=OFF causes the metrics unit tests to fail. 

## Changes

- Add the missing guard on adding the exemplar test directory

For significant contributions please make sure you have completed the following items:

* [ ] `CHANGELOG.md` updated for non-trivial changes
* [ ] Unit tests have been added
* [ ] Changes in public API reviewed