### PR TITLE
[CONFIGURATION] File configuration - parser location

### DIFF
--- a/.iwyu.imp
+++ b/.iwyu.imp
@@ -14,6 +14,7 @@
   # Work around for ryml
   { "include": ["<c4/std/string.hpp>", "private", "<ryml_std.hpp>", "public"] },
 
+  { "include": ["<c4/yml/common.hpp>", "private", "<ryml.hpp>", "public"] },
   { "include": ["<c4/yml/node.hpp>", "private", "<ryml.hpp>", "public"] },
   { "include": ["<c4/yml/parse.hpp>", "private", "<ryml.hpp>", "public"] },
   { "include": ["<c4/yml/parse_engine.hpp>", "private", "<ryml.hpp>", "public"] },

--- a/functional/configuration/shelltests/empty.test
+++ b/functional/configuration/shelltests/empty.test
@@ -3,6 +3,6 @@
 
 $ example_yaml --test --yaml shelltests/empty.yaml
 >
-[ERROR] [Yaml Configuration Parser] Parse failed with exception: Yaml: not a map, looking for: file_format
+[ERROR] <shelltests/empty.yaml>:0[0](0): Yaml: not a map, looking for: file_format
 FAILED TO PARSE MODEL
 >= 1

--- a/functional/configuration/shelltests/format_empty.test
+++ b/functional/configuration/shelltests/format_empty.test
@@ -3,6 +3,6 @@
 
 $ example_yaml --test --yaml shelltests/format_empty.yaml
 >
-[ERROR] [Yaml Configuration Parser] Parse failed with exception: Yaml: string value is empty: file_format
+[ERROR] <shelltests/format_empty.yaml>:4[0](94): Yaml: string value is empty: file_format
 FAILED TO PARSE MODEL
 >= 1

--- a/functional/configuration/shelltests/propagator_broken.test
+++ b/functional/configuration/shelltests/propagator_broken.test
@@ -3,6 +3,6 @@
 
 $ example_yaml --test --yaml shelltests/propagator_broken.yaml
 >
-[ERROR] [Yaml Configuration Parser] Parse failed with exception: Illegal composite child 2, properties count: 3
+[ERROR] <shelltests/propagator_broken.yaml>:10[6](206): Illegal composite child 2, properties count: 3
 FAILED TO PARSE MODEL
 >= 1

--- a/sdk/include/opentelemetry/sdk/configuration/configuration_parser.h
+++ b/sdk/include/opentelemetry/sdk/configuration/configuration_parser.h
@@ -99,7 +99,8 @@ namespace configuration
 class ConfigurationParser
 {
 public:
-  OtlpHttpEncoding ParseOtlpHttpEncoding(const std::string &name) const;
+  OtlpHttpEncoding ParseOtlpHttpEncoding(const std::unique_ptr<DocumentNode> &node,
+                                         const std::string &name) const;
 
   std::unique_ptr<StringArrayConfiguration> ParseStringArrayConfiguration(
       const std::unique_ptr<DocumentNode> &node) const;
@@ -151,9 +152,12 @@ public:
   std::unique_ptr<LoggerProviderConfiguration> ParseLoggerProviderConfiguration(
       const std::unique_ptr<DocumentNode> &node) const;
 
-  DefaultHistogramAggregation ParseDefaultHistogramAggregation(const std::string &name) const;
+  DefaultHistogramAggregation ParseDefaultHistogramAggregation(
+      const std::unique_ptr<DocumentNode> &node,
+      const std::string &name) const;
 
-  TemporalityPreference ParseTemporalityPreference(const std::string &name) const;
+  TemporalityPreference ParseTemporalityPreference(const std::unique_ptr<DocumentNode> &node,
+                                                   const std::string &name) const;
 
   std::unique_ptr<OtlpHttpPushMetricExporterConfiguration>
   ParseOtlpHttpPushMetricExporterConfiguration(const std::unique_ptr<DocumentNode> &node) const;
@@ -203,7 +207,8 @@ public:
   std::unique_ptr<MetricReaderConfiguration> ParseMetricReaderConfiguration(
       const std::unique_ptr<DocumentNode> &node) const;
 
-  InstrumentType ParseInstrumentType(const std::string &name) const;
+  InstrumentType ParseInstrumentType(const std::unique_ptr<DocumentNode> &node,
+                                     const std::string &name) const;
 
   std::unique_ptr<ViewSelectorConfiguration> ParseViewSelectorConfiguration(
       const std::unique_ptr<DocumentNode> &node) const;

--- a/sdk/include/opentelemetry/sdk/configuration/document_node.h
+++ b/sdk/include/opentelemetry/sdk/configuration/document_node.h
@@ -16,6 +16,7 @@ namespace configuration
 
 class DocumentNodeConstIterator;
 class PropertiesNodeConstIterator;
+class DocumentNodeLocation;
 
 class DocumentNode
 {
@@ -29,6 +30,8 @@ public:
   DocumentNode &operator=(DocumentNode &&)           = default;
   DocumentNode &operator=(const DocumentNode &other) = default;
   virtual ~DocumentNode()                            = default;
+
+  virtual DocumentNodeLocation Location() const = 0;
 
   virtual std::string Key() const = 0;
 
@@ -170,6 +173,17 @@ public:
 
 private:
   std::unique_ptr<PropertiesNodeConstIteratorImpl> impl_;
+};
+
+class DocumentNodeLocation
+{
+public:
+  size_t offset;
+  size_t line;
+  size_t col;
+  std::string filename;
+
+  std::string ToString() const;
 };
 
 }  // namespace configuration

--- a/sdk/include/opentelemetry/sdk/configuration/invalid_schema_exception.h
+++ b/sdk/include/opentelemetry/sdk/configuration/invalid_schema_exception.h
@@ -19,7 +19,14 @@ namespace configuration
 class InvalidSchemaException : public std::runtime_error
 {
 public:
-  InvalidSchemaException(const std::string &msg) : std::runtime_error(msg) {}
+  InvalidSchemaException(const DocumentNodeLocation &location, const std::string &msg)
+      : std::runtime_error(msg), location_(location)
+  {}
+
+  std::string Where() const { return location_.ToString(); }
+
+private:
+  DocumentNodeLocation location_;
 };
 
 }  // namespace configuration

--- a/sdk/include/opentelemetry/sdk/configuration/ryml_document.h
+++ b/sdk/include/opentelemetry/sdk/configuration/ryml_document.h
@@ -22,16 +22,23 @@ class RymlDocument : public Document
 public:
   static std::unique_ptr<Document> Parse(const std::string &source, const std::string &content);
 
-  RymlDocument(ryml::Tree tree) : tree_(std::move(tree)) {}
+  RymlDocument() {}
   RymlDocument(RymlDocument &&)                      = delete;
   RymlDocument(const RymlDocument &)                 = delete;
   RymlDocument &operator=(RymlDocument &&)           = delete;
   RymlDocument &operator=(const RymlDocument &other) = delete;
   ~RymlDocument() override                           = default;
 
+  int ParseDocument(const std::string &source, const std::string &content);
+
   std::unique_ptr<DocumentNode> GetRootNode() override;
 
+  DocumentNodeLocation Location(ryml::ConstNodeRef node) const;
+
 private:
+  ryml::ParserOptions opts_;
+  ryml::Parser::handler_type event_handler_;
+  std::unique_ptr<ryml::Parser> parser_;
   ryml::Tree tree_;
 };
 

--- a/sdk/include/opentelemetry/sdk/configuration/ryml_document_node.h
+++ b/sdk/include/opentelemetry/sdk/configuration/ryml_document_node.h
@@ -17,15 +17,21 @@ namespace sdk
 namespace configuration
 {
 
+class RymlDocument;
+
 class RymlDocumentNode : public DocumentNode
 {
 public:
-  RymlDocumentNode(ryml::ConstNodeRef node, std::size_t depth) : node_(node), depth_(depth) {}
+  RymlDocumentNode(const RymlDocument *doc, ryml::ConstNodeRef node, std::size_t depth)
+      : doc_(doc), node_(node), depth_(depth)
+  {}
   RymlDocumentNode(RymlDocumentNode &&)                      = delete;
   RymlDocumentNode(const RymlDocumentNode &)                 = delete;
   RymlDocumentNode &operator=(RymlDocumentNode &&)           = delete;
   RymlDocumentNode &operator=(const RymlDocumentNode &other) = delete;
   ~RymlDocumentNode() override                               = default;
+
+  DocumentNodeLocation Location() const override;
 
   std::string Key() const override;
 
@@ -62,6 +68,7 @@ private:
   ryml::ConstNodeRef GetRequiredRymlChildNode(const std::string &name) const;
   ryml::ConstNodeRef GetRymlChildNode(const std::string &name) const;
 
+  const RymlDocument *doc_;
   ryml::ConstNodeRef node_;
   std::size_t depth_;
 };
@@ -69,7 +76,8 @@ private:
 class RymlDocumentNodeConstIteratorImpl : public DocumentNodeConstIteratorImpl
 {
 public:
-  RymlDocumentNodeConstIteratorImpl(ryml::ConstNodeRef parent,
+  RymlDocumentNodeConstIteratorImpl(const RymlDocument *doc,
+                                    ryml::ConstNodeRef parent,
                                     std::size_t index,
                                     std::size_t depth);
   RymlDocumentNodeConstIteratorImpl(RymlDocumentNodeConstIteratorImpl &&)            = delete;
@@ -84,6 +92,7 @@ public:
   bool Equal(const DocumentNodeConstIteratorImpl *rhs) const override;
 
 private:
+  const RymlDocument *doc_;
   ryml::ConstNodeRef parent_;
   std::size_t index_;
   std::size_t depth_;
@@ -92,7 +101,8 @@ private:
 class RymlPropertiesNodeConstIteratorImpl : public PropertiesNodeConstIteratorImpl
 {
 public:
-  RymlPropertiesNodeConstIteratorImpl(ryml::ConstNodeRef parent,
+  RymlPropertiesNodeConstIteratorImpl(const RymlDocument *doc,
+                                      ryml::ConstNodeRef parent,
                                       std::size_t index,
                                       std::size_t depth);
   RymlPropertiesNodeConstIteratorImpl(RymlPropertiesNodeConstIteratorImpl &&)            = delete;
@@ -108,6 +118,7 @@ public:
   bool Equal(const PropertiesNodeConstIteratorImpl *rhs) const override;
 
 private:
+  const RymlDocument *doc_;
   ryml::ConstNodeRef parent_;
   std::size_t index_;
   std::size_t depth_;

--- a/sdk/src/configuration/document_node.cc
+++ b/sdk/src/configuration/document_node.cc
@@ -112,7 +112,7 @@ std::string DocumentNode::DoOneSubstitution(const std::string &text) const
   {
     std::string message = illegal_msg;
     message.append(text);
-    throw InvalidSchemaException(message);
+    throw InvalidSchemaException(Location(), message);
   }
 
   c = text[0];
@@ -120,7 +120,7 @@ std::string DocumentNode::DoOneSubstitution(const std::string &text) const
   {
     std::string message = illegal_msg;
     message.append(text);
-    throw InvalidSchemaException(message);
+    throw InvalidSchemaException(Location(), message);
   }
 
   c = text[1];
@@ -128,7 +128,7 @@ std::string DocumentNode::DoOneSubstitution(const std::string &text) const
   {
     std::string message = illegal_msg;
     message.append(text);
-    throw InvalidSchemaException(message);
+    throw InvalidSchemaException(Location(), message);
   }
 
   c = text[len - 1];
@@ -136,7 +136,7 @@ std::string DocumentNode::DoOneSubstitution(const std::string &text) const
   {
     std::string message = illegal_msg;
     message.append(text);
-    throw InvalidSchemaException(message);
+    throw InvalidSchemaException(Location(), message);
   }
 
   begin_name = 2;
@@ -160,7 +160,7 @@ std::string DocumentNode::DoOneSubstitution(const std::string &text) const
   {
     std::string message = illegal_msg;
     message.append(text);
-    throw InvalidSchemaException(message);
+    throw InvalidSchemaException(Location(), message);
   }
 
   end_name = begin_name + 1;
@@ -195,7 +195,7 @@ std::string DocumentNode::DoOneSubstitution(const std::string &text) const
     {
       std::string message = illegal_msg;
       message.append(text);
-      throw InvalidSchemaException(message);
+      throw InvalidSchemaException(Location(), message);
     }
     // text is of the form ${ENV_NAME:-fallback}
     begin_fallback = pos + replacement_token.length();
@@ -233,7 +233,7 @@ bool DocumentNode::BooleanFromString(const std::string &value) const
 
   std::string message("Illegal boolean value: ");
   message.append(value);
-  throw InvalidSchemaException(message);
+  throw InvalidSchemaException(Location(), message);
 }
 
 size_t DocumentNode::IntegerFromString(const std::string &value) const
@@ -246,7 +246,7 @@ size_t DocumentNode::IntegerFromString(const std::string &value) const
   {
     std::string message("Illegal integer value: ");
     message.append(value);
-    throw InvalidSchemaException(message);
+    throw InvalidSchemaException(Location(), message);
   }
   return val;
 }
@@ -261,9 +261,25 @@ double DocumentNode::DoubleFromString(const std::string &value) const
   {
     std::string message("Illegal double value: ");
     message.append(value);
-    throw InvalidSchemaException(message);
+    throw InvalidSchemaException(Location(), message);
   }
   return val;
+}
+
+std::string DocumentNodeLocation::ToString() const
+{
+  // Format: <filename>:line-number[column-number](offset)
+  std::string where;
+  where.append("<");
+  where.append(filename);
+  where.append(">:");
+  where.append(std::to_string(line));
+  where.append("[");
+  where.append(std::to_string(col));
+  where.append("](");
+  where.append(std::to_string(offset));
+  where.append(")");
+  return where;
 }
 
 }  // namespace configuration

--- a/sdk/src/configuration/ryml_document.cc
+++ b/sdk/src/configuration/ryml_document.cc
@@ -23,44 +23,64 @@ namespace configuration
 
 std::unique_ptr<Document> RymlDocument::Parse(const std::string &source, const std::string &content)
 {
-  ryml::ParserOptions opts;
-  opts.locations(true);
+  auto doc = std::make_unique<RymlDocument>();
+  int rc;
 
-  ryml::Parser::handler_type event_handler;
-  ryml::Parser parser(&event_handler, opts);
+  rc = doc->ParseDocument(source, content);
+  if (rc == 0)
+  {
+    return doc;
+  }
 
-  ryml::Tree tree;
+  return nullptr;
+}
+
+int RymlDocument::ParseDocument(const std::string &source, const std::string &content)
+{
+  opts_.locations(true);
+  parser_ = std::make_unique<ryml::Parser>(&event_handler_, opts_);
+
   ryml::csubstr filename;
   ryml::csubstr csubstr_content;
-  std::unique_ptr<Document> doc;
 
   filename        = ryml::to_csubstr(source);
   csubstr_content = ryml::to_csubstr(content);
 
   try
   {
-    tree = parse_in_arena(&parser, filename, csubstr_content);
-    tree.resolve();
+    tree_ = parse_in_arena(parser_.get(), filename, csubstr_content);
+    tree_.resolve();
   }
   catch (const std::exception &e)
   {
     OTEL_INTERNAL_LOG_ERROR("[Ryml Document] Parse failed with exception: " << e.what());
-    return doc;
+    return 1;
   }
   catch (...)
   {
     OTEL_INTERNAL_LOG_ERROR("[Ryml Document] Parse failed with unknown exception.");
-    return doc;
+    return 2;
   }
 
-  doc = std::make_unique<RymlDocument>(tree);
-  return doc;
+  return 0;
 }
 
 std::unique_ptr<DocumentNode> RymlDocument::GetRootNode()
 {
-  auto node = std::make_unique<RymlDocumentNode>(tree_.rootref(), 0);
+  auto node = std::make_unique<RymlDocumentNode>(this, tree_.rootref(), 0);
   return node;
+}
+
+DocumentNodeLocation RymlDocument::Location(ryml::ConstNodeRef node) const
+{
+  DocumentNodeLocation loc;
+  auto ryml_loc = parser_->location(node);
+  loc.offset    = ryml_loc.offset;
+  loc.line      = ryml_loc.line;
+  loc.col       = ryml_loc.col;
+  loc.filename  = std::string(ryml_loc.name.str, ryml_loc.name.len);
+
+  return loc;
 }
 
 }  // namespace configuration

--- a/sdk/src/configuration/yaml_configuration_parser.cc
+++ b/sdk/src/configuration/yaml_configuration_parser.cc
@@ -13,6 +13,7 @@
 #include "opentelemetry/sdk/configuration/configuration.h"
 #include "opentelemetry/sdk/configuration/configuration_parser.h"
 #include "opentelemetry/sdk/configuration/document.h"
+#include "opentelemetry/sdk/configuration/invalid_schema_exception.h"
 #include "opentelemetry/sdk/configuration/ryml_document.h"
 #include "opentelemetry/sdk/configuration/yaml_configuration_parser.h"
 #include "opentelemetry/version.h"
@@ -76,6 +77,10 @@ std::unique_ptr<Configuration> YamlConfigurationParser::ParseString(const std::s
     {
       config = config_parser.Parse(std::move(doc));
     }
+  }
+  catch (const InvalidSchemaException &e)
+  {
+    OTEL_INTERNAL_LOG_ERROR(e.Where() << ": " << e.what());
   }
   catch (const std::exception &e)
   {


### PR DESCRIPTION
Contributes to #2481

This is a partial fix, to implement parser location, for better yaml error messages.

## Changes

Please provide a brief description of the changes here.

* Implement the "Location" of a yaml node in the parser
  * Make all document nodes point to the document root
  * Make the document root own the yaml parser that is used to create the document
  * Inspect a node location by following the links up to the document root, and then invoke the rapidyaml parser.

* Implement a location property in yaml related exceptions

* Change all the parsing code to pass the current yaml node as context, in case code needs to access a node location to raise an exception.

With all these changes, when the parser fails with an invalid schema exception, the exception contains:

* the name of the yaml input file used
* the line number, column number, and offset from the document start, where the error was detected.

This helps ease of use, so error messages about invalid config.yaml files point precisely at the error location.

For significant contributions please make sure you have completed the following items:

* [ ] `CHANGELOG.md` updated for non-trivial changes
* [ ] Unit tests have been added
* [ ] Changes in public API reviewed