### PR TITLE
[CODE HEALTH] Fix clang-tidy performance-for-range-copy warnings

### DIFF
--- a/exporters/ostream/include/opentelemetry/exporters/ostream/common_utils.h
+++ b/exporters/ostream/include/opentelemetry/exporters/ostream/common_utils.h
@@ -31,7 +31,7 @@ void print_value(const std::vector<T> &vec, std::ostream &sout)
   sout << '[';
   size_t i  = 1;
   size_t sz = vec.size();
-  for (auto v : vec)
+  for (const auto &v : vec)
   {
     sout << v;
     if (i != sz)
@@ -47,7 +47,7 @@ void print_value(const nostd::span<T> &vec, std::ostream &sout)
   sout << '[';
   size_t i  = 1;
   size_t sz = vec.size();
-  for (auto v : vec)
+  for (const auto &v : vec)
   {
     sout << v;
     if (i != sz)

--- a/sdk/include/opentelemetry/sdk/common/attributemap_hash.h
+++ b/sdk/include/opentelemetry/sdk/common/attributemap_hash.h
@@ -32,7 +32,7 @@ inline void GetHash(size_t &seed, const T &arg)
 template <class T>
 inline void GetHash(size_t &seed, const std::vector<T> &arg)
 {
-  for (auto v : arg)
+  for (const auto &v : arg)
   {
     GetHash<T>(seed, v);
   }

--- a/sdk/include/opentelemetry/sdk/instrumentationscope/scope_configurator.h
+++ b/sdk/include/opentelemetry/sdk/instrumentationscope/scope_configurator.h
@@ -89,7 +89,7 @@ public:
       return ScopeConfigurator<T>(
           [conditions_ = this->conditions_, default_scope_config_ = this->default_scope_config_](
               const InstrumentationScope &scope_info) {
-            for (Condition condition : conditions_)
+            for (const Condition &condition : conditions_)
             {
               if (condition.scope_matcher(scope_info))
               {


### PR DESCRIPTION
Fixes clang-tidy warnings

----

performance-for-range-copy (3 warnings)

| File | Line | Message |
|---|---|---|
| `opentelemetry-cpp/exporters/ostream/include/opentelemetry/exporters/ostream/common_utils.h` | 34 | loop variable is copied but only used as const reference; consider making it a const reference |
| `opentelemetry-cpp/sdk/include/opentelemetry/sdk/common/attributemap_hash.h` | 35 | loop variable is copied but only used as const reference; consider making it a const reference |
| `opentelemetry-cpp/sdk/include/opentelemetry/sdk/instrumentationscope/scope_configurator.h` | 92 | loop variable is copied but only used as const reference; consider making it a const reference |


----

## Changes

- fix performance-for-range-copy warnings

For significant contributions please make sure you have completed the following items:

* [ ] `CHANGELOG.md` updated for non-trivial changes
* [ ] Unit tests have been added
* [ ] Changes in public API reviewed