### PR TITLE
Enable ENABLE_OTLP_RETRY_PREVIEW for bazel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,9 @@ Increment the:
 * [CODE HEALTH] Fix clang-tidy warnings in base2 exponential histogram aggregation
   [#3997](https://github.com/open-telemetry/opentelemetry-cpp/pull/3997)
 
+* Enable ENABLE_OTLP_RETRY_PREVIEW for bazel
+  [#4010](https://github.com/open-telemetry/opentelemetry-cpp/pull/4010)
+
 Important changes:
 
 * Enable WITH_OTLP_RETRY_PREVIEW by default
@@ -77,6 +80,11 @@ Important changes:
   * Bazel now always builds with ENABLE_OTLP_GRPC_SSL_MTLS_PREVIEW.
   * grpc properties for ssl KEY and CERT are always available,
     adjust the application code to initialize all members in grpc options.
+
+* Enable ENABLE_OTLP_RETRY_PREVIEW for bazel
+  [#4010](https://github.com/open-telemetry/opentelemetry-cpp/pull/4010)
+
+  * Bazel now always builds with ENABLE_OTLP_RETRY_PREVIEW.
 
 ## [1.26.0] 2026-03-19
 

--- a/DEPRECATED.md
+++ b/DEPRECATED.md
@@ -76,10 +76,8 @@ Applications built with `WITH_OTLP_RETRY_PREVIEW=OFF` need to:
 * remove the WITH_OTLP_RETRY_PREVIEW flag from CMake scripts
 * use `retry_policy_max_attempts` = 0 in the OTLP exporter options.
 
-For Bazel, no compilation flag exists.
-
-When WITH_OTLP_RETRY_PREVIEW / ENABLE_OTLP_RETRY_PREVIEW gets
-removed from the code base, the bazel build will have the retry feature.
+For Bazel, no compilation option exists,
+the bazel build enables unconditionally ENABLE_OTLP_RETRY_PREVIEW.
 
 Make sure to properly initialize `retry_policy_max_attempts`
 to enable or disable the retry feature.

--- a/exporters/otlp/BUILD
+++ b/exporters/otlp/BUILD
@@ -76,7 +76,7 @@ cc_library(
     defines = select({
         ":enable_otlp_grpc_credential_preview": ["ENABLE_OTLP_GRPC_CREDENTIAL_PREVIEW"],
         "//conditions:default": [],
-    }) + ["ENABLE_OTLP_GRPC_SSL_MTLS_PREVIEW"],
+    }) + ["ENABLE_OTLP_GRPC_SSL_MTLS_PREVIEW"] + ["ENABLE_OTLP_RETRY_PREVIEW"],
     strip_include_prefix = "include",
     tags = [
         "otlp",
@@ -718,6 +718,7 @@ cc_test(
 cc_test(
     name = "otlp_http_exporter_test",
     srcs = ["test/otlp_http_exporter_test.cc"],
+    defines = ["ENABLE_OTLP_RETRY_PREVIEW"],
     tags = [
         "otlp",
         "otlp_http",

--- a/ext/src/http/client/curl/BUILD
+++ b/ext/src/http/client/curl/BUILD
@@ -12,6 +12,7 @@ cc_library(
         "http_client_factory_curl.cc",
         "http_operation_curl.cc",
     ],
+    defines = ["ENABLE_OTLP_RETRY_PREVIEW"],
     include_prefix = "src/http/client/curl",
     linkopts = select({
         "//bazel:windows": [

--- a/ext/test/http/BUILD
+++ b/ext/test/http/BUILD
@@ -8,6 +8,7 @@ cc_test(
     srcs = [
         "curl_http_test.cc",
     ],
+    defines = ["ENABLE_OTLP_RETRY_PREVIEW"],
     tags = ["test"],
     deps = [
         "//ext:headers",


### PR DESCRIPTION
Follow up on #3481

## Changes

Please provide a brief description of the changes here.

* Enable `ENABLE_OTLP_RETRY_PREVIEW` for bazel, to match the `CMake` build

For significant contributions please make sure you have completed the following items:

* [X] `CHANGELOG.md` updated for non-trivial changes
* [ ] Unit tests have been added
* [ ] Changes in public API reviewed