### PR TITLE
[CODE HEALTH] Move context propagation test classes into anonymous namespace

### DIFF
--- a/.github/workflows/clang-tidy.yaml
+++ b/.github/workflows/clang-tidy.yaml
@@ -17,9 +17,9 @@ jobs:
       matrix:
         include:
           - cmake_options: all-options-abiv1-preview
-            warning_limit: 328
+            warning_limit: 325
           - cmake_options: all-options-abiv2-preview
-            warning_limit: 338
+            warning_limit: 335
     env:
       CC: /usr/bin/clang-22
       CXX: /usr/bin/clang++-22

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -117,7 +117,7 @@ Increment the:
   [#4170](https://github.com/open-telemetry/opentelemetry-cpp/pull/4170)
 
 * [CODE HEALTH] Move context propagation test classes into anonymous namespace
-  [#XXXX](https://github.com/open-telemetry/opentelemetry-cpp/pull/XXXX)
+  [#4200](https://github.com/open-telemetry/opentelemetry-cpp/pull/4200)
 
 ## [1.27.0] 2026-05-13
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -116,6 +116,9 @@ Increment the:
 * [CONFIGURATION] Apply default sampler when none is specified
   [#4170](https://github.com/open-telemetry/opentelemetry-cpp/pull/4170)
 
+* [CODE HEALTH] Move context propagation test classes into anonymous namespace
+  [#XXXX](https://github.com/open-telemetry/opentelemetry-cpp/pull/XXXX)
+
 ## [1.27.0] 2026-05-13
 
 * [RELEASE] Bump main branch to 1.27.0-dev

--- a/api/test/context/propagation/composite_propagator_test.cc
+++ b/api/test/context/propagation/composite_propagator_test.cc
@@ -38,6 +38,9 @@ static std::string Hex(const T &id_item)
   return std::string(buf, sizeof(buf));
 }
 
+namespace
+{
+
 class TextMapCarrierTest : public context::propagation::TextMapCarrier
 {
 public:
@@ -147,3 +150,5 @@ TEST_F(CompositePropagatorTest, Inject)
   EXPECT_EQ(fields[1], trace::propagation::kTraceState);
   EXPECT_EQ(fields[2], trace::propagation::kB3CombinedHeader);
 }
+
+}  // namespace

--- a/api/test/context/propagation/environment_carrier_test.cc
+++ b/api/test/context/propagation/environment_carrier_test.cc
@@ -56,6 +56,9 @@ static std::string Hex(const T &id_item)
   return std::string(buf, sizeof(buf));
 }
 
+namespace
+{
+
 class EnvironmentCarrierTest : public ::testing::Test
 {
 protected:
@@ -306,3 +309,5 @@ TEST_F(EnvironmentCarrierTest, RoundTrip)
   EXPECT_EQ(extracted_span->GetContext().IsSampled(), span_context.IsSampled());
   EXPECT_TRUE(extracted_span->GetContext().IsRemote());
 }
+
+}  // namespace


### PR DESCRIPTION
Moves the `TextMapCarrierTest`, `CompositePropagatorTest` and `EnvironmentCarrierTest` classes in the context propagation tests into an anonymous namespace, resolving their `misc-use-internal-linkage` clang-tidy warnings. Test-only, no behavior change.

Lowered the clang-tidy `warning_limit` by 3 for both ABI presets accordingly.

Part of #4196.
