### PR TITLE
[DOC] Fix typos in SDK header comments

### DIFF
--- a/sdk/include/opentelemetry/sdk/common/attribute_utils.h
+++ b/sdk/include/opentelemetry/sdk/common/attribute_utils.h
@@ -251,10 +251,10 @@ public:
 class OrderedAttributeMap : public std::map<std::string, OwnedAttributeValue>
 {
 public:
-  // Contruct empty attribute map
+  // Construct empty attribute map
   OrderedAttributeMap() : std::map<std::string, OwnedAttributeValue>() {}
 
-  // Contruct attribute map and populate with attributes
+  // Construct attribute map and populate with attributes
   OrderedAttributeMap(const opentelemetry::common::KeyValueIterable &attributes)
       : OrderedAttributeMap()
   {

--- a/sdk/include/opentelemetry/sdk/metrics/export/periodic_exporting_metric_reader_options.h
+++ b/sdk/include/opentelemetry/sdk/metrics/export/periodic_exporting_metric_reader_options.h
@@ -17,7 +17,7 @@ constexpr std::chrono::milliseconds kExportIntervalMillis = std::chrono::millise
 constexpr std::chrono::milliseconds kExportTimeOutMillis  = std::chrono::milliseconds(30000);
 
 /**
- * Struct to hold PeriodicExortingMetricReader options.
+ * Struct to hold PeriodicExportingMetricReader options.
  */
 
 struct OPENTELEMETRY_EXPORT PeriodicExportingMetricReaderOptions

--- a/sdk/include/opentelemetry/sdk/metrics/export/periodic_exporting_metric_reader_runtime_options.h
+++ b/sdk/include/opentelemetry/sdk/metrics/export/periodic_exporting_metric_reader_runtime_options.h
@@ -15,7 +15,7 @@ namespace metrics
 {
 
 /**
- * Struct to hold PeriodicExortingMetricReader runtime options.
+ * Struct to hold PeriodicExportingMetricReader runtime options.
  */
 struct PeriodicExportingMetricReaderRuntimeOptions
 {

--- a/sdk/include/opentelemetry/sdk/metrics/multi_observer_result.h
+++ b/sdk/include/opentelemetry/sdk/metrics/multi_observer_result.h
@@ -40,7 +40,7 @@ protected:
 private:
   // This is _different_ to opentelemetry::metrics::ObserverResult because this variant is
   // a variant directly of ObserverResultT, not of _pointers_ to ObserverResultT.
-  // This allows us to avoid an unnescessary layer of inderection and a bunch of allocations.
+  // This allows us to avoid an unnecessary layer of indirection and a bunch of allocations.
   using ObserverResultDirect =
       nostd::variant<nostd::monostate, ObserverResultT<double>, ObserverResultT<int64_t>>;
   std::unordered_map<opentelemetry::metrics::ObservableInstrument *, ObserverResultDirect>

--- a/sdk/include/opentelemetry/sdk/metrics/state/metric_storage.h
+++ b/sdk/include/opentelemetry/sdk/metrics/state/metric_storage.h
@@ -77,7 +77,7 @@ public:
                             const opentelemetry::context::Context &context) noexcept = 0;
 };
 
-/* Represents the async metric stroage */
+/* Represents the async metric storage */
 class AsyncWritableMetricStorage
 {
 public:


### PR DESCRIPTION
Fixes a handful of spelling typos in comments under `sdk/include/` (these doc-comments feed the generated API docs, e.g. the `PeriodicExportingMetricReaderOptions` page).

| File | Was | Now |
| --- | --- | --- |
| `metrics/export/periodic_exporting_metric_reader_options.h` | PeriodicEx**or**tingMetricReader | PeriodicEx**por**tingMetricReader |
| `metrics/export/periodic_exporting_metric_reader_runtime_options.h` | PeriodicEx**or**tingMetricReader | PeriodicEx**por**tingMetricReader |
| `common/attribute_utils.h` (×2) | Con**t**ruct | Con**st**ruct |
| `metrics/multi_observer_result.h` | unne**s**cessary layer of in**de**rection | unne**c**essary layer of in**di**rection |
| `metrics/state/metric_storage.h` | async metric st**ro**age | async metric st**or**age |

Comment-only changes — no behaviour change.

Fixes #4110