### PR TITLE
[CODE HEALTH] Move logger_sdk_test classes into anonymous namespace

### DIFF
--- a/.github/workflows/clang-tidy.yaml
+++ b/.github/workflows/clang-tidy.yaml
@@ -17,9 +17,9 @@ jobs:
       matrix:
         include:
           - cmake_options: all-options-abiv1-preview
-            warning_limit: 356
+            warning_limit: 352
           - cmake_options: all-options-abiv2-preview
-            warning_limit: 362
+            warning_limit: 356
     env:
       CC: /usr/bin/clang-22
       CXX: /usr/bin/clang++-22

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,9 @@ Increment the:
 * [CODE HEALTH] Move sdk_builder.cc builders into anonymous namespace
   [#4122](https://github.com/open-telemetry/opentelemetry-cpp/pull/4122)
 
+* [CODE HEALTH] Move logger_sdk_test classes into anonymous namespace
+  [#4124](https://github.com/open-telemetry/opentelemetry-cpp/pull/4124)
+
 ## [1.27.0] 2026-05-13
 
 * [RELEASE] Bump main branch to 1.27.0-dev

--- a/sdk/test/logs/logger_sdk_test.cc
+++ b/sdk/test/logs/logger_sdk_test.cc
@@ -116,6 +116,9 @@ TEST(LoggerSDK, LogToNullProcessor)
   logger->Debug("Test log");
 }
 
+namespace
+{
+
 class MockLogRecordable final : public opentelemetry::sdk::logs::Recordable
 {
 public:
@@ -847,3 +850,5 @@ TEST(LoggerSDK, EventLog)
   ASSERT_FALSE(shared_recordable->GetSpanId().IsValid());
 }
 #endif
+
+}  // namespace


### PR DESCRIPTION
## Summary

Wraps the 6 file-scope class and struct declarations in
`sdk/test/logs/logger_sdk_test.cc` within an anonymous namespace,
clearing the corresponding `misc-use-internal-linkage` warnings.

This is the 5th PR of the misc-use-internal-linkage campaign (#4115,
#4116, #4121, #4122 already merged) and the first with an **asymmetric
ratchet drop** because 2 of the 6 wrapped classes are inside an
`#if OPENTELEMETRY_ABI_VERSION_NO >= 2` gate.

## Changes

- `sdk/test/logs/logger_sdk_test.cc`: insert `namespace {` after the
  first `TEST(LoggerSDK, LogToNullProcessor)` (ends at line 117) and
  `}  // namespace` after the final `#endif` of the file-trailing
  `#if OPENTELEMETRY_ABI_VERSION_NO < 2` block. Wrap covers:
  - `MockLogRecordable` (line 119, always-on)
  - `MockProcessor` (line 241, always-on)
  - `EnabledProcessorCallState` struct (line 276, **abiv2-only**)
  - `EnablementAwareProcessor` (line 286, **abiv2-only**)
  - `CustomLogConfiguratorTestData` (line 668, always-on)
  - `CustomLoggerConfiguratorTestFixture` TEST_P fixture (line 747,
    always-on)
- The pre-existing anonymous namespace at lines 65-99 (wrapping two
  abiv2 helper functions inside an existing `#if abiv2` gate) is left
  in place.
- `.github/workflows/clang-tidy.yaml`: abiv1 356 -> 352 (-4),
  abiv2 362 -> 356 (-6).
- `CHANGELOG.md`: one bullet under [Unreleased].

## Why the ratchet drop is asymmetric

`#if OPENTELEMETRY_ABI_VERSION_NO >= 2` at lines 275-338 contains
`EnabledProcessorCallState` and `EnablementAwareProcessor`. In abiv1
builds the preprocessor strips these out, so clang-tidy never sees
them and they are not counted in the abiv1 baseline of 356. In abiv2
builds they are visible and contribute 2 of the 362 total warnings.

After this PR clears all 6 sites, both ratchets drop by the count
visible in that build (abiv1: -4, abiv2: -6), and 2 of the abiv2-only
classes also stop counting against the abiv2 baseline. Net new limits:
abiv1 352, abiv2 356.

This is mechanically the same wrap as #4115 / #4116 / #4121 / #4122;
the only novelty is that this is the first wrapped file containing an
ABI-gated class.

## Test plan

- [x] Local abiv1 build of `logger_sdk_test`: 59/59 ninja steps
  (`WITH_OTLP_HTTP=OFF -DWITH_OTLP_GRPC=OFF`)
- [x] Local abiv1 run: 9/9 tests pass
- [x] Local abiv2 build of `logger_sdk_test`:
  `-DWITH_ABI_VERSION_2=ON -DWITH_ABI_VERSION_1=OFF`, 59/59 steps
- [x] Local abiv2 run: 15/15 tests pass (extra 6 tests are
  abiv2-only, exercising `EnabledProcessorCallState` and
  `EnablementAwareProcessor`)
- [x] `clang-format --dry-run --Werror` clean on the modified file
- [x] DCO signed off

Part of #2053