### PR TITLE
[TEST] set a maximum thread count for the metrics stress test

### DIFF
--- a/sdk/test/metrics/metric_test_stress.cc
+++ b/sdk/test/metrics/metric_test_stress.cc
@@ -4,6 +4,7 @@
 #include <gtest/gtest.h>
 
 #include <stdint.h>
+#include <algorithm>
 #include <atomic>
 #include <chrono>
 #include <initializer_list>  // IWYU pragma: keep
@@ -95,7 +96,7 @@ TEST(HistogramStress, UnsignedInt64)
   //
   // Start logging threads
   //
-  int record_thread_count = static_cast<int>(std::thread::hardware_concurrency()) - 1;
+  int record_thread_count = std::min(static_cast<int>(std::thread::hardware_concurrency()) - 1, 4);
   if (record_thread_count <= 0)
   {
     record_thread_count = 1;

--- a/sdk/test/metrics/metric_test_stress.cc
+++ b/sdk/test/metrics/metric_test_stress.cc
@@ -96,7 +96,10 @@ TEST(HistogramStress, UnsignedInt64)
   //
   // Start logging threads
   //
-  int record_thread_count = std::min(static_cast<int>(std::thread::hardware_concurrency()) - 1, 4);
+
+  constexpr int kMaxStressThreads = 4;
+  int record_thread_count =
+      (std::min)(static_cast<int>(std::thread::hardware_concurrency()) - 1, kMaxStressThreads);
   if (record_thread_count <= 0)
   {
     record_thread_count = 1;


### PR DESCRIPTION
Fixes # (issue)

The metrics stress test creates threads matching the number of cores on the host machine. This can take a long time to execute and time varies per machine. This PR sets a limit of 4 threads for the test.  

```
          Start  523: metrics.HistogramStress.UnsignedInt64
 523/1050 Test  #523: metrics.HistogramStress.UnsignedInt64 ................................................................   Passed  297.10 sec
```

## Changes

- limit metrics.HistogramStress.UnsignedInt64 to create up to 4 threads

For significant contributions please make sure you have completed the following items:

* [ ] `CHANGELOG.md` updated for non-trivial changes
* [ ] Unit tests have been added
* [ ] Changes in public API reviewed