### PR TITLE
[EXPORTER] Convert uint64_t attribute values exceeding INT64_MAX to string per OTel spec

### DIFF
--- a/.github/workflows/clang-tidy.yaml
+++ b/.github/workflows/clang-tidy.yaml
@@ -17,9 +17,9 @@ jobs:
       matrix:
         include:
           - cmake_options: all-options-abiv1-preview
-            warning_limit: 389
+            warning_limit: 385
           - cmake_options: all-options-abiv2-preview
-            warning_limit: 395
+            warning_limit: 391
     env:
       CC: /usr/bin/clang-22
       CXX: /usr/bin/clang++-22

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,9 @@ Increment the:
 * [CODE HEALTH] Fix IWYU Clang22 warnings
   [#4083](https://github.com/open-telemetry/opentelemetry-cpp/pull/4083)
 
+* [EXPORTER] Spec-compliant uint64_t attribute encoding in OTLP
+  [#4090](https://github.com/open-telemetry/opentelemetry-cpp/pull/4090)
+
 * [CODE HEALTH] Remove unused alias declarations
   [#4091](https://github.com/open-telemetry/opentelemetry-cpp/pull/4091)
 

--- a/exporters/otlp/src/otlp_populate_attribute_utils.cc
+++ b/exporters/otlp/src/otlp_populate_attribute_utils.cc
@@ -6,6 +6,7 @@
 #endif
 
 #include <stdint.h>
+#include <limits>
 #include <string>
 #include <utility>
 #include <vector>
@@ -41,6 +42,24 @@ namespace otlp
 const int kAttributeValueSize      = 16;
 const int kOwnedAttributeValueSize = 15;
 
+namespace
+{
+// Per OpenTelemetry spec, uint64_t attribute values exceeding INT64_MAX must be
+// encoded as a decimal string rather than wrapping to a negative int64 via narrowing.
+// https://opentelemetry.io/docs/specs/otel/common/attribute-type-mapping/#integer-values
+inline void SetUint64Value(opentelemetry::proto::common::v1::AnyValue *proto_value, uint64_t val)
+{
+  if (val <= static_cast<uint64_t>(std::numeric_limits<int64_t>::max()))
+  {
+    proto_value->set_int_value(static_cast<int64_t>(val));
+  }
+  else
+  {
+    proto_value->set_string_value(std::to_string(val));
+  }
+}
+}  // namespace
+
 void OtlpPopulateAttributeUtils::PopulateAnyValue(
     opentelemetry::proto::common::v1::AnyValue *proto_value,
     const opentelemetry::common::AttributeValue &value,
@@ -75,8 +94,7 @@ void OtlpPopulateAttributeUtils::PopulateAnyValue(
   }
   else if (nostd::holds_alternative<uint64_t>(value))
   {
-    proto_value->set_int_value(
-        nostd::get<uint64_t>(value));  // NOLINT(cppcoreguidelines-narrowing-conversions)
+    SetUint64Value(proto_value, nostd::get<uint64_t>(value));
   }
   else if (nostd::holds_alternative<double>(value))
   {
@@ -168,8 +186,7 @@ void OtlpPopulateAttributeUtils::PopulateAnyValue(
     auto array_value = proto_value->mutable_array_value();
     for (const auto &val : nostd::get<nostd::span<const uint64_t>>(value))
     {
-      array_value->add_values()->set_int_value(
-          val);  // NOLINT(cppcoreguidelines-narrowing-conversions)
+      SetUint64Value(array_value->add_values(), val);
     }
   }
   else if (nostd::holds_alternative<nostd::span<const double>>(value))
@@ -235,8 +252,7 @@ void OtlpPopulateAttributeUtils::PopulateAnyValue(
   }
   else if (nostd::holds_alternative<uint64_t>(value))
   {
-    proto_value->set_int_value(
-        nostd::get<uint64_t>(value));  // NOLINT(cppcoreguidelines-narrowing-conversions)
+    SetUint64Value(proto_value, nostd::get<uint64_t>(value));
   }
   else if (nostd::holds_alternative<double>(value))
   {
@@ -313,8 +329,7 @@ void OtlpPopulateAttributeUtils::PopulateAnyValue(
     auto array_value = proto_value->mutable_array_value();
     for (const auto &val : nostd::get<std::vector<uint64_t>>(value))
     {
-      array_value->add_values()->set_int_value(
-          val);  // NOLINT(cppcoreguidelines-narrowing-conversions)
+      SetUint64Value(array_value->add_values(), val);
     }
   }
   else if (nostd::holds_alternative<std::vector<double>>(value))

--- a/exporters/otlp/test/otlp_recordable_test.cc
+++ b/exporters/otlp/test/otlp_recordable_test.cc
@@ -5,6 +5,7 @@
 #include <chrono>
 #include <cstdint>
 #include <cstring>
+#include <limits>
 #include <map>
 #include <string>
 #include <utility>
@@ -609,6 +610,50 @@ TYPED_TEST(IntAttributeTest, SetIntArrayAttribute)
   {
     EXPECT_EQ(rec.span().attributes(0).value().array_value().values(i).int_value(), int_span[i]);
   }
+}
+
+// Per OpenTelemetry spec, uint64_t attribute values exceeding INT64_MAX must be
+// encoded as a decimal string rather than wrapping to a negative int64.
+// https://opentelemetry.io/docs/specs/otel/common/attribute-type-mapping/#integer-values
+TEST(OtlpRecordable, SetUint64OverflowAsStringPerSpec)
+{
+  const uint64_t overflow_val = static_cast<uint64_t>(std::numeric_limits<int64_t>::max()) + 1U;
+  common::AttributeValue val(overflow_val);
+  OtlpRecordable rec;
+  rec.SetAttribute("u64_overflow", val);
+  EXPECT_EQ(rec.span().attributes(0).value().value_case(),
+            opentelemetry::proto::common::v1::AnyValue::kStringValue);
+  EXPECT_EQ(rec.span().attributes(0).value().string_value(), std::to_string(overflow_val));
+}
+
+TEST(OtlpRecordable, SetUint64BoundaryAsIntPerSpec)
+{
+  // INT64_MAX boundary still fits int_value (encoding split is val > INT64_MAX).
+  const uint64_t boundary = static_cast<uint64_t>(std::numeric_limits<int64_t>::max());
+  common::AttributeValue val(boundary);
+  OtlpRecordable rec;
+  rec.SetAttribute("u64_boundary", val);
+  EXPECT_EQ(rec.span().attributes(0).value().value_case(),
+            opentelemetry::proto::common::v1::AnyValue::kIntValue);
+  EXPECT_EQ(rec.span().attributes(0).value().int_value(), std::numeric_limits<int64_t>::max());
+}
+
+TEST(OtlpRecordable, SetUint64ArrayOverflowAsStringPerSpec)
+{
+  const uint64_t overflow_val = static_cast<uint64_t>(std::numeric_limits<int64_t>::max()) + 1U;
+  const uint64_t in_range_val = 42;
+  const uint64_t arr[]        = {in_range_val, overflow_val};
+  nostd::span<const uint64_t> arr_span(arr, 2);
+  common::AttributeValue val(arr_span);
+  OtlpRecordable rec;
+  rec.SetAttribute("u64_arr_mixed", val);
+  const auto &array_v = rec.span().attributes(0).value().array_value();
+  ASSERT_EQ(array_v.values_size(), 2);
+  EXPECT_EQ(array_v.values(0).value_case(), opentelemetry::proto::common::v1::AnyValue::kIntValue);
+  EXPECT_EQ(array_v.values(0).int_value(), static_cast<int64_t>(in_range_val));
+  EXPECT_EQ(array_v.values(1).value_case(),
+            opentelemetry::proto::common::v1::AnyValue::kStringValue);
+  EXPECT_EQ(array_v.values(1).string_value(), std::to_string(overflow_val));
 }
 
 TEST(OtlpRecordableTest, TestCollectionLimits)


### PR DESCRIPTION
## Summary

Per [OpenTelemetry attribute type-mapping spec](https://opentelemetry.io/docs/specs/otel/common/attribute-type-mapping/#integer-values):

> Integer values which are within the range of 64 bit signed numbers `[-2^63..2^63-1]` SHOULD be converted to AnyValue's `int_value` field.
> Integer values which are outside the range of 64 bit signed numbers SHOULD be converted to AnyValue's `string_value` field using decimal representation.

Pre-PR behavior at the four `uint64_t` conversion sites in `exporters/otlp/src/otlp_populate_attribute_utils.cc` implicitly narrowed via `// NOLINT(cppcoreguidelines-narrowing-conversions)`. For `uint64_t` values exceeding `INT64_MAX`, this produced negative `int_value` on the wire — a **long-standing spec violation that predates this PR**.

This PR replaces the four narrowing call sites with a file-local helper that dispatches per spec:

```cpp
inline void SetUint64Value(opentelemetry::proto::common::v1::AnyValue *proto_value, uint64_t val)
{
  if (val <= static_cast<uint64_t>(std::numeric_limits<int64_t>::max()))
    proto_value->set_int_value(static_cast<int64_t>(val));
  else
    proto_value->set_string_value(std::to_string(val));
}
```

Both `PopulateAnyValue` overloads (for `AttributeValue` and `OwnedAttributeValue`) and both shapes (scalar and array element) route through the same helper. Spec-link comment is attached to the helper for future readers.

## Scope of fix (4 sites, 1 file)

| Site | Variant |
|---|---|
| `otlp_populate_attribute_utils.cc:~94` | `uint64_t` scalar in `AttributeValue` overload |
| `otlp_populate_attribute_utils.cc:~187` | `nostd::span<const uint64_t>` array |
| `otlp_populate_attribute_utils.cc:~254` | `uint64_t` scalar in `OwnedAttributeValue` overload |
| `otlp_populate_attribute_utils.cc:~331` | `std::vector<uint64_t>` array |

Other integer conversions (`int`, `int64_t`, `unsigned int`, `uint32_t`) always fit in `int64_t` and were not affected by the spec rule. No other files in `exporters/` or `sdk/` call `set_int_value` with `uint64_t` source (verified via grep).

## Tests (new, in `otlp_recordable_test.cc`)

1. `SetUint64OverflowAsStringPerSpec` — `INT64_MAX + 1` → `string_value` with decimal representation
2. `SetUint64BoundaryAsIntPerSpec` — `INT64_MAX` → `int_value` (encoding split is `val > INT64_MAX`)
3. `SetUint64ArrayOverflowAsStringPerSpec` — mixed-value array dispatches per element (int + string in same array)

## Ratchet

Helper's explicit `static_cast` is now in a value-guarded branch, so the `bugprone-narrowing-conversions` diagnostics on these four sites are still silenced.

* `all-options-abiv1-preview` `warning_limit` lowered from **389 to 385**
* `all-options-abiv2-preview` `warning_limit` lowered from **395 to 391**

## Behavior change disclosure

For `uint64_t` attribute values exceeding `INT64_MAX` (~9.2e18):

- **Before:** wrapped to negative `int_value` on the wire (non-spec-conformant)
- **After:** decimal string in `string_value` (spec-conformant)

Callers relying on the wrap-to-negative behavior would see breakage. This behavior was never spec-conformant; the new behavior aligns OTLP output with the protocol specification.

## Review history

Originally opened as a `[CODE HEALTH]` PR to fix `bugprone-narrowing-conversions` warnings via `static_cast`. @dbarker [pointed out in review](https://github.com/open-telemetry/opentelemetry-cpp/pull/4090#discussion_r3307896023) that the static_cast preserves the spec-violating wrap behavior and asked for spec-compliant string fallback. This PR was then upgraded in scope to the present spec fix.

## Test plan

- [x] CI `clang-tidy` job passes both abiv1-preview and abiv2-preview at the new limits
- [x] CI `Format` job passes (verified locally via `clang-format --dry-run --Werror`)
- [x] CI build matrices pass — new tests build and run as part of the OTLP test suite
- [x] No behavior change for `int`, `int64_t`, `unsigned int`, `uint32_t` paths

Part of #2053