### PR TITLE
[CODE HEALTH] Move curl_http_test classes into anonymous namespace

### DIFF
--- a/.github/workflows/clang-tidy.yaml
+++ b/.github/workflows/clang-tidy.yaml
@@ -17,9 +17,9 @@ jobs:
       matrix:
         include:
           - cmake_options: all-options-abiv1-preview
-            warning_limit: 384
+            warning_limit: 376
           - cmake_options: all-options-abiv2-preview
-            warning_limit: 390
+            warning_limit: 382
     env:
       CC: /usr/bin/clang-22
       CXX: /usr/bin/clang++-22

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,9 @@ Increment the:
 * [CODE HEALTH] Remove last unused nostd namespace alias in otlp_populate
   [#4114](https://github.com/open-telemetry/opentelemetry-cpp/pull/4114)
 
+* [CODE HEALTH] Move curl_http_test classes into anonymous namespace
+  [#4115](https://github.com/open-telemetry/opentelemetry-cpp/pull/4115)
+
 ## [1.27.0] 2026-05-13
 
 * [RELEASE] Bump main branch to 1.27.0-dev

--- a/ext/test/http/curl_http_test.cc
+++ b/ext/test/http/curl_http_test.cc
@@ -40,6 +40,9 @@ namespace curl        = opentelemetry::ext::http::client::curl;
 namespace http_client = opentelemetry::ext::http::client;
 namespace nostd       = opentelemetry::nostd;
 
+namespace
+{
+
 class CustomEventHandler : public http_client::EventHandler
 {
 public:
@@ -822,3 +825,5 @@ TEST_F(BasicCurlHttpTests, GzipIncompressibleData)
   session_manager->FinishAllSessions();
 }
 #endif  // ENABLE_OTLP_COMPRESSION_PREVIEW
+
+}  // namespace


### PR DESCRIPTION
## Summary

Wraps the 8 file-scope class declarations in `ext/test/http/curl_http_test.cc` within a single anonymous namespace to give them internal linkage. This clears all 8 `misc-use-internal-linkage` warnings clang-tidy reports on this file.

The wrap spans from the first class declaration (line 43, `CustomEventHandler`) through the end of the file. All 8 flagged sites are covered:

| Line | Identifier |
|---|---|
| 43 | `class CustomEventHandler` |
| 70 | `class GetEventHandler` |
| 81 | `class PostEventHandler` |
| 93 | `class FinishInCallbackHandler` |
| 118 | `class RetryEventHandler` |
| 129 | `class BasicCurlHttpTests` |
| 219 | `class DISABLED_BasicCurlHttpTests` |
| 704 | `struct GzipEventHandler` |

## Inheritance and macros

The inheritance chains are preserved because all classes sit in the same anonymous namespace:

- `CustomEventHandler` is the common base for 5 derived event handlers plus the `GzipEventHandler` struct. All 6 derived types live in the same anonymous namespace as `CustomEventHandler`, so unqualified base-class lookup resolves.
- `BasicCurlHttpTests` inherits from `::testing::Test` and `HTTP_SERVER_NS::HttpRequestCallback`. Both bases are external symbols reached via qualified name lookup, which pierces the anonymous namespace cleanly. `HTTP_SERVER_NS` is a preprocessor macro that expands to a file-scope namespace name, so its expansion is unaffected by the wrap.
- `DISABLED_BasicCurlHttpTests` inherits from `BasicCurlHttpTests`. Both are in the same anonymous namespace.

## TEST_F inside the wrap

`TEST_F` macros are wrapped together with their fixture class. This is the layout gtest recommends for test files that do not need to share fixtures across translation units. The expanded test class becomes a member of the same anonymous namespace as its fixture, and the static `TestInfo` registrar gets internal linkage. gtest registers tests at static initialization time regardless of linkage, so test discovery is unchanged.

## Ratchet

* \`all-options-abiv1-preview\` \`warning_limit\` lowered from **384 to 376**
* \`all-options-abiv2-preview\` \`warning_limit\` lowered from **390 to 382**

Both presets report the same 8 sites; ratchets drop symmetrically by 8.

## Verification

Counts measured against artifacts of the most recent successful CI run on \`main\` (workflow \`clang-tidy.yaml\`, run \`26867486946\`, head \`58ca2a49\`):

| Preset | Before (count / limit) | After (predicted) |
|---|---|---|
| abiv1-preview | 384 / 384 | 376 / 376 |
| abiv2-preview | 390 / 390 | 382 / 382 |

Local build + test verification in the project dev container:

\`\`\`
[==========] 19 tests from 1 test suite ran. (14052 ms total)
[  PASSED  ] 19 tests.

  YOU HAVE 1 DISABLED TEST
\`\`\`

The 1 disabled test is \`DISABLED_BasicCurlHttpTests\` (the gtest \`DISABLED_\` prefix convention), unchanged by this PR.

Local \`clang-format --dry-run --Werror\` against the modified file: clean.

## Out of scope

The three file-scope namespace alias declarations at lines 39-41 (\`curl\`, \`http_client\`, \`nostd\`) remain outside the anonymous namespace. They are not flagged by \`misc-use-internal-linkage\` (which targets classes), and moving them is not required to clear the 8 reported warnings. Deferred to a follow-up if anyone wants to clean them up.

## Test plan

- [x] CI \`clang-tidy\` job passes both \`all-options-abiv1-preview\` and \`all-options-abiv2-preview\` at the new limits
- [x] Local build of the \`curl_http_test\` target succeeds in the project dev container
- [x] Local \`curl_http_test\` binary runs all 19 tests green, with no behavioral change from main

Part of #2053