### PR TITLE
[chore] Add clo monitor exemption for artifact hub 

### DIFF
--- a/.clomonitor.yml
+++ b/.clomonitor.yml
@@ -1,3 +1,5 @@
+# Copyright The OpenTelemetry Authors
+# SPDX-License-Identifier: Apache-2.0
 # see https://github.com/cncf/clomonitor/blob/main/docs/checks.md#exemptions
 exemptions:
   - check: artifacthub_badge

--- a/.copyright-ignore
+++ b/.copyright-ignore
@@ -46,7 +46,6 @@
 
 ./.bazelignore
 ./.bazelversion
-./.clomonitor.yml
 ./docker/.gitignore
 .markdownlintignore
 ./ci/toc.yml


### PR DESCRIPTION
Fixes # (issue)

## Changes

This defines a .clomonitor.yml file which is used by [clo monitor](https://clomonitor.io/projects/cncf/open-telemetry).

This file contains an exemption for artifact hub as artifact's produced by this library are not supported by artifact hub. By including the exemption we can improve the score for this project and the organisation. File contents have been copied from other repos where the exemption has been applied.

For significant contributions please make sure you have completed the following items:

* [ ] `CHANGELOG.md` updated for non-trivial changes
* [ ] Unit tests have been added
* [ ] Changes in public API reviewed