### PR TITLE
[BAZEL] Add linkstatic = True to http_client_curl

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -17,9 +17,9 @@ build --copt -DGRPC_BAZEL_BUILD
 build:windows --dynamic_mode=off
 
 # Set minimum supported C++ version
-build:macos --host_cxxopt=-std=c++14 --cxxopt=-std=c++14
-build:linux --host_cxxopt=-std=c++14 --cxxopt=-std=c++14
-build:windows --host_cxxopt=/std:c++14 --cxxopt=/std:c++14
+build:macos --host_cxxopt=-std=c++17 --cxxopt=-std=c++17
+build:linux --host_cxxopt=-std=c++17 --cxxopt=-std=c++17
+build:windows --host_cxxopt=/std:c++17 --cxxopt=/std:c++17
 
 # --config=asan : Address Sanitizer.
 common:asan --copt -DADDRESS_SANITIZER

--- a/.bcr/presubmit.yml
+++ b/.bcr/presubmit.yml
@@ -2,13 +2,13 @@
 # SPDX-License-Identifier: Apache-2.0
 matrix:
   platform: ["debian10", "macos", "ubuntu2004", "windows"]
-  bazel: ["7.x", "8.x", "9.*"]
+  bazel: ["7.x", "8.x", "9.x"]
 tasks:
   verify_targets:
     platform: ${{ platform }}
     bazel: ${{ bazel }}
     build_flags:
-    - '--cxxopt=-std=c++14'
-    - '--host_cxxopt=-std=c++14'
+    - '--cxxopt=-std=c++17'
+    - '--host_cxxopt=-std=c++17'
     build_targets:
     - '@opentelemetry-cpp//api'

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -20,6 +20,7 @@ bazel_dep(name = "prometheus-cpp", version = "1.3.0", repo_name = "com_github_ju
 bazel_dep(name = "protobuf", version = "29.0", repo_name = "com_google_protobuf")
 bazel_dep(name = "rapidyaml", version = "0.9.0")
 bazel_dep(name = "rules_cc", version = "0.2.9")
+bazel_dep(name = "rules_foreign_cc", version = "0.15.1")
 bazel_dep(name = "rules_proto", version = "7.0.2")
 bazel_dep(name = "zlib", version = "1.3.1.bcr.5")
 

--- a/ext/src/http/client/curl/BUILD
+++ b/ext/src/http/client/curl/BUILD
@@ -22,6 +22,7 @@ cc_library(
         ],
         "//conditions:default": [],
     }),
+    linkstatic = True,
     deps = [
         "//api",
         "//ext:headers",


### PR DESCRIPTION
Fixes # (issue)

## Context
When consuming opentelemetry-cpp 1.24.0 via Bazel 9 using toolchains_llvm on linux, I ran into link errors like:
```
cc_wrapper.sh failed: error executing CppLink command (from cc_test rule target //cpp/example_meerkat:example_meerkat_unit_test) external/toolchains_llvm++llvm+llvm_toolchain/bin/cc_wrapper.sh @bazel-out/k8-opt/bin/cpp/example_meerkat/example_meerkat_unit_test-0.params

Use --sandbox_debug to see verbose messages from the sandbox and retain the sandbox build root for debugging
ld.lld: error: undefined reference: curl_global_init
>>> referenced by bazel-out/k8-opt/bin/_solib_k8/libexternal_Sopentelemetry-cpp+_Sext_Ssrc_Shttp_Sclient_Scurl_Slibhttp_Uclient_Ucurl.so (disallowed by --no-allow-shlib-undefined)
```
My project built fine on mac, and Claude suggested that the problem is that opentelemetry-cpp's `http_client_curl` isn't statically linking against curl. If I'm reading it right, the recommendation in [library-distribution.md](https://github.com/open-telemetry/opentelemetry-cpp/blob/main/docs/library-distribution.md#recommendations) seems to suggest linking deps statically as well.

Please let me know if there's a better way to solve this problem.

## Changes

* Add `linkstatic = True` to the `http_client_curl` cc_library target

This ensures the curl HTTP client is statically linked when used as a dependency, matching (what I think is) the default CMake behavior.

## Testing?
 - [x] bazel test //ext/test/http:curl_http_test
 - [x] built my project against this patch in my [bcr fork](https://github.com/bazelbuild/bazel-central-registry/compare/main...aaylward:bazel-central-registry:otel_cpp_bazel_8_9)

## Significant changes require:
* [ ] `CHANGELOG.md` updated for non-trivial changes
* [ ] Unit tests have been added
* [ ] Changes in public API reviewed