### PR TITLE
[SDK] Fix off-by-one error in  `Base2ExponentialHistogramAggregation::Merge()` downscaling

### DIFF
--- a/sdk/src/metrics/aggregation/base2_exponential_histogram_aggregation.cc
+++ b/sdk/src/metrics/aggregation/base2_exponential_histogram_aggregation.cc
@@ -310,9 +310,11 @@ std::unique_ptr<Aggregation> Base2ExponentialHistogramAggregation::Merge(
     auto neg_max_index =
         (std::max)(low_res.negative_buckets_->EndIndex(), high_res.negative_buckets_->EndIndex());
 
-    if (static_cast<size_t>(pos_max_index) >
+    // The range [pos_min_index, pos_max_index] contains (pos_max_index - pos_min_index + 1)
+    // buckets. We need to downscale if this count exceeds max_buckets_.
+    if (static_cast<size_t>(pos_max_index) >=
             static_cast<size_t>(pos_min_index) + result_value.max_buckets_ ||
-        static_cast<size_t>(neg_max_index) >
+        static_cast<size_t>(neg_max_index) >=
             static_cast<size_t>(neg_min_index) + result_value.max_buckets_)
     {
       // We need to downscale the buckets to fit into the new max_buckets_.


### PR DESCRIPTION
## Issue

The count invariant (`count == zero_count + sum(bucket_counts)`) was being violated during `Base2ExponentialHistogramAggregation::Merge()` operations when the combined bucket range of two histograms exceeded `max_buckets` by exactly 1.

## Changes

The offending condition [`if (pos_max_index > pos_min_index + max_buckets) ... `](https://github.com/open-telemetry/opentelemetry-cpp/blob/5fc4707a8b7820f6bdbc782ccdffac7ccafbe80d/sdk/src/metrics/aggregation/base2_exponential_histogram_aggregation.cc#L313) fails when the combined range exceeds `max_buckets` by exactly 1.

Step-by-step example with max_buckets=5 at scale 0:
* Add values `2,4,8,16,32`:  histogram spans indices 0-4
* Add values `4,8,16,32,64`: histogram spans indices 1-5 (64 extends one position beyond the previous range)

During Merge:
* `pos_min_index = min(0, 1) = 0`
* `pos_max_index = max(4, 5) = 5`
* combined range = indices 0-5 = 6 positions = `max_buckets + 1`

Old condition check:
* `pos_max_index > pos_min_index + max_buckets`
* `5 > 0 + 5`
* `5 > 5 = FALSE` <-- downscaling NOT triggered (BUG!)

Fixed condition check:
* `pos_max_index >= pos_min_index + max_buckets`
* `5 >= 0 + 5`
* `5 >= 5 = TRUE` <-- downscaling correctly triggered

When downscaling wasn't triggered but the range exceeded `max_buckets`, `MergeBuckets()` created a result that couldn't fit in the circular buffer, causing bucket counts to be silently lost.

Prometheus rejects histograms with mismatching counts here:  https://github.com/prometheus/prometheus/blob/main/model/histogram/histogram.go#L474


For significant contributions please make sure you have completed the following items:

* ~[ ] `CHANGELOG.md` updated for non-trivial changes~
* [x] Unit tests have been added
* ~[ ] Changes in public API reviewed~