### PR TITLE
[Docs] Fix Read the Docs configuration

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,16 @@
+version: 2
+
+build:
+  os: ubuntu-24.04
+  tools:
+    python: "3.12"
+  apt_packages:
+    - doxygen
+    - graphviz
+
+sphinx:
+  configuration: docs/public/conf.py
+
+python:
+  install:
+    - requirements: docs/public/requirements.txt

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,3 +1,9 @@
+# Copyright The OpenTelemetry Authors
+# SPDX-License-Identifier: Apache-2.0
+
+# Read the Docs configuration file for Sphinx projects
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+
 version: 2
 
 build:

--- a/docs/public/requirements.txt
+++ b/docs/public/requirements.txt
@@ -1,3 +1,4 @@
 breathe
 exhale
 furo
+sphinx-rtd-theme


### PR DESCRIPTION
Fixes # (issue)

## Changes

 Adds the repository-root `.readthedocs.yaml` file so Read the Docs can build this repository again.

  The config:
  - points RTD at the existing Sphinx config in `docs/public/conf.py`
  - installs `doxygen` and `graphviz`, which are needed by the current Doxygen/Exhale docs flow
  - installs the existing Python docs requirements from `docs/public/requirements.txt`

  Also adds `sphinx-rtd-theme` explicitly because `docs/public/conf.py` uses `html_theme = "sphinx_rtd_theme"`.

 ## Validation

  Tested this branch on a forked Read the Docs project.

  Builds:
  https://app.readthedocs.org/projects/labhas-opentelemetry-cpp/builds/

  Rendered docs:
  https://labhas-opentelemetry-cpp.readthedocs.io/en/latest/

  Generated API page:
  https://labhas-opentelemetry-cpp.readthedocs.io/en/latest/otel_docs/classopentelemetry_1_1trace_1_1Tracer.html


For significant contributions please make sure you have completed the following items:

* [ ] `CHANGELOG.md` updated for non-trivial changes
* [ ] Unit tests have been added
* [ ] Changes in public API reviewed