### PR TITLE
fix segfault in opentelemetry::v1::context::RuntimeContext::GetCurrent () during exit() in multi-thread envs

### DIFF
--- a/api/include/opentelemetry/context/runtime_context.h
+++ b/api/include/opentelemetry/context/runtime_context.h
@@ -178,7 +178,7 @@ private:
 
   OPENTELEMETRY_API_SINGLETON static nostd::shared_ptr<RuntimeContextStorage> &GetStorage() noexcept
   {
-    static nostd::shared_ptr<RuntimeContextStorage> context(GetDefaultStorage());
+    static thread_local nostd::shared_ptr<RuntimeContextStorage> context(GetDefaultStorage());
     return context;
   }
 };


### PR DESCRIPTION
Fixes # (3766)

## Changes

Please provide a brief description of the changes here.

In a multi-threaded environment, when the process exits, this static object could get destructed while there are still running threading doing the export and therefore hitting crash.

Application could explicitly stop the threads before exit, but it is an extra constraints, and it is not always doable when opentelemetry-cpp is built as a lib.

registered in std::atexit() does not guaranteed the destruct order as well, thence we need this fix.


For significant contributions please make sure you have completed the following items:

* [ ] `CHANGELOG.md` updated for non-trivial changes
* [ ] Unit tests have been added
* [ ] Changes in public API reviewed