### PR TITLE
[CODE HEALTH] Move sdk_builder.cc builders into anonymous namespace

### DIFF
--- a/.github/workflows/clang-tidy.yaml
+++ b/.github/workflows/clang-tidy.yaml
@@ -17,9 +17,9 @@ jobs:
       matrix:
         include:
           - cmake_options: all-options-abiv1-preview
-            warning_limit: 366
+            warning_limit: 356
           - cmake_options: all-options-abiv2-preview
-            warning_limit: 372
+            warning_limit: 362
     env:
       CC: /usr/bin/clang-22
       CXX: /usr/bin/clang++-22

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,9 @@ Increment the:
 * [CODE HEALTH] Move registry.cc propagator builders into anonymous namespace
   [#4121](https://github.com/open-telemetry/opentelemetry-cpp/pull/4121)
 
+* [CODE HEALTH] Move sdk_builder.cc builders into anonymous namespace
+  [#4122](https://github.com/open-telemetry/opentelemetry-cpp/pull/4122)
+
 ## [1.27.0] 2026-05-13
 
 * [RELEASE] Bump main branch to 1.27.0-dev

--- a/sdk/src/configuration/sdk_builder.cc
+++ b/sdk/src/configuration/sdk_builder.cc
@@ -188,6 +188,9 @@ namespace configuration
 
 using common::WildcardMatch;
 
+namespace
+{
+
 class ResourceAttributeValueSetter
     : public opentelemetry::sdk::configuration::AttributeValueConfigurationVisitor
 {
@@ -746,6 +749,8 @@ public:
 private:
   const SdkBuilder *sdk_builder_;
 };
+
+}  // namespace
 
 std::unique_ptr<opentelemetry::sdk::trace::Sampler> SdkBuilder::CreateAlwaysOffSampler(
     const opentelemetry::sdk::configuration::AlwaysOffSamplerConfiguration * /* model */) const


### PR DESCRIPTION
## Summary

Wraps the 10 file-local builder classes in
`sdk/src/configuration/sdk_builder.cc` within an anonymous namespace,
clearing the 10 `misc-use-internal-linkage` warnings clang-tidy reports
on this file. Second production-code PR of the misc-use-internal-linkage
campaign, after #4121 (registry.cc).

## Changes

- `sdk/src/configuration/sdk_builder.cc`: insert `namespace {` after the
  `using common::WildcardMatch;` declaration at line 189 and
  `}  // namespace` before the first `SdkBuilder::` member function
  definition at line 750. Wrap covers `ResourceAttributeValueSetter`,
  `SamplerBuilder`, `SpanProcessorBuilder`, `SpanExporterBuilder`,
  `MetricReaderBuilder`, `PushMetricExporterBuilder`,
  `PullMetricExporterBuilder`, `AggregationConfigBuilder`,
  `LogRecordProcessorBuilder`, and `LogRecordExporterBuilder`. The 10
  classes use inline methods only and are not referenced from any other
  translation unit (verified by repository-wide grep).
- `.github/workflows/clang-tidy.yaml`: abiv1 366 -> 356 (-10),
  abiv2 372 -> 362 (-10).
- `CHANGELOG.md`: one bullet under [Unreleased].

## Linkage rationale

`SdkBuilder::` member function definitions remain at namespace scope
outside the anonymous namespace, because as members of `class SdkBuilder`
they must keep external linkage to satisfy ODR. The anonymous namespace
contents are reachable from the member function bodies via the implicit
using-directive that hoists anonymous namespace symbols into the
enclosing `configuration` namespace. This is the same structure used in
#4121.

## Test plan

- [x] Local build of `opentelemetry_configuration` and 7 yaml tests
  (`-DWITH_CONFIGURATION=ON`, 119/119 ninja steps)
- [x] `yaml_propagator_test` passes 9/9
- [x] `yaml_test` passes 50/50
- [x] `yaml_trace_test` passes 38/38 (exercises Sampler / SpanProcessor /
  SpanExporter builders)
- [x] `yaml_metrics_test` passes 32/32 (exercises MetricReader /
  PushMetricExporter / PullMetricExporter / AggregationConfig builders)
- [x] `yaml_logs_test` passes 20/20 (exercises LogRecordProcessor /
  LogRecordExporter builders)
- [x] `yaml_resource_test` passes 13/13 (exercises ResourceAttributeValueSetter)
- [x] `yaml_distribution_test` passes 3/3
- [x] `clang-format --dry-run --Werror` clean on the modified file
- [x] DCO signed off

Part of #2053