### PR TITLE
[SDK] Trace StartSpan - do not call GetCurrentSpan() unless needed

### DIFF
--- a/sdk/src/trace/tracer.cc
+++ b/sdk/src/trace/tracer.cc
@@ -71,7 +71,7 @@ nostd::shared_ptr<opentelemetry::trace::Span> Tracer::StartSpan(
     auto span_context = nostd::get<opentelemetry::trace::SpanContext>(options.parent);
     if (span_context.IsValid())
     {
-      parent_context = span_context;
+      parent_context      = span_context;
       get_current_context = false;
     }
   }
@@ -82,7 +82,7 @@ nostd::shared_ptr<opentelemetry::trace::Span> Tracer::StartSpan(
     auto span_context = opentelemetry::trace::GetSpan(context)->GetContext();
     if (span_context.IsValid())
     {
-      parent_context = span_context;
+      parent_context      = span_context;
       get_current_context = false;
     }
     else


### PR DESCRIPTION
Fixes # (issue)
it turns out that calling GetCurrentSpan() is not a very cheap operation.  it is not uncommon to have that single call take ~10% of the functions total time. Calling it without using the result seems to cause needless slowdown of the user application.

## Changes

opentelemetry-cpp/sdk/src/trace/tracer.cc StartSpan used to call GetCurrentSpan() regardless if the caller came with a parent context or not, causing work to be performed that would be thrown away in the if statements right after.

## 
I am using opentelemetry-cpp via conan. The issue was observed with version 1.24.0 (https://conan.io/center/recipes/opentelemetry-cpp?version=1.24.0) currently the latest available on conan center.
I am unable to link the application to a local version of opentelemtry-cpp, and I am therefore unable to verify this change with the application that found the issue.


please make edits as you see fit.


Here is a picture of a trace that illustrates the issue. Time flows left to right, stacks go top to bottom. The marked box on the left is GetCurrentSpan(), a couple of boxes to the right are related such as calling GetContext() on the span, destroying,  and deleting a DefaultSpan. in this particular instance GetCurrentSpan() took 2.4us while the entire StartSpan() took 16us.
<img width="1601" height="206" alt="image" src="https://github.com/user-attachments/assets/803ba5f7-46ac-4487-863c-e702f5993ec6" />
