### PR TITLE
[CHORE] Fix warnings in publish-to-bcr workflow

### DIFF
--- a/.github/workflows/publish-to-bcr.yml
+++ b/.github/workflows/publish-to-bcr.yml
@@ -16,13 +16,16 @@ on:
   release:
     types: [published]
 
+permissions:
+  contents: read
+
 jobs:
   publish:
     permissions:
       contents: write
       id-token: write
       attestations: write
-    uses: bazel-contrib/publish-to-bcr/.github/workflows/publish.yaml@v1.2.0
+    uses: bazel-contrib/publish-to-bcr/.github/workflows/publish.yaml@0a23c53c2baffdaf2ce8dd23c2c0e45eb3b79093 # v1.2.0
     with:
       tag_name: ${{ inputs.tag_name || github.event.release.tag_name }}
       registry_fork: ${{ inputs.registry_fork || 'open-telemetry/bazel-central-registry' }}


### PR DESCRIPTION
Fixes # (issue)

Fix code scanning warnings in the `publish-to-bcr` workflow.

## Changes

- add workflow level permissions for contents set to read
- pin the `bazel-contrib/publish-to-bcr` action to v1.2.0 (https://github.com/bazel-contrib/publish-to-bcr/releases/tag/v1.2.0)
 
For significant contributions please make sure you have completed the following items:

* [ ] `CHANGELOG.md` updated for non-trivial changes
* [ ] Unit tests have been added
* [ ] Changes in public API reviewed