### PR TITLE
[METRICS] Drop stale async attribute sets from cumulative exports

### DIFF
--- a/sdk/include/opentelemetry/sdk/metrics/state/async_metric_storage.h
+++ b/sdk/include/opentelemetry/sdk/metrics/state/async_metric_storage.h
@@ -141,9 +141,9 @@ public:
                                                   Aggregation &aggregation) {
             if (delta_metrics->Has(attributes))
             {
-              new_cumulative->Set(attributes, DefaultAggregation::CloneAggregation(
-                                                  aggregation_type_, instrument_descriptor_,
-                                                  aggregation));
+              new_cumulative->Set(attributes,
+                                  DefaultAggregation::CloneAggregation(
+                                      aggregation_type_, instrument_descriptor_, aggregation));
             }
             return true;
           });

--- a/sdk/include/opentelemetry/sdk/metrics/state/async_metric_storage.h
+++ b/sdk/include/opentelemetry/sdk/metrics/state/async_metric_storage.h
@@ -52,7 +52,7 @@ public:
         exemplar_filter_type_(exempler_filter_type),
         exemplar_reservoir_(std::move(exemplar_reservoir)),
 #endif
-        temporal_metric_storage_(instrument_descriptor, aggregation_type, aggregation_config)
+        temporal_metric_storage_(instrument_descriptor, aggregation_type, aggregation_config, true)
   {}
 
   template <class T>
@@ -130,6 +130,24 @@ public:
       delta_metrics = std::move(delta_hash_map_);
       delta_hash_map_ =
           std::make_unique<AttributesHashMap>(aggregation_config_->cardinality_limit_);
+
+      // Drop entries from cumulative_hash_map_ that were not observed this cycle.
+      // This prevents memory growth and ensures correct delta computation if an
+      // attribute set reappears after being absent.
+      auto new_cumulative =
+          std::make_unique<AttributesHashMap>(aggregation_config_->cardinality_limit_);
+      cumulative_hash_map_->GetAllEntries(
+          [&new_cumulative, &delta_metrics, this](const MetricAttributes &attributes,
+                                                  Aggregation &aggregation) {
+            if (delta_metrics->Has(attributes))
+            {
+              new_cumulative->Set(attributes, DefaultAggregation::CloneAggregation(
+                                                  aggregation_type_, instrument_descriptor_,
+                                                  aggregation));
+            }
+            return true;
+          });
+      cumulative_hash_map_ = std::move(new_cumulative);
     }
 
     auto status =

--- a/sdk/include/opentelemetry/sdk/metrics/state/temporal_metric_storage.h
+++ b/sdk/include/opentelemetry/sdk/metrics/state/temporal_metric_storage.h
@@ -34,7 +34,8 @@ class TemporalMetricStorage
 public:
   TemporalMetricStorage(InstrumentDescriptor instrument_descriptor,
                         AggregationType aggregation_type,
-                        const AggregationConfig *aggregation_config);
+                        const AggregationConfig *aggregation_config,
+                        bool is_async = false);
 
   bool buildMetrics(CollectorHandle *collector,
                     nostd::span<std::shared_ptr<CollectorHandle>> collectors,
@@ -56,6 +57,7 @@ private:
   // Lock while building metrics
   mutable opentelemetry::common::SpinLockMutex lock_;
   const AggregationConfig *aggregation_config_;
+  bool is_async_;
   opentelemetry::common::SystemTimestamp last_delta_collection_ts_;
   bool has_last_delta_collection_ts_ = false;
 };

--- a/sdk/src/metrics/state/temporal_metric_storage.cc
+++ b/sdk/src/metrics/state/temporal_metric_storage.cc
@@ -31,10 +31,12 @@ namespace metrics
 
 TemporalMetricStorage::TemporalMetricStorage(InstrumentDescriptor instrument_descriptor,
                                              AggregationType aggregation_type,
-                                             const AggregationConfig *aggregation_config)
+                                             const AggregationConfig *aggregation_config,
+                                             bool is_async)
     : instrument_descriptor_(std::move(instrument_descriptor)),
       aggregation_type_(aggregation_type),
-      aggregation_config_(aggregation_config)
+      aggregation_config_(aggregation_config),
+      is_async_(is_async)
 {}
 
 bool TemporalMetricStorage::buildMetrics(CollectorHandle *collector,
@@ -148,8 +150,11 @@ bool TemporalMetricStorage::buildMetrics(CollectorHandle *collector,
             {
               merged_metrics->Set(attributes, agg->Merge(aggregation));
             }
-            else
+            else if (!is_async_)
             {
+              // For sync instruments, carry forward attribute sets not observed this cycle.
+              // For async instruments, drop them per the spec: the SDK SHOULD NOT produce
+              // aggregated metric data for attribute sets not observed in the current callback.
               auto def_agg = DefaultAggregation::CreateAggregation(
                   aggregation_type_, instrument_descriptor_, aggregation_config_);
               merged_metrics->Set(attributes, def_agg->Merge(aggregation));


### PR DESCRIPTION
Fixes #4108

## Summary

The OpenTelemetry SDK spec states:

> The implementation SHOULD NOT produce aggregated metric data for a previously-observed attribute set which is **not observed during a successful callback**.

**Bug**: Under cumulative temporality, async instruments (`ObservableCounter`, `ObservableGauge`, `ObservableUpDownCounter`) kept emitting attribute sets indefinitely after the callback stopped reporting them. The frozen values would appear in every subsequent export with the stale last-observed value (and for `ObservableGauge`, even with a frozen timestamp).

**Root cause** in `TemporalMetricStorage::buildMetrics()`: the cumulative merge unconditionally carried every entry from `last_reported_metrics_` into the output even if it was absent from the current delta.

## Changes (3 files)

### `temporal_metric_storage.h` / `.cc`
- Add `is_async_` boolean (default `false`) to `TemporalMetricStorage`
- In the cumulative merge lambda, add `else if (!is_async_)` guard: sync instruments still carry forward all attribute sets (existing behaviour, spec-correct); async instruments skip stale entries not present in the current delta

### `async_metric_storage.h`
- Pass `is_async = true` when constructing `TemporalMetricStorage`
- In `Collect()`, rebuild `cumulative_hash_map_` to contain only entries present in `delta_metrics` — prevents unbounded memory growth and ensures correct delta computation if an attribute set reappears after a gap

## Behaviour

| Scenario | Before | After |
|---|---|---|
| Async cumulative, attribute dropped by callback | Emitted forever with stale value | Dropped from next export |
| Sync cumulative, attribute not measured this cycle | Carried forward (correct) | Unchanged |
| Delta temporality (async or sync) | Correct (unaffected) | Unchanged |

Sister SDKs: opentelemetry-dotnet [#6883](https://github.com/open-telemetry/opentelemetry-dotnet/pull/6883) and opentelemetry-rust [#2618](https://github.com/open-telemetry/opentelemetry-rust/pull/2618) have shipped equivalent fixes.

cc @marcalff @lalitb @ThomsonTan @kyusic