### PR TITLE
[CMAKE] Upgrade curl to 8.21.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,7 +58,7 @@ jobs:
     runs-on: ubuntu-24.04
     env:
       CXX_STANDARD: '17'
-      CMAKE_VERSION: '3.16.0'
+      CMAKE_VERSION: '3.18.0' # CMake version 3.18+ is required by curl 8.21.0+
       BUILD_TYPE: 'Release'
     steps:
     - name: Harden the runner (Audit all outbound calls)

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -23,7 +23,8 @@ You can link OpenTelemetry C++ SDK with libraries provided in
   repository. To install Git, consult the [Set up
   Git](https://help.github.com/articles/set-up-git/) guide on GitHub.
 - [CMake](https://cmake.org/) for building opentelemetry-cpp API, SDK with their
-  unittests. The minimum CMake version is 3.16 (3.18+ is recommended to support FetchContent with the latest dependencies).
+  unittests. The minimum CMake version is 3.16 (3.18+ is recommended to support
+  FetchContent with the latest dependencies).
   To install CMake,
   consult the [Installing CMake](https://cmake.org/install/) guide.
 - [GoogleTest](https://github.com/google/googletest) framework to build and run

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -23,7 +23,7 @@ You can link OpenTelemetry C++ SDK with libraries provided in
   repository. To install Git, consult the [Set up
   Git](https://help.github.com/articles/set-up-git/) guide on GitHub.
 - [CMake](https://cmake.org/) for building opentelemetry-cpp API, SDK with their
-  unittests. The minimum CMake version is 3.16.
+  unittests. The minimum CMake version is 3.16 (3.18+ is recommended to support FetchContent with the latest dependencies).
   To install CMake,
   consult the [Installing CMake](https://cmake.org/install/) guide.
 - [GoogleTest](https://github.com/google/googletest) framework to build and run

--- a/install/cmake/third_party_latest
+++ b/install/cmake/third_party_latest
@@ -6,7 +6,7 @@
 
 abseil=20250512.1
 zlib=v1.3.2
-curl=curl-8_19_0
+curl=curl-8_21_0
 protobuf=v33.6
 grpc=v1.81.1
 benchmark=v1.9.4

--- a/install/test/cmake/fetch_content_test/CMakeLists.txt
+++ b/install/test/cmake/fetch_content_test/CMakeLists.txt
@@ -4,7 +4,8 @@
 # This test uses CMake's FetchContent module to build opentelemetry-cpp from src
 # and make its targets available within an external project.
 
-cmake_minimum_required(VERSION 3.16)
+# CMake 3.18+ is required to build curl 8.21.0+
+cmake_minimum_required(VERSION 3.18)
 
 project(opentelemetry-cpp-fetch-content-test LANGUAGES CXX)
 

--- a/third_party_release
+++ b/third_party_release
@@ -15,7 +15,7 @@
 
 abseil=20250512.1
 zlib=v1.3.2
-curl=curl-8_19_0
+curl=curl-8_21_0
 protobuf=v33.6
 grpc=v1.81.1
 benchmark=v1.9.4


### PR DESCRIPTION
Contributes to #4163 

## Changes

- upgrade curl to [8.21.0](https://github.com/curl/curl/releases/tag/curl-8_21_0)
- curl 8.21.0 has a cmake minimum of 3.18 and the otel-cpp minimum is 3.16. This only impacts the FetchContent (and add_subdirectory) use case. Many other dependencies are still at 3.16 (grpc, protobuf, googletest) so bumping the project CMake minimum is not appropriate right now. Instead this PR: 

  - Updates the FetchContent test is updated to install CMake 3.18 
  - Updates the INSTALL.md guide accordingly. 
  
  
For significant contributions please make sure you have completed the following items:

* [ ] `CHANGELOG.md` updated for non-trivial changes
* [ ] Unit tests have been added
* [ ] Changes in public API reviewed