### PR TITLE
[SDK] Fix typo in hashmap method GetEnteries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,9 @@ Increment the:
 * [TEST] Remove workaround for metrics cardinality limit test
   [#3663](https://github.com/open-telemetry/opentelemetry-cpp/pull/3663)
 
+* [SDK] Fix typo in hashmap method GetEnteries
+  [#3680](https://github.com/open-telemetry/opentelemetry-cpp/pull/3680)
+
 ## [1.23 2025-09-25]
 
 * [CodeHealth] Fix clang-tidy warnings part 6

--- a/sdk/include/opentelemetry/sdk/metrics/state/attributes_hashmap.h
+++ b/sdk/include/opentelemetry/sdk/metrics/state/attributes_hashmap.h
@@ -188,7 +188,7 @@ public:
   /**
    * Iterate the hash to yield key and value stored in hash.
    */
-  bool GetAllEnteries(
+  bool GetAllEntries(
       nostd::function_ref<bool(const MetricAttributes &, Aggregation &)> callback) const
   {
     for (auto &kv : hash_map_)

--- a/sdk/src/metrics/state/temporal_metric_storage.cc
+++ b/sdk/src/metrics/state/temporal_metric_storage.cc
@@ -67,7 +67,7 @@ bool TemporalMetricStorage::buildMetrics(CollectorHandle *collector,
     metric_data.end_ts                  = collection_ts;
 
     // Direct conversion of delta metrics to point data
-    delta_metrics->GetAllEnteries(
+    delta_metrics->GetAllEntries(
         [&metric_data](const MetricAttributes &attributes, Aggregation &aggregation) {
           PointDataAttributes point_data_attr;
           point_data_attr.point_data = aggregation.ToPoint();
@@ -102,7 +102,7 @@ bool TemporalMetricStorage::buildMetrics(CollectorHandle *collector,
                                                 : kAggregationCardinalityLimit));
   for (auto &agg_hashmap : unreported_list)
   {
-    agg_hashmap->GetAllEnteries(
+    agg_hashmap->GetAllEntries(
         [&merged_metrics, this](const MetricAttributes &attributes, Aggregation &aggregation) {
           auto agg = merged_metrics->Get(attributes);
           if (agg)
@@ -135,7 +135,7 @@ bool TemporalMetricStorage::buildMetrics(CollectorHandle *collector,
     if (aggregation_temporarily == AggregationTemporality::kCumulative)
     {
       // merge current delta to previous cumulative
-      last_aggr_hashmap->GetAllEnteries(
+      last_aggr_hashmap->GetAllEntries(
           [&merged_metrics, this](const MetricAttributes &attributes, Aggregation &aggregation) {
             auto agg = merged_metrics->Get(attributes);
             if (agg)
@@ -172,7 +172,7 @@ bool TemporalMetricStorage::buildMetrics(CollectorHandle *collector,
   metric_data.aggregation_temporality = aggregation_temporarily;
   metric_data.start_ts                = last_collection_ts;
   metric_data.end_ts                  = collection_ts;
-  result_to_export->GetAllEnteries(
+  result_to_export->GetAllEntries(
       [&metric_data](const MetricAttributes &attributes, Aggregation &aggregation) {
         PointDataAttributes point_data_attr;
         point_data_attr.point_data = aggregation.ToPoint();

--- a/sdk/test/metrics/attributes_hashmap_test.cc
+++ b/sdk/test/metrics/attributes_hashmap_test.cc
@@ -71,9 +71,9 @@ TEST(AttributesHashMap, BasicTests)
   MetricAttributes m6 = {{"k1", "v2"}, {"k2", "v1"}};
   EXPECT_EQ(hash_map.Has(m6), false);
 
-  // GetAllEnteries
+  // GetAllEntries
   size_t count = 0;
-  hash_map.GetAllEnteries(
+  hash_map.GetAllEntries(
       [&count](const MetricAttributes & /* attributes */, Aggregation & /* aggregation */) {
         count++;
         return true;
@@ -210,7 +210,7 @@ TEST(AttributesHashMap, OverflowCardinalityLimitBehavior)
 
   // Copy the hash map to a new map in non-determistic order and verify all entries are present
   AttributesHashMapWithCustomHash<> map_copy(limit);
-  map.GetAllEnteries([&map_copy](const MetricAttributes &attributes, Aggregation &) {
+  map.GetAllEntries([&map_copy](const MetricAttributes &attributes, Aggregation &) {
     map_copy.Set(attributes, std::unique_ptr<Aggregation>(new DropAggregation()));
     return true;
   });


### PR DESCRIPTION
# Changes

This pull request makes a consistent naming correction across the codebase, changing the method name `GetAllEnteries` to the correct spelling `GetAllEntries`. This update affects the implementation, usage in metric storage logic, and related unit tests.

For significant contributions please make sure you have completed the following items:

* [x] `CHANGELOG.md` updated for non-trivial changes
* [x] Unit tests have been added
* [ ] Changes in public API reviewed