### PR TITLE
[CODE HEALTH] Remove last unused nostd namespace alias in otlp_populate_attribute_utils

### DIFF
--- a/.github/workflows/clang-tidy.yaml
+++ b/.github/workflows/clang-tidy.yaml
@@ -17,9 +17,9 @@ jobs:
       matrix:
         include:
           - cmake_options: all-options-abiv1-preview
-            warning_limit: 385
+            warning_limit: 384
           - cmake_options: all-options-abiv2-preview
-            warning_limit: 391
+            warning_limit: 390
     env:
       CC: /usr/bin/clang-22
       CXX: /usr/bin/clang++-22

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,9 @@ Increment the:
 * [SDK] MeterProvider: do not warn in destructor after explicit Shutdown
   [#4085](https://github.com/open-telemetry/opentelemetry-cpp/pull/4085)
 
+* [CODE HEALTH] Remove last unused nostd namespace alias in otlp_populate
+  [#4114](https://github.com/open-telemetry/opentelemetry-cpp/pull/4114)
+
 ## [1.27.0] 2026-05-13
 
 * [RELEASE] Bump main branch to 1.27.0-dev

--- a/exporters/otlp/src/otlp_populate_attribute_utils.cc
+++ b/exporters/otlp/src/otlp_populate_attribute_utils.cc
@@ -28,8 +28,6 @@
 #include "opentelemetry/exporters/otlp/protobuf_include_suffix.h" // IWYU pragma: keep
 // clang-format on
 
-namespace nostd = opentelemetry::nostd;
-
 OPENTELEMETRY_BEGIN_NAMESPACE
 namespace exporter
 {


### PR DESCRIPTION
## Summary

Removes the single remaining `misc-unused-alias-decls` warning in the project: a file-scope `namespace nostd = opentelemetry::nostd;` declaration at `exporters/otlp/src/otlp_populate_attribute_utils.cc:31`.

This declaration was deliberately left in place by #4091 to avoid conflicting with the then in-flight #4090 on the same file. Both have now merged (#4091 by marcalff on 2026-05-18, #4090 by lalitb on 2026-06-01), so the conflict surface is gone.

After this PR, the `misc-unused-alias-decls` warning count for the project is `0` under both `all-options-abiv1-preview` and `all-options-abiv2-preview`.

## Why the alias is unused

References to `nostd::` inside the `OPENTELEMETRY_BEGIN_NAMESPACE` block resolve via parent-namespace lookup to `opentelemetry::nostd` without needing the file-scope alias. The alias was redundant from day one; clang-tidy's `misc-unused-alias-decls` check correctly flagged it.

There are no global-scope references to `nostd::` in this file (only the alias declaration itself, which is removed). Removing it does not affect any include or any other code path. Same pattern as the 29 alias removals in #4091.

## Ratchet

* `all-options-abiv1-preview` `warning_limit` lowered from **385 to 384**
* `all-options-abiv2-preview` `warning_limit` lowered from **391 to 390**

Both presets reported the warning at this site; both ratchets drop by 1.

## Verification

Counts measured against artifacts of the most recent successful CI run on `main` (workflow `clang-tidy.yaml`, run `26782221265`, head `83c135d8`):

| Preset | Before (count / limit) | After (predicted) |
|---|---|---|
| abiv1-preview | 385 / 385 | 384 / 384 |
| abiv2-preview | 391 / 391 | 390 / 390 |

Local `clang-format --dry-run --Werror` against the modified source file: clean.

## Test plan

- [x] CI `clang-tidy` job passes both abiv1-preview and abiv2-preview at the new limits
- [x] No behavioral change (declaration removal only, all uses already resolve via namespace nesting)

Part of #2053