### PR TITLE
[CODE HEALTH] Move simple_log_record_processor_test into anonymous namespace

### DIFF
--- a/.github/workflows/clang-tidy.yaml
+++ b/.github/workflows/clang-tidy.yaml
@@ -17,9 +17,9 @@ jobs:
       matrix:
         include:
           - cmake_options: all-options-abiv1-preview
-            warning_limit: 376
+            warning_limit: 371
           - cmake_options: all-options-abiv2-preview
-            warning_limit: 382
+            warning_limit: 377
     env:
       CC: /usr/bin/clang-22
       CXX: /usr/bin/clang++-22

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,9 @@ Increment the:
 * [CODE HEALTH] Move curl_http_test classes into anonymous namespace
   [#4115](https://github.com/open-telemetry/opentelemetry-cpp/pull/4115)
 
+* [CODE HEALTH] Move simple_log_record_processor_test into anonymous namespace
+  [#4116](https://github.com/open-telemetry/opentelemetry-cpp/pull/4116)
+
 ## [1.27.0] 2026-05-13
 
 * [RELEASE] Bump main branch to 1.27.0-dev

--- a/sdk/test/logs/simple_log_record_processor_test.cc
+++ b/sdk/test/logs/simple_log_record_processor_test.cc
@@ -32,6 +32,9 @@ namespace logs_api              = opentelemetry::logs;
 namespace instrumentation_scope = opentelemetry::sdk::instrumentationscope;
 namespace nostd                 = opentelemetry::nostd;
 
+namespace
+{
+
 class TestLogRecordable final : public opentelemetry::sdk::logs::Recordable
 {
 public:
@@ -386,3 +389,5 @@ TEST(SimpleLogRecordProcessorTest, EmptyMultiLogRecordProcessorIsDisabled)
   EXPECT_FALSE(
       processor.Enabled(test_context, *scope, logs_api::Severity::kDebug, "test-event-name"));
 }
+
+}  // namespace


### PR DESCRIPTION
## Summary

Wraps the 5 file-scope class and struct declarations in
`sdk/test/logs/simple_log_record_processor_test.cc` within an anonymous
namespace, clearing the 5 `misc-use-internal-linkage` warnings clang-tidy
reports on this file.

Continues the misc-use-internal-linkage campaign opened by #4115.

## Changes

- `sdk/test/logs/simple_log_record_processor_test.cc`: insert `namespace {`
  after the existing namespace aliases at line 33 and `}  // namespace` at
  end of file. Whole-file wrap covers `TestLogRecordable`, `TestExporter`,
  `FailShutDownForceFlushExporter`, `EnabledCallState`, and
  `EnabledProcessor`. `TEST()` macros remain inside the wrap; gtest
  registers tests via static initialization regardless of linkage.
- `.github/workflows/clang-tidy.yaml`: abiv1 376 -> 371 (-5),
  abiv2 382 -> 377 (-5).
- `CHANGELOG.md`: one bullet under [Unreleased].

## Out of scope

The 4 file-scope namespace aliases at lines 30-33 (`context`, `logs_api`,
`instrumentation_scope`, `nostd`) could also be moved inside the anonymous
namespace, but they are not flagged by `misc-use-internal-linkage` and are
out of scope.

## Test plan

- [x] Local build of `simple_log_record_processor_test` succeeded
  (59/59 ninja steps, Debug, CXX_STANDARD=17)
- [x] All 10 `SimpleLogRecordProcessorTest.*` tests pass
- [x] `clang-format --dry-run --Werror` clean on the modified file
- [x] DCO signed off

Part of #2053