### PR TITLE
[METRICS] Use instrument creation time as delta start_ts for first interval

### DIFF
--- a/sdk/include/opentelemetry/sdk/metrics/state/temporal_metric_storage.h
+++ b/sdk/include/opentelemetry/sdk/metrics/state/temporal_metric_storage.h
@@ -56,6 +56,7 @@ private:
   // Lock while building metrics
   mutable opentelemetry::common::SpinLockMutex lock_;
   const AggregationConfig *aggregation_config_;
+  opentelemetry::common::SystemTimestamp instrument_creation_ts_;
   opentelemetry::common::SystemTimestamp last_delta_collection_ts_;
   bool has_last_delta_collection_ts_ = false;
 };

--- a/sdk/src/metrics/state/temporal_metric_storage.cc
+++ b/sdk/src/metrics/state/temporal_metric_storage.cc
@@ -1,6 +1,7 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
+#include <chrono>
 #include <list>
 #include <memory>
 #include <mutex>
@@ -34,7 +35,8 @@ TemporalMetricStorage::TemporalMetricStorage(InstrumentDescriptor instrument_des
                                              const AggregationConfig *aggregation_config)
     : instrument_descriptor_(std::move(instrument_descriptor)),
       aggregation_type_(aggregation_type),
-      aggregation_config_(aggregation_config)
+      aggregation_config_(aggregation_config),
+      instrument_creation_ts_(std::chrono::system_clock::now())
 {}
 
 bool TemporalMetricStorage::buildMetrics(CollectorHandle *collector,
@@ -45,7 +47,7 @@ bool TemporalMetricStorage::buildMetrics(CollectorHandle *collector,
                                          nostd::function_ref<bool(MetricData)> callback) noexcept
 {
   std::lock_guard<opentelemetry::common::SpinLockMutex> guard(lock_);
-  opentelemetry::common::SystemTimestamp last_collection_ts = sdk_start_ts;
+  opentelemetry::common::SystemTimestamp last_collection_ts = instrument_creation_ts_;
   AggregationTemporality aggregation_temporarily =
       collector->GetAggregationTemporality(instrument_descriptor_.type_);
 
@@ -56,7 +58,7 @@ bool TemporalMetricStorage::buildMetrics(CollectorHandle *collector,
   {
     if (!has_last_delta_collection_ts_)
     {
-      last_delta_collection_ts_     = sdk_start_ts;
+      last_delta_collection_ts_     = instrument_creation_ts_;
       has_last_delta_collection_ts_ = true;
     }
     // If no metrics, early return

--- a/sdk/src/metrics/state/temporal_metric_storage.cc
+++ b/sdk/src/metrics/state/temporal_metric_storage.cc
@@ -41,7 +41,7 @@ TemporalMetricStorage::TemporalMetricStorage(InstrumentDescriptor instrument_des
 
 bool TemporalMetricStorage::buildMetrics(CollectorHandle *collector,
                                          nostd::span<std::shared_ptr<CollectorHandle>> collectors,
-                                         opentelemetry::common::SystemTimestamp sdk_start_ts,
+                                         opentelemetry::common::SystemTimestamp /* sdk_start_ts */,
                                          opentelemetry::common::SystemTimestamp collection_ts,
                                          const std::shared_ptr<AttributesHashMap> &delta_metrics,
                                          nostd::function_ref<bool(MetricData)> callback) noexcept


### PR DESCRIPTION
Fixes #4062

## Summary

For delta aggregations, the OpenTelemetry spec requires:

> The start timestamp MUST equal the previous collection interval's timestamp, or **the creation time of the instrument** if this is the first collection interval.

The bug: `TemporalMetricStorage::buildMetrics` was using `sdk_start_ts` (MeterProvider creation time) as the `start_ts` for the **first** delta collection interval in both the fast path and slow path. This meant all instruments shared the same (wrong) start time regardless of when they were individually created.

**Fix**: Store `instrument_creation_ts_` (captured via `std::chrono::system_clock::now()` in the `TemporalMetricStorage` constructor) and use it instead of `sdk_start_ts` for the first delta interval in both code paths:

- **Fast path** (single collector, delta): `last_delta_collection_ts_` initialised to `instrument_creation_ts_` instead of `sdk_start_ts`
- **Slow path**: default `last_collection_ts` set to `instrument_creation_ts_` instead of `sdk_start_ts`

This matches the Java SDK behaviour in `DefaultSynchronousMetricStorage`, which stores `instrumentCreationEpochNanos` at construction and uses it as the fallback for the first collection.

## Test plan

- [ ] Existing `sync_metric_storage_*` tests pass
- [ ] Manual verification: instrument created at T=30s after MeterProvider init shows `start_time_unix_nano ≈ T=30s` (not T=0) on first delta export

cc @marcalff @lalitb @pixerit @ThomsonTan