### PR TITLE
[CI] Update ci scripts and documentation

### DIFF
--- a/.devcontainer/Dockerfile.dev
+++ b/.devcontainer/Dockerfile.dev
@@ -29,11 +29,8 @@ RUN update-alternatives --install /usr/bin/clang-tidy clang-tidy /usr/bin/clang-
 
 RUN cd /opt/ci && bash setup_ci_environment.sh
 RUN cd /opt/ci && bash install_iwyu.sh
-
-ADD https://github.com/bazelbuild/bazelisk/releases/download/v1.22.1/bazelisk-linux-amd64 /usr/local/bin
-	
-RUN git config --global core.autocrlf input \
-	&& chmod +x /usr/local/bin/bazelisk-linux-amd64
+RUN cd /opt/ci && bash install_bazelisk.sh
+RUN git config --global core.autocrlf input
 
 ENV INSTALL_PACKAGES=${INSTALL_PACKAGES}
 ENV USER_NAME=devuser

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -200,9 +200,7 @@ third_party/          - External dependencies
 cmake.test                       # Standard CMake build with exporters (~5.2 min)
 cmake.maintainer.sync.test       # Maintainer mode: -Wall -Werror -Wextra (~4-6 min)
 cmake.maintainer.async.test      # Maintainer mode with async export enabled
-cmake.maintainer.cpp11.async.test # Maintainer mode with C++11
 cmake.maintainer.abiv2.test      # Maintainer mode with ABI v2
-cmake.legacy.test                # GCC 4.8 compatibility testing
 cmake.c++20.test                # C++20 standard testing
 bazel.test                      # Standard Bazel build and test
 format                          # Run formatting tools

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -439,6 +439,10 @@ jobs:
     - name: install dependencies
       run: |
         sudo -E ./ci/install_thirdparty.sh --install-dir /usr/local --tags-file ./install/cmake/third_party_stable --packages "googletest;benchmark"
+    - name: run tests
+      env:
+        CXX_STANDARD: '14'
+      run: ./ci/do_ci.sh cmake.c++14.test
     - name: run tests (enable stl)
       env:
         CXX_STANDARD: '14'
@@ -459,6 +463,10 @@ jobs:
     - name: setup
       run: |
         sudo -E ./ci/setup_ci_environment.sh
+    - name: run tests
+      env:
+        CXX_STANDARD: '17'
+      run: ./ci/do_ci.sh cmake.c++17.test
     - name: run tests (enable stl)
       env:
         CXX_STANDARD: '17'

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -360,6 +360,15 @@ if(WITH_OPENTRACING)
   include("${opentelemetry-cpp_SOURCE_DIR}/cmake/opentracing-cpp.cmake")
 endif()
 
+include(CTest)
+if(BUILD_TESTING)
+  include("${opentelemetry-cpp_SOURCE_DIR}/cmake/googletest.cmake")
+  enable_testing()
+  if(WITH_BENCHMARK)
+    include("${opentelemetry-cpp_SOURCE_DIR}/cmake/benchmark.cmake")
+  endif()
+endif()
+
 if(OTELCPP_MAINTAINER_MODE)
   if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
     message(STATUS "Building with gcc in maintainer mode.")
@@ -452,15 +461,6 @@ if(OTELCPP_MAINTAINER_MODE)
 endif(OTELCPP_MAINTAINER_MODE)
 
 list(APPEND CMAKE_PREFIX_PATH "${CMAKE_BINARY_DIR}")
-
-include(CTest)
-if(BUILD_TESTING)
-  include("${opentelemetry-cpp_SOURCE_DIR}/cmake/googletest.cmake")
-  enable_testing()
-  if(WITH_BENCHMARK)
-    include("${opentelemetry-cpp_SOURCE_DIR}/cmake/benchmark.cmake")
-  endif()
-endif()
 
 # Record build config and versions
 message(STATUS "---------------------------------------------")

--- a/ci/README.md
+++ b/ci/README.md
@@ -1,32 +1,130 @@
-# Building and running tests as a developer
+# CI Scripts
 
-CI tests can be run on docker by invoking the script `./ci/run_docker.sh
-./ci/do_ci.sh {TARGET}`or inside
-[devcontainer](../CONTRIBUTING.md#devcontainer-setup-for-project)
-by invoking the script
-`./ci/do_ci.sh {TARGET}` where the targets are:
+`./ci/do_ci.sh` is the main build, test, and validation script used by CI
+and local development.
 
-* `cmake.test`: build cmake targets and run tests.
-* `cmake.maintainer.test`: build with cmake and test, in maintainer mode.
-* `cmake.legacy.test`: build cmake targets with gcc 4.8 and run tests.
-* `cmake.c++20.test`: build cmake targets with the C++20 standard and run tests.
-* `cmake.test_example_plugin`: build and test an example OpenTelemetry plugin.
-* `cmake.exporter.otprotocol.test`: build and test the otprotocol exporter
-* `bazel.test`: build bazel targets and run tests.
-* `bazel.legacy.test`: build bazel targets and run tests for the targets meant
-  to work with older compilers.
-* `bazel.noexcept`: build bazel targets and run tests with exceptions disabled.
-* `bazel.nortti`: build bazel targets and run tests with runtime type
-  identification disabled.
-* `bazel.asan`: build bazel targets and run tests with AddressSanitizer.
-* `bazel.tsan`: build bazel targets and run tests with ThreadSanitizer.
-* `bazel.valgrind`: build bazel targets and run tests under the valgrind memory
-  checker.
-* `benchmark`: run all benchmarks.
-* `format`: use `tools/format.sh` to enforce text formatting.
-* `third_party.tags`: store third_party release tags.
-* `code.coverage`: build cmake targets with CXX option `--coverage` and run
-  tests.
+## Usage
 
-Additionally, `./ci/run_docker.sh` can be invoked with no arguments to get a
-docker shell where tests can be run manually.
+Run targets directly inside the
+[devcontainer](../CONTRIBUTING.md#devcontainer-setup-for-project):
+
+```sh
+./ci/do_ci.sh <target>
+```
+
+Run targets in Docker:
+
+```sh
+./ci/run_docker.sh ./ci/do_ci.sh <target>
+```
+
+You can also run `./ci/run_docker.sh` with no arguments to open an interactive
+Docker shell and invoke targets manually.
+
+## Examples
+
+### Format Checks
+
+```sh
+./ci/do_ci.sh format
+markdownlint .
+shellcheck --severity=error <path to shell script>.sh
+```
+
+### Testing 
+```sh
+./ci/do_ci.sh cmake.maintainer.sync.test
+./ci/do_ci.sh cmake.c++20.stl.test
+./ci/run_docker.sh ./ci/do_ci.sh bazel.test
+```
+
+
+
+## Build configuration
+
+The script accepts several environment variables to configure the build:
+
+```sh
+BUILD_DIR=$HOME/build
+BUILD_TYPE=Debug|Release|RelWithDebInfo|MinSizeRel
+CXX_STANDARD=14|17|20|23
+BUILD_SHARED_LIBS=ON|OFF
+OTELCPP_CMAKE_VERBOSE_BUILD=ON|OFF
+OTELCPP_CMAKE_CACHE_FILE=<cache-file-name>
+```
+
+`OTELCPP_CMAKE_CACHE_FILE` should be the basename of a cache file from
+`test_common/cmake`, for example `all-options-abiv1-preview.cmake` or
+`all-options-abiv2.cmake`.
+
+## Targets
+
+### Formatting and coverage
+
+* `format`: Run formatting tools (`clang-format`, `cmake-format`,
+  `buildifier`) and fail if files change.
+* `code.coverage`: Build with coverage flags and generate `coverage.info`.
+* `cmake.clang_tidy.test`: Build with `clang-tidy` enabled and emit a build
+  log.
+
+### Maintainer CMake builds
+
+These targets use the `all-options-*` cache files in `test_common/cmake` and
+build all CMake components with preview options enabled.
+
+* `cmake.maintainer.sync.test`: Maintainer mode ABI v1 build with synchronous
+  export and tests.
+* `cmake.maintainer.async.test`: Maintainer mode ABI v1 build with async export
+  and tests.
+* `cmake.maintainer.abiv2.test`: Maintainer mode ABI v2 build and tests.
+* `cmake.maintainer.yaml.test`: Maintainer mode build with YAML configuration.
+
+### CMake language-standard matrix
+
+These tests build the core API and SDK components in maintainer mode.
+
+* `cmake.c++14.test`: C++14, WITH_STL=OFF
+* `cmake.c++17.test`: C++17, WITH_STL=OFF
+* `cmake.c++20.test`: C++20, WITH_STL=OFF
+* `cmake.c++23.test`: C++23, WITH_STL=OFF
+* `cmake.c++14.stl.test`: C++14, WITH_STL=CXX14
+* `cmake.c++17.stl.test`: C++17, WITH_STL=CXX17
+* `cmake.c++20.stl.test`: C++20, WITH_STL=CXX20
+* `cmake.c++23.stl.test`: C++23, WITH_STL=CXX23
+
+### CMake feature and packaging tests
+
+* `cmake.with_async_export.test`: Standard CMake build with async export
+  enabled.
+* `cmake.opentracing_shim.test`: OpenTracing shim build and tests.
+* `cmake.opentracing_shim.install.test`: OpenTracing shim install validation
+  test.
+* `cmake.exporter.otprotocol.test`: OTLP exporter build and tests.
+* `cmake.exporter.otprotocol.shared_libs.with_static_grpc.test`: OTLP exporter
+  test with shared libraries enabled.
+* `cmake.exporter.otprotocol.with_async_export.test`: OTLP exporter test with
+  async export enabled.
+* `cmake.w3c.trace-context.build-server`: Build the W3C trace-context test
+  server.
+* `cmake.do_not_install.test`: Build and test with installation disabled.
+* `cmake.install.test`: Install-tree validation and downstream CMake package
+  test.
+* `cmake.fetch_content.test`: Validate building the project via
+  `FetchContent`.
+* `cmake.test_example_plugin`: Build and load-test the example plugin.
+
+### Bazel targets
+
+* `bazel.test`: Build and test all Bazel targets.
+* `bazel.with_async_export.test`: Build and test with async export enabled.
+* `bazel.macos.test`: Build and test using the macOS Bazel configuration.
+* `bazel.legacy.test`: Bazel legacy compatibility test subset.
+* `bazel.noexcept`: Build and test with exceptions disabled where supported.
+* `bazel.nortti`: Build and test with RTTI disabled where supported.
+* `bazel.asan`: Run Bazel tests with AddressSanitizer.
+* `bazel.tsan`: Run Bazel tests with ThreadSanitizer.
+* `bazel.valgrind`: Run Bazel tests under Valgrind.
+
+### Benchmarks
+
+* `benchmark`: Build benchmark binaries and collect result artifacts.

--- a/ci/README.md
+++ b/ci/README.md
@@ -31,14 +31,13 @@ markdownlint .
 shellcheck --severity=error <path to shell script>.sh
 ```
 
-### Testing 
+### Testing
+
 ```sh
 ./ci/do_ci.sh cmake.maintainer.sync.test
 ./ci/do_ci.sh cmake.c++20.stl.test
 ./ci/run_docker.sh ./ci/do_ci.sh bazel.test
 ```
-
-
 
 ## Build configuration
 

--- a/ci/do_ci.sh
+++ b/ci/do_ci.sh
@@ -87,7 +87,7 @@ fi
 CMAKE_OPTIONS+=("-DCMAKE_CXX_STANDARD_REQUIRED=ON")
 CMAKE_OPTIONS+=("-DCMAKE_CXX_EXTENSIONS=OFF")
 
-CMAKE_BUILD_ARGS=(--parallel "$(nproc)")
+CMAKE_BUILD_ARGS=(--parallel)
 
 if [[ "${OTELCPP_CMAKE_VERBOSE_BUILD:-OFF}" =~ ^(1|ON|on|TRUE|true|YES|yes)$ ]]; then
   CMAKE_BUILD_ARGS+=(--verbose)

--- a/ci/do_ci.sh
+++ b/ci/do_ci.sh
@@ -5,18 +5,6 @@
 
 set -eo pipefail
 
-function install_prometheus_cpp_client
-{
-  pushd third_party/prometheus-cpp
-  git submodule update --recursive --init
-  [[ -d _build ]] && rm -rf ./_build
-  mkdir _build && cd _build
-  cmake .. -DBUILD_SHARED_LIBS=ON -DUSE_THIRDPARTY_LIBRARIES=ON
-  make -j $(nproc)
-  sudo make install
-  popd
-}
-
 function run_benchmarks
 {
   docker run -d --rm -it -p 4317:4317 -p 4318:4318 -v \
@@ -65,10 +53,6 @@ mkdir -p "${PLUGIN_DIR}"
 [ -z "${INSTALL_TEST_DIR}" ] && export INSTALL_TEST_DIR=$HOME/install_test
 mkdir -p "${INSTALL_TEST_DIR}"
 
-MAKE_COMMAND="make -k -j \$(nproc)"
-
-echo "make command: ${MAKE_COMMAND}"
-
 export BAZEL_CXXOPTS="-std=c++17"
 
 # Work around for https://github.com/actions/runner-images/issues/13564
@@ -103,6 +87,16 @@ fi
 CMAKE_OPTIONS+=("-DCMAKE_CXX_STANDARD_REQUIRED=ON")
 CMAKE_OPTIONS+=("-DCMAKE_CXX_EXTENSIONS=OFF")
 
+CMAKE_BUILD_ARGS=(--parallel "$(nproc)")
+
+if [[ "${OTELCPP_CMAKE_VERBOSE_BUILD:-OFF}" =~ ^(1|ON|on|TRUE|true|YES|yes)$ ]]; then
+  CMAKE_BUILD_ARGS+=(--verbose)
+fi
+
+if command -v ninja >/dev/null 2>&1; then
+  CMAKE_OPTIONS+=("-G" "Ninja")
+fi
+
 if [ -n "$CMAKE_TOOLCHAIN_FILE" ]; then
   echo "CMAKE_TOOLCHAIN_FILE is set to: $CMAKE_TOOLCHAIN_FILE"
   CMAKE_OPTIONS+=("-DCMAKE_TOOLCHAIN_FILE=$CMAKE_TOOLCHAIN_FILE")
@@ -113,8 +107,6 @@ if [ -n "$OTELCPP_CMAKE_CACHE_FILE" ]; then
 else
   OTELCPP_CMAKE_CACHE_FILE_PATH="${SRC_DIR}/test_common/cmake/all-options-abiv1-preview.cmake"
 fi
-
-echo "CMAKE_OPTIONS:" "${CMAKE_OPTIONS[@]}"
 
 export CTEST_OUTPUT_ON_FAILURE=1
 
@@ -128,8 +120,8 @@ if [[ "$1" == "cmake.test" ]]; then
         -DWITH_METRICS_EXEMPLAR_PREVIEW=ON \
         -DCMAKE_CXX_FLAGS="-Werror $CXXFLAGS" \
         "${SRC_DIR}"
-  make -j $(nproc)
-  make test
+  cmake --build . "${CMAKE_BUILD_ARGS[@]}"
+  ctest --output-on-failure
   exit 0
 elif [[ "$1" == "cmake.maintainer.sync.test" ]]; then
   cd "${BUILD_DIR}"
@@ -141,8 +133,8 @@ elif [[ "$1" == "cmake.maintainer.sync.test" ]]; then
         -DOTELCPP_MAINTAINER_MODE=ON \
         -DWITH_NO_DEPRECATED_CODE=ON \
         "${SRC_DIR}"
-  eval "$MAKE_COMMAND"
-  make test
+  cmake --build . "${CMAKE_BUILD_ARGS[@]}"
+  ctest --output-on-failure
   exit 0
 elif [[ "$1" == "cmake.maintainer.async.test" ]]; then
   cd "${BUILD_DIR}"
@@ -153,21 +145,8 @@ elif [[ "$1" == "cmake.maintainer.async.test" ]]; then
         -DOTELCPP_MAINTAINER_MODE=ON \
         -DWITH_NO_DEPRECATED_CODE=ON \
         "${SRC_DIR}"
-  eval "$MAKE_COMMAND"
-  make test
-  exit 0
-elif [[ "$1" == "cmake.maintainer.cpp11.async.test" ]]; then
-  cd "${BUILD_DIR}"
-  rm -rf *
-  cmake "${CMAKE_OPTIONS[@]}"  \
-        -DCMAKE_CXX_STANDARD=11 \
-        -C ${SRC_DIR}/test_common/cmake/all-options-abiv1-preview.cmake \
-        -DWITH_OPENTRACING=OFF \
-        -DOTELCPP_MAINTAINER_MODE=ON \
-        -DWITH_NO_DEPRECATED_CODE=ON \
-        "${SRC_DIR}"
-  make -k -j $(nproc)
-  make test
+  cmake --build . "${CMAKE_BUILD_ARGS[@]}"
+  ctest --output-on-failure
   exit 0
 elif [[ "$1" == "cmake.maintainer.abiv2.test" ]]; then
   cd "${BUILD_DIR}"
@@ -179,8 +158,8 @@ elif [[ "$1" == "cmake.maintainer.abiv2.test" ]]; then
         -DOTELCPP_MAINTAINER_MODE=ON \
         -DWITH_NO_DEPRECATED_CODE=ON \
         "${SRC_DIR}"
-  eval "$MAKE_COMMAND"
-  make test
+  cmake --build . "${CMAKE_BUILD_ARGS[@]}"
+  ctest --output-on-failure
   exit 0
 elif [[ "$1" == "cmake.maintainer.yaml.test" ]]; then
   cd "${BUILD_DIR}"
@@ -204,8 +183,8 @@ elif [[ "$1" == "cmake.maintainer.yaml.test" ]]; then
         -DWITH_THREAD_INSTRUMENTATION_PREVIEW=ON \
         -DWITH_CONFIGURATION=ON \
         "${SRC_DIR}"
-  eval "$MAKE_COMMAND"
-  make test
+  cmake --build . "${CMAKE_BUILD_ARGS[@]}"
+  ctest --output-on-failure
   exit 0
 elif [[ "$1" == "cmake.with_async_export.test" ]]; then
   cd "${BUILD_DIR}"
@@ -218,8 +197,8 @@ elif [[ "$1" == "cmake.with_async_export.test" ]]; then
         -DCMAKE_CXX_FLAGS="-Werror $CXXFLAGS" \
         -DWITH_ASYNC_EXPORT_PREVIEW=ON \
         "${SRC_DIR}"
-  make -j $(nproc)
-  make test
+  cmake --build . "${CMAKE_BUILD_ARGS[@]}"
+  ctest --output-on-failure
   exit 0
 elif [[ "$1" == "cmake.opentracing_shim.test" ]]; then
   cd "${BUILD_DIR}"
@@ -229,8 +208,8 @@ elif [[ "$1" == "cmake.opentracing_shim.test" ]]; then
         -DWITH_OPENTRACING=ON \
         -DCMAKE_POSITION_INDEPENDENT_CODE=ON \
         "${SRC_DIR}"
-  make -j $(nproc)
-  make test
+  cmake --build . "${CMAKE_BUILD_ARGS[@]}"
+  ctest --output-on-failure
   exit 0
 elif [[ "$1" == "cmake.opentracing_shim.install.test" ]]; then
   cd "${BUILD_DIR}"
@@ -242,9 +221,9 @@ elif [[ "$1" == "cmake.opentracing_shim.install.test" ]]; then
         -DCMAKE_POSITION_INDEPENDENT_CODE=ON \
         -DCMAKE_INSTALL_PREFIX=${INSTALL_TEST_DIR} \
         "${SRC_DIR}"
-  make -j $(nproc)
-  make test
-  make install
+  cmake --build . "${CMAKE_BUILD_ARGS[@]}"
+  ctest --output-on-failure
+  cmake --build . "${CMAKE_BUILD_ARGS[@]}" --target install
   export LD_LIBRARY_PATH="${INSTALL_TEST_DIR}/lib:$LD_LIBRARY_PATH"
   CMAKE_OPTIONS_STRING=$(IFS=" "; echo "${CMAKE_OPTIONS[*]}")
   EXPECTED_COMPONENTS=(
@@ -265,86 +244,105 @@ elif [[ "$1" == "cmake.opentracing_shim.install.test" ]]; then
         -S "${SRC_DIR}/install/test/cmake"
   ctest --output-on-failure
   exit 0
+ elif [[ "$1" == "cmake.c++14.test" ]]; then
+  cd "${BUILD_DIR}"
+  rm -rf *
+  cmake "${CMAKE_OPTIONS[@]}"  \
+        -DCMAKE_CXX_STANDARD=14 \
+        -DOTELCPP_MAINTAINER_MODE=ON \
+        -DWITH_ASYNC_EXPORT_PREVIEW=ON \
+        -DWITH_STL=OFF \
+        "${SRC_DIR}"
+  cmake --build . "${CMAKE_BUILD_ARGS[@]}"
+  ctest --output-on-failure
+  exit 0
+elif [[ "$1" == "cmake.c++17.test" ]]; then
+  cd "${BUILD_DIR}"
+  rm -rf *
+  cmake "${CMAKE_OPTIONS[@]}"  \
+        -DCMAKE_CXX_STANDARD=17 \
+        -DOTELCPP_MAINTAINER_MODE=ON \
+        -DWITH_ASYNC_EXPORT_PREVIEW=ON \
+        -DWITH_STL=OFF \
+        "${SRC_DIR}"
+  cmake --build . "${CMAKE_BUILD_ARGS[@]}"
+  ctest --output-on-failure
+  exit 0
 elif [[ "$1" == "cmake.c++20.test" ]]; then
   cd "${BUILD_DIR}"
   rm -rf *
   cmake "${CMAKE_OPTIONS[@]}"  \
-        -DCMAKE_CXX_FLAGS="-Werror $CXXFLAGS" \
+        -DCMAKE_CXX_STANDARD=20 \
+        -DOTELCPP_MAINTAINER_MODE=ON \
         -DWITH_ASYNC_EXPORT_PREVIEW=ON \
-        -DWITH_STL=CXX20 \
+        -DWITH_STL=OFF \
         "${SRC_DIR}"
-  eval "$MAKE_COMMAND"
-  make test
+  cmake --build . "${CMAKE_BUILD_ARGS[@]}"
+  ctest --output-on-failure
   exit 0
 elif [[ "$1" == "cmake.c++23.test" ]]; then
   cd "${BUILD_DIR}"
   rm -rf *
   cmake "${CMAKE_OPTIONS[@]}"  \
-        -DCMAKE_CXX_FLAGS="-Werror $CXXFLAGS" \
+        -DCMAKE_CXX_STANDARD=23 \
+        -DOTELCPP_MAINTAINER_MODE=ON \
         -DWITH_ASYNC_EXPORT_PREVIEW=ON \
-        -DWITH_STL=CXX23 \
+        -DWITH_STL=OFF \
         "${SRC_DIR}"
-  eval "$MAKE_COMMAND"
-  make test
+  cmake --build . "${CMAKE_BUILD_ARGS[@]}"
+  ctest --output-on-failure
   exit 0
 elif [[ "$1" == "cmake.c++14.stl.test" ]]; then
   cd "${BUILD_DIR}"
   rm -rf *
   cmake "${CMAKE_OPTIONS[@]}"  \
         -DWITH_METRICS_EXEMPLAR_PREVIEW=ON \
-        -DCMAKE_CXX_FLAGS="-Werror $CXXFLAGS" \
+        -DCMAKE_CXX_STANDARD=14 \
+        -DOTELCPP_MAINTAINER_MODE=ON \
         -DWITH_ASYNC_EXPORT_PREVIEW=ON \
         -DWITH_STL=CXX14 \
         "${SRC_DIR}"
-  eval "$MAKE_COMMAND"
-  make test
+  cmake --build . "${CMAKE_BUILD_ARGS[@]}"
+  ctest --output-on-failure
   exit 0
 elif [[ "$1" == "cmake.c++17.stl.test" ]]; then
   cd "${BUILD_DIR}"
   rm -rf *
   cmake "${CMAKE_OPTIONS[@]}"  \
         -DWITH_METRICS_EXEMPLAR_PREVIEW=ON \
-        -DCMAKE_CXX_FLAGS="-Werror $CXXFLAGS" \
+        -DCMAKE_CXX_STANDARD=17 \
+        -DOTELCPP_MAINTAINER_MODE=ON \
         -DWITH_ASYNC_EXPORT_PREVIEW=ON \
         -DWITH_STL=CXX17 \
         "${SRC_DIR}"
-  eval "$MAKE_COMMAND"
-  make test
+  cmake --build . "${CMAKE_BUILD_ARGS[@]}"
+  ctest --output-on-failure
   exit 0
 elif [[ "$1" == "cmake.c++20.stl.test" ]]; then
   cd "${BUILD_DIR}"
   rm -rf *
   cmake "${CMAKE_OPTIONS[@]}"  \
         -DWITH_METRICS_EXEMPLAR_PREVIEW=ON \
-        -DCMAKE_CXX_FLAGS="-Werror $CXXFLAGS" \
+        -DCMAKE_CXX_STANDARD=20 \
+        -DOTELCPP_MAINTAINER_MODE=ON \
         -DWITH_ASYNC_EXPORT_PREVIEW=ON \
         -DWITH_STL=CXX20 \
         "${SRC_DIR}"
-  eval "$MAKE_COMMAND"
-  make test
+  cmake --build . "${CMAKE_BUILD_ARGS[@]}"
+  ctest --output-on-failure
   exit 0
 elif [[ "$1" == "cmake.c++23.stl.test" ]]; then
   cd "${BUILD_DIR}"
   rm -rf *
   cmake "${CMAKE_OPTIONS[@]}"  \
         -DWITH_METRICS_EXEMPLAR_PREVIEW=ON \
-        -DCMAKE_CXX_FLAGS="-Werror $CXXFLAGS" \
+        -DCMAKE_CXX_STANDARD=23 \
+        -DOTELCPP_MAINTAINER_MODE=ON \
         -DWITH_ASYNC_EXPORT_PREVIEW=ON \
         -DWITH_STL=CXX23 \
         "${SRC_DIR}"
-  eval "$MAKE_COMMAND"
-  make test
-  exit 0
-elif [[ "$1" == "cmake.legacy.test" ]]; then
-  cd "${BUILD_DIR}"
-  rm -rf *
-  export BUILD_ROOT="${BUILD_DIR}"
-  ${SRC_DIR}/tools/build-benchmark.sh
-  cmake "${CMAKE_OPTIONS[@]}"  \
-        -DCMAKE_CXX_FLAGS="-Werror $CXXFLAGS" \
-        "${SRC_DIR}"
-  make -j $(nproc)
-  make test
+  cmake --build . "${CMAKE_BUILD_ARGS[@]}"
+  ctest --output-on-failure
   exit 0
 elif [[ "$1" == "cmake.clang_tidy.test" ]]; then
   rm -rf "${BUILD_DIR}"
@@ -359,7 +357,7 @@ elif [[ "$1" == "cmake.clang_tidy.test" ]]; then
     -DCMAKE_CXX_FLAGS="-Wno-deprecated-declarations" \
     -DCMAKE_EXPORT_COMPILE_COMMANDS=ON \
     -DCMAKE_CXX_CLANG_TIDY="clang-tidy;--header-filter=.*/opentelemetry-cpp/.*;--exclude-header-filter=.*(internal/absl|third_party|third-party|build.*|/usr|/opt)/.*|.*\.pb\.h;--quiet"
-  cmake --build "${BUILD_DIR}" -- -j $(nproc) 2>&1 | tee "$LOG_FILE"
+  cmake --build "${BUILD_DIR}" "${CMAKE_BUILD_ARGS[@]}" 2>&1 | tee "$LOG_FILE"
   if [ ! -s "$LOG_FILE" ]; then
     echo "Error: Build log was not created at $LOG_FILE"
     exit 1
@@ -367,24 +365,6 @@ elif [[ "$1" == "cmake.clang_tidy.test" ]]; then
   echo "Build log written to: $LOG_FILE"
   echo "To generate a clang-tidy report, use the following command:"
   echo "  python3 ./ci/create_clang_tidy_report.py --build_log $LOG_FILE"
-  exit 0
-elif [[ "$1" == "cmake.legacy.exporter.otprotocol.test" ]]; then
-  cd "${BUILD_DIR}"
-  rm -rf *
-  export BUILD_ROOT="${BUILD_DIR}"
-  ${SRC_DIR}/tools/build-benchmark.sh
-  cmake "${CMAKE_OPTIONS[@]}"  \
-        -DCMAKE_CXX_STANDARD=11 \
-        -DWITH_OTLP_GRPC=ON \
-        -DWITH_OTLP_HTTP=ON \
-        -DWITH_OTLP_FILE=ON \
-        -DWITH_ASYNC_EXPORT_PREVIEW=ON \
-        "${SRC_DIR}"
-  grpc_cpp_plugin=`which grpc_cpp_plugin`
-  proto_make_file="CMakeFiles/opentelemetry_proto.dir/build.make"
-  sed -i "s~gRPC_CPP_PLUGIN_EXECUTABLE-NOTFOUND~$grpc_cpp_plugin~" ${proto_make_file} #fixme
-  make -j $(nproc)
-  cd exporters/otlp && make test
   exit 0
 elif [[ "$1" == "cmake.exporter.otprotocol.test" ]]; then
   cd "${BUILD_DIR}"
@@ -397,11 +377,8 @@ elif [[ "$1" == "cmake.exporter.otprotocol.test" ]]; then
         -DWITH_OTLP_GRPC_CREDENTIAL_PREVIEW=ON \
         -DWITH_OTLP_RETRY_PREVIEW=ON \
         "${SRC_DIR}"
-  grpc_cpp_plugin=`which grpc_cpp_plugin`
-  proto_make_file="CMakeFiles/opentelemetry_proto.dir/build.make"
-  sed -i "s~gRPC_CPP_PLUGIN_EXECUTABLE-NOTFOUND~$grpc_cpp_plugin~" ${proto_make_file} #fixme
-  make -j $(nproc)
-  cd exporters/otlp && make test
+  cmake --build . "${CMAKE_BUILD_ARGS[@]}"
+  ctest --output-on-failure
   exit 0
 elif [[ "$1" == "cmake.exporter.otprotocol.shared_libs.with_static_grpc.test" ]]; then
   cd "${BUILD_DIR}"
@@ -413,11 +390,8 @@ elif [[ "$1" == "cmake.exporter.otprotocol.shared_libs.with_static_grpc.test" ]]
         -DBUILD_SHARED_LIBS=ON \
         -DCMAKE_POSITION_INDEPENDENT_CODE=ON \
         "${SRC_DIR}"
-  grpc_cpp_plugin=`which grpc_cpp_plugin`
-  proto_make_file="CMakeFiles/opentelemetry_proto.dir/build.make"
-  sed -i "s~gRPC_CPP_PLUGIN_EXECUTABLE-NOTFOUND~$grpc_cpp_plugin~" ${proto_make_file} #fixme
-  make -j $(nproc)
-  cd exporters/otlp && make test
+  cmake --build . "${CMAKE_BUILD_ARGS[@]}"
+  ctest --output-on-failure
   exit 0
 elif [[ "$1" == "cmake.exporter.otprotocol.with_async_export.test" ]]; then
   cd "${BUILD_DIR}"
@@ -428,11 +402,8 @@ elif [[ "$1" == "cmake.exporter.otprotocol.with_async_export.test" ]]; then
         -DWITH_OTLP_FILE=ON \
         -DWITH_ASYNC_EXPORT_PREVIEW=ON \
         "${SRC_DIR}"
-  grpc_cpp_plugin=`which grpc_cpp_plugin`
-  proto_make_file="CMakeFiles/opentelemetry_proto.dir/build.make"
-  sed -i "s~gRPC_CPP_PLUGIN_EXECUTABLE-NOTFOUND~$grpc_cpp_plugin~" ${proto_make_file} #fixme
-  make -j $(nproc)
-  cd exporters/otlp && make test
+  cmake --build . "${CMAKE_BUILD_ARGS[@]}"
+  ctest --output-on-failure
   exit 0
 elif [[ "$1" == "cmake.w3c.trace-context.build-server" ]]; then
   echo "Building w3c trace context test server"
@@ -442,7 +413,7 @@ elif [[ "$1" == "cmake.w3c.trace-context.build-server" ]]; then
           -DBUILD_W3CTRACECONTEXT_TEST=ON \
           -DCMAKE_CXX_STANDARD=${CXX_STANDARD} \
           "${SRC_DIR}"
-  eval "$MAKE_COMMAND"
+  cmake --build . "${CMAKE_BUILD_ARGS[@]}"
   exit 0
 elif [[ "$1" == "cmake.do_not_install.test" ]]; then
   cd "${BUILD_DIR}"
@@ -454,11 +425,8 @@ elif [[ "$1" == "cmake.do_not_install.test" ]]; then
         -DWITH_ASYNC_EXPORT_PREVIEW=ON \
         -DOPENTELEMETRY_INSTALL=OFF \
         "${SRC_DIR}"
-  grpc_cpp_plugin=`which grpc_cpp_plugin`
-  proto_make_file="CMakeFiles/opentelemetry_proto.dir/build.make"
-  sed -i "s~gRPC_CPP_PLUGIN_EXECUTABLE-NOTFOUND~$grpc_cpp_plugin~" ${proto_make_file} #fixme
-  make -j $(nproc)
-  cd exporters/otlp && make test
+  cmake --build . "${CMAKE_BUILD_ARGS[@]}"
+  ctest --output-on-failure
   exit 0
 elif [[ "$1" == "cmake.install.test" ]]; then
   if [[ -n "${BUILD_SHARED_LIBS}" && "${BUILD_SHARED_LIBS}" == "ON" ]]; then
@@ -480,9 +448,9 @@ elif [[ "$1" == "cmake.install.test" ]]; then
         -DOPENTELEMETRY_INSTALL=ON \
         "${SRC_DIR}"
 
-  make -j $(nproc)
-  make test
-  make install
+  cmake --build . "${CMAKE_BUILD_ARGS[@]}"
+  ctest --output-on-failure
+  cmake --build . "${CMAKE_BUILD_ARGS[@]}" --target install
   export LD_LIBRARY_PATH="${INSTALL_TEST_DIR}/lib:$LD_LIBRARY_PATH"
 
   CMAKE_OPTIONS_STRING=$(IFS=" "; echo "${CMAKE_OPTIONS[*]}")
@@ -537,8 +505,8 @@ elif [[ "$1" == "cmake.fetch_content.test" ]]; then
         -DOPENTELEMETRY_INSTALL=OFF \
         -DOPENTELEMETRY_CPP_SRC_DIR="${SRC_DIR}" \
         "${SRC_DIR}/install/test/cmake/fetch_content_test"
-  make -j $(nproc)
-  make test
+  cmake --build . "${CMAKE_BUILD_ARGS[@]}"
+  ctest --output-on-failure
   exit 0
 
 elif [[ "$1" == "cmake.test_example_plugin" ]]; then
@@ -559,20 +527,20 @@ EOF
     -Wl,--version-script=${PWD}/export.map \
   "
   cmake "${CMAKE_OPTIONS[@]}"  \
-        -DCMAKE_CXX_FLAGS="-Werror $CXXFLAGS" \
+        -DOTELCPP_MAINTAINER_MODE=ON \
         -DCMAKE_EXE_LINKER_FLAGS="$LINKER_FLAGS" \
         -DCMAKE_SHARED_LINKER_FLAGS="$LINKER_FLAGS" \
         "${SRC_DIR}"
-  make example_plugin
+  cmake --build . "${CMAKE_BUILD_ARGS[@]}" --target example_plugin
   cp examples/plugin/plugin/libexample_plugin.so ${PLUGIN_DIR}
 
   # Verify we can load the plugin
   cd "${BUILD_DIR}"
   rm -rf *
   cmake "${CMAKE_OPTIONS[@]}"  \
-        -DCMAKE_CXX_FLAGS="-Werror $CXXFLAGS" \
+        -DOTELCPP_MAINTAINER_MODE=ON \
         "${SRC_DIR}"
-  make load_plugin_example
+  cmake --build . "${CMAKE_BUILD_ARGS[@]}" --target load_plugin_example
   examples/plugin/load/load_plugin_example ${PLUGIN_DIR}/libexample_plugin.so /dev/null
   exit 0
 elif [[ "$1" == "bazel.test" ]]; then
@@ -623,10 +591,6 @@ elif [[ "$1" == "bazel.valgrind" ]]; then
   bazel $BAZEL_STARTUP_OPTIONS build $BAZEL_OPTIONS_ASYNC //...
   bazel $BAZEL_STARTUP_OPTIONS test --test_timeout=600 --run_under="/usr/bin/valgrind --leak-check=full --error-exitcode=1 --errors-for-leak-kinds=definite --suppressions=\"${SRC_DIR}/ci/valgrind-suppressions\"" $BAZEL_TEST_OPTIONS_ASYNC //...
   exit 0
-elif [[ "$1" == "bazel.e2e" ]]; then
-  cd examples/e2e
-  bazel $BAZEL_STARTUP_OPTIONS build $BAZEL_OPTIONS_DEFAULT //...
-  exit 0
 elif [[ "$1" == "benchmark" ]]; then
   [ -z "${BENCHMARK_DIR}" ] && export BENCHMARK_DIR=$HOME/benchmark
   bazel $BAZEL_STARTUP_OPTIONS build $BAZEL_OPTIONS_ASYNC -c opt -- \
@@ -656,17 +620,12 @@ elif [[ "$1" == "code.coverage" ]]; then
   cmake "${CMAKE_OPTIONS[@]}"  \
         -DCMAKE_CXX_FLAGS="-Werror --coverage $CXXFLAGS" \
         "${SRC_DIR}"
-  make
-  make test
+  cmake --build . "${CMAKE_BUILD_ARGS[@]}"
+  ctest --output-on-failure
   lcov --directory $PWD --capture --output-file coverage.info
   # removing test http server coverage from the total coverage. We don't use this server completely.
   lcov --remove coverage.info '*/ext/http/server/*'> tmp_coverage.info 2>/dev/null
   cp tmp_coverage.info coverage.info
-  exit 0
-elif [[ "$1" == "third_party.tags" ]]; then
-  echo "gRPC=v1.49.2" > third_party_release
-  echo "abseil=20240116.1" >> third_party_release
-  git submodule foreach --quiet 'echo "$name=$(git describe --tags HEAD)"' | sed 's:.*/::' >> third_party_release
   exit 0
 fi
 


### PR DESCRIPTION
Contributes to #3999

## Changes

- Clean up do_ci.sh 
  - remove legacy c++11 targets
  - remove unused targets (thirdparty tag update, ..)
  - use modern cmake build and ctest commands
  - use ninja if available
  - add missing c++14 and c++17 cmake tests and set all to use maintainer mode
- Update devcontainer to install bazel the same way as CI
- Update ci script README

For significant contributions please make sure you have completed the following items:

* [ ] `CHANGELOG.md` updated for non-trivial changes
* [ ] Unit tests have been added
* [ ] Changes in public API reviewed