### PR TITLE
[DOC] Document adding attributes on span creation

### DIFF
--- a/api/include/opentelemetry/trace/tracer.h
+++ b/api/include/opentelemetry/trace/tracer.h
@@ -43,7 +43,7 @@ public:
    * Attributes will be processed in order, previous attributes with the same
    * key will be overwritten.
    *
-   * Note: Adding attributes at span creation is preferred to calling SetAttribute later,
+   * Note: Adding attributes and links at span creation is preferred to adding them later,
    * as samplers can only consider information already present during span creation.
    */
   virtual nostd::shared_ptr<Span> StartSpan(nostd::string_view name,

--- a/api/include/opentelemetry/trace/tracer.h
+++ b/api/include/opentelemetry/trace/tracer.h
@@ -42,6 +42,9 @@ public:
    *
    * Attributes will be processed in order, previous attributes with the same
    * key will be overwritten.
+   *
+   * Note: Adding attributes at span creation is preferred to calling SetAttribute later, 
+   * as samplers can only consider information already present during span creation.
    */
   virtual nostd::shared_ptr<Span> StartSpan(nostd::string_view name,
                                             const common::KeyValueIterable &attributes,

--- a/api/include/opentelemetry/trace/tracer.h
+++ b/api/include/opentelemetry/trace/tracer.h
@@ -43,7 +43,7 @@ public:
    * Attributes will be processed in order, previous attributes with the same
    * key will be overwritten.
    *
-   * Note: Adding attributes at span creation is preferred to calling SetAttribute later, 
+   * Note: Adding attributes at span creation is preferred to calling SetAttribute later,
    * as samplers can only consider information already present during span creation.
    */
   virtual nostd::shared_ptr<Span> StartSpan(nostd::string_view name,


### PR DESCRIPTION
Fixes #4044 

[Documentation defines adding attributes at span creation as preferred](https://opentelemetry.io/docs/specs/otel/trace/api/#span-creation)

## Changes

Updated the tracer.h header file to document that attributes should be added during span creation and why

For significant contributions please make sure you have completed the following items:

* [ ] `CHANGELOG.md` updated for non-trivial changes
* [ ] Unit tests have been added
* [X] Changes in public API reviewed