### PR TITLE
[CODE HEALTH] Move registry.cc propagator builders into anonymous namespace

### DIFF
--- a/.github/workflows/clang-tidy.yaml
+++ b/.github/workflows/clang-tidy.yaml
@@ -17,9 +17,9 @@ jobs:
       matrix:
         include:
           - cmake_options: all-options-abiv1-preview
-            warning_limit: 371
+            warning_limit: 366
           - cmake_options: all-options-abiv2-preview
-            warning_limit: 377
+            warning_limit: 372
     env:
       CC: /usr/bin/clang-22
       CXX: /usr/bin/clang++-22

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,9 @@ Increment the:
 * [CODE HEALTH] Move simple_log_record_processor_test into anonymous namespace
   [#4116](https://github.com/open-telemetry/opentelemetry-cpp/pull/4116)
 
+* [CODE HEALTH] Move registry.cc propagator builders into anonymous namespace
+  [#4121](https://github.com/open-telemetry/opentelemetry-cpp/pull/4121)
+
 ## [1.27.0] 2026-05-13
 
 * [RELEASE] Bump main branch to 1.27.0-dev

--- a/sdk/src/configuration/registry.cc
+++ b/sdk/src/configuration/registry.cc
@@ -27,6 +27,9 @@ namespace sdk
 namespace configuration
 {
 
+namespace
+{
+
 class TraceContextBuilder : public TextMapPropagatorBuilder
 {
 public:
@@ -76,6 +79,8 @@ public:
     return result;
   }
 };
+
+}  // namespace
 
 Registry::Registry()
 {


### PR DESCRIPTION
## Summary

Wraps the 5 file-local `TextMapPropagatorBuilder` subclasses in
`sdk/src/configuration/registry.cc` within an anonymous namespace,
clearing the 5 `misc-use-internal-linkage` warnings clang-tidy reports
on this file. First production-code PR of the
`misc-use-internal-linkage` campaign opened by #4115 / #4116.

## Changes

- `sdk/src/configuration/registry.cc`: insert `namespace {` after the
  `namespace configuration {` opening and `}  // namespace` before
  `Registry::Registry()`. Wrap covers `TraceContextBuilder`,
  `BaggageBuilder`, `B3Builder`, `B3MultiBuilder`, and `JaegerBuilder`.
  The 5 classes are only instantiated in `Registry::Registry()` via
  `std::make_unique` and are not referenced from any other translation
  unit (verified by repository-wide grep).
- `.github/workflows/clang-tidy.yaml`: abiv1 371 -> 366 (-5),
  abiv2 377 -> 372 (-5).
- `CHANGELOG.md`: one bullet under [Unreleased].

## Linkage rationale

`Registry::Registry()` and the other `Registry::` member function
definitions remain at namespace scope outside the anonymous namespace,
because as members of `class Registry` (declared in `registry.h`) they
must keep external linkage to satisfy ODR. The anonymous namespace
contents are reachable from the member function bodies via the implicit
using-directive that hoists anonymous namespace symbols into the
enclosing `configuration` namespace.

## Test plan

- [x] Local build of `opentelemetry_configuration`,
  `yaml_propagator_test`, and `yaml_test` succeeded (109/109 ninja
  steps with `-DWITH_CONFIGURATION=ON`)
- [x] `yaml_propagator_test` passes 9/9 (directly exercises the 5
  builders via YAML propagator configuration)
- [x] `yaml_test` passes 50/50
- [x] `clang-format --dry-run --Werror` clean on the modified file
- [x] DCO signed off

Part of #2053