### PR TITLE
[CODE HEALTH] Fix gcc warnings in release maintainer build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -104,14 +104,14 @@ jobs:
     - name: install dependencies
       run: |
         sudo -E ./ci/install_thirdparty.sh --install-dir /usr/local --tags-file third_party_release
-    - name: run cmake gcc (maintainer mode, sync, Release)
-      env:
-        BUILD_TYPE: Release
-      run: |
-        ./ci/do_ci.sh cmake.maintainer.sync.test
     - name: run cmake gcc (maintainer mode, sync, Debug)
       env:
         BUILD_TYPE: Debug
+      run: |
+        ./ci/do_ci.sh cmake.maintainer.sync.test
+    - name: run cmake gcc (maintainer mode, sync, Release)
+      env:
+        BUILD_TYPE: Release
       run: |
         ./ci/do_ci.sh cmake.maintainer.sync.test
     - name: generate test cert
@@ -142,14 +142,14 @@ jobs:
     - name: install dependencies
       run: |
         sudo -E ./ci/install_thirdparty.sh --install-dir /usr/local --tags-file third_party_release
-    - name: run cmake gcc (maintainer mode, async, Release)
-      env:
-        BUILD_TYPE: Release
-      run: |
-        ./ci/do_ci.sh cmake.maintainer.async.test
     - name: run cmake gcc (maintainer mode, async, Debug)
       env:
         BUILD_TYPE: Debug
+      run: |
+        ./ci/do_ci.sh cmake.maintainer.async.test
+    - name: run cmake gcc (maintainer mode, async, Release)
+      env:
+        BUILD_TYPE: Release
       run: |
         ./ci/do_ci.sh cmake.maintainer.async.test
     - name: generate test cert

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -104,7 +104,14 @@ jobs:
     - name: install dependencies
       run: |
         sudo -E ./ci/install_thirdparty.sh --install-dir /usr/local --tags-file third_party_release
-    - name: run cmake gcc (maintainer mode, sync)
+    - name: run cmake gcc (maintainer mode, sync, Release)
+      env:
+        BUILD_TYPE: Release
+      run: |
+        ./ci/do_ci.sh cmake.maintainer.sync.test
+    - name: run cmake gcc (maintainer mode, sync, Debug)
+      env:
+        BUILD_TYPE: Debug
       run: |
         ./ci/do_ci.sh cmake.maintainer.sync.test
     - name: generate test cert
@@ -135,7 +142,14 @@ jobs:
     - name: install dependencies
       run: |
         sudo -E ./ci/install_thirdparty.sh --install-dir /usr/local --tags-file third_party_release
-    - name: run cmake gcc (maintainer mode, async)
+    - name: run cmake gcc (maintainer mode, async, Release)
+      env:
+        BUILD_TYPE: Release
+      run: |
+        ./ci/do_ci.sh cmake.maintainer.async.test
+    - name: run cmake gcc (maintainer mode, async, Debug)
+      env:
+        BUILD_TYPE: Debug
       run: |
         ./ci/do_ci.sh cmake.maintainer.async.test
     - name: generate test cert

--- a/exporters/otlp/src/otlp_file_client.cc
+++ b/exporters/otlp/src/otlp_file_client.cc
@@ -1256,7 +1256,8 @@ private:
         strerror_s(error_message, sizeof(error_message) - 1, error_code);
 #else
         char error_message[256] = {0};
-        strerror_r(error_code, error_message, sizeof(error_message) - 1);
+        OPENTELEMETRY_MAYBE_UNUSED auto strerror_r_result =
+            strerror_r(error_code, error_message, sizeof(error_message) - 1);
 #endif
         OTEL_INTERNAL_LOG_ERROR("[OTLP FILE Client] Create directory \""
                                 << directory_name << "\" failed.errno: " << error_code

--- a/sdk/src/metrics/data/circular_buffer.cc
+++ b/sdk/src/metrics/data/circular_buffer.cc
@@ -123,8 +123,8 @@ void AdaptingIntegerArray::EnlargeToFit(uint64_t value)
   {
     backing = std::vector<uint64_t>(backing_size, 0);
   }
-  std::swap(backing_, backing);
-  nostd::visit(AdaptingIntegerArrayCopy{}, backing, backing_);
+  nostd::visit(AdaptingIntegerArrayCopy{}, backing_, backing);
+  backing_ = std::move(backing);
 }
 
 void AdaptingCircularBufferCounter::Clear()


### PR DESCRIPTION
Fixes #3983

## Changes

- Fix `warn_unused_result` in otlp_file_client.cc
- Fix `maybe-uninitialized` in circular_buffer.cc
- Update CI to run the gcc maintainer tests in both release and debug

For significant contributions please make sure you have completed the following items:

* [ ] `CHANGELOG.md` updated for non-trivial changes
* [ ] Unit tests have been added
* [ ] Changes in public API reviewed