### PR TITLE
[EXPORTER] Implement non-utf8 string to bytes in OTLP

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,9 @@ Increment the:
 * [CODE HEALTH] Fix clang-tidy narrowing conversions in baggage
   [#3989](https://github.com/open-telemetry/opentelemetry-cpp/pull/3989)
 
+* [EXPORTER] implement non-utf8 string to bytes in OTLP exporters
+  [#3991](https://github.com/open-telemetry/opentelemetry-cpp/pull/3991)
+
 * [CODE HEALTH] Fix misc clang-tidy warnings
   [#3993](https://github.com/open-telemetry/opentelemetry-cpp/pull/3993)
 
@@ -106,6 +109,10 @@ Important changes:
   * Bazel now always builds with ENABLE_OTLP_GRPC_SSL_MTLS_PREVIEW.
   * grpc properties for ssl KEY and CERT are always available,
     adjust the application code to initialize all members in grpc options.
+
+* Add WITH_OTLP_UTF8_VALIDITY for CMake and enable ENABLE_OTLP_UTF8_VALIDITY for
+  Bazel to export non-UTF-8 strings as bytes in OTLP.
+  [#3991](https://github.com/open-telemetry/opentelemetry-cpp/pull/3991)
 
 * Enable ENABLE_OTLP_RETRY_PREVIEW for bazel
   [#4010](https://github.com/open-telemetry/opentelemetry-cpp/pull/4010)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -153,6 +153,10 @@ option(
   "Whether to include gzip compression for the OTLP http exporter in the SDK"
   OFF)
 
+option(
+  WITH_OTLP_UTF8_VALIDITY
+  "Whether to enable UTF-8 validity checks for the OTLP exporter in the SDK" ON)
+
 option(WITH_CURL_LOGGING "Whether to enable select CURL verbosity in OTel logs"
        OFF)
 

--- a/cmake/protobuf.cmake
+++ b/cmake/protobuf.cmake
@@ -108,6 +108,12 @@ message(STATUS "PROTOBUF_PROTOC_EXECUTABLE=${PROTOBUF_PROTOC_EXECUTABLE}")
 # but may need the alias target created
 if(TARGET utf8_validity AND NOT TARGET utf8_range::utf8_validity)
   add_library(utf8_range::utf8_validity ALIAS utf8_validity)
+  if(protobuf_SOURCE_DIR AND EXISTS
+                             "${protobuf_SOURCE_DIR}/third_party/utf8_range")
+    target_include_directories(
+      utf8_validity
+      PUBLIC "$<BUILD_INTERFACE:${protobuf_SOURCE_DIR}/third_party/utf8_range>")
+  endif()
 endif()
 
 # For the find_package(Protobuf) path, utf8_range can also be found

--- a/cmake/protobuf.cmake
+++ b/cmake/protobuf.cmake
@@ -1,29 +1,37 @@
 # Copyright The OpenTelemetry Authors
 # SPDX-License-Identifier: Apache-2.0
 
+# Import Protobuf targets (protobuf::libprotobuf and protobuf::protoc) and set
+# PROTOBUF_PROTOC_EXECUTABLE. 1. If gRPC was fetched from github then use the
+# Protobuf submodule built with gRPC 2. Find an installed Protobuf package 3.
+# Use FetchContent to fetch and build Protobuf from GitHub
 
-# Import Protobuf targets (protobuf::libprotobuf and protobuf::protoc) and set PROTOBUF_PROTOC_EXECUTABLE.
-# 1. If gRPC was fetched from github then use the Protobuf submodule built with gRPC
-# 2. Find an installed Protobuf package
-# 3. Use FetchContent to fetch and build Protobuf from GitHub
-
-if(DEFINED gRPC_PROVIDER AND NOT gRPC_PROVIDER STREQUAL "find_package" AND TARGET libprotobuf)
+if(DEFINED gRPC_PROVIDER
+   AND NOT gRPC_PROVIDER STREQUAL "find_package"
+   AND TARGET libprotobuf)
   # gRPC was fetched and built Protobuf as a submodule
 
-  set(_Protobuf_VERSION_REGEX "\"cpp\"[ \t]*:[ \t]*\"([0-9]+\\.[0-9]+(\\.[0-9]+)?)\"")
-  set(_Protobuf_VERSION_FILE "${grpc_SOURCE_DIR}/third_party/protobuf/version.json")
+  set(_Protobuf_VERSION_REGEX
+      "\"cpp\"[ \t]*:[ \t]*\"([0-9]+\\.[0-9]+(\\.[0-9]+)?)\"")
+  set(_Protobuf_VERSION_FILE
+      "${grpc_SOURCE_DIR}/third_party/protobuf/version.json")
 
   file(READ "${_Protobuf_VERSION_FILE}" _Protobuf_VERSION_FILE_CONTENTS)
   if(_Protobuf_VERSION_FILE_CONTENTS MATCHES ${_Protobuf_VERSION_REGEX})
     set(Protobuf_VERSION "${CMAKE_MATCH_1}")
   else()
-    message(WARNING "Failed to parse Protobuf version from ${_Protobuf_VERSION_FILE} using regex ${_Protobuf_VERSION_REGEX}")
+    message(
+      WARNING
+        "Failed to parse Protobuf version from ${_Protobuf_VERSION_FILE} using regex ${_Protobuf_VERSION_REGEX}"
+    )
   endif()
   set(Protobuf_PROVIDER "grpc_submodule")
 else()
 
-  # Search for an installed Protobuf package explicitly using the CONFIG search mode first followed by the MODULE search mode.
-  # Protobuf versions < 3.22.0 may be found using the module mode and some protobuf apt packages do not support the CONFIG search.
+  # Search for an installed Protobuf package explicitly using the CONFIG search
+  # mode first followed by the MODULE search mode. Protobuf versions < 3.22.0
+  # may be found using the module mode and some protobuf apt packages do not
+  # support the CONFIG search.
 
   find_package(Protobuf CONFIG QUIET)
   set(Protobuf_PROVIDER "find_package")
@@ -36,33 +44,48 @@ else()
     FetchContent_Declare(
       "protobuf"
       GIT_REPOSITORY "https://github.com/protocolbuffers/protobuf.git"
-      GIT_TAG "${protobuf_GIT_TAG}"
-    )
+      GIT_TAG "${protobuf_GIT_TAG}")
 
-    set(protobuf_INSTALL ${OPENTELEMETRY_INSTALL} CACHE BOOL "" FORCE)
-    set(protobuf_BUILD_TESTS OFF CACHE BOOL "" FORCE)
-    set(protobuf_BUILD_EXAMPLES OFF CACHE BOOL "" FORCE)
+    set(protobuf_INSTALL
+        ${OPENTELEMETRY_INSTALL}
+        CACHE BOOL "" FORCE)
+    set(protobuf_BUILD_TESTS
+        OFF
+        CACHE BOOL "" FORCE)
+    set(protobuf_BUILD_EXAMPLES
+        OFF
+        CACHE BOOL "" FORCE)
 
     FetchContent_MakeAvailable(protobuf)
 
     set(Protobuf_PROVIDER "fetch_repository")
 
     # Set the Protobuf_VERSION variable from the git tag.
-    string(REGEX REPLACE "^v([0-9]+\\.[0-9]+\\.[0-9]+)$" "\\1" Protobuf_VERSION "${protobuf_GIT_TAG}")
+    string(REGEX REPLACE "^v([0-9]+\\.[0-9]+\\.[0-9]+)$" "\\1" Protobuf_VERSION
+                         "${protobuf_GIT_TAG}")
 
     if(TARGET libprotobuf)
-      set_target_properties(libprotobuf PROPERTIES POSITION_INDEPENDENT_CODE ON CXX_CLANG_TIDY "" CXX_INCLUDE_WHAT_YOU_USE "")
+      set_target_properties(
+        libprotobuf
+        PROPERTIES POSITION_INDEPENDENT_CODE ON
+                   CXX_CLANG_TIDY ""
+                   CXX_INCLUDE_WHAT_YOU_USE "")
     endif()
 
   endif()
 endif()
 
 if(NOT TARGET protobuf::libprotobuf)
-  message(FATAL_ERROR "A required protobuf target (protobuf::libprotobuf) was not imported")
+  message(
+    FATAL_ERROR
+      "A required protobuf target (protobuf::libprotobuf) was not imported")
 endif()
 
 if(PROTOBUF_PROTOC_EXECUTABLE AND NOT Protobuf_PROTOC_EXECUTABLE)
-  message(WARNING "Use of PROTOBUF_PROTOC_EXECUTABLE is deprecated. Please use Protobuf_PROTOC_EXECUTABLE instead.")
+  message(
+    WARNING
+      "Use of PROTOBUF_PROTOC_EXECUTABLE is deprecated. Please use Protobuf_PROTOC_EXECUTABLE instead."
+  )
   set(Protobuf_PROTOC_EXECUTABLE "${PROTOBUF_PROTOC_EXECUTABLE}")
 endif()
 
@@ -70,7 +93,9 @@ if(CMAKE_CROSSCOMPILING)
   find_program(Protobuf_PROTOC_EXECUTABLE protoc)
 else()
   if(NOT TARGET protobuf::protoc)
-    message(FATAL_ERROR "A required protobuf target (protobuf::protoc) was not imported")
+    message(
+      FATAL_ERROR
+        "A required protobuf target (protobuf::protoc) was not imported")
   endif()
   set(Protobuf_PROTOC_EXECUTABLE "$<TARGET_FILE:protobuf::protoc>")
 endif()
@@ -78,3 +103,23 @@ endif()
 set(PROTOBUF_PROTOC_EXECUTABLE "${Protobuf_PROTOC_EXECUTABLE}")
 
 message(STATUS "PROTOBUF_PROTOC_EXECUTABLE=${PROTOBUF_PROTOC_EXECUTABLE}")
+
+# When protobuf is fetched or built as a gRPC submodule utf8_range is compiled
+# but may need the alias target created
+if(TARGET utf8_validity AND NOT TARGET utf8_range::utf8_validity)
+  add_library(utf8_range::utf8_validity ALIAS utf8_validity)
+endif()
+
+# For the find_package(Protobuf) path, utf8_range can also be found
+if(NOT TARGET utf8_range::utf8_validity)
+  find_package(utf8_range CONFIG QUIET)
+endif()
+
+# The utf8_range target should now be available for use in otel-cpp
+if(NOT TARGET utf8_range::utf8_validity)
+  message(
+    WARNING
+      "Target (utf8_range::utf8_validity) was not found. "
+      "We will not validate UTF-8 strings in the OTLP exporter."
+      "Which may lead to record drops when sending non UTF-8 data as string.")
+endif()

--- a/cmake/protobuf.cmake
+++ b/cmake/protobuf.cmake
@@ -1,37 +1,29 @@
 # Copyright The OpenTelemetry Authors
 # SPDX-License-Identifier: Apache-2.0
 
-# Import Protobuf targets (protobuf::libprotobuf and protobuf::protoc) and set
-# PROTOBUF_PROTOC_EXECUTABLE. 1. If gRPC was fetched from github then use the
-# Protobuf submodule built with gRPC 2. Find an installed Protobuf package 3.
-# Use FetchContent to fetch and build Protobuf from GitHub
 
-if(DEFINED gRPC_PROVIDER
-   AND NOT gRPC_PROVIDER STREQUAL "find_package"
-   AND TARGET libprotobuf)
+# Import Protobuf targets (protobuf::libprotobuf and protobuf::protoc) and set PROTOBUF_PROTOC_EXECUTABLE.
+# 1. If gRPC was fetched from github then use the Protobuf submodule built with gRPC
+# 2. Find an installed Protobuf package
+# 3. Use FetchContent to fetch and build Protobuf from GitHub
+
+if(DEFINED gRPC_PROVIDER AND NOT gRPC_PROVIDER STREQUAL "find_package" AND TARGET libprotobuf)
   # gRPC was fetched and built Protobuf as a submodule
 
-  set(_Protobuf_VERSION_REGEX
-      "\"cpp\"[ \t]*:[ \t]*\"([0-9]+\\.[0-9]+(\\.[0-9]+)?)\"")
-  set(_Protobuf_VERSION_FILE
-      "${grpc_SOURCE_DIR}/third_party/protobuf/version.json")
+  set(_Protobuf_VERSION_REGEX "\"cpp\"[ \t]*:[ \t]*\"([0-9]+\\.[0-9]+(\\.[0-9]+)?)\"")
+  set(_Protobuf_VERSION_FILE "${grpc_SOURCE_DIR}/third_party/protobuf/version.json")
 
   file(READ "${_Protobuf_VERSION_FILE}" _Protobuf_VERSION_FILE_CONTENTS)
   if(_Protobuf_VERSION_FILE_CONTENTS MATCHES ${_Protobuf_VERSION_REGEX})
     set(Protobuf_VERSION "${CMAKE_MATCH_1}")
   else()
-    message(
-      WARNING
-        "Failed to parse Protobuf version from ${_Protobuf_VERSION_FILE} using regex ${_Protobuf_VERSION_REGEX}"
-    )
+    message(WARNING "Failed to parse Protobuf version from ${_Protobuf_VERSION_FILE} using regex ${_Protobuf_VERSION_REGEX}")
   endif()
   set(Protobuf_PROVIDER "grpc_submodule")
 else()
 
-  # Search for an installed Protobuf package explicitly using the CONFIG search
-  # mode first followed by the MODULE search mode. Protobuf versions < 3.22.0
-  # may be found using the module mode and some protobuf apt packages do not
-  # support the CONFIG search.
+  # Search for an installed Protobuf package explicitly using the CONFIG search mode first followed by the MODULE search mode.
+  # Protobuf versions < 3.22.0 may be found using the module mode and some protobuf apt packages do not support the CONFIG search.
 
   find_package(Protobuf CONFIG QUIET)
   set(Protobuf_PROVIDER "find_package")
@@ -44,48 +36,33 @@ else()
     FetchContent_Declare(
       "protobuf"
       GIT_REPOSITORY "https://github.com/protocolbuffers/protobuf.git"
-      GIT_TAG "${protobuf_GIT_TAG}")
+      GIT_TAG "${protobuf_GIT_TAG}"
+    )
 
-    set(protobuf_INSTALL
-        ${OPENTELEMETRY_INSTALL}
-        CACHE BOOL "" FORCE)
-    set(protobuf_BUILD_TESTS
-        OFF
-        CACHE BOOL "" FORCE)
-    set(protobuf_BUILD_EXAMPLES
-        OFF
-        CACHE BOOL "" FORCE)
+    set(protobuf_INSTALL ${OPENTELEMETRY_INSTALL} CACHE BOOL "" FORCE)
+    set(protobuf_BUILD_TESTS OFF CACHE BOOL "" FORCE)
+    set(protobuf_BUILD_EXAMPLES OFF CACHE BOOL "" FORCE)
 
     FetchContent_MakeAvailable(protobuf)
 
     set(Protobuf_PROVIDER "fetch_repository")
 
     # Set the Protobuf_VERSION variable from the git tag.
-    string(REGEX REPLACE "^v([0-9]+\\.[0-9]+\\.[0-9]+)$" "\\1" Protobuf_VERSION
-                         "${protobuf_GIT_TAG}")
+    string(REGEX REPLACE "^v([0-9]+\\.[0-9]+\\.[0-9]+)$" "\\1" Protobuf_VERSION "${protobuf_GIT_TAG}")
 
     if(TARGET libprotobuf)
-      set_target_properties(
-        libprotobuf
-        PROPERTIES POSITION_INDEPENDENT_CODE ON
-                   CXX_CLANG_TIDY ""
-                   CXX_INCLUDE_WHAT_YOU_USE "")
+      set_target_properties(libprotobuf PROPERTIES POSITION_INDEPENDENT_CODE ON CXX_CLANG_TIDY "" CXX_INCLUDE_WHAT_YOU_USE "")
     endif()
 
   endif()
 endif()
 
 if(NOT TARGET protobuf::libprotobuf)
-  message(
-    FATAL_ERROR
-      "A required protobuf target (protobuf::libprotobuf) was not imported")
+  message(FATAL_ERROR "A required protobuf target (protobuf::libprotobuf) was not imported")
 endif()
 
 if(PROTOBUF_PROTOC_EXECUTABLE AND NOT Protobuf_PROTOC_EXECUTABLE)
-  message(
-    WARNING
-      "Use of PROTOBUF_PROTOC_EXECUTABLE is deprecated. Please use Protobuf_PROTOC_EXECUTABLE instead."
-  )
+  message(WARNING "Use of PROTOBUF_PROTOC_EXECUTABLE is deprecated. Please use Protobuf_PROTOC_EXECUTABLE instead.")
   set(Protobuf_PROTOC_EXECUTABLE "${PROTOBUF_PROTOC_EXECUTABLE}")
 endif()
 
@@ -93,9 +70,7 @@ if(CMAKE_CROSSCOMPILING)
   find_program(Protobuf_PROTOC_EXECUTABLE protoc)
 else()
   if(NOT TARGET protobuf::protoc)
-    message(
-      FATAL_ERROR
-        "A required protobuf target (protobuf::protoc) was not imported")
+    message(FATAL_ERROR "A required protobuf target (protobuf::protoc) was not imported")
   endif()
   set(Protobuf_PROTOC_EXECUTABLE "$<TARGET_FILE:protobuf::protoc>")
 endif()
@@ -106,26 +81,29 @@ message(STATUS "PROTOBUF_PROTOC_EXECUTABLE=${PROTOBUF_PROTOC_EXECUTABLE}")
 
 # When protobuf is fetched or built as a gRPC submodule utf8_range is compiled
 # but may need the alias target created
-if(TARGET utf8_validity AND NOT TARGET utf8_range::utf8_validity)
-  add_library(utf8_range::utf8_validity ALIAS utf8_validity)
-  if(protobuf_SOURCE_DIR AND EXISTS
-                             "${protobuf_SOURCE_DIR}/third_party/utf8_range")
-    target_include_directories(
-      utf8_validity
-      PUBLIC "$<BUILD_INTERFACE:${protobuf_SOURCE_DIR}/third_party/utf8_range>")
+if(WITH_OTLP_UTF8_VALIDITY)
+  if(TARGET utf8_validity AND NOT TARGET utf8_range::utf8_validity)
+    add_library(utf8_range::utf8_validity ALIAS utf8_validity)
+    if(protobuf_SOURCE_DIR AND EXISTS
+                               "${protobuf_SOURCE_DIR}/third_party/utf8_range")
+      target_include_directories(
+        utf8_validity
+        PUBLIC
+          "$<BUILD_INTERFACE:${protobuf_SOURCE_DIR}/third_party/utf8_range>")
+    endif()
   endif()
-endif()
 
-# For the find_package(Protobuf) path, utf8_range can also be found
-if(NOT TARGET utf8_range::utf8_validity)
-  find_package(utf8_range CONFIG QUIET)
-endif()
+  # For the find_package(Protobuf) path, utf8_range can also be found
+  if(NOT TARGET utf8_range::utf8_validity)
+    find_package(utf8_range CONFIG QUIET)
+  endif()
 
-# The utf8_range target should now be available for use in otel-cpp
-if(NOT TARGET utf8_range::utf8_validity)
-  message(
-    WARNING
-      "Target (utf8_range::utf8_validity) was not found. "
-      "We will not validate UTF-8 strings in the OTLP exporter."
-      "Which may lead to record drops when sending non UTF-8 data as string.")
+  # The utf8_range target should now be available for use in otel-cpp
+  if(NOT TARGET utf8_range::utf8_validity)
+    message(
+      WARNING
+        "Target (utf8_range::utf8_validity) was not found. "
+        "We will not validate UTF-8 strings in the OTLP exporter."
+        "Which may lead to record drops when sending non UTF-8 data as string.")
+  endif()
 endif()

--- a/exporters/otlp/BUILD
+++ b/exporters/otlp/BUILD
@@ -8,6 +8,19 @@ load("//bazel:otel_cc_benchmark.bzl", "otel_cc_benchmark")
 
 package(default_visibility = ["//visibility:public"])
 
+# utf8_range from protobuf source tree for UTF-8 validation in OTLP
+# value conversion. This mirrors the CMake opentelemetry_otlp_utf8_validity
+# target.
+cc_library(
+    name = "otlp_utf8_validity",
+    defines = ["ENABLE_OTLP_UTF8_VALIDITY"],
+    tags = ["otlp"],
+    deps = [
+        "@com_google_protobuf//third_party/utf8_range",
+        "@com_google_protobuf//third_party/utf8_range:utf8_validity",
+    ],
+)
+
 cc_library(
     name = "otlp_recordable",
     srcs = [
@@ -32,6 +45,7 @@ cc_library(
     strip_include_prefix = "include",
     tags = ["otlp"],
     deps = [
+        ":otlp_utf8_validity",
         "//sdk/src/logs",
         "//sdk/src/resource",
         "//sdk/src/trace",

--- a/exporters/otlp/CMakeLists.txt
+++ b/exporters/otlp/CMakeLists.txt
@@ -33,9 +33,16 @@ target_include_directories(
 
 set(OPENTELEMETRY_OTLP_TARGETS opentelemetry_otlp_recordable)
 
-target_link_libraries(opentelemetry_otlp_recordable PUBLIC opentelemetry_logs)
-target_link_libraries(opentelemetry_otlp_recordable
-                      PUBLIC opentelemetry_metrics)
+if(TARGET utf8_range::utf8_validity)
+  target_link_libraries(
+    opentelemetry_otlp_recordable
+    PUBLIC opentelemetry_logs opentelemetry_metrics utf8_range::utf8_validity)
+  target_compile_definitions(opentelemetry_otlp_recordable
+                             PRIVATE ENABLE_OTLP_UTF8_VALIDITY)
+else()
+  target_link_libraries(opentelemetry_otlp_recordable
+                        PUBLIC opentelemetry_logs opentelemetry_metrics)
+endif()
 
 #
 # opentelemetry_exporter_otlp_builder_utils
@@ -57,6 +64,12 @@ target_link_libraries(opentelemetry_exporter_otlp_builder_utils
                       PUBLIC opentelemetry_otlp_recordable)
 
 if(OPENTELEMETRY_INSTALL)
+  if(TARGET opentelemetry_otlp_utf8_validity)
+    opentelemetry_add_pkgconfig(
+      otlp_utf8_validity "OpenTelemetry OTLP - UTF-8 Validity"
+      "OTLP UTF-8 validity implementation for value conversion.")
+  endif()
+
   opentelemetry_add_pkgconfig(
     otlp_recordable
     "OpenTelemetry OTLP - Recordable"
@@ -875,6 +888,10 @@ if(BUILD_TESTING)
   add_executable(otlp_log_recordable_test test/otlp_log_recordable_test.cc)
   target_link_libraries(otlp_log_recordable_test ${GTEST_BOTH_LIBRARIES}
                         ${CMAKE_THREAD_LIBS_INIT} opentelemetry_otlp_recordable)
+  if(TARGET utf8_range::utf8_validity)
+    target_compile_definitions(otlp_log_recordable_test
+                               PRIVATE ENABLE_OTLP_UTF8_VALIDITY)
+  endif()
   gtest_add_tests(
     TARGET otlp_log_recordable_test
     TEST_PREFIX exporter.otlp.

--- a/exporters/otlp/CMakeLists.txt
+++ b/exporters/otlp/CMakeLists.txt
@@ -33,10 +33,11 @@ target_include_directories(
 
 set(OPENTELEMETRY_OTLP_TARGETS opentelemetry_otlp_recordable)
 
-if(TARGET utf8_range::utf8_validity)
+if(WITH_OTLP_UTF8_VALIDITY AND TARGET utf8_range::utf8_validity)
   target_link_libraries(
     opentelemetry_otlp_recordable
-    PUBLIC opentelemetry_logs opentelemetry_metrics utf8_range::utf8_validity)
+    PUBLIC opentelemetry_logs opentelemetry_metrics
+    PRIVATE utf8_range::utf8_validity)
   target_compile_definitions(opentelemetry_otlp_recordable
                              PRIVATE ENABLE_OTLP_UTF8_VALIDITY)
 else()
@@ -64,12 +65,6 @@ target_link_libraries(opentelemetry_exporter_otlp_builder_utils
                       PUBLIC opentelemetry_otlp_recordable)
 
 if(OPENTELEMETRY_INSTALL)
-  if(TARGET opentelemetry_otlp_utf8_validity)
-    opentelemetry_add_pkgconfig(
-      otlp_utf8_validity "OpenTelemetry OTLP - UTF-8 Validity"
-      "OTLP UTF-8 validity implementation for value conversion.")
-  endif()
-
   opentelemetry_add_pkgconfig(
     otlp_recordable
     "OpenTelemetry OTLP - Recordable"
@@ -888,7 +883,7 @@ if(BUILD_TESTING)
   add_executable(otlp_log_recordable_test test/otlp_log_recordable_test.cc)
   target_link_libraries(otlp_log_recordable_test ${GTEST_BOTH_LIBRARIES}
                         ${CMAKE_THREAD_LIBS_INIT} opentelemetry_otlp_recordable)
-  if(TARGET utf8_range::utf8_validity)
+  if(WITH_OTLP_UTF8_VALIDITY AND TARGET utf8_range::utf8_validity)
     target_compile_definitions(otlp_log_recordable_test
                                PRIVATE ENABLE_OTLP_UTF8_VALIDITY)
   endif()

--- a/exporters/otlp/src/otlp_populate_attribute_utils.cc
+++ b/exporters/otlp/src/otlp_populate_attribute_utils.cc
@@ -1,6 +1,10 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
+#if defined(ENABLE_OTLP_UTF8_VALIDITY)
+#  include <utf8_validity.h>
+#endif
+
 #include <stdint.h>
 #include <string>
 #include <unordered_map>
@@ -81,12 +85,35 @@ void OtlpPopulateAttributeUtils::PopulateAnyValue(
   }
   else if (nostd::holds_alternative<const char *>(value))
   {
-    proto_value->set_string_value(nostd::get<const char *>(value));
+    const char *str_value = nostd::get<const char *>(value);
+#if defined(ENABLE_OTLP_UTF8_VALIDITY)
+    if (utf8_range::IsStructurallyValid(str_value))
+    {
+      proto_value->set_string_value(str_value);
+    }
+    else
+    {
+      proto_value->set_bytes_value(str_value, strlen(str_value));
+    }
+#else
+    proto_value->set_string_value(str_value);
+#endif
   }
   else if (nostd::holds_alternative<nostd::string_view>(value))
   {
-    proto_value->set_string_value(nostd::get<nostd::string_view>(value).data(),
-                                  nostd::get<nostd::string_view>(value).size());
+    nostd::string_view str_value = nostd::get<nostd::string_view>(value);
+#if defined(ENABLE_OTLP_UTF8_VALIDITY)
+    if (utf8_range::IsStructurallyValid({str_value.data(), str_value.size()}))
+    {
+      proto_value->set_string_value(str_value.data(), str_value.size());
+    }
+    else
+    {
+      proto_value->set_bytes_value(str_value.data(), str_value.size());
+    }
+#else
+    proto_value->set_string_value(str_value.data(), str_value.size());
+#endif
   }
   else if (nostd::holds_alternative<nostd::span<const uint8_t>>(value))
   {
@@ -159,7 +186,18 @@ void OtlpPopulateAttributeUtils::PopulateAnyValue(
     auto array_value = proto_value->mutable_array_value();
     for (const auto &val : nostd::get<nostd::span<const nostd::string_view>>(value))
     {
+#if defined(ENABLE_OTLP_UTF8_VALIDITY)
+      if (utf8_range::IsStructurallyValid({val.data(), val.size()}))
+      {
+        array_value->add_values()->set_string_value(val.data(), val.size());
+      }
+      else
+      {
+        array_value->add_values()->set_bytes_value(val.data(), val.size());
+      }
+#else
       array_value->add_values()->set_string_value(val.data(), val.size());
+#endif
     }
   }
 }
@@ -224,7 +262,19 @@ void OtlpPopulateAttributeUtils::PopulateAnyValue(
   }
   else if (nostd::holds_alternative<std::string>(value))
   {
-    proto_value->set_string_value(nostd::get<std::string>(value));
+    const std::string &str_value = nostd::get<std::string>(value);
+#if defined(ENABLE_OTLP_UTF8_VALIDITY)
+    if (utf8_range::IsStructurallyValid(str_value))
+    {
+      proto_value->set_string_value(str_value);
+    }
+    else
+    {
+      proto_value->set_bytes_value(str_value);
+    }
+#else
+    proto_value->set_string_value(str_value);
+#endif
   }
   else if (nostd::holds_alternative<std::vector<bool>>(value))
   {
@@ -281,7 +331,18 @@ void OtlpPopulateAttributeUtils::PopulateAnyValue(
     auto array_value = proto_value->mutable_array_value();
     for (const auto &val : nostd::get<std::vector<std::string>>(value))
     {
+#if defined(ENABLE_OTLP_UTF8_VALIDITY)
+      if (utf8_range::IsStructurallyValid(val))
+      {
+        array_value->add_values()->set_string_value(val);
+      }
+      else
+      {
+        array_value->add_values()->set_bytes_value(val);
+      }
+#else
       array_value->add_values()->set_string_value(val);
+#endif
     }
   }
 }

--- a/exporters/otlp/test/otlp_log_recordable_test.cc
+++ b/exporters/otlp/test/otlp_log_recordable_test.cc
@@ -84,6 +84,17 @@ TEST(OtlpLogRecordable, Basic)
               memcmp(reinterpret_cast<const void *>(rec.log_record().body().bytes_value().data()),
                      reinterpret_cast<const void *>(byte_arr), 5));
   EXPECT_EQ(rec.log_record().body().bytes_value().size(), 5);
+
+#if defined(ENABLE_OTLP_UTF8_VALIDITY)
+  // Test bytes body: non-UTF8 string_view is automatically converted to bytes_value
+  const char byte_body[] = {'\x80', '\x81', '\x82', '\x83', '\x84'};
+  nostd::string_view byte_body_view(byte_body, 5);
+  rec.SetBody(byte_body_view);
+  EXPECT_TRUE(0 ==
+              memcmp(reinterpret_cast<const void *>(rec.log_record().body().bytes_value().data()),
+                     reinterpret_cast<const void *>(byte_body), 5));
+  EXPECT_EQ(rec.log_record().body().bytes_value().size(), 5);
+#endif
 }
 
 TEST(OtlpLogRecordable, GetResource)
@@ -128,6 +139,14 @@ TEST(OtlpLogRecordable, SetSingleAttribute)
       nostd::span<const uint8_t>{reinterpret_cast<const uint8_t *>(byte_arr), 4});
   rec.SetAttribute(byte_key, byte_val);
 
+#if defined(ENABLE_OTLP_UTF8_VALIDITY)
+  // Non-UTF8 string_view is automatically converted to bytes_value
+  nostd::string_view non_utf8_string_key = "non_utf8_string_attr";
+  const char non_utf8_string_arr[]       = {'\x80', '\x81', '\x82', '\x83'};
+  common::AttributeValue non_utf8_string_val(nostd::string_view(non_utf8_string_arr, 4));
+  rec.SetAttribute(non_utf8_string_key, non_utf8_string_val);
+#endif
+
   int checked_attributes = 0;
   for (auto &attribute : rec.log_record().attributes())
   {
@@ -154,8 +173,22 @@ TEST(OtlpLogRecordable, SetSingleAttribute)
                          reinterpret_cast<const void *>(byte_arr), 4));
       EXPECT_EQ(attribute.value().bytes_value().size(), 4);
     }
+#if defined(ENABLE_OTLP_UTF8_VALIDITY)
+    else if (attribute.key() == non_utf8_string_key)
+    {
+      ++checked_attributes;
+      EXPECT_TRUE(0 ==
+                  memcmp(reinterpret_cast<const void *>(attribute.value().bytes_value().data()),
+                         reinterpret_cast<const void *>(non_utf8_string_arr), 4));
+      EXPECT_EQ(attribute.value().bytes_value().size(), 4);
+    }
+#endif
   }
+#if defined(ENABLE_OTLP_UTF8_VALIDITY)
+  EXPECT_EQ(5, checked_attributes);
+#else
   EXPECT_EQ(4, checked_attributes);
+#endif
 }
 
 // Test non-int array types. Int array types are tested using templates (see IntAttributeTest)


### PR DESCRIPTION

Fixes #3491

## Changes

- Mapping non UTF8 string to bytes in OLTP exporters.

> https://github.com/open-telemetry/opentelemetry-specification/blame/v1.55.0/specification/common/attribute-type-mapping.md.
> Reimplement #3512 to meet the latest spec.

For significant contributions please make sure you have completed the following items:

* [x] `CHANGELOG.md` updated for non-trivial changes
* [x] Unit tests have been added
* [x] Changes in public API reviewed