### PR TITLE
[EXPORTER] Replace new operator with std::make_unique

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ For more information about the maintainer role, see the [community repository](h
 
 ### Approvers
 
-* [WenTao Ou](https://github.com/owent), Tencent
+* [WenTao Ou](https://github.com/owent)
 
 For more information about the approver role, see the [community repository](https://github.com/open-telemetry/community/blob/main/guides/contributor/membership.md#approver).
 

--- a/exporters/otlp/README.md
+++ b/exporters/otlp/README.md
@@ -27,7 +27,7 @@ like so:
 ```cpp
 OtlpGrpcExporterOptions options;
 options.endpoint = "localhost:12345";
-auto exporter = std::make_unique<sdktrace::SpanExporter>(options);
+auto exporter = std::make_unique<otlp::OtlpGrpcExporter>(options);
 ```
 
 The OTLP HTTP exporter offers some configuration options. To configure the exporter,
@@ -39,7 +39,7 @@ like so:
 ```cpp
 OtlpHttpExporterOptions options;
 options.url = "localhost:12345";
-auto exporter = std::make_unique<sdktrace::SpanExporter>(options);
+auto exporter = std::make_unique<otlp::OtlpHttpExporter>(options);
 ```
 
 The OTLP File exporter offers some configuration options. To configure the exporter,
@@ -55,7 +55,7 @@ OtlpFileExporterOptions options;
 OtlpFileClientFileSystemOptions fs_backend;
 fs_backend.file_pattern = "trace.%N.log";
 options.backend_options = fs_backend;
-auto exporter = std::make_unique<sdktrace::SpanExporter>(options);
+auto exporter = std::make_unique<otlp::OtlpFileExporter>(options);
 ```
 
 ### Configuration options ( OTLP GRPC Exporter )

--- a/exporters/otlp/README.md
+++ b/exporters/otlp/README.md
@@ -27,7 +27,7 @@ like so:
 ```cpp
 OtlpGrpcExporterOptions options;
 options.endpoint = "localhost:12345";
-auto exporter = std::unique_ptr<sdktrace::SpanExporter>(new otlp::OtlpGrpcExporter(options));
+auto exporter = std::make_unique<sdktrace::SpanExporter>(options);
 ```
 
 The OTLP HTTP exporter offers some configuration options. To configure the exporter,
@@ -39,7 +39,7 @@ like so:
 ```cpp
 OtlpHttpExporterOptions options;
 options.url = "localhost:12345";
-auto exporter = std::unique_ptr<sdktrace::SpanExporter>(new otlp::OtlpHttpExporter(options));
+auto exporter = std::make_unique<sdktrace::SpanExporter>(options);
 ```
 
 The OTLP File exporter offers some configuration options. To configure the exporter,
@@ -55,7 +55,7 @@ OtlpFileExporterOptions options;
 OtlpFileClientFileSystemOptions fs_backend;
 fs_backend.file_pattern = "trace.%N.log";
 options.backend_options = fs_backend;
-auto exporter = std::unique_ptr<sdktrace::SpanExporter>(new otlp::OtlpFileExporter(options));
+auto exporter = std::make_unique<sdktrace::SpanExporter>(options);
 ```
 
 ### Configuration options ( OTLP GRPC Exporter )

--- a/exporters/otlp/src/otlp_file_client.cc
+++ b/exporters/otlp/src/otlp_file_client.cc
@@ -1458,6 +1458,7 @@ private:
       std::shared_ptr<FileStats> concurrency_file = file_;
       std::chrono::microseconds flush_interval    = options_.flush_interval;
       auto thread_instrumentation                 = runtime_options_.thread_instrumentation;
+
       file_->background_flush_thread = std::make_unique<std::thread>([concurrency_file,
                                                                       flush_interval,
                                                                       thread_instrumentation]() {

--- a/exporters/otlp/src/otlp_file_client.cc
+++ b/exporters/otlp/src/otlp_file_client.cc
@@ -1458,8 +1458,9 @@ private:
       std::shared_ptr<FileStats> concurrency_file = file_;
       std::chrono::microseconds flush_interval    = options_.flush_interval;
       auto thread_instrumentation                 = runtime_options_.thread_instrumentation;
-      file_->background_flush_thread.reset(new std::thread([concurrency_file, flush_interval,
-                                                            thread_instrumentation]() {
+      file_->background_flush_thread = std::make_unique<std::thread>([concurrency_file,
+                                                                      flush_interval,
+                                                                      thread_instrumentation]() {
         std::chrono::system_clock::time_point last_free_job_timepoint =
             std::chrono::system_clock::now();
         std::size_t last_record_count = 0;
@@ -1544,7 +1545,7 @@ private:
         {
           background_flush_thread->detach();
         }
-      }));
+      });
 #if OPENTELEMETRY_HAVE_EXCEPTIONS
     }
     catch (std::exception &e)

--- a/exporters/otlp/src/otlp_file_exporter.cc
+++ b/exporters/otlp/src/otlp_file_exporter.cc
@@ -42,16 +42,16 @@ OtlpFileExporter::OtlpFileExporter(const OtlpFileExporterOptions &options,
                                    const OtlpFileExporterRuntimeOptions &runtime_options)
     : options_(options),
       runtime_options_(runtime_options),
-      file_client_(new OtlpFileClient(OtlpFileClientOptions(options),
-                                      OtlpFileExporterRuntimeOptions(runtime_options)))
+      file_client_(
+          std::make_unique<OtlpFileClient>(OtlpFileClientOptions(options),
+                                           OtlpFileExporterRuntimeOptions(runtime_options)))
 {}
 
 // ----------------------------- Exporter methods ------------------------------
 
 std::unique_ptr<opentelemetry::sdk::trace::Recordable> OtlpFileExporter::MakeRecordable() noexcept
 {
-  return std::unique_ptr<opentelemetry::sdk::trace::Recordable>(
-      new exporter::otlp::OtlpRecordable());
+  return std::make_unique<exporter::otlp::OtlpRecordable>();
 }
 
 opentelemetry::sdk::common::ExportResult OtlpFileExporter::Export(

--- a/exporters/otlp/src/otlp_file_exporter.cc
+++ b/exporters/otlp/src/otlp_file_exporter.cc
@@ -16,7 +16,6 @@
 #include "opentelemetry/nostd/span.h"
 #include "opentelemetry/sdk/common/exporter_utils.h"
 #include "opentelemetry/sdk/common/global_log_handler.h"
-#include "opentelemetry/sdk/trace/recordable.h"
 #include "opentelemetry/version.h"
 
 // clang-format off

--- a/exporters/otlp/src/otlp_file_exporter_factory.cc
+++ b/exporters/otlp/src/otlp_file_exporter_factory.cc
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "opentelemetry/exporters/otlp/otlp_file_exporter_factory.h"
+#include <memory>
 #include "opentelemetry/exporters/otlp/otlp_file_exporter.h"
 #include "opentelemetry/exporters/otlp/otlp_file_exporter_options.h"
 #include "opentelemetry/exporters/otlp/otlp_file_exporter_runtime_options.h"
@@ -30,9 +31,7 @@ std::unique_ptr<opentelemetry::sdk::trace::SpanExporter> OtlpFileExporterFactory
     const OtlpFileExporterOptions &options,
     const OtlpFileExporterRuntimeOptions &runtime_options)
 {
-  std::unique_ptr<opentelemetry::sdk::trace::SpanExporter> exporter(
-      new OtlpFileExporter(options, runtime_options));
-  return exporter;
+  return std::make_unique<OtlpFileExporter>(options, runtime_options);
 }
 
 }  // namespace otlp

--- a/exporters/otlp/src/otlp_file_log_record_exporter.cc
+++ b/exporters/otlp/src/otlp_file_log_record_exporter.cc
@@ -16,7 +16,6 @@
 #include "opentelemetry/nostd/span.h"
 #include "opentelemetry/sdk/common/exporter_utils.h"
 #include "opentelemetry/sdk/common/global_log_handler.h"
-#include "opentelemetry/sdk/logs/recordable.h"
 #include "opentelemetry/version.h"
 
 // clang-format off

--- a/exporters/otlp/src/otlp_file_log_record_exporter.cc
+++ b/exporters/otlp/src/otlp_file_log_record_exporter.cc
@@ -46,15 +46,16 @@ OtlpFileLogRecordExporter::OtlpFileLogRecordExporter(
     const OtlpFileLogRecordExporterRuntimeOptions &runtime_options)
     : options_(options),
       runtime_options_(runtime_options),
-      file_client_(new OtlpFileClient(OtlpFileClientOptions(options),
-                                      OtlpFileLogRecordExporterRuntimeOptions(runtime_options)))
+      file_client_(std::make_unique<OtlpFileClient>(
+          OtlpFileClientOptions(options),
+          OtlpFileLogRecordExporterRuntimeOptions(runtime_options)))
 {}
 // ----------------------------- Exporter methods ------------------------------
 
 std::unique_ptr<opentelemetry::sdk::logs::Recordable>
 OtlpFileLogRecordExporter::MakeRecordable() noexcept
 {
-  return std::unique_ptr<opentelemetry::sdk::logs::Recordable>(new OtlpLogRecordable());
+  return std::make_unique<OtlpLogRecordable>();
 }
 
 opentelemetry::sdk::common::ExportResult OtlpFileLogRecordExporter::Export(

--- a/exporters/otlp/src/otlp_file_log_record_exporter_factory.cc
+++ b/exporters/otlp/src/otlp_file_log_record_exporter_factory.cc
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "opentelemetry/exporters/otlp/otlp_file_log_record_exporter_factory.h"
+#include <memory>
 #include "opentelemetry/exporters/otlp/otlp_file_log_record_exporter.h"
 #include "opentelemetry/exporters/otlp/otlp_file_log_record_exporter_options.h"
 #include "opentelemetry/exporters/otlp/otlp_file_log_record_exporter_runtime_options.h"
@@ -32,9 +33,7 @@ OtlpFileLogRecordExporterFactory::Create(
     const OtlpFileLogRecordExporterOptions &options,
     const OtlpFileLogRecordExporterRuntimeOptions &runtime_options)
 {
-  std::unique_ptr<opentelemetry::sdk::logs::LogRecordExporter> exporter(
-      new OtlpFileLogRecordExporter(options, runtime_options));
-  return exporter;
+  return std::make_unique<OtlpFileLogRecordExporter>(options, runtime_options);
 }
 
 }  // namespace otlp

--- a/exporters/otlp/src/otlp_file_metric_exporter.cc
+++ b/exporters/otlp/src/otlp_file_metric_exporter.cc
@@ -47,7 +47,7 @@ OtlpFileMetricExporter::OtlpFileMetricExporter(
       runtime_options_(runtime_options),
       aggregation_temporality_selector_{
           OtlpMetricUtils::ChooseTemporalitySelector(options_.aggregation_temporality)},
-      file_client_(new OtlpFileClient(
+      file_client_(std::make_unique<OtlpFileClient>(
           OtlpFileClientOptions(static_cast<const OtlpFileClientOptions &>(options)),
           OtlpFileClientRuntimeOptions(runtime_options)))
 {}

--- a/exporters/otlp/src/otlp_file_metric_exporter_factory.cc
+++ b/exporters/otlp/src/otlp_file_metric_exporter_factory.cc
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "opentelemetry/exporters/otlp/otlp_file_metric_exporter_factory.h"
+#include <memory>
 #include "opentelemetry/exporters/otlp/otlp_file_metric_exporter.h"
 #include "opentelemetry/exporters/otlp/otlp_file_metric_exporter_options.h"
 #include "opentelemetry/exporters/otlp/otlp_file_metric_exporter_runtime_options.h"
@@ -31,9 +32,7 @@ std::unique_ptr<opentelemetry::sdk::metrics::PushMetricExporter>
 OtlpFileMetricExporterFactory::Create(const OtlpFileMetricExporterOptions &options,
                                       const OtlpFileMetricExporterRuntimeOptions &runtime_options)
 {
-  std::unique_ptr<opentelemetry::sdk::metrics::PushMetricExporter> exporter(
-      new OtlpFileMetricExporter(options, runtime_options));
-  return exporter;
+  return std::make_unique<OtlpFileMetricExporter>(options, runtime_options);
 }
 
 }  // namespace otlp

--- a/exporters/otlp/src/otlp_grpc_client.cc
+++ b/exporters/otlp/src/otlp_grpc_client.cc
@@ -459,7 +459,7 @@ void OtlpGrpcClient::PopulateChannelArguments(const OtlpGrpcClientOptions &optio
 std::unique_ptr<grpc::ClientContext> OtlpGrpcClient::MakeClientContext(
     const OtlpGrpcClientOptions &options)
 {
-  std::unique_ptr<grpc::ClientContext> context{new grpc::ClientContext()};
+  std::unique_ptr<grpc::ClientContext> context = std::make_unique<grpc::ClientContext>();
   if (!context)
   {
     return context;

--- a/exporters/otlp/src/otlp_grpc_exporter.cc
+++ b/exporters/otlp/src/otlp_grpc_exporter.cc
@@ -93,9 +93,9 @@ OtlpGrpcExporter::~OtlpGrpcExporter()
 
 std::unique_ptr<sdk::trace::Recordable> OtlpGrpcExporter::MakeRecordable() noexcept
 {
-  return std::unique_ptr<sdk::trace::Recordable>(
-      new OtlpRecordable(options_.max_attributes, options_.max_events, options_.max_links,
-                         options_.max_attributes_per_event, options_.max_attributes_per_link));
+  return std::make_unique<OtlpRecordable>(options_.max_attributes, options_.max_events,
+                                          options_.max_links, options_.max_attributes_per_event,
+                                          options_.max_attributes_per_link);
 }
 
 sdk::common::ExportResult OtlpGrpcExporter::Export(
@@ -127,7 +127,8 @@ sdk::common::ExportResult OtlpGrpcExporter::Export(
   // When in batch mode, it's easy to export a large number of spans at once, we can alloc a larger
   // block to reduce memory fragments.
   arena_options.max_block_size = 65536;
-  std::unique_ptr<google::protobuf::Arena> arena{new google::protobuf::Arena{arena_options}};
+  std::unique_ptr<google::protobuf::Arena> arena =
+      std::make_unique<google::protobuf::Arena>(arena_options);
 
   proto::collector::trace::v1::ExportTraceServiceRequest *request =
       google::protobuf::Arena::Create<proto::collector::trace::v1::ExportTraceServiceRequest>(

--- a/exporters/otlp/src/otlp_grpc_exporter.cc
+++ b/exporters/otlp/src/otlp_grpc_exporter.cc
@@ -21,7 +21,6 @@
 #include "opentelemetry/nostd/span.h"
 #include "opentelemetry/sdk/common/exporter_utils.h"
 #include "opentelemetry/sdk/common/global_log_handler.h"
-#include "opentelemetry/sdk/trace/recordable.h"
 #include "opentelemetry/version.h"
 
 // clang-format off

--- a/exporters/otlp/src/otlp_grpc_exporter_factory.cc
+++ b/exporters/otlp/src/otlp_grpc_exporter_factory.cc
@@ -28,9 +28,7 @@ std::unique_ptr<opentelemetry::sdk::trace::SpanExporter> OtlpGrpcExporterFactory
 std::unique_ptr<opentelemetry::sdk::trace::SpanExporter> OtlpGrpcExporterFactory::Create(
     const OtlpGrpcExporterOptions &options)
 {
-  std::unique_ptr<opentelemetry::sdk::trace::SpanExporter> exporter =
-      std::make_unique<OtlpGrpcExporter>(options);
-  return exporter;
+  return std::make_unique<OtlpGrpcExporter>(options);
 }
 
 std::unique_ptr<opentelemetry::sdk::trace::SpanExporter> OtlpGrpcExporterFactory::Create(

--- a/exporters/otlp/src/otlp_grpc_exporter_factory.cc
+++ b/exporters/otlp/src/otlp_grpc_exporter_factory.cc
@@ -28,7 +28,8 @@ std::unique_ptr<opentelemetry::sdk::trace::SpanExporter> OtlpGrpcExporterFactory
 std::unique_ptr<opentelemetry::sdk::trace::SpanExporter> OtlpGrpcExporterFactory::Create(
     const OtlpGrpcExporterOptions &options)
 {
-  std::unique_ptr<opentelemetry::sdk::trace::SpanExporter> exporter(new OtlpGrpcExporter(options));
+  std::unique_ptr<opentelemetry::sdk::trace::SpanExporter> exporter =
+      std::make_unique<OtlpGrpcExporter>(options);
   return exporter;
 }
 
@@ -36,9 +37,7 @@ std::unique_ptr<opentelemetry::sdk::trace::SpanExporter> OtlpGrpcExporterFactory
     const OtlpGrpcExporterOptions &options,
     const std::shared_ptr<OtlpGrpcClient> &client)
 {
-  std::unique_ptr<opentelemetry::sdk::trace::SpanExporter> exporter(
-      new OtlpGrpcExporter(options, client));
-  return exporter;
+  return std::make_unique<OtlpGrpcExporter>(options, client);
 }
 
 }  // namespace otlp

--- a/exporters/otlp/src/otlp_grpc_log_record_exporter.cc
+++ b/exporters/otlp/src/otlp_grpc_log_record_exporter.cc
@@ -20,7 +20,6 @@
 #include "opentelemetry/nostd/span.h"
 #include "opentelemetry/sdk/common/exporter_utils.h"
 #include "opentelemetry/sdk/common/global_log_handler.h"
-#include "opentelemetry/sdk/logs/recordable.h"
 #include "opentelemetry/version.h"
 
 // clang-format off

--- a/exporters/otlp/src/otlp_grpc_log_record_exporter.cc
+++ b/exporters/otlp/src/otlp_grpc_log_record_exporter.cc
@@ -98,7 +98,7 @@ OtlpGrpcLogRecordExporter::~OtlpGrpcLogRecordExporter()
 std::unique_ptr<opentelemetry::sdk::logs::Recordable>
 OtlpGrpcLogRecordExporter::MakeRecordable() noexcept
 {
-  return std::unique_ptr<opentelemetry::sdk::logs::Recordable>(new OtlpLogRecordable());
+  return std::make_unique<OtlpLogRecordable>();
 }
 
 opentelemetry::sdk::common::ExportResult OtlpGrpcLogRecordExporter::Export(
@@ -129,7 +129,8 @@ opentelemetry::sdk::common::ExportResult OtlpGrpcLogRecordExporter::Export(
   // When in batch mode, it's easy to export a large number of spans at once, we can alloc a lager
   // block to reduce memory fragments.
   arena_options.max_block_size = 65536;
-  std::unique_ptr<google::protobuf::Arena> arena{new google::protobuf::Arena{arena_options}};
+  std::unique_ptr<google::protobuf::Arena> arena =
+      std::make_unique<google::protobuf::Arena>(arena_options);
 
   proto::collector::logs::v1::ExportLogsServiceRequest *request =
       google::protobuf::Arena::Create<proto::collector::logs::v1::ExportLogsServiceRequest>(

--- a/exporters/otlp/src/otlp_grpc_log_record_exporter_factory.cc
+++ b/exporters/otlp/src/otlp_grpc_log_record_exporter_factory.cc
@@ -27,18 +27,14 @@ OtlpGrpcLogRecordExporterFactory::Create()
 std::unique_ptr<opentelemetry::sdk::logs::LogRecordExporter>
 OtlpGrpcLogRecordExporterFactory::Create(const OtlpGrpcLogRecordExporterOptions &options)
 {
-  std::unique_ptr<opentelemetry::sdk::logs::LogRecordExporter> exporter(
-      new OtlpGrpcLogRecordExporter(options));
-  return exporter;
+  return std::make_unique<OtlpGrpcLogRecordExporter>(options);
 }
 
 std::unique_ptr<opentelemetry::sdk::logs::LogRecordExporter>
 OtlpGrpcLogRecordExporterFactory::Create(const OtlpGrpcLogRecordExporterOptions &options,
                                          const std::shared_ptr<OtlpGrpcClient> &client)
 {
-  std::unique_ptr<opentelemetry::sdk::logs::LogRecordExporter> exporter(
-      new OtlpGrpcLogRecordExporter(options, client));
-  return exporter;
+  return std::make_unique<OtlpGrpcLogRecordExporter>(options, client);
 }
 
 }  // namespace otlp

--- a/exporters/otlp/src/otlp_grpc_metric_exporter.cc
+++ b/exporters/otlp/src/otlp_grpc_metric_exporter.cc
@@ -138,7 +138,8 @@ opentelemetry::sdk::common::ExportResult OtlpGrpcMetricExporter::Export(
   // When in batch mode, it's easy to export a large number of spans at once, we can alloc a lager
   // block to reduce memory fragments.
   arena_options.max_block_size = 65536;
-  std::unique_ptr<google::protobuf::Arena> arena{new google::protobuf::Arena{arena_options}};
+  std::unique_ptr<google::protobuf::Arena> arena =
+      std::make_unique<google::protobuf::Arena>(arena_options);
 
   proto::collector::metrics::v1::ExportMetricsServiceRequest *request =
       google::protobuf::Arena::Create<proto::collector::metrics::v1::ExportMetricsServiceRequest>(

--- a/exporters/otlp/src/otlp_grpc_metric_exporter_factory.cc
+++ b/exporters/otlp/src/otlp_grpc_metric_exporter_factory.cc
@@ -27,18 +27,14 @@ OtlpGrpcMetricExporterFactory::Create()
 std::unique_ptr<opentelemetry::sdk::metrics::PushMetricExporter>
 OtlpGrpcMetricExporterFactory::Create(const OtlpGrpcMetricExporterOptions &options)
 {
-  std::unique_ptr<opentelemetry::sdk::metrics::PushMetricExporter> exporter(
-      new OtlpGrpcMetricExporter(options));
-  return exporter;
+  return std::make_unique<OtlpGrpcMetricExporter>(options);
 }
 
 std::unique_ptr<opentelemetry::sdk::metrics::PushMetricExporter>
 OtlpGrpcMetricExporterFactory::Create(const OtlpGrpcMetricExporterOptions &options,
                                       const std::shared_ptr<OtlpGrpcClient> &client)
 {
-  std::unique_ptr<opentelemetry::sdk::metrics::PushMetricExporter> exporter(
-      new OtlpGrpcMetricExporter(options, client));
-  return exporter;
+  return std::make_unique<OtlpGrpcMetricExporter>(options, client);
 }
 
 }  // namespace otlp

--- a/exporters/otlp/src/otlp_http_client.cc
+++ b/exporters/otlp/src/otlp_http_client.cc
@@ -1043,8 +1043,9 @@ OtlpHttpClient::createSession(
 
   return HttpSessionData{
       std::move(session),
-      std::shared_ptr<opentelemetry::ext::http::client::EventHandler>{new ResponseHandler(
-          std::move(result_callback), response, options_.content_type, options_.console_debug)},
+      std::shared_ptr<opentelemetry::ext::http::client::EventHandler>{
+          std::make_shared<ResponseHandler>(std::move(result_callback), response,
+                                            options_.content_type, options_.console_debug)},
       std::move(arena), response};
 }
 

--- a/exporters/otlp/src/otlp_http_exporter.cc
+++ b/exporters/otlp/src/otlp_http_exporter.cc
@@ -22,7 +22,6 @@
 #include "opentelemetry/sdk/common/exporter_utils.h"
 #include "opentelemetry/sdk/common/global_log_handler.h"
 #include "opentelemetry/sdk/common/thread_instrumentation.h"
-#include "opentelemetry/sdk/trace/recordable.h"
 #include "opentelemetry/version.h"
 
 // clang-format off

--- a/exporters/otlp/src/otlp_http_exporter.cc
+++ b/exporters/otlp/src/otlp_http_exporter.cc
@@ -51,7 +51,7 @@ OtlpHttpExporter::OtlpHttpExporter() : OtlpHttpExporter(OtlpHttpExporterOptions(
 OtlpHttpExporter::OtlpHttpExporter(const OtlpHttpExporterOptions &options)
     : options_(options),
       runtime_options_(),
-      http_client_(new OtlpHttpClient(OtlpHttpClientOptions(
+      http_client_(std::make_unique<OtlpHttpClient>(OtlpHttpClientOptions(
           options.url,
           options.ssl_insecure_skip_verify,
           options.ssl_ca_cert_path,
@@ -88,36 +88,37 @@ OtlpHttpExporter::OtlpHttpExporter(const OtlpHttpExporterOptions &options,
                                    const OtlpHttpExporterRuntimeOptions &runtime_options)
     : options_(options),
       runtime_options_(runtime_options),
-      http_client_(new OtlpHttpClient(OtlpHttpClientOptions(options.url,
-                                                            options.ssl_insecure_skip_verify,
-                                                            options.ssl_ca_cert_path,
-                                                            options.ssl_ca_cert_string,
-                                                            options.ssl_client_key_path,
-                                                            options.ssl_client_key_string,
-                                                            options.ssl_client_cert_path,
-                                                            options.ssl_client_cert_string,
-                                                            options.ssl_min_tls,
-                                                            options.ssl_max_tls,
-                                                            options.ssl_cipher,
-                                                            options.ssl_cipher_suite,
-                                                            options.content_type,
-                                                            options.json_bytes_mapping,
-                                                            options.compression,
-                                                            options.use_json_name,
-                                                            options.console_debug,
-                                                            options.timeout,
-                                                            options.http_headers,
-                                                            options.retry_policy_max_attempts,
-                                                            options.retry_policy_initial_backoff,
-                                                            options.retry_policy_max_backoff,
-                                                            options.retry_policy_backoff_multiplier,
-                                                            runtime_options.thread_instrumentation
+      http_client_(std::make_unique<OtlpHttpClient>(OtlpHttpClientOptions(
+          options.url,
+          options.ssl_insecure_skip_verify,
+          options.ssl_ca_cert_path,
+          options.ssl_ca_cert_string,
+          options.ssl_client_key_path,
+          options.ssl_client_key_string,
+          options.ssl_client_cert_path,
+          options.ssl_client_cert_string,
+          options.ssl_min_tls,
+          options.ssl_max_tls,
+          options.ssl_cipher,
+          options.ssl_cipher_suite,
+          options.content_type,
+          options.json_bytes_mapping,
+          options.compression,
+          options.use_json_name,
+          options.console_debug,
+          options.timeout,
+          options.http_headers,
+          options.retry_policy_max_attempts,
+          options.retry_policy_initial_backoff,
+          options.retry_policy_max_backoff,
+          options.retry_policy_backoff_multiplier,
+          runtime_options.thread_instrumentation
 #ifdef ENABLE_ASYNC_EXPORT
-                                                            ,
-                                                            options.max_concurrent_requests,
-                                                            options.max_requests_per_connection
+          ,
+          options.max_concurrent_requests,
+          options.max_requests_per_connection
 #endif
-                                                            )))
+          )))
 {}
 
 OtlpHttpExporter::OtlpHttpExporter(
@@ -125,7 +126,7 @@ OtlpHttpExporter::OtlpHttpExporter(
     const std::shared_ptr<ext::http::client::HttpClientFactory> &factory)
     : options_(options),
       runtime_options_(),
-      http_client_(new OtlpHttpClient(
+      http_client_(std::make_unique<OtlpHttpClient>(
           OtlpHttpClientOptions(options.url,
                                 options.ssl_insecure_skip_verify,
                                 options.ssl_ca_cert_path,
@@ -165,44 +166,45 @@ OtlpHttpExporter::OtlpHttpExporter(
     const std::shared_ptr<ext::http::client::HttpClientFactory> &factory)
     : options_(options),
       runtime_options_(runtime_options),
-      http_client_(new OtlpHttpClient(OtlpHttpClientOptions(options.url,
-                                                            options.ssl_insecure_skip_verify,
-                                                            options.ssl_ca_cert_path,
-                                                            options.ssl_ca_cert_string,
-                                                            options.ssl_client_key_path,
-                                                            options.ssl_client_key_string,
-                                                            options.ssl_client_cert_path,
-                                                            options.ssl_client_cert_string,
-                                                            options.ssl_min_tls,
-                                                            options.ssl_max_tls,
-                                                            options.ssl_cipher,
-                                                            options.ssl_cipher_suite,
-                                                            options.content_type,
-                                                            options.json_bytes_mapping,
-                                                            options.compression,
-                                                            options.use_json_name,
-                                                            options.console_debug,
-                                                            options.timeout,
-                                                            options.http_headers,
-                                                            options.retry_policy_max_attempts,
-                                                            options.retry_policy_initial_backoff,
-                                                            options.retry_policy_max_backoff,
-                                                            options.retry_policy_backoff_multiplier,
-                                                            runtime_options.thread_instrumentation
+      http_client_(std::make_unique<OtlpHttpClient>(
+          OtlpHttpClientOptions(options.url,
+                                options.ssl_insecure_skip_verify,
+                                options.ssl_ca_cert_path,
+                                options.ssl_ca_cert_string,
+                                options.ssl_client_key_path,
+                                options.ssl_client_key_string,
+                                options.ssl_client_cert_path,
+                                options.ssl_client_cert_string,
+                                options.ssl_min_tls,
+                                options.ssl_max_tls,
+                                options.ssl_cipher,
+                                options.ssl_cipher_suite,
+                                options.content_type,
+                                options.json_bytes_mapping,
+                                options.compression,
+                                options.use_json_name,
+                                options.console_debug,
+                                options.timeout,
+                                options.http_headers,
+                                options.retry_policy_max_attempts,
+                                options.retry_policy_initial_backoff,
+                                options.retry_policy_max_backoff,
+                                options.retry_policy_backoff_multiplier,
+                                runtime_options.thread_instrumentation
 #ifdef ENABLE_ASYNC_EXPORT
-                                                            ,
-                                                            options.max_concurrent_requests,
-                                                            options.max_requests_per_connection
+                                ,
+                                options.max_concurrent_requests,
+                                options.max_requests_per_connection
 #endif
-                                                            ),
-                                      factory))
+                                ),
+          factory))
 {}
 
 OtlpHttpExporter::OtlpHttpExporter(const OtlpHttpExporterOptions &options,
                                    std::shared_ptr<ext::http::client::HttpClient> http_client)
     : options_(options),
       runtime_options_(),
-      http_client_(new OtlpHttpClient(
+      http_client_(std::make_unique<OtlpHttpClient>(
           OtlpHttpClientOptions(options.url,
                                 options.ssl_insecure_skip_verify,
                                 options.ssl_ca_cert_path,
@@ -241,37 +243,38 @@ OtlpHttpExporter::OtlpHttpExporter(const OtlpHttpExporterOptions &options,
                                    std::shared_ptr<ext::http::client::HttpClient> http_client)
     : options_(options),
       runtime_options_(runtime_options),
-      http_client_(new OtlpHttpClient(OtlpHttpClientOptions(options.url,
-                                                            options.ssl_insecure_skip_verify,
-                                                            options.ssl_ca_cert_path,
-                                                            options.ssl_ca_cert_string,
-                                                            options.ssl_client_key_path,
-                                                            options.ssl_client_key_string,
-                                                            options.ssl_client_cert_path,
-                                                            options.ssl_client_cert_string,
-                                                            options.ssl_min_tls,
-                                                            options.ssl_max_tls,
-                                                            options.ssl_cipher,
-                                                            options.ssl_cipher_suite,
-                                                            options.content_type,
-                                                            options.json_bytes_mapping,
-                                                            options.compression,
-                                                            options.use_json_name,
-                                                            options.console_debug,
-                                                            options.timeout,
-                                                            options.http_headers,
-                                                            options.retry_policy_max_attempts,
-                                                            options.retry_policy_initial_backoff,
-                                                            options.retry_policy_max_backoff,
-                                                            options.retry_policy_backoff_multiplier,
-                                                            runtime_options.thread_instrumentation
+      http_client_(std::make_unique<OtlpHttpClient>(
+          OtlpHttpClientOptions(options.url,
+                                options.ssl_insecure_skip_verify,
+                                options.ssl_ca_cert_path,
+                                options.ssl_ca_cert_string,
+                                options.ssl_client_key_path,
+                                options.ssl_client_key_string,
+                                options.ssl_client_cert_path,
+                                options.ssl_client_cert_string,
+                                options.ssl_min_tls,
+                                options.ssl_max_tls,
+                                options.ssl_cipher,
+                                options.ssl_cipher_suite,
+                                options.content_type,
+                                options.json_bytes_mapping,
+                                options.compression,
+                                options.use_json_name,
+                                options.console_debug,
+                                options.timeout,
+                                options.http_headers,
+                                options.retry_policy_max_attempts,
+                                options.retry_policy_initial_backoff,
+                                options.retry_policy_max_backoff,
+                                options.retry_policy_backoff_multiplier,
+                                runtime_options.thread_instrumentation
 #ifdef ENABLE_ASYNC_EXPORT
-                                                            ,
-                                                            options.max_concurrent_requests,
-                                                            options.max_requests_per_connection
+                                ,
+                                options.max_concurrent_requests,
+                                options.max_requests_per_connection
 #endif
-                                                            ),
-                                      std::move(http_client)))
+                                ),
+          std::move(http_client)))
 {}
 
 OtlpHttpExporter::OtlpHttpExporter(std::unique_ptr<OtlpHttpClient> http_client)
@@ -299,9 +302,9 @@ OtlpHttpExporter::OtlpHttpExporter(std::unique_ptr<OtlpHttpClient> http_client)
 
 std::unique_ptr<opentelemetry::sdk::trace::Recordable> OtlpHttpExporter::MakeRecordable() noexcept
 {
-  return std::unique_ptr<opentelemetry::sdk::trace::Recordable>(new exporter::otlp::OtlpRecordable(
+  return std::make_unique<exporter::otlp::OtlpRecordable>(
       options_.max_attributes, options_.max_events, options_.max_links,
-      options_.max_attributes_per_event, options_.max_attributes_per_link));
+      options_.max_attributes_per_event, options_.max_attributes_per_link);
 }
 
 opentelemetry::sdk::common::ExportResult OtlpHttpExporter::Export(

--- a/exporters/otlp/src/otlp_http_exporter_factory.cc
+++ b/exporters/otlp/src/otlp_http_exporter_factory.cc
@@ -36,17 +36,14 @@ std::unique_ptr<opentelemetry::sdk::trace::SpanExporter> OtlpHttpExporterFactory
     const OtlpHttpExporterOptions &options,
     const OtlpHttpExporterRuntimeOptions &runtime_options)
 {
-  std::unique_ptr<opentelemetry::sdk::trace::SpanExporter> exporter(
-      new OtlpHttpExporter(options, runtime_options));
-  return exporter;
+  return std::make_unique<OtlpHttpExporter>(options, runtime_options);
 }
 
 std::unique_ptr<opentelemetry::sdk::trace::SpanExporter> OtlpHttpExporterFactory::Create(
     const OtlpHttpExporterOptions &options,
     const std::shared_ptr<opentelemetry::ext::http::client::HttpClientFactory> &factory)
 {
-  return std::unique_ptr<opentelemetry::sdk::trace::SpanExporter>(
-      new OtlpHttpExporter(options, factory));
+  return std::make_unique<OtlpHttpExporter>(options, factory);
 }
 
 std::unique_ptr<opentelemetry::sdk::trace::SpanExporter> OtlpHttpExporterFactory::Create(
@@ -54,16 +51,14 @@ std::unique_ptr<opentelemetry::sdk::trace::SpanExporter> OtlpHttpExporterFactory
     const OtlpHttpExporterRuntimeOptions &runtime_options,
     const std::shared_ptr<opentelemetry::ext::http::client::HttpClientFactory> &factory)
 {
-  return std::unique_ptr<opentelemetry::sdk::trace::SpanExporter>(
-      new OtlpHttpExporter(options, runtime_options, factory));
+  return std::make_unique<OtlpHttpExporter>(options, runtime_options, factory);
 }
 
 std::unique_ptr<opentelemetry::sdk::trace::SpanExporter> OtlpHttpExporterFactory::Create(
     const OtlpHttpExporterOptions &options,
     std::shared_ptr<opentelemetry::ext::http::client::HttpClient> http_client)
 {
-  return std::unique_ptr<opentelemetry::sdk::trace::SpanExporter>(
-      new OtlpHttpExporter(options, std::move(http_client)));
+  return std::make_unique<OtlpHttpExporter>(options, std::move(http_client));
 }
 
 std::unique_ptr<opentelemetry::sdk::trace::SpanExporter> OtlpHttpExporterFactory::Create(
@@ -71,8 +66,7 @@ std::unique_ptr<opentelemetry::sdk::trace::SpanExporter> OtlpHttpExporterFactory
     const OtlpHttpExporterRuntimeOptions &runtime_options,
     std::shared_ptr<opentelemetry::ext::http::client::HttpClient> http_client)
 {
-  return std::unique_ptr<opentelemetry::sdk::trace::SpanExporter>(
-      new OtlpHttpExporter(options, runtime_options, std::move(http_client)));
+  return std::make_unique<OtlpHttpExporter>(options, runtime_options, std::move(http_client));
 }
 
 }  // namespace otlp

--- a/exporters/otlp/src/otlp_http_log_record_exporter.cc
+++ b/exporters/otlp/src/otlp_http_log_record_exporter.cc
@@ -54,7 +54,7 @@ OtlpHttpLogRecordExporter::OtlpHttpLogRecordExporter(
     const OtlpHttpLogRecordExporterOptions &options)
     : options_(options),
       runtime_options_(),
-      http_client_(new OtlpHttpClient(OtlpHttpClientOptions(
+      http_client_(std::make_unique<OtlpHttpClient>(OtlpHttpClientOptions(
           options.url,
           options.ssl_insecure_skip_verify,
           options.ssl_ca_cert_path,
@@ -92,36 +92,37 @@ OtlpHttpLogRecordExporter::OtlpHttpLogRecordExporter(
     const OtlpHttpLogRecordExporterRuntimeOptions &runtime_options)
     : options_(options),
       runtime_options_(runtime_options),
-      http_client_(new OtlpHttpClient(OtlpHttpClientOptions(options.url,
-                                                            options.ssl_insecure_skip_verify,
-                                                            options.ssl_ca_cert_path,
-                                                            options.ssl_ca_cert_string,
-                                                            options.ssl_client_key_path,
-                                                            options.ssl_client_key_string,
-                                                            options.ssl_client_cert_path,
-                                                            options.ssl_client_cert_string,
-                                                            options.ssl_min_tls,
-                                                            options.ssl_max_tls,
-                                                            options.ssl_cipher,
-                                                            options.ssl_cipher_suite,
-                                                            options.content_type,
-                                                            options.json_bytes_mapping,
-                                                            options.compression,
-                                                            options.use_json_name,
-                                                            options.console_debug,
-                                                            options.timeout,
-                                                            options.http_headers,
-                                                            options.retry_policy_max_attempts,
-                                                            options.retry_policy_initial_backoff,
-                                                            options.retry_policy_max_backoff,
-                                                            options.retry_policy_backoff_multiplier,
-                                                            runtime_options.thread_instrumentation
+      http_client_(std::make_unique<OtlpHttpClient>(OtlpHttpClientOptions(
+          options.url,
+          options.ssl_insecure_skip_verify,
+          options.ssl_ca_cert_path,
+          options.ssl_ca_cert_string,
+          options.ssl_client_key_path,
+          options.ssl_client_key_string,
+          options.ssl_client_cert_path,
+          options.ssl_client_cert_string,
+          options.ssl_min_tls,
+          options.ssl_max_tls,
+          options.ssl_cipher,
+          options.ssl_cipher_suite,
+          options.content_type,
+          options.json_bytes_mapping,
+          options.compression,
+          options.use_json_name,
+          options.console_debug,
+          options.timeout,
+          options.http_headers,
+          options.retry_policy_max_attempts,
+          options.retry_policy_initial_backoff,
+          options.retry_policy_max_backoff,
+          options.retry_policy_backoff_multiplier,
+          runtime_options.thread_instrumentation
 #ifdef ENABLE_ASYNC_EXPORT
-                                                            ,
-                                                            options.max_concurrent_requests,
-                                                            options.max_requests_per_connection
+          ,
+          options.max_concurrent_requests,
+          options.max_requests_per_connection
 #endif
-                                                            )))
+          )))
 {}
 
 OtlpHttpLogRecordExporter::OtlpHttpLogRecordExporter(
@@ -129,7 +130,7 @@ OtlpHttpLogRecordExporter::OtlpHttpLogRecordExporter(
     const std::shared_ptr<ext::http::client::HttpClientFactory> &factory)
     : options_(options),
       runtime_options_(),
-      http_client_(new OtlpHttpClient(
+      http_client_(std::make_unique<OtlpHttpClient>(
           OtlpHttpClientOptions(options.url,
                                 options.ssl_insecure_skip_verify,
                                 options.ssl_ca_cert_path,
@@ -169,37 +170,38 @@ OtlpHttpLogRecordExporter::OtlpHttpLogRecordExporter(
     const std::shared_ptr<ext::http::client::HttpClientFactory> &factory)
     : options_(options),
       runtime_options_(runtime_options),
-      http_client_(new OtlpHttpClient(OtlpHttpClientOptions(options.url,
-                                                            options.ssl_insecure_skip_verify,
-                                                            options.ssl_ca_cert_path,
-                                                            options.ssl_ca_cert_string,
-                                                            options.ssl_client_key_path,
-                                                            options.ssl_client_key_string,
-                                                            options.ssl_client_cert_path,
-                                                            options.ssl_client_cert_string,
-                                                            options.ssl_min_tls,
-                                                            options.ssl_max_tls,
-                                                            options.ssl_cipher,
-                                                            options.ssl_cipher_suite,
-                                                            options.content_type,
-                                                            options.json_bytes_mapping,
-                                                            options.compression,
-                                                            options.use_json_name,
-                                                            options.console_debug,
-                                                            options.timeout,
-                                                            options.http_headers,
-                                                            options.retry_policy_max_attempts,
-                                                            options.retry_policy_initial_backoff,
-                                                            options.retry_policy_max_backoff,
-                                                            options.retry_policy_backoff_multiplier,
-                                                            runtime_options.thread_instrumentation
+      http_client_(std::make_unique<OtlpHttpClient>(
+          OtlpHttpClientOptions(options.url,
+                                options.ssl_insecure_skip_verify,
+                                options.ssl_ca_cert_path,
+                                options.ssl_ca_cert_string,
+                                options.ssl_client_key_path,
+                                options.ssl_client_key_string,
+                                options.ssl_client_cert_path,
+                                options.ssl_client_cert_string,
+                                options.ssl_min_tls,
+                                options.ssl_max_tls,
+                                options.ssl_cipher,
+                                options.ssl_cipher_suite,
+                                options.content_type,
+                                options.json_bytes_mapping,
+                                options.compression,
+                                options.use_json_name,
+                                options.console_debug,
+                                options.timeout,
+                                options.http_headers,
+                                options.retry_policy_max_attempts,
+                                options.retry_policy_initial_backoff,
+                                options.retry_policy_max_backoff,
+                                options.retry_policy_backoff_multiplier,
+                                runtime_options.thread_instrumentation
 #ifdef ENABLE_ASYNC_EXPORT
-                                                            ,
-                                                            options.max_concurrent_requests,
-                                                            options.max_requests_per_connection
+                                ,
+                                options.max_concurrent_requests,
+                                options.max_requests_per_connection
 #endif
-                                                            ),
-                                      factory))
+                                ),
+          factory))
 {}
 
 OtlpHttpLogRecordExporter::OtlpHttpLogRecordExporter(
@@ -207,7 +209,7 @@ OtlpHttpLogRecordExporter::OtlpHttpLogRecordExporter(
     std::shared_ptr<ext::http::client::HttpClient> http_client)
     : options_(options),
       runtime_options_(),
-      http_client_(new OtlpHttpClient(
+      http_client_(std::make_unique<OtlpHttpClient>(
           OtlpHttpClientOptions(options.url,
                                 options.ssl_insecure_skip_verify,
                                 options.ssl_ca_cert_path,
@@ -247,37 +249,38 @@ OtlpHttpLogRecordExporter::OtlpHttpLogRecordExporter(
     std::shared_ptr<ext::http::client::HttpClient> http_client)
     : options_(options),
       runtime_options_(runtime_options),
-      http_client_(new OtlpHttpClient(OtlpHttpClientOptions(options.url,
-                                                            options.ssl_insecure_skip_verify,
-                                                            options.ssl_ca_cert_path,
-                                                            options.ssl_ca_cert_string,
-                                                            options.ssl_client_key_path,
-                                                            options.ssl_client_key_string,
-                                                            options.ssl_client_cert_path,
-                                                            options.ssl_client_cert_string,
-                                                            options.ssl_min_tls,
-                                                            options.ssl_max_tls,
-                                                            options.ssl_cipher,
-                                                            options.ssl_cipher_suite,
-                                                            options.content_type,
-                                                            options.json_bytes_mapping,
-                                                            options.compression,
-                                                            options.use_json_name,
-                                                            options.console_debug,
-                                                            options.timeout,
-                                                            options.http_headers,
-                                                            options.retry_policy_max_attempts,
-                                                            options.retry_policy_initial_backoff,
-                                                            options.retry_policy_max_backoff,
-                                                            options.retry_policy_backoff_multiplier,
-                                                            runtime_options.thread_instrumentation
+      http_client_(std::make_unique<OtlpHttpClient>(
+          OtlpHttpClientOptions(options.url,
+                                options.ssl_insecure_skip_verify,
+                                options.ssl_ca_cert_path,
+                                options.ssl_ca_cert_string,
+                                options.ssl_client_key_path,
+                                options.ssl_client_key_string,
+                                options.ssl_client_cert_path,
+                                options.ssl_client_cert_string,
+                                options.ssl_min_tls,
+                                options.ssl_max_tls,
+                                options.ssl_cipher,
+                                options.ssl_cipher_suite,
+                                options.content_type,
+                                options.json_bytes_mapping,
+                                options.compression,
+                                options.use_json_name,
+                                options.console_debug,
+                                options.timeout,
+                                options.http_headers,
+                                options.retry_policy_max_attempts,
+                                options.retry_policy_initial_backoff,
+                                options.retry_policy_max_backoff,
+                                options.retry_policy_backoff_multiplier,
+                                runtime_options.thread_instrumentation
 #ifdef ENABLE_ASYNC_EXPORT
-                                                            ,
-                                                            options.max_concurrent_requests,
-                                                            options.max_requests_per_connection
+                                ,
+                                options.max_concurrent_requests,
+                                options.max_requests_per_connection
 #endif
-                                                            ),
-                                      std::move(http_client)))
+                                ),
+          std::move(http_client)))
 {}
 
 OtlpHttpLogRecordExporter::OtlpHttpLogRecordExporter(std::unique_ptr<OtlpHttpClient> http_client)
@@ -306,7 +309,7 @@ OtlpHttpLogRecordExporter::OtlpHttpLogRecordExporter(std::unique_ptr<OtlpHttpCli
 std::unique_ptr<opentelemetry::sdk::logs::Recordable>
 OtlpHttpLogRecordExporter::MakeRecordable() noexcept
 {
-  return std::unique_ptr<opentelemetry::sdk::logs::Recordable>(new OtlpLogRecordable());
+  return std::make_unique<OtlpLogRecordable>();
 }
 
 opentelemetry::sdk::common::ExportResult OtlpHttpLogRecordExporter::Export(

--- a/exporters/otlp/src/otlp_http_log_record_exporter.cc
+++ b/exporters/otlp/src/otlp_http_log_record_exporter.cc
@@ -22,7 +22,6 @@
 #include "opentelemetry/sdk/common/exporter_utils.h"
 #include "opentelemetry/sdk/common/global_log_handler.h"
 #include "opentelemetry/sdk/common/thread_instrumentation.h"
-#include "opentelemetry/sdk/logs/recordable.h"
 #include "opentelemetry/version.h"
 
 // clang-format off

--- a/exporters/otlp/src/otlp_http_log_record_exporter_factory.cc
+++ b/exporters/otlp/src/otlp_http_log_record_exporter_factory.cc
@@ -38,9 +38,7 @@ OtlpHttpLogRecordExporterFactory::Create(
     const OtlpHttpLogRecordExporterOptions &options,
     const OtlpHttpLogRecordExporterRuntimeOptions &runtime_options)
 {
-  std::unique_ptr<opentelemetry::sdk::logs::LogRecordExporter> exporter(
-      new OtlpHttpLogRecordExporter(options, runtime_options));
-  return exporter;
+  return std::make_unique<OtlpHttpLogRecordExporter>(options, runtime_options);
 }
 
 std::unique_ptr<opentelemetry::sdk::logs::LogRecordExporter>
@@ -48,8 +46,7 @@ OtlpHttpLogRecordExporterFactory::Create(
     const OtlpHttpLogRecordExporterOptions &options,
     const std::shared_ptr<opentelemetry::ext::http::client::HttpClientFactory> &factory)
 {
-  return std::unique_ptr<opentelemetry::sdk::logs::LogRecordExporter>(
-      new OtlpHttpLogRecordExporter(options, factory));
+  return std::make_unique<OtlpHttpLogRecordExporter>(options, factory);
 }
 
 std::unique_ptr<opentelemetry::sdk::logs::LogRecordExporter>
@@ -58,8 +55,7 @@ OtlpHttpLogRecordExporterFactory::Create(
     const OtlpHttpLogRecordExporterRuntimeOptions &runtime_options,
     const std::shared_ptr<opentelemetry::ext::http::client::HttpClientFactory> &factory)
 {
-  return std::unique_ptr<opentelemetry::sdk::logs::LogRecordExporter>(
-      new OtlpHttpLogRecordExporter(options, runtime_options, factory));
+  return std::make_unique<OtlpHttpLogRecordExporter>(options, runtime_options, factory);
 }
 
 std::unique_ptr<opentelemetry::sdk::logs::LogRecordExporter>
@@ -67,8 +63,7 @@ OtlpHttpLogRecordExporterFactory::Create(
     const OtlpHttpLogRecordExporterOptions &options,
     std::shared_ptr<opentelemetry::ext::http::client::HttpClient> http_client)
 {
-  return std::unique_ptr<opentelemetry::sdk::logs::LogRecordExporter>(
-      new OtlpHttpLogRecordExporter(options, std::move(http_client)));
+  return std::make_unique<OtlpHttpLogRecordExporter>(options, std::move(http_client));
 }
 
 std::unique_ptr<opentelemetry::sdk::logs::LogRecordExporter>
@@ -77,8 +72,8 @@ OtlpHttpLogRecordExporterFactory::Create(
     const OtlpHttpLogRecordExporterRuntimeOptions &runtime_options,
     std::shared_ptr<opentelemetry::ext::http::client::HttpClient> http_client)
 {
-  return std::unique_ptr<opentelemetry::sdk::logs::LogRecordExporter>(
-      new OtlpHttpLogRecordExporter(options, runtime_options, std::move(http_client)));
+  return std::make_unique<OtlpHttpLogRecordExporter>(options, runtime_options,
+                                                     std::move(http_client));
 }
 
 }  // namespace otlp

--- a/exporters/otlp/src/otlp_http_metric_exporter.cc
+++ b/exporters/otlp/src/otlp_http_metric_exporter.cc
@@ -54,7 +54,7 @@ OtlpHttpMetricExporter::OtlpHttpMetricExporter(const OtlpHttpMetricExporterOptio
       runtime_options_(),
       aggregation_temporality_selector_{
           OtlpMetricUtils::ChooseTemporalitySelector(options_.aggregation_temporality)},
-      http_client_(new OtlpHttpClient(OtlpHttpClientOptions(
+      http_client_(std::make_unique<OtlpHttpClient>(OtlpHttpClientOptions(
           options.url,
           options.ssl_insecure_skip_verify,
           options.ssl_ca_cert_path,
@@ -94,36 +94,37 @@ OtlpHttpMetricExporter::OtlpHttpMetricExporter(
       runtime_options_(runtime_options),
       aggregation_temporality_selector_{
           OtlpMetricUtils::ChooseTemporalitySelector(options_.aggregation_temporality)},
-      http_client_(new OtlpHttpClient(OtlpHttpClientOptions(options.url,
-                                                            options.ssl_insecure_skip_verify,
-                                                            options.ssl_ca_cert_path,
-                                                            options.ssl_ca_cert_string,
-                                                            options.ssl_client_key_path,
-                                                            options.ssl_client_key_string,
-                                                            options.ssl_client_cert_path,
-                                                            options.ssl_client_cert_string,
-                                                            options.ssl_min_tls,
-                                                            options.ssl_max_tls,
-                                                            options.ssl_cipher,
-                                                            options.ssl_cipher_suite,
-                                                            options.content_type,
-                                                            options.json_bytes_mapping,
-                                                            options.compression,
-                                                            options.use_json_name,
-                                                            options.console_debug,
-                                                            options.timeout,
-                                                            options.http_headers,
-                                                            options.retry_policy_max_attempts,
-                                                            options.retry_policy_initial_backoff,
-                                                            options.retry_policy_max_backoff,
-                                                            options.retry_policy_backoff_multiplier,
-                                                            runtime_options.thread_instrumentation
+      http_client_(std::make_unique<OtlpHttpClient>(OtlpHttpClientOptions(
+          options.url,
+          options.ssl_insecure_skip_verify,
+          options.ssl_ca_cert_path,
+          options.ssl_ca_cert_string,
+          options.ssl_client_key_path,
+          options.ssl_client_key_string,
+          options.ssl_client_cert_path,
+          options.ssl_client_cert_string,
+          options.ssl_min_tls,
+          options.ssl_max_tls,
+          options.ssl_cipher,
+          options.ssl_cipher_suite,
+          options.content_type,
+          options.json_bytes_mapping,
+          options.compression,
+          options.use_json_name,
+          options.console_debug,
+          options.timeout,
+          options.http_headers,
+          options.retry_policy_max_attempts,
+          options.retry_policy_initial_backoff,
+          options.retry_policy_max_backoff,
+          options.retry_policy_backoff_multiplier,
+          runtime_options.thread_instrumentation
 #ifdef ENABLE_ASYNC_EXPORT
-                                                            ,
-                                                            options.max_concurrent_requests,
-                                                            options.max_requests_per_connection
+          ,
+          options.max_concurrent_requests,
+          options.max_requests_per_connection
 #endif
-                                                            )))
+          )))
 {}
 
 OtlpHttpMetricExporter::OtlpHttpMetricExporter(
@@ -133,7 +134,7 @@ OtlpHttpMetricExporter::OtlpHttpMetricExporter(
       runtime_options_(),
       aggregation_temporality_selector_{
           OtlpMetricUtils::ChooseTemporalitySelector(options_.aggregation_temporality)},
-      http_client_(new OtlpHttpClient(
+      http_client_(std::make_unique<OtlpHttpClient>(
           OtlpHttpClientOptions(options.url,
                                 options.ssl_insecure_skip_verify,
                                 options.ssl_ca_cert_path,
@@ -175,37 +176,38 @@ OtlpHttpMetricExporter::OtlpHttpMetricExporter(
       runtime_options_(runtime_options),
       aggregation_temporality_selector_{
           OtlpMetricUtils::ChooseTemporalitySelector(options_.aggregation_temporality)},
-      http_client_(new OtlpHttpClient(OtlpHttpClientOptions(options.url,
-                                                            options.ssl_insecure_skip_verify,
-                                                            options.ssl_ca_cert_path,
-                                                            options.ssl_ca_cert_string,
-                                                            options.ssl_client_key_path,
-                                                            options.ssl_client_key_string,
-                                                            options.ssl_client_cert_path,
-                                                            options.ssl_client_cert_string,
-                                                            options.ssl_min_tls,
-                                                            options.ssl_max_tls,
-                                                            options.ssl_cipher,
-                                                            options.ssl_cipher_suite,
-                                                            options.content_type,
-                                                            options.json_bytes_mapping,
-                                                            options.compression,
-                                                            options.use_json_name,
-                                                            options.console_debug,
-                                                            options.timeout,
-                                                            options.http_headers,
-                                                            options.retry_policy_max_attempts,
-                                                            options.retry_policy_initial_backoff,
-                                                            options.retry_policy_max_backoff,
-                                                            options.retry_policy_backoff_multiplier,
-                                                            runtime_options.thread_instrumentation
+      http_client_(std::make_unique<OtlpHttpClient>(
+          OtlpHttpClientOptions(options.url,
+                                options.ssl_insecure_skip_verify,
+                                options.ssl_ca_cert_path,
+                                options.ssl_ca_cert_string,
+                                options.ssl_client_key_path,
+                                options.ssl_client_key_string,
+                                options.ssl_client_cert_path,
+                                options.ssl_client_cert_string,
+                                options.ssl_min_tls,
+                                options.ssl_max_tls,
+                                options.ssl_cipher,
+                                options.ssl_cipher_suite,
+                                options.content_type,
+                                options.json_bytes_mapping,
+                                options.compression,
+                                options.use_json_name,
+                                options.console_debug,
+                                options.timeout,
+                                options.http_headers,
+                                options.retry_policy_max_attempts,
+                                options.retry_policy_initial_backoff,
+                                options.retry_policy_max_backoff,
+                                options.retry_policy_backoff_multiplier,
+                                runtime_options.thread_instrumentation
 #ifdef ENABLE_ASYNC_EXPORT
-                                                            ,
-                                                            options.max_concurrent_requests,
-                                                            options.max_requests_per_connection
+                                ,
+                                options.max_concurrent_requests,
+                                options.max_requests_per_connection
 #endif
-                                                            ),
-                                      factory))
+                                ),
+          factory))
 {}
 
 OtlpHttpMetricExporter::OtlpHttpMetricExporter(
@@ -215,7 +217,7 @@ OtlpHttpMetricExporter::OtlpHttpMetricExporter(
       runtime_options_(),
       aggregation_temporality_selector_{
           OtlpMetricUtils::ChooseTemporalitySelector(options_.aggregation_temporality)},
-      http_client_(new OtlpHttpClient(
+      http_client_(std::make_unique<OtlpHttpClient>(
           OtlpHttpClientOptions(options.url,
                                 options.ssl_insecure_skip_verify,
                                 options.ssl_ca_cert_path,
@@ -257,37 +259,38 @@ OtlpHttpMetricExporter::OtlpHttpMetricExporter(
       runtime_options_(runtime_options),
       aggregation_temporality_selector_{
           OtlpMetricUtils::ChooseTemporalitySelector(options_.aggregation_temporality)},
-      http_client_(new OtlpHttpClient(OtlpHttpClientOptions(options.url,
-                                                            options.ssl_insecure_skip_verify,
-                                                            options.ssl_ca_cert_path,
-                                                            options.ssl_ca_cert_string,
-                                                            options.ssl_client_key_path,
-                                                            options.ssl_client_key_string,
-                                                            options.ssl_client_cert_path,
-                                                            options.ssl_client_cert_string,
-                                                            options.ssl_min_tls,
-                                                            options.ssl_max_tls,
-                                                            options.ssl_cipher,
-                                                            options.ssl_cipher_suite,
-                                                            options.content_type,
-                                                            options.json_bytes_mapping,
-                                                            options.compression,
-                                                            options.use_json_name,
-                                                            options.console_debug,
-                                                            options.timeout,
-                                                            options.http_headers,
-                                                            options.retry_policy_max_attempts,
-                                                            options.retry_policy_initial_backoff,
-                                                            options.retry_policy_max_backoff,
-                                                            options.retry_policy_backoff_multiplier,
-                                                            runtime_options.thread_instrumentation
+      http_client_(std::make_unique<OtlpHttpClient>(
+          OtlpHttpClientOptions(options.url,
+                                options.ssl_insecure_skip_verify,
+                                options.ssl_ca_cert_path,
+                                options.ssl_ca_cert_string,
+                                options.ssl_client_key_path,
+                                options.ssl_client_key_string,
+                                options.ssl_client_cert_path,
+                                options.ssl_client_cert_string,
+                                options.ssl_min_tls,
+                                options.ssl_max_tls,
+                                options.ssl_cipher,
+                                options.ssl_cipher_suite,
+                                options.content_type,
+                                options.json_bytes_mapping,
+                                options.compression,
+                                options.use_json_name,
+                                options.console_debug,
+                                options.timeout,
+                                options.http_headers,
+                                options.retry_policy_max_attempts,
+                                options.retry_policy_initial_backoff,
+                                options.retry_policy_max_backoff,
+                                options.retry_policy_backoff_multiplier,
+                                runtime_options.thread_instrumentation
 #ifdef ENABLE_ASYNC_EXPORT
-                                                            ,
-                                                            options.max_concurrent_requests,
-                                                            options.max_requests_per_connection
+                                ,
+                                options.max_concurrent_requests,
+                                options.max_requests_per_connection
 #endif
-                                                            ),
-                                      std::move(http_client)))
+                                ),
+          std::move(http_client)))
 {}
 
 OtlpHttpMetricExporter::OtlpHttpMetricExporter(std::unique_ptr<OtlpHttpClient> http_client)

--- a/exporters/otlp/src/otlp_http_metric_exporter_factory.cc
+++ b/exporters/otlp/src/otlp_http_metric_exporter_factory.cc
@@ -37,9 +37,7 @@ std::unique_ptr<opentelemetry::sdk::metrics::PushMetricExporter>
 OtlpHttpMetricExporterFactory::Create(const OtlpHttpMetricExporterOptions &options,
                                       const OtlpHttpMetricExporterRuntimeOptions &runtime_options)
 {
-  std::unique_ptr<opentelemetry::sdk::metrics::PushMetricExporter> exporter(
-      new OtlpHttpMetricExporter(options, runtime_options));
-  return exporter;
+  return std::make_unique<OtlpHttpMetricExporter>(options, runtime_options);
 }
 
 std::unique_ptr<opentelemetry::sdk::metrics::PushMetricExporter>
@@ -47,8 +45,7 @@ OtlpHttpMetricExporterFactory::Create(
     const OtlpHttpMetricExporterOptions &options,
     const std::shared_ptr<opentelemetry::ext::http::client::HttpClientFactory> &factory)
 {
-  return std::unique_ptr<opentelemetry::sdk::metrics::PushMetricExporter>(
-      new OtlpHttpMetricExporter(options, factory));
+  return std::make_unique<OtlpHttpMetricExporter>(options, factory);
 }
 
 std::unique_ptr<opentelemetry::sdk::metrics::PushMetricExporter>
@@ -57,8 +54,7 @@ OtlpHttpMetricExporterFactory::Create(
     const OtlpHttpMetricExporterRuntimeOptions &runtime_options,
     const std::shared_ptr<opentelemetry::ext::http::client::HttpClientFactory> &factory)
 {
-  return std::unique_ptr<opentelemetry::sdk::metrics::PushMetricExporter>(
-      new OtlpHttpMetricExporter(options, runtime_options, factory));
+  return std::make_unique<OtlpHttpMetricExporter>(options, runtime_options, factory);
 }
 
 std::unique_ptr<opentelemetry::sdk::metrics::PushMetricExporter>
@@ -66,8 +62,7 @@ OtlpHttpMetricExporterFactory::Create(
     const OtlpHttpMetricExporterOptions &options,
     std::shared_ptr<opentelemetry::ext::http::client::HttpClient> http_client)
 {
-  return std::unique_ptr<opentelemetry::sdk::metrics::PushMetricExporter>(
-      new OtlpHttpMetricExporter(options, std::move(http_client)));
+  return std::make_unique<OtlpHttpMetricExporter>(options, std::move(http_client));
 }
 
 std::unique_ptr<opentelemetry::sdk::metrics::PushMetricExporter>
@@ -76,8 +71,7 @@ OtlpHttpMetricExporterFactory::Create(
     const OtlpHttpMetricExporterRuntimeOptions &runtime_options,
     std::shared_ptr<opentelemetry::ext::http::client::HttpClient> http_client)
 {
-  return std::unique_ptr<opentelemetry::sdk::metrics::PushMetricExporter>(
-      new OtlpHttpMetricExporter(options, runtime_options, std::move(http_client)));
+  return std::make_unique<OtlpHttpMetricExporter>(options, runtime_options, std::move(http_client));
 }
 
 }  // namespace otlp

--- a/exporters/otlp/test/otlp_file_client_test.cc
+++ b/exporters/otlp/test/otlp_file_client_test.cc
@@ -128,7 +128,7 @@ static std::unique_ptr<opentelemetry::sdk::trace::Recordable> MakeRecordable(
     const resource::Resource &resource,
     const opentelemetry::sdk::instrumentationscope::InstrumentationScope &instrumentation_scope)
 {
-  OtlpRecordable *recordable = new OtlpRecordable();
+  auto recordable = std::make_unique<OtlpRecordable>();
   recordable->SetResource(resource);
   recordable->SetInstrumentationScope(instrumentation_scope);
 
@@ -156,16 +156,17 @@ static std::unique_ptr<opentelemetry::sdk::trace::Recordable> MakeRecordable(
     recordable->SetIdentity(span_context, parent_span_id);
   }
 
-  return std::unique_ptr<opentelemetry::sdk::trace::Recordable>(recordable);
+  // We should not depends NRVO of compilers, so do not return std::move(recordable) or recordable.
+  return {std::move(recordable)};
 }
 
 TEST(OtlpFileClientTest, Shutdown)
 {
   opentelemetry::proto::collector::trace::v1::ExportTraceServiceRequest request;
-  auto client = std::unique_ptr<opentelemetry::exporter::otlp::OtlpFileClient>(
-      new opentelemetry::exporter::otlp::OtlpFileClient(
+  std::unique_ptr<opentelemetry::exporter::otlp::OtlpFileClient> client =
+      std::make_unique<opentelemetry::exporter::otlp::OtlpFileClient>(
           opentelemetry::exporter::otlp::OtlpFileClientOptions(),
-          opentelemetry::exporter::otlp::OtlpFileClientRuntimeOptions()));
+          opentelemetry::exporter::otlp::OtlpFileClientRuntimeOptions());
   ASSERT_FALSE(client->IsShutdown());
   ASSERT_TRUE(client->Shutdown());
   ASSERT_TRUE(client->IsShutdown());
@@ -191,8 +192,8 @@ TEST(OtlpFileClientTest, ExportToOstreamTest)
   opentelemetry::exporter::otlp::OtlpFileClientRuntimeOptions rt_opts;
   opts.backend_options = std::ref(output_stream);
 
-  auto client = std::unique_ptr<opentelemetry::exporter::otlp::OtlpFileClient>(
-      new opentelemetry::exporter::otlp::OtlpFileClient(std::move(opts), std::move(rt_opts)));
+  auto client = std::make_unique<opentelemetry::exporter::otlp::OtlpFileClient>(std::move(opts),
+                                                                                std::move(rt_opts));
   client->Export(request, 1);
 
   {
@@ -291,8 +292,8 @@ TEST(OtlpFileClientTest, ExportToFileSystemRotateIndexTest)
   opentelemetry::exporter::otlp::OtlpFileClientRuntimeOptions rt_opts;
   opts.backend_options = backend_opts;
 
-  auto client = std::unique_ptr<opentelemetry::exporter::otlp::OtlpFileClient>(
-      new opentelemetry::exporter::otlp::OtlpFileClient(std::move(opts), std::move(rt_opts)));
+  auto client = std::make_unique<opentelemetry::exporter::otlp::OtlpFileClient>(std::move(opts),
+                                                                                std::move(rt_opts));
 
   // Write 5 records with rotatation index 1,2,3,1,2
   for (int i = 0; i < 4; ++i)
@@ -304,16 +305,12 @@ TEST(OtlpFileClientTest, ExportToFileSystemRotateIndexTest)
   client->ForceFlush();
 
   std::unique_ptr<std::ifstream> input_file[5] = {
-      std::unique_ptr<std::ifstream>(
-          new std::ifstream("otlp_file_client_test_dir/trace-1.jsonl", std::ios::in)),
-      std::unique_ptr<std::ifstream>(
-          new std::ifstream("otlp_file_client_test_dir/trace-2.jsonl", std::ios::in)),
-      std::unique_ptr<std::ifstream>(
-          new std::ifstream("otlp_file_client_test_dir/trace-3.jsonl", std::ios::in)),
-      std::unique_ptr<std::ifstream>(
-          new std::ifstream("otlp_file_client_test_dir/trace-4.jsonl", std::ios::in)),
-      std::unique_ptr<std::ifstream>(
-          new std::ifstream("otlp_file_client_test_dir/trace-latest.jsonl", std::ios::in))};
+      std::make_unique<std::ifstream>("otlp_file_client_test_dir/trace-1.jsonl", std::ios::in),
+      std::make_unique<std::ifstream>("otlp_file_client_test_dir/trace-2.jsonl", std::ios::in),
+      std::make_unique<std::ifstream>("otlp_file_client_test_dir/trace-3.jsonl", std::ios::in),
+      std::make_unique<std::ifstream>("otlp_file_client_test_dir/trace-4.jsonl", std::ios::in),
+      std::make_unique<std::ifstream>("otlp_file_client_test_dir/trace-latest.jsonl",
+                                      std::ios::in)};
 
   EXPECT_TRUE(input_file[0]->is_open());
   EXPECT_TRUE(input_file[1]->is_open());
@@ -413,8 +410,8 @@ TEST(OtlpFileClientTest, ExportToFileSystemRotateByTimeTest)
   opentelemetry::exporter::otlp::OtlpFileClientRuntimeOptions rt_opts;
   opts.backend_options = backend_opts;
 
-  auto client = std::unique_ptr<opentelemetry::exporter::otlp::OtlpFileClient>(
-      new opentelemetry::exporter::otlp::OtlpFileClient(std::move(opts), std::move(rt_opts)));
+  auto client = std::make_unique<opentelemetry::exporter::otlp::OtlpFileClient>(std::move(opts),
+                                                                                std::move(rt_opts));
 
   auto start_time = std::chrono::system_clock::now();
   client->Export(request, 1);
@@ -433,8 +430,7 @@ TEST(OtlpFileClientTest, ExportToFileSystemRotateByTimeTest)
                   "otlp_file_client_test_dir/trace-%Y-%m-%d-%H-%M-%S.jsonl", &local_tm);
     start_time += std::chrono::seconds{1};
 
-    input_file[found_file_index] =
-        std::unique_ptr<std::ifstream>(new std::ifstream(file_path_buf, std::ios::in));
+    input_file[found_file_index] = std::make_unique<std::ifstream>(file_path_buf, std::ios::in);
     if (input_file[found_file_index]->is_open())
     {
       ++found_file_index;
@@ -522,8 +518,8 @@ TEST(OtlpFileClientTest, ConfigTest)
     opts.console_debug   = true;
     opts.backend_options = std::ref(std::cout);
 
-    auto client = std::unique_ptr<opentelemetry::exporter::otlp::OtlpFileClient>(
-        new opentelemetry::exporter::otlp::OtlpFileClient(std::move(opts), std::move(rt_opts)));
+    auto client = std::make_unique<opentelemetry::exporter::otlp::OtlpFileClient>(
+        std::move(opts), std::move(rt_opts));
 
     ASSERT_TRUE(client->GetOptions().console_debug);
     ASSERT_TRUE(opentelemetry::nostd::holds_alternative<std::reference_wrapper<std::ostream>>(
@@ -539,8 +535,8 @@ TEST(OtlpFileClientTest, ConfigTest)
     opts.console_debug   = false;
     opts.backend_options = backend_opts;
 
-    auto client = std::unique_ptr<opentelemetry::exporter::otlp::OtlpFileClient>(
-        new opentelemetry::exporter::otlp::OtlpFileClient(std::move(opts), std::move(rt_opts)));
+    auto client = std::make_unique<opentelemetry::exporter::otlp::OtlpFileClient>(
+        std::move(opts), std::move(rt_opts));
 
     ASSERT_FALSE(client->GetOptions().console_debug);
     ASSERT_TRUE(opentelemetry::nostd::holds_alternative<

--- a/exporters/otlp/test/otlp_file_exporter_test.cc
+++ b/exporters/otlp/test/otlp_file_exporter_test.cc
@@ -111,8 +111,8 @@ public:
     processor_opts.max_queue_size        = 5;
     processor_opts.schedule_delay_millis = std::chrono::milliseconds(256);
 
-    auto processor = std::unique_ptr<sdk::trace::SpanProcessor>(
-        new sdk::trace::BatchSpanProcessor(std::move(exporter), processor_opts));
+    std::unique_ptr<sdk::trace::SpanProcessor> processor =
+        std::make_unique<sdk::trace::BatchSpanProcessor>(std::move(exporter), processor_opts);
     auto provider = nostd::shared_ptr<sdk::trace::TracerProvider>(
         new sdk::trace::TracerProvider(std::move(processor), resource));
 
@@ -186,7 +186,8 @@ public:
 
 TEST(OtlpFileExporterTest, Shutdown)
 {
-  auto exporter = std::unique_ptr<opentelemetry::sdk::trace::SpanExporter>(new OtlpFileExporter());
+  std::unique_ptr<opentelemetry::sdk::trace::SpanExporter> exporter =
+      std::make_unique<OtlpFileExporter>();
   ASSERT_TRUE(exporter->Shutdown());
 
   nostd::span<std::unique_ptr<opentelemetry::sdk::trace::Recordable>> spans = {};

--- a/exporters/otlp/test/otlp_file_log_record_exporter_test.cc
+++ b/exporters/otlp/test/otlp_file_log_record_exporter_test.cc
@@ -85,9 +85,9 @@ public:
 
     auto provider = nostd::shared_ptr<sdk::logs::LoggerProvider>(new sdk::logs::LoggerProvider());
 
-    provider->AddProcessor(
-        std::unique_ptr<sdk::logs::LogRecordProcessor>(new sdk::logs::BatchLogRecordProcessor(
-            std::move(exporter), 5, std::chrono::milliseconds(256), 5)));
+    provider->AddProcessor(std::unique_ptr<sdk::logs::LogRecordProcessor>(
+        std::make_unique<sdk::logs::BatchLogRecordProcessor>(std::move(exporter), 5,
+                                                             std::chrono::milliseconds(256), 5)));
 
     std::string report_trace_id;
     std::string report_span_id;
@@ -172,8 +172,8 @@ public:
 
 TEST(OtlpFileLogRecordExporterTest, Shutdown)
 {
-  auto exporter =
-      std::unique_ptr<opentelemetry::sdk::logs::LogRecordExporter>(new OtlpFileLogRecordExporter());
+  std::unique_ptr<opentelemetry::sdk::logs::LogRecordExporter> exporter =
+      std::make_unique<OtlpFileLogRecordExporter>();
   ASSERT_TRUE(exporter->Shutdown());
 
   nostd::span<std::unique_ptr<opentelemetry::sdk::logs::Recordable>> logs = {};

--- a/exporters/otlp/test/otlp_file_log_record_exporter_test.cc
+++ b/exporters/otlp/test/otlp_file_log_record_exporter_test.cc
@@ -85,9 +85,8 @@ public:
 
     auto provider = nostd::shared_ptr<sdk::logs::LoggerProvider>(new sdk::logs::LoggerProvider());
 
-    provider->AddProcessor(std::unique_ptr<sdk::logs::LogRecordProcessor>(
-        std::make_unique<sdk::logs::BatchLogRecordProcessor>(std::move(exporter), 5,
-                                                             std::chrono::milliseconds(256), 5)));
+    provider->AddProcessor(std::make_unique<sdk::logs::BatchLogRecordProcessor>(
+        std::move(exporter), 5, std::chrono::milliseconds(256), 5));
 
     std::string report_trace_id;
     std::string report_span_id;

--- a/exporters/otlp/test/otlp_file_metric_exporter_test.cc
+++ b/exporters/otlp/test/otlp_file_metric_exporter_test.cc
@@ -20,7 +20,6 @@
 #include "opentelemetry/exporters/otlp/otlp_file_metric_exporter_options.h"
 #include "opentelemetry/exporters/otlp/otlp_metric_utils.h"
 #include "opentelemetry/exporters/otlp/otlp_preferred_temporality.h"
-#include "opentelemetry/nostd/unique_ptr.h"
 #include "opentelemetry/sdk/common/exporter_utils.h"
 #include "opentelemetry/sdk/instrumentationscope/instrumentation_scope.h"
 #include "opentelemetry/sdk/metrics/data/metric_data.h"

--- a/exporters/otlp/test/otlp_file_metric_exporter_test.cc
+++ b/exporters/otlp/test/otlp_file_metric_exporter_test.cc
@@ -7,6 +7,7 @@
 #include <cstdint>
 #include <cstdlib>
 #include <functional>
+#include <memory>
 #include <nlohmann/json.hpp>
 #include <sstream>
 #include <string>
@@ -327,8 +328,8 @@ public:
 
 TEST(OtlpFileMetricExporterTest, Shutdown)
 {
-  auto exporter = std::unique_ptr<opentelemetry::sdk::metrics::PushMetricExporter>(
-      new OtlpFileMetricExporter());
+  std::unique_ptr<opentelemetry::sdk::metrics::PushMetricExporter> exporter =
+      std::make_unique<OtlpFileMetricExporter>();
   ASSERT_TRUE(exporter->Shutdown());
   auto result = exporter->Export(opentelemetry::sdk::metrics::ResourceMetrics{});
   EXPECT_EQ(result, opentelemetry::sdk::common::ExportResult::kFailure);
@@ -353,7 +354,7 @@ TEST_F(OtlpFileMetricExporterTestPeer, ExportJsonIntegrationTestHistogramPointDa
 TEST_F(OtlpFileMetricExporterTestPeer, PreferredAggergationTemporality)
 {
   // Cummulative aggregation selector : use cummulative aggregation for all instruments.
-  std::unique_ptr<OtlpFileMetricExporter> exporter(new OtlpFileMetricExporter());
+  std::unique_ptr<OtlpFileMetricExporter> exporter = std::make_unique<OtlpFileMetricExporter>();
   EXPECT_EQ(GetOptions(exporter).aggregation_temporality,
             PreferredAggregationTemporality::kCumulative);
   auto cumm_selector =
@@ -377,7 +378,8 @@ TEST_F(OtlpFileMetricExporterTestPeer, PreferredAggergationTemporality)
   //   up-down counter
   OtlpFileMetricExporterOptions opts2;
   opts2.aggregation_temporality = PreferredAggregationTemporality::kLowMemory;
-  std::unique_ptr<OtlpFileMetricExporter> exporter2(new OtlpFileMetricExporter(opts2));
+  std::unique_ptr<OtlpFileMetricExporter> exporter2 =
+      std::make_unique<OtlpFileMetricExporter>(opts2);
   EXPECT_EQ(GetOptions(exporter2).aggregation_temporality,
             PreferredAggregationTemporality::kLowMemory);
   auto lowmemory_selector =
@@ -402,7 +404,8 @@ TEST_F(OtlpFileMetricExporterTestPeer, PreferredAggergationTemporality)
   //   - cummulative aggregation for up-down counter, observable up-down counter
   OtlpFileMetricExporterOptions opts3;
   opts3.aggregation_temporality = PreferredAggregationTemporality::kDelta;
-  std::unique_ptr<OtlpFileMetricExporter> exporter3(new OtlpFileMetricExporter(opts3));
+  std::unique_ptr<OtlpFileMetricExporter> exporter3 =
+      std::make_unique<OtlpFileMetricExporter>(opts3);
   EXPECT_EQ(GetOptions(exporter3).aggregation_temporality, PreferredAggregationTemporality::kDelta);
   auto delta_selector =
       OtlpMetricUtils::ChooseTemporalitySelector(GetOptions(exporter3).aggregation_temporality);

--- a/exporters/otlp/test/otlp_grpc_exporter_benchmark.cc
+++ b/exporters/otlp/test/otlp_grpc_exporter_benchmark.cc
@@ -5,6 +5,7 @@
 #include "opentelemetry/exporters/otlp/otlp_recordable.h"
 
 #include <benchmark/benchmark.h>
+#include <memory>
 #include "opentelemetry/sdk/trace/simple_processor.h"
 #include "opentelemetry/sdk/trace/tracer_provider.h"
 #include "opentelemetry/trace/provider.h"
@@ -137,9 +138,8 @@ class OtlpGrpcExporterTestPeer
 public:
   std::unique_ptr<sdk::trace::SpanExporter> GetExporter()
   {
-    auto mock_stub = new FakeServiceStub();
-    std::unique_ptr<proto::collector::trace::v1::TraceService::StubInterface> stub_interface(
-        mock_stub);
+    std::unique_ptr<proto::collector::trace::v1::TraceService::StubInterface> stub_interface =
+        std::make_unique<FakeServiceStub>();
     return std::unique_ptr<sdk::trace::SpanExporter>(
         new exporter::otlp::OtlpGrpcExporter(std::move(stub_interface)));
   }
@@ -150,8 +150,8 @@ void CreateEmptySpans(std::array<std::unique_ptr<sdk::trace::Recordable>, kBatch
 {
   for (int i = 0; i < kBatchSize; i++)
   {
-    auto recordable = std::unique_ptr<sdk::trace::Recordable>(new OtlpRecordable);
-    recordables[i]  = std::move(recordable);
+    std::unique_ptr<sdk::trace::Recordable> recordable = std::make_unique<OtlpRecordable>();
+    recordables[i]                                     = std::move(recordable);
   }
 }
 
@@ -160,7 +160,7 @@ void CreateSparseSpans(std::array<std::unique_ptr<sdk::trace::Recordable>, kBatc
 {
   for (int i = 0; i < kBatchSize; i++)
   {
-    auto recordable = std::unique_ptr<sdk::trace::Recordable>(new OtlpRecordable);
+    std::unique_ptr<sdk::trace::Recordable> recordable = std::make_unique<OtlpRecordable>();
 
     recordable->SetIdentity(kSpanContext, kParentSpanId);
     recordable->SetName("TestSpan");
@@ -176,7 +176,7 @@ void CreateDenseSpans(std::array<std::unique_ptr<sdk::trace::Recordable>, kBatch
 {
   for (int i = 0; i < kBatchSize; i++)
   {
-    auto recordable = std::unique_ptr<sdk::trace::Recordable>(new OtlpRecordable);
+    std::unique_ptr<sdk::trace::Recordable> recordable = std::make_unique<OtlpRecordable>();
 
     recordable->SetIdentity(kSpanContext, kParentSpanId);
     recordable->SetName("TestSpan");
@@ -199,8 +199,8 @@ void CreateDenseSpans(std::array<std::unique_ptr<sdk::trace::Recordable>, kBatch
 // Benchmark Export() with empty spans
 void BM_OtlpExporterEmptySpans(benchmark::State &state)
 {
-  std::unique_ptr<OtlpGrpcExporterTestPeer> testpeer(new OtlpGrpcExporterTestPeer());
-  auto exporter = testpeer->GetExporter();
+  std::unique_ptr<OtlpGrpcExporterTestPeer> testpeer = std::make_unique<OtlpGrpcExporterTestPeer>();
+  auto exporter                                      = testpeer->GetExporter();
 
   while (state.KeepRunningBatch(kNumIterations))
   {
@@ -214,8 +214,8 @@ BENCHMARK(BM_OtlpExporterEmptySpans);
 // Benchmark Export() with sparse spans
 void BM_OtlpExporterSparseSpans(benchmark::State &state)
 {
-  std::unique_ptr<OtlpGrpcExporterTestPeer> testpeer(new OtlpGrpcExporterTestPeer());
-  auto exporter = testpeer->GetExporter();
+  std::unique_ptr<OtlpGrpcExporterTestPeer> testpeer = std::make_unique<OtlpGrpcExporterTestPeer>();
+  auto exporter                                      = testpeer->GetExporter();
 
   while (state.KeepRunningBatch(kNumIterations))
   {
@@ -229,8 +229,8 @@ BENCHMARK(BM_OtlpExporterSparseSpans);
 // Benchmark Export() with dense spans
 void BM_OtlpExporterDenseSpans(benchmark::State &state)
 {
-  std::unique_ptr<OtlpGrpcExporterTestPeer> testpeer(new OtlpGrpcExporterTestPeer());
-  auto exporter = testpeer->GetExporter();
+  std::unique_ptr<OtlpGrpcExporterTestPeer> testpeer = std::make_unique<OtlpGrpcExporterTestPeer>();
+  auto exporter                                      = testpeer->GetExporter();
 
   while (state.KeepRunningBatch(kNumIterations))
   {
@@ -255,9 +255,10 @@ opentelemetry::exporter::otlp::OtlpGrpcExporterOptions opts;
 void InitTracer()
 {
   // Create OTLP exporter instance
-  auto exporter  = std::unique_ptr<trace_sdk::SpanExporter>(new otlp::OtlpGrpcExporter(opts));
-  auto processor = std::unique_ptr<trace_sdk::SpanProcessor>(
-      new trace_sdk::SimpleSpanProcessor(std::move(exporter)));
+  std::unique_ptr<trace_sdk::SpanExporter> exporter =
+      std::make_unique<otlp::OtlpGrpcExporter>(opts);
+  std::unique_ptr<trace_sdk::SpanProcessor> processor =
+      std::make_unique<trace_sdk::SimpleSpanProcessor>(std::move(exporter));
   auto provider =
       nostd::shared_ptr<trace::TracerProvider>(new trace_sdk::TracerProvider(std::move(processor)));
   // Set the global trace provider

--- a/exporters/otlp/test/otlp_grpc_exporter_benchmark.cc
+++ b/exporters/otlp/test/otlp_grpc_exporter_benchmark.cc
@@ -138,8 +138,7 @@ class OtlpGrpcExporterTestPeer
 public:
   std::unique_ptr<sdk::trace::SpanExporter> GetExporter()
   {
-    std::unique_ptr<proto::collector::trace::v1::TraceService::StubInterface> stub_interface =
-        std::make_unique<FakeServiceStub>();
+    auto stub_interface = std::make_unique<FakeServiceStub>();
     return std::unique_ptr<sdk::trace::SpanExporter>(
         new exporter::otlp::OtlpGrpcExporter(std::move(stub_interface)));
   }

--- a/exporters/otlp/test/otlp_grpc_exporter_test.cc
+++ b/exporters/otlp/test/otlp_grpc_exporter_test.cc
@@ -1,6 +1,7 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
+#include <memory>
 #ifndef OPENTELEMETRY_STL_VERSION
 // Unfortunately as of 04/27/2021 the fix is NOT in the vcpkg snapshot of Google Test.
 // Remove above `#ifdef` once the GMock fix for C++20 is in the mainline.
@@ -253,8 +254,8 @@ TEST_F(OtlpGrpcExporterTestPeer, ExportIntegrationTest)
 
   auto exporter = GetExporter(stub_interface);
 
-  auto processor = std::unique_ptr<sdk::trace::SpanProcessor>(
-      new sdk::trace::SimpleSpanProcessor(std::move(exporter)));
+  std::unique_ptr<sdk::trace::SpanProcessor> processor =
+      std::make_unique<sdk::trace::SimpleSpanProcessor>(std::move(exporter));
   auto provider = nostd::shared_ptr<trace::TracerProvider>(
       new sdk::trace::TracerProvider(std::move(processor)));
   auto tracer = provider->GetTracer("test");
@@ -273,8 +274,8 @@ TEST_F(OtlpGrpcExporterTestPeer, ExportIntegrationTest)
 TEST_F(OtlpGrpcExporterTestPeer, ConfigTest)
 {
   OtlpGrpcExporterOptions opts;
-  opts.endpoint = "localhost:45454";
-  std::unique_ptr<OtlpGrpcExporter> exporter(new OtlpGrpcExporter(opts));
+  opts.endpoint                              = "localhost:45454";
+  std::unique_ptr<OtlpGrpcExporter> exporter = std::make_unique<OtlpGrpcExporter>(opts);
   EXPECT_EQ(GetOptions(exporter).endpoint, "localhost:45454");
 }
 
@@ -283,9 +284,9 @@ TEST_F(OtlpGrpcExporterTestPeer, ConfigSslCredentialsTest)
 {
   std::string cacert_str = "--begin and end fake cert--";
   OtlpGrpcExporterOptions opts;
-  opts.use_ssl_credentials              = true;
-  opts.ssl_credentials_cacert_as_string = cacert_str;
-  std::unique_ptr<OtlpGrpcExporter> exporter(new OtlpGrpcExporter(opts));
+  opts.use_ssl_credentials                   = true;
+  opts.ssl_credentials_cacert_as_string      = cacert_str;
+  std::unique_ptr<OtlpGrpcExporter> exporter = std::make_unique<OtlpGrpcExporter>(opts);
   EXPECT_EQ(GetOptions(exporter).ssl_credentials_cacert_as_string, cacert_str);
   EXPECT_EQ(GetOptions(exporter).use_ssl_credentials, true);
 }
@@ -303,7 +304,7 @@ TEST_F(OtlpGrpcExporterTestPeer, ConfigFromEnv)
   setenv("OTEL_EXPORTER_OTLP_HEADERS", "k1=v1,k2=v2", 1);
   setenv("OTEL_EXPORTER_OTLP_TRACES_HEADERS", "k1=v3,k1=v4", 1);
 
-  std::unique_ptr<OtlpGrpcExporter> exporter(new OtlpGrpcExporter());
+  std::unique_ptr<OtlpGrpcExporter> exporter = std::make_unique<OtlpGrpcExporter>();
   EXPECT_EQ(GetOptions(exporter).ssl_credentials_cacert_as_string, cacert_str);
   EXPECT_EQ(GetOptions(exporter).use_ssl_credentials, true);
   EXPECT_EQ(GetOptions(exporter).endpoint, endpoint);
@@ -347,7 +348,7 @@ TEST_F(OtlpGrpcExporterTestPeer, ConfigHttpsSecureFromEnv)
   setenv("OTEL_EXPORTER_OTLP_ENDPOINT", endpoint.c_str(), 1);
   setenv("OTEL_EXPORTER_OTLP_TRACES_INSECURE", "true", 1);
 
-  std::unique_ptr<OtlpGrpcExporter> exporter(new OtlpGrpcExporter());
+  std::unique_ptr<OtlpGrpcExporter> exporter = std::make_unique<OtlpGrpcExporter>();
   EXPECT_EQ(GetOptions(exporter).use_ssl_credentials, true);
   EXPECT_EQ(GetOptions(exporter).endpoint, endpoint);
 
@@ -363,7 +364,7 @@ TEST_F(OtlpGrpcExporterTestPeer, ConfigHttpInsecureFromEnv)
   setenv("OTEL_EXPORTER_OTLP_ENDPOINT", endpoint.c_str(), 1);
   setenv("OTEL_EXPORTER_OTLP_TRACES_INSECURE", "false", 1);
 
-  std::unique_ptr<OtlpGrpcExporter> exporter(new OtlpGrpcExporter());
+  std::unique_ptr<OtlpGrpcExporter> exporter = std::make_unique<OtlpGrpcExporter>();
   EXPECT_EQ(GetOptions(exporter).use_ssl_credentials, false);
   EXPECT_EQ(GetOptions(exporter).endpoint, endpoint);
 
@@ -378,7 +379,7 @@ TEST_F(OtlpGrpcExporterTestPeer, ConfigUnknownSecureFromEnv)
   setenv("OTEL_EXPORTER_OTLP_ENDPOINT", endpoint.c_str(), 1);
   setenv("OTEL_EXPORTER_OTLP_TRACES_INSECURE", "false", 1);
 
-  std::unique_ptr<OtlpGrpcExporter> exporter(new OtlpGrpcExporter());
+  std::unique_ptr<OtlpGrpcExporter> exporter = std::make_unique<OtlpGrpcExporter>();
   EXPECT_EQ(GetOptions(exporter).use_ssl_credentials, true);
   EXPECT_EQ(GetOptions(exporter).endpoint, endpoint);
 
@@ -393,7 +394,7 @@ TEST_F(OtlpGrpcExporterTestPeer, ConfigUnknownInsecureFromEnv)
   setenv("OTEL_EXPORTER_OTLP_ENDPOINT", endpoint.c_str(), 1);
   setenv("OTEL_EXPORTER_OTLP_TRACES_INSECURE", "true", 1);
 
-  std::unique_ptr<OtlpGrpcExporter> exporter(new OtlpGrpcExporter());
+  std::unique_ptr<OtlpGrpcExporter> exporter = std::make_unique<OtlpGrpcExporter>();
   EXPECT_EQ(GetOptions(exporter).use_ssl_credentials, false);
   EXPECT_EQ(GetOptions(exporter).endpoint, endpoint);
 
@@ -403,8 +404,8 @@ TEST_F(OtlpGrpcExporterTestPeer, ConfigUnknownInsecureFromEnv)
 
 TEST_F(OtlpGrpcExporterTestPeer, ConfigRetryDefaultValues)
 {
-  std::unique_ptr<OtlpGrpcExporter> exporter(new OtlpGrpcExporter());
-  const auto options = GetOptions(exporter);
+  std::unique_ptr<OtlpGrpcExporter> exporter = std::make_unique<OtlpGrpcExporter>();
+  const auto options                         = GetOptions(exporter);
   ASSERT_EQ(options.retry_policy_max_attempts, 5);
   ASSERT_FLOAT_EQ(options.retry_policy_initial_backoff.count(), 1.0f);
   ASSERT_FLOAT_EQ(options.retry_policy_max_backoff.count(), 5.0f);
@@ -418,8 +419,8 @@ TEST_F(OtlpGrpcExporterTestPeer, ConfigRetryValuesFromEnv)
   setenv("OTEL_CPP_EXPORTER_OTLP_TRACES_RETRY_MAX_BACKOFF", "6.7", 1);
   setenv("OTEL_CPP_EXPORTER_OTLP_TRACES_RETRY_BACKOFF_MULTIPLIER", "8.9", 1);
 
-  std::unique_ptr<OtlpGrpcExporter> exporter(new OtlpGrpcExporter());
-  const auto options = GetOptions(exporter);
+  std::unique_ptr<OtlpGrpcExporter> exporter = std::make_unique<OtlpGrpcExporter>();
+  const auto options                         = GetOptions(exporter);
   ASSERT_EQ(options.retry_policy_max_attempts, 123);
   ASSERT_FLOAT_EQ(options.retry_policy_initial_backoff.count(), 4.5f);
   ASSERT_FLOAT_EQ(options.retry_policy_max_backoff.count(), 6.7f);
@@ -438,8 +439,8 @@ TEST_F(OtlpGrpcExporterTestPeer, ConfigRetryGenericValuesFromEnv)
   setenv("OTEL_CPP_EXPORTER_OTLP_RETRY_MAX_BACKOFF", "7.6", 1);
   setenv("OTEL_CPP_EXPORTER_OTLP_RETRY_BACKOFF_MULTIPLIER", "9.8", 1);
 
-  std::unique_ptr<OtlpGrpcExporter> exporter(new OtlpGrpcExporter());
-  const auto options = GetOptions(exporter);
+  std::unique_ptr<OtlpGrpcExporter> exporter = std::make_unique<OtlpGrpcExporter>();
+  const auto options                         = GetOptions(exporter);
   ASSERT_EQ(options.retry_policy_max_attempts, 321);
   ASSERT_FLOAT_EQ(options.retry_policy_initial_backoff.count(), 5.4f);
   ASSERT_FLOAT_EQ(options.retry_policy_max_backoff.count(), 7.6f);

--- a/exporters/otlp/test/otlp_grpc_exporter_test.cc
+++ b/exporters/otlp/test/otlp_grpc_exporter_test.cc
@@ -1,7 +1,6 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-#include <memory>
 #ifndef OPENTELEMETRY_STL_VERSION
 // Unfortunately as of 04/27/2021 the fix is NOT in the vcpkg snapshot of Google Test.
 // Remove above `#ifdef` once the GMock fix for C++20 is in the mainline.

--- a/exporters/otlp/test/otlp_grpc_log_record_exporter_test.cc
+++ b/exporters/otlp/test/otlp_grpc_log_record_exporter_test.cc
@@ -9,7 +9,6 @@
 #include <algorithm>
 #include <chrono>
 #include <functional>
-#include <memory>
 #include <string>
 #include <unordered_map>
 #include <utility>

--- a/exporters/otlp/test/otlp_grpc_log_record_exporter_test.cc
+++ b/exporters/otlp/test/otlp_grpc_log_record_exporter_test.cc
@@ -9,6 +9,7 @@
 #include <algorithm>
 #include <chrono>
 #include <functional>
+#include <memory>
 #include <string>
 #include <unordered_map>
 #include <utility>
@@ -316,9 +317,8 @@ TEST_F(OtlpGrpcLogRecordExporterTestPeer, ExportIntegrationTest)
   opentelemetry::nostd::string_view attribute_storage_string_value[] = {"vector", "string"};
 
   auto provider = nostd::shared_ptr<sdk::logs::LoggerProvider>(new sdk::logs::LoggerProvider());
-  provider->AddProcessor(
-      std::unique_ptr<sdk::logs::LogRecordProcessor>(new sdk::logs::BatchLogRecordProcessor(
-          std::move(exporter), 5, std::chrono::milliseconds(256), 1)));
+  provider->AddProcessor(std::make_unique<sdk::logs::BatchLogRecordProcessor>(
+      std::move(exporter), 5, std::chrono::milliseconds(256), 1));
 
   EXPECT_CALL(*mock_stub, Export(_, _, _))
       .Times(AtLeast(1))
@@ -401,9 +401,8 @@ TEST_F(OtlpGrpcLogRecordExporterTestPeer, ShareClientTest)
   opentelemetry::nostd::string_view attribute_storage_string_value[] = {"vector", "string"};
 
   auto provider = nostd::shared_ptr<sdk::logs::LoggerProvider>(new sdk::logs::LoggerProvider());
-  provider->AddProcessor(
-      std::unique_ptr<sdk::logs::LogRecordProcessor>(new sdk::logs::BatchLogRecordProcessor(
-          std::move(exporter), 5, std::chrono::milliseconds(256), 1)));
+  provider->AddProcessor(std::make_unique<sdk::logs::BatchLogRecordProcessor>(
+      std::move(exporter), 5, std::chrono::milliseconds(256), 1));
 
   EXPECT_CALL(*mock_stub, Export(_, _, _))
       .Times(Exactly(1))
@@ -494,7 +493,8 @@ TEST_F(OtlpGrpcLogRecordExporterTestPeer, ShareClientTest)
 #ifndef NO_GETENV
 TEST_F(OtlpGrpcLogRecordExporterTestPeer, ConfigRetryDefaultValues)
 {
-  std::unique_ptr<OtlpGrpcLogRecordExporter> exporter(new OtlpGrpcLogRecordExporter());
+  std::unique_ptr<OtlpGrpcLogRecordExporter> exporter =
+      std::make_unique<OtlpGrpcLogRecordExporter>();
   const auto options = GetOptions(exporter);
   ASSERT_EQ(options.retry_policy_max_attempts, 5);
   ASSERT_FLOAT_EQ(options.retry_policy_initial_backoff.count(), 1.0f);
@@ -509,7 +509,8 @@ TEST_F(OtlpGrpcLogRecordExporterTestPeer, ConfigRetryValuesFromEnv)
   setenv("OTEL_CPP_EXPORTER_OTLP_LOGS_RETRY_MAX_BACKOFF", "6.7", 1);
   setenv("OTEL_CPP_EXPORTER_OTLP_LOGS_RETRY_BACKOFF_MULTIPLIER", "8.9", 1);
 
-  std::unique_ptr<OtlpGrpcLogRecordExporter> exporter(new OtlpGrpcLogRecordExporter());
+  std::unique_ptr<OtlpGrpcLogRecordExporter> exporter =
+      std::make_unique<OtlpGrpcLogRecordExporter>();
   const auto options = GetOptions(exporter);
   ASSERT_EQ(options.retry_policy_max_attempts, 123);
   ASSERT_FLOAT_EQ(options.retry_policy_initial_backoff.count(), 4.5f);
@@ -529,7 +530,8 @@ TEST_F(OtlpGrpcLogRecordExporterTestPeer, ConfigRetryGenericValuesFromEnv)
   setenv("OTEL_CPP_EXPORTER_OTLP_RETRY_MAX_BACKOFF", "7.6", 1);
   setenv("OTEL_CPP_EXPORTER_OTLP_RETRY_BACKOFF_MULTIPLIER", "9.8", 1);
 
-  std::unique_ptr<OtlpGrpcLogRecordExporter> exporter(new OtlpGrpcLogRecordExporter());
+  std::unique_ptr<OtlpGrpcLogRecordExporter> exporter =
+      std::make_unique<OtlpGrpcLogRecordExporter>();
   const auto options = GetOptions(exporter);
   ASSERT_EQ(options.retry_policy_max_attempts, 321);
   ASSERT_FLOAT_EQ(options.retry_policy_initial_backoff.count(), 5.4f);

--- a/exporters/otlp/test/otlp_grpc_metric_exporter_test.cc
+++ b/exporters/otlp/test/otlp_grpc_metric_exporter_test.cc
@@ -138,7 +138,7 @@ public:
   std::unique_ptr<sdk::metrics::PushMetricExporter> GetExporter(
       const OtlpGrpcMetricExporterOptions &options)
   {
-    return std::unique_ptr<sdk::metrics::PushMetricExporter>(new OtlpGrpcMetricExporter(options));
+    return std::make_unique<OtlpGrpcMetricExporter>(options);
   }
 
   std::unique_ptr<sdk::metrics::PushMetricExporter> GetExporter(
@@ -175,8 +175,8 @@ public:
 TEST_F(OtlpGrpcMetricExporterTestPeer, ConfigTest)
 {
   OtlpGrpcMetricExporterOptions opts;
-  opts.endpoint = "localhost:45454";
-  std::unique_ptr<OtlpGrpcMetricExporter> exporter(new OtlpGrpcMetricExporter(opts));
+  opts.endpoint                                    = "localhost:45454";
+  std::unique_ptr<OtlpGrpcMetricExporter> exporter = std::make_unique<OtlpGrpcMetricExporter>(opts);
   EXPECT_EQ(GetOptions(exporter).endpoint, "localhost:45454");
 }
 
@@ -185,9 +185,10 @@ TEST_F(OtlpGrpcMetricExporterTestPeer, ConfigSslCredentialsTest)
 {
   std::string cacert_str = "--begin and end fake cert--";
   OtlpGrpcMetricExporterOptions opts;
-  opts.use_ssl_credentials              = true;
-  opts.ssl_credentials_cacert_as_string = cacert_str;
-  std::unique_ptr<OtlpGrpcMetricExporter> exporter(new OtlpGrpcMetricExporter(opts));
+  opts.use_ssl_credentials                         = true;
+  opts.ssl_credentials_cacert_as_string            = cacert_str;
+  std::unique_ptr<OtlpGrpcMetricExporter> exporter = std::make_unique<OtlpGrpcMetricExporter>(opts);
+  ;
   EXPECT_EQ(GetOptions(exporter).ssl_credentials_cacert_as_string, cacert_str);
   EXPECT_EQ(GetOptions(exporter).use_ssl_credentials, true);
 }
@@ -205,7 +206,8 @@ TEST_F(OtlpGrpcMetricExporterTestPeer, ConfigFromEnv)
   setenv("OTEL_EXPORTER_OTLP_HEADERS", "k1=v1,k2=v2", 1);
   setenv("OTEL_EXPORTER_OTLP_METRICS_HEADERS", "k1=v3,k1=v4", 1);
 
-  std::unique_ptr<OtlpGrpcMetricExporter> exporter(new OtlpGrpcMetricExporter());
+  std::unique_ptr<OtlpGrpcMetricExporter> exporter = std::make_unique<OtlpGrpcMetricExporter>();
+  ;
   EXPECT_EQ(GetOptions(exporter).ssl_credentials_cacert_as_string, cacert_str);
   EXPECT_EQ(GetOptions(exporter).use_ssl_credentials, true);
   EXPECT_EQ(GetOptions(exporter).endpoint, endpoint);
@@ -249,7 +251,8 @@ TEST_F(OtlpGrpcMetricExporterTestPeer, ConfigHttpsSecureFromEnv)
   setenv("OTEL_EXPORTER_OTLP_ENDPOINT", endpoint.c_str(), 1);
   setenv("OTEL_EXPORTER_OTLP_METRICS_INSECURE", "true", 1);
 
-  std::unique_ptr<OtlpGrpcMetricExporter> exporter(new OtlpGrpcMetricExporter());
+  std::unique_ptr<OtlpGrpcMetricExporter> exporter = std::make_unique<OtlpGrpcMetricExporter>();
+  ;
   EXPECT_EQ(GetOptions(exporter).use_ssl_credentials, true);
   EXPECT_EQ(GetOptions(exporter).endpoint, endpoint);
 
@@ -265,7 +268,8 @@ TEST_F(OtlpGrpcMetricExporterTestPeer, ConfigHttpInsecureFromEnv)
   setenv("OTEL_EXPORTER_OTLP_ENDPOINT", endpoint.c_str(), 1);
   setenv("OTEL_EXPORTER_OTLP_METRICS_INSECURE", "false", 1);
 
-  std::unique_ptr<OtlpGrpcMetricExporter> exporter(new OtlpGrpcMetricExporter());
+  std::unique_ptr<OtlpGrpcMetricExporter> exporter = std::make_unique<OtlpGrpcMetricExporter>();
+  ;
   EXPECT_EQ(GetOptions(exporter).use_ssl_credentials, false);
   EXPECT_EQ(GetOptions(exporter).endpoint, endpoint);
 
@@ -280,7 +284,8 @@ TEST_F(OtlpGrpcMetricExporterTestPeer, ConfigUnknownSecureFromEnv)
   setenv("OTEL_EXPORTER_OTLP_ENDPOINT", endpoint.c_str(), 1);
   setenv("OTEL_EXPORTER_OTLP_METRICS_INSECURE", "false", 1);
 
-  std::unique_ptr<OtlpGrpcMetricExporter> exporter(new OtlpGrpcMetricExporter());
+  std::unique_ptr<OtlpGrpcMetricExporter> exporter = std::make_unique<OtlpGrpcMetricExporter>();
+  ;
   EXPECT_EQ(GetOptions(exporter).use_ssl_credentials, true);
   EXPECT_EQ(GetOptions(exporter).endpoint, endpoint);
 
@@ -295,7 +300,8 @@ TEST_F(OtlpGrpcMetricExporterTestPeer, ConfigUnknownInsecureFromEnv)
   setenv("OTEL_EXPORTER_OTLP_ENDPOINT", endpoint.c_str(), 1);
   setenv("OTEL_EXPORTER_OTLP_METRICS_INSECURE", "true", 1);
 
-  std::unique_ptr<OtlpGrpcMetricExporter> exporter(new OtlpGrpcMetricExporter());
+  std::unique_ptr<OtlpGrpcMetricExporter> exporter = std::make_unique<OtlpGrpcMetricExporter>();
+  ;
   EXPECT_EQ(GetOptions(exporter).use_ssl_credentials, false);
   EXPECT_EQ(GetOptions(exporter).endpoint, endpoint);
 
@@ -305,7 +311,8 @@ TEST_F(OtlpGrpcMetricExporterTestPeer, ConfigUnknownInsecureFromEnv)
 
 TEST_F(OtlpGrpcMetricExporterTestPeer, ConfigRetryDefaultValues)
 {
-  std::unique_ptr<OtlpGrpcMetricExporter> exporter(new OtlpGrpcMetricExporter());
+  std::unique_ptr<OtlpGrpcMetricExporter> exporter = std::make_unique<OtlpGrpcMetricExporter>();
+  ;
   const auto options = GetOptions(exporter);
   ASSERT_EQ(options.retry_policy_max_attempts, 5);
   ASSERT_FLOAT_EQ(options.retry_policy_initial_backoff.count(), 1.0f);
@@ -320,7 +327,8 @@ TEST_F(OtlpGrpcMetricExporterTestPeer, ConfigRetryValuesFromEnv)
   setenv("OTEL_CPP_EXPORTER_OTLP_METRICS_RETRY_MAX_BACKOFF", "6.7", 1);
   setenv("OTEL_CPP_EXPORTER_OTLP_METRICS_RETRY_BACKOFF_MULTIPLIER", "8.9", 1);
 
-  std::unique_ptr<OtlpGrpcMetricExporter> exporter(new OtlpGrpcMetricExporter());
+  std::unique_ptr<OtlpGrpcMetricExporter> exporter = std::make_unique<OtlpGrpcMetricExporter>();
+  ;
   const auto options = GetOptions(exporter);
   ASSERT_EQ(options.retry_policy_max_attempts, 123);
   ASSERT_FLOAT_EQ(options.retry_policy_initial_backoff.count(), 4.5f);
@@ -340,7 +348,8 @@ TEST_F(OtlpGrpcMetricExporterTestPeer, ConfigRetryGenericValuesFromEnv)
   setenv("OTEL_CPP_EXPORTER_OTLP_RETRY_MAX_BACKOFF", "7.6", 1);
   setenv("OTEL_CPP_EXPORTER_OTLP_RETRY_BACKOFF_MULTIPLIER", "9.8", 1);
 
-  std::unique_ptr<OtlpGrpcMetricExporter> exporter(new OtlpGrpcMetricExporter());
+  std::unique_ptr<OtlpGrpcMetricExporter> exporter = std::make_unique<OtlpGrpcMetricExporter>();
+  ;
   const auto options = GetOptions(exporter);
   ASSERT_EQ(options.retry_policy_max_attempts, 321);
   ASSERT_FLOAT_EQ(options.retry_policy_initial_backoff.count(), 5.4f);

--- a/exporters/otlp/test/otlp_grpc_metric_exporter_test.cc
+++ b/exporters/otlp/test/otlp_grpc_metric_exporter_test.cc
@@ -188,7 +188,7 @@ TEST_F(OtlpGrpcMetricExporterTestPeer, ConfigSslCredentialsTest)
   opts.use_ssl_credentials                         = true;
   opts.ssl_credentials_cacert_as_string            = cacert_str;
   std::unique_ptr<OtlpGrpcMetricExporter> exporter = std::make_unique<OtlpGrpcMetricExporter>(opts);
-  ;
+
   EXPECT_EQ(GetOptions(exporter).ssl_credentials_cacert_as_string, cacert_str);
   EXPECT_EQ(GetOptions(exporter).use_ssl_credentials, true);
 }
@@ -207,7 +207,7 @@ TEST_F(OtlpGrpcMetricExporterTestPeer, ConfigFromEnv)
   setenv("OTEL_EXPORTER_OTLP_METRICS_HEADERS", "k1=v3,k1=v4", 1);
 
   std::unique_ptr<OtlpGrpcMetricExporter> exporter = std::make_unique<OtlpGrpcMetricExporter>();
-  ;
+
   EXPECT_EQ(GetOptions(exporter).ssl_credentials_cacert_as_string, cacert_str);
   EXPECT_EQ(GetOptions(exporter).use_ssl_credentials, true);
   EXPECT_EQ(GetOptions(exporter).endpoint, endpoint);
@@ -252,7 +252,7 @@ TEST_F(OtlpGrpcMetricExporterTestPeer, ConfigHttpsSecureFromEnv)
   setenv("OTEL_EXPORTER_OTLP_METRICS_INSECURE", "true", 1);
 
   std::unique_ptr<OtlpGrpcMetricExporter> exporter = std::make_unique<OtlpGrpcMetricExporter>();
-  ;
+
   EXPECT_EQ(GetOptions(exporter).use_ssl_credentials, true);
   EXPECT_EQ(GetOptions(exporter).endpoint, endpoint);
 
@@ -269,7 +269,7 @@ TEST_F(OtlpGrpcMetricExporterTestPeer, ConfigHttpInsecureFromEnv)
   setenv("OTEL_EXPORTER_OTLP_METRICS_INSECURE", "false", 1);
 
   std::unique_ptr<OtlpGrpcMetricExporter> exporter = std::make_unique<OtlpGrpcMetricExporter>();
-  ;
+
   EXPECT_EQ(GetOptions(exporter).use_ssl_credentials, false);
   EXPECT_EQ(GetOptions(exporter).endpoint, endpoint);
 
@@ -285,7 +285,7 @@ TEST_F(OtlpGrpcMetricExporterTestPeer, ConfigUnknownSecureFromEnv)
   setenv("OTEL_EXPORTER_OTLP_METRICS_INSECURE", "false", 1);
 
   std::unique_ptr<OtlpGrpcMetricExporter> exporter = std::make_unique<OtlpGrpcMetricExporter>();
-  ;
+
   EXPECT_EQ(GetOptions(exporter).use_ssl_credentials, true);
   EXPECT_EQ(GetOptions(exporter).endpoint, endpoint);
 
@@ -301,7 +301,7 @@ TEST_F(OtlpGrpcMetricExporterTestPeer, ConfigUnknownInsecureFromEnv)
   setenv("OTEL_EXPORTER_OTLP_METRICS_INSECURE", "true", 1);
 
   std::unique_ptr<OtlpGrpcMetricExporter> exporter = std::make_unique<OtlpGrpcMetricExporter>();
-  ;
+
   EXPECT_EQ(GetOptions(exporter).use_ssl_credentials, false);
   EXPECT_EQ(GetOptions(exporter).endpoint, endpoint);
 
@@ -312,7 +312,7 @@ TEST_F(OtlpGrpcMetricExporterTestPeer, ConfigUnknownInsecureFromEnv)
 TEST_F(OtlpGrpcMetricExporterTestPeer, ConfigRetryDefaultValues)
 {
   std::unique_ptr<OtlpGrpcMetricExporter> exporter = std::make_unique<OtlpGrpcMetricExporter>();
-  ;
+
   const auto options = GetOptions(exporter);
   ASSERT_EQ(options.retry_policy_max_attempts, 5);
   ASSERT_FLOAT_EQ(options.retry_policy_initial_backoff.count(), 1.0f);
@@ -328,7 +328,7 @@ TEST_F(OtlpGrpcMetricExporterTestPeer, ConfigRetryValuesFromEnv)
   setenv("OTEL_CPP_EXPORTER_OTLP_METRICS_RETRY_BACKOFF_MULTIPLIER", "8.9", 1);
 
   std::unique_ptr<OtlpGrpcMetricExporter> exporter = std::make_unique<OtlpGrpcMetricExporter>();
-  ;
+
   const auto options = GetOptions(exporter);
   ASSERT_EQ(options.retry_policy_max_attempts, 123);
   ASSERT_FLOAT_EQ(options.retry_policy_initial_backoff.count(), 4.5f);
@@ -349,7 +349,7 @@ TEST_F(OtlpGrpcMetricExporterTestPeer, ConfigRetryGenericValuesFromEnv)
   setenv("OTEL_CPP_EXPORTER_OTLP_RETRY_BACKOFF_MULTIPLIER", "9.8", 1);
 
   std::unique_ptr<OtlpGrpcMetricExporter> exporter = std::make_unique<OtlpGrpcMetricExporter>();
-  ;
+
   const auto options = GetOptions(exporter);
   ASSERT_EQ(options.retry_policy_max_attempts, 321);
   ASSERT_FLOAT_EQ(options.retry_policy_initial_backoff.count(), 5.4f);

--- a/exporters/otlp/test/otlp_http_exporter_custom_client_test.cc
+++ b/exporters/otlp/test/otlp_http_exporter_custom_client_test.cc
@@ -124,8 +124,8 @@ TEST_F(OtlpHttpExporterCustomClientTestPeer, ExportCallsSendRequest)
   processor_opts.max_queue_size        = 5;
   processor_opts.schedule_delay_millis = std::chrono::milliseconds(256);
 
-  auto processor = std::unique_ptr<sdk::trace::SpanProcessor>(
-      new sdk::trace::BatchSpanProcessor(std::move(exporter), processor_opts));
+  std::unique_ptr<sdk::trace::SpanProcessor> processor =
+      std::make_unique<sdk::trace::BatchSpanProcessor>(std::move(exporter), processor_opts);
   auto provider = nostd::shared_ptr<sdk::trace::TracerProvider>(
       new sdk::trace::TracerProvider(std::move(processor)));
 

--- a/exporters/otlp/test/otlp_http_exporter_test.cc
+++ b/exporters/otlp/test/otlp_http_exporter_test.cc
@@ -166,8 +166,8 @@ public:
     processor_opts.max_queue_size        = 5;
     processor_opts.schedule_delay_millis = std::chrono::milliseconds(256);
 
-    auto processor = std::unique_ptr<sdk::trace::SpanProcessor>(
-        new sdk::trace::BatchSpanProcessor(std::move(exporter), processor_opts));
+    std::unique_ptr<sdk::trace::SpanProcessor> processor =
+        std::make_unique<sdk::trace::BatchSpanProcessor>(std::move(exporter), processor_opts);
     auto provider = nostd::shared_ptr<sdk::trace::TracerProvider>(
         new sdk::trace::TracerProvider(std::move(processor), resource));
 
@@ -278,8 +278,8 @@ public:
     processor_opts.max_queue_size        = 5;
     processor_opts.schedule_delay_millis = std::chrono::milliseconds(256);
 
-    auto processor = std::unique_ptr<sdk::trace::SpanProcessor>(
-        new sdk::trace::BatchSpanProcessor(std::move(exporter), processor_opts));
+    std::unique_ptr<sdk::trace::SpanProcessor> processor =
+        std::make_unique<sdk::trace::BatchSpanProcessor>(std::move(exporter), processor_opts);
     auto provider = nostd::shared_ptr<sdk::trace::TracerProvider>(
         new sdk::trace::TracerProvider(std::move(processor), resource));
 
@@ -394,8 +394,8 @@ public:
     processor_opts.max_queue_size        = 5;
     processor_opts.schedule_delay_millis = std::chrono::milliseconds(256);
 
-    auto processor = std::unique_ptr<sdk::trace::SpanProcessor>(
-        new sdk::trace::BatchSpanProcessor(std::move(exporter), processor_opts));
+    std::unique_ptr<sdk::trace::SpanProcessor> processor =
+        std::make_unique<sdk::trace::BatchSpanProcessor>(std::move(exporter), processor_opts);
     auto provider = nostd::shared_ptr<sdk::trace::TracerProvider>(
         new sdk::trace::TracerProvider(std::move(processor), resource));
 
@@ -491,8 +491,8 @@ public:
     processor_opts.max_queue_size        = 5;
     processor_opts.schedule_delay_millis = std::chrono::milliseconds(256);
 
-    auto processor = std::unique_ptr<sdk::trace::SpanProcessor>(
-        new sdk::trace::BatchSpanProcessor(std::move(exporter), processor_opts));
+    std::unique_ptr<sdk::trace::SpanProcessor> processor =
+        std::make_unique<sdk::trace::BatchSpanProcessor>(std::move(exporter), processor_opts);
     auto provider = nostd::shared_ptr<sdk::trace::TracerProvider>(
         new sdk::trace::TracerProvider(std::move(processor), resource));
 
@@ -565,7 +565,8 @@ public:
 
 TEST(OtlpHttpExporterTest, Shutdown)
 {
-  auto exporter = std::unique_ptr<opentelemetry::sdk::trace::SpanExporter>(new OtlpHttpExporter());
+  std::unique_ptr<opentelemetry::sdk::trace::SpanExporter> exporter =
+      std::make_unique<OtlpHttpExporter>();
   ASSERT_TRUE(exporter->Shutdown());
 
   nostd::span<std::unique_ptr<opentelemetry::sdk::trace::Recordable>> spans = {};
@@ -605,8 +606,8 @@ TEST_F(OtlpHttpExporterTestPeer, ExportBinaryIntegrationTestAsync)
 TEST_F(OtlpHttpExporterTestPeer, ConfigTest)
 {
   OtlpHttpExporterOptions opts;
-  opts.url = "http://localhost:45455/v1/traces";
-  std::unique_ptr<OtlpHttpExporter> exporter(new OtlpHttpExporter(opts));
+  opts.url                                   = "http://localhost:45455/v1/traces";
+  std::unique_ptr<OtlpHttpExporter> exporter = std::make_unique<OtlpHttpExporter>(opts);
   EXPECT_EQ(GetOptions(exporter).url, "http://localhost:45455/v1/traces");
 }
 
@@ -614,8 +615,8 @@ TEST_F(OtlpHttpExporterTestPeer, ConfigTest)
 TEST_F(OtlpHttpExporterTestPeer, ConfigUseJsonNameTest)
 {
   OtlpHttpExporterOptions opts;
-  opts.use_json_name = true;
-  std::unique_ptr<OtlpHttpExporter> exporter(new OtlpHttpExporter(opts));
+  opts.use_json_name                         = true;
+  std::unique_ptr<OtlpHttpExporter> exporter = std::make_unique<OtlpHttpExporter>(opts);
   EXPECT_EQ(GetOptions(exporter).use_json_name, true);
 }
 
@@ -623,8 +624,8 @@ TEST_F(OtlpHttpExporterTestPeer, ConfigUseJsonNameTest)
 TEST_F(OtlpHttpExporterTestPeer, ConfigJsonBytesMappingTest)
 {
   OtlpHttpExporterOptions opts;
-  opts.json_bytes_mapping = JsonBytesMappingKind::kHex;
-  std::unique_ptr<OtlpHttpExporter> exporter(new OtlpHttpExporter(opts));
+  opts.json_bytes_mapping                    = JsonBytesMappingKind::kHex;
+  std::unique_ptr<OtlpHttpExporter> exporter = std::make_unique<OtlpHttpExporter>(opts);
   EXPECT_EQ(GetOptions(exporter).json_bytes_mapping, JsonBytesMappingKind::kHex);
 }
 
@@ -645,7 +646,7 @@ TEST_F(OtlpHttpExporterTestPeer, ConfigFromEnv)
   setenv("OTEL_EXPORTER_OTLP_TRACES_HEADERS", "k1=v3,k1=v4", 1);
   setenv("OTEL_EXPORTER_OTLP_PROTOCOL", "http/json", 1);
 
-  std::unique_ptr<OtlpHttpExporter> exporter(new OtlpHttpExporter());
+  std::unique_ptr<OtlpHttpExporter> exporter = std::make_unique<OtlpHttpExporter>();
   EXPECT_EQ(GetOptions(exporter).url, url);
   EXPECT_EQ(
       GetOptions(exporter).timeout.count(),
@@ -688,7 +689,7 @@ TEST_F(OtlpHttpExporterTestPeer, ConfigFromTracesEnv)
   setenv("OTEL_EXPORTER_OTLP_TRACES_HEADERS", "k1=v3,k1=v4", 1);
   setenv("OTEL_EXPORTER_OTLP_TRACES_PROTOCOL", "http/json", 1);
 
-  std::unique_ptr<OtlpHttpExporter> exporter(new OtlpHttpExporter());
+  std::unique_ptr<OtlpHttpExporter> exporter = std::make_unique<OtlpHttpExporter>();
   EXPECT_EQ(GetOptions(exporter).url, url);
   EXPECT_EQ(
       GetOptions(exporter).timeout.count(),
@@ -724,8 +725,8 @@ TEST_F(OtlpHttpExporterTestPeer, ConfigFromTracesEnv)
 
 TEST_F(OtlpHttpExporterTestPeer, ConfigRetryDefaultValues)
 {
-  std::unique_ptr<OtlpHttpExporter> exporter(new OtlpHttpExporter());
-  const auto options = GetOptions(exporter);
+  std::unique_ptr<OtlpHttpExporter> exporter = std::make_unique<OtlpHttpExporter>();
+  const auto options                         = GetOptions(exporter);
   ASSERT_EQ(options.retry_policy_max_attempts, 5);
   ASSERT_FLOAT_EQ(options.retry_policy_initial_backoff.count(), 1.0f);
   ASSERT_FLOAT_EQ(options.retry_policy_max_backoff.count(), 5.0f);
@@ -739,8 +740,8 @@ TEST_F(OtlpHttpExporterTestPeer, ConfigRetryValuesFromEnv)
   setenv("OTEL_CPP_EXPORTER_OTLP_TRACES_RETRY_MAX_BACKOFF", "6.7", 1);
   setenv("OTEL_CPP_EXPORTER_OTLP_TRACES_RETRY_BACKOFF_MULTIPLIER", "8.9", 1);
 
-  std::unique_ptr<OtlpHttpExporter> exporter(new OtlpHttpExporter());
-  const auto options = GetOptions(exporter);
+  std::unique_ptr<OtlpHttpExporter> exporter = std::make_unique<OtlpHttpExporter>();
+  const auto options                         = GetOptions(exporter);
   ASSERT_EQ(options.retry_policy_max_attempts, 123);
   ASSERT_FLOAT_EQ(options.retry_policy_initial_backoff.count(), 4.5f);
   ASSERT_FLOAT_EQ(options.retry_policy_max_backoff.count(), 6.7f);
@@ -759,8 +760,8 @@ TEST_F(OtlpHttpExporterTestPeer, ConfigRetryGenericValuesFromEnv)
   setenv("OTEL_CPP_EXPORTER_OTLP_RETRY_MAX_BACKOFF", "7.6", 1);
   setenv("OTEL_CPP_EXPORTER_OTLP_RETRY_BACKOFF_MULTIPLIER", "9.8", 1);
 
-  std::unique_ptr<OtlpHttpExporter> exporter(new OtlpHttpExporter());
-  const auto options = GetOptions(exporter);
+  std::unique_ptr<OtlpHttpExporter> exporter = std::make_unique<OtlpHttpExporter>();
+  const auto options                         = GetOptions(exporter);
   ASSERT_EQ(options.retry_policy_max_attempts, 321);
   ASSERT_FLOAT_EQ(options.retry_policy_initial_backoff.count(), 5.4f);
   ASSERT_FLOAT_EQ(options.retry_policy_max_backoff.count(), 7.6f);

--- a/exporters/otlp/test/otlp_http_log_record_exporter_test.cc
+++ b/exporters/otlp/test/otlp_http_log_record_exporter_test.cc
@@ -1,7 +1,6 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-#include <memory>
 #ifndef OPENTELEMETRY_STL_VERSION
 
 #  include <algorithm>

--- a/exporters/otlp/test/otlp_http_log_record_exporter_test.cc
+++ b/exporters/otlp/test/otlp_http_log_record_exporter_test.cc
@@ -1,6 +1,7 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
+#include <memory>
 #ifndef OPENTELEMETRY_STL_VERSION
 
 #  include <algorithm>
@@ -152,9 +153,8 @@ public:
 
     auto provider = nostd::shared_ptr<sdk::logs::LoggerProvider>(new sdk::logs::LoggerProvider());
 
-    provider->AddProcessor(
-        std::unique_ptr<sdk::logs::LogRecordProcessor>(new sdk::logs::BatchLogRecordProcessor(
-            std::move(exporter), 5, std::chrono::milliseconds(256), 5)));
+    provider->AddProcessor(std::make_unique<sdk::logs::BatchLogRecordProcessor>(
+        std::move(exporter), 5, std::chrono::milliseconds(256), 5));
 
     std::string report_trace_id;
     std::string report_span_id;
@@ -289,8 +289,8 @@ public:
     options.schedule_delay_millis = std::chrono::milliseconds(256);
     options.max_export_batch_size = 5;
 
-    provider->AddProcessor(std::unique_ptr<sdk::logs::LogRecordProcessor>(
-        new sdk::logs::BatchLogRecordProcessor(std::move(exporter), options)));
+    provider->AddProcessor(
+        std::make_unique<sdk::logs::BatchLogRecordProcessor>(std::move(exporter), options));
 
     std::string report_trace_id;
     std::string report_span_id;
@@ -435,8 +435,8 @@ public:
     processor_options.max_export_batch_size = 5;
     processor_options.max_queue_size        = 5;
     processor_options.schedule_delay_millis = std::chrono::milliseconds(256);
-    provider->AddProcessor(std::unique_ptr<sdk::logs::LogRecordProcessor>(
-        new sdk::logs::BatchLogRecordProcessor(std::move(exporter), processor_options)));
+    provider->AddProcessor(std::make_unique<sdk::logs::BatchLogRecordProcessor>(std::move(exporter),
+                                                                                processor_options));
 
     std::string report_trace_id;
     std::string report_span_id;
@@ -563,8 +563,8 @@ public:
     processor_options.max_export_batch_size = 5;
     processor_options.max_queue_size        = 5;
     processor_options.schedule_delay_millis = std::chrono::milliseconds(256);
-    provider->AddProcessor(std::unique_ptr<sdk::logs::LogRecordProcessor>(
-        new sdk::logs::BatchLogRecordProcessor(std::move(exporter), processor_options)));
+    provider->AddProcessor(std::make_unique<sdk::logs::BatchLogRecordProcessor>(std::move(exporter),
+                                                                                processor_options));
 
     std::string report_trace_id;
     std::string report_span_id;
@@ -675,8 +675,8 @@ public:
 
 TEST(OtlpHttpLogRecordExporterTest, Shutdown)
 {
-  auto exporter =
-      std::unique_ptr<opentelemetry::sdk::logs::LogRecordExporter>(new OtlpHttpLogRecordExporter());
+  std::unique_ptr<opentelemetry::sdk::logs::LogRecordExporter> exporter =
+      std::make_unique<OtlpHttpLogRecordExporter>();
   ASSERT_TRUE(exporter->Shutdown());
 
   nostd::span<std::unique_ptr<opentelemetry::sdk::logs::Recordable>> logs = {};
@@ -717,7 +717,8 @@ TEST_F(OtlpHttpLogRecordExporterTestPeer, ConfigTest)
 {
   OtlpHttpLogRecordExporterOptions opts;
   opts.url = "http://localhost:45456/v1/logs";
-  std::unique_ptr<OtlpHttpLogRecordExporter> exporter(new OtlpHttpLogRecordExporter(opts));
+  std::unique_ptr<OtlpHttpLogRecordExporter> exporter =
+      std::make_unique<OtlpHttpLogRecordExporter>(opts);
   EXPECT_EQ(GetOptions(exporter).url, "http://localhost:45456/v1/logs");
 }
 
@@ -726,7 +727,8 @@ TEST_F(OtlpHttpLogRecordExporterTestPeer, ConfigUseJsonNameTest)
 {
   OtlpHttpLogRecordExporterOptions opts;
   opts.use_json_name = true;
-  std::unique_ptr<OtlpHttpLogRecordExporter> exporter(new OtlpHttpLogRecordExporter(opts));
+  std::unique_ptr<OtlpHttpLogRecordExporter> exporter =
+      std::make_unique<OtlpHttpLogRecordExporter>(opts);
   EXPECT_EQ(GetOptions(exporter).use_json_name, true);
 }
 
@@ -735,7 +737,8 @@ TEST_F(OtlpHttpLogRecordExporterTestPeer, ConfigJsonBytesMappingTest)
 {
   OtlpHttpLogRecordExporterOptions opts;
   opts.json_bytes_mapping = JsonBytesMappingKind::kHex;
-  std::unique_ptr<OtlpHttpLogRecordExporter> exporter(new OtlpHttpLogRecordExporter(opts));
+  std::unique_ptr<OtlpHttpLogRecordExporter> exporter =
+      std::make_unique<OtlpHttpLogRecordExporter>(opts);
   EXPECT_EQ(GetOptions(exporter).json_bytes_mapping, JsonBytesMappingKind::kHex);
 }
 
@@ -756,7 +759,8 @@ TEST_F(OtlpHttpLogRecordExporterTestPeer, ConfigFromEnv)
   setenv("OTEL_EXPORTER_OTLP_LOGS_HEADERS", "k1=v3,k1=v4", 1);
   setenv("OTEL_EXPORTER_OTLP_PROTOCOL", "http/json", 1);
 
-  std::unique_ptr<OtlpHttpLogRecordExporter> exporter(new OtlpHttpLogRecordExporter());
+  std::unique_ptr<OtlpHttpLogRecordExporter> exporter =
+      std::make_unique<OtlpHttpLogRecordExporter>();
   EXPECT_EQ(GetOptions(exporter).url, url);
   EXPECT_EQ(
       GetOptions(exporter).timeout.count(),
@@ -799,7 +803,8 @@ TEST_F(OtlpHttpLogRecordExporterTestPeer, ConfigFromLogsEnv)
   setenv("OTEL_EXPORTER_OTLP_LOGS_HEADERS", "k1=v3,k1=v4", 1);
   setenv("OTEL_EXPORTER_OTLP_LOGS_PROTOCOL", "http/json", 1);
 
-  std::unique_ptr<OtlpHttpLogRecordExporter> exporter(new OtlpHttpLogRecordExporter());
+  std::unique_ptr<OtlpHttpLogRecordExporter> exporter =
+      std::make_unique<OtlpHttpLogRecordExporter>();
   EXPECT_EQ(GetOptions(exporter).url, url);
   EXPECT_EQ(
       GetOptions(exporter).timeout.count(),
@@ -842,7 +847,8 @@ TEST_F(OtlpHttpLogRecordExporterTestPeer, DefaultEndpoint)
 
 TEST_F(OtlpHttpLogRecordExporterTestPeer, ConfigRetryDefaultValues)
 {
-  std::unique_ptr<OtlpHttpLogRecordExporter> exporter(new OtlpHttpLogRecordExporter());
+  std::unique_ptr<OtlpHttpLogRecordExporter> exporter =
+      std::make_unique<OtlpHttpLogRecordExporter>();
   const auto options = GetOptions(exporter);
   ASSERT_EQ(options.retry_policy_max_attempts, 5);
   ASSERT_FLOAT_EQ(options.retry_policy_initial_backoff.count(), 1.0f);
@@ -857,7 +863,8 @@ TEST_F(OtlpHttpLogRecordExporterTestPeer, ConfigRetryValuesFromEnv)
   setenv("OTEL_CPP_EXPORTER_OTLP_LOGS_RETRY_MAX_BACKOFF", "6.7", 1);
   setenv("OTEL_CPP_EXPORTER_OTLP_LOGS_RETRY_BACKOFF_MULTIPLIER", "8.9", 1);
 
-  std::unique_ptr<OtlpHttpLogRecordExporter> exporter(new OtlpHttpLogRecordExporter());
+  std::unique_ptr<OtlpHttpLogRecordExporter> exporter =
+      std::make_unique<OtlpHttpLogRecordExporter>();
   const auto options = GetOptions(exporter);
   ASSERT_EQ(options.retry_policy_max_attempts, 123);
   ASSERT_FLOAT_EQ(options.retry_policy_initial_backoff.count(), 4.5f);
@@ -877,7 +884,8 @@ TEST_F(OtlpHttpLogRecordExporterTestPeer, ConfigRetryGenericValuesFromEnv)
   setenv("OTEL_CPP_EXPORTER_OTLP_RETRY_MAX_BACKOFF", "7.6", 1);
   setenv("OTEL_CPP_EXPORTER_OTLP_RETRY_BACKOFF_MULTIPLIER", "9.8", 1);
 
-  std::unique_ptr<OtlpHttpLogRecordExporter> exporter(new OtlpHttpLogRecordExporter());
+  std::unique_ptr<OtlpHttpLogRecordExporter> exporter =
+      std::make_unique<OtlpHttpLogRecordExporter>();
   const auto options = GetOptions(exporter);
   ASSERT_EQ(options.retry_policy_max_attempts, 321);
   ASSERT_FLOAT_EQ(options.retry_policy_initial_backoff.count(), 5.4f);

--- a/exporters/otlp/test/otlp_http_metric_exporter_test.cc
+++ b/exporters/otlp/test/otlp_http_metric_exporter_test.cc
@@ -882,8 +882,8 @@ public:
 
 TEST(OtlpHttpMetricExporterTest, Shutdown)
 {
-  auto exporter = std::unique_ptr<opentelemetry::sdk::metrics::PushMetricExporter>(
-      new OtlpHttpMetricExporter());
+  std::unique_ptr<opentelemetry::sdk::metrics::PushMetricExporter> exporter =
+      std::make_unique<OtlpHttpMetricExporter>();
   ASSERT_TRUE(exporter->Shutdown());
   auto result = exporter->Export(opentelemetry::sdk::metrics::ResourceMetrics{});
   EXPECT_EQ(result, opentelemetry::sdk::common::ExportResult::kFailure);
@@ -974,8 +974,8 @@ TEST_F(OtlpHttpMetricExporterTestPeer, ExportBinaryIntegrationTestHistogramPoint
 TEST_F(OtlpHttpMetricExporterTestPeer, ConfigTest)
 {
   OtlpHttpMetricExporterOptions opts;
-  opts.url = "http://localhost:45456/v1/metrics";
-  std::unique_ptr<OtlpHttpMetricExporter> exporter(new OtlpHttpMetricExporter(opts));
+  opts.url                                         = "http://localhost:45456/v1/metrics";
+  std::unique_ptr<OtlpHttpMetricExporter> exporter = std::make_unique<OtlpHttpMetricExporter>(opts);
   EXPECT_EQ(GetOptions(exporter).url, "http://localhost:45456/v1/metrics");
 }
 
@@ -983,8 +983,8 @@ TEST_F(OtlpHttpMetricExporterTestPeer, ConfigTest)
 TEST_F(OtlpHttpMetricExporterTestPeer, ConfigUseJsonNameTest)
 {
   OtlpHttpMetricExporterOptions opts;
-  opts.use_json_name = true;
-  std::unique_ptr<OtlpHttpMetricExporter> exporter(new OtlpHttpMetricExporter(opts));
+  opts.use_json_name                               = true;
+  std::unique_ptr<OtlpHttpMetricExporter> exporter = std::make_unique<OtlpHttpMetricExporter>(opts);
   EXPECT_EQ(GetOptions(exporter).use_json_name, true);
 }
 
@@ -992,8 +992,8 @@ TEST_F(OtlpHttpMetricExporterTestPeer, ConfigUseJsonNameTest)
 TEST_F(OtlpHttpMetricExporterTestPeer, ConfigJsonBytesMappingTest)
 {
   OtlpHttpMetricExporterOptions opts;
-  opts.json_bytes_mapping = JsonBytesMappingKind::kHex;
-  std::unique_ptr<OtlpHttpMetricExporter> exporter(new OtlpHttpMetricExporter(opts));
+  opts.json_bytes_mapping                          = JsonBytesMappingKind::kHex;
+  std::unique_ptr<OtlpHttpMetricExporter> exporter = std::make_unique<OtlpHttpMetricExporter>(opts);
   EXPECT_EQ(GetOptions(exporter).json_bytes_mapping, JsonBytesMappingKind::kHex);
   static ProtobufGlobalSymbolGuard global_symbol_guard;
 }
@@ -1015,7 +1015,7 @@ TEST_F(OtlpHttpMetricExporterTestPeer, ConfigFromEnv)
   setenv("OTEL_EXPORTER_OTLP_METRICS_HEADERS", "k1=v3,k1=v4", 1);
   setenv("OTEL_EXPORTER_OTLP_PROTOCOL", "http/json", 1);
 
-  std::unique_ptr<OtlpHttpMetricExporter> exporter(new OtlpHttpMetricExporter());
+  std::unique_ptr<OtlpHttpMetricExporter> exporter = std::make_unique<OtlpHttpMetricExporter>();
   EXPECT_EQ(GetOptions(exporter).url, url);
   EXPECT_EQ(
       GetOptions(exporter).timeout.count(),
@@ -1058,7 +1058,7 @@ TEST_F(OtlpHttpMetricExporterTestPeer, ConfigFromMetricsEnv)
   setenv("OTEL_EXPORTER_OTLP_METRICS_HEADERS", "k1=v3,k1=v4", 1);
   setenv("OTEL_EXPORTER_OTLP_METRICS_PROTOCOL", "http/json", 1);
 
-  std::unique_ptr<OtlpHttpMetricExporter> exporter(new OtlpHttpMetricExporter());
+  std::unique_ptr<OtlpHttpMetricExporter> exporter = std::make_unique<OtlpHttpMetricExporter>();
   EXPECT_EQ(GetOptions(exporter).url, url);
   EXPECT_EQ(
       GetOptions(exporter).timeout.count(),
@@ -1099,7 +1099,7 @@ TEST_F(OtlpHttpMetricExporterTestPeer, DefaultEndpoint)
 
 TEST_F(OtlpHttpMetricExporterTestPeer, CheckDefaultTemporality)
 {
-  std::unique_ptr<OtlpHttpMetricExporter> exporter(new OtlpHttpMetricExporter());
+  std::unique_ptr<OtlpHttpMetricExporter> exporter = std::make_unique<OtlpHttpMetricExporter>();
   EXPECT_EQ(
       opentelemetry::sdk::metrics::AggregationTemporality::kCumulative,
       exporter->GetAggregationTemporality(opentelemetry::sdk::metrics::InstrumentType::kCounter));
@@ -1122,8 +1122,8 @@ TEST_F(OtlpHttpMetricExporterTestPeer, CheckDefaultTemporality)
 
 TEST_F(OtlpHttpMetricExporterTestPeer, ConfigRetryDefaultValues)
 {
-  std::unique_ptr<OtlpHttpMetricExporter> exporter(new OtlpHttpMetricExporter());
-  const auto options = GetOptions(exporter);
+  std::unique_ptr<OtlpHttpMetricExporter> exporter = std::make_unique<OtlpHttpMetricExporter>();
+  const auto options                               = GetOptions(exporter);
   ASSERT_EQ(options.retry_policy_max_attempts, 5);
   ASSERT_FLOAT_EQ(options.retry_policy_initial_backoff.count(), 1.0f);
   ASSERT_FLOAT_EQ(options.retry_policy_max_backoff.count(), 5.0f);
@@ -1137,8 +1137,8 @@ TEST_F(OtlpHttpMetricExporterTestPeer, ConfigRetryValuesFromEnv)
   setenv("OTEL_CPP_EXPORTER_OTLP_METRICS_RETRY_MAX_BACKOFF", "6.7", 1);
   setenv("OTEL_CPP_EXPORTER_OTLP_METRICS_RETRY_BACKOFF_MULTIPLIER", "8.9", 1);
 
-  std::unique_ptr<OtlpHttpMetricExporter> exporter(new OtlpHttpMetricExporter());
-  const auto options = GetOptions(exporter);
+  std::unique_ptr<OtlpHttpMetricExporter> exporter = std::make_unique<OtlpHttpMetricExporter>();
+  const auto options                               = GetOptions(exporter);
   ASSERT_EQ(options.retry_policy_max_attempts, 123);
   ASSERT_FLOAT_EQ(options.retry_policy_initial_backoff.count(), 4.5f);
   ASSERT_FLOAT_EQ(options.retry_policy_max_backoff.count(), 6.7f);
@@ -1157,8 +1157,8 @@ TEST_F(OtlpHttpMetricExporterTestPeer, ConfigRetryGenericValuesFromEnv)
   setenv("OTEL_CPP_EXPORTER_OTLP_RETRY_MAX_BACKOFF", "7.6", 1);
   setenv("OTEL_CPP_EXPORTER_OTLP_RETRY_BACKOFF_MULTIPLIER", "9.8", 1);
 
-  std::unique_ptr<OtlpHttpMetricExporter> exporter(new OtlpHttpMetricExporter());
-  const auto options = GetOptions(exporter);
+  std::unique_ptr<OtlpHttpMetricExporter> exporter = std::make_unique<OtlpHttpMetricExporter>();
+  const auto options                               = GetOptions(exporter);
   ASSERT_EQ(options.retry_policy_max_attempts, 321);
   ASSERT_FLOAT_EQ(options.retry_policy_initial_backoff.count(), 5.4f);
   ASSERT_FLOAT_EQ(options.retry_policy_max_backoff.count(), 7.6f);
@@ -1175,7 +1175,7 @@ TEST_F(OtlpHttpMetricExporterTestPeer, ConfigRetryGenericValuesFromEnv)
 TEST_F(OtlpHttpMetricExporterTestPeer, PreferredAggergationTemporality)
 {
   // Cummulative aggregation selector : use cummulative aggregation for all instruments.
-  std::unique_ptr<OtlpHttpMetricExporter> exporter(new OtlpHttpMetricExporter());
+  std::unique_ptr<OtlpHttpMetricExporter> exporter = std::make_unique<OtlpHttpMetricExporter>();
   EXPECT_EQ(GetOptions(exporter).aggregation_temporality,
             PreferredAggregationTemporality::kCumulative);
   auto cumm_selector =
@@ -1199,7 +1199,8 @@ TEST_F(OtlpHttpMetricExporterTestPeer, PreferredAggergationTemporality)
   //   up-down counter
   OtlpHttpMetricExporterOptions opts2;
   opts2.aggregation_temporality = PreferredAggregationTemporality::kLowMemory;
-  std::unique_ptr<OtlpHttpMetricExporter> exporter2(new OtlpHttpMetricExporter(opts2));
+  std::unique_ptr<OtlpHttpMetricExporter> exporter2 =
+      std::make_unique<OtlpHttpMetricExporter>(opts2);
   EXPECT_EQ(GetOptions(exporter2).aggregation_temporality,
             PreferredAggregationTemporality::kLowMemory);
   auto lowmemory_selector =
@@ -1224,7 +1225,8 @@ TEST_F(OtlpHttpMetricExporterTestPeer, PreferredAggergationTemporality)
   //   - cummulative aggregation for up-down counter, observable up-down counter
   OtlpHttpMetricExporterOptions opts3;
   opts3.aggregation_temporality = PreferredAggregationTemporality::kDelta;
-  std::unique_ptr<OtlpHttpMetricExporter> exporter3(new OtlpHttpMetricExporter(opts3));
+  std::unique_ptr<OtlpHttpMetricExporter> exporter3 =
+      std::make_unique<OtlpHttpMetricExporter>(opts3);
   EXPECT_EQ(GetOptions(exporter3).aggregation_temporality, PreferredAggregationTemporality::kDelta);
   auto delta_selector =
       OtlpMetricUtils::ChooseTemporalitySelector(GetOptions(exporter3).aggregation_temporality);

--- a/exporters/otlp/test/otlp_log_recordable_test.cc
+++ b/exporters/otlp/test/otlp_log_recordable_test.cc
@@ -296,14 +296,14 @@ TYPED_TEST(OtlpLogRecordableIntAttributeTest, SetIntArrayAttribute)
 // Test logs PopulateRequest groups records by resource and instrumentation scope
 TEST(OtlpLogRecordable, PopulateRequest)
 {
-  auto rec1      = std::unique_ptr<sdk::logs::Recordable>(new OtlpLogRecordable);
+  std::unique_ptr<sdk::logs::Recordable> rec1 = std::make_unique<OtlpLogRecordable>();
   auto resource1 = resource::Resource::Create({{"service.name", "one"}});
   auto inst_lib1 =
       opentelemetry::sdk::instrumentationscope::InstrumentationScope::Create("one", "1");
   rec1->SetResource(resource1);
   rec1->SetInstrumentationScope(*inst_lib1);
 
-  auto rec2      = std::unique_ptr<sdk::logs::Recordable>(new OtlpLogRecordable);
+  std::unique_ptr<sdk::logs::Recordable> rec2 = std::make_unique<OtlpLogRecordable>();
   auto resource2 = resource::Resource::Create({{"service.name", "two"}});
   auto inst_lib2 =
       opentelemetry::sdk::instrumentationscope::InstrumentationScope::Create("two", "2");
@@ -311,7 +311,7 @@ TEST(OtlpLogRecordable, PopulateRequest)
   rec2->SetInstrumentationScope(*inst_lib2);
 
   // Same resource as rec2, different scope
-  auto rec3 = std::unique_ptr<sdk::logs::Recordable>(new OtlpLogRecordable);
+  std::unique_ptr<sdk::logs::Recordable> rec3 = std::make_unique<OtlpLogRecordable>();
   auto inst_lib3 =
       opentelemetry::sdk::instrumentationscope::InstrumentationScope::Create("three", "3");
   rec3->SetResource(resource2);
@@ -347,12 +347,12 @@ TEST(OtlpLogRecordable, PopulateRequest)
 TEST(OtlpLogRecordable, PopulateRequestMissing)
 {
   // Missing scope (no SetInstrumentationScope call)
-  auto rec1      = std::unique_ptr<sdk::logs::Recordable>(new OtlpLogRecordable);
+  std::unique_ptr<sdk::logs::Recordable> rec1 = std::make_unique<OtlpLogRecordable>();
   auto resource1 = resource::Resource::Create({{"service.name", "one"}});
   rec1->SetResource(resource1);
 
   // Missing resource (no SetResource call)
-  auto rec2 = std::unique_ptr<sdk::logs::Recordable>(new OtlpLogRecordable);
+  std::unique_ptr<sdk::logs::Recordable> rec2 = std::make_unique<OtlpLogRecordable>();
   auto inst_lib2 =
       opentelemetry::sdk::instrumentationscope::InstrumentationScope::Create("two", "2");
   rec2->SetInstrumentationScope(*inst_lib2);
@@ -375,7 +375,7 @@ TEST(OtlpLogRecordable, PopulateRequestMissing)
 // Test logs PopulateRequest ignores a null request pointer
 TEST(OtlpLogRecordable, PopulateRequestNullRequest)
 {
-  auto rec1      = std::unique_ptr<sdk::logs::Recordable>(new OtlpLogRecordable);
+  std::unique_ptr<sdk::logs::Recordable> rec1 = std::make_unique<OtlpLogRecordable>();
   auto resource1 = resource::Resource::Create({{"service.name", "one"}});
   rec1->SetResource(resource1);
 
@@ -398,11 +398,11 @@ TEST(OtlpLogRecordable, PopulateRequestSameScope)
   auto inst_lib_b =
       opentelemetry::sdk::instrumentationscope::InstrumentationScope::Create("lib", "1.0");
 
-  auto rec1 = std::unique_ptr<sdk::logs::Recordable>(new OtlpLogRecordable);
+  std::unique_ptr<sdk::logs::Recordable> rec1 = std::make_unique<OtlpLogRecordable>();
   rec1->SetResource(resource);
   rec1->SetInstrumentationScope(*inst_lib_a);
 
-  auto rec2 = std::unique_ptr<sdk::logs::Recordable>(new OtlpLogRecordable);
+  std::unique_ptr<sdk::logs::Recordable> rec2 = std::make_unique<OtlpLogRecordable>();
   rec2->SetResource(resource);
   rec2->SetInstrumentationScope(*inst_lib_b);
 

--- a/exporters/otlp/test/otlp_recordable_test.cc
+++ b/exporters/otlp/test/otlp_recordable_test.cc
@@ -452,21 +452,21 @@ TEST(OtlpRecordable, SetArrayAttribute)
 // Test otlp resource populate request util
 TEST(OtlpRecordable, PopulateRequest)
 {
-  auto rec1      = std::unique_ptr<sdk::trace::Recordable>(new OtlpRecordable);
+  std::unique_ptr<sdk::trace::Recordable> rec1 = std::make_unique<OtlpRecordable>();
   auto resource1 = resource::Resource::Create({{"service.name", "one"}});
   rec1->SetResource(resource1);
   auto inst_lib1 = trace_sdk::InstrumentationScope::Create("one", "1", "scope_schema",
                                                            {{"scope_key", "scope_value"}});
   rec1->SetInstrumentationScope(*inst_lib1);
 
-  auto rec2      = std::unique_ptr<sdk::trace::Recordable>(new OtlpRecordable);
+  std::unique_ptr<sdk::trace::Recordable> rec2 = std::make_unique<OtlpRecordable>();
   auto resource2 = resource::Resource::Create({{"service.name", "two"}});
   rec2->SetResource(resource2);
   auto inst_lib2 = trace_sdk::InstrumentationScope::Create("two", "2");
   rec2->SetInstrumentationScope(*inst_lib2);
 
   // This has the same resource as rec2, but a different scope
-  auto rec3 = std::unique_ptr<sdk::trace::Recordable>(new OtlpRecordable);
+  std::unique_ptr<sdk::trace::Recordable> rec3 = std::make_unique<OtlpRecordable>();
   rec3->SetResource(resource2);
   auto inst_lib3 = trace_sdk::InstrumentationScope::Create("three", "3");
   rec3->SetInstrumentationScope(*inst_lib3);
@@ -511,12 +511,12 @@ TEST(OtlpRecordable, PopulateRequest)
 TEST(OtlpRecordable, PopulateRequestMissing)
 {
   // Missing scope
-  auto rec1      = std::unique_ptr<sdk::trace::Recordable>(new OtlpRecordable);
+  std::unique_ptr<sdk::trace::Recordable> rec1 = std::make_unique<OtlpRecordable>();
   auto resource1 = resource::Resource::Create({{"service.name", "one"}});
   rec1->SetResource(resource1);
 
   // Missing resource
-  auto rec2      = std::unique_ptr<sdk::trace::Recordable>(new OtlpRecordable);
+  std::unique_ptr<sdk::trace::Recordable> rec2 = std::make_unique<OtlpRecordable>();
   auto inst_lib2 = trace_sdk::InstrumentationScope::Create("two", "2");
   rec2->SetInstrumentationScope(*inst_lib2);
 


### PR DESCRIPTION
Fixes #4168

## Changes

+ Replace all new operator usage for creating unique_ptr in  OTLP with `std::make_unique` for better safety and style conformance.
+ I'm no longer employed by Tencent. This PR removes the organization information from the approvers list. I'll continue to contribute to this repository in my personal free time.

For significant contributions please make sure you have completed the following items:

* [ ] `CHANGELOG.md` updated for non-trivial changes
* [x] Unit tests have been added
* [x] Changes in public API reviewed