### PR TITLE
[CODE HEALTH] Fix clang-tidy bugprone-unused-local-non-trivial-variable warnings

### DIFF
--- a/.github/workflows/clang-tidy.yaml
+++ b/.github/workflows/clang-tidy.yaml
@@ -17,9 +17,9 @@ jobs:
       matrix:
         include:
           - cmake_options: all-options-abiv1-preview
-            warning_limit: 324
+            warning_limit: 312
           - cmake_options: all-options-abiv2-preview
-            warning_limit: 334
+            warning_limit: 322
     env:
       CC: /usr/bin/clang-22
       CXX: /usr/bin/clang++-22

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -128,6 +128,9 @@ Increment the:
 * [CODE HEALTH] Move trace and baggage propagation test classes into anonymous namespace
   [#4199](https://github.com/open-telemetry/opentelemetry-cpp/pull/4199)
 
+* [CODE HEALTH] Fix clang-tidy bugprone-unused-local-non-trivial-variable warnings
+  [#4202](https://github.com/open-telemetry/opentelemetry-cpp/pull/4202)
+
 ## [1.27.0] 2026-05-13
 
 * [RELEASE] Bump main branch to 1.27.0-dev

--- a/api/test/baggage/baggage_benchmark.cc
+++ b/api/test/baggage/baggage_benchmark.cc
@@ -102,7 +102,7 @@ void BM_BaggageToHeaderTenEntries(benchmark::State &state)
   auto baggage = Baggage::FromHeader(header_with_custom_entries(kNumEntries));
   while (state.KeepRunning())
   {
-    auto new_baggage = baggage->ToHeader();
+    benchmark::DoNotOptimize(baggage->ToHeader());
   }
 }
 BENCHMARK(BM_BaggageToHeaderTenEntries);
@@ -112,7 +112,7 @@ void BM_BaggageToHeader180Entries(benchmark::State &state)
   auto baggage = Baggage::FromHeader(header_with_custom_entries(Baggage::kMaxKeyValuePairs));
   while (state.KeepRunning())
   {
-    auto new_baggage = baggage->ToHeader();
+    benchmark::DoNotOptimize(baggage->ToHeader());
   }
 }
 BENCHMARK(BM_BaggageToHeader180Entries);

--- a/examples/otlp/file_metric_main.cc
+++ b/examples/otlp/file_metric_main.cc
@@ -40,9 +40,6 @@ void InitMetrics()
 {
   auto exporter = otlp_exporter::OtlpFileMetricExporterFactory::Create(exporter_options);
 
-  std::string version{"1.2.0"};
-  std::string schema{"https://opentelemetry.io/schemas/1.2.0"};
-
   // Initialize and set the global MeterProvider
   metrics_sdk::PeriodicExportingMetricReaderOptions reader_options;
   reader_options.export_interval_millis = std::chrono::milliseconds(1000);

--- a/examples/otlp/http_instrumented_main.cc
+++ b/examples/otlp/http_instrumented_main.cc
@@ -217,9 +217,6 @@ void InitMetrics()
   auto exporter =
       opentelemetry::exporter::otlp::OtlpHttpMetricExporterFactory::Create(meter_opts, exp_rt_opts);
 
-  std::string version{"1.2.0"};
-  std::string schema{"https://opentelemetry.io/schemas/1.2.0"};
-
   // Initialize and set the global MeterProvider
   opentelemetry::sdk::metrics::PeriodicExportingMetricReaderOptions reader_options;
   reader_options.export_interval_millis = std::chrono::milliseconds(1000);

--- a/examples/otlp/http_metric_main.cc
+++ b/examples/otlp/http_metric_main.cc
@@ -43,9 +43,6 @@ void InitMetrics()
 {
   auto exporter = otlp_exporter::OtlpHttpMetricExporterFactory::Create(exporter_options);
 
-  std::string version{"1.2.0"};
-  std::string schema{"https://opentelemetry.io/schemas/1.2.0"};
-
   // Initialize and set the global MeterProvider
   metrics_sdk::PeriodicExportingMetricReaderOptions reader_options;
   reader_options.export_interval_millis = std::chrono::milliseconds(1000);

--- a/exporters/otlp/test/otlp_file_client_test.cc
+++ b/exporters/otlp/test/otlp_file_client_test.cc
@@ -267,8 +267,6 @@ TEST(OtlpFileClientTest, ExportToFileSystemRotateIndexTest)
   opentelemetry::proto::collector::trace::v1::ExportTraceServiceRequest request;
   OtlpRecordableUtils::PopulateRequest(MakeSpan(recordable), &request);
 
-  std::stringstream output_stream;
-
   // Clear old files
   {
     std::fstream clear_file1("otlp_file_client_test_dir/trace-1.jsonl",
@@ -397,8 +395,6 @@ TEST(OtlpFileClientTest, ExportToFileSystemRotateByTimeTest)
 
   opentelemetry::proto::collector::trace::v1::ExportTraceServiceRequest request;
   OtlpRecordableUtils::PopulateRequest(MakeSpan(recordable), &request);
-
-  std::stringstream output_stream;
 
   opentelemetry::exporter::otlp::OtlpFileClientFileSystemOptions backend_opts;
   backend_opts.file_pattern  = "otlp_file_client_test_dir/trace-%Y-%m-%d-%H-%M-%S.jsonl";

--- a/exporters/prometheus/src/exporter_utils.cc
+++ b/exporters/prometheus/src/exporter_utils.cc
@@ -143,8 +143,6 @@ std::vector<prometheus_client::MetricFamily> PrometheusExporterUtils::TranslateT
   {
     for (const auto &metric_data : instrumentation_info.metric_data_)
     {
-      auto origin_name = metric_data.instrument_descriptor.name_;
-      auto unit        = metric_data.instrument_descriptor.unit_;
       prometheus_client::MetricFamily metric_family;
       metric_family.help = metric_data.instrument_descriptor.description_;
       auto front         = metric_data.point_data_attr_.front();


### PR DESCRIPTION
Resolves the `bugprone-unused-local-non-trivial-variable` warnings tracked in #4198 (part of #2053). 12 warnings across 6 files.

- `exporters/prometheus/src/exporter_utils.cc`: removed two dead local copies (`origin_name`, `unit`); the loop already uses `instrument_descriptor.name_` / `.unit_` directly.
- `api/test/baggage/baggage_benchmark.cc`: the two `ToHeader()` results are the benchmarked work but were unused; wrapped them in `benchmark::DoNotOptimize(...)` so the calls are not optimized away and the locals are no longer flagged.
- `examples/otlp/{file_metric,http_instrumented,http_metric}_main.cc`: removed unused `version` / `schema` locals.
- `exporters/otlp/test/otlp_file_client_test.cc`: removed two unused `output_stream` locals in the file-rotation tests (the ostream test keeps its own).

Ratchet lowered 328 -> 316 (abiv1-preview) and 338 -> 326 (abiv2-preview).

Verified locally: IWYU (all-options-abiv1-preview) clean, clang-format fixed point; the 12 warnings are the complete set for this check per the main clang-tidy CI report.

Fixes #4198
