### PR TITLE
[CODE HEALTH] Move trace and baggage propagation test classes into anonymous namespace

### DIFF
--- a/.github/workflows/clang-tidy.yaml
+++ b/.github/workflows/clang-tidy.yaml
@@ -17,9 +17,9 @@ jobs:
       matrix:
         include:
           - cmake_options: all-options-abiv1-preview
-            warning_limit: 328
+            warning_limit: 324
           - cmake_options: all-options-abiv2-preview
-            warning_limit: 338
+            warning_limit: 334
     env:
       CC: /usr/bin/clang-22
       CXX: /usr/bin/clang++-22

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -116,6 +116,9 @@ Increment the:
 * [CONFIGURATION] Apply default sampler when none is specified
   [#4170](https://github.com/open-telemetry/opentelemetry-cpp/pull/4170)
 
+* [CODE HEALTH] Move trace and baggage propagation test classes into anonymous namespace
+  [#XXXX](https://github.com/open-telemetry/opentelemetry-cpp/pull/XXXX)
+
 ## [1.27.0] 2026-05-13
 
 * [RELEASE] Bump main branch to 1.27.0-dev

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -117,7 +117,7 @@ Increment the:
   [#4170](https://github.com/open-telemetry/opentelemetry-cpp/pull/4170)
 
 * [CODE HEALTH] Move trace and baggage propagation test classes into anonymous namespace
-  [#XXXX](https://github.com/open-telemetry/opentelemetry-cpp/pull/XXXX)
+  [#4199](https://github.com/open-telemetry/opentelemetry-cpp/pull/4199)
 
 ## [1.27.0] 2026-05-13
 

--- a/api/test/baggage/propagation/baggage_propagator_test.cc
+++ b/api/test/baggage/propagation/baggage_propagator_test.cc
@@ -20,6 +20,9 @@
 using namespace opentelemetry;
 using namespace opentelemetry::baggage::propagation;
 
+namespace
+{
+
 class BaggageCarrierTest : public context::propagation::TextMapCarrier
 {
 public:
@@ -120,3 +123,5 @@ TEST(BaggagePropagatorTest, InjectEmptyHeader)
     EXPECT_EQ(carrier.headers_.find(baggage::kBaggageHeader), carrier.headers_.end());
   }
 }
+
+}  // namespace

--- a/api/test/trace/propagation/b3_propagation_test.cc
+++ b/api/test/trace/propagation/b3_propagation_test.cc
@@ -27,6 +27,9 @@
 
 using namespace opentelemetry;
 
+namespace
+{
+
 class TextMapCarrierTest : public context::propagation::TextMapCarrier
 {
 public:
@@ -219,3 +222,5 @@ TEST(B3PropagationTest, GetCurrentSpanMultiHeader)
   EXPECT_EQ(carrier.headers_["X-B3-SpanId"], "0102030405060708");
   EXPECT_EQ(carrier.headers_["X-B3-Sampled"], "1");
 }
+
+}  // namespace

--- a/api/test/trace/propagation/http_text_format_test.cc
+++ b/api/test/trace/propagation/http_text_format_test.cc
@@ -32,6 +32,9 @@
 
 using namespace opentelemetry;
 
+namespace
+{
+
 class TextMapCarrierTest : public context::propagation::TextMapCarrier
 {
 public:
@@ -266,3 +269,5 @@ TEST(GlobalPropagator, SetAndGet)
   EXPECT_EQ(fields[0], trace::propagation::kTraceParent);
   EXPECT_EQ(fields[1], trace::propagation::kTraceState);
 }
+
+}  // namespace

--- a/api/test/trace/propagation/jaeger_propagation_test.cc
+++ b/api/test/trace/propagation/jaeger_propagation_test.cc
@@ -30,6 +30,9 @@
 
 using namespace opentelemetry;
 
+namespace
+{
+
 class TextMapCarrierTest : public context::propagation::TextMapCarrier
 {
 public:
@@ -204,3 +207,5 @@ TEST(JaegerPropagatorTest, DoNotInjectInvalidContext)
   format.Inject(carrier, ctx);
   EXPECT_TRUE(carrier.headers_.count("uber-trace-id") == 0);
 }
+
+}  // namespace


### PR DESCRIPTION
Moves the `TextMapCarrierTest` helper in the b3, http_text_format and jaeger trace propagation tests, and `BaggageCarrierTest` in the baggage propagation test, into anonymous namespaces, resolving their `misc-use-internal-linkage` clang-tidy warnings. Test-only, no behavior change.

Lowered the clang-tidy `warning_limit` by 4 for both ABI presets accordingly.

Part of #4196.
