### PR TITLE
[EXPORTER] Fix PrometheusExporter to propagate new options to collector

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,6 +90,9 @@ Increment the:
 * [SDK] env var durations non conforming to spec
   [#4020](https://github.com/open-telemetry/opentelemetry-cpp/pull/4020)
 
+* [EXPORTER] Fix Prometheus exporter ignoring without_units/without_type_suffix
+  [#4055](https://github.com/open-telemetry/opentelemetry-cpp/pull/4055)
+
 Important changes:
 
 * Enable WITH_OTLP_RETRY_PREVIEW by default

--- a/exporters/prometheus/include/opentelemetry/exporters/prometheus/collector.h
+++ b/exporters/prometheus/include/opentelemetry/exporters/prometheus/collector.h
@@ -32,7 +32,9 @@ public:
    */
   explicit PrometheusCollector(sdk::metrics::MetricReader *reader,
                                bool populate_target_info,
-                               bool without_otel_scope);
+                               bool without_otel_scope,
+                               bool without_units       = false,
+                               bool without_type_suffix = false);
 
   /**
    * Collects all metrics data from metricsToCollect collection.
@@ -45,6 +47,8 @@ private:
   sdk::metrics::MetricReader *reader_;
   bool populate_target_info_;
   bool without_otel_scope_;
+  bool without_units_;
+  bool without_type_suffix_;
 
   /*
    * Lock when operating the metricsToCollect collection

--- a/exporters/prometheus/src/collector.cc
+++ b/exporters/prometheus/src/collector.cc
@@ -58,8 +58,8 @@ std::vector<prometheus_client::MetricFamily> PrometheusCollector::Collect() cons
 
   reader_->Collect([&result, this](sdk::metrics::ResourceMetrics &metric_data) {
     auto prometheus_metric_data = PrometheusExporterUtils::TranslateToPrometheus(
-        metric_data, this->populate_target_info_, this->without_otel_scope_,
-        this->without_units_, this->without_type_suffix_);
+        metric_data, this->populate_target_info_, this->without_otel_scope_, this->without_units_,
+        this->without_type_suffix_);
     for (auto &data : prometheus_metric_data)
       result.emplace_back(data);
     return true;

--- a/exporters/prometheus/src/collector.cc
+++ b/exporters/prometheus/src/collector.cc
@@ -28,10 +28,14 @@ namespace metrics
  */
 PrometheusCollector::PrometheusCollector(sdk::metrics::MetricReader *reader,
                                          bool populate_target_info,
-                                         bool without_otel_scope)
+                                         bool without_otel_scope,
+                                         bool without_units,
+                                         bool without_type_suffix)
     : reader_(reader),
       populate_target_info_(populate_target_info),
-      without_otel_scope_(without_otel_scope)
+      without_otel_scope_(without_otel_scope),
+      without_units_(without_units),
+      without_type_suffix_(without_type_suffix)
 {}
 
 /**
@@ -54,7 +58,8 @@ std::vector<prometheus_client::MetricFamily> PrometheusCollector::Collect() cons
 
   reader_->Collect([&result, this](sdk::metrics::ResourceMetrics &metric_data) {
     auto prometheus_metric_data = PrometheusExporterUtils::TranslateToPrometheus(
-        metric_data, this->populate_target_info_, this->without_otel_scope_);
+        metric_data, this->populate_target_info_, this->without_otel_scope_,
+        this->without_units_, this->without_type_suffix_);
     for (auto &data : prometheus_metric_data)
       result.emplace_back(data);
     return true;

--- a/exporters/prometheus/src/exporter.cc
+++ b/exporters/prometheus/src/exporter.cc
@@ -42,7 +42,8 @@ PrometheusExporter::PrometheusExporter(const PrometheusExporterOptions &options)
     return;
   }
   collector_ = std::shared_ptr<PrometheusCollector>(
-      new PrometheusCollector(this, options_.populate_target_info, options_.without_otel_scope));
+      new PrometheusCollector(this, options_.populate_target_info, options_.without_otel_scope,
+                              options_.without_units, options_.without_type_suffix));
 
   exposer_->RegisterCollectable(collector_);
 }

--- a/exporters/prometheus/test/collector_test.cc
+++ b/exporters/prometheus/test/collector_test.cc
@@ -78,7 +78,7 @@ TEST(PrometheusCollector, BasicTests)
   MockMetricReader reader;
   MockMetricProducer producer;
   reader.SetMetricProducer(&producer);
-  PrometheusCollector collector(&reader, true, false);
+  PrometheusCollector collector(&reader, true, false, false, false);
   auto data = collector.Collect();
 
   // Collection size should be the same as the size


### PR DESCRIPTION
Fixes #4052

## Changes

Please provide a brief description of the changes here.

I read the comment at https://github.com/open-telemetry/opentelemetry-cpp/issues/4052#issuecomment-4382623957, but understood that the topic of discussion there is more general in scope and has wider impact than this issue. Therefore, this PR aims to focus on fixing the bug described in the issue while maintaining public API backward compatibility (though ABI compatibility may be affected).

* Added member variables and constructor arguments to `PrometheusCollector` (with default values for backward compatibility)
* Updated `PrometheusExporter` to pass the new options when constructing `PrometheusCollector`

For significant contributions please make sure you have completed the following items:

* [x] `CHANGELOG.md` updated for non-trivial changes
* [ ] Unit tests have been added
* [ ] Changes in public API reviewed