### PR TITLE
[TEST] Replace routable IP with RFC 5737 TEST-NET address in curl test

### DIFF
--- a/ext/test/http/curl_http_test.cc
+++ b/ext/test/http/curl_http_test.cc
@@ -322,7 +322,7 @@ TEST_F(BasicCurlHttpTests, RequestTimeout)
   auto session_manager = http_client::HttpClientFactory::Create();
   EXPECT_TRUE(session_manager != nullptr);
 
-  auto session = session_manager->CreateSession("222.222.222.200:19000");  // Non Existing address
+  auto session = session_manager->CreateSession("192.0.2.0:19000");  // RFC 5737 TEST-NET-1
   auto request = session->CreateRequest();
   request->SetUri("get/");
   auto handler = std::make_shared<GetEventHandler>();


### PR DESCRIPTION
Fixes #1723.

## Changes

Replace `222.222.222.200` with `192.0.2.0` (RFC 5737 TEST-NET-1) in the `RequestTimeout` test.

`222.222.222.200` was intended as a non-existing address but is actually routable. This triggers Windows Defender Firewall prompts during `ctest` (#1723) and sends unintended traffic to production infrastructure.

RFC 5737 reserves `192.0.2.0/24` (TEST-NET-1) for exactly this purpose -- routers must not forward traffic to it. Two other tests in the same file already use `192.0.2.0`; this aligns the last remaining instance.

For significant contributions please make sure you have completed the following items:

* [ ] `CHANGELOG.md` updated for non-trivial changes
* [ ] Unit tests have been added
* [ ] Changes in public API reviewed