### PR TITLE
[DOC] Fix extra blank line in GettingStarted example

### DIFF
--- a/docs/public/sdk/GettingStarted.rst
+++ b/docs/public/sdk/GettingStarted.rst
@@ -200,7 +200,6 @@ The custom log handler can be defined by inheriting from `opentelemetry::sdk::co
                     int line,
                     const char *msg,
                     const opentelemetry::sdk::common::AttributeMap &attributes) noexcept override
-
         {
             // add implementation here
         }


### PR DESCRIPTION
Contributes to #3763

The `Handle` method in the `CustomLogHandler` code example had an 
extra blank line between the `noexcept override` specifier and the 
opening brace `{`, which is inconsistent with C++ style conventions 
and could confuse readers.

Removed the extra blank line to make the example cleaner and consistent.