### PR TITLE
[CODE HEALTH] Fix clang-tidy misc-use-internal-linkage warnings

### DIFF
--- a/.github/workflows/clang-tidy.yaml
+++ b/.github/workflows/clang-tidy.yaml
@@ -17,9 +17,9 @@ jobs:
       matrix:
         include:
           - cmake_options: all-options-abiv1-preview
-            warning_limit: 57
+            warning_limit: 53
           - cmake_options: all-options-abiv2-preview
-            warning_limit: 59
+            warning_limit: 55
     env:
       CC: /usr/bin/clang-18
       CXX: /usr/bin/clang++-18

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,9 @@ Increment the:
 * [CODE HEALTH] Cleanup nostd variant access in API and SDK
   [#3965](https://github.com/open-telemetry/opentelemetry-cpp/pull/3965)
 
+* [CODE HEALTH] Fix clang-tidy misc-use-internal-linkage warnings
+  [#3977](https://github.com/open-telemetry/opentelemetry-cpp/issues/3977)
+
 * Enable WITH_OTLP_RETRY_PREVIEW by default
   [#3953](https://github.com/open-telemetry/opentelemetry-cpp/pull/3953)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,7 +38,7 @@ Increment the:
   [#3965](https://github.com/open-telemetry/opentelemetry-cpp/pull/3965)
 
 * [CODE HEALTH] Fix clang-tidy misc-use-internal-linkage warnings
-  [#3977](https://github.com/open-telemetry/opentelemetry-cpp/issues/3977)
+  [#3985](https://github.com/open-telemetry/opentelemetry-cpp/pull/3985)
 
 * Enable WITH_OTLP_RETRY_PREVIEW by default
   [#3953](https://github.com/open-telemetry/opentelemetry-cpp/pull/3953)

--- a/examples/common/foo_library/foo_library.cc
+++ b/examples/common/foo_library/foo_library.cc
@@ -8,6 +8,12 @@
 #include "opentelemetry/trace/tracer.h"
 #include "opentelemetry/trace/tracer_provider.h"
 
+#ifdef BAZEL_BUILD
+#  include "examples/common/foo_library/foo_library.h"
+#else
+#  include "foo_library/foo_library.h"
+#endif
+
 namespace trace = opentelemetry::trace;
 namespace nostd = opentelemetry::nostd;
 
@@ -33,7 +39,6 @@ void f2()
 }
 }  // namespace
 
-// NOLINTNEXTLINE(misc-use-internal-linkage)
 void foo_library()
 {
   auto scoped_span = trace::Scope(get_tracer()->StartSpan("library"));

--- a/examples/common/foo_library/foo_library.cc
+++ b/examples/common/foo_library/foo_library.cc
@@ -33,6 +33,7 @@ void f2()
 }
 }  // namespace
 
+// NOLINTNEXTLINE(misc-use-internal-linkage)
 void foo_library()
 {
   auto scoped_span = trace::Scope(get_tracer()->StartSpan("library"));

--- a/examples/common/logs_foo_library/foo_library.cc
+++ b/examples/common/logs_foo_library/foo_library.cc
@@ -31,6 +31,7 @@ opentelemetry::nostd::shared_ptr<logs::Logger> get_logger()
 }
 }  // namespace
 
+// NOLINTNEXTLINE(misc-use-internal-linkage)
 void foo_library()
 {
   auto span        = get_tracer()->StartSpan("span 1");

--- a/examples/common/logs_foo_library/foo_library.cc
+++ b/examples/common/logs_foo_library/foo_library.cc
@@ -13,6 +13,12 @@
 #include "opentelemetry/trace/tracer.h"
 #include "opentelemetry/trace/tracer_provider.h"
 
+#ifdef BAZEL_BUILD
+#  include "examples/common/logs_foo_library/foo_library.h"
+#else
+#  include "logs_foo_library/foo_library.h"
+#endif
+
 namespace logs  = opentelemetry::logs;
 namespace trace = opentelemetry::trace;
 
@@ -31,7 +37,6 @@ opentelemetry::nostd::shared_ptr<logs::Logger> get_logger()
 }
 }  // namespace
 
-// NOLINTNEXTLINE(misc-use-internal-linkage)
 void foo_library()
 {
   auto span        = get_tracer()->StartSpan("span 1");

--- a/functional/otlp/func_grpc_main.cc
+++ b/functional/otlp/func_grpc_main.cc
@@ -353,7 +353,7 @@ static const test_case all_tests[] = {{"basic", test_basic},
 #endif  // ENABLE_OTLP_GRPC_SSL_MTLS_PREVIEW
                                       {"", nullptr}};
 
-void list_test_cases()
+static void list_test_cases()
 {
   const test_case *current = all_tests;
 

--- a/sdk/test/common/circular_buffer_benchmark.cc
+++ b/sdk/test/common/circular_buffer_benchmark.cc
@@ -55,7 +55,7 @@ static uint64_t ConsumeBufferNumbers(CircularBuffer<uint64_t> &buffer) noexcept
 template <class Buffer>
 static void GenerateNumbersForThread(Buffer &buffer, int n, std::atomic<uint64_t> &sum) noexcept
 {
-  thread_local std::mt19937_64 random_number_generator{std::random_device{}()};
+  static thread_local std::mt19937_64 random_number_generator{std::random_device{}()};
   for (int i = 0; i < n; ++i)
   {
     auto x = random_number_generator();


### PR DESCRIPTION
Fixes #3977

marked `list_test_cases` in `func_grpc_main.cc` as static since it is only called in the same TU, and added `static` to the `thread_local` RNG in `circular_buffer_benchmark.cc`. the two `foo_library` functions in `examples/common/foo_library` and `examples/common/logs_foo_library` are exported via headers and linked into many example binaries, so internal linkage is not possible there. suppressed those with NOLINTNEXTLINE.

also decremented the clang-tidy warning limits by 4 to match the reduced unique warning count, consistent with prior code-health PRs.

keeping as draft until clang-tidy CI confirms the new limits are correct.

## Changes

* Fix clang-tidy `misc-use-internal-linkage` warnings.

For significant contributions please make sure you have completed the following items:

* [X] `CHANGELOG.md` updated for non-trivial changes
* [ ] Unit tests have been added
* [ ] Changes in public API reviewed