### PR TITLE
[CODE HEALTH] Remove unused alias declarations

### DIFF
--- a/.github/workflows/clang-tidy.yaml
+++ b/.github/workflows/clang-tidy.yaml
@@ -17,9 +17,9 @@ jobs:
       matrix:
         include:
           - cmake_options: all-options-abiv1-preview
-            warning_limit: 418
+            warning_limit: 389
           - cmake_options: all-options-abiv2-preview
-            warning_limit: 424
+            warning_limit: 395
     env:
       CC: /usr/bin/clang-22
       CXX: /usr/bin/clang++-22

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,9 @@ Increment the:
 * [CODE HEALTH] Fix IWYU Clang22 warnings
   [#4083](https://github.com/open-telemetry/opentelemetry-cpp/pull/4083)
 
+* [CODE HEALTH] Remove unused alias declarations
+  [#4091](https://github.com/open-telemetry/opentelemetry-cpp/pull/4091)
+
 ## [1.27.0] 2026-05-13
 
 * [RELEASE] Bump main branch to 1.27.0-dev

--- a/api/test/trace/tracer_test.cc
+++ b/api/test/trace/tracer_test.cc
@@ -4,7 +4,6 @@
 #include <gtest/gtest.h>
 #include <string>
 
-#include "opentelemetry/context/context_value.h"
 #include "opentelemetry/nostd/shared_ptr.h"
 #include "opentelemetry/trace/noop.h"
 #include "opentelemetry/trace/scope.h"
@@ -14,7 +13,6 @@
 
 namespace trace_api = opentelemetry::trace;
 namespace nostd     = opentelemetry::nostd;
-namespace context   = opentelemetry::context;
 
 TEST(TracerTest, GetCurrentSpan)
 {

--- a/examples/metrics_simple/metrics_ostream.cc
+++ b/examples/metrics_simple/metrics_ostream.cc
@@ -8,7 +8,6 @@
 #include <utility>
 #include <vector>
 
-#include "opentelemetry/common/attribute_value.h"
 #include "opentelemetry/exporters/ostream/metric_exporter_factory.h"
 #include "opentelemetry/metrics/meter_provider.h"
 #include "opentelemetry/sdk/metrics/aggregation/aggregation_config.h"
@@ -36,7 +35,6 @@
 #endif
 
 namespace metrics_sdk     = opentelemetry::sdk::metrics;
-namespace common          = opentelemetry::common;
 namespace exportermetrics = opentelemetry::exporter::metrics;
 namespace metrics_api     = opentelemetry::metrics;
 

--- a/examples/otlp/file_log_main.cc
+++ b/examples/otlp/file_log_main.cc
@@ -33,7 +33,6 @@
 #  include "logs_foo_library/foo_library.h"
 #endif
 
-namespace trace     = opentelemetry::trace;
 namespace nostd     = opentelemetry::nostd;
 namespace otlp      = opentelemetry::exporter::otlp;
 namespace logs_sdk  = opentelemetry::sdk::logs;

--- a/examples/otlp/file_main.cc
+++ b/examples/otlp/file_main.cc
@@ -22,7 +22,6 @@
 #  include "foo_library/foo_library.h"
 #endif
 
-namespace trace     = opentelemetry::trace;
 namespace trace_sdk = opentelemetry::sdk::trace;
 namespace otlp      = opentelemetry::exporter::otlp;
 

--- a/examples/otlp/file_metric_main.cc
+++ b/examples/otlp/file_metric_main.cc
@@ -7,7 +7,6 @@
 #include <thread>
 #include <utility>
 
-#include "opentelemetry/common/attribute_value.h"
 #include "opentelemetry/exporters/otlp/otlp_file_client_options.h"
 #include "opentelemetry/exporters/otlp/otlp_file_metric_exporter_factory.h"
 #include "opentelemetry/exporters/otlp/otlp_file_metric_exporter_options.h"
@@ -29,7 +28,6 @@
 #endif
 
 namespace metrics_sdk   = opentelemetry::sdk::metrics;
-namespace common        = opentelemetry::common;
 namespace metrics_api   = opentelemetry::metrics;
 namespace otlp_exporter = opentelemetry::exporter::otlp;
 

--- a/examples/otlp/grpc_log_main.cc
+++ b/examples/otlp/grpc_log_main.cc
@@ -31,7 +31,6 @@
 #  include "logs_foo_library/foo_library.h"
 #endif
 
-namespace trace     = opentelemetry::trace;
 namespace nostd     = opentelemetry::nostd;
 namespace otlp      = opentelemetry::exporter::otlp;
 namespace logs_sdk  = opentelemetry::sdk::logs;

--- a/examples/otlp/grpc_main.cc
+++ b/examples/otlp/grpc_main.cc
@@ -21,7 +21,6 @@
 #  include "foo_library/foo_library.h"
 #endif
 
-namespace trace     = opentelemetry::trace;
 namespace trace_sdk = opentelemetry::sdk::trace;
 namespace otlp      = opentelemetry::exporter::otlp;
 

--- a/examples/otlp/grpc_metric_main.cc
+++ b/examples/otlp/grpc_metric_main.cc
@@ -8,7 +8,6 @@
 #include <thread>
 #include <utility>
 
-#include "opentelemetry/common/attribute_value.h"
 #include "opentelemetry/exporters/otlp/otlp_grpc_metric_exporter_factory.h"
 #include "opentelemetry/exporters/otlp/otlp_grpc_metric_exporter_options.h"
 #include "opentelemetry/metrics/meter_provider.h"
@@ -37,7 +36,6 @@
 #endif
 
 namespace metric_sdk    = opentelemetry::sdk::metrics;
-namespace common        = opentelemetry::common;
 namespace metrics_api   = opentelemetry::metrics;
 namespace otlp_exporter = opentelemetry::exporter::otlp;
 

--- a/examples/otlp/http_log_main.cc
+++ b/examples/otlp/http_log_main.cc
@@ -34,7 +34,6 @@
 #  include "logs_foo_library/foo_library.h"
 #endif
 
-namespace trace     = opentelemetry::trace;
 namespace otlp      = opentelemetry::exporter::otlp;
 namespace logs_sdk  = opentelemetry::sdk::logs;
 namespace logs      = opentelemetry::logs;

--- a/examples/otlp/http_main.cc
+++ b/examples/otlp/http_main.cc
@@ -23,7 +23,6 @@
 #  include "foo_library/foo_library.h"
 #endif
 
-namespace trace     = opentelemetry::trace;
 namespace trace_sdk = opentelemetry::sdk::trace;
 namespace otlp      = opentelemetry::exporter::otlp;
 

--- a/examples/otlp/http_metric_main.cc
+++ b/examples/otlp/http_metric_main.cc
@@ -7,7 +7,6 @@
 #include <thread>
 #include <utility>
 
-#include "opentelemetry/common/attribute_value.h"
 #include "opentelemetry/exporters/otlp/otlp_http.h"
 #include "opentelemetry/exporters/otlp/otlp_http_metric_exporter_factory.h"
 #include "opentelemetry/exporters/otlp/otlp_http_metric_exporter_options.h"
@@ -30,7 +29,6 @@
 #endif
 
 namespace metrics_sdk   = opentelemetry::sdk::metrics;
-namespace common        = opentelemetry::common;
 namespace metrics_api   = opentelemetry::metrics;
 namespace otlp_exporter = opentelemetry::exporter::otlp;
 

--- a/examples/prometheus/main.cc
+++ b/examples/prometheus/main.cc
@@ -7,7 +7,6 @@
 #include <thread>
 #include <utility>
 
-#include "opentelemetry/common/attribute_value.h"
 #include "opentelemetry/exporters/prometheus/exporter_factory.h"
 #include "opentelemetry/exporters/prometheus/exporter_options.h"
 #include "opentelemetry/metrics/meter_provider.h"
@@ -30,7 +29,6 @@
 #endif
 
 namespace metrics_sdk      = opentelemetry::sdk::metrics;
-namespace common           = opentelemetry::common;
 namespace metrics_exporter = opentelemetry::exporter::metrics;
 namespace metrics_api      = opentelemetry::metrics;
 

--- a/examples/simple/main.cc
+++ b/examples/simple/main.cc
@@ -19,7 +19,6 @@
 #  include "foo_library/foo_library.h"
 #endif
 
-namespace trace_api      = opentelemetry::trace;
 namespace trace_sdk      = opentelemetry::sdk::trace;
 namespace trace_exporter = opentelemetry::exporter::trace;
 

--- a/examples/zipkin/main.cc
+++ b/examples/zipkin/main.cc
@@ -22,7 +22,6 @@
 #  include "foo_library/foo_library.h"
 #endif
 
-namespace trace     = opentelemetry::trace;
 namespace trace_sdk = opentelemetry::sdk::trace;
 namespace zipkin    = opentelemetry::exporter::zipkin;
 namespace resource  = opentelemetry::sdk::resource;

--- a/exporters/elasticsearch/src/es_log_record_exporter.cc
+++ b/exporters/elasticsearch/src/es_log_record_exporter.cc
@@ -32,7 +32,6 @@
 #  include "opentelemetry/common/timestamp.h"
 #endif
 
-namespace nostd       = opentelemetry::nostd;
 namespace sdklogs     = opentelemetry::sdk::logs;
 namespace http_client = opentelemetry::ext::http::client;
 

--- a/exporters/ostream/test/ostream_metric_test.cc
+++ b/exporters/ostream/test/ostream_metric_test.cc
@@ -25,7 +25,6 @@
 #include "opentelemetry/sdk/version/version.h"
 
 namespace metric_sdk      = opentelemetry::sdk::metrics;
-namespace nostd           = opentelemetry::nostd;
 namespace exportermetrics = opentelemetry::exporter::metrics;
 
 TEST(OStreamMetricsExporter, Shutdown)

--- a/exporters/otlp/src/otlp_recordable.cc
+++ b/exporters/otlp/src/otlp_recordable.cc
@@ -31,8 +31,6 @@
 #include "opentelemetry/exporters/otlp/protobuf_include_suffix.h" // IWYU pragma: keep
 // clang-format on
 
-namespace nostd = opentelemetry::nostd;
-
 OPENTELEMETRY_BEGIN_NAMESPACE
 namespace exporter
 {

--- a/exporters/otlp/test/otlp_recordable_test.cc
+++ b/exporters/otlp/test/otlp_recordable_test.cc
@@ -57,8 +57,6 @@ namespace trace_sdk = opentelemetry::sdk::trace;
 namespace resource  = opentelemetry::sdk::resource;
 namespace proto     = opentelemetry::proto;
 
-namespace trace_sdk_2 = opentelemetry::sdk::trace;
-
 TEST(OtlpRecordable, SetIdentity)
 {
   constexpr uint8_t trace_id_buf[]       = {1, 2, 3, 4, 5, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7, 8};

--- a/exporters/prometheus/src/collector.cc
+++ b/exporters/prometheus/src/collector.cc
@@ -13,8 +13,6 @@
 #include "opentelemetry/sdk/metrics/metric_reader.h"
 #include "opentelemetry/version.h"
 
-namespace metric_sdk = opentelemetry::sdk::metrics;
-
 OPENTELEMETRY_BEGIN_NAMESPACE
 namespace exporter
 {

--- a/exporters/prometheus/test/collector_test.cc
+++ b/exporters/prometheus/test/collector_test.cc
@@ -10,7 +10,6 @@
 #include <vector>
 
 #include "opentelemetry/exporters/prometheus/collector.h"
-#include "opentelemetry/metrics/meter_provider.h"
 #include "opentelemetry/sdk/metrics/export/metric_producer.h"
 #include "opentelemetry/sdk/metrics/instruments.h"
 #include "opentelemetry/sdk/metrics/metric_reader.h"
@@ -20,9 +19,6 @@ using namespace prometheus_test;
 using opentelemetry::exporter::metrics::PrometheusCollector;
 using opentelemetry::sdk::metrics::MetricProducer;
 using opentelemetry::sdk::metrics::ResourceMetrics;
-namespace metric_api      = opentelemetry::metrics;
-namespace metric_sdk      = opentelemetry::sdk::metrics;
-namespace metric_exporter = opentelemetry::exporter::metrics;
 
 class MockMetricProducer : public MetricProducer
 {

--- a/exporters/zipkin/src/zipkin_exporter_factory.cc
+++ b/exporters/zipkin/src/zipkin_exporter_factory.cc
@@ -4,10 +4,7 @@
 #include "opentelemetry/exporters/zipkin/zipkin_exporter_factory.h"
 #include "opentelemetry/exporters/zipkin/zipkin_exporter.h"
 #include "opentelemetry/exporters/zipkin/zipkin_exporter_options.h"
-#include "opentelemetry/ext/http/client/http_client.h"
 #include "opentelemetry/version.h"
-
-namespace http_client = opentelemetry::ext::http::client;
 
 OPENTELEMETRY_BEGIN_NAMESPACE
 namespace exporter

--- a/sdk/src/logs/logger.cc
+++ b/sdk/src/logs/logger.cc
@@ -39,7 +39,6 @@ namespace sdk
 namespace logs
 {
 namespace trace_api = opentelemetry::trace;
-namespace common    = opentelemetry::common;
 namespace context   = opentelemetry::context;
 namespace nostd     = opentelemetry::nostd;
 

--- a/sdk/test/metrics/async_metric_storage_test.cc
+++ b/sdk/test/metrics/async_metric_storage_test.cc
@@ -4,7 +4,6 @@
 #include <gtest/gtest.h>
 #include <chrono>
 #include <cstdint>
-#include <map>
 #include <memory>
 #include <string>
 #include <unordered_map>
@@ -37,9 +36,6 @@ using namespace opentelemetry::sdk::metrics;
 using namespace opentelemetry::sdk::instrumentationscope;
 using namespace opentelemetry::sdk::resource;
 using namespace opentelemetry::common;
-namespace nostd = opentelemetry::nostd;
-
-using M = std::map<std::string, std::string>;
 
 class WritableMetricStorageTestFixture : public ::testing::TestWithParam<AggregationTemporality>
 {};

--- a/sdk/test/metrics/sync_metric_storage_counter_test.cc
+++ b/sdk/test/metrics/sync_metric_storage_counter_test.cc
@@ -33,8 +33,6 @@
 
 using namespace opentelemetry::sdk::metrics;
 using namespace opentelemetry::common;
-using M         = std::map<std::string, std::string>;
-namespace nostd = opentelemetry::nostd;
 
 class WritableMetricStorageTestFixture : public ::testing::TestWithParam<AggregationTemporality>
 {};

--- a/sdk/test/metrics/sync_metric_storage_gauge_test.cc
+++ b/sdk/test/metrics/sync_metric_storage_gauge_test.cc
@@ -35,7 +35,6 @@
 
 using namespace opentelemetry::sdk::metrics;
 using namespace opentelemetry::common;
-namespace nostd = opentelemetry::nostd;
 
 class WritableMetricStorageTestFixture : public ::testing::TestWithParam<AggregationTemporality>
 {};

--- a/sdk/test/metrics/sync_metric_storage_histogram_test.cc
+++ b/sdk/test/metrics/sync_metric_storage_histogram_test.cc
@@ -34,8 +34,6 @@
 
 using namespace opentelemetry::sdk::metrics;
 using namespace opentelemetry::common;
-using M         = std::map<std::string, std::string>;
-namespace nostd = opentelemetry::nostd;
 
 class WritableMetricStorageHistogramTestFixture
     : public ::testing::TestWithParam<AggregationTemporality>

--- a/sdk/test/metrics/sync_metric_storage_up_down_counter_test.cc
+++ b/sdk/test/metrics/sync_metric_storage_up_down_counter_test.cc
@@ -33,8 +33,6 @@
 
 using namespace opentelemetry::sdk::metrics;
 using namespace opentelemetry::common;
-using M         = std::map<std::string, std::string>;
-namespace nostd = opentelemetry::nostd;
 
 class WritableMetricStorageTestFixture : public ::testing::TestWithParam<AggregationTemporality>
 {};


### PR DESCRIPTION
## Summary

Eliminates **29** `misc-unused-alias-decls` warnings flagged by clang-tidy v22, spread across **27 files** in examples, exporters, sdk source, and tests. The dominant pattern was a file-scope declaration like:

```cpp
namespace nostd = opentelemetry::nostd;
```

that was never referenced via the file-scope alias path. Uses of `nostd::` inside the surrounding `OPENTELEMETRY_BEGIN_NAMESPACE` block resolved through namespace nesting (finding `opentelemetry::nostd` via parent-namespace lookup) before ever reaching the file-scope alias. Other variants flagged: `common`, `context`, `metric_sdk`, `metric_api`, `metric_exporter`, `http_client`, `trace`, `trace_api`, `trace_sdk_2`.

**No behavior change.** Every removed declaration was genuinely unreferenced per clang-tidy. Verified against three representative samples (production code with namespace nesting, test code with `using namespace`, examples with zero references).

Where removing a declaration left adjacent aligned lines (e.g. `using M         = std::map<...>;` next to a removed `namespace nostd = ...;`), clang-format auto-collapsed the now-unnecessary alignment whitespace.

## Excluded from this PR

The 30th `misc-unused-alias-decls` site at `exporters/otlp/src/otlp_populate_attribute_utils.cc:30` is intentionally not touched, to avoid a file-level conflict with the in-flight #4090. It can be cleaned up in a trivial follow-up after #4090 lands.

## Ratchet

* `all-options-abiv1-preview` `warning_limit` lowered from **418 to 389**
* `all-options-abiv2-preview` `warning_limit` lowered from **424 to 395**

(If #4090 lands first, this PR will need a trivial ratchet rebase from 414→385 and 420→391 — the relative drop of 29 is unchanged.)

## Verification

Counts measured against artifacts of the most recent successful CI run on `main` (workflow `clang-tidy.yaml`, run `26018587378`):

| Preset | Before (count / limit) | After (predicted) |
|---|---|---|
| abiv1-preview | 418 / 418 | 389 / 389 |
| abiv2-preview | 424 / 424 | 395 / 395 |

Sample verification of the "unused" claim was performed on three representative files (`exporters/elasticsearch/src/es_log_record_exporter.cc`, `sdk/test/metrics/sync_metric_storage_counter_test.cc`, `examples/simple/main.cc`) — all three confirmed the alias is genuinely dead.

Local format verification: ran `clang-format --dry-run --Werror` via the project's clang-format-compatible toolchain against all 27 modified source files; clean.

## Test plan

- [x] CI `clang-tidy` job passes both abiv1-preview and abiv2-preview at the new limits
- [x] CI `Format` job passes
- [x] CI build and test matrices pass — declarations being removed were not in any active use path

Part of #2053