### PR TITLE
[ADMIN] Update link to SIG meeting notes.

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,8 +91,9 @@ contributors' availability. Check the [OpenTelemetry community
 calendar](https://github.com/open-telemetry/community#calendar)
 for specific dates and Zoom meeting links.
 
-Meeting notes are available as a public [Google
-doc](https://docs.google.com/document/d/1i1E4-_y4uJ083lCutKGDhkpi3n4_e774SBLi9hPLocw/edit?usp=sharing).
+Meeting notes are available as a public
+[Google doc](https://docs.google.com/document/d/1rdF6GZcCqH9huo3oqur5x_McsPS_qQ9OPSRFjIqndm8/edit?usp=sharing).
+
 For edit access, get in touch on
 [Slack](https://cloud-native.slack.com/archives/C01N3AT62SJ).
 


### PR DESCRIPTION
Fixes # (issue)

## Changes

Please provide a brief description of the changes here.

* The meeting notes document was moved, due to https://github.com/open-telemetry/community/issues/3182
* Adjust the link accordingly.

For significant contributions please make sure you have completed the following items:

* [ ] `CHANGELOG.md` updated for non-trivial changes
* [ ] Unit tests have been added
* [ ] Changes in public API reviewed