### PR TITLE
[CODE HEALTH] Move func_grpc_main classes into anonymous namespace

### DIFF
--- a/.github/workflows/clang-tidy.yaml
+++ b/.github/workflows/clang-tidy.yaml
@@ -17,9 +17,9 @@ jobs:
       matrix:
         include:
           - cmake_options: all-options-abiv1-preview
-            warning_limit: 349
+            warning_limit: 346
           - cmake_options: all-options-abiv2-preview
-            warning_limit: 353
+            warning_limit: 350
     env:
       CC: /usr/bin/clang-22
       CXX: /usr/bin/clang++-22

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,9 @@ Increment the:
 * [CODE HEALTH] Move func_http_main classes into anonymous namespace
   [#4128](https://github.com/open-telemetry/opentelemetry-cpp/pull/4128)
 
+* [CODE HEALTH] Move func_grpc_main classes into anonymous namespace
+  [#4129](https://github.com/open-telemetry/opentelemetry-cpp/pull/4129)
+
 ## [1.27.0] 2026-05-13
 
 * [RELEASE] Bump main branch to 1.27.0-dev

--- a/functional/otlp/func_grpc_main.cc
+++ b/functional/otlp/func_grpc_main.cc
@@ -56,6 +56,9 @@ static std::string opt_cert_dir;
 static std::string opt_test_name;
 static TestMode opt_mode = TestMode::kNone;
 
+namespace
+{
+
 /*
   Log parsing
 */
@@ -318,6 +321,8 @@ struct test_case
   std::string m_name;
   test_func_t m_func;
 };
+
+}  // namespace
 
 static int test_basic();
 


### PR DESCRIPTION
## Summary

Wraps the 3 file-scope class/struct declarations in
`functional/otlp/func_grpc_main.cc` within an anonymous namespace,
clearing the misc-use-internal-linkage warnings.

7th PR of the misc-use-internal-linkage campaign and the twin of
#4128 (func_http_main, merged). Same wrap pattern, same boundary
rationale, same +3 site clearance.

## Changes

- `functional/otlp/func_grpc_main.cc`: insert `namespace {` after
  the command-line `opt_*` variables and `}  // namespace` after the
  `test_case` struct closing brace. Wrap covers `TestResult` (line
  63), `TestLogHandler` (line 128), and `test_case` (line 316).
- `.github/workflows/clang-tidy.yaml`: abiv1 349 -> 346 (-3),
  abiv2 353 -> 350 (-3).
- `CHANGELOG.md`: one bullet under [Unreleased].

## Why the wrap ends before line 322

Same rationale as #4128: the `static int test_*()` forward
declarations are matched by definitions in the lower half of the
file (after `main()`). Wrapping declarations alone would produce
`(anonymous namespace)::test_*` symbols that fail to link.

`main()`, the `static const test_case all_tests[]` table,
`list_test_cases`, `run_test_case`, and the test definitions remain
at file scope.

## Test plan

- [x] Local build of `func_otlp_grpc`: 122/122 ninja steps
  (`-DWITH_OTLP_HTTP=ON -DWITH_OTLP_GRPC=ON` per the CMake quirk
  that the outer `functional/CMakeLists.txt` only adds `otlp` subdir
  when `WITH_OTLP_HTTP=ON`)
- [x] `func_otlp_grpc --help` smoke test prints usage
- [x] `clang-format --dry-run --Werror` clean on the modified file
- [x] DCO signed off

Part of #2053