### PR TITLE
fix examples/configuration

### DIFF
--- a/examples/configuration/CMakeLists.txt
+++ b/examples/configuration/CMakeLists.txt
@@ -20,7 +20,7 @@ add_executable(
   custom_log_record_processor_builder.cc)
 
 target_link_libraries(
-  example_yaml 
+  example_yaml
   PRIVATE ${CMAKE_THREAD_LIBS_INIT}
           common_metrics_foo_library
           common_logs_foo_library

--- a/examples/configuration/CMakeLists.txt
+++ b/examples/configuration/CMakeLists.txt
@@ -20,8 +20,9 @@ add_executable(
   custom_log_record_processor_builder.cc)
 
 target_link_libraries(
-  example_yaml ${CMAKE_THREAD_LIBS_INIT}
-  PRIVATE common_metrics_foo_library
+  example_yaml 
+  PRIVATE ${CMAKE_THREAD_LIBS_INIT}
+          common_metrics_foo_library
           common_logs_foo_library
           opentelemetry-cpp::ostream_span_exporter_builder
           opentelemetry-cpp::ostream_metrics_exporter_builder


### PR DESCRIPTION
## Changes

cmake with WITH_CONFIGURATION flag would break build now, as target link library is not recognizing private keyword

To reproduce this issue, run `cmake -S . -B build -G Ninja -DWITH_CONFIGURATION=1 && ninja -C build`

For significant contributions please make sure you have completed the following items:

* [ ] `CHANGELOG.md` updated for non-trivial changes
* [ ] Unit tests have been added
* [ ] Changes in public API reviewed