### PR TITLE
[SDK] Fix overflow attribute name to match the spec (otel.metric.overflow)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -118,6 +118,19 @@ Important changes:
   * namespace opentelemetry::plugin is deprecated
   * See file DEPRECATED.md for details.
 
+* [SDK] Fix cardinality-limit overflow attribute name to match the
+  specification
+  [#4060](https://github.com/open-telemetry/opentelemetry-cpp/pull/4060)
+
+  * The synthetic overflow data point attribute is now exported as
+    `otel.metric.overflow` (singular) per the
+    [Metrics SDK specification](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/metrics/sdk.md#cardinality-limits).
+  * Previously the SDK exported `otel.metrics.overflow` (plural), which
+    diverged from the spec and from every other language SDK
+    (Go, Java, JS, .NET).
+  * Downstream consumers (dashboards, alerts, queries) that filtered on
+    the old name must be updated to the spec-correct name.
+
 Breaking changes:
 
 * [SDK] env var durations non conforming to spec

--- a/sdk/include/opentelemetry/sdk/metrics/state/attributes_hashmap.h
+++ b/sdk/include/opentelemetry/sdk/metrics/state/attributes_hashmap.h
@@ -26,7 +26,7 @@ namespace metrics
 using opentelemetry::sdk::common::OrderedAttributeMap;
 
 constexpr size_t kAggregationCardinalityLimit = 2000;
-const std::string kAttributesLimitOverflowKey = "otel.metrics.overflow";
+const std::string kAttributesLimitOverflowKey = "otel.metric.overflow";
 const bool kAttributesLimitOverflowValue      = true;
 const MetricAttributes kOverflowAttributes    = {
     {kAttributesLimitOverflowKey,

--- a/sdk/test/metrics/cardinality_limit_test.cc
+++ b/sdk/test/metrics/cardinality_limit_test.cc
@@ -158,3 +158,16 @@ TEST_P(WritableMetricStorageCardinalityLimitTestFixture, LongCounterSumAggregati
 INSTANTIATE_TEST_SUITE_P(All,
                          WritableMetricStorageCardinalityLimitTestFixture,
                          ::testing::Values(AggregationTemporality::kDelta));
+
+// Pin the overflow attribute key to the value defined in the OpenTelemetry
+// Metrics SDK specification. The previous value `otel.metrics.overflow`
+// (plural) silently diverged from the spec for years because every other
+// metrics test referenced the C++ symbol instead of the literal, so a typo
+// in the constant could not be caught by tests. Keep this assertion against
+// the literal string so any future drift is detected immediately.
+// Spec:
+// https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/metrics/sdk.md#cardinality-limits
+TEST(CardinalityLimitOverflowAttribute, MatchesSpecLiteral)
+{
+  EXPECT_EQ(opentelemetry::sdk::metrics::kAttributesLimitOverflowKey, "otel.metric.overflow");
+}


### PR DESCRIPTION
## Changes

Fix the cardinality-limit overflow attribute key so it matches the
[Metrics SDK specification](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/metrics/sdk.md#cardinality-limits).

The spec defines the synthetic overflow data point's attribute as
**`otel.metric.overflow`** (singular *metric*). The C++ SDK has been
exporting **`otel.metrics.overflow`** (plural *metrics*) since the
cardinality-limit feature was first added in #2255 (merged Nov 2023).

All other language SDKs that the spec compliance matrix lists as
implementing cardinality limits use the spec-correct singular name:

| SDK   | Attribute name           |
|-------|--------------------------|
| Go    | `otel.metric.overflow`   |
| Java  | `otel.metric.overflow`   |
| JS    | `otel.metric.overflow`   |
| .NET  | `otel.metric.overflow`   |
| C++   | `otel.metrics.overflow` (this PR fixes) |

## Why it matters

The whole point of the spec-defined overflow attribute is that backends,
dashboards, and alerting tools can detect cardinality overflow the same
way regardless of which language SDK produced the metric. Today a query
like `{otel.metric.overflow="true"}` silently misses overflow data
emitted by C++ applications.

## Compatibility note

The constant `kAttributesLimitOverflowKey` symbol is unchanged, so
in-process consumers using the symbol pick up the new value
automatically. Existing dashboards/alerts/queries that filtered on the
old (incorrect) string `otel.metrics.overflow` must be updated to
`otel.metric.overflow`. This is called out in the CHANGELOG under
*Important changes*.

## Checklist

- [x] `CHANGELOG.md` updated
- [x] No new unit tests required — existing tests in
  `sum_aggregation_test.cc` and `cardinality_limit_test.cc` use the
  `kAttributesLimitOverflowKey` symbol, so they continue to pass with
  the corrected value.
- [x] Public API not changed (only the value of an internal const string).
