### PR TITLE
docs: Expand SIG meeting welcoming language

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,11 @@ Meeting notes are available as a public
 For edit access, get in touch on
 [Slack](https://cloud-native.slack.com/archives/C01N3AT62SJ).
 
+The meeting is open for all to join. We invite everyone to join our meeting,
+regardless of your experience level. Whether you're a seasoned OpenTelemetry
+developer, just starting your journey, or simply curious about the work we do,
+you're more than welcome to participate!
+
 ### Maintainers
 
 * [Doug Barker](https://github.com/dbarker)


### PR DESCRIPTION
Adds a welcoming paragraph to the SIG meeting section, matching the wording used in [opentelemetry-rust](https://github.com/open-telemetry/opentelemetry-rust#contributing) and [opentelemetry-dotnet](https://github.com/open-telemetry/opentelemetry-dotnet#contributing). Per discussion in [community#1805](https://github.com/open-telemetry/community/issues/1805).