### PR TITLE
[CODE HEALTH] Fix misc clang-tidy warnings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,9 @@ Increment the:
 * [BAZEL] Add ENABLE_OTLP_GRPC_SSL_MTLS_PREVIEW define to otlp_grpc_log_record_exporter
   [#3988](https://github.com/open-telemetry/opentelemetry-cpp/pull/3988)
 
+* [CODE HEALTH] Fix misc clang-tidy warnings
+  [#3993](https://github.com/open-telemetry/opentelemetry-cpp/pull/3993)
+
 Important changes:
 
 * Enable WITH_OTLP_RETRY_PREVIEW by default

--- a/ext/include/opentelemetry/ext/http/client/curl/http_operation_curl.h
+++ b/ext/include/opentelemetry/ext/http/client/curl/http_operation_curl.h
@@ -294,6 +294,8 @@ private:
     return SetCurlPtrOption(option, list);
   }
 
+  // Curl parameter must really be a long
+  // NOLINTNEXTLINE(google-runtime-int)
   CURLcode SetCurlLongOption(CURLoption option, long value);
 
   CURLcode SetCurlOffOption(CURLoption option, curl_off_t value);
@@ -334,6 +336,9 @@ private:
   std::chrono::system_clock::time_point last_attempt_time_;
 
   // Processed response headers and body
+
+  // See CURLINFO_RESPONSE_CODE, type is long
+  // NOLINTNEXTLINE(google-runtime-int)
   long response_code_{0};
   std::vector<uint8_t> response_headers_;
   std::vector<uint8_t> response_body_;

--- a/ext/include/opentelemetry/ext/http/client/curl/http_operation_curl.h
+++ b/ext/include/opentelemetry/ext/http/client/curl/http_operation_curl.h
@@ -336,7 +336,6 @@ private:
   std::chrono::system_clock::time_point last_attempt_time_;
 
   // Processed response headers and body
-
   // See CURLINFO_RESPONSE_CODE, type is long
   // NOLINTNEXTLINE(google-runtime-int)
   long response_code_{0};

--- a/ext/include/opentelemetry/ext/http/server/socket_tools.h
+++ b/ext/include/opentelemetry/ext/http/server/socket_tools.h
@@ -52,10 +52,6 @@
 
 #endif
 
-#ifndef _Out_cap_
-#  define _Out_cap_(size)
-#endif
-
 #if defined(HAVE_CONSOLE_LOG) && !defined(LOG_DEBUG)
 // Log to console if there's no standard log facility defined
 #  include <cstdio>
@@ -336,7 +332,7 @@ struct Socket
     m_sock = Invalid;
   }
 
-  int recv(_Out_cap_(size) void *buffer, unsigned size)
+  int recv(void *buffer, unsigned size)
   {
     assert(m_sock != Invalid);
     int flags = 0;


### PR DESCRIPTION
Contributes to #2053

## Changes

Fixes the following warnings:

----

**google-runtime-int** (2 warnings)

| File | Line | Message |
|---|---|---|
| `opentelemetry-cpp/ext/include/opentelemetry/ext/http/client/curl/http_operation_curl.h` | 297 | consider replacing 'long' with 'int64' |
| `opentelemetry-cpp/ext/include/opentelemetry/ext/http/client/curl/http_operation_curl.h` | 337 | consider replacing 'long' with 'int64' |


----

**bugprone-reserved-identifier** (1 warnings)

| File | Line | Message |
|---|---|---|
| `opentelemetry-cpp/ext/include/opentelemetry/ext/http/server/socket_tools.h` | 56 | declaration uses identifier '_Out_cap_', which is a reserved identifier |


----


For significant contributions please make sure you have completed the following items:

* [X] `CHANGELOG.md` updated for non-trivial changes
* [ ] Unit tests have been added
* [ ] Changes in public API reviewed