### PR TITLE
docs: update custom log handler example

### DIFF
--- a/docs/public/sdk/GettingStarted.rst
+++ b/docs/public/sdk/GettingStarted.rst
@@ -190,6 +190,7 @@ and it can be changed at compile time.
     OTEL_INTERNAL_LOG_DEBUG(" Connection Established Successfully. Headers:", http_attributes);
 
 The custom log handler can be defined by inheriting from `opentelemetry::sdk::common::internal_log::LogHandler` class.
+Register the handler as an `opentelemetry::nostd::shared_ptr`.
 
 .. code:: cpp
 
@@ -204,5 +205,7 @@ The custom log handler can be defined by inheriting from `opentelemetry::sdk::co
             // add implementation here
         }
     };
-    opentelemetry::sdk::common::internal_log::GlobalLogHandler::SetLogHandler(std::make_shared<CustomLogHandler>());
+    using opentelemetry::sdk::common::internal_log::LogHandler;
+    opentelemetry::nostd::shared_ptr<LogHandler> custom_log_handler(new CustomLogHandler{});
+    opentelemetry::sdk::common::internal_log::GlobalLogHandler::SetLogHandler(custom_log_handler);
     opentelemetry::sdk::common::internal_log::GlobalLogHandler::SetLogLevel(opentelemetry::sdk::common::internal_log::LogLevel::Debug);


### PR DESCRIPTION
Fixes #3763

## Changes

Updates the Getting Started custom log handler example to register the handler using `opentelemetry::nostd::shared_ptr<LogHandler>`, matching the current `GlobalLogHandler::SetLogHandler` API.

The previous documentation used `std::make_shared<CustomLogHandler>()`, which does not match the exact API type when `nostd::shared_ptr` is not an alias to `std::shared_ptr`.

This change also makes the documentation consistent with the SDK test pattern in `sdk/test/common/global_log_handle_test.cc`.

This is a documentation-only change, so no changelog entry, unit test, or public API review is required.

Please provide a brief description of the changes here.
## Testing

- Ran `git diff --check`
- Searched `SetLogHandler`, `CustomLogHandler`, and `GlobalLogHandler` usages
- Compiled the revised snippet with `c++ -std=c++11 -Iapi/include -Isdk/include`

For significant contributions please make sure you have completed the following items:

* [ ] `CHANGELOG.md` updated for non-trivial changes
* [ ] Unit tests have been added
* [ ] Changes in public API reviewed