### PR TITLE
[CI] update code.coverage job to report on all components and preview features

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1096,9 +1096,6 @@ jobs:
       with:
         submodules: 'recursive'
     - name: setup
-      env:
-        CC: /usr/bin/gcc-13
-        CXX: /usr/bin/g++-13
       run: |
         sudo -E ./ci/setup_ci_environment.sh
     - name: install dependencies
@@ -1108,6 +1105,7 @@ jobs:
       env:
         CC: /usr/bin/gcc-13
         CXX: /usr/bin/g++-13
+        OTELCPP_CMAKE_BUILD_ARGS: "--parallel 2" # Limit parallelism to avoid hitting runner limits
       run: ./ci/do_ci.sh code.coverage
     - name: upload report
       uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2 # v6.0.0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1077,7 +1077,7 @@ jobs:
 
   code_coverage:
     name: Code coverage
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
     - name: Harden the runner (Audit all outbound calls)
       uses: step-security/harden-runner@f808768d1510423e83855289c910610ca9b43176 # v2.17.0
@@ -1089,14 +1089,14 @@ jobs:
         submodules: 'recursive'
     - name: setup
       env:
-        CC: /usr/bin/gcc-10
-        CXX: /usr/bin/g++-10
+        CC: /usr/bin/gcc-13
+        CXX: /usr/bin/g++-13
       run: |
         sudo -E ./ci/setup_ci_environment.sh
     - name: run tests and generate report
       env:
-        CC: /usr/bin/gcc-10
-        CXX: /usr/bin/g++-10
+        CC: /usr/bin/gcc-13
+        CXX: /usr/bin/g++-13
       run: ./ci/do_ci.sh code.coverage
     - name: upload report
       uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2 # v6.0.0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1093,6 +1093,9 @@ jobs:
         CXX: /usr/bin/g++-13
       run: |
         sudo -E ./ci/setup_ci_environment.sh
+    - name: install dependencies
+      run: |
+        sudo -E ./ci/install_thirdparty.sh --install-dir /usr/local --tags-file third_party_release
     - name: run tests and generate report
       env:
         CC: /usr/bin/gcc-13

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,15 @@ Increment the:
 * [CODE HEALTH] Fix clang-tidy warnings in base2 exponential histogram aggregation
   [#3997](https://github.com/open-telemetry/opentelemetry-cpp/pull/3997)
 
+* [CI] Build third-party dependencies in release with ninja
+  [#3995](https://github.com/open-telemetry/opentelemetry-cpp/pull/3995)
+
+* [CI] Update ci scripts and documentation
+  [#4000](https://github.com/open-telemetry/opentelemetry-cpp/pull/4000)
+
+* [CI] Update code.coverage job to report on all components and features
+  [#4002](https://github.com/open-telemetry/opentelemetry-cpp/pull/4002)
+
 Important changes:
 
 * Enable WITH_OTLP_RETRY_PREVIEW by default

--- a/ci/README.md
+++ b/ci/README.md
@@ -48,13 +48,20 @@ BUILD_DIR=$HOME/build
 BUILD_TYPE=Debug|Release|RelWithDebInfo|MinSizeRel
 CXX_STANDARD=14|17|20|23
 BUILD_SHARED_LIBS=ON|OFF
-OTELCPP_CMAKE_VERBOSE_BUILD=ON|OFF
+OTELCPP_CMAKE_BUILD_ARGS=<cmake-build-args>
 OTELCPP_CMAKE_CACHE_FILE=<cache-file-name>
 ```
 
 `OTELCPP_CMAKE_CACHE_FILE` should be the basename of a cache file from
 `test_common/cmake`, for example `all-options-abiv1-preview.cmake` or
 `all-options-abiv2.cmake`.
+
+`OTELCPP_CMAKE_BUILD_ARGS` overrides the default `cmake --build` arguments
+(`--parallel`). For example, to limit parallelism and enable verbose output:
+
+```sh
+OTELCPP_CMAKE_BUILD_ARGS="--parallel 2 --verbose" ./ci/do_ci.sh code.coverage
+```
 
 ## Targets
 

--- a/ci/do_ci.sh
+++ b/ci/do_ci.sh
@@ -655,13 +655,27 @@ elif [[ "$1" == "code.coverage" ]]; then
   rm -rf *
   cmake "${CMAKE_OPTIONS[@]}"  \
         -DCMAKE_CXX_FLAGS="-Werror --coverage $CXXFLAGS" \
+        -C "${SRC_DIR}/test_common/cmake/all-options-abiv2-preview.cmake" \
+        -DWITH_EXAMPLES=OFF \
+        -DWITH_EXAMPLES_HTTP=OFF \
+        -DWITH_BENCHMARK=OFF \
         "${SRC_DIR}"
-  make
-  make test
-  lcov --directory $PWD --capture --output-file coverage.info
-  # removing test http server coverage from the total coverage. We don't use this server completely.
-  lcov --remove coverage.info '*/ext/http/server/*'> tmp_coverage.info 2>/dev/null
-  cp tmp_coverage.info coverage.info
+  cmake --build "${BUILD_DIR}" --parallel
+  ctest --output-on-failure
+
+  lcov --directory "$PWD" --capture \
+  --include "${SRC_DIR}/*" \
+  --exclude "${SRC_DIR}/third_party/*" \
+  --exclude "${SRC_DIR}/test_common/*" \
+  --exclude "${SRC_DIR}/*/test/*" \
+  --exclude "${SRC_DIR}/functional/*" \
+  --exclude "${SRC_DIR}/semconv/*" \
+  --exclude "${SRC_DIR}/examples/*" \
+  --ignore-errors gcov,mismatch,negative,unused \
+  --output-file coverage.info
+
+  echo "Code coverage output file generated at ${BUILD_DIR}/coverage.info. To generate an HTML report run:"
+  echo "genhtml ${BUILD_DIR}/coverage.info -o coverage_html"
   exit 0
 elif [[ "$1" == "third_party.tags" ]]; then
   echo "gRPC=v1.49.2" > third_party_release

--- a/ci/do_ci.sh
+++ b/ci/do_ci.sh
@@ -624,6 +624,8 @@ elif [[ "$1" == "code.coverage" ]]; then
         -DWITH_EXAMPLES_HTTP=OFF \
         -DWITH_BENCHMARK=OFF \
         "${SRC_DIR}"
+
+  # Limit parallelism to 2 to avoid hitting github runner limits
   cmake --build "${BUILD_DIR}" --parallel 2
   ctest --output-on-failure
 

--- a/ci/do_ci.sh
+++ b/ci/do_ci.sh
@@ -660,7 +660,7 @@ elif [[ "$1" == "code.coverage" ]]; then
         -DWITH_EXAMPLES_HTTP=OFF \
         -DWITH_BENCHMARK=OFF \
         "${SRC_DIR}"
-  cmake --build "${BUILD_DIR}" --parallel
+  cmake --build "${BUILD_DIR}" --parallel 2
   ctest --output-on-failure
 
   lcov --directory "$PWD" --capture \

--- a/ci/do_ci.sh
+++ b/ci/do_ci.sh
@@ -618,7 +618,7 @@ elif [[ "$1" == "code.coverage" ]]; then
   cd "${BUILD_DIR}"
   rm -rf *
   cmake "${CMAKE_OPTIONS[@]}"  \
-        -DCMAKE_CXX_FLAGS="-Werror --coverage $CXXFLAGS" \
+        -DCMAKE_CXX_FLAGS="-Werror --coverage -fprofile-update=atomic $CXXFLAGS" \
         -C "${SRC_DIR}/test_common/cmake/all-options-abiv2-preview.cmake" \
         -DWITH_EXAMPLES=OFF \
         -DWITH_EXAMPLES_HTTP=OFF \

--- a/ci/do_ci.sh
+++ b/ci/do_ci.sh
@@ -87,10 +87,10 @@ fi
 CMAKE_OPTIONS+=("-DCMAKE_CXX_STANDARD_REQUIRED=ON")
 CMAKE_OPTIONS+=("-DCMAKE_CXX_EXTENSIONS=OFF")
 
-CMAKE_BUILD_ARGS=(--parallel)
-
-if [[ "${OTELCPP_CMAKE_VERBOSE_BUILD:-OFF}" =~ ^(1|ON|on|TRUE|true|YES|yes)$ ]]; then
-  CMAKE_BUILD_ARGS+=(--verbose)
+if [ -n "${OTELCPP_CMAKE_BUILD_ARGS}" ]; then
+  read -ra CMAKE_BUILD_ARGS <<< "${OTELCPP_CMAKE_BUILD_ARGS}"
+else
+  CMAKE_BUILD_ARGS=(--parallel)
 fi
 
 if command -v ninja >/dev/null 2>&1; then
@@ -625,8 +625,7 @@ elif [[ "$1" == "code.coverage" ]]; then
         -DWITH_BENCHMARK=OFF \
         "${SRC_DIR}"
 
-  # Limit parallelism to 2 to avoid hitting github runner limits
-  cmake --build "${BUILD_DIR}" --parallel 2
+  cmake --build . "${CMAKE_BUILD_ARGS[@]}"
   ctest --output-on-failure
 
   lcov --directory "$PWD" --capture \
@@ -637,7 +636,7 @@ elif [[ "$1" == "code.coverage" ]]; then
   --exclude "${SRC_DIR}/functional/*" \
   --exclude "${SRC_DIR}/semconv/*" \
   --exclude "${SRC_DIR}/examples/*" \
-  --ignore-errors gcov,mismatch,negative,unused \
+  --ignore-errors unused \
   --output-file coverage.info
 
   echo "Code coverage output file generated at ${BUILD_DIR}/coverage.info. To generate an HTML report run:"


### PR DESCRIPTION
Fixes # (issue)

Code coverage does not include all components and preview features. This PR expands coverage reporting. 

## Changes

- run the coverage test with `test_common/cmake/all-options-abiv2-preview.cmake` CMake cache to cover all components and preview features with ABI v2.
- update the ci code coverage runner to Ubuntu 24.04

For significant contributions please make sure you have completed the following items:

* [x] `CHANGELOG.md` updated for non-trivial changes
* [ ] Unit tests have been added
* [ ] Changes in public API reviewed