### PR TITLE
[BUILD] Fix protobuf build failure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -98,6 +98,9 @@ Increment the:
   ParentThreshold, RuleBased)
   [#4028](https://github.com/open-telemetry/opentelemetry-cpp/issues/4028)
 
+* [BUILD] Fix protobuf build failure
+  [#4154](https://github.com/open-telemetry/opentelemetry-cpp/pull/4154)
+
 ## [1.27.0] 2026-05-13
 
 * [RELEASE] Bump main branch to 1.27.0-dev

--- a/exporters/otlp/test/otlp_http_metric_exporter_test.cc
+++ b/exporters/otlp/test/otlp_http_metric_exporter_test.cc
@@ -1,7 +1,6 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-#include <google/protobuf/stubs/common.h>
 #include <gtest/gtest.h>
 #include <chrono>
 #include <cstdint>
@@ -41,6 +40,7 @@
 #include "opentelemetry/exporters/otlp/protobuf_include_prefix.h" // IWYU pragma: keep
 // IWYU pragma: no_include "net/proto2/public/repeated_field.h"
 // IWYU pragma: no_include <google/protobuf/repeated_ptr_field.h>
+// IWYU pragma: no_include <google/protobuf/stubs/common.h>
 #include "opentelemetry/proto/collector/metrics/v1/metrics_service.pb.h"
 #include "opentelemetry/proto/common/v1/common.pb.h"
 #include "opentelemetry/proto/metrics/v1/metrics.pb.h"

--- a/exporters/otlp/test/otlp_http_metric_exporter_test.cc
+++ b/exporters/otlp/test/otlp_http_metric_exporter_test.cc
@@ -1,7 +1,6 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-#include <google/protobuf/repeated_ptr_field.h>
 #include <google/protobuf/stubs/common.h>
 #include <gtest/gtest.h>
 #include <chrono>
@@ -41,6 +40,7 @@
 // clang-format off
 #include "opentelemetry/exporters/otlp/protobuf_include_prefix.h" // IWYU pragma: keep
 // IWYU pragma: no_include "net/proto2/public/repeated_field.h"
+// IWYU pragma: no_include <google/protobuf/repeated_ptr_field.h>
 #include "opentelemetry/proto/collector/metrics/v1/metrics_service.pb.h"
 #include "opentelemetry/proto/common/v1/common.pb.h"
 #include "opentelemetry/proto/metrics/v1/metrics.pb.h"

--- a/exporters/otlp/test/otlp_log_recordable_test.cc
+++ b/exporters/otlp/test/otlp_log_recordable_test.cc
@@ -1,7 +1,6 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-#include <google/protobuf/repeated_ptr_field.h>
 #include <gtest/gtest.h>
 #include <stdint.h>
 #include <chrono>
@@ -30,6 +29,7 @@
 // clang-format off
 #include "opentelemetry/exporters/otlp/protobuf_include_prefix.h" // IWYU pragma: keep
 // IWYU pragma: no_include "net/proto2/public/repeated_field.h"
+// IWYU pragma: no_include <google/protobuf/repeated_ptr_field.h>
 #include "opentelemetry/proto/collector/logs/v1/logs_service.pb.h"
 #include "opentelemetry/proto/resource/v1/resource.pb.h"
 #include "opentelemetry/proto/common/v1/common.pb.h"

--- a/exporters/otlp/test/otlp_recordable_test.cc
+++ b/exporters/otlp/test/otlp_recordable_test.cc
@@ -1,7 +1,6 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-#include <google/protobuf/repeated_ptr_field.h>
 #include <gtest/gtest.h>
 #include <chrono>
 #include <cstdint>
@@ -42,6 +41,7 @@
 // clang-format off
 #include "opentelemetry/exporters/otlp/protobuf_include_prefix.h" // IWYU pragma: keep
 // IWYU pragma: no_include "net/proto2/public/repeated_field.h"
+// IWYU pragma: no_include <google/protobuf/repeated_ptr_field.h>
 #include "opentelemetry/proto/collector/trace/v1/trace_service.pb.h"
 #include "opentelemetry/proto/common/v1/common.pb.h"
 #include "opentelemetry/proto/resource/v1/resource.pb.h"


### PR DESCRIPTION
Fixes # (issue)

## Changes

Please provide a brief description of the changes here.

* Fixed a build regression introduced by #4136:
  * header `google/protobuf/repeated_ptr_field.h` is not available in every protobuf versions, including it causes a build break
* Used include-what-you-use pragmas instead, this header is not used directly.
* Used the same pattern for `google/protobuf/stubs/common.h`, not used directly.

For significant contributions please make sure you have completed the following items:

* [X] `CHANGELOG.md` updated for non-trivial changes
* [ ] Unit tests have been added
* [ ] Changes in public API reviewed