### PR TITLE
[BUILD] Add rules_cc load statements

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -19,6 +19,7 @@ bazel_dep(name = "platforms", version = "0.0.11")
 bazel_dep(name = "prometheus-cpp", version = "1.3.0", repo_name = "com_github_jupp0r_prometheus_cpp")
 bazel_dep(name = "protobuf", version = "29.0", repo_name = "com_google_protobuf")
 bazel_dep(name = "rapidyaml", version = "0.9.0")
+bazel_dep(name = "rules_cc", version = "0.2.9")
 bazel_dep(name = "rules_proto", version = "7.0.2")
 bazel_dep(name = "zlib", version = "1.3.1.bcr.5")
 

--- a/api/BUILD
+++ b/api/BUILD
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 load("@bazel_skylib//rules:common_settings.bzl", "bool_flag", "int_flag", "string_flag")
+load("@rules_cc//cc:cc_library.bzl", "cc_library")
 
 package(default_visibility = ["//visibility:public"])
 

--- a/api/test/baggage/BUILD
+++ b/api/test/baggage/BUILD
@@ -1,6 +1,7 @@
 # Copyright The OpenTelemetry Authors
 # SPDX-License-Identifier: Apache-2.0
 
+load("@rules_cc//cc:cc_test.bzl", "cc_test")
 load("//bazel:otel_cc_benchmark.bzl", "otel_cc_benchmark")
 
 cc_test(

--- a/api/test/baggage/propagation/BUILD
+++ b/api/test/baggage/propagation/BUILD
@@ -1,7 +1,7 @@
 # Copyright The OpenTelemetry Authors
 # SPDX-License-Identifier: Apache-2.0
 
-load("//bazel:otel_cc_benchmark.bzl", "otel_cc_benchmark")
+load("@rules_cc//cc:cc_test.bzl", "cc_test")
 
 cc_test(
     name = "baggage_propagator_test",

--- a/api/test/common/BUILD
+++ b/api/test/common/BUILD
@@ -1,6 +1,7 @@
 # Copyright The OpenTelemetry Authors
 # SPDX-License-Identifier: Apache-2.0
 
+load("@rules_cc//cc:cc_test.bzl", "cc_test")
 load("//bazel:otel_cc_benchmark.bzl", "otel_cc_benchmark")
 
 otel_cc_benchmark(

--- a/api/test/context/BUILD
+++ b/api/test/context/BUILD
@@ -1,7 +1,7 @@
 # Copyright The OpenTelemetry Authors
 # SPDX-License-Identifier: Apache-2.0
 
-load("//bazel:otel_cc_benchmark.bzl", "otel_cc_benchmark")
+load("@rules_cc//cc:cc_test.bzl", "cc_test")
 
 cc_test(
     name = "context_test",

--- a/api/test/context/propagation/BUILD
+++ b/api/test/context/propagation/BUILD
@@ -1,7 +1,7 @@
 # Copyright The OpenTelemetry Authors
 # SPDX-License-Identifier: Apache-2.0
 
-load("//bazel:otel_cc_benchmark.bzl", "otel_cc_benchmark")
+load("@rules_cc//cc:cc_test.bzl", "cc_test")
 
 cc_test(
     name = "composite_propagator_test",

--- a/api/test/core/BUILD
+++ b/api/test/core/BUILD
@@ -1,6 +1,8 @@
 # Copyright The OpenTelemetry Authors
 # SPDX-License-Identifier: Apache-2.0
 
+load("@rules_cc//cc:cc_test.bzl", "cc_test")
+
 cc_test(
     name = "timestamp_test",
     srcs = [

--- a/api/test/logs/BUILD
+++ b/api/test/logs/BUILD
@@ -1,7 +1,7 @@
 # Copyright The OpenTelemetry Authors
 # SPDX-License-Identifier: Apache-2.0
 
-load("//bazel:otel_cc_benchmark.bzl", "otel_cc_benchmark")
+load("@rules_cc//cc:cc_test.bzl", "cc_test")
 
 cc_test(
     name = "provider_test",

--- a/api/test/metrics/BUILD
+++ b/api/test/metrics/BUILD
@@ -1,7 +1,7 @@
 # Copyright The OpenTelemetry Authors
 # SPDX-License-Identifier: Apache-2.0
 
-load("//bazel:otel_cc_benchmark.bzl", "otel_cc_benchmark")
+load("@rules_cc//cc:cc_test.bzl", "cc_test")
 
 cc_test(
     name = "noop_sync_instrument_test",

--- a/api/test/nostd/BUILD
+++ b/api/test/nostd/BUILD
@@ -1,6 +1,8 @@
 # Copyright The OpenTelemetry Authors
 # SPDX-License-Identifier: Apache-2.0
 
+load("@rules_cc//cc:cc_test.bzl", "cc_test")
+
 cc_test(
     name = "function_ref_test",
     srcs = [

--- a/api/test/plugin/BUILD
+++ b/api/test/plugin/BUILD
@@ -1,6 +1,8 @@
 # Copyright The OpenTelemetry Authors
 # SPDX-License-Identifier: Apache-2.0
 
+load("@rules_cc//cc:cc_test.bzl", "cc_test")
+
 cc_test(
     name = "dynamic_load_test",
     srcs = [

--- a/api/test/singleton/BUILD
+++ b/api/test/singleton/BUILD
@@ -1,6 +1,10 @@
 # Copyright The OpenTelemetry Authors
 # SPDX-License-Identifier: Apache-2.0
 
+load("@rules_cc//cc:cc_binary.bzl", "cc_binary")
+load("@rules_cc//cc:cc_library.bzl", "cc_library")
+load("@rules_cc//cc:cc_test.bzl", "cc_test")
+
 # gcc and clang, assumed to be used on this platform
 DEFAULT_NOWIN_COPTS = [
     "-fvisibility=default",

--- a/api/test/trace/BUILD
+++ b/api/test/trace/BUILD
@@ -1,6 +1,7 @@
 # Copyright The OpenTelemetry Authors
 # SPDX-License-Identifier: Apache-2.0
 
+load("@rules_cc//cc:cc_test.bzl", "cc_test")
 load("//bazel:otel_cc_benchmark.bzl", "otel_cc_benchmark")
 
 cc_test(

--- a/api/test/trace/propagation/BUILD
+++ b/api/test/trace/propagation/BUILD
@@ -1,7 +1,7 @@
 # Copyright The OpenTelemetry Authors
 # SPDX-License-Identifier: Apache-2.0
 
-load("//bazel:otel_cc_benchmark.bzl", "otel_cc_benchmark")
+load("@rules_cc//cc:cc_test.bzl", "cc_test")
 
 cc_test(
     name = "http_text_format_test",

--- a/api/test/trace/propagation/detail/BUILD
+++ b/api/test/trace/propagation/detail/BUILD
@@ -1,7 +1,7 @@
 # Copyright The OpenTelemetry Authors
 # SPDX-License-Identifier: Apache-2.0
 
-load("//bazel:otel_cc_benchmark.bzl", "otel_cc_benchmark")
+load("@rules_cc//cc:cc_test.bzl", "cc_test")
 
 cc_test(
     name = "hex_test",

--- a/bazel/otel_cc_benchmark.bzl
+++ b/bazel/otel_cc_benchmark.bzl
@@ -1,6 +1,9 @@
 # Copyright The OpenTelemetry Authors
 # SPDX-License-Identifier: Apache-2.0
 
+load("@rules_cc//cc:cc_binary.bzl", "cc_binary")
+load("@rules_cc//cc:cc_test.bzl", "cc_test")
+
 def otel_cc_benchmark(name, srcs, deps, tags = [""]):
     """
     Creates targets for the benchmark and related targets.
@@ -22,7 +25,7 @@ def otel_cc_benchmark(name, srcs, deps, tags = [""]):
 
     # This is the benchmark as a binary, it can be run manually, and is used
     # to generate the _result below.
-    native.cc_binary(
+    cc_binary(
         name = name,
         srcs = srcs,
         deps = deps + ["@com_github_google_benchmark//:benchmark"],
@@ -42,7 +45,7 @@ def otel_cc_benchmark(name, srcs, deps, tags = [""]):
 
     # This is run as part of "bazel test ..." to smoke-test benchmarks. It's
     # meant to complete quickly rather than get accurate results.
-    native.cc_test(
+    cc_test(
         name = name + "_smoketest",
         srcs = srcs,
         deps = deps + ["@com_github_google_benchmark//:benchmark"],

--- a/examples/batch/BUILD
+++ b/examples/batch/BUILD
@@ -1,6 +1,8 @@
 # Copyright The OpenTelemetry Authors
 # SPDX-License-Identifier: Apache-2.0
 
+load("@rules_cc//cc:cc_binary.bzl", "cc_binary")
+
 cc_binary(
     name = "example_simple",
     srcs = [

--- a/examples/common/foo_library/BUILD
+++ b/examples/common/foo_library/BUILD
@@ -1,6 +1,8 @@
 # Copyright The OpenTelemetry Authors
 # SPDX-License-Identifier: Apache-2.0
 
+load("@rules_cc//cc:cc_library.bzl", "cc_library")
+
 package(default_visibility = ["//visibility:public"])
 
 cc_library(

--- a/examples/common/logs_foo_library/BUILD
+++ b/examples/common/logs_foo_library/BUILD
@@ -1,6 +1,8 @@
 # Copyright The OpenTelemetry Authors
 # SPDX-License-Identifier: Apache-2.0
 
+load("@rules_cc//cc:cc_library.bzl", "cc_library")
+
 package(default_visibility = ["//visibility:public"])
 
 cc_library(

--- a/examples/common/metrics_foo_library/BUILD
+++ b/examples/common/metrics_foo_library/BUILD
@@ -1,6 +1,8 @@
 # Copyright The OpenTelemetry Authors
 # SPDX-License-Identifier: Apache-2.0
 
+load("@rules_cc//cc:cc_library.bzl", "cc_library")
+
 package(default_visibility = ["//visibility:public"])
 
 cc_library(

--- a/examples/configuration/BUILD
+++ b/examples/configuration/BUILD
@@ -1,6 +1,8 @@
 # Copyright The OpenTelemetry Authors
 # SPDX-License-Identifier: Apache-2.0
 
+load("@rules_cc//cc:cc_binary.bzl", "cc_binary")
+
 cc_binary(
     name = "example_yaml",
     srcs = glob(["*.cc"]) + glob(["*.h"]),

--- a/examples/etw_threads/BUILD
+++ b/examples/etw_threads/BUILD
@@ -1,6 +1,8 @@
 # Copyright The OpenTelemetry Authors
 # SPDX-License-Identifier: Apache-2.0
 
+load("@rules_cc//cc:cc_binary.bzl", "cc_binary")
+
 cc_binary(
     name = "example_etw_threads",
     srcs = [

--- a/examples/grpc/BUILD
+++ b/examples/grpc/BUILD
@@ -2,6 +2,9 @@
 # SPDX-License-Identifier: Apache-2.0
 
 load("@com_github_grpc_grpc//bazel:cc_grpc_library.bzl", "cc_grpc_library")
+load("@com_google_protobuf//bazel:cc_proto_library.bzl", "cc_proto_library")
+load("@rules_cc//cc:cc_binary.bzl", "cc_binary")
+load("@rules_cc//cc:cc_library.bzl", "cc_library")
 load("@rules_proto//proto:defs.bzl", "proto_library")
 
 package(default_visibility = ["//visibility:public"])

--- a/examples/http/BUILD
+++ b/examples/http/BUILD
@@ -1,6 +1,8 @@
 # Copyright The OpenTelemetry Authors
 # SPDX-License-Identifier: Apache-2.0
 
+load("@rules_cc//cc:cc_binary.bzl", "cc_binary")
+
 cc_binary(
     name = "example_http_client",
     srcs = [

--- a/examples/logs_simple/BUILD
+++ b/examples/logs_simple/BUILD
@@ -1,6 +1,8 @@
 # Copyright The OpenTelemetry Authors
 # SPDX-License-Identifier: Apache-2.0
 
+load("@rules_cc//cc:cc_binary.bzl", "cc_binary")
+
 cc_binary(
     name = "example_logs_simple",
     srcs = [

--- a/examples/metrics_simple/BUILD
+++ b/examples/metrics_simple/BUILD
@@ -1,6 +1,8 @@
 # Copyright The OpenTelemetry Authors
 # SPDX-License-Identifier: Apache-2.0
 
+load("@rules_cc//cc:cc_binary.bzl", "cc_binary")
+
 cc_binary(
     name = "metrics_ostream_example",
     srcs = [

--- a/examples/multi_processor/BUILD
+++ b/examples/multi_processor/BUILD
@@ -1,6 +1,8 @@
 # Copyright The OpenTelemetry Authors
 # SPDX-License-Identifier: Apache-2.0
 
+load("@rules_cc//cc:cc_binary.bzl", "cc_binary")
+
 cc_binary(
     name = "example_multi_processor",
     srcs = [

--- a/examples/multithreaded/BUILD
+++ b/examples/multithreaded/BUILD
@@ -1,6 +1,8 @@
 # Copyright The OpenTelemetry Authors
 # SPDX-License-Identifier: Apache-2.0
 
+load("@rules_cc//cc:cc_binary.bzl", "cc_binary")
+
 cc_binary(
     name = "example_multithreaded",
     srcs = [

--- a/examples/otlp/BUILD
+++ b/examples/otlp/BUILD
@@ -1,6 +1,8 @@
 # Copyright The OpenTelemetry Authors
 # SPDX-License-Identifier: Apache-2.0
 
+load("@rules_cc//cc:cc_binary.bzl", "cc_binary")
+
 cc_binary(
     name = "example_otlp_grpc",
     srcs = [

--- a/examples/plugin/load/BUILD
+++ b/examples/plugin/load/BUILD
@@ -1,6 +1,8 @@
 # Copyright The OpenTelemetry Authors
 # SPDX-License-Identifier: Apache-2.0
 
+load("@rules_cc//cc:cc_binary.bzl", "cc_binary")
+
 cc_binary(
     name = "load_plugin",
     srcs = [

--- a/examples/plugin/plugin/BUILD
+++ b/examples/plugin/plugin/BUILD
@@ -1,6 +1,8 @@
 # Copyright The OpenTelemetry Authors
 # SPDX-License-Identifier: Apache-2.0
 
+load("@rules_cc//cc:cc_binary.bzl", "cc_binary")
+
 cc_binary(
     name = "example_plugin.so",
     srcs = [

--- a/examples/prometheus/BUILD
+++ b/examples/prometheus/BUILD
@@ -1,6 +1,8 @@
 # Copyright The OpenTelemetry Authors
 # SPDX-License-Identifier: Apache-2.0
 
+load("@rules_cc//cc:cc_binary.bzl", "cc_binary")
+
 cc_binary(
     name = "prometheus_example",
     srcs = [

--- a/examples/simple/BUILD
+++ b/examples/simple/BUILD
@@ -1,6 +1,8 @@
 # Copyright The OpenTelemetry Authors
 # SPDX-License-Identifier: Apache-2.0
 
+load("@rules_cc//cc:cc_binary.bzl", "cc_binary")
+
 cc_binary(
     name = "example_simple",
     srcs = [

--- a/exporters/elasticsearch/BUILD
+++ b/exporters/elasticsearch/BUILD
@@ -1,6 +1,9 @@
 # Copyright The OpenTelemetry Authors
 # SPDX-License-Identifier: Apache-2.0
 
+load("@rules_cc//cc:cc_library.bzl", "cc_library")
+load("@rules_cc//cc:cc_test.bzl", "cc_test")
+
 package(default_visibility = ["//visibility:public"])
 
 cc_library(

--- a/exporters/etw/BUILD
+++ b/exporters/etw/BUILD
@@ -1,6 +1,9 @@
 # Copyright The OpenTelemetry Authors
 # SPDX-License-Identifier: Apache-2.0
 
+load("@rules_cc//cc:cc_library.bzl", "cc_library")
+load("@rules_cc//cc:cc_test.bzl", "cc_test")
+
 package(default_visibility = ["//visibility:public"])
 
 cc_library(

--- a/exporters/memory/BUILD
+++ b/exporters/memory/BUILD
@@ -1,6 +1,9 @@
 # Copyright The OpenTelemetry Authors
 # SPDX-License-Identifier: Apache-2.0
 
+load("@rules_cc//cc:cc_library.bzl", "cc_library")
+load("@rules_cc//cc:cc_test.bzl", "cc_test")
+
 package(default_visibility = ["//visibility:public"])
 
 cc_library(

--- a/exporters/ostream/BUILD
+++ b/exporters/ostream/BUILD
@@ -1,6 +1,9 @@
 # Copyright The OpenTelemetry Authors
 # SPDX-License-Identifier: Apache-2.0
 
+load("@rules_cc//cc:cc_library.bzl", "cc_library")
+load("@rules_cc//cc:cc_test.bzl", "cc_test")
+
 package(default_visibility = ["//visibility:public"])
 
 cc_library(

--- a/exporters/otlp/BUILD
+++ b/exporters/otlp/BUILD
@@ -2,6 +2,8 @@
 # SPDX-License-Identifier: Apache-2.0
 
 load("@bazel_skylib//rules:common_settings.bzl", "bool_flag")
+load("@rules_cc//cc:cc_library.bzl", "cc_library")
+load("@rules_cc//cc:cc_test.bzl", "cc_test")
 load("//bazel:otel_cc_benchmark.bzl", "otel_cc_benchmark")
 
 package(default_visibility = ["//visibility:public"])

--- a/exporters/prometheus/BUILD
+++ b/exporters/prometheus/BUILD
@@ -1,6 +1,9 @@
 # Copyright The OpenTelemetry Authors
 # SPDX-License-Identifier: Apache-2.0
 
+load("@rules_cc//cc:cc_library.bzl", "cc_library")
+load("@rules_cc//cc:cc_test.bzl", "cc_test")
+
 package(default_visibility = ["//visibility:public"])
 
 cc_library(

--- a/exporters/zipkin/BUILD
+++ b/exporters/zipkin/BUILD
@@ -1,6 +1,9 @@
 # Copyright The OpenTelemetry Authors
 # SPDX-License-Identifier: Apache-2.0
 
+load("@rules_cc//cc:cc_library.bzl", "cc_library")
+load("@rules_cc//cc:cc_test.bzl", "cc_test")
+
 package(default_visibility = ["//visibility:public"])
 
 cc_library(

--- a/ext/BUILD
+++ b/ext/BUILD
@@ -1,6 +1,8 @@
 # Copyright The OpenTelemetry Authors
 # SPDX-License-Identifier: Apache-2.0
 
+load("@rules_cc//cc:cc_library.bzl", "cc_library")
+
 package(default_visibility = ["//visibility:public"])
 
 cc_library(

--- a/ext/src/http/client/curl/BUILD
+++ b/ext/src/http/client/curl/BUILD
@@ -1,6 +1,8 @@
 # Copyright The OpenTelemetry Authors
 # SPDX-License-Identifier: Apache-2.0
 
+load("@rules_cc//cc:cc_library.bzl", "cc_library")
+
 package(default_visibility = ["//visibility:public"])
 
 cc_library(

--- a/ext/test/http/BUILD
+++ b/ext/test/http/BUILD
@@ -1,6 +1,8 @@
 # Copyright The OpenTelemetry Authors
 # SPDX-License-Identifier: Apache-2.0
 
+load("@rules_cc//cc:cc_test.bzl", "cc_test")
+
 cc_test(
     name = "curl_http_test",
     srcs = [

--- a/ext/test/w3c_tracecontext_http_test_server/BUILD
+++ b/ext/test/w3c_tracecontext_http_test_server/BUILD
@@ -1,6 +1,8 @@
 # Copyright The OpenTelemetry Authors
 # SPDX-License-Identifier: Apache-2.0
 
+load("@rules_cc//cc:cc_binary.bzl", "cc_binary")
+
 cc_binary(
     name = "w3c_tracecontext_http_test_server",
     srcs = [

--- a/opentracing-shim/BUILD
+++ b/opentracing-shim/BUILD
@@ -1,6 +1,9 @@
 # Copyright The OpenTelemetry Authors
 # SPDX-License-Identifier: Apache-2.0
 
+load("@rules_cc//cc:cc_library.bzl", "cc_library")
+load("@rules_cc//cc:cc_test.bzl", "cc_test")
+
 package(default_visibility = ["//visibility:public"])
 
 cc_library(

--- a/resource_detectors/BUILD
+++ b/resource_detectors/BUILD
@@ -1,6 +1,8 @@
 # Copyright The OpenTelemetry Authors
 # SPDX-License-Identifier: Apache-2.0
 
+load("@rules_cc//cc:cc_library.bzl", "cc_library")
+
 package(default_visibility = ["//visibility:public"])
 
 cc_library(

--- a/resource_detectors/test/BUILD
+++ b/resource_detectors/test/BUILD
@@ -1,6 +1,8 @@
 # Copyright The OpenTelemetry Authors
 # SPDX-License-Identifier: Apache-2.0
 
+load("@rules_cc//cc:cc_test.bzl", "cc_test")
+
 cc_test(
     name = "resource_detector_test",
     srcs = [

--- a/sdk/BUILD
+++ b/sdk/BUILD
@@ -1,6 +1,8 @@
 # Copyright The OpenTelemetry Authors
 # SPDX-License-Identifier: Apache-2.0
 
+load("@rules_cc//cc:cc_library.bzl", "cc_library")
+
 package(default_visibility = ["//visibility:public"])
 
 cc_library(

--- a/sdk/src/common/BUILD
+++ b/sdk/src/common/BUILD
@@ -1,6 +1,8 @@
 # Copyright The OpenTelemetry Authors
 # SPDX-License-Identifier: Apache-2.0
 
+load("@rules_cc//cc:cc_library.bzl", "cc_library")
+
 package(default_visibility = ["//visibility:public"])
 
 cc_library(

--- a/sdk/src/common/platform/BUILD
+++ b/sdk/src/common/platform/BUILD
@@ -1,6 +1,8 @@
 # Copyright The OpenTelemetry Authors
 # SPDX-License-Identifier: Apache-2.0
 
+load("@rules_cc//cc:cc_library.bzl", "cc_library")
+
 package(default_visibility = ["//visibility:public"])
 
 cc_library(

--- a/sdk/src/configuration/BUILD
+++ b/sdk/src/configuration/BUILD
@@ -1,6 +1,8 @@
 # Copyright The OpenTelemetry Authors
 # SPDX-License-Identifier: Apache-2.0
 
+load("@rules_cc//cc:cc_library.bzl", "cc_library")
+
 package(default_visibility = ["//visibility:public"])
 
 cc_library(

--- a/sdk/src/logs/BUILD
+++ b/sdk/src/logs/BUILD
@@ -1,6 +1,8 @@
 # Copyright The OpenTelemetry Authors
 # SPDX-License-Identifier: Apache-2.0
 
+load("@rules_cc//cc:cc_library.bzl", "cc_library")
+
 package(default_visibility = ["//visibility:public"])
 
 cc_library(

--- a/sdk/src/metrics/BUILD
+++ b/sdk/src/metrics/BUILD
@@ -1,6 +1,8 @@
 # Copyright The OpenTelemetry Authors
 # SPDX-License-Identifier: Apache-2.0
 
+load("@rules_cc//cc:cc_library.bzl", "cc_library")
+
 package(default_visibility = ["//visibility:public"])
 
 cc_library(

--- a/sdk/src/resource/BUILD
+++ b/sdk/src/resource/BUILD
@@ -1,6 +1,8 @@
 # Copyright The OpenTelemetry Authors
 # SPDX-License-Identifier: Apache-2.0
 
+load("@rules_cc//cc:cc_library.bzl", "cc_library")
+
 package(default_visibility = ["//visibility:public"])
 
 cc_library(

--- a/sdk/src/trace/BUILD
+++ b/sdk/src/trace/BUILD
@@ -1,6 +1,8 @@
 # Copyright The OpenTelemetry Authors
 # SPDX-License-Identifier: Apache-2.0
 
+load("@rules_cc//cc:cc_library.bzl", "cc_library")
+
 package(default_visibility = ["//visibility:public"])
 
 cc_library(

--- a/sdk/test/common/BUILD
+++ b/sdk/test/common/BUILD
@@ -1,6 +1,8 @@
 # Copyright The OpenTelemetry Authors
 # SPDX-License-Identifier: Apache-2.0
 
+load("@rules_cc//cc:cc_library.bzl", "cc_library")
+load("@rules_cc//cc:cc_test.bzl", "cc_test")
 load("//bazel:otel_cc_benchmark.bzl", "otel_cc_benchmark")
 
 cc_test(

--- a/sdk/test/configuration/BUILD
+++ b/sdk/test/configuration/BUILD
@@ -1,6 +1,8 @@
 # Copyright The OpenTelemetry Authors
 # SPDX-License-Identifier: Apache-2.0
 
+load("@rules_cc//cc:cc_test.bzl", "cc_test")
+
 cc_test(
     name = "yaml_logs_test",
     srcs = [

--- a/sdk/test/instrumentationscope/BUILD
+++ b/sdk/test/instrumentationscope/BUILD
@@ -1,6 +1,8 @@
 # Copyright The OpenTelemetry Authors
 # SPDX-License-Identifier: Apache-2.0
 
+load("@rules_cc//cc:cc_test.bzl", "cc_test")
+
 cc_test(
     name = "instrumentationscope_test",
     srcs = [

--- a/sdk/test/logs/BUILD
+++ b/sdk/test/logs/BUILD
@@ -1,6 +1,8 @@
 # Copyright The OpenTelemetry Authors
 # SPDX-License-Identifier: Apache-2.0
 
+load("@rules_cc//cc:cc_test.bzl", "cc_test")
+
 cc_test(
     name = "logger_provider_sdk_test",
     srcs = [

--- a/sdk/test/metrics/BUILD
+++ b/sdk/test/metrics/BUILD
@@ -1,6 +1,8 @@
 # Copyright The OpenTelemetry Authors
 # SPDX-License-Identifier: Apache-2.0
 
+load("@rules_cc//cc:cc_library.bzl", "cc_library")
+load("@rules_cc//cc:cc_test.bzl", "cc_test")
 load("//bazel:otel_cc_benchmark.bzl", "otel_cc_benchmark")
 
 cc_library(

--- a/sdk/test/metrics/exemplar/BUILD
+++ b/sdk/test/metrics/exemplar/BUILD
@@ -1,6 +1,8 @@
 # Copyright The OpenTelemetry Authors
 # SPDX-License-Identifier: Apache-2.0
 
+load("@rules_cc//cc:cc_test.bzl", "cc_test")
+
 cc_test(
     name = "no_exemplar_reservoir_test",
     srcs = [

--- a/sdk/test/resource/BUILD
+++ b/sdk/test/resource/BUILD
@@ -1,6 +1,8 @@
 # Copyright The OpenTelemetry Authors
 # SPDX-License-Identifier: Apache-2.0
 
+load("@rules_cc//cc:cc_test.bzl", "cc_test")
+
 cc_test(
     name = "resource_test",
     srcs = [

--- a/sdk/test/trace/BUILD
+++ b/sdk/test/trace/BUILD
@@ -1,6 +1,7 @@
 # Copyright The OpenTelemetry Authors
 # SPDX-License-Identifier: Apache-2.0
 
+load("@rules_cc//cc:cc_test.bzl", "cc_test")
 load("//bazel:otel_cc_benchmark.bzl", "otel_cc_benchmark")
 
 cc_test(

--- a/test_common/BUILD
+++ b/test_common/BUILD
@@ -1,6 +1,8 @@
 # Copyright The OpenTelemetry Authors
 # SPDX-License-Identifier: Apache-2.0
 
+load("@rules_cc//cc:cc_library.bzl", "cc_library")
+
 package(default_visibility = ["//visibility:public"])
 
 cc_library(

--- a/test_common/src/http/client/nosend/BUILD
+++ b/test_common/src/http/client/nosend/BUILD
@@ -1,6 +1,8 @@
 # Copyright The OpenTelemetry Authors
 # SPDX-License-Identifier: Apache-2.0
 
+load("@rules_cc//cc:cc_library.bzl", "cc_library")
+
 package(default_visibility = ["//visibility:public"])
 
 cc_library(

--- a/tools/WORKSPACE
+++ b/tools/WORKSPACE
@@ -2,6 +2,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
 local_repository(
-  name = "vcpkg",
-  path = "./vcpkg",
+    name = "vcpkg",
+    path = "./vcpkg",
 )


### PR DESCRIPTION
With the next major version of bazel this becomes required. This change
was automated with `buildifier -r . --lint=fix`
