### PR TITLE
[Bazel] Add ENABLE_OTLP_GRPC_SSL_MTLS_PREVIEW define to otlp_grpc_log_record_exporter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,9 @@ Increment the:
 * Enable WITH_OTLP_GRPC_SSL_MTLS_PREVIEW by default
   [#3970](https://github.com/open-telemetry/opentelemetry-cpp/pull/3970)
 
+* [BAZEL] Add ENABLE_OTLP_GRPC_SSL_MTLS_PREVIEW define to otlp_grpc_log_record_exporter
+  [#3988](https://github.com/open-telemetry/opentelemetry-cpp/pull/3988)
+
 Important changes:
 
 * Enable WITH_OTLP_RETRY_PREVIEW by default

--- a/exporters/otlp/BUILD
+++ b/exporters/otlp/BUILD
@@ -583,6 +583,7 @@ cc_library(
         "include/opentelemetry/exporters/otlp/protobuf_include_prefix.h",
         "include/opentelemetry/exporters/otlp/protobuf_include_suffix.h",
     ],
+    defines = ["ENABLE_OTLP_GRPC_SSL_MTLS_PREVIEW"],
     strip_include_prefix = "include",
     tags = [
         "otlp",


### PR DESCRIPTION
## Changes

Add missing `defines = ["ENABLE_OTLP_GRPC_SSL_MTLS_PREVIEW"]` to the
`otlp_grpc_log_record_exporter` Bazel target in `exporters/otlp/BUILD`.

For significant contributions please make sure you have completed the following items:

* [x] `CHANGELOG.md` updated for non-trivial changes
* [ ] Unit tests have been added
* [ ] Changes in public API reviewed