### PR TITLE
[SDK] Rename parameters in logger_provider

### DIFF
--- a/api/include/opentelemetry/logs/logger_provider.h
+++ b/api/include/opentelemetry/logs/logger_provider.h
@@ -43,19 +43,19 @@ public:
 
   virtual nostd::shared_ptr<Logger> GetLogger(
       nostd::string_view logger_name,
-      nostd::string_view library_name            = "",
-      nostd::string_view library_version         = "",
+      nostd::string_view name = "",
+      nostd::string_view version = "",
       nostd::string_view schema_url              = "",
       const common::KeyValueIterable &attributes = common::NoopKeyValueIterable()) = 0;
 
   nostd::shared_ptr<Logger> GetLogger(
       nostd::string_view logger_name,
-      nostd::string_view library_name,
-      nostd::string_view library_version,
+      nostd::string_view name,
+      nostd::string_view version,
       nostd::string_view schema_url,
       std::initializer_list<std::pair<nostd::string_view, common::AttributeValue>> attributes)
   {
-    return GetLogger(logger_name, library_name, library_version, schema_url,
+    return GetLogger(logger_name, name, version, schema_url,
                      nostd::span<const std::pair<nostd::string_view, common::AttributeValue>>{
                          attributes.begin(), attributes.end()});
   }
@@ -63,12 +63,12 @@ public:
   template <class T,
             nostd::enable_if_t<common::detail::is_key_value_iterable<T>::value> * = nullptr>
   nostd::shared_ptr<Logger> GetLogger(nostd::string_view logger_name,
-                                      nostd::string_view library_name,
-                                      nostd::string_view library_version,
+                                      nostd::string_view name,
+                                      nostd::string_view version,
                                       nostd::string_view schema_url,
                                       const T &attributes)
   {
-    return GetLogger(logger_name, library_name, library_version, schema_url,
+    return GetLogger(logger_name, name, version, schema_url,
                      common::KeyValueIterableView<T>(attributes));
   }
 };

--- a/api/include/opentelemetry/logs/logger_provider.h
+++ b/api/include/opentelemetry/logs/logger_provider.h
@@ -43,8 +43,8 @@ public:
 
   virtual nostd::shared_ptr<Logger> GetLogger(
       nostd::string_view logger_name,
-      nostd::string_view name = "",
-      nostd::string_view version = "",
+      nostd::string_view name                    = "",
+      nostd::string_view version                 = "",
       nostd::string_view schema_url              = "",
       const common::KeyValueIterable &attributes = common::NoopKeyValueIterable()) = 0;
 

--- a/sdk/include/opentelemetry/sdk/logs/logger_provider.h
+++ b/sdk/include/opentelemetry/sdk/logs/logger_provider.h
@@ -87,7 +87,7 @@ public:
    * Creates a logger with the given name, and returns a shared pointer to it.
    * If a logger with that name already exists, return a shared pointer to it
    * @param logger_name The name of the logger to be created.
-   * @param name The version of the library.
+   * @param name The name of the library.
    * @param version The version of the library.
    * @param schema_url The schema URL.
    * @param attributes The attributes to be associated with the logger.
@@ -95,8 +95,8 @@ public:
   nostd::shared_ptr<opentelemetry::logs::Logger> GetLogger(
       nostd::string_view logger_name,
       nostd::string_view name,
-      nostd::string_view version = "",
-      nostd::string_view schema_url      = "",
+      nostd::string_view version    = "",
+      nostd::string_view schema_url = "",
       const opentelemetry::common::KeyValueIterable &attributes =
           opentelemetry::common::NoopKeyValueIterable()) noexcept override;
 

--- a/sdk/include/opentelemetry/sdk/logs/logger_provider.h
+++ b/sdk/include/opentelemetry/sdk/logs/logger_provider.h
@@ -87,15 +87,15 @@ public:
    * Creates a logger with the given name, and returns a shared pointer to it.
    * If a logger with that name already exists, return a shared pointer to it
    * @param logger_name The name of the logger to be created.
-   * @param library_name The version of the library.
-   * @param library_version The version of the library.
+   * @param name The version of the library.
+   * @param version The version of the library.
    * @param schema_url The schema URL.
    * @param attributes The attributes to be associated with the logger.
    */
   nostd::shared_ptr<opentelemetry::logs::Logger> GetLogger(
       nostd::string_view logger_name,
-      nostd::string_view library_name,
-      nostd::string_view library_version = "",
+      nostd::string_view name,
+      nostd::string_view version = "",
       nostd::string_view schema_url      = "",
       const opentelemetry::common::KeyValueIterable &attributes =
           opentelemetry::common::NoopKeyValueIterable()) noexcept override;

--- a/sdk/src/logs/logger_provider.cc
+++ b/sdk/src/logs/logger_provider.cc
@@ -71,15 +71,15 @@ LoggerProvider::~LoggerProvider()
 
 opentelemetry::nostd::shared_ptr<opentelemetry::logs::Logger> LoggerProvider::GetLogger(
     opentelemetry::nostd::string_view logger_name,
-    opentelemetry::nostd::string_view library_name,
-    opentelemetry::nostd::string_view library_version,
+    opentelemetry::nostd::string_view name,
+    opentelemetry::nostd::string_view version,
     opentelemetry::nostd::string_view schema_url,
     const opentelemetry::common::KeyValueIterable &attributes) noexcept
 {
   // https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/logs/data-model.md#field-instrumentationscope
-  if (library_name.empty())
+  if (name.empty())
   {
-    library_name = logger_name;
+    name = logger_name;
   }
 
   // Ensure only one thread can read/write from the map of loggers
@@ -90,14 +90,14 @@ opentelemetry::nostd::shared_ptr<opentelemetry::logs::Logger> LoggerProvider::Ge
   {
     auto &logger_lib = logger->GetInstrumentationScope();
     if (logger->GetName() == logger_name &&
-        logger_lib.equal(library_name, library_version, schema_url, &attributes))
+        logger_lib.equal(name, version, schema_url, &attributes))
     {
       return opentelemetry::nostd::shared_ptr<opentelemetry::logs::Logger>{logger};
     }
   }
 
   std::unique_ptr<instrumentationscope::InstrumentationScope> lib =
-      instrumentationscope::InstrumentationScope::Create(library_name, library_version, schema_url,
+      instrumentationscope::InstrumentationScope::Create(name, version, schema_url,
                                                          attributes);
 
   loggers_.push_back(std::shared_ptr<opentelemetry::sdk::logs::Logger>(

--- a/sdk/src/logs/logger_provider.cc
+++ b/sdk/src/logs/logger_provider.cc
@@ -97,8 +97,7 @@ opentelemetry::nostd::shared_ptr<opentelemetry::logs::Logger> LoggerProvider::Ge
   }
 
   std::unique_ptr<instrumentationscope::InstrumentationScope> lib =
-      instrumentationscope::InstrumentationScope::Create(name, version, schema_url,
-                                                         attributes);
+      instrumentationscope::InstrumentationScope::Create(name, version, schema_url, attributes);
 
   loggers_.push_back(std::shared_ptr<opentelemetry::sdk::logs::Logger>(
       new Logger(logger_name, context_, std::move(lib))));


### PR DESCRIPTION
Fixes #2689 

## Changes

Rename params in [logger_provider.cc](https://github.com/open-telemetry/opentelemetry-cpp/blob/a42027af9b396a1570c22d4c9c91be5a259962b9/api/include/opentelemetry/logs/logger_provider.h#L48)

For significant contributions please make sure you have completed the following items:

* [ ] `CHANGELOG.md` updated for non-trivial changes
* [ ] Unit tests have been added
* [X] Changes in public API reviewed