### PR TITLE
[CI] pin ci `Bazel on MacOS` job runner to macos-15

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -957,7 +957,7 @@ jobs:
 
   bazel_osx:
     name: Bazel on MacOS
-    runs-on: macos-latest
+    runs-on: macos-15
     steps:
     - name: Harden the runner (Audit all outbound calls)
       uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4


### PR DESCRIPTION
Fixes # (issue)

The macos-latest alias is pulling the `macos-26-arm64` image and CI is failing. Revert to macos-15. 

> Runner Image
>   Image: macos-26-arm64
>   Version: 20260610.0145.2
>   Included Software: https://github.com/actions/runner-images/blob/macos-26-arm64/20260610.0145/images/macos/macos-26-arm64-Readme.md
>   Image Release: https://github.com/actions/runner-images/releases/tag/macos-26-arm64%2F20260610.0145

## Changes

- pin the CI workflow runner to `macos-15`

For significant contributions please make sure you have completed the following items:

* [ ] `CHANGELOG.md` updated for non-trivial changes
* [ ] Unit tests have been added
* [ ] Changes in public API reviewed