### PR TITLE
fix: noexcept for Observer

### DIFF
--- a/sdk/include/opentelemetry/sdk/metrics/observer_result.h
+++ b/sdk/include/opentelemetry/sdk/metrics/observer_result.h
@@ -7,6 +7,7 @@
 
 #include "opentelemetry/common/attribute_value.h"
 #include "opentelemetry/common/key_value_iterable.h"
+#include "opentelemetry/common/macros.h"
 #include "opentelemetry/metrics/observer_result.h"
 #include "opentelemetry/nostd/string_view.h"
 #include "opentelemetry/sdk/metrics/state/attributes_hashmap.h"
@@ -34,15 +35,37 @@ public:
   ~ObserverResultT() override = default;
 
   void Observe(T value) noexcept override
+#if OPENTELEMETRY_HAVE_EXCEPTIONS
+  try
+#endif
   {
     data_[MetricAttributes{{}, attributes_processor_}] = value;
   }
+#if OPENTELEMETRY_HAVE_EXCEPTIONS
+  catch (...)
+  {
+    // Silently drop the measurement; per opentelemetry-cpp guidance (PR #3964),
+    // exceptions in noexcept API/SDK code must not log or abort.
+    return;
+  }
+#endif
 
   void Observe(T value, const opentelemetry::common::KeyValueIterable &attributes) noexcept override
+#if OPENTELEMETRY_HAVE_EXCEPTIONS
+  try
+#endif
   {
     data_[MetricAttributes{attributes, attributes_processor_}] =
         value;  // overwrites the previous value if present
   }
+#if OPENTELEMETRY_HAVE_EXCEPTIONS
+  catch (...)
+  {
+    // Silently drop the measurement; per opentelemetry-cpp guidance (PR #3964),
+    // exceptions in noexcept API/SDK code must not log or abort.
+    return;
+  }
+#endif
 
   const std::unordered_map<MetricAttributes, T, AttributeHashGenerator> &GetMeasurements()
   {


### PR DESCRIPTION
Fixes #2053

## Changes

bad allocation, bad variant access can happen. First i try to logging when exception happens, But following the [comment](https://github.com/open-telemetry/opentelemetry-cpp/pull/3964#issuecomment-4217428324), ignore it.


* [ ] `CHANGELOG.md` updated for non-trivial changes
* [ ] Unit tests have been added
* [ ] Changes in public API reviewed