### PR TITLE
[CONFIGURATION] Implementing minimum_severity and trace_based attributes for LoggerConfig

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,9 @@ Increment the:
 * [CODE HEALTH] Move func_grpc_main classes into anonymous namespace
   [#4129](https://github.com/open-telemetry/opentelemetry-cpp/pull/4129)
 
+* [CONFIGURATION] Implement missing minimum_severity and trace_based for LoggerConfig declarative configuration
+  [#4131](https://github.com/open-telemetry/opentelemetry-cpp/pull/4131)
+
 ## [1.27.0] 2026-05-13
 
 * [RELEASE] Bump main branch to 1.27.0-dev

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,7 +54,8 @@ Increment the:
 * [CODE HEALTH] Move func_grpc_main classes into anonymous namespace
   [#4129](https://github.com/open-telemetry/opentelemetry-cpp/pull/4129)
 
-* [CONFIGURATION] Implement missing minimum_severity and trace_based for LoggerConfig declarative configuration
+* [CONFIGURATION] Implement missing minimum_severity and trace_based for
+  LoggerConfig declarative configuration
   [#4131](https://github.com/open-telemetry/opentelemetry-cpp/pull/4131)
 
 ## [1.27.0] 2026-05-13

--- a/sdk/include/opentelemetry/sdk/configuration/logger_config_configuration.h
+++ b/sdk/include/opentelemetry/sdk/configuration/logger_config_configuration.h
@@ -3,6 +3,7 @@
 
 #pragma once
 
+#include "opentelemetry/sdk/configuration/severity_number.h"
 #include "opentelemetry/version.h"
 
 OPENTELEMETRY_BEGIN_NAMESPACE
@@ -17,8 +18,11 @@ class LoggerConfigConfiguration
 {
 public:
   bool enabled{true};
+  SeverityNumber minimum_severity{SeverityNumber::trace};
+  bool trace_based{false};
 };
 
 }  // namespace configuration
 }  // namespace sdk
 OPENTELEMETRY_END_NAMESPACE
+

--- a/sdk/include/opentelemetry/sdk/configuration/logger_config_configuration.h
+++ b/sdk/include/opentelemetry/sdk/configuration/logger_config_configuration.h
@@ -25,4 +25,3 @@ public:
 }  // namespace configuration
 }  // namespace sdk
 OPENTELEMETRY_END_NAMESPACE
-

--- a/sdk/src/configuration/configuration_parser.cc
+++ b/sdk/src/configuration/configuration_parser.cc
@@ -624,6 +624,12 @@ LoggerConfigConfiguration ConfigurationParser::ParseLoggerConfigConfiguration(
 {
   LoggerConfigConfiguration model;
   model.enabled = node->GetBoolean("enabled", true);
+  
+  const std::string minimum_severity_str = node->GetString("minimum_severity", "trace");
+  model.minimum_severity = ParseSeverityNumber(node, minimum_severity_str);
+  
+  model.trace_based = node->GetBoolean("trace_based", false);
+  
   return model;
 }
 

--- a/sdk/src/configuration/configuration_parser.cc
+++ b/sdk/src/configuration/configuration_parser.cc
@@ -624,12 +624,12 @@ LoggerConfigConfiguration ConfigurationParser::ParseLoggerConfigConfiguration(
 {
   LoggerConfigConfiguration model;
   model.enabled = node->GetBoolean("enabled", true);
-  
+
   const std::string minimum_severity_str = node->GetString("minimum_severity", "trace");
-  model.minimum_severity = ParseSeverityNumber(node, minimum_severity_str);
-  
+  model.minimum_severity                 = ParseSeverityNumber(node, minimum_severity_str);
+
   model.trace_based = node->GetBoolean("trace_based", false);
-  
+
   return model;
 }
 

--- a/sdk/test/configuration/yaml_logs_test.cc
+++ b/sdk/test/configuration/yaml_logs_test.cc
@@ -21,6 +21,7 @@
 #include "opentelemetry/sdk/configuration/otlp_grpc_log_record_exporter_configuration.h"
 #include "opentelemetry/sdk/configuration/otlp_http_encoding.h"
 #include "opentelemetry/sdk/configuration/otlp_http_log_record_exporter_configuration.h"
+#include "opentelemetry/sdk/configuration/severity_number.h"
 #include "opentelemetry/sdk/configuration/simple_log_record_processor_configuration.h"
 #include "opentelemetry/sdk/configuration/yaml_configuration_parser.h"
 

--- a/sdk/test/configuration/yaml_logs_test.cc
+++ b/sdk/test/configuration/yaml_logs_test.cc
@@ -590,3 +590,107 @@ logger_provider:
   ASSERT_EQ(configurator->loggers[0].name, "noisy.library");
   ASSERT_EQ(configurator->loggers[0].config.enabled, false);
 }
+
+TEST(YamlLogs, logger_config_with_minimum_severity)
+{
+  std::string yaml = R"YAML(
+file_format: "1.0-logs"
+logger_provider:
+  processors:
+    - simple:
+        exporter:
+          console:
+  logger_configurator/development:
+    default_config:
+      enabled: true
+      minimum_severity: warn
+      trace_based: false
+    loggers:
+      - name: my.logger
+        config:
+          enabled: true
+          minimum_severity: error
+          trace_based: true
+)YAML";
+
+  auto config = DoParse(yaml);
+  ASSERT_NE(config, nullptr);
+  ASSERT_NE(config->logger_provider, nullptr);
+  ASSERT_NE(config->logger_provider->logger_configurator, nullptr);
+
+  auto &configurator = config->logger_provider->logger_configurator;
+  ASSERT_EQ(configurator->default_config.enabled, true);
+  ASSERT_EQ(configurator->default_config.minimum_severity,
+            opentelemetry::sdk::configuration::SeverityNumber::warn);
+  ASSERT_EQ(configurator->default_config.trace_based, false);
+  ASSERT_EQ(configurator->loggers.size(), 1);
+
+  ASSERT_EQ(configurator->loggers[0].name, "my.logger");
+  ASSERT_EQ(configurator->loggers[0].config.enabled, true);
+  ASSERT_EQ(configurator->loggers[0].config.minimum_severity,
+            opentelemetry::sdk::configuration::SeverityNumber::error);
+  ASSERT_EQ(configurator->loggers[0].config.trace_based, true);
+}
+
+TEST(YamlLogs, logger_config_with_default_minimum_severity)
+{
+  std::string yaml = R"YAML(
+file_format: "1.0-logs"
+logger_provider:
+  processors:
+    - simple:
+        exporter:
+          console:
+  logger_configurator/development:
+    default_config:
+      enabled: true
+    loggers:
+      - name: my.logger
+        config:
+          enabled: false
+)YAML";
+
+  auto config = DoParse(yaml);
+  ASSERT_NE(config, nullptr);
+  ASSERT_NE(config->logger_provider, nullptr);
+  ASSERT_NE(config->logger_provider->logger_configurator, nullptr);
+
+  auto &configurator = config->logger_provider->logger_configurator;
+  ASSERT_EQ(configurator->default_config.enabled, true);
+  ASSERT_EQ(configurator->default_config.minimum_severity,
+            opentelemetry::sdk::configuration::SeverityNumber::trace);
+  ASSERT_EQ(configurator->default_config.trace_based, false);
+
+  ASSERT_EQ(configurator->loggers[0].config.enabled, false);
+  ASSERT_EQ(configurator->loggers[0].config.minimum_severity,
+            opentelemetry::sdk::configuration::SeverityNumber::trace);
+  ASSERT_EQ(configurator->loggers[0].config.trace_based, false);
+}
+
+TEST(YamlLogs, logger_config_trace_based_true)
+{
+  std::string yaml = R"YAML(
+file_format: "1.0-logs"
+logger_provider:
+  processors:
+    - simple:
+        exporter:
+          console:
+  logger_configurator/development:
+    default_config:
+      enabled: true
+      minimum_severity: info
+      trace_based: true
+)YAML";
+
+  auto config = DoParse(yaml);
+  ASSERT_NE(config, nullptr);
+  ASSERT_NE(config->logger_provider, nullptr);
+  ASSERT_NE(config->logger_provider->logger_configurator, nullptr);
+
+  auto &configurator = config->logger_provider->logger_configurator;
+  ASSERT_EQ(configurator->default_config.enabled, true);
+  ASSERT_EQ(configurator->default_config.minimum_severity,
+            opentelemetry::sdk::configuration::SeverityNumber::info);
+  ASSERT_EQ(configurator->default_config.trace_based, true);
+}


### PR DESCRIPTION
Fixes #4130 

## Changes

## Description

Implements the missing `minimum_severity` and `trace_based` attributes for `LoggerConfig` in the declarative configuration spec.

Previously, `LoggerConfigConfiguration` only had an `enabled` boolean field. This PR adds:
- **`minimum_severity`** (type: `SeverityNumber`, default: `trace`) — allows filtering log records by severity level
- **`trace_based`** (type: `bool`, default: `false`) — enables/disables trace-based log filtering

These attributes align with the OpenTelemetry specification for logger configuration and enable users to control logging behavior via YAML configuration.

**Example YAML usage:**
```yaml
logger_provider:
  logger_configurator/development:
    default_config:
      enabled: true
      minimum_severity: warn
      trace_based: false
    loggers:
      - name: my.noisy.logger
        config:
          minimum_severity: error
          trace_based: true
```          
          
For significant contributions, please make sure you have completed the following items:

* [x] `CHANGELOG.md` updated for non-trivial changes
* [x] Unit tests have been added
* [ ] Changes in public API reviewed