### PR TITLE
[TEST] add test for invalid OTEL_BLRP_SCHEDULE_DELAY env value

### DIFF
--- a/sdk/test/logs/batch_log_record_processor_test.cc
+++ b/sdk/test/logs/batch_log_record_processor_test.cc
@@ -396,6 +396,17 @@ TEST_F(BatchLogRecordProcessorTest, TestScheduleDelayFromEnv)
   unsetenv("OTEL_BLRP_SCHEDULE_DELAY");
 }
 
+TEST_F(BatchLogRecordProcessorTest, TestScheduleDelayInvalidValueFromEnv)
+{
+  setenv("OTEL_BLRP_SCHEDULE_DELAY", "invalid_value", 1);
+
+  BatchLogRecordProcessorOptions options;
+
+  EXPECT_EQ(options.schedule_delay_millis, std::chrono::milliseconds(1000));
+
+  unsetenv("OTEL_BLRP_SCHEDULE_DELAY");
+}
+
 TEST_F(BatchLogRecordProcessorTest, TestExportTimeoutFromEnv)
 {
   setenv("OTEL_BLRP_EXPORT_TIMEOUT", "250ms", 1);


### PR DESCRIPTION
This PR adds a unit test covering the behavior when OTEL_BLRP_SCHEDULE_DELAY
is set to an invalid value.

Invalid values are logged with a warning and the default schedule delay
(1000ms) is used. The new test documents and locks in this fallback behavior
to reduce the risk of future regressions.

Related to #3806 .