### PR TITLE
[CODE HEALTH] Move func_http_main classes into anonymous namespace

### DIFF
--- a/.github/workflows/clang-tidy.yaml
+++ b/.github/workflows/clang-tidy.yaml
@@ -17,9 +17,9 @@ jobs:
       matrix:
         include:
           - cmake_options: all-options-abiv1-preview
-            warning_limit: 352
+            warning_limit: 349
           - cmake_options: all-options-abiv2-preview
-            warning_limit: 356
+            warning_limit: 353
     env:
       CC: /usr/bin/clang-22
       CXX: /usr/bin/clang++-22

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,9 @@ Increment the:
 * [CODE HEALTH] Move logger_sdk_test classes into anonymous namespace
   [#4124](https://github.com/open-telemetry/opentelemetry-cpp/pull/4124)
 
+* [CODE HEALTH] Move func_http_main classes into anonymous namespace
+  [#4128](https://github.com/open-telemetry/opentelemetry-cpp/pull/4128)
+
 ## [1.27.0] 2026-05-13
 
 * [RELEASE] Bump main branch to 1.27.0-dev

--- a/functional/otlp/func_http_main.cc
+++ b/functional/otlp/func_http_main.cc
@@ -55,6 +55,9 @@ static std::string opt_cert_dir;
 static std::string opt_test_name;
 static test_mode opt_mode = MODE_NONE;
 
+namespace
+{
+
 /*
   Log parsing
 */
@@ -335,6 +338,8 @@ struct test_case
   std::string m_name;
   test_func_t m_func;
 };
+
+}  // namespace
 
 static int test_basic();
 


### PR DESCRIPTION
## Summary

Wraps the 3 file-scope class/struct declarations in
`functional/otlp/func_http_main.cc` within an anonymous namespace,
clearing the misc-use-internal-linkage warnings.

6th PR of the misc-use-internal-linkage campaign (#4115, #4116, #4121,
#4122, #4124 already merged). First PR in the campaign touching the
`functional/` tree.

## Changes

- `functional/otlp/func_http_main.cc`: insert `namespace {` after the
  command-line `opt_*` variables and `}  // namespace` after the
  `test_case` struct closing brace. Wrap covers `TestResult` (line 62),
  `TestLogHandler` (line 145), and `test_case` (line 333).
- `.github/workflows/clang-tidy.yaml`: abiv1 352 -> 349 (-3),
  abiv2 356 -> 353 (-3).
- `CHANGELOG.md`: one bullet under [Unreleased].

## Why the wrap ends before line 339 (NOT before main())

The `static int test_*()` forward declarations (lines 339-440) are
matched by definitions in the lower half of the file (lines 1484-1882,
after `main()`). Wrapping declarations alone would produce
`(anonymous namespace)::test_*` symbols that do not link against the
file-scope `static int test_*()` definitions.

Verified locally: a wrap extending to line 453 (just before `main()`)
produced 12+ undefined reference linker errors. The shortened wrap
ending at line 337 builds cleanly.

`main()` keeps external linkage. The `static const test_case
all_tests[]` table and `list_test_cases` / `run_test_case` helpers
remain at file scope with their existing `static` linkage.

## Test plan

- [x] Local build of `func_otlp_http`: 121/121 ninja steps
  (`-DWITH_OTLP_HTTP=ON -DWITH_OTLP_GRPC=OFF`)
- [x] `func_otlp_http --help` smoke test prints usage
- [x] `clang-format --dry-run --Werror` clean on the modified file
- [x] DCO signed off

Part of #2053