### PR TITLE
[TEST] Multiple exports in OTLP HTTP exporters tests

### DIFF
--- a/exporters/otlp/test/otlp_http_exporter_test.cc
+++ b/exporters/otlp/test/otlp_http_exporter_test.cc
@@ -170,17 +170,34 @@ public:
     auto no_send_client = std::static_pointer_cast<http_client::nosend::HttpClient>(client);
     auto mock_session =
         std::static_pointer_cast<http_client::nosend::Session>(no_send_client->session_);
+    auto received_trace_id_counter = 0;
     EXPECT_CALL(*mock_session, SendRequest)
-        .WillOnce(
-            [&mock_session, report_trace_id](
+        .WillRepeatedly(
+            [&mock_session, report_trace_id, &received_trace_id_counter](
                 const std::shared_ptr<opentelemetry::ext::http::client::EventHandler> &callback) {
               auto check_json =
                   nlohmann::json::parse(mock_session->GetRequest()->body_, nullptr, false);
-              auto resource_span     = *check_json["resourceSpans"].begin();
-              auto scope_span        = *resource_span["scopeSpans"].begin();
+              if (check_json["resourceSpans"].size() == 0)
+              {
+                return;
+              }
+              auto resource_span = *check_json["resourceSpans"].begin();
+              if (resource_span["scopeSpans"].size() == 0)
+              {
+                return;
+              }
+              auto scope_span = *resource_span["scopeSpans"].begin();
+              if (scope_span["spans"].size() == 0)
+              {
+                return;
+              }
               auto span              = *scope_span["spans"].begin();
               auto received_trace_id = span["traceId"].get<std::string>();
-              EXPECT_EQ(received_trace_id, report_trace_id);
+              if (received_trace_id != report_trace_id)
+              {
+                return;
+              }
+              ++received_trace_id_counter;
 
               auto custom_header = mock_session->GetRequest()->headers_.find("Custom-Header-Key");
               ASSERT_TRUE(custom_header != mock_session->GetRequest()->headers_.end());
@@ -205,6 +222,9 @@ public:
     parent_span->End();
 
     provider->ForceFlush();
+
+    // Exporting can be retryed
+    EXPECT_GE(received_trace_id_counter, 1);
   }
 
 #  ifdef ENABLE_ASYNC_EXPORT
@@ -262,17 +282,34 @@ public:
     auto no_send_client = std::static_pointer_cast<http_client::nosend::HttpClient>(client);
     auto mock_session =
         std::static_pointer_cast<http_client::nosend::Session>(no_send_client->session_);
+    auto received_trace_id_counter = 0;
     EXPECT_CALL(*mock_session, SendRequest)
-        .WillOnce(
-            [&mock_session, report_trace_id](
+        .WillRepeatedly(
+            [&mock_session, report_trace_id, &received_trace_id_counter](
                 const std::shared_ptr<opentelemetry::ext::http::client::EventHandler> &callback) {
               auto check_json =
                   nlohmann::json::parse(mock_session->GetRequest()->body_, nullptr, false);
-              auto resource_span     = *check_json["resourceSpans"].begin();
-              auto scope_span        = *resource_span["scopeSpans"].begin();
+              if (check_json["resourceSpans"].size() == 0)
+              {
+                return;
+              }
+              auto resource_span = *check_json["resourceSpans"].begin();
+              if (resource_span["scopeSpans"].size() == 0)
+              {
+                return;
+              }
+              auto scope_span = *resource_span["scopeSpans"].begin();
+              if (scope_span["spans"].size() == 0)
+              {
+                return;
+              }
               auto span              = *scope_span["spans"].begin();
               auto received_trace_id = span["traceId"].get<std::string>();
-              EXPECT_EQ(received_trace_id, report_trace_id);
+              if (received_trace_id != report_trace_id)
+              {
+                return;
+              }
+              ++received_trace_id_counter;
 
               auto custom_header = mock_session->GetRequest()->headers_.find("Custom-Header-Key");
               ASSERT_TRUE(custom_header != mock_session->GetRequest()->headers_.end());
@@ -301,6 +338,9 @@ public:
     parent_span->End();
 
     provider->ForceFlush();
+
+    // Exporting can be retryed
+    EXPECT_GE(received_trace_id_counter, 1);
   }
 #  endif
 
@@ -357,17 +397,28 @@ public:
     auto no_send_client = std::static_pointer_cast<http_client::nosend::HttpClient>(client);
     auto mock_session =
         std::static_pointer_cast<http_client::nosend::Session>(no_send_client->session_);
+    auto received_trace_id_counter = 0;
     EXPECT_CALL(*mock_session, SendRequest)
-        .WillOnce(
-            [&mock_session, report_trace_id](
+        .WillRepeatedly(
+            [&mock_session, report_trace_id, &received_trace_id_counter](
                 const std::shared_ptr<opentelemetry::ext::http::client::EventHandler> &callback) {
               opentelemetry::proto::collector::trace::v1::ExportTraceServiceRequest request_body;
               request_body.ParseFromArray(
                   &mock_session->GetRequest()->body_[0],
                   static_cast<int>(mock_session->GetRequest()->body_.size()));
+              if (request_body.resource_spans_size() == 0 ||
+                  request_body.resource_spans(0).scope_spans_size() == 0 ||
+                  request_body.resource_spans(0).scope_spans(0).spans_size() == 0)
+              {
+                return;
+              }
               auto received_trace_id =
                   request_body.resource_spans(0).scope_spans(0).spans(0).trace_id();
-              EXPECT_EQ(received_trace_id, report_trace_id);
+              if (received_trace_id != report_trace_id)
+              {
+                return;
+              }
+              ++received_trace_id_counter;
 
               auto custom_header = mock_session->GetRequest()->headers_.find("Custom-Header-Key");
               ASSERT_TRUE(custom_header != mock_session->GetRequest()->headers_.end());
@@ -384,6 +435,9 @@ public:
     parent_span->End();
 
     provider->ForceFlush();
+
+    // Exporting can be retryed
+    EXPECT_GE(received_trace_id_counter, 1);
   }
 
 #  ifdef ENABLE_ASYNC_EXPORT
@@ -440,17 +494,28 @@ public:
     auto no_send_client = std::static_pointer_cast<http_client::nosend::HttpClient>(client);
     auto mock_session =
         std::static_pointer_cast<http_client::nosend::Session>(no_send_client->session_);
+    auto received_trace_id_counter = 0;
     EXPECT_CALL(*mock_session, SendRequest)
-        .WillOnce(
-            [&mock_session, report_trace_id](
+        .WillRepeatedly(
+            [&mock_session, report_trace_id, &received_trace_id_counter](
                 const std::shared_ptr<opentelemetry::ext::http::client::EventHandler> &callback) {
               opentelemetry::proto::collector::trace::v1::ExportTraceServiceRequest request_body;
               request_body.ParseFromArray(
                   &mock_session->GetRequest()->body_[0],
                   static_cast<int>(mock_session->GetRequest()->body_.size()));
+              if (request_body.resource_spans_size() == 0 ||
+                  request_body.resource_spans(0).scope_spans_size() == 0 ||
+                  request_body.resource_spans(0).scope_spans(0).spans_size() == 0)
+              {
+                return;
+              }
               auto received_trace_id =
                   request_body.resource_spans(0).scope_spans(0).spans(0).trace_id();
-              EXPECT_EQ(received_trace_id, report_trace_id);
+              if (received_trace_id != report_trace_id)
+              {
+                return;
+              }
+              ++received_trace_id_counter;
 
               auto custom_header = mock_session->GetRequest()->headers_.find("Custom-Header-Key");
               ASSERT_TRUE(custom_header != mock_session->GetRequest()->headers_.end());
@@ -472,6 +537,8 @@ public:
     parent_span->End();
 
     provider->ForceFlush();
+    // Exporting can be retryed
+    EXPECT_GE(received_trace_id_counter, 1);
   }
 #  endif
 };

--- a/exporters/otlp/test/otlp_http_exporter_test.cc
+++ b/exporters/otlp/test/otlp_http_exporter_test.cc
@@ -223,7 +223,7 @@ public:
 
     provider->ForceFlush();
 
-    // Exporting can be retryed
+    // Exporting can be retried
     EXPECT_GE(received_trace_id_counter, 1);
   }
 
@@ -339,7 +339,7 @@ public:
 
     provider->ForceFlush();
 
-    // Exporting can be retryed
+    // Exporting can be retried
     EXPECT_GE(received_trace_id_counter, 1);
   }
 #  endif
@@ -436,7 +436,7 @@ public:
 
     provider->ForceFlush();
 
-    // Exporting can be retryed
+    // Exporting can be retried
     EXPECT_GE(received_trace_id_counter, 1);
   }
 
@@ -537,7 +537,7 @@ public:
     parent_span->End();
 
     provider->ForceFlush();
-    // Exporting can be retryed
+    // Exporting can be retried
     EXPECT_GE(received_trace_id_counter, 1);
   }
 #  endif

--- a/exporters/otlp/test/otlp_http_log_record_exporter_test.cc
+++ b/exporters/otlp/test/otlp_http_log_record_exporter_test.cc
@@ -158,20 +158,35 @@ public:
     auto no_send_client = std::static_pointer_cast<http_client::nosend::HttpClient>(client);
     auto mock_session =
         std::static_pointer_cast<http_client::nosend::Session>(no_send_client->session_);
+    auto received_record_counter = 0;
     EXPECT_CALL(*mock_session, SendRequest)
-        .WillOnce(
-            [&mock_session, report_trace_id, report_span_id](
+        .WillRepeatedly(
+            [&mock_session, report_trace_id, report_span_id, &received_record_counter](
                 const std::shared_ptr<opentelemetry::ext::http::client::EventHandler> &callback) {
               auto check_json =
                   nlohmann::json::parse(mock_session->GetRequest()->body_, nullptr, false);
-              auto resource_logs     = *check_json["resourceLogs"].begin();
-              auto scope_logs        = *resource_logs["scopeLogs"].begin();
+              if (check_json["resourceLogs"].size() == 0)
+              {
+                return;
+              }
+              auto resource_logs = *check_json["resourceLogs"].begin();
+              if (resource_logs["scopeLogs"].size() == 0)
+              {
+                return;
+              }
+              auto scope_logs = *resource_logs["scopeLogs"].begin();
+              if (scope_logs["logRecords"].size() == 0)
+              {
+                return;
+              }
               auto scope             = scope_logs["scope"];
               auto log               = *scope_logs["logRecords"].begin();
               auto received_trace_id = log["traceId"].get<std::string>();
               auto received_span_id  = log["spanId"].get<std::string>();
-              EXPECT_EQ(received_trace_id, report_trace_id);
-              EXPECT_EQ(received_span_id, report_span_id);
+              if (received_trace_id == report_trace_id && received_span_id == report_span_id)
+              {
+                ++received_record_counter;
+              }
               EXPECT_EQ("Log message", log["body"]["stringValue"].get<std::string>());
               EXPECT_LE(15, log["attributes"].size());
               auto custom_header = mock_session->GetRequest()->headers_.find("Custom-Header-Key");
@@ -224,6 +239,9 @@ public:
         std::chrono::system_clock::now());
 
     provider->ForceFlush();
+
+    // Exporting can be retryed
+    EXPECT_GE(received_record_counter, 1);
   }
 
 #  ifdef ENABLE_ASYNC_EXPORT
@@ -276,14 +294,27 @@ public:
     auto no_send_client = std::static_pointer_cast<http_client::nosend::HttpClient>(client);
     auto mock_session =
         std::static_pointer_cast<http_client::nosend::Session>(no_send_client->session_);
+    auto received_record_counter = 0;
     EXPECT_CALL(*mock_session, SendRequest)
-        .WillOnce(
-            [&mock_session, report_trace_id, report_span_id](
+        .WillRepeatedly(
+            [&mock_session, report_trace_id, report_span_id, &received_record_counter](
                 const std::shared_ptr<opentelemetry::ext::http::client::EventHandler> &callback) {
               auto check_json =
                   nlohmann::json::parse(mock_session->GetRequest()->body_, nullptr, false);
-              auto resource_logs     = *check_json["resourceLogs"].begin();
-              auto scope_logs        = *resource_logs["scopeLogs"].begin();
+              if (check_json["resourceLogs"].size() == 0)
+              {
+                return;
+              }
+              auto resource_logs = *check_json["resourceLogs"].begin();
+              if (resource_logs["scopeLogs"].size() == 0)
+              {
+                return;
+              }
+              auto scope_logs = *resource_logs["scopeLogs"].begin();
+              if (scope_logs["logRecords"].size() == 0)
+              {
+                return;
+              }
               auto schema_url        = scope_logs["schemaUrl"].get<std::string>();
               auto scope             = scope_logs["scope"];
               auto scope_name        = scope["name"];
@@ -291,11 +322,13 @@ public:
               auto log               = *scope_logs["logRecords"].begin();
               auto received_trace_id = log["traceId"].get<std::string>();
               auto received_span_id  = log["spanId"].get<std::string>();
+              if (received_trace_id == report_trace_id && received_span_id == report_span_id)
+              {
+                ++received_record_counter;
+              }
               EXPECT_EQ(schema_url, "https://opentelemetry.io/schemas/1.2.0");
               EXPECT_EQ(scope_name, "opentelelemtry_library");
               EXPECT_EQ(scope_version, "1.2.0");
-              EXPECT_EQ(received_trace_id, report_trace_id);
-              EXPECT_EQ(received_span_id, report_span_id);
               EXPECT_EQ("Log message", log["body"]["stringValue"].get<std::string>());
               EXPECT_LE(15, log["attributes"].size());
               auto custom_header = mock_session->GetRequest()->headers_.find("Custom-Header-Key");
@@ -353,6 +386,9 @@ public:
         std::chrono::system_clock::now());
 
     provider->ForceFlush();
+
+    // Exporting can be retryed
+    EXPECT_GE(received_record_counter, 1);
   }
 #  endif
 
@@ -399,21 +435,31 @@ public:
     auto no_send_client = std::static_pointer_cast<http_client::nosend::HttpClient>(client);
     auto mock_session =
         std::static_pointer_cast<http_client::nosend::Session>(no_send_client->session_);
+    auto received_record_counter = 0;
     EXPECT_CALL(*mock_session, SendRequest)
-        .WillOnce(
-            [&mock_session, report_trace_id, report_span_id](
+        .WillRepeatedly(
+            [&mock_session, report_trace_id, report_span_id, &received_record_counter](
                 const std::shared_ptr<opentelemetry::ext::http::client::EventHandler> &callback) {
               opentelemetry::proto::collector::logs::v1::ExportLogsServiceRequest request_body;
               request_body.ParseFromArray(
                   &mock_session->GetRequest()->body_[0],
                   static_cast<int>(mock_session->GetRequest()->body_.size()));
+              if (request_body.resource_logs_size() == 0 ||
+                  request_body.resource_logs(0).scope_logs_size() == 0 ||
+                  request_body.resource_logs(0).scope_logs(0).log_records_size() == 0)
+              {
+                return;
+              }
               auto scope_log = request_body.resource_logs(0).scope_logs(0);
               EXPECT_EQ(scope_log.schema_url(), "https://opentelemetry.io/schemas/1.2.0");
               EXPECT_EQ(scope_log.scope().name(), "opentelelemtry_library");
               EXPECT_EQ(scope_log.scope().version(), "1.2.0");
               const auto &received_log = scope_log.log_records(0);
-              EXPECT_EQ(received_log.trace_id(), report_trace_id);
-              EXPECT_EQ(received_log.span_id(), report_span_id);
+              if (received_log.trace_id() == report_trace_id &&
+                  received_log.span_id() == report_span_id)
+              {
+                ++received_record_counter;
+              }
               EXPECT_EQ("Log message", received_log.body().string_value());
               EXPECT_LE(15, received_log.attributes_size());
               bool check_service_name = false;
@@ -467,6 +513,9 @@ public:
         std::chrono::system_clock::now());
 
     provider->ForceFlush();
+
+    // Exporting can be retryed
+    EXPECT_GE(received_record_counter, 1);
   }
 
 #  ifdef ENABLE_ASYNC_EXPORT
@@ -514,18 +563,28 @@ public:
     auto no_send_client = std::static_pointer_cast<http_client::nosend::HttpClient>(client);
     auto mock_session =
         std::static_pointer_cast<http_client::nosend::Session>(no_send_client->session_);
+    auto received_record_counter = 0;
     EXPECT_CALL(*mock_session, SendRequest)
-        .WillOnce(
-            [&mock_session, report_trace_id, report_span_id, schema_url](
+        .WillRepeatedly(
+            [&mock_session, report_trace_id, report_span_id, schema_url, &received_record_counter](
                 const std::shared_ptr<opentelemetry::ext::http::client::EventHandler> &callback) {
               opentelemetry::proto::collector::logs::v1::ExportLogsServiceRequest request_body;
               request_body.ParseFromArray(
                   &mock_session->GetRequest()->body_[0],
                   static_cast<int>(mock_session->GetRequest()->body_.size()));
+              if (request_body.resource_logs_size() == 0 ||
+                  request_body.resource_logs(0).scope_logs_size() == 0 ||
+                  request_body.resource_logs(0).scope_logs(0).log_records_size() == 0)
+              {
+                return;
+              }
               auto &scope_log   = request_body.resource_logs(0).scope_logs(0);
               auto received_log = scope_log.log_records(0);
-              EXPECT_EQ(received_log.trace_id(), report_trace_id);
-              EXPECT_EQ(received_log.span_id(), report_span_id);
+              if (received_log.trace_id() == report_trace_id &&
+                  received_log.span_id() == report_span_id)
+              {
+                ++received_record_counter;
+              }
               EXPECT_EQ("Log message", received_log.body().string_value());
               EXPECT_LE(15, received_log.attributes_size());
               bool check_service_name = false;
@@ -586,6 +645,8 @@ public:
         std::chrono::system_clock::now());
 
     provider->ForceFlush();
+    // Exporting can be retryed
+    EXPECT_GE(received_record_counter, 1);
   }
 #  endif
 };

--- a/exporters/otlp/test/otlp_http_log_record_exporter_test.cc
+++ b/exporters/otlp/test/otlp_http_log_record_exporter_test.cc
@@ -240,7 +240,7 @@ public:
 
     provider->ForceFlush();
 
-    // Exporting can be retryed
+    // Exporting can be retried
     EXPECT_GE(received_record_counter, 1);
   }
 
@@ -387,7 +387,7 @@ public:
 
     provider->ForceFlush();
 
-    // Exporting can be retryed
+    // Exporting can be retried
     EXPECT_GE(received_record_counter, 1);
   }
 #  endif
@@ -514,7 +514,7 @@ public:
 
     provider->ForceFlush();
 
-    // Exporting can be retryed
+    // Exporting can be retried
     EXPECT_GE(received_record_counter, 1);
   }
 
@@ -645,7 +645,7 @@ public:
         std::chrono::system_clock::now());
 
     provider->ForceFlush();
-    // Exporting can be retryed
+    // Exporting can be retried
     EXPECT_GE(received_record_counter, 1);
   }
 #  endif

--- a/exporters/otlp/test/otlp_http_metric_exporter_test.cc
+++ b/exporters/otlp/test/otlp_http_metric_exporter_test.cc
@@ -228,7 +228,7 @@ public:
 
     exporter->ForceFlush();
 
-    // Exporting can be retryed
+    // Exporting can be retried
     EXPECT_GE(received_record_counter, 1);
   }
 
@@ -335,7 +335,7 @@ public:
 
     exporter->ForceFlush();
 
-    // Exporting can be retryed
+    // Exporting can be retried
     EXPECT_GE(received_record_counter, 1);
   }
 
@@ -440,7 +440,7 @@ public:
 
     exporter->ForceFlush();
 
-    // Exporting can be retryed
+    // Exporting can be retried
     EXPECT_GE(received_record_counter, 1);
   }
 
@@ -557,7 +557,7 @@ public:
 
     exporter->ForceFlush();
 
-    // Exporting can be retryed
+    // Exporting can be retried
     EXPECT_GE(received_record_counter, 1);
   }
 
@@ -702,7 +702,7 @@ public:
 
     exporter->ForceFlush();
 
-    // Exporting can be retryed
+    // Exporting can be retried
     EXPECT_GE(received_record_counter, 1);
   }
 
@@ -856,7 +856,7 @@ public:
 
     exporter->ForceFlush();
 
-    // Exporting can be retryed
+    // Exporting can be retried
     EXPECT_GE(received_record_counter, 1);
   }
 };

--- a/exporters/otlp/test/otlp_http_metric_exporter_test.cc
+++ b/exporters/otlp/test/otlp_http_metric_exporter_test.cc
@@ -175,16 +175,31 @@ public:
     auto no_send_client = std::static_pointer_cast<http_client::nosend::HttpClient>(client);
     auto mock_session =
         std::static_pointer_cast<http_client::nosend::Session>(no_send_client->session_);
+    auto received_record_counter = 0;
     EXPECT_CALL(*mock_session, SendRequest)
-        .WillOnce(
-            [&mock_session](
+        .WillRepeatedly(
+            [&mock_session, &received_record_counter](
                 const std::shared_ptr<opentelemetry::ext::http::client::EventHandler> &callback) {
               auto check_json =
                   nlohmann::json::parse(mock_session->GetRequest()->body_, nullptr, false);
 
+              if (check_json["resourceMetrics"].size() == 0)
+              {
+                return;
+              }
               auto resource_metrics = *check_json["resourceMetrics"].begin();
-              auto scope_metrics    = *resource_metrics["scopeMetrics"].begin();
-              auto scope            = scope_metrics["scope"];
+              if (resource_metrics["scopeMetrics"].size() == 0)
+              {
+                return;
+              }
+              auto scope_metrics = *resource_metrics["scopeMetrics"].begin();
+              if (scope_metrics["metrics"].size() == 0)
+              {
+                return;
+              }
+              ++received_record_counter;
+
+              auto scope = scope_metrics["scope"];
               EXPECT_EQ("library_name", scope["name"].get<std::string>());
               EXPECT_EQ("1.5.0", scope["version"].get<std::string>());
 
@@ -212,6 +227,9 @@ public:
     EXPECT_EQ(result, opentelemetry::sdk::common::ExportResult::kSuccess);
 
     exporter->ForceFlush();
+
+    // Exporting can be retryed
+    EXPECT_GE(received_record_counter, 1);
   }
 
   void ExportBinaryIntegrationTestExportSumPointData(
@@ -258,13 +276,21 @@ public:
     auto mock_session =
         std::static_pointer_cast<http_client::nosend::Session>(no_send_client->session_);
 
+    auto received_record_counter = 0;
     EXPECT_CALL(*mock_session, SendRequest)
-        .WillOnce([&mock_session](
-                      const std::shared_ptr<opentelemetry::ext::http::client::EventHandler>
-                          &callback) {
+        .WillRepeatedly([&mock_session, &received_record_counter](
+                            const std::shared_ptr<opentelemetry::ext::http::client::EventHandler>
+                                &callback) {
           opentelemetry::proto::collector::metrics::v1::ExportMetricsServiceRequest request_body;
           request_body.ParseFromArray(&mock_session->GetRequest()->body_[0],
                                       static_cast<int>(mock_session->GetRequest()->body_.size()));
+          if (request_body.resource_metrics_size() == 0 ||
+              request_body.resource_metrics(0).scope_metrics_size() == 0 ||
+              request_body.resource_metrics(0).scope_metrics(0).metrics_size() == 0)
+          {
+            return;
+          }
+          ++received_record_counter;
           auto &scope_metrics = request_body.resource_metrics(0).scope_metrics(0);
           auto &scope         = scope_metrics.scope();
           EXPECT_EQ("library_name", scope.name());
@@ -308,6 +334,9 @@ public:
     EXPECT_EQ(result, opentelemetry::sdk::common::ExportResult::kSuccess);
 
     exporter->ForceFlush();
+
+    // Exporting can be retryed
+    EXPECT_GE(received_record_counter, 1);
   }
 
   void ExportJsonIntegrationTestExportLastValuePointData(
@@ -358,16 +387,31 @@ public:
     auto no_send_client = std::static_pointer_cast<http_client::nosend::HttpClient>(client);
     auto mock_session =
         std::static_pointer_cast<http_client::nosend::Session>(no_send_client->session_);
+    auto received_record_counter = 0;
     EXPECT_CALL(*mock_session, SendRequest)
-        .WillOnce(
-            [&mock_session](
+        .WillRepeatedly(
+            [&mock_session, &received_record_counter](
                 const std::shared_ptr<opentelemetry::ext::http::client::EventHandler> &callback) {
               auto check_json =
                   nlohmann::json::parse(mock_session->GetRequest()->body_, nullptr, false);
 
+              if (check_json["resourceMetrics"].size() == 0)
+              {
+                return;
+              }
               auto resource_metrics = *check_json["resourceMetrics"].begin();
-              auto scope_metrics    = *resource_metrics["scopeMetrics"].begin();
-              auto scope            = scope_metrics["scope"];
+              if (resource_metrics["scopeMetrics"].size() == 0)
+              {
+                return;
+              }
+              auto scope_metrics = *resource_metrics["scopeMetrics"].begin();
+              if (scope_metrics["metrics"].size() == 0)
+              {
+                return;
+              }
+              ++received_record_counter;
+
+              auto scope = scope_metrics["scope"];
               EXPECT_EQ("library_name", scope["name"].get<std::string>());
               EXPECT_EQ("1.5.0", scope["version"].get<std::string>());
 
@@ -395,6 +439,9 @@ public:
     EXPECT_EQ(result, opentelemetry::sdk::common::ExportResult::kSuccess);
 
     exporter->ForceFlush();
+
+    // Exporting can be retryed
+    EXPECT_GE(received_record_counter, 1);
   }
 
   void ExportBinaryIntegrationTestExportLastValuePointData(
@@ -450,13 +497,22 @@ public:
     auto mock_session =
         std::static_pointer_cast<http_client::nosend::Session>(no_send_client->session_);
 
+    auto received_record_counter = 0;
     EXPECT_CALL(*mock_session, SendRequest)
-        .WillOnce([&mock_session](
-                      const std::shared_ptr<opentelemetry::ext::http::client::EventHandler>
-                          &callback) {
+        .WillRepeatedly([&mock_session, &received_record_counter](
+                            const std::shared_ptr<opentelemetry::ext::http::client::EventHandler>
+                                &callback) {
           opentelemetry::proto::collector::metrics::v1::ExportMetricsServiceRequest request_body;
           request_body.ParseFromArray(&mock_session->GetRequest()->body_[0],
                                       static_cast<int>(mock_session->GetRequest()->body_.size()));
+          if (request_body.resource_metrics_size() == 0 ||
+              request_body.resource_metrics(0).scope_metrics_size() == 0 ||
+              request_body.resource_metrics(0).scope_metrics(0).metrics_size() == 0)
+          {
+            return;
+          }
+          ++received_record_counter;
+
           auto &scope_metrics = request_body.resource_metrics(0).scope_metrics(0);
           auto &scope         = scope_metrics.scope();
           EXPECT_EQ("library_name", scope.name());
@@ -500,6 +556,9 @@ public:
     EXPECT_EQ(result, opentelemetry::sdk::common::ExportResult::kSuccess);
 
     exporter->ForceFlush();
+
+    // Exporting can be retryed
+    EXPECT_GE(received_record_counter, 1);
   }
 
   void ExportJsonIntegrationTestExportHistogramPointData(
@@ -555,16 +614,31 @@ public:
     auto no_send_client = std::static_pointer_cast<http_client::nosend::HttpClient>(client);
     auto mock_session =
         std::static_pointer_cast<http_client::nosend::Session>(no_send_client->session_);
+    auto received_record_counter = 0;
     EXPECT_CALL(*mock_session, SendRequest)
-        .WillOnce(
-            [&mock_session](
+        .WillRepeatedly(
+            [&mock_session, &received_record_counter](
                 const std::shared_ptr<opentelemetry::ext::http::client::EventHandler> &callback) {
               auto check_json =
                   nlohmann::json::parse(mock_session->GetRequest()->body_, nullptr, false);
 
+              if (check_json["resourceMetrics"].size() == 0)
+              {
+                return;
+              }
               auto resource_metrics = *check_json["resourceMetrics"].begin();
-              auto scope_metrics    = *resource_metrics["scopeMetrics"].begin();
-              auto scope            = scope_metrics["scope"];
+              if (resource_metrics["scopeMetrics"].size() == 0)
+              {
+                return;
+              }
+              auto scope_metrics = *resource_metrics["scopeMetrics"].begin();
+              if (scope_metrics["metrics"].size() == 0)
+              {
+                return;
+              }
+              ++received_record_counter;
+
+              auto scope = scope_metrics["scope"];
               EXPECT_EQ("library_name", scope["name"].get<std::string>());
               EXPECT_EQ("1.5.0", scope["version"].get<std::string>());
 
@@ -627,6 +701,9 @@ public:
     EXPECT_EQ(result, opentelemetry::sdk::common::ExportResult::kSuccess);
 
     exporter->ForceFlush();
+
+    // Exporting can be retryed
+    EXPECT_GE(received_record_counter, 1);
   }
 
   void ExportBinaryIntegrationTestExportHistogramPointData(
@@ -686,13 +763,22 @@ public:
     auto mock_session =
         std::static_pointer_cast<http_client::nosend::Session>(no_send_client->session_);
 
+    auto received_record_counter = 0;
     EXPECT_CALL(*mock_session, SendRequest)
-        .WillOnce([&mock_session](
-                      const std::shared_ptr<opentelemetry::ext::http::client::EventHandler>
-                          &callback) {
+        .WillRepeatedly([&mock_session, &received_record_counter](
+                            const std::shared_ptr<opentelemetry::ext::http::client::EventHandler>
+                                &callback) {
           opentelemetry::proto::collector::metrics::v1::ExportMetricsServiceRequest request_body;
           request_body.ParseFromArray(&mock_session->GetRequest()->body_[0],
                                       static_cast<int>(mock_session->GetRequest()->body_.size()));
+          if (request_body.resource_metrics_size() == 0 ||
+              request_body.resource_metrics(0).scope_metrics_size() == 0 ||
+              request_body.resource_metrics(0).scope_metrics(0).metrics_size() == 0)
+          {
+            return;
+          }
+          ++received_record_counter;
+
           auto &scope_metrics = request_body.resource_metrics(0).scope_metrics(0);
           auto &scope         = scope_metrics.scope();
           EXPECT_EQ("library_name", scope.name());
@@ -769,6 +855,9 @@ public:
     EXPECT_EQ(result, opentelemetry::sdk::common::ExportResult::kSuccess);
 
     exporter->ForceFlush();
+
+    // Exporting can be retryed
+    EXPECT_GE(received_record_counter, 1);
   }
 };
 


### PR DESCRIPTION
Fixes #3721 

## Changes

+ Allow retryable exports or split them into two batch jobs for OTLP HTTP exporters.

For significant contributions please make sure you have completed the following items:

* [ ] `CHANGELOG.md` updated for non-trivial changes
* [x] Unit tests have been added
* [x] Changes in public API reviewed