### PR TITLE
[SDK] Add destructor to PeriodicExportingMetricReader to fix shutdown race

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,9 @@ Increment the:
 
 ## [Unreleased]
 
+* [SDK] Fix PeriodicExportingMetricReader shutdown race on destruction
+  [#4008](https://github.com/open-telemetry/opentelemetry-cpp/pull/4008)
+
 * [SDK] Move inline implementation from SDK headers to .cc files.
   Note: `GetEmptyAttributes()` now requires linking `opentelemetry_common`.
   [#3887](https://github.com/open-telemetry/opentelemetry-cpp/pull/3887)

--- a/sdk/include/opentelemetry/sdk/metrics/export/periodic_exporting_metric_reader.h
+++ b/sdk/include/opentelemetry/sdk/metrics/export/periodic_exporting_metric_reader.h
@@ -36,6 +36,8 @@ public:
                                 const PeriodicExportingMetricReaderOptions &options,
                                 const PeriodicExportingMetricReaderRuntimeOptions &runtime_options);
 
+  ~PeriodicExportingMetricReader() override;
+
   AggregationTemporality GetAggregationTemporality(
       InstrumentType instrument_type) const noexcept override;
 

--- a/sdk/include/opentelemetry/sdk/metrics/export/periodic_exporting_metric_reader.h
+++ b/sdk/include/opentelemetry/sdk/metrics/export/periodic_exporting_metric_reader.h
@@ -38,6 +38,11 @@ public:
 
   ~PeriodicExportingMetricReader() override;
 
+  PeriodicExportingMetricReader(const PeriodicExportingMetricReader &)            = delete;
+  PeriodicExportingMetricReader &operator=(const PeriodicExportingMetricReader &) = delete;
+  PeriodicExportingMetricReader(PeriodicExportingMetricReader &&)                 = delete;
+  PeriodicExportingMetricReader &operator=(PeriodicExportingMetricReader &&)      = delete;
+
   AggregationTemporality GetAggregationTemporality(
       InstrumentType instrument_type) const noexcept override;
 

--- a/sdk/src/metrics/export/periodic_exporting_metric_reader.cc
+++ b/sdk/src/metrics/export/periodic_exporting_metric_reader.cc
@@ -80,12 +80,6 @@ PeriodicExportingMetricReader::~PeriodicExportingMetricReader()
   {
     Shutdown();
   }
-
-  if (worker_thread_.joinable())
-  {
-    cv_.notify_all();
-    worker_thread_.join();
-  }
 }
 
 AggregationTemporality PeriodicExportingMetricReader::GetAggregationTemporality(

--- a/sdk/src/metrics/export/periodic_exporting_metric_reader.cc
+++ b/sdk/src/metrics/export/periodic_exporting_metric_reader.cc
@@ -74,6 +74,20 @@ PeriodicExportingMetricReader::PeriodicExportingMetricReader(
   }
 }
 
+PeriodicExportingMetricReader::~PeriodicExportingMetricReader()
+{
+  if (!IsShutdown())
+  {
+    Shutdown();
+  }
+
+  if (worker_thread_.joinable())
+  {
+    cv_.notify_all();
+    worker_thread_.join();
+  }
+}
+
 AggregationTemporality PeriodicExportingMetricReader::GetAggregationTemporality(
     InstrumentType instrument_type) const noexcept
 {

--- a/sdk/test/metrics/periodic_exporting_metric_reader_test.cc
+++ b/sdk/test/metrics/periodic_exporting_metric_reader_test.cc
@@ -124,8 +124,7 @@ TEST(PeriodicExportingMetricReader, DestroyWithoutShutdown)
   // background worker thread.  Before the destructor fix this test would fail
   // under ThreadSanitizer with:
   //   WARNING: ThreadSanitizer: unlock of an unlocked mutex (or by a wrong thread)
-  std::unique_ptr<PushMetricExporter> exporter(
-      new MockPushMetricExporter(std::chrono::milliseconds{0}));
+  auto exporter = std::make_unique<MockPushMetricExporter>(std::chrono::milliseconds{0});
   PeriodicExportingMetricReaderOptions options;
   options.export_timeout_millis  = std::chrono::milliseconds(200);
   options.export_interval_millis = std::chrono::milliseconds(500);
@@ -133,8 +132,7 @@ TEST(PeriodicExportingMetricReader, DestroyWithoutShutdown)
   // destructor joins the background thread which may still call Produce().
   MockMetricProducer producer;
   {
-    auto reader =
-        std::make_shared<PeriodicExportingMetricReader>(std::move(exporter), options);
+    auto reader = std::make_shared<PeriodicExportingMetricReader>(std::move(exporter), options);
     reader->SetMetricProducer(&producer);
     // Let the background thread start and enter its wait loop.
     std::this_thread::sleep_for(std::chrono::milliseconds(50));

--- a/sdk/test/metrics/periodic_exporting_metric_reader_test.cc
+++ b/sdk/test/metrics/periodic_exporting_metric_reader_test.cc
@@ -117,6 +117,31 @@ TEST(PeriodicExportingMetricReader, Timeout)
   reader->Shutdown();
 }
 
+TEST(PeriodicExportingMetricReader, DestroyWithoutShutdown)
+{
+  // Verify that destroying a reader without calling Shutdown() does not cause
+  // use-after-destroy races on the condition variable / mutex used by the
+  // background worker thread.  Before the destructor fix this test would fail
+  // under ThreadSanitizer with:
+  //   WARNING: ThreadSanitizer: unlock of an unlocked mutex (or by a wrong thread)
+  std::unique_ptr<PushMetricExporter> exporter(
+      new MockPushMetricExporter(std::chrono::milliseconds{0}));
+  PeriodicExportingMetricReaderOptions options;
+  options.export_timeout_millis  = std::chrono::milliseconds(200);
+  options.export_interval_millis = std::chrono::milliseconds(500);
+  // producer must be declared before reader so it outlives it — the reader's
+  // destructor joins the background thread which may still call Produce().
+  MockMetricProducer producer;
+  {
+    auto reader =
+        std::make_shared<PeriodicExportingMetricReader>(std::move(exporter), options);
+    reader->SetMetricProducer(&producer);
+    // Let the background thread start and enter its wait loop.
+    std::this_thread::sleep_for(std::chrono::milliseconds(50));
+    // reader goes out of scope here — no Shutdown() call.
+  }
+}
+
 TEST(PeriodicExportingMetricReaderOptions, UsesEnvVars)
 {
   const char *env_interval = "OTEL_METRIC_EXPORT_INTERVAL";


### PR DESCRIPTION
Fixes #4007

## Changes

Destroying a PeriodicExportingMetricReader without calling Shutdown()
leaves the background worker thread running inside cv_.wait_for() while
the mutex and condition variable members are destroyed. This causes a
use-after-destroy race detected by ThreadSanitizer.

Add an explicit destructor that calls Shutdown() and joins the worker
thread before member destruction, matching the pattern already used by
BatchSpanProcessor and BatchLogRecordProcessor.

Add a DestroyWithoutShutdown test to verify safe destruction without
an explicit Shutdown() call.

* [x] `CHANGELOG.md` updated for non-trivial changes
* [x] Unit tests have been added
* [x] Changes in public API reviewed — the only addition is the destructor declaration in the header; no existing API is changed
