### PR TITLE
[CODE HEALTH] Fix clang-tidy narrowing conversions in baggage

### DIFF
--- a/.github/workflows/clang-tidy.yaml
+++ b/.github/workflows/clang-tidy.yaml
@@ -17,9 +17,9 @@ jobs:
       matrix:
         include:
           - cmake_options: all-options-abiv1-preview
-            warning_limit: 57
+            warning_limit: 54
           - cmake_options: all-options-abiv2-preview
-            warning_limit: 59
+            warning_limit: 56
     env:
       CC: /usr/bin/clang-18
       CXX: /usr/bin/clang++-18

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,9 @@ Increment the:
 * [CODE HEALTH] Cleanup nostd variant access in API and SDK
   [#3965](https://github.com/open-telemetry/opentelemetry-cpp/pull/3965)
 
+* [CODE HEALTH] Fix clang-tidy narrowing conversions in baggage
+  [#3989](https://github.com/open-telemetry/opentelemetry-cpp/pull/3989)
+
 * Enable WITH_OTLP_RETRY_PREVIEW by default
   [#3953](https://github.com/open-telemetry/opentelemetry-cpp/pull/3953)
 

--- a/api/include/opentelemetry/baggage/baggage.h
+++ b/api/include/opentelemetry/baggage/baggage.h
@@ -235,8 +235,8 @@ private:
       else
       {
         ret.push_back('%');
-        ret.push_back(to_hex(c >> 4));
-        ret.push_back(to_hex(c & 15));
+        ret.push_back(to_hex(static_cast<char>(c >> 4)));
+        ret.push_back(to_hex(static_cast<char>(c & 15)));
       }
     }
 
@@ -267,7 +267,7 @@ private:
           err = 1;
           return "";
         }
-        ret.push_back(from_hex(str[i + 1]) << 4 | from_hex(str[i + 2]));
+        ret.push_back(static_cast<char>(from_hex(str[i + 1]) << 4 | from_hex(str[i + 2])));
         i += 2;
       }
       else if (str[i] == '+')


### PR DESCRIPTION
Fixes #3980
Contributes to #2053

## Changes

- Wrap three implicit `int -> char` conversions inside `Baggage::UrlEncode`
  and `Baggage::UrlDecode` with explicit `static_cast<char>(...)` so that
  `cppcoreguidelines-narrowing-conversions` stops firing under clang-tidy 20.
- Decrement the `clang-tidy.yaml` `warning_limit` by 3 for both
  `all-options-abiv1-preview` and `all-options-abiv2-preview` matrix entries
  to ratchet the limit down to the new measured count.

The arithmetic is unchanged: `c >> 4` and `c & 15` are already bounded to
`[0, 15]` by the existing shift/mask, and the bitwise OR of two `from_hex`
nibbles in `UrlDecode` fits in a single byte. PR #1353 already added the same
`static_cast<char>` inside the `from_hex` lambda body back in 2022; this
change just finishes the job at the call sites that clang-tidy 20 newly
flags.

Fixes the following warnings:

----

**opentelemetry-cpp/api/include/opentelemetry/baggage/baggage.h** (3 warnings)

| Line | Check | Message |
|---|---|---|
| 238 | `cppcoreguidelines-narrowing-conversions` | narrowing conversion from 'int' to signed type 'char' is implementation-defined |
| 239 | `cppcoreguidelines-narrowing-conversions` | narrowing conversion from 'int' to signed type 'char' is implementation-defined |
| 270 | `cppcoreguidelines-narrowing-conversions` | narrowing conversion from 'int' to signed type 'char' is implementation-defined |

----

For significant contributions please make sure you have completed the following items:

* [x] `CHANGELOG.md` updated for non-trivial changes
* [ ] Unit tests have been added
* [x] Changes in public API reviewed
