### PR TITLE
[API] fix sign-conversion warnings in span & trace id

### DIFF
--- a/api/include/opentelemetry/nostd/internal/absl/types/internal/variant.h
+++ b/api/include/opentelemetry/nostd/internal/absl/types/internal/variant.h
@@ -45,7 +45,7 @@ OTABSL_NAMESPACE_BEGIN
 template <class... Types>
 class variant;
 
-OTABSL_INTERNAL_INLINE_CONSTEXPR(size_t, variant_npos, -1);
+OTABSL_INTERNAL_INLINE_CONSTEXPR(size_t, variant_npos, static_cast<std::size_t>(-1));
 
 template <class T>
 struct variant_size;

--- a/api/include/opentelemetry/nostd/string_view.h
+++ b/api/include/opentelemetry/nostd/string_view.h
@@ -124,7 +124,7 @@ public:
       auto found = Traits::find(data() + pos, length() - pos, ch);
       if (found)
       {
-        res = found - data();
+        res = static_cast<size_type>(found - data());
       }
     }
     return res;

--- a/api/include/opentelemetry/trace/span_id.h
+++ b/api/include/opentelemetry/trace/span_id.h
@@ -17,7 +17,7 @@ class SpanId final
 {
 public:
   // The size in bytes of the SpanId.
-  static constexpr int kSize = 8;
+  static constexpr size_t kSize = 8;
 
   // An invalid SpanId (all zeros).
   SpanId() noexcept : rep_{0} {}
@@ -29,7 +29,7 @@ public:
   void ToLowerBase16(nostd::span<char, 2 * kSize> buffer) const noexcept
   {
     constexpr char kHex[] = "0123456789abcdef";
-    for (int i = 0; i < kSize; ++i)
+    for (size_t i = 0; i < kSize; ++i)
     {
       buffer[i * 2 + 0] = kHex[(rep_[i] >> 4) & 0xF];
       buffer[i * 2 + 1] = kHex[(rep_[i] >> 0) & 0xF];

--- a/api/include/opentelemetry/trace/trace_id.h
+++ b/api/include/opentelemetry/trace/trace_id.h
@@ -20,7 +20,7 @@ class TraceId final
 {
 public:
   // The size in bytes of the TraceId.
-  static constexpr int kSize = 16;
+  static constexpr size_t kSize = 16;
 
   // An invalid TraceId (all zeros).
   TraceId() noexcept : rep_{0} {}
@@ -35,7 +35,7 @@ public:
   void ToLowerBase16(nostd::span<char, 2 * kSize> buffer) const noexcept
   {
     constexpr char kHex[] = "0123456789abcdef";
-    for (int i = 0; i < kSize; ++i)
+    for (size_t i = 0; i < kSize; ++i)
     {
       buffer[i * 2 + 0] = kHex[(rep_[i] >> 4) & 0xF];
       buffer[i * 2 + 1] = kHex[(rep_[i] >> 0) & 0xF];


### PR DESCRIPTION
# Changes

Fix some warnings appearing with `-Wsign-conversion`:

```
opentelemetry_cpp-src/api/include/opentelemetry/trace/span_id.h:34:20: warning: conversion to ‘size_t’ {aka ‘long unsigned int’} from ‘int’ may change the sign of the result [-Wsign-conversion]
   34 |       buffer[i * 2 + 0] = kHex[(rep_[i] >> 4) & 0xF];
      |              ~~~~~~^~~
opentelemetry_cpp-src/api/include/opentelemetry/trace/span_id.h:35:20: warning: conversion to ‘size_t’ {aka ‘long unsigned int’} from ‘int’ may change the sign of the result [-Wsign-conversion]
   35 |       buffer[i * 2 + 1] = kHex[(rep_[i] >> 0) & 0xF];
      |              ~~~~~~^~~

api/include/opentelemetry/trace/trace_id.h:40:20: warning: conversion to ‘size_t’ {aka ‘long unsigned int’} from ‘int’ may change the sign of the result [-Wsign-conversion]
   40 |       buffer[i * 2 + 0] = kHex[(rep_[i] >> 4) & 0xF];
      |              ~~~~~~^~~
api/include/opentelemetry/trace/trace_id.h:41:20: warning: conversion to ‘size_t’ {aka ‘long unsigned int’} from ‘int’ may change the sign of the result [-Wsign-conversion]
   41 |       buffer[i * 2 + 1] = kHex[(rep_[i] >> 0) & 0xF];
      |              ~~~~~~^~~
opentelemetry_cpp-src/api/include/opentelemetry/nostd/string_view.h:127:21: warning: conversion to ‘opentelemetry::v1::nostd::string_view::size_type’ {aka ‘long unsigned int’} from ‘long int’ may change the sign of the result [-Wsign-conversion]
  127 |         res = found - data();
      |               ~~~~~~^~~~~~~~
opentelemetry_cpp-src/api/include/opentelemetry/nostd/internal/absl/types/../types/internal/variant.h:48:56: warning: unsigned conversion from ‘int’ to ‘absl::otel_v1::internal::identity_t<long unsigned int>’ {aka ‘long unsigned int’} changes value from ‘-1’ to ‘18446744073709551615’ [-Wsign-conversion]
   48 | OTABSL_INTERNAL_INLINE_CONSTEXPR(size_t, variant_npos, -1);
      |                                                        ^~

```