### PR TITLE
[TEST] Only run the multi_observer_test when building with ABI v2

### DIFF
--- a/sdk/test/metrics/CMakeLists.txt
+++ b/sdk/test/metrics/CMakeLists.txt
@@ -35,8 +35,7 @@ foreach(
   periodic_exporting_metric_reader_test
   instrument_metadata_validator_test
   metric_test_stress
-  instrument_descriptor_test
-  multi_observer_test)
+  instrument_descriptor_test)
   add_executable(${testname} "${testname}.cc")
   target_link_libraries(
     ${testname} ${GTEST_BOTH_LIBRARIES} ${GMOCK_LIB} ${CMAKE_THREAD_LIBS_INIT}
@@ -47,6 +46,18 @@ foreach(
     TEST_PREFIX metrics.
     TEST_LIST ${testname})
 endforeach()
+
+if(OPENTELEMETRY_ABI_VERSION_NO GREATER_EQUAL 2)
+  add_executable(multi_observer_test multi_observer_test.cc)
+  target_link_libraries(
+    multi_observer_test ${GTEST_BOTH_LIBRARIES} ${GMOCK_LIB}
+    ${CMAKE_THREAD_LIBS_INIT} metrics_common_test_utils opentelemetry_resources)
+  target_compile_definitions(multi_observer_test PRIVATE UNIT_TESTING)
+  gtest_add_tests(
+    TARGET multi_observer_test
+    TEST_PREFIX metrics.
+    TEST_LIST multi_observer_test)
+endif()
 
 if(WITH_BENCHMARK)
   add_executable(attributes_processor_benchmark


### PR DESCRIPTION
The MultiObserverTest cases require ABI v2, however ctest attempts to run test even when CMake is configured with ABI v1. 

`gtest_add_tests()` scans source files with regex at configure time, ignoring #ifdef guards. The four MultiObserverTest cases run and fail locally in the devcontainer (ie: `./ci/do_ci.sh cmake.maintainer.async.test`).

```bash
The following tests FAILED:
        480 - metrics.MultiObserverTest.BasicMultiObservableCallback (Failed)
        481 - metrics.MultiObserverTest.EmptyInstrumentsList (Failed)
        482 - metrics.MultiObserverTest.NonRegisteredInstrument (Failed)
        483 - metrics.MultiObserverTest.CallbackDeregisteredWhenInstrumentDestroyed (Failed)
```

## Changes
- Only add the test when ABI >= 2 in CMakeLists.txt.

For significant contributions please make sure you have completed the following items:

* [ ] `CHANGELOG.md` updated for non-trivial changes
* [ ] Unit tests have been added
* [ ] Changes in public API reviewed