### PR TITLE
[CODE HEALTH] Fix clang-tidy `bugprone-throwing-static-initialization` warnings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -153,6 +153,9 @@ Increment the:
 * [CODE HEALTH] Fix clang-tidy misc-override-with-different-visibility warnings
   [#4215](https://github.com/open-telemetry/opentelemetry-cpp/pull/4215)
 
+* [CODE HEALTH] Fix clang-tidy `bugprone-throwing-static-initialization` warnings
+  [#4206](https://github.com/open-telemetry/opentelemetry-cpp/pull/4206)
+
 ## [1.27.0] 2026-05-13
 
 * [RELEASE] Bump main branch to 1.27.0-dev

--- a/api/include/opentelemetry/baggage/baggage_context.h
+++ b/api/include/opentelemetry/baggage/baggage_context.h
@@ -6,7 +6,6 @@
 #include "opentelemetry/baggage/baggage.h"
 #include "opentelemetry/context/context.h"
 #include "opentelemetry/nostd/shared_ptr.h"
-#include "opentelemetry/nostd/string_view.h"
 #include "opentelemetry/version.h"
 
 OPENTELEMETRY_BEGIN_NAMESPACE
@@ -14,7 +13,7 @@ OPENTELEMETRY_BEGIN_NAMESPACE
 namespace baggage
 {
 
-static const nostd::string_view kBaggageHeader = "baggage";
+constexpr char kBaggageHeader[] = "baggage";
 
 inline nostd::shared_ptr<Baggage> GetBaggage(const context::Context &context) noexcept
 {

--- a/api/include/opentelemetry/baggage/baggage_context.h
+++ b/api/include/opentelemetry/baggage/baggage_context.h
@@ -6,6 +6,7 @@
 #include "opentelemetry/baggage/baggage.h"
 #include "opentelemetry/context/context.h"
 #include "opentelemetry/nostd/shared_ptr.h"
+#include "opentelemetry/nostd/string_view.h"
 #include "opentelemetry/version.h"
 
 OPENTELEMETRY_BEGIN_NAMESPACE
@@ -13,7 +14,7 @@ OPENTELEMETRY_BEGIN_NAMESPACE
 namespace baggage
 {
 
-static const std::string kBaggageHeader = "baggage";
+static const nostd::string_view kBaggageHeader = "baggage";
 
 inline nostd::shared_ptr<Baggage> GetBaggage(const context::Context &context) noexcept
 {

--- a/api/include/opentelemetry/common/key_value_iterable_view.h
+++ b/api/include/opentelemetry/common/key_value_iterable_view.h
@@ -39,7 +39,8 @@ std::false_type is_key_value_iterable_impl(...);
 template <class T>
 struct is_key_value_iterable
 {
-  static const bool value = decltype(detail::is_key_value_iterable_impl(std::declval<T>()))::value;
+  static constexpr bool value =
+      decltype(detail::is_key_value_iterable_impl(std::declval<T>()))::value;
 };
 }  // namespace detail
 

--- a/api/include/opentelemetry/trace/span_context_kv_iterable_view.h
+++ b/api/include/opentelemetry/trace/span_context_kv_iterable_view.h
@@ -48,7 +48,7 @@ std::false_type is_span_context_kv_iterable_impl(...);
 template <class T>
 struct is_span_context_kv_iterable
 {
-  static const bool value =
+  static constexpr bool value =
       decltype(detail::is_span_context_kv_iterable_impl(std::declval<T>()))::value;
 };
 }  // namespace detail

--- a/api/test/baggage/propagation/baggage_propagator_test.cc
+++ b/api/test/baggage/propagation/baggage_propagator_test.cc
@@ -77,13 +77,13 @@ TEST(BaggagePropagatorTest, ExtractAndInjectBaggage)
   for (const auto &baggage : baggages)
   {
     BaggageCarrierTest carrier1;
-    carrier1.headers_[baggage::kBaggageHeader.data()] = baggage.first;
-    context::Context ctx1                             = context::Context{};
-    context::Context ctx2                             = format.Extract(carrier1, ctx1);
+    carrier1.headers_[baggage::kBaggageHeader] = baggage.first;
+    context::Context ctx1                      = context::Context{};
+    context::Context ctx2                      = format.Extract(carrier1, ctx1);
 
     BaggageCarrierTest carrier2;
     format.Inject(carrier2, ctx2);
-    EXPECT_EQ(carrier2.headers_[baggage::kBaggageHeader.data()], baggage.second);
+    EXPECT_EQ(carrier2.headers_[baggage::kBaggageHeader], baggage.second);
 
     std::vector<std::string> fields;
     format.Fields([&fields](nostd::string_view field) {
@@ -91,7 +91,7 @@ TEST(BaggagePropagatorTest, ExtractAndInjectBaggage)
       return true;
     });
     EXPECT_EQ(fields.size(), 1);
-    EXPECT_EQ(fields[0], baggage::kBaggageHeader.data());
+    EXPECT_EQ(fields[0], baggage::kBaggageHeader);
   }
 }
 
@@ -101,26 +101,26 @@ TEST(BaggagePropagatorTest, InjectEmptyHeader)
   BaggageCarrierTest carrier;
   context::Context ctx = context::Context{};
   format.Inject(carrier, ctx);
-  EXPECT_EQ(carrier.headers_.find(std::string(baggage::kBaggageHeader)), carrier.headers_.end());
+  EXPECT_EQ(carrier.headers_.find(baggage::kBaggageHeader), carrier.headers_.end());
 
   {
     // Test empty baggage in context
     BaggageCarrierTest carrier1;
-    carrier1.headers_[baggage::kBaggageHeader.data()] = "";
-    context::Context ctx1                             = context::Context{};
-    context::Context ctx2                             = format.Extract(carrier1, ctx1);
+    carrier1.headers_[baggage::kBaggageHeader] = "";
+    context::Context ctx1                      = context::Context{};
+    context::Context ctx2                      = format.Extract(carrier1, ctx1);
     format.Inject(carrier, ctx2);
-    EXPECT_EQ(carrier.headers_.find(std::string(baggage::kBaggageHeader)), carrier.headers_.end());
+    EXPECT_EQ(carrier.headers_.find(baggage::kBaggageHeader), carrier.headers_.end());
   }
   {
     // Invalid baggage in context
     BaggageCarrierTest carrier1;
-    carrier1.headers_[baggage::kBaggageHeader.data()] = "InvalidBaggageData";
-    context::Context ctx1                             = context::Context{};
-    context::Context ctx2                             = format.Extract(carrier1, ctx1);
+    carrier1.headers_[baggage::kBaggageHeader] = "InvalidBaggageData";
+    context::Context ctx1                      = context::Context{};
+    context::Context ctx2                      = format.Extract(carrier1, ctx1);
 
     format.Inject(carrier, ctx2);
-    EXPECT_EQ(carrier.headers_.find(std::string(baggage::kBaggageHeader)), carrier.headers_.end());
+    EXPECT_EQ(carrier.headers_.find(baggage::kBaggageHeader), carrier.headers_.end());
   }
 }
 

--- a/api/test/baggage/propagation/baggage_propagator_test.cc
+++ b/api/test/baggage/propagation/baggage_propagator_test.cc
@@ -101,7 +101,7 @@ TEST(BaggagePropagatorTest, InjectEmptyHeader)
   BaggageCarrierTest carrier;
   context::Context ctx = context::Context{};
   format.Inject(carrier, ctx);
-  EXPECT_EQ(carrier.headers_.find(baggage::kBaggageHeader), carrier.headers_.end());
+  EXPECT_EQ(carrier.headers_.find(std::string(baggage::kBaggageHeader)), carrier.headers_.end());
 
   {
     // Test empty baggage in context
@@ -110,7 +110,7 @@ TEST(BaggagePropagatorTest, InjectEmptyHeader)
     context::Context ctx1                             = context::Context{};
     context::Context ctx2                             = format.Extract(carrier1, ctx1);
     format.Inject(carrier, ctx2);
-    EXPECT_EQ(carrier.headers_.find(baggage::kBaggageHeader), carrier.headers_.end());
+    EXPECT_EQ(carrier.headers_.find(std::string(baggage::kBaggageHeader)), carrier.headers_.end());
   }
   {
     // Invalid baggage in context
@@ -120,7 +120,7 @@ TEST(BaggagePropagatorTest, InjectEmptyHeader)
     context::Context ctx2                             = format.Extract(carrier1, ctx1);
 
     format.Inject(carrier, ctx2);
-    EXPECT_EQ(carrier.headers_.find(baggage::kBaggageHeader), carrier.headers_.end());
+    EXPECT_EQ(carrier.headers_.find(std::string(baggage::kBaggageHeader)), carrier.headers_.end());
   }
 }
 

--- a/examples/configuration/main.cc
+++ b/examples/configuration/main.cc
@@ -54,10 +54,10 @@
 #  include "opentelemetry/exporters/prometheus/prometheus_pull_builder.h"
 #endif
 
-static bool opt_help              = false;
-static bool opt_debug             = false;
-static bool opt_test              = false;
-static bool opt_no_registry       = false;
+static bool opt_help        = false;
+static bool opt_debug       = false;
+static bool opt_test        = false;
+static bool opt_no_registry = false;
 static std::string yaml_file_path;
 
 static std::unique_ptr<opentelemetry::sdk::configuration::ConfiguredSdk> sdk;

--- a/examples/configuration/main.cc
+++ b/examples/configuration/main.cc
@@ -58,7 +58,7 @@ static bool opt_help              = false;
 static bool opt_debug             = false;
 static bool opt_test              = false;
 static bool opt_no_registry       = false;
-static std::string yaml_file_path = "";
+static std::string yaml_file_path;
 
 static std::unique_ptr<opentelemetry::sdk::configuration::ConfiguredSdk> sdk;
 

--- a/examples/otlp/file_log_main.cc
+++ b/examples/otlp/file_log_main.cc
@@ -41,13 +41,10 @@ namespace trace_sdk = opentelemetry::sdk::trace;
 
 namespace
 {
-opentelemetry::exporter::otlp::OtlpFileExporterOptions opts;
-opentelemetry::exporter::otlp::OtlpFileLogRecordExporterOptions log_opts;
-
 std::shared_ptr<opentelemetry::sdk::trace::TracerProvider> tracer_provider;
 std::shared_ptr<opentelemetry::sdk::logs::LoggerProvider> logger_provider;
 
-void InitTracer()
+void InitTracer(const otlp::OtlpFileExporterOptions &opts)
 {
   // Create OTLP exporter instance
   auto exporter   = otlp::OtlpFileExporterFactory::Create(opts);
@@ -72,7 +69,7 @@ void CleanupTracer()
   trace_sdk::Provider::SetTracerProvider(none);
 }
 
-void InitLogger()
+void InitLogger(const otlp::OtlpFileLogRecordExporterOptions &log_opts)
 {
   // Create OTLP exporter instance
   auto exporter   = otlp::OtlpFileLogRecordExporterFactory::Create(log_opts);
@@ -99,6 +96,8 @@ void CleanupLogger()
 
 int main(int argc, char *argv[])
 {
+  otlp::OtlpFileExporterOptions opts;
+  otlp::OtlpFileLogRecordExporterOptions log_opts;
   if (argc > 1)
   {
     opentelemetry::exporter::otlp::OtlpFileClientFileSystemOptions fs_backend;
@@ -119,8 +118,8 @@ int main(int argc, char *argv[])
   {
     opts.backend_options = std::ref(std::cout);
   }
-  InitLogger();
-  InitTracer();
+  InitLogger(log_opts);
+  InitTracer(opts);
   foo_library();
   CleanupTracer();
   CleanupLogger();

--- a/examples/otlp/file_main.cc
+++ b/examples/otlp/file_main.cc
@@ -27,11 +27,9 @@ namespace otlp      = opentelemetry::exporter::otlp;
 
 namespace
 {
-opentelemetry::exporter::otlp::OtlpFileExporterOptions opts;
-
 std::shared_ptr<opentelemetry::sdk::trace::TracerProvider> provider;
 
-void InitTracer()
+void InitTracer(const otlp::OtlpFileExporterOptions &opts)
 {
   // Create OTLP exporter instance
   auto exporter  = otlp::OtlpFileExporterFactory::Create(opts);
@@ -59,6 +57,7 @@ void CleanupTracer()
 
 int main(int argc, char *argv[])
 {
+  otlp::OtlpFileExporterOptions opts;
   if (argc > 1)
   {
     opentelemetry::exporter::otlp::OtlpFileClientFileSystemOptions fs_backend;
@@ -66,7 +65,7 @@ int main(int argc, char *argv[])
     opts.backend_options    = fs_backend;
   }
   // Removing this line will leave the default noop TracerProvider in place.
-  InitTracer();
+  InitTracer(opts);
 
   foo_library();
 

--- a/examples/otlp/file_metric_main.cc
+++ b/examples/otlp/file_metric_main.cc
@@ -34,9 +34,7 @@ namespace otlp_exporter = opentelemetry::exporter::otlp;
 namespace
 {
 
-otlp_exporter::OtlpFileMetricExporterOptions exporter_options;
-
-void InitMetrics()
+void InitMetrics(const otlp_exporter::OtlpFileMetricExporterOptions &exporter_options)
 {
   auto exporter = otlp_exporter::OtlpFileMetricExporterFactory::Create(exporter_options);
 
@@ -66,6 +64,7 @@ void CleanupMetrics()
 
 int main(int argc, char *argv[])
 {
+  otlp_exporter::OtlpFileMetricExporterOptions exporter_options;
   std::string example_type;
   if (argc > 1)
   {
@@ -78,7 +77,7 @@ int main(int argc, char *argv[])
     }
   }
   // Removing this line will leave the default noop MetricProvider in place.
-  InitMetrics();
+  InitMetrics(exporter_options);
   std::string name{"otlp_file_metric_example"};
 
   if (example_type == "counter")

--- a/examples/otlp/grpc_log_main.cc
+++ b/examples/otlp/grpc_log_main.cc
@@ -39,13 +39,11 @@ namespace trace_sdk = opentelemetry::sdk::trace;
 
 namespace
 {
-opentelemetry::exporter::otlp::OtlpGrpcExporterOptions opts;
-opentelemetry::exporter::otlp::OtlpGrpcLogRecordExporterOptions log_opts;
-
 std::shared_ptr<opentelemetry::sdk::trace::TracerProvider> tracer_provider;
 std::shared_ptr<opentelemetry::sdk::logs::LoggerProvider> logger_provider;
 
-void InitTracer(const std::shared_ptr<otlp::OtlpGrpcClient> &shared_client)
+void InitTracer(const otlp::OtlpGrpcExporterOptions &opts,
+                const std::shared_ptr<otlp::OtlpGrpcClient> &shared_client)
 {
   // Create OTLP exporter instance
   auto exporter   = otlp::OtlpGrpcExporterFactory::Create(opts, shared_client);
@@ -70,7 +68,8 @@ void CleanupTracer()
   trace_sdk::Provider::SetTracerProvider(none);
 }
 
-void InitLogger(const std::shared_ptr<otlp::OtlpGrpcClient> &shared_client)
+void InitLogger(const otlp::OtlpGrpcLogRecordExporterOptions &log_opts,
+                const std::shared_ptr<otlp::OtlpGrpcClient> &shared_client)
 {
   // Create OTLP exporter instance
   auto exporter   = otlp::OtlpGrpcLogRecordExporterFactory::Create(log_opts, shared_client);
@@ -98,6 +97,8 @@ void CleanupLogger()
 
 int main(int argc, char *argv[])
 {
+  otlp::OtlpGrpcExporterOptions opts;
+  otlp::OtlpGrpcLogRecordExporterOptions log_opts;
   if (argc > 1)
   {
     opts.endpoint     = argv[1];
@@ -113,8 +114,8 @@ int main(int argc, char *argv[])
 
   std::shared_ptr<otlp::OtlpGrpcClient> shared_client = otlp::OtlpGrpcClientFactory::Create(opts);
 
-  InitLogger(shared_client);
-  InitTracer(shared_client);
+  InitLogger(log_opts, shared_client);
+  InitTracer(opts, shared_client);
   foo_library();
   CleanupTracer();
   CleanupLogger();

--- a/examples/otlp/grpc_main.cc
+++ b/examples/otlp/grpc_main.cc
@@ -26,11 +26,9 @@ namespace otlp      = opentelemetry::exporter::otlp;
 
 namespace
 {
-opentelemetry::exporter::otlp::OtlpGrpcExporterOptions opts;
-
 std::shared_ptr<opentelemetry::sdk::trace::TracerProvider> provider;
 
-void InitTracer()
+void InitTracer(const otlp::OtlpGrpcExporterOptions &opts)
 {
   // Create OTLP exporter instance
   auto exporter  = otlp::OtlpGrpcExporterFactory::Create(opts);
@@ -58,6 +56,7 @@ void CleanupTracer()
 
 int main(int argc, char *argv[])
 {
+  otlp::OtlpGrpcExporterOptions opts;
   if (argc > 1)
   {
     opts.endpoint = argv[1];
@@ -68,7 +67,7 @@ int main(int argc, char *argv[])
     }
   }
   // Removing this line will leave the default noop TracerProvider in place.
-  InitTracer();
+  InitTracer(opts);
 
   foo_library();
 

--- a/examples/otlp/grpc_metric_main.cc
+++ b/examples/otlp/grpc_metric_main.cc
@@ -42,9 +42,8 @@ namespace otlp_exporter = opentelemetry::exporter::otlp;
 namespace
 {
 
-otlp_exporter::OtlpGrpcMetricExporterOptions exporter_options;
-
-void InitMetrics(std::string &name)
+void InitMetrics(const otlp_exporter::OtlpGrpcMetricExporterOptions &exporter_options,
+                 std::string &name)
 {
   auto exporter = otlp_exporter::OtlpGrpcMetricExporterFactory::Create(exporter_options);
 
@@ -100,6 +99,7 @@ void CleanupMetrics()
 
 int main(int argc, char *argv[])
 {
+  otlp_exporter::OtlpGrpcMetricExporterOptions exporter_options;
   std::string example_type;
   if (argc > 1)
   {
@@ -123,7 +123,7 @@ int main(int argc, char *argv[])
 
   std::string name{"otlp_grpc_metric_example"};
 
-  InitMetrics(name);
+  InitMetrics(exporter_options, name);
 
   if (example_type == "counter")
   {

--- a/examples/otlp/http_instrumented_main.cc
+++ b/examples/otlp/http_instrumented_main.cc
@@ -152,15 +152,11 @@ private:
 
 #endif /* ENABLE_THREAD_INSTRUMENTATION_PREVIEW */
 
-opentelemetry::exporter::otlp::OtlpHttpExporterOptions tracer_opts;
-opentelemetry::exporter::otlp::OtlpHttpMetricExporterOptions meter_opts;
-opentelemetry::exporter::otlp::OtlpHttpLogRecordExporterOptions logger_opts;
-
 std::shared_ptr<opentelemetry::sdk::trace::TracerProvider> tracer_provider;
 std::shared_ptr<opentelemetry::sdk::metrics::MeterProvider> meter_provider;
 std::shared_ptr<opentelemetry::sdk::logs::LoggerProvider> logger_provider;
 
-void InitTracer()
+void InitTracer(const opentelemetry::exporter::otlp::OtlpHttpExporterOptions &tracer_opts)
 {
   // Create OTLP exporter instance
   opentelemetry::exporter::otlp::OtlpHttpExporterRuntimeOptions exp_rt_opts;
@@ -205,7 +201,7 @@ void CleanupTracer()
   opentelemetry::sdk::trace::Provider::SetTracerProvider(none);
 }
 
-void InitMetrics()
+void InitMetrics(const opentelemetry::exporter::otlp::OtlpHttpMetricExporterOptions &meter_opts)
 {
   // Create OTLP exporter instance
   opentelemetry::exporter::otlp::OtlpHttpMetricExporterRuntimeOptions exp_rt_opts;
@@ -254,7 +250,7 @@ void CleanupMetrics()
   opentelemetry::sdk::metrics::Provider::SetMeterProvider(none);
 }
 
-void InitLogger()
+void InitLogger(const opentelemetry::exporter::otlp::OtlpHttpLogRecordExporterOptions &logger_opts)
 {
   // Create OTLP exporter instance
   opentelemetry::exporter::otlp::OtlpHttpLogRecordExporterRuntimeOptions exp_rt_opts;
@@ -306,6 +302,9 @@ void CleanupLogger()
 */
 int main(int argc, char *argv[])
 {
+  opentelemetry::exporter::otlp::OtlpHttpExporterOptions tracer_opts;
+  opentelemetry::exporter::otlp::OtlpHttpMetricExporterOptions meter_opts;
+  opentelemetry::exporter::otlp::OtlpHttpLogRecordExporterOptions logger_opts;
   if (argc > 1)
   {
     tracer_opts.url = argv[1];
@@ -335,9 +334,9 @@ int main(int argc, char *argv[])
 
   std::cout << "Initializing opentelemetry-cpp\n" << std::flush;
 
-  InitTracer();
-  InitMetrics();
-  InitLogger();
+  InitTracer(tracer_opts);
+  InitMetrics(meter_opts);
+  InitLogger(logger_opts);
 
   std::cout << "Application payload\n" << std::flush;
 

--- a/examples/otlp/http_log_main.cc
+++ b/examples/otlp/http_log_main.cc
@@ -44,11 +44,9 @@ namespace internal_log = opentelemetry::sdk::common::internal_log;
 namespace
 {
 
-opentelemetry::exporter::otlp::OtlpHttpExporterOptions trace_opts;
-
 std::shared_ptr<opentelemetry::sdk::trace::TracerProvider> tracer_provider;
 
-void InitTracer()
+void InitTracer(otlp::OtlpHttpExporterOptions &trace_opts)
 {
   if (trace_opts.url.size() > 9)
   {
@@ -90,11 +88,9 @@ void CleanupTracer()
   trace_sdk::Provider::SetTracerProvider(none);
 }
 
-opentelemetry::exporter::otlp::OtlpHttpLogRecordExporterOptions logger_opts;
-
 std::shared_ptr<opentelemetry::sdk::logs::LoggerProvider> logger_provider;
 
-void InitLogger()
+void InitLogger(otlp::OtlpHttpLogRecordExporterOptions &logger_opts)
 {
   std::cout << "Using " << logger_opts.url << " to export log records." << '\n';
   logger_opts.console_debug = true;
@@ -132,6 +128,8 @@ void CleanupLogger()
 */
 int main(int argc, char *argv[])
 {
+  otlp::OtlpHttpExporterOptions trace_opts;
+  otlp::OtlpHttpLogRecordExporterOptions logger_opts;
   if (argc > 1)
   {
     trace_opts.url  = argv[1];
@@ -158,8 +156,8 @@ int main(int argc, char *argv[])
     internal_log::GlobalLogHandler::SetLogLevel(internal_log::LogLevel::Debug);
   }
 
-  InitLogger();
-  InitTracer();
+  InitLogger(logger_opts);
+  InitTracer(trace_opts);
   foo_library();
   CleanupTracer();
   CleanupLogger();

--- a/examples/otlp/http_main.cc
+++ b/examples/otlp/http_main.cc
@@ -30,11 +30,9 @@ namespace internal_log = opentelemetry::sdk::common::internal_log;
 
 namespace
 {
-opentelemetry::exporter::otlp::OtlpHttpExporterOptions opts;
-
 std::shared_ptr<opentelemetry::sdk::trace::TracerProvider> provider;
 
-void InitTracer()
+void InitTracer(const otlp::OtlpHttpExporterOptions &opts)
 {
   // Create OTLP exporter instance
   auto exporter  = otlp::OtlpHttpExporterFactory::Create(opts);
@@ -70,6 +68,7 @@ void CleanupTracer()
 */
 int main(int argc, char *argv[])
 {
+  otlp::OtlpHttpExporterOptions opts;
   if (argc > 1)
   {
     opts.url = argv[1];
@@ -95,7 +94,7 @@ int main(int argc, char *argv[])
   }
 
   // Removing this line will leave the default noop TracerProvider in place.
-  InitTracer();
+  InitTracer(opts);
 
   foo_library();
 

--- a/examples/otlp/http_metric_main.cc
+++ b/examples/otlp/http_metric_main.cc
@@ -37,9 +37,7 @@ namespace internal_log = opentelemetry::sdk::common::internal_log;
 namespace
 {
 
-otlp_exporter::OtlpHttpMetricExporterOptions exporter_options;
-
-void InitMetrics()
+void InitMetrics(const otlp_exporter::OtlpHttpMetricExporterOptions &exporter_options)
 {
   auto exporter = otlp_exporter::OtlpHttpMetricExporterFactory::Create(exporter_options);
 
@@ -80,6 +78,7 @@ void CleanupMetrics()
 */
 int main(int argc, char *argv[])
 {
+  otlp_exporter::OtlpHttpMetricExporterOptions exporter_options;
   std::string example_type;
   if (argc > 1)
   {
@@ -112,7 +111,7 @@ int main(int argc, char *argv[])
   }
 
   // Removing this line will leave the default noop MetricProvider in place.
-  InitMetrics();
+  InitMetrics(exporter_options);
   std::string name{"otlp_http_metric_example"};
 
   if (example_type == "counter")

--- a/examples/zipkin/main.cc
+++ b/examples/zipkin/main.cc
@@ -28,8 +28,7 @@ namespace resource  = opentelemetry::sdk::resource;
 
 namespace
 {
-zipkin::ZipkinExporterOptions opts;
-void InitTracer()
+void InitTracer(const zipkin::ZipkinExporterOptions &opts)
 {
   // Create zipkin exporter instance
   resource::ResourceAttributes attributes = {{"service.name", "zipkin_demo_service"}};
@@ -51,12 +50,13 @@ void CleanupTracer()
 
 int main(int argc, char *argv[])
 {
+  zipkin::ZipkinExporterOptions opts;
   if (argc == 2)
   {
     opts.endpoint = argv[1];
   }
   // Removing this line will leave the default noop TracerProvider in place.
-  InitTracer();
+  InitTracer(opts);
 
   foo_library();
 

--- a/exporters/prometheus/src/exporter_utils.cc
+++ b/exporters/prometheus/src/exporter_utils.cc
@@ -288,14 +288,6 @@ std::string PrometheusExporterUtils::SanitizeNames(std::string name)
   return name;
 }
 
-#if OPENTELEMETRY_HAVE_WORKING_REGEX
-const std::regex INVALID_CHARACTERS_PATTERN("[^a-zA-Z0-9]");
-const std::regex CHARACTERS_BETWEEN_BRACES_PATTERN("\\{(.*?)\\}");
-const std::regex SANITIZE_LEADING_UNDERSCORES("^_+");
-const std::regex SANITIZE_TRAILING_UNDERSCORES("_+$");
-const std::regex SANITIZE_CONSECUTIVE_UNDERSCORES("[_]{2,}");
-#endif
-
 std::string PrometheusExporterUtils::GetEquivalentPrometheusUnit(
     const std::string &raw_metric_unit_name)
 {
@@ -371,6 +363,7 @@ std::string PrometheusExporterUtils::GetPrometheusPerUnit(const std::string &per
 std::string PrometheusExporterUtils::RemoveUnitPortionInBraces(const std::string &unit)
 {
 #if OPENTELEMETRY_HAVE_WORKING_REGEX
+  static const std::regex CHARACTERS_BETWEEN_BRACES_PATTERN("\\{(.*?)\\}");
   return std::regex_replace(unit, CHARACTERS_BETWEEN_BRACES_PATTERN, "");
 #else
   bool in_braces = false;
@@ -425,6 +418,10 @@ std::string PrometheusExporterUtils::ConvertRateExpressedToPrometheusUnit(
 std::string PrometheusExporterUtils::CleanUpString(const std::string &str)
 {
 #if OPENTELEMETRY_HAVE_WORKING_REGEX
+  static const std::regex INVALID_CHARACTERS_PATTERN("[^a-zA-Z0-9]");
+  static const std::regex SANITIZE_LEADING_UNDERSCORES("^_+");
+  static const std::regex SANITIZE_TRAILING_UNDERSCORES("_+$");
+  static const std::regex SANITIZE_CONSECUTIVE_UNDERSCORES("[_]{2,}");
   std::string cleaned_string = std::regex_replace(str, INVALID_CHARACTERS_PATTERN, "_");
   cleaned_string = std::regex_replace(cleaned_string, SANITIZE_CONSECUTIVE_UNDERSCORES, "_");
   cleaned_string = std::regex_replace(cleaned_string, SANITIZE_TRAILING_UNDERSCORES, "");

--- a/exporters/zipkin/src/recordable.cc
+++ b/exporters/zipkin/src/recordable.cc
@@ -39,14 +39,6 @@ namespace trace_api = opentelemetry::trace;
 namespace common    = opentelemetry::common;
 namespace sdk       = opentelemetry::sdk;
 
-// constexpr needs keys to be constexpr, const is next best to use.
-static const std::map<trace_api::SpanKind, std::string> kSpanKindMap = {
-    {trace_api::SpanKind::kClient, "CLIENT"},
-    {trace_api::SpanKind::kServer, "SERVER"},
-    {trace_api::SpanKind::kConsumer, "CONSUMER"},
-    {trace_api::SpanKind::kProducer, "PRODUCER"},
-};
-
 //
 // See `attribute_value.h` for details.
 //
@@ -262,6 +254,14 @@ void Recordable::SetDuration(std::chrono::nanoseconds duration) noexcept
 
 void Recordable::SetSpanKind(trace_api::SpanKind span_kind) noexcept
 {
+  // constexpr needs keys to be constexpr, const is next best to use.
+  static const std::map<trace_api::SpanKind, std::string> kSpanKindMap = {
+      {trace_api::SpanKind::kClient, "CLIENT"},
+      {trace_api::SpanKind::kServer, "SERVER"},
+      {trace_api::SpanKind::kConsumer, "CONSUMER"},
+      {trace_api::SpanKind::kProducer, "PRODUCER"},
+  };
+
   auto span_iter = kSpanKindMap.find(span_kind);
   if (span_iter != kSpanKindMap.end())
   {

--- a/exporters/zipkin/src/recordable.cc
+++ b/exporters/zipkin/src/recordable.cc
@@ -3,7 +3,6 @@
 
 #include <stdint.h>
 #include <chrono>
-#include <map>
 #include <string>
 #include <unordered_map>
 #include <utility>
@@ -254,18 +253,22 @@ void Recordable::SetDuration(std::chrono::nanoseconds duration) noexcept
 
 void Recordable::SetSpanKind(trace_api::SpanKind span_kind) noexcept
 {
-  // constexpr needs keys to be constexpr, const is next best to use.
-  static const std::map<trace_api::SpanKind, std::string> kSpanKindMap = {
-      {trace_api::SpanKind::kClient, "CLIENT"},
-      {trace_api::SpanKind::kServer, "SERVER"},
-      {trace_api::SpanKind::kConsumer, "CONSUMER"},
-      {trace_api::SpanKind::kProducer, "PRODUCER"},
-  };
-
-  auto span_iter = kSpanKindMap.find(span_kind);
-  if (span_iter != kSpanKindMap.end())
+  switch (span_kind)
   {
-    span_["kind"] = span_iter->second;
+    case trace_api::SpanKind::kClient:
+      span_["kind"] = "CLIENT";
+      break;
+    case trace_api::SpanKind::kServer:
+      span_["kind"] = "SERVER";
+      break;
+    case trace_api::SpanKind::kConsumer:
+      span_["kind"] = "CONSUMER";
+      break;
+    case trace_api::SpanKind::kProducer:
+      span_["kind"] = "PRODUCER";
+      break;
+    default:
+      break;
   }
 }
 

--- a/exporters/zipkin/src/recordable.cc
+++ b/exporters/zipkin/src/recordable.cc
@@ -5,7 +5,6 @@
 #include <chrono>
 #include <string>
 #include <unordered_map>
-#include <utility>
 
 #include "nlohmann/json.hpp"
 

--- a/ext/include/opentelemetry/ext/http/client/curl/http_operation_curl.h
+++ b/ext/include/opentelemetry/ext/http/client/curl/http_operation_curl.h
@@ -39,9 +39,9 @@ namespace client
 {
 namespace curl
 {
-const std::chrono::milliseconds kDefaultHttpConnTimeout(5000);  // ms
-const std::string kHttpStatusRegexp = "HTTP\\/\\d\\.\\d (\\d+)\\ .*";
-const std::string kHttpHeaderRegexp = "(.*)\\: (.*)\\n*";
+constexpr std::chrono::milliseconds kDefaultHttpConnTimeout{5000};  // ms
+constexpr const char *kHttpStatusRegexp = "HTTP\\/\\d\\.\\d (\\d+)\\ .*";
+constexpr const char *kHttpHeaderRegexp = "(.*)\\: (.*)\\n*";
 
 /**
  * Default max HTTP Response size.

--- a/functional/otlp/func_grpc_main.cc
+++ b/functional/otlp/func_grpc_main.cc
@@ -51,7 +51,7 @@ static bool opt_list   = false;
 static bool opt_debug  = false;
 static bool opt_secure = false;
 // HTTPS by default
-static std::string &opt_endpoint()
+static std::string &GetOptEndpoint()
 {
   static std::string endpoint = "https://127.0.0.1:4317";
   return endpoint;
@@ -268,7 +268,7 @@ static int parse_args(int argc, char *argv[])
       {
         remaining_argc--;
         remaining_argv++;
-        opt_endpoint() = *remaining_argv;
+        GetOptEndpoint() = *remaining_argv;
         remaining_argc--;
         remaining_argv++;
         continue;
@@ -416,7 +416,7 @@ int main(int argc, char *argv[])
     return 0;
   }
 
-  if (opt_endpoint().find("https:") != std::string::npos)
+  if (GetOptEndpoint().find("https:") != std::string::npos)
   {
     opt_secure = true;
   }
@@ -436,7 +436,7 @@ int main(int argc, char *argv[])
 
 static void set_common_opts(otlp::OtlpGrpcExporterOptions &opts)
 {
-  opts.endpoint            = opt_endpoint();
+  opts.endpoint            = GetOptEndpoint();
   opts.timeout             = std::chrono::milliseconds{100};
   opts.use_ssl_credentials = (opt_mode == TestMode::kHttps);
 

--- a/functional/otlp/func_grpc_main.cc
+++ b/functional/otlp/func_grpc_main.cc
@@ -51,11 +51,8 @@ static bool opt_list   = false;
 static bool opt_debug  = false;
 static bool opt_secure = false;
 // HTTPS by default
-static std::string &GetOptEndpoint()
-{
-  static std::string endpoint = "https://127.0.0.1:4317";
-  return endpoint;
-}
+constexpr char kDefaultOptEndpoint[] = "https://127.0.0.1:4317";
+static std::string opt_endpoint;
 static std::string opt_cert_dir;
 static std::string opt_test_name;
 static TestMode opt_mode = TestMode::kNone;
@@ -268,7 +265,7 @@ static int parse_args(int argc, char *argv[])
       {
         remaining_argc--;
         remaining_argv++;
-        GetOptEndpoint() = *remaining_argv;
+        opt_endpoint = *remaining_argv;
         remaining_argc--;
         remaining_argv++;
         continue;
@@ -322,7 +319,7 @@ typedef int (*test_func_t)();
 
 struct test_case
 {
-  const char *m_name;
+  nostd::string_view m_name;
   test_func_t m_func;
 };
 
@@ -396,6 +393,8 @@ int main(int argc, char *argv[])
   argc--;
   argv++;
 
+  opt_endpoint = kDefaultOptEndpoint;
+
   int rc = parse_args(argc, argv);
 
   if (rc != 0)
@@ -416,7 +415,7 @@ int main(int argc, char *argv[])
     return 0;
   }
 
-  if (GetOptEndpoint().find("https:") != std::string::npos)
+  if (opt_endpoint.find("https:") != std::string::npos)
   {
     opt_secure = true;
   }
@@ -436,7 +435,7 @@ int main(int argc, char *argv[])
 
 static void set_common_opts(otlp::OtlpGrpcExporterOptions &opts)
 {
-  opts.endpoint            = GetOptEndpoint();
+  opts.endpoint            = opt_endpoint;
   opts.timeout             = std::chrono::milliseconds{100};
   opts.use_ssl_credentials = (opt_mode == TestMode::kHttps);
 

--- a/functional/otlp/func_grpc_main.cc
+++ b/functional/otlp/func_grpc_main.cc
@@ -51,7 +51,11 @@ static bool opt_list   = false;
 static bool opt_debug  = false;
 static bool opt_secure = false;
 // HTTPS by default
-static std::string opt_endpoint = "https://127.0.0.1:4317";
+static std::string &opt_endpoint()
+{
+  static std::string endpoint = "https://127.0.0.1:4317";
+  return endpoint;
+}
 static std::string opt_cert_dir;
 static std::string opt_test_name;
 static TestMode opt_mode = TestMode::kNone;
@@ -264,7 +268,7 @@ static int parse_args(int argc, char *argv[])
       {
         remaining_argc--;
         remaining_argv++;
-        opt_endpoint = *remaining_argv;
+        opt_endpoint() = *remaining_argv;
         remaining_argc--;
         remaining_argv++;
         continue;
@@ -318,7 +322,7 @@ typedef int (*test_func_t)();
 
 struct test_case
 {
-  std::string m_name;
+  const char *m_name;
   test_func_t m_func;
 };
 
@@ -412,7 +416,7 @@ int main(int argc, char *argv[])
     return 0;
   }
 
-  if (opt_endpoint.find("https:") != std::string::npos)
+  if (opt_endpoint().find("https:") != std::string::npos)
   {
     opt_secure = true;
   }
@@ -432,7 +436,7 @@ int main(int argc, char *argv[])
 
 static void set_common_opts(otlp::OtlpGrpcExporterOptions &opts)
 {
-  opts.endpoint            = opt_endpoint;
+  opts.endpoint            = opt_endpoint();
   opts.timeout             = std::chrono::milliseconds{100};
   opts.use_ssl_credentials = (opt_mode == TestMode::kHttps);
 

--- a/functional/otlp/func_http_main.cc
+++ b/functional/otlp/func_http_main.cc
@@ -50,7 +50,11 @@ static bool opt_list   = false;
 static bool opt_debug  = false;
 static bool opt_secure = false;
 // HTTPS by default
-static std::string opt_endpoint = "https://localhost:4318/v1/traces";
+static std::string &opt_endpoint()
+{
+  static std::string endpoint = "https://localhost:4318/v1/traces";
+  return endpoint;
+}
 static std::string opt_cert_dir;
 static std::string opt_test_name;
 static test_mode opt_mode = MODE_NONE;
@@ -281,7 +285,7 @@ static int parse_args(int argc, char *argv[])
       {
         remaining_argc--;
         remaining_argv++;
-        opt_endpoint = *remaining_argv;
+        opt_endpoint() = *remaining_argv;
         remaining_argc--;
         remaining_argv++;
         continue;
@@ -335,7 +339,7 @@ typedef int (*test_func_t)();
 
 struct test_case
 {
-  std::string m_name;
+  const char *m_name;
   test_func_t m_func;
 };
 
@@ -482,7 +486,7 @@ int main(int argc, char *argv[])
     return 0;
   }
 
-  if (opt_endpoint.find("https:") != std::string::npos)
+  if (opt_endpoint().find("https:") != std::string::npos)
   {
     opt_secure = true;
   }
@@ -502,7 +506,7 @@ int main(int argc, char *argv[])
 
 static void set_common_opts(otlp::OtlpHttpExporterOptions &opts)
 {
-  opts.url = opt_endpoint;
+  opts.url = opt_endpoint();
 
   if (opt_debug)
   {

--- a/functional/otlp/func_http_main.cc
+++ b/functional/otlp/func_http_main.cc
@@ -50,11 +50,8 @@ static bool opt_list   = false;
 static bool opt_debug  = false;
 static bool opt_secure = false;
 // HTTPS by default
-static std::string &GetOptEndpoint()
-{
-  static std::string endpoint = "https://localhost:4318/v1/traces";
-  return endpoint;
-}
+constexpr char kDefaultOptEndpoint[] = "https://localhost:4318/v1/traces";
+static std::string opt_endpoint;
 static std::string opt_cert_dir;
 static std::string opt_test_name;
 static test_mode opt_mode = MODE_NONE;
@@ -285,7 +282,7 @@ static int parse_args(int argc, char *argv[])
       {
         remaining_argc--;
         remaining_argv++;
-        GetOptEndpoint() = *remaining_argv;
+        opt_endpoint = *remaining_argv;
         remaining_argc--;
         remaining_argv++;
         continue;
@@ -339,7 +336,7 @@ typedef int (*test_func_t)();
 
 struct test_case
 {
-  const char *m_name;
+  nostd::string_view m_name;
   test_func_t m_func;
 };
 
@@ -466,6 +463,8 @@ int main(int argc, char *argv[])
   argc--;
   argv++;
 
+  opt_endpoint = kDefaultOptEndpoint;
+
   int rc = parse_args(argc, argv);
 
   if (rc != 0)
@@ -486,7 +485,7 @@ int main(int argc, char *argv[])
     return 0;
   }
 
-  if (GetOptEndpoint().find("https:") != std::string::npos)
+  if (opt_endpoint.find("https:") != std::string::npos)
   {
     opt_secure = true;
   }
@@ -506,7 +505,7 @@ int main(int argc, char *argv[])
 
 static void set_common_opts(otlp::OtlpHttpExporterOptions &opts)
 {
-  opts.url = GetOptEndpoint();
+  opts.url = opt_endpoint;
 
   if (opt_debug)
   {

--- a/functional/otlp/func_http_main.cc
+++ b/functional/otlp/func_http_main.cc
@@ -50,7 +50,7 @@ static bool opt_list   = false;
 static bool opt_debug  = false;
 static bool opt_secure = false;
 // HTTPS by default
-static std::string &opt_endpoint()
+static std::string &GetOptEndpoint()
 {
   static std::string endpoint = "https://localhost:4318/v1/traces";
   return endpoint;
@@ -285,7 +285,7 @@ static int parse_args(int argc, char *argv[])
       {
         remaining_argc--;
         remaining_argv++;
-        opt_endpoint() = *remaining_argv;
+        GetOptEndpoint() = *remaining_argv;
         remaining_argc--;
         remaining_argv++;
         continue;
@@ -486,7 +486,7 @@ int main(int argc, char *argv[])
     return 0;
   }
 
-  if (opt_endpoint().find("https:") != std::string::npos)
+  if (GetOptEndpoint().find("https:") != std::string::npos)
   {
     opt_secure = true;
   }
@@ -506,7 +506,7 @@ int main(int argc, char *argv[])
 
 static void set_common_opts(otlp::OtlpHttpExporterOptions &opts)
 {
-  opts.url = opt_endpoint();
+  opts.url = GetOptEndpoint();
 
   if (opt_debug)
   {

--- a/sdk/include/opentelemetry/sdk/metrics/state/attributes_hashmap.h
+++ b/sdk/include/opentelemetry/sdk/metrics/state/attributes_hashmap.h
@@ -30,7 +30,7 @@ const bool kAttributesLimitOverflowValue      = true;
 
 constexpr char kAttributesLimitOverflowKey[] = "otel.metric.overflow";
 
-inline const MetricAttributes &kOverflowAttributes()
+inline const MetricAttributes &GetOverflowAttributes()
 {
   static const MetricAttributes value = {
       {kAttributesLimitOverflowKey,
@@ -133,7 +133,7 @@ public:
     }
     else if (IsOverflowAttributes(attributes))
     {
-      hash_map_[kOverflowAttributes()] = std::move(aggr);
+      hash_map_[GetOverflowAttributes()] = std::move(aggr);
     }
     else
     {
@@ -150,7 +150,7 @@ public:
     }
     else if (IsOverflowAttributes(attributes))
     {
-      hash_map_[kOverflowAttributes()] = std::move(aggr);
+      hash_map_[GetOverflowAttributes()] = std::move(aggr);
     }
     else
     {
@@ -197,13 +197,13 @@ private:
 
   Aggregation *GetOrSetOveflowAttributes(std::unique_ptr<Aggregation> agg)
   {
-    auto it = hash_map_.find(kOverflowAttributes());
+    auto it = hash_map_.find(GetOverflowAttributes());
     if (it != hash_map_.end())
     {
       return it->second.get();
     }
 
-    auto result = hash_map_.emplace(kOverflowAttributes(), std::move(agg));
+    auto result = hash_map_.emplace(GetOverflowAttributes(), std::move(agg));
     return result.first->second.get();
   }
 
@@ -211,12 +211,12 @@ private:
   {
     // If the incoming attributes are exactly the overflow sentinel, route
     // directly to the overflow entry.
-    if (attributes == kOverflowAttributes())
+    if (attributes == GetOverflowAttributes())
     {
       return true;
     }
     // Determine if overflow entry already exists.
-    bool has_overflow = (hash_map_.find(kOverflowAttributes()) != hash_map_.end());
+    bool has_overflow = (hash_map_.find(GetOverflowAttributes()) != hash_map_.end());
     // If overflow already present, total size already includes it; trigger overflow
     // when current size (including overflow) is >= limit.
     if (has_overflow)

--- a/sdk/include/opentelemetry/sdk/metrics/state/attributes_hashmap.h
+++ b/sdk/include/opentelemetry/sdk/metrics/state/attributes_hashmap.h
@@ -26,11 +26,21 @@ namespace metrics
 using opentelemetry::sdk::common::OrderedAttributeMap;
 
 constexpr size_t kAggregationCardinalityLimit = 2000;
-const std::string kAttributesLimitOverflowKey = "otel.metric.overflow";
 const bool kAttributesLimitOverflowValue      = true;
-const MetricAttributes kOverflowAttributes    = {
-    {kAttributesLimitOverflowKey,
-        kAttributesLimitOverflowValue}};  // precalculated for optimization
+
+inline const std::string &kAttributesLimitOverflowKey()
+{
+  static const std::string value = "otel.metric.overflow";
+  return value;
+}
+
+inline const MetricAttributes &kOverflowAttributes()
+{
+  static const MetricAttributes value = {
+      {kAttributesLimitOverflowKey(),
+       kAttributesLimitOverflowValue}};  // precalculated for optimization
+  return value;
+}
 
 class AttributeHashGenerator
 {
@@ -127,7 +137,7 @@ public:
     }
     else if (IsOverflowAttributes(attributes))
     {
-      hash_map_[kOverflowAttributes] = std::move(aggr);
+      hash_map_[kOverflowAttributes()] = std::move(aggr);
     }
     else
     {
@@ -144,7 +154,7 @@ public:
     }
     else if (IsOverflowAttributes(attributes))
     {
-      hash_map_[kOverflowAttributes] = std::move(aggr);
+      hash_map_[kOverflowAttributes()] = std::move(aggr);
     }
     else
     {
@@ -191,13 +201,13 @@ private:
 
   Aggregation *GetOrSetOveflowAttributes(std::unique_ptr<Aggregation> agg)
   {
-    auto it = hash_map_.find(kOverflowAttributes);
+    auto it = hash_map_.find(kOverflowAttributes());
     if (it != hash_map_.end())
     {
       return it->second.get();
     }
 
-    auto result = hash_map_.emplace(kOverflowAttributes, std::move(agg));
+    auto result = hash_map_.emplace(kOverflowAttributes(), std::move(agg));
     return result.first->second.get();
   }
 
@@ -205,12 +215,12 @@ private:
   {
     // If the incoming attributes are exactly the overflow sentinel, route
     // directly to the overflow entry.
-    if (attributes == kOverflowAttributes)
+    if (attributes == kOverflowAttributes())
     {
       return true;
     }
     // Determine if overflow entry already exists.
-    bool has_overflow = (hash_map_.find(kOverflowAttributes) != hash_map_.end());
+    bool has_overflow = (hash_map_.find(kOverflowAttributes()) != hash_map_.end());
     // If overflow already present, total size already includes it; trigger overflow
     // when current size (including overflow) is >= limit.
     if (has_overflow)

--- a/sdk/include/opentelemetry/sdk/metrics/state/attributes_hashmap.h
+++ b/sdk/include/opentelemetry/sdk/metrics/state/attributes_hashmap.h
@@ -28,16 +28,12 @@ using opentelemetry::sdk::common::OrderedAttributeMap;
 constexpr size_t kAggregationCardinalityLimit = 2000;
 const bool kAttributesLimitOverflowValue      = true;
 
-inline const std::string &kAttributesLimitOverflowKey()
-{
-  static const std::string value = "otel.metric.overflow";
-  return value;
-}
+constexpr char kAttributesLimitOverflowKey[] = "otel.metric.overflow";
 
 inline const MetricAttributes &kOverflowAttributes()
 {
   static const MetricAttributes value = {
-      {kAttributesLimitOverflowKey(),
+      {kAttributesLimitOverflowKey,
        kAttributesLimitOverflowValue}};  // precalculated for optimization
   return value;
 }

--- a/sdk/include/opentelemetry/sdk/metrics/state/sync_metric_storage.h
+++ b/sdk/include/opentelemetry/sdk/metrics/state/sync_metric_storage.h
@@ -264,17 +264,17 @@ private:
   // Must be called with attribute_hashmap_lock_ held.
   MetricAttributes ResolveCardinality(const MetricAttributes &filtered) noexcept
   {
-    if (filtered == kOverflowAttributes)
+    if (filtered == kOverflowAttributes())
     {
-      active_keys_.insert(kOverflowAttributes);
-      return kOverflowAttributes;
+      active_keys_.insert(kOverflowAttributes());
+      return kOverflowAttributes();
     }
     if (active_keys_.find(filtered) != active_keys_.end())
     {
       return filtered;
     }
     const size_t limit      = aggregation_config_->cardinality_limit_;
-    const bool has_overflow = active_keys_.find(kOverflowAttributes) != active_keys_.end();
+    const bool has_overflow = active_keys_.find(kOverflowAttributes()) != active_keys_.end();
     // Mirror AttributesHashMap::IsOverflowAttributes() exactly. When the
     // overflow slot is already counted in active_keys_, only route to
     // overflow when total active keys reach the limit. Otherwise simulate
@@ -283,8 +283,8 @@ private:
         has_overflow ? (active_keys_.size() >= limit) : (active_keys_.size() + 1 >= limit);
     if (would_overflow)
     {
-      active_keys_.insert(kOverflowAttributes);
-      return kOverflowAttributes;
+      active_keys_.insert(kOverflowAttributes());
+      return kOverflowAttributes();
     }
     active_keys_.insert(filtered);
     return filtered;

--- a/sdk/include/opentelemetry/sdk/metrics/state/sync_metric_storage.h
+++ b/sdk/include/opentelemetry/sdk/metrics/state/sync_metric_storage.h
@@ -264,17 +264,17 @@ private:
   // Must be called with attribute_hashmap_lock_ held.
   MetricAttributes ResolveCardinality(const MetricAttributes &filtered) noexcept
   {
-    if (filtered == kOverflowAttributes())
+    if (filtered == GetOverflowAttributes())
     {
-      active_keys_.insert(kOverflowAttributes());
-      return kOverflowAttributes();
+      active_keys_.insert(GetOverflowAttributes());
+      return GetOverflowAttributes();
     }
     if (active_keys_.find(filtered) != active_keys_.end())
     {
       return filtered;
     }
     const size_t limit      = aggregation_config_->cardinality_limit_;
-    const bool has_overflow = active_keys_.find(kOverflowAttributes()) != active_keys_.end();
+    const bool has_overflow = active_keys_.find(GetOverflowAttributes()) != active_keys_.end();
     // Mirror AttributesHashMap::IsOverflowAttributes() exactly. When the
     // overflow slot is already counted in active_keys_, only route to
     // overflow when total active keys reach the limit. Otherwise simulate
@@ -283,8 +283,8 @@ private:
         has_overflow ? (active_keys_.size() >= limit) : (active_keys_.size() + 1 >= limit);
     if (would_overflow)
     {
-      active_keys_.insert(kOverflowAttributes());
-      return kOverflowAttributes();
+      active_keys_.insert(GetOverflowAttributes());
+      return GetOverflowAttributes();
     }
     active_keys_.insert(filtered);
     return filtered;

--- a/sdk/include/opentelemetry/sdk/trace/tracer.h
+++ b/sdk/include/opentelemetry/sdk/trace/tracer.h
@@ -137,7 +137,6 @@ private:
 #if OPENTELEMETRY_ABI_VERSION_NO < 2
   std::atomic<bool> is_enabled_{false};
 #endif
-  static const std::shared_ptr<opentelemetry::trace::NoopTracer> kNoopTracer;
 };
 }  // namespace trace
 }  // namespace sdk

--- a/sdk/src/metrics/instrument_metadata_validator.cc
+++ b/sdk/src/metrics/instrument_metadata_validator.cc
@@ -20,9 +20,9 @@ namespace metrics
 {
 #if OPENTELEMETRY_HAVE_WORKING_REGEX
 // instrument-name = ALPHA 0*254 ("_" / "." / "-" / "/" / ALPHA / DIGIT)
-const std::string kInstrumentNamePattern = "[a-zA-Z][-_./a-zA-Z0-9]{0,254}";
+constexpr const char *kInstrumentNamePattern = "[a-zA-Z][-_./a-zA-Z0-9]{0,254}";
 //
-const std::string kInstrumentUnitPattern = "[\x01-\x7F]{0,63}";
+constexpr const char *kInstrumentUnitPattern = "[\x01-\x7F]{0,63}";
 // instrument-unit = It can have a maximum length of 63 ASCII chars
 #endif
 

--- a/sdk/src/metrics/instrument_metadata_validator.cc
+++ b/sdk/src/metrics/instrument_metadata_validator.cc
@@ -1,10 +1,8 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-#include <string>
-
-#include "opentelemetry/nostd/string_view.h"
 #include "opentelemetry/sdk/metrics/instrument_metadata_validator.h"
+#include "opentelemetry/nostd/string_view.h"
 #include "opentelemetry/version.h"
 
 #if OPENTELEMETRY_HAVE_WORKING_REGEX

--- a/sdk/src/metrics/state/sync_metric_storage.cc
+++ b/sdk/src/metrics/state/sync_metric_storage.cc
@@ -204,7 +204,7 @@ std::shared_ptr<BoundSyncWritableMetricStorage> SyncMetricStorage::Bind(
   MetricAttributes key = ResolveCardinality(filtered);
 
   // If we ended up at overflow, dedupe against an existing overflow entry.
-  if (key == kOverflowAttributes())
+  if (key == GetOverflowAttributes())
   {
     auto ov_it = bound_entries_.find(key);
     if (ov_it != bound_entries_.end())

--- a/sdk/src/metrics/state/sync_metric_storage.cc
+++ b/sdk/src/metrics/state/sync_metric_storage.cc
@@ -204,7 +204,7 @@ std::shared_ptr<BoundSyncWritableMetricStorage> SyncMetricStorage::Bind(
   MetricAttributes key = ResolveCardinality(filtered);
 
   // If we ended up at overflow, dedupe against an existing overflow entry.
-  if (key == kOverflowAttributes)
+  if (key == kOverflowAttributes())
   {
     auto ov_it = bound_entries_.find(key);
     if (ov_it != bound_entries_.end())

--- a/sdk/src/trace/tracer.cc
+++ b/sdk/src/trace/tracer.cc
@@ -37,9 +37,6 @@ namespace sdk
 {
 namespace trace
 {
-const std::shared_ptr<opentelemetry::trace::NoopTracer> Tracer::kNoopTracer =
-    std::make_shared<opentelemetry::trace::NoopTracer>();
-
 Tracer::Tracer(std::shared_ptr<TracerContext> context,
                std::unique_ptr<InstrumentationScope> instrumentation_scope) noexcept
     : instrumentation_scope_{std::move(instrumentation_scope)},
@@ -58,6 +55,8 @@ nostd::shared_ptr<opentelemetry::trace::Span> Tracer::StartSpan(
   // Check if the tracer is enabled using the API Tracer::Enabled() accessor if available.
   if (!Enabled())
   {
+    static const std::shared_ptr<opentelemetry::trace::NoopTracer> kNoopTracer =
+        std::make_shared<opentelemetry::trace::NoopTracer>();
     return kNoopTracer->StartSpan(name, attributes, links, options);
   }
 

--- a/sdk/test/common/circular_buffer_test.cc
+++ b/sdk/test/common/circular_buffer_test.cc
@@ -23,7 +23,11 @@ using opentelemetry::sdk::common::AtomicUniquePtr;
 using opentelemetry::sdk::common::CircularBuffer;
 using opentelemetry::sdk::common::CircularBufferRange;
 
-static thread_local std::mt19937 RandomNumberGenerator{std::random_device{}()};
+static std::mt19937 &RandomNumberGenerator()
+{
+  static thread_local std::mt19937 generator{std::random_device{}()};
+  return generator;
+}
 
 static void GenerateRandomNumbers(CircularBuffer<uint32_t> &buffer,
                                   std::vector<uint32_t> &numbers,
@@ -31,7 +35,7 @@ static void GenerateRandomNumbers(CircularBuffer<uint32_t> &buffer,
 {
   for (int i = 0; i < n; ++i)
   {
-    auto value = static_cast<uint32_t>(RandomNumberGenerator());
+    auto value = static_cast<uint32_t>(RandomNumberGenerator()());
     std::unique_ptr<uint32_t> x{new uint32_t{value}};
     if (buffer.Add(x))
     {
@@ -73,7 +77,8 @@ static void RunNumberConsumer(CircularBuffer<uint32_t> &buffer,
     {
       return;
     }
-    auto n = std::uniform_int_distribution<size_t>{0, buffer.Peek().size()}(RandomNumberGenerator);
+    auto n =
+        std::uniform_int_distribution<size_t>{0, buffer.Peek().size()}(RandomNumberGenerator());
     buffer.Consume(n, [&](CircularBufferRange<AtomicUniquePtr<uint32_t>> range) noexcept {
       assert(range.size() == n);
       range.ForEach([&](AtomicUniquePtr<uint32_t> &ptr) noexcept {

--- a/sdk/test/logs/logger_config_test.cc
+++ b/sdk/test/logs/logger_config_test.cc
@@ -54,40 +54,65 @@ TEST(LoggerConfig, CheckCreateWorksAsExpected)
 
 /** Tests to verify the behavior of logs_sdk::LoggerConfig::Default */
 
-static std::pair<opentelemetry::nostd::string_view, opentelemetry::common::AttributeValue> attr1 = {
-    "accept_single_attr", true};
-static std::pair<opentelemetry::nostd::string_view, opentelemetry::common::AttributeValue> attr2 = {
-    "accept_second_attr", "some other attr"};
-static std::pair<opentelemetry::nostd::string_view, opentelemetry::common::AttributeValue> attr3 = {
-    "accept_third_attr", 3};
+static std::pair<opentelemetry::nostd::string_view, opentelemetry::common::AttributeValue> &attr1()
+{
+  static std::pair<opentelemetry::nostd::string_view, opentelemetry::common::AttributeValue> value{
+      "accept_single_attr", true};
+  return value;
+}
+static std::pair<opentelemetry::nostd::string_view, opentelemetry::common::AttributeValue> &attr2()
+{
+  static std::pair<opentelemetry::nostd::string_view, opentelemetry::common::AttributeValue> value{
+      "accept_second_attr", "some other attr"};
+  return value;
+}
+static std::pair<opentelemetry::nostd::string_view, opentelemetry::common::AttributeValue> &attr3()
+{
+  static std::pair<opentelemetry::nostd::string_view, opentelemetry::common::AttributeValue> value{
+      "accept_third_attr", 3};
+  return value;
+}
 
-static instrumentation_scope::InstrumentationScope test_scope_1 =
-    *instrumentation_scope::InstrumentationScope::Create("test_scope_1");
-static instrumentation_scope::InstrumentationScope test_scope_2 =
-    *instrumentation_scope::InstrumentationScope::Create("test_scope_2", "1.0");
-static instrumentation_scope::InstrumentationScope test_scope_3 =
-    *instrumentation_scope::InstrumentationScope::Create(
-        "test_scope_3",
-        "0",
-        "https://opentelemetry.io/schemas/v1.18.0");
-static instrumentation_scope::InstrumentationScope test_scope_4 =
-    *instrumentation_scope::InstrumentationScope::Create("test_scope_4",
-                                                         "0",
-                                                         "https://opentelemetry.io/schemas/v1.18.0",
-                                                         {attr1});
-static instrumentation_scope::InstrumentationScope test_scope_5 =
-    *instrumentation_scope::InstrumentationScope::Create("test_scope_5",
-                                                         "0",
-                                                         "https://opentelemetry.io/schemas/v1.18.0",
-                                                         {attr1, attr2, attr3});
+static instrumentation_scope::InstrumentationScope &test_scope_1()
+{
+  static auto value = *instrumentation_scope::InstrumentationScope::Create("test_scope_1");
+  return value;
+}
+static instrumentation_scope::InstrumentationScope &test_scope_2()
+{
+  static auto value = *instrumentation_scope::InstrumentationScope::Create("test_scope_2", "1.0");
+  return value;
+}
+static instrumentation_scope::InstrumentationScope &test_scope_3()
+{
+  static auto value = *instrumentation_scope::InstrumentationScope::Create(
+      "test_scope_3", "0", "https://opentelemetry.io/schemas/v1.18.0");
+  return value;
+}
+static instrumentation_scope::InstrumentationScope &test_scope_4()
+{
+  static auto value = *instrumentation_scope::InstrumentationScope::Create(
+      "test_scope_4", "0", "https://opentelemetry.io/schemas/v1.18.0", {attr1()});
+  return value;
+}
+static instrumentation_scope::InstrumentationScope &test_scope_5()
+{
+  static auto value = *instrumentation_scope::InstrumentationScope::Create(
+      "test_scope_5", "0", "https://opentelemetry.io/schemas/v1.18.0", {attr1(), attr2(), attr3()});
+  return value;
+}
 
 // This array could also directly contain the reference types, but that  leads to 'uninitialized
 // value was created by heap allocation' errors in Valgrind memcheck. This is a bug in Googletest
 // library, see https://github.com/google/googletest/issues/3805#issuecomment-1397301790 for more
 // details. Using pointers is a workaround to prevent the Valgrind warnings.
-const std::array<instrumentation_scope::InstrumentationScope *, 5> instrumentation_scopes = {
-    &test_scope_1, &test_scope_2, &test_scope_3, &test_scope_4, &test_scope_5,
-};
+static const std::array<instrumentation_scope::InstrumentationScope *, 5> &instrumentation_scopes()
+{
+  static const std::array<instrumentation_scope::InstrumentationScope *, 5> value = {
+      &test_scope_1(), &test_scope_2(), &test_scope_3(), &test_scope_4(), &test_scope_5(),
+  };
+  return value;
+}
 
 namespace
 {
@@ -121,12 +146,12 @@ TEST(LoggerConfig, ScopeConfiguratorPreservesCustomConfig)
           .AddConditionNameEquals("test_scope_1", matching_config)
           .Build();
 
-  ASSERT_EQ(configurator.ComputeConfig(test_scope_1), matching_config);
-  ASSERT_EQ(configurator.ComputeConfig(test_scope_2), default_config);
+  ASSERT_EQ(configurator.ComputeConfig(test_scope_1()), matching_config);
+  ASSERT_EQ(configurator.ComputeConfig(test_scope_2()), default_config);
 }
 
 INSTANTIATE_TEST_SUITE_P(InstrumentationScopes,
                          DefaultLoggerConfiguratorTestFixture,
-                         ::testing::ValuesIn(instrumentation_scopes));
+                         ::testing::ValuesIn(instrumentation_scopes()));
 
 }  // namespace

--- a/sdk/test/logs/logger_config_test.cc
+++ b/sdk/test/logs/logger_config_test.cc
@@ -54,51 +54,55 @@ TEST(LoggerConfig, CheckCreateWorksAsExpected)
 
 /** Tests to verify the behavior of logs_sdk::LoggerConfig::Default */
 
-static std::pair<opentelemetry::nostd::string_view, opentelemetry::common::AttributeValue> &attr1()
+static std::pair<opentelemetry::nostd::string_view, opentelemetry::common::AttributeValue> &
+GetAttr1()
 {
   static std::pair<opentelemetry::nostd::string_view, opentelemetry::common::AttributeValue> value{
       "accept_single_attr", true};
   return value;
 }
-static std::pair<opentelemetry::nostd::string_view, opentelemetry::common::AttributeValue> &attr2()
+static std::pair<opentelemetry::nostd::string_view, opentelemetry::common::AttributeValue> &
+GetAttr2()
 {
   static std::pair<opentelemetry::nostd::string_view, opentelemetry::common::AttributeValue> value{
       "accept_second_attr", "some other attr"};
   return value;
 }
-static std::pair<opentelemetry::nostd::string_view, opentelemetry::common::AttributeValue> &attr3()
+static std::pair<opentelemetry::nostd::string_view, opentelemetry::common::AttributeValue> &
+GetAttr3()
 {
   static std::pair<opentelemetry::nostd::string_view, opentelemetry::common::AttributeValue> value{
       "accept_third_attr", 3};
   return value;
 }
 
-static instrumentation_scope::InstrumentationScope &test_scope_1()
+static instrumentation_scope::InstrumentationScope &GetTestScope1()
 {
   static auto value = *instrumentation_scope::InstrumentationScope::Create("test_scope_1");
   return value;
 }
-static instrumentation_scope::InstrumentationScope &test_scope_2()
+static instrumentation_scope::InstrumentationScope &GetTestScope2()
 {
   static auto value = *instrumentation_scope::InstrumentationScope::Create("test_scope_2", "1.0");
   return value;
 }
-static instrumentation_scope::InstrumentationScope &test_scope_3()
+static instrumentation_scope::InstrumentationScope &GetTestScope3()
 {
   static auto value = *instrumentation_scope::InstrumentationScope::Create(
       "test_scope_3", "0", "https://opentelemetry.io/schemas/v1.18.0");
   return value;
 }
-static instrumentation_scope::InstrumentationScope &test_scope_4()
+static instrumentation_scope::InstrumentationScope &GetTestScope4()
 {
   static auto value = *instrumentation_scope::InstrumentationScope::Create(
-      "test_scope_4", "0", "https://opentelemetry.io/schemas/v1.18.0", {attr1()});
+      "test_scope_4", "0", "https://opentelemetry.io/schemas/v1.18.0", {GetAttr1()});
   return value;
 }
-static instrumentation_scope::InstrumentationScope &test_scope_5()
+static instrumentation_scope::InstrumentationScope &GetTestScope5()
 {
   static auto value = *instrumentation_scope::InstrumentationScope::Create(
-      "test_scope_5", "0", "https://opentelemetry.io/schemas/v1.18.0", {attr1(), attr2(), attr3()});
+      "test_scope_5", "0", "https://opentelemetry.io/schemas/v1.18.0",
+      {GetAttr1(), GetAttr2(), GetAttr3()});
   return value;
 }
 
@@ -106,10 +110,11 @@ static instrumentation_scope::InstrumentationScope &test_scope_5()
 // value was created by heap allocation' errors in Valgrind memcheck. This is a bug in Googletest
 // library, see https://github.com/google/googletest/issues/3805#issuecomment-1397301790 for more
 // details. Using pointers is a workaround to prevent the Valgrind warnings.
-static const std::array<instrumentation_scope::InstrumentationScope *, 5> &instrumentation_scopes()
+static const std::array<instrumentation_scope::InstrumentationScope *, 5> &
+GetInstrumentationScopes()
 {
   static const std::array<instrumentation_scope::InstrumentationScope *, 5> value = {
-      &test_scope_1(), &test_scope_2(), &test_scope_3(), &test_scope_4(), &test_scope_5(),
+      &GetTestScope1(), &GetTestScope2(), &GetTestScope3(), &GetTestScope4(), &GetTestScope5(),
   };
   return value;
 }
@@ -146,12 +151,12 @@ TEST(LoggerConfig, ScopeConfiguratorPreservesCustomConfig)
           .AddConditionNameEquals("test_scope_1", matching_config)
           .Build();
 
-  ASSERT_EQ(configurator.ComputeConfig(test_scope_1()), matching_config);
-  ASSERT_EQ(configurator.ComputeConfig(test_scope_2()), default_config);
+  ASSERT_EQ(configurator.ComputeConfig(GetTestScope1()), matching_config);
+  ASSERT_EQ(configurator.ComputeConfig(GetTestScope2()), default_config);
 }
 
 INSTANTIATE_TEST_SUITE_P(InstrumentationScopes,
                          DefaultLoggerConfiguratorTestFixture,
-                         ::testing::ValuesIn(instrumentation_scopes()));
+                         ::testing::ValuesIn(GetInstrumentationScopes()));
 
 }  // namespace

--- a/sdk/test/logs/logger_sdk_test.cc
+++ b/sdk/test/logs/logger_sdk_test.cc
@@ -773,62 +773,117 @@ public:
 
 // constants used in VerifyCustomConfiguratorBehavior test
 static auto noop_logger = logs_api::NoopLogger();
-const std::string schema{"https://opentelemetry.io/schemas/1.11.0"};
+static const std::string &schema()
+{
+  static const std::string value{"https://opentelemetry.io/schemas/1.11.0"};
+  return value;
+}
 
 // Generate test case data
 // Test Case 1
-static auto instrumentation_scope_1 =
-    *InstrumentationScope::Create("opentelemetry_library", "1.0.0", schema);
-static auto test_log_recordable_1 =
-    create_mock_log_recordable("Log Message", opentelemetry::logs::Severity::kWarn);
-static auto expected_log_recordable_1 =
-    create_mock_log_recordable("Log Message", opentelemetry::logs::Severity::kWarn);
-static auto custom_log_configurator_test_data_1 =
-    CustomLogConfiguratorTestData(instrumentation_scope_1,
-                                  *test_log_recordable_1,
-                                  *expected_log_recordable_1,
-                                  false);
+static InstrumentationScope &instrumentation_scope_1()
+{
+  static auto value = *InstrumentationScope::Create("opentelemetry_library", "1.0.0", schema());
+  return value;
+}
+static std::unique_ptr<MockLogRecordable> &test_log_recordable_1()
+{
+  static auto value =
+      create_mock_log_recordable("Log Message", opentelemetry::logs::Severity::kWarn);
+  return value;
+}
+static std::unique_ptr<MockLogRecordable> &expected_log_recordable_1()
+{
+  static auto value =
+      create_mock_log_recordable("Log Message", opentelemetry::logs::Severity::kWarn);
+  return value;
+}
+static CustomLogConfiguratorTestData &custom_log_configurator_test_data_1()
+{
+  static auto value = CustomLogConfiguratorTestData(
+      instrumentation_scope_1(), *test_log_recordable_1(), *expected_log_recordable_1(), false);
+  return value;
+}
 // Test Case 2
-static auto instrumentation_scope_2 = *InstrumentationScope::Create("bar_library", "1.0.0", schema);
-static auto test_log_recordable_2 =
-    create_mock_log_recordable("", opentelemetry::logs::Severity::kDebug);
-static auto expected_log_recordable_2 =
-    create_mock_log_recordable("", opentelemetry::logs::Severity::kDebug);
-static auto custom_log_configurator_test_data_2 =
-    CustomLogConfiguratorTestData(instrumentation_scope_2,
-                                  *test_log_recordable_2,
-                                  *expected_log_recordable_2,
-                                  false);
+static InstrumentationScope &instrumentation_scope_2()
+{
+  static auto value = *InstrumentationScope::Create("bar_library", "1.0.0", schema());
+  return value;
+}
+static std::unique_ptr<MockLogRecordable> &test_log_recordable_2()
+{
+  static auto value = create_mock_log_recordable("", opentelemetry::logs::Severity::kDebug);
+  return value;
+}
+static std::unique_ptr<MockLogRecordable> &expected_log_recordable_2()
+{
+  static auto value = create_mock_log_recordable("", opentelemetry::logs::Severity::kDebug);
+  return value;
+}
+static CustomLogConfiguratorTestData &custom_log_configurator_test_data_2()
+{
+  static auto value = CustomLogConfiguratorTestData(
+      instrumentation_scope_2(), *test_log_recordable_2(), *expected_log_recordable_2(), false);
+  return value;
+}
 // Test Case 3
-static auto instrumentation_scope_3 = *InstrumentationScope::Create("foo_library", "", schema);
-static auto test_log_recordable_3 =
-    create_mock_log_recordable("Info message", opentelemetry::logs::Severity::kInfo);
-static auto expected_log_recordable_3 =
-    create_mock_log_recordable("", opentelemetry::logs::Severity::kInvalid);
-static auto custom_log_configurator_test_data_3 =
-    CustomLogConfiguratorTestData(instrumentation_scope_3,
-                                  *test_log_recordable_3,
-                                  *expected_log_recordable_3,
-                                  true);
+static InstrumentationScope &instrumentation_scope_3()
+{
+  static auto value = *InstrumentationScope::Create("foo_library", "", schema());
+  return value;
+}
+static std::unique_ptr<MockLogRecordable> &test_log_recordable_3()
+{
+  static auto value =
+      create_mock_log_recordable("Info message", opentelemetry::logs::Severity::kInfo);
+  return value;
+}
+static std::unique_ptr<MockLogRecordable> &expected_log_recordable_3()
+{
+  static auto value = create_mock_log_recordable("", opentelemetry::logs::Severity::kInvalid);
+  return value;
+}
+static CustomLogConfiguratorTestData &custom_log_configurator_test_data_3()
+{
+  static auto value = CustomLogConfiguratorTestData(
+      instrumentation_scope_3(), *test_log_recordable_3(), *expected_log_recordable_3(), true);
+  return value;
+}
 // Test Case 4
-static auto instrumentation_scope_4 = *InstrumentationScope::Create("allowed_library", "", schema);
-static auto test_log_recordable_4 =
-    create_mock_log_recordable("Scope version missing", opentelemetry::logs::Severity::kInfo);
-static auto expected_log_recordable_4 =
-    create_mock_log_recordable("", opentelemetry::logs::Severity::kInvalid);
-static auto custom_log_configurator_test_data_4 =
-    CustomLogConfiguratorTestData(instrumentation_scope_4,
-                                  *test_log_recordable_4,
-                                  *expected_log_recordable_4,
-                                  true);
+static InstrumentationScope &instrumentation_scope_4()
+{
+  static auto value = *InstrumentationScope::Create("allowed_library", "", schema());
+  return value;
+}
+static std::unique_ptr<MockLogRecordable> &test_log_recordable_4()
+{
+  static auto value =
+      create_mock_log_recordable("Scope version missing", opentelemetry::logs::Severity::kInfo);
+  return value;
+}
+static std::unique_ptr<MockLogRecordable> &expected_log_recordable_4()
+{
+  static auto value = create_mock_log_recordable("", opentelemetry::logs::Severity::kInvalid);
+  return value;
+}
+static CustomLogConfiguratorTestData &custom_log_configurator_test_data_4()
+{
+  static auto value = CustomLogConfiguratorTestData(
+      instrumentation_scope_4(), *test_log_recordable_4(), *expected_log_recordable_4(), true);
+  return value;
+}
 
 // This array could also directly contain the reference types, but that  leads to 'uninitialized
 // value was created by heap allocation' errors in Valgrind memcheck. This is a bug in Googletest
 // library, see https://github.com/google/googletest/issues/3805#issuecomment-1397301790 for more
 // details. Using pointers is a workaround to prevent the Valgrind warnings.
-constexpr std::array<CustomLogConfiguratorTestData *, 4> log_configurator_test_cases = {
-    &custom_log_configurator_test_data_1, &custom_log_configurator_test_data_2,
-    &custom_log_configurator_test_data_3, &custom_log_configurator_test_data_4};
+static const std::array<CustomLogConfiguratorTestData *, 4> &log_configurator_test_cases()
+{
+  static const std::array<CustomLogConfiguratorTestData *, 4> value = {
+      &custom_log_configurator_test_data_1(), &custom_log_configurator_test_data_2(),
+      &custom_log_configurator_test_data_3(), &custom_log_configurator_test_data_4()};
+  return value;
+}
 
 // Test fixture for VerifyCustomConfiguratorBehavior
 class CustomLoggerConfiguratorTestFixture
@@ -899,7 +954,7 @@ TEST_P(CustomLoggerConfiguratorTestFixture, VerifyCustomConfiguratorBehavior)
 
 INSTANTIATE_TEST_SUITE_P(CustomLogConfiguratorTestData,
                          CustomLoggerConfiguratorTestFixture,
-                         ::testing::ValuesIn(log_configurator_test_cases));
+                         ::testing::ValuesIn(log_configurator_test_cases()));
 
 #if OPENTELEMETRY_ABI_VERSION_NO < 2
 TEST(LoggerSDK, EventLog)

--- a/sdk/test/logs/logger_sdk_test.cc
+++ b/sdk/test/logs/logger_sdk_test.cc
@@ -777,95 +777,95 @@ constexpr char schema[] = "https://opentelemetry.io/schemas/1.11.0";
 
 // Generate test case data
 // Test Case 1
-static InstrumentationScope &instrumentation_scope_1()
+static InstrumentationScope &GetInstrumentationScope1()
 {
   static auto value = *InstrumentationScope::Create("opentelemetry_library", "1.0.0", schema);
   return value;
 }
-static std::unique_ptr<MockLogRecordable> &test_log_recordable_1()
+static std::unique_ptr<MockLogRecordable> &GetTestLogRecordable1()
 {
   static auto value =
       create_mock_log_recordable("Log Message", opentelemetry::logs::Severity::kWarn);
   return value;
 }
-static std::unique_ptr<MockLogRecordable> &expected_log_recordable_1()
+static std::unique_ptr<MockLogRecordable> &GetExpectedLogRecordable1()
 {
   static auto value =
       create_mock_log_recordable("Log Message", opentelemetry::logs::Severity::kWarn);
   return value;
 }
-static CustomLogConfiguratorTestData &custom_log_configurator_test_data_1()
+static CustomLogConfiguratorTestData &GetCustomLogConfiguratorTestData1()
 {
   static auto value = CustomLogConfiguratorTestData(
-      instrumentation_scope_1(), *test_log_recordable_1(), *expected_log_recordable_1(), false);
+      GetInstrumentationScope1(), *GetTestLogRecordable1(), *GetExpectedLogRecordable1(), false);
   return value;
 }
 // Test Case 2
-static InstrumentationScope &instrumentation_scope_2()
+static InstrumentationScope &GetInstrumentationScope2()
 {
   static auto value = *InstrumentationScope::Create("bar_library", "1.0.0", schema);
   return value;
 }
-static std::unique_ptr<MockLogRecordable> &test_log_recordable_2()
+static std::unique_ptr<MockLogRecordable> &GetTestLogRecordable2()
 {
   static auto value = create_mock_log_recordable("", opentelemetry::logs::Severity::kDebug);
   return value;
 }
-static std::unique_ptr<MockLogRecordable> &expected_log_recordable_2()
+static std::unique_ptr<MockLogRecordable> &GetExpectedLogRecordable2()
 {
   static auto value = create_mock_log_recordable("", opentelemetry::logs::Severity::kDebug);
   return value;
 }
-static CustomLogConfiguratorTestData &custom_log_configurator_test_data_2()
+static CustomLogConfiguratorTestData &GetCustomLogConfiguratorTestData2()
 {
   static auto value = CustomLogConfiguratorTestData(
-      instrumentation_scope_2(), *test_log_recordable_2(), *expected_log_recordable_2(), false);
+      GetInstrumentationScope2(), *GetTestLogRecordable2(), *GetExpectedLogRecordable2(), false);
   return value;
 }
 // Test Case 3
-static InstrumentationScope &instrumentation_scope_3()
+static InstrumentationScope &GetInstrumentationScope3()
 {
   static auto value = *InstrumentationScope::Create("foo_library", "", schema);
   return value;
 }
-static std::unique_ptr<MockLogRecordable> &test_log_recordable_3()
+static std::unique_ptr<MockLogRecordable> &GetTestLogRecordable3()
 {
   static auto value =
       create_mock_log_recordable("Info message", opentelemetry::logs::Severity::kInfo);
   return value;
 }
-static std::unique_ptr<MockLogRecordable> &expected_log_recordable_3()
+static std::unique_ptr<MockLogRecordable> &GetExpectedLogRecordable3()
 {
   static auto value = create_mock_log_recordable("", opentelemetry::logs::Severity::kInvalid);
   return value;
 }
-static CustomLogConfiguratorTestData &custom_log_configurator_test_data_3()
+static CustomLogConfiguratorTestData &GetCustomLogConfiguratorTestData3()
 {
   static auto value = CustomLogConfiguratorTestData(
-      instrumentation_scope_3(), *test_log_recordable_3(), *expected_log_recordable_3(), true);
+      GetInstrumentationScope3(), *GetTestLogRecordable3(), *GetExpectedLogRecordable3(), true);
   return value;
 }
 // Test Case 4
-static InstrumentationScope &instrumentation_scope_4()
+static InstrumentationScope &GetInstrumentationScope4()
 {
   static auto value = *InstrumentationScope::Create("allowed_library", "", schema);
   return value;
 }
-static std::unique_ptr<MockLogRecordable> &test_log_recordable_4()
+static std::unique_ptr<MockLogRecordable> &GetTestLogRecordable4()
 {
   static auto value =
       create_mock_log_recordable("Scope version missing", opentelemetry::logs::Severity::kInfo);
   return value;
 }
-static std::unique_ptr<MockLogRecordable> &expected_log_recordable_4()
+static std::unique_ptr<MockLogRecordable> &GetExpectedLogRecordable4()
 {
   static auto value = create_mock_log_recordable("", opentelemetry::logs::Severity::kInvalid);
   return value;
 }
-static CustomLogConfiguratorTestData &custom_log_configurator_test_data_4()
+static CustomLogConfiguratorTestData &GetCustomLogConfiguratorTestData4()
 {
   static auto value = CustomLogConfiguratorTestData(
-      instrumentation_scope_4(), *test_log_recordable_4(), *expected_log_recordable_4(), true);
+      GetInstrumentationScope4(), *GetTestLogRecordable4(), *GetExpectedLogRecordable4(), true);
   return value;
 }
 
@@ -873,11 +873,11 @@ static CustomLogConfiguratorTestData &custom_log_configurator_test_data_4()
 // value was created by heap allocation' errors in Valgrind memcheck. This is a bug in Googletest
 // library, see https://github.com/google/googletest/issues/3805#issuecomment-1397301790 for more
 // details. Using pointers is a workaround to prevent the Valgrind warnings.
-static const std::array<CustomLogConfiguratorTestData *, 4> &log_configurator_test_cases()
+static const std::array<CustomLogConfiguratorTestData *, 4> &GetLogConfiguratorTestCases()
 {
   static const std::array<CustomLogConfiguratorTestData *, 4> value = {
-      &custom_log_configurator_test_data_1(), &custom_log_configurator_test_data_2(),
-      &custom_log_configurator_test_data_3(), &custom_log_configurator_test_data_4()};
+      &GetCustomLogConfiguratorTestData1(), &GetCustomLogConfiguratorTestData2(),
+      &GetCustomLogConfiguratorTestData3(), &GetCustomLogConfiguratorTestData4()};
   return value;
 }
 
@@ -950,7 +950,7 @@ TEST_P(CustomLoggerConfiguratorTestFixture, VerifyCustomConfiguratorBehavior)
 
 INSTANTIATE_TEST_SUITE_P(CustomLogConfiguratorTestData,
                          CustomLoggerConfiguratorTestFixture,
-                         ::testing::ValuesIn(log_configurator_test_cases()));
+                         ::testing::ValuesIn(GetLogConfiguratorTestCases()));
 
 #if OPENTELEMETRY_ABI_VERSION_NO < 2
 TEST(LoggerSDK, EventLog)

--- a/sdk/test/logs/logger_sdk_test.cc
+++ b/sdk/test/logs/logger_sdk_test.cc
@@ -773,17 +773,13 @@ public:
 
 // constants used in VerifyCustomConfiguratorBehavior test
 static auto noop_logger = logs_api::NoopLogger();
-static const std::string &schema()
-{
-  static const std::string value{"https://opentelemetry.io/schemas/1.11.0"};
-  return value;
-}
+constexpr char schema[] = "https://opentelemetry.io/schemas/1.11.0";
 
 // Generate test case data
 // Test Case 1
 static InstrumentationScope &instrumentation_scope_1()
 {
-  static auto value = *InstrumentationScope::Create("opentelemetry_library", "1.0.0", schema());
+  static auto value = *InstrumentationScope::Create("opentelemetry_library", "1.0.0", schema);
   return value;
 }
 static std::unique_ptr<MockLogRecordable> &test_log_recordable_1()
@@ -807,7 +803,7 @@ static CustomLogConfiguratorTestData &custom_log_configurator_test_data_1()
 // Test Case 2
 static InstrumentationScope &instrumentation_scope_2()
 {
-  static auto value = *InstrumentationScope::Create("bar_library", "1.0.0", schema());
+  static auto value = *InstrumentationScope::Create("bar_library", "1.0.0", schema);
   return value;
 }
 static std::unique_ptr<MockLogRecordable> &test_log_recordable_2()
@@ -829,7 +825,7 @@ static CustomLogConfiguratorTestData &custom_log_configurator_test_data_2()
 // Test Case 3
 static InstrumentationScope &instrumentation_scope_3()
 {
-  static auto value = *InstrumentationScope::Create("foo_library", "", schema());
+  static auto value = *InstrumentationScope::Create("foo_library", "", schema);
   return value;
 }
 static std::unique_ptr<MockLogRecordable> &test_log_recordable_3()
@@ -852,7 +848,7 @@ static CustomLogConfiguratorTestData &custom_log_configurator_test_data_3()
 // Test Case 4
 static InstrumentationScope &instrumentation_scope_4()
 {
-  static auto value = *InstrumentationScope::Create("allowed_library", "", schema());
+  static auto value = *InstrumentationScope::Create("allowed_library", "", schema);
   return value;
 }
 static std::unique_ptr<MockLogRecordable> &test_log_recordable_4()

--- a/sdk/test/metrics/attributes_hashmap_test.cc
+++ b/sdk/test/metrics/attributes_hashmap_test.cc
@@ -203,7 +203,7 @@ TEST(AttributesHashMap, OverflowCardinalityLimitBehavior)
   EXPECT_EQ(map.Size(), limit);
 
   // Ensure overflow key was actually created and accessible via Get
-  EXPECT_NE(map.Get(kOverflowAttributes()), nullptr);
+  EXPECT_NE(map.Get(GetOverflowAttributes()), nullptr);
 
   // Ensure original real attributes still present
   for (size_t i = 0; i < limit - 1; ++i)
@@ -219,7 +219,7 @@ TEST(AttributesHashMap, OverflowCardinalityLimitBehavior)
     return true;
   });
   EXPECT_EQ(map_copy.Size(), map.Size());
-  EXPECT_NE(map_copy.Get(kOverflowAttributes()), nullptr);
+  EXPECT_NE(map_copy.Get(GetOverflowAttributes()), nullptr);
   for (size_t i = 0; i < limit - 1; ++i)
   {
     MetricAttributes attr = {{"k", std::to_string(i)}};

--- a/sdk/test/metrics/attributes_hashmap_test.cc
+++ b/sdk/test/metrics/attributes_hashmap_test.cc
@@ -203,7 +203,7 @@ TEST(AttributesHashMap, OverflowCardinalityLimitBehavior)
   EXPECT_EQ(map.Size(), limit);
 
   // Ensure overflow key was actually created and accessible via Get
-  EXPECT_NE(map.Get(kOverflowAttributes), nullptr);
+  EXPECT_NE(map.Get(kOverflowAttributes()), nullptr);
 
   // Ensure original real attributes still present
   for (size_t i = 0; i < limit - 1; ++i)
@@ -219,7 +219,7 @@ TEST(AttributesHashMap, OverflowCardinalityLimitBehavior)
     return true;
   });
   EXPECT_EQ(map_copy.Size(), map.Size());
-  EXPECT_NE(map_copy.Get(kOverflowAttributes), nullptr);
+  EXPECT_NE(map_copy.Get(kOverflowAttributes()), nullptr);
   for (size_t i = 0; i < limit - 1; ++i)
   {
     MetricAttributes attr = {{"k", std::to_string(i)}};

--- a/sdk/test/metrics/bound_sync_instruments_test.cc
+++ b/sdk/test/metrics/bound_sync_instruments_test.cc
@@ -148,7 +148,7 @@ bool HasOverflowPoint(SyncMetricStorage &storage, AggregationTemporality tempora
                   std::chrono::system_clock::now(), [&](const MetricData &md) {
                     for (const auto &p : md.point_data_attr_)
                     {
-                      if (p.attributes.find(kAttributesLimitOverflowKey) != p.attributes.end())
+                      if (p.attributes.find(kAttributesLimitOverflowKey()) != p.attributes.end())
                       {
                         found = true;
                       }
@@ -668,7 +668,7 @@ TEST(BoundSyncInstruments, BindingAtOverflowGoesToOverflowBucket)
                   std::chrono::system_clock::now(), [&](const MetricData &md) {
                     for (const auto &p : md.point_data_attr_)
                     {
-                      if (p.attributes.find(kAttributesLimitOverflowKey) != p.attributes.end())
+                      if (p.attributes.find(kAttributesLimitOverflowKey()) != p.attributes.end())
                       {
                         seen           = true;
                         const auto &sp = opentelemetry::nostd::get<SumPointData>(p.point_data);
@@ -797,7 +797,7 @@ TEST(BoundSyncInstruments, BindOnExistingUnboundKeyDoesNotOverflow)
       std::chrono::system_clock::now(), [&](const MetricData &md) {
         for (const auto &p : md.point_data_attr_)
         {
-          if (p.attributes.find(kAttributesLimitOverflowKey) != p.attributes.end())
+          if (p.attributes.find(kAttributesLimitOverflowKey()) != p.attributes.end())
             overflow_seen = true;
           auto it = p.attributes.find("k");
           if (it != p.attributes.end() && opentelemetry::nostd::get<std::string>(it->second) == "1")
@@ -838,7 +838,7 @@ TEST(BoundSyncInstruments, UnboundOnExistingBoundKeyDoesNotOverflow)
                   std::chrono::system_clock::now(), [&](const MetricData &md) {
                     for (const auto &p : md.point_data_attr_)
                     {
-                      if (p.attributes.find(kAttributesLimitOverflowKey) != p.attributes.end())
+                      if (p.attributes.find(kAttributesLimitOverflowKey()) != p.attributes.end())
                         overflow_seen = true;
                       auto it = p.attributes.find("k");
                       if (it == p.attributes.end())
@@ -906,7 +906,7 @@ TEST(BoundSyncInstruments, RetainedBoundEntriesOverflowValue)
                   std::chrono::system_clock::now(), [&](const MetricData &md) {
                     for (const auto &p : md.point_data_attr_)
                     {
-                      if (p.attributes.find(kAttributesLimitOverflowKey) == p.attributes.end())
+                      if (p.attributes.find(kAttributesLimitOverflowKey()) == p.attributes.end())
                         continue;
                       const auto &sp = opentelemetry::nostd::get<SumPointData>(p.point_data);
                       overflow_sum += opentelemetry::nostd::get<int64_t>(sp.value_);
@@ -941,7 +941,7 @@ TEST(BoundSyncInstruments, NoAttributeUnboundFollowsUnifiedPolicyLong)
                   std::chrono::system_clock::now(), [&](const MetricData &md) {
                     for (const auto &p : md.point_data_attr_)
                     {
-                      if (p.attributes.find(kAttributesLimitOverflowKey) == p.attributes.end())
+                      if (p.attributes.find(kAttributesLimitOverflowKey()) == p.attributes.end())
                         continue;
                       const auto &sp = opentelemetry::nostd::get<SumPointData>(p.point_data);
                       overflow_sum += opentelemetry::nostd::get<int64_t>(sp.value_);
@@ -972,7 +972,7 @@ TEST(BoundSyncInstruments, NoAttributeUnboundFollowsUnifiedPolicyDouble)
                   std::chrono::system_clock::now(), [&](const MetricData &md) {
                     for (const auto &p : md.point_data_attr_)
                     {
-                      if (p.attributes.find(kAttributesLimitOverflowKey) == p.attributes.end())
+                      if (p.attributes.find(kAttributesLimitOverflowKey()) == p.attributes.end())
                         continue;
                       const auto &sp = opentelemetry::nostd::get<SumPointData>(p.point_data);
                       overflow_sum += opentelemetry::nostd::get<double>(sp.value_);
@@ -1110,7 +1110,7 @@ TEST(BoundSyncInstruments, OverflowParityAllowsFillingRemainingSlot)
                   std::chrono::system_clock::now(), [&](const MetricData &md) {
                     for (const auto &p : md.point_data_attr_)
                     {
-                      if (p.attributes.find(kAttributesLimitOverflowKey) != p.attributes.end())
+                      if (p.attributes.find(kAttributesLimitOverflowKey()) != p.attributes.end())
                       {
                         overflow_seen = true;
                       }

--- a/sdk/test/metrics/bound_sync_instruments_test.cc
+++ b/sdk/test/metrics/bound_sync_instruments_test.cc
@@ -148,7 +148,7 @@ bool HasOverflowPoint(SyncMetricStorage &storage, AggregationTemporality tempora
                   std::chrono::system_clock::now(), [&](const MetricData &md) {
                     for (const auto &p : md.point_data_attr_)
                     {
-                      if (p.attributes.find(kAttributesLimitOverflowKey()) != p.attributes.end())
+                      if (p.attributes.find(kAttributesLimitOverflowKey) != p.attributes.end())
                       {
                         found = true;
                       }
@@ -668,7 +668,7 @@ TEST(BoundSyncInstruments, BindingAtOverflowGoesToOverflowBucket)
                   std::chrono::system_clock::now(), [&](const MetricData &md) {
                     for (const auto &p : md.point_data_attr_)
                     {
-                      if (p.attributes.find(kAttributesLimitOverflowKey()) != p.attributes.end())
+                      if (p.attributes.find(kAttributesLimitOverflowKey) != p.attributes.end())
                       {
                         seen           = true;
                         const auto &sp = opentelemetry::nostd::get<SumPointData>(p.point_data);
@@ -797,7 +797,7 @@ TEST(BoundSyncInstruments, BindOnExistingUnboundKeyDoesNotOverflow)
       std::chrono::system_clock::now(), [&](const MetricData &md) {
         for (const auto &p : md.point_data_attr_)
         {
-          if (p.attributes.find(kAttributesLimitOverflowKey()) != p.attributes.end())
+          if (p.attributes.find(kAttributesLimitOverflowKey) != p.attributes.end())
             overflow_seen = true;
           auto it = p.attributes.find("k");
           if (it != p.attributes.end() && opentelemetry::nostd::get<std::string>(it->second) == "1")
@@ -838,7 +838,7 @@ TEST(BoundSyncInstruments, UnboundOnExistingBoundKeyDoesNotOverflow)
                   std::chrono::system_clock::now(), [&](const MetricData &md) {
                     for (const auto &p : md.point_data_attr_)
                     {
-                      if (p.attributes.find(kAttributesLimitOverflowKey()) != p.attributes.end())
+                      if (p.attributes.find(kAttributesLimitOverflowKey) != p.attributes.end())
                         overflow_seen = true;
                       auto it = p.attributes.find("k");
                       if (it == p.attributes.end())
@@ -906,7 +906,7 @@ TEST(BoundSyncInstruments, RetainedBoundEntriesOverflowValue)
                   std::chrono::system_clock::now(), [&](const MetricData &md) {
                     for (const auto &p : md.point_data_attr_)
                     {
-                      if (p.attributes.find(kAttributesLimitOverflowKey()) == p.attributes.end())
+                      if (p.attributes.find(kAttributesLimitOverflowKey) == p.attributes.end())
                         continue;
                       const auto &sp = opentelemetry::nostd::get<SumPointData>(p.point_data);
                       overflow_sum += opentelemetry::nostd::get<int64_t>(sp.value_);
@@ -941,7 +941,7 @@ TEST(BoundSyncInstruments, NoAttributeUnboundFollowsUnifiedPolicyLong)
                   std::chrono::system_clock::now(), [&](const MetricData &md) {
                     for (const auto &p : md.point_data_attr_)
                     {
-                      if (p.attributes.find(kAttributesLimitOverflowKey()) == p.attributes.end())
+                      if (p.attributes.find(kAttributesLimitOverflowKey) == p.attributes.end())
                         continue;
                       const auto &sp = opentelemetry::nostd::get<SumPointData>(p.point_data);
                       overflow_sum += opentelemetry::nostd::get<int64_t>(sp.value_);
@@ -972,7 +972,7 @@ TEST(BoundSyncInstruments, NoAttributeUnboundFollowsUnifiedPolicyDouble)
                   std::chrono::system_clock::now(), [&](const MetricData &md) {
                     for (const auto &p : md.point_data_attr_)
                     {
-                      if (p.attributes.find(kAttributesLimitOverflowKey()) == p.attributes.end())
+                      if (p.attributes.find(kAttributesLimitOverflowKey) == p.attributes.end())
                         continue;
                       const auto &sp = opentelemetry::nostd::get<SumPointData>(p.point_data);
                       overflow_sum += opentelemetry::nostd::get<double>(sp.value_);
@@ -1110,7 +1110,7 @@ TEST(BoundSyncInstruments, OverflowParityAllowsFillingRemainingSlot)
                   std::chrono::system_clock::now(), [&](const MetricData &md) {
                     for (const auto &p : md.point_data_attr_)
                     {
-                      if (p.attributes.find(kAttributesLimitOverflowKey()) != p.attributes.end())
+                      if (p.attributes.find(kAttributesLimitOverflowKey) != p.attributes.end())
                       {
                         overflow_seen = true;
                       }

--- a/sdk/test/metrics/cardinality_limit_test.cc
+++ b/sdk/test/metrics/cardinality_limit_test.cc
@@ -177,7 +177,7 @@ INSTANTIATE_TEST_SUITE_P(All,
 // https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/metrics/sdk.md#cardinality-limits
 TEST(CardinalityLimitOverflowAttribute, MatchesSpecLiteral)
 {
-  EXPECT_EQ(opentelemetry::sdk::metrics::kAttributesLimitOverflowKey, "otel.metric.overflow");
+  EXPECT_STREQ(opentelemetry::sdk::metrics::kAttributesLimitOverflowKey, "otel.metric.overflow");
   EXPECT_EQ(opentelemetry::sdk::metrics::kAttributesLimitOverflowValue, true);
   // The precomputed overflow attribute set MUST contain exactly the spec key
   // mapped to the boolean value `true`.

--- a/sdk/test/metrics/cardinality_limit_test.cc
+++ b/sdk/test/metrics/cardinality_limit_test.cc
@@ -76,7 +76,7 @@ TEST(CardinalityLimit, AttributesHashMapBasicTests)
   EXPECT_EQ(hash_map.Size(), 10);  // no new metric point added
 
   // get the overflow metric point
-  auto agg1 = hash_map.GetOrSetDefault(kOverflowAttributes, aggregation_callback);
+  auto agg1 = hash_map.GetOrSetDefault(kOverflowAttributes(), aggregation_callback);
   EXPECT_NE(agg1, nullptr);
   auto sum_agg1 = static_cast<LongSumAggregation *>(agg1);
   EXPECT_EQ(nostd::get<int64_t>(nostd::get<SumPointData>(sum_agg1->ToPoint()).value_),
@@ -147,7 +147,7 @@ TEST_P(WritableMetricStorageCardinalityLimitTestFixture, LongCounterSumAggregati
         {
           const auto &data = opentelemetry::nostd::get<SumPointData>(data_attr.point_data);
           count_attributes++;
-          if (data_attr.attributes.begin()->first == kAttributesLimitOverflowKey)
+          if (data_attr.attributes.begin()->first == kAttributesLimitOverflowKey())
           {
             // Per the spec, the overflow data point MUST contain exactly one
             // attribute, with the key `otel.metric.overflow` and the boolean
@@ -177,12 +177,12 @@ INSTANTIATE_TEST_SUITE_P(All,
 // https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/metrics/sdk.md#cardinality-limits
 TEST(CardinalityLimitOverflowAttribute, MatchesSpecLiteral)
 {
-  EXPECT_EQ(opentelemetry::sdk::metrics::kAttributesLimitOverflowKey, "otel.metric.overflow");
+  EXPECT_EQ(opentelemetry::sdk::metrics::kAttributesLimitOverflowKey(), "otel.metric.overflow");
   EXPECT_EQ(opentelemetry::sdk::metrics::kAttributesLimitOverflowValue, true);
   // The precomputed overflow attribute set MUST contain exactly the spec key
   // mapped to the boolean value `true`.
-  ASSERT_EQ(opentelemetry::sdk::metrics::kOverflowAttributes.size(), 1u);
-  const auto &entry = *opentelemetry::sdk::metrics::kOverflowAttributes.begin();
+  ASSERT_EQ(opentelemetry::sdk::metrics::kOverflowAttributes().size(), 1u);
+  const auto &entry = *opentelemetry::sdk::metrics::kOverflowAttributes().begin();
   EXPECT_EQ(entry.first, "otel.metric.overflow");
   EXPECT_EQ(nostd::get<bool>(entry.second), true);
 }

--- a/sdk/test/metrics/cardinality_limit_test.cc
+++ b/sdk/test/metrics/cardinality_limit_test.cc
@@ -147,7 +147,7 @@ TEST_P(WritableMetricStorageCardinalityLimitTestFixture, LongCounterSumAggregati
         {
           const auto &data = opentelemetry::nostd::get<SumPointData>(data_attr.point_data);
           count_attributes++;
-          if (data_attr.attributes.begin()->first == kAttributesLimitOverflowKey())
+          if (data_attr.attributes.begin()->first == kAttributesLimitOverflowKey)
           {
             // Per the spec, the overflow data point MUST contain exactly one
             // attribute, with the key `otel.metric.overflow` and the boolean
@@ -177,7 +177,7 @@ INSTANTIATE_TEST_SUITE_P(All,
 // https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/metrics/sdk.md#cardinality-limits
 TEST(CardinalityLimitOverflowAttribute, MatchesSpecLiteral)
 {
-  EXPECT_EQ(opentelemetry::sdk::metrics::kAttributesLimitOverflowKey(), "otel.metric.overflow");
+  EXPECT_EQ(opentelemetry::sdk::metrics::kAttributesLimitOverflowKey, "otel.metric.overflow");
   EXPECT_EQ(opentelemetry::sdk::metrics::kAttributesLimitOverflowValue, true);
   // The precomputed overflow attribute set MUST contain exactly the spec key
   // mapped to the boolean value `true`.

--- a/sdk/test/metrics/cardinality_limit_test.cc
+++ b/sdk/test/metrics/cardinality_limit_test.cc
@@ -76,7 +76,7 @@ TEST(CardinalityLimit, AttributesHashMapBasicTests)
   EXPECT_EQ(hash_map.Size(), 10);  // no new metric point added
 
   // get the overflow metric point
-  auto agg1 = hash_map.GetOrSetDefault(kOverflowAttributes(), aggregation_callback);
+  auto agg1 = hash_map.GetOrSetDefault(GetOverflowAttributes(), aggregation_callback);
   EXPECT_NE(agg1, nullptr);
   auto sum_agg1 = static_cast<LongSumAggregation *>(agg1);
   EXPECT_EQ(nostd::get<int64_t>(nostd::get<SumPointData>(sum_agg1->ToPoint()).value_),
@@ -181,8 +181,8 @@ TEST(CardinalityLimitOverflowAttribute, MatchesSpecLiteral)
   EXPECT_EQ(opentelemetry::sdk::metrics::kAttributesLimitOverflowValue, true);
   // The precomputed overflow attribute set MUST contain exactly the spec key
   // mapped to the boolean value `true`.
-  ASSERT_EQ(opentelemetry::sdk::metrics::kOverflowAttributes().size(), 1u);
-  const auto &entry = *opentelemetry::sdk::metrics::kOverflowAttributes().begin();
+  ASSERT_EQ(opentelemetry::sdk::metrics::GetOverflowAttributes().size(), 1u);
+  const auto &entry = *opentelemetry::sdk::metrics::GetOverflowAttributes().begin();
   EXPECT_EQ(entry.first, "otel.metric.overflow");
   EXPECT_EQ(nostd::get<bool>(entry.second), true);
 }

--- a/sdk/test/metrics/meter_config_test.cc
+++ b/sdk/test/metrics/meter_config_test.cc
@@ -36,40 +36,65 @@ TEST(MeterConfig, CheckDefaultConfigWorksAccToSpec)
 
 /** Tests to verify the behavior of metrics_sdk::MeterConfig::Default */
 
-static std::pair<opentelemetry::nostd::string_view, opentelemetry::common::AttributeValue> attr1 = {
-    "accept_single_attr", true};
-static std::pair<opentelemetry::nostd::string_view, opentelemetry::common::AttributeValue> attr2 = {
-    "accept_second_attr", "some other attr"};
-static std::pair<opentelemetry::nostd::string_view, opentelemetry::common::AttributeValue> attr3 = {
-    "accept_third_attr", 3};
+static std::pair<opentelemetry::nostd::string_view, opentelemetry::common::AttributeValue> &attr1()
+{
+  static std::pair<opentelemetry::nostd::string_view, opentelemetry::common::AttributeValue> value{
+      "accept_single_attr", true};
+  return value;
+}
+static std::pair<opentelemetry::nostd::string_view, opentelemetry::common::AttributeValue> &attr2()
+{
+  static std::pair<opentelemetry::nostd::string_view, opentelemetry::common::AttributeValue> value{
+      "accept_second_attr", "some other attr"};
+  return value;
+}
+static std::pair<opentelemetry::nostd::string_view, opentelemetry::common::AttributeValue> &attr3()
+{
+  static std::pair<opentelemetry::nostd::string_view, opentelemetry::common::AttributeValue> value{
+      "accept_third_attr", 3};
+  return value;
+}
 
-static instrumentation_scope::InstrumentationScope test_scope_1 =
-    *instrumentation_scope::InstrumentationScope::Create("test_scope_1");
-static instrumentation_scope::InstrumentationScope test_scope_2 =
-    *instrumentation_scope::InstrumentationScope::Create("test_scope_2", "1.0");
-static instrumentation_scope::InstrumentationScope test_scope_3 =
-    *instrumentation_scope::InstrumentationScope::Create(
-        "test_scope_3",
-        "0",
-        "https://opentelemetry.io/schemas/v1.18.0");
-static instrumentation_scope::InstrumentationScope test_scope_4 =
-    *instrumentation_scope::InstrumentationScope::Create("test_scope_4",
-                                                         "0",
-                                                         "https://opentelemetry.io/schemas/v1.18.0",
-                                                         {attr1});
-static instrumentation_scope::InstrumentationScope test_scope_5 =
-    *instrumentation_scope::InstrumentationScope::Create("test_scope_5",
-                                                         "0",
-                                                         "https://opentelemetry.io/schemas/v1.18.0",
-                                                         {attr1, attr2, attr3});
+static instrumentation_scope::InstrumentationScope &test_scope_1()
+{
+  static auto value = *instrumentation_scope::InstrumentationScope::Create("test_scope_1");
+  return value;
+}
+static instrumentation_scope::InstrumentationScope &test_scope_2()
+{
+  static auto value = *instrumentation_scope::InstrumentationScope::Create("test_scope_2", "1.0");
+  return value;
+}
+static instrumentation_scope::InstrumentationScope &test_scope_3()
+{
+  static auto value = *instrumentation_scope::InstrumentationScope::Create(
+      "test_scope_3", "0", "https://opentelemetry.io/schemas/v1.18.0");
+  return value;
+}
+static instrumentation_scope::InstrumentationScope &test_scope_4()
+{
+  static auto value = *instrumentation_scope::InstrumentationScope::Create(
+      "test_scope_4", "0", "https://opentelemetry.io/schemas/v1.18.0", {attr1()});
+  return value;
+}
+static instrumentation_scope::InstrumentationScope &test_scope_5()
+{
+  static auto value = *instrumentation_scope::InstrumentationScope::Create(
+      "test_scope_5", "0", "https://opentelemetry.io/schemas/v1.18.0", {attr1(), attr2(), attr3()});
+  return value;
+}
 
 // This array could also directly contain the reference types, but that  leads to 'uninitialized
 // value was created by heap allocation' errors in Valgrind memcheck. This is a bug in Googletest
 // library, see https://github.com/google/googletest/issues/3805#issuecomment-1397301790 for more
 // details. Using pointers is a workaround to prevent the Valgrind warnings.
-const std::array<instrumentation_scope::InstrumentationScope *, 5> instrumentation_scopes = {
-    &test_scope_1, &test_scope_2, &test_scope_3, &test_scope_4, &test_scope_5,
-};
+static const std::array<instrumentation_scope::InstrumentationScope *, 5> &instrumentation_scopes()
+{
+  static const std::array<instrumentation_scope::InstrumentationScope *, 5> value = {
+      &test_scope_1(), &test_scope_2(), &test_scope_3(), &test_scope_4(), &test_scope_5(),
+  };
+  return value;
+}
 
 namespace
 {
@@ -93,6 +118,6 @@ TEST_P(DefaultMeterConfiguratorTestFixture, VerifyDefaultConfiguratorBehavior)
 
 INSTANTIATE_TEST_SUITE_P(InstrumentationScopes,
                          DefaultMeterConfiguratorTestFixture,
-                         ::testing::ValuesIn(instrumentation_scopes));
+                         ::testing::ValuesIn(instrumentation_scopes()));
 
 }  // namespace

--- a/sdk/test/metrics/meter_config_test.cc
+++ b/sdk/test/metrics/meter_config_test.cc
@@ -36,51 +36,55 @@ TEST(MeterConfig, CheckDefaultConfigWorksAccToSpec)
 
 /** Tests to verify the behavior of metrics_sdk::MeterConfig::Default */
 
-static std::pair<opentelemetry::nostd::string_view, opentelemetry::common::AttributeValue> &attr1()
+static std::pair<opentelemetry::nostd::string_view, opentelemetry::common::AttributeValue> &
+GetAttr1()
 {
   static std::pair<opentelemetry::nostd::string_view, opentelemetry::common::AttributeValue> value{
       "accept_single_attr", true};
   return value;
 }
-static std::pair<opentelemetry::nostd::string_view, opentelemetry::common::AttributeValue> &attr2()
+static std::pair<opentelemetry::nostd::string_view, opentelemetry::common::AttributeValue> &
+GetAttr2()
 {
   static std::pair<opentelemetry::nostd::string_view, opentelemetry::common::AttributeValue> value{
       "accept_second_attr", "some other attr"};
   return value;
 }
-static std::pair<opentelemetry::nostd::string_view, opentelemetry::common::AttributeValue> &attr3()
+static std::pair<opentelemetry::nostd::string_view, opentelemetry::common::AttributeValue> &
+GetAttr3()
 {
   static std::pair<opentelemetry::nostd::string_view, opentelemetry::common::AttributeValue> value{
       "accept_third_attr", 3};
   return value;
 }
 
-static instrumentation_scope::InstrumentationScope &test_scope_1()
+static instrumentation_scope::InstrumentationScope &GetTestScope1()
 {
   static auto value = *instrumentation_scope::InstrumentationScope::Create("test_scope_1");
   return value;
 }
-static instrumentation_scope::InstrumentationScope &test_scope_2()
+static instrumentation_scope::InstrumentationScope &GetTestScope2()
 {
   static auto value = *instrumentation_scope::InstrumentationScope::Create("test_scope_2", "1.0");
   return value;
 }
-static instrumentation_scope::InstrumentationScope &test_scope_3()
+static instrumentation_scope::InstrumentationScope &GetTestScope3()
 {
   static auto value = *instrumentation_scope::InstrumentationScope::Create(
       "test_scope_3", "0", "https://opentelemetry.io/schemas/v1.18.0");
   return value;
 }
-static instrumentation_scope::InstrumentationScope &test_scope_4()
+static instrumentation_scope::InstrumentationScope &GetTestScope4()
 {
   static auto value = *instrumentation_scope::InstrumentationScope::Create(
-      "test_scope_4", "0", "https://opentelemetry.io/schemas/v1.18.0", {attr1()});
+      "test_scope_4", "0", "https://opentelemetry.io/schemas/v1.18.0", {GetAttr1()});
   return value;
 }
-static instrumentation_scope::InstrumentationScope &test_scope_5()
+static instrumentation_scope::InstrumentationScope &GetTestScope5()
 {
   static auto value = *instrumentation_scope::InstrumentationScope::Create(
-      "test_scope_5", "0", "https://opentelemetry.io/schemas/v1.18.0", {attr1(), attr2(), attr3()});
+      "test_scope_5", "0", "https://opentelemetry.io/schemas/v1.18.0",
+      {GetAttr1(), GetAttr2(), GetAttr3()});
   return value;
 }
 
@@ -88,10 +92,11 @@ static instrumentation_scope::InstrumentationScope &test_scope_5()
 // value was created by heap allocation' errors in Valgrind memcheck. This is a bug in Googletest
 // library, see https://github.com/google/googletest/issues/3805#issuecomment-1397301790 for more
 // details. Using pointers is a workaround to prevent the Valgrind warnings.
-static const std::array<instrumentation_scope::InstrumentationScope *, 5> &instrumentation_scopes()
+static const std::array<instrumentation_scope::InstrumentationScope *, 5> &
+GetInstrumentationScopes()
 {
   static const std::array<instrumentation_scope::InstrumentationScope *, 5> value = {
-      &test_scope_1(), &test_scope_2(), &test_scope_3(), &test_scope_4(), &test_scope_5(),
+      &GetTestScope1(), &GetTestScope2(), &GetTestScope3(), &GetTestScope4(), &GetTestScope5(),
   };
   return value;
 }
@@ -118,6 +123,6 @@ TEST_P(DefaultMeterConfiguratorTestFixture, VerifyDefaultConfiguratorBehavior)
 
 INSTANTIATE_TEST_SUITE_P(InstrumentationScopes,
                          DefaultMeterConfiguratorTestFixture,
-                         ::testing::ValuesIn(instrumentation_scopes()));
+                         ::testing::ValuesIn(GetInstrumentationScopes()));
 
 }  // namespace

--- a/sdk/test/metrics/sum_aggregation_test.cc
+++ b/sdk/test/metrics/sum_aggregation_test.cc
@@ -208,8 +208,8 @@ TEST(HistogramToSumFilterAttributesWithCardinalityLimit, Double)
             }
             else
             {
-              const auto overflow_it = md.point_data_attr_[i].attributes.find(
-                  sdk::metrics::kAttributesLimitOverflowKey());
+              const auto overflow_it =
+                  md.point_data_attr_[i].attributes.find(sdk::metrics::kAttributesLimitOverflowKey);
               EXPECT_NE(md.point_data_attr_[i].attributes.end(), overflow_it);
               if (overflow_it != md.point_data_attr_[i].attributes.end())
               {
@@ -396,8 +396,8 @@ TEST(CounterToSumFilterAttributesWithCardinalityLimit, Double)
             }
             else
             {
-              const auto overflow_it = md.point_data_attr_[i].attributes.find(
-                  sdk::metrics::kAttributesLimitOverflowKey());
+              const auto overflow_it =
+                  md.point_data_attr_[i].attributes.find(sdk::metrics::kAttributesLimitOverflowKey);
               EXPECT_NE(md.point_data_attr_[i].attributes.end(), overflow_it);
               if (overflow_it != md.point_data_attr_[i].attributes.end())
               {

--- a/sdk/test/metrics/sum_aggregation_test.cc
+++ b/sdk/test/metrics/sum_aggregation_test.cc
@@ -208,8 +208,8 @@ TEST(HistogramToSumFilterAttributesWithCardinalityLimit, Double)
             }
             else
             {
-              const auto overflow_it =
-                  md.point_data_attr_[i].attributes.find(sdk::metrics::kAttributesLimitOverflowKey);
+              const auto overflow_it = md.point_data_attr_[i].attributes.find(
+                  sdk::metrics::kAttributesLimitOverflowKey());
               EXPECT_NE(md.point_data_attr_[i].attributes.end(), overflow_it);
               if (overflow_it != md.point_data_attr_[i].attributes.end())
               {
@@ -396,8 +396,8 @@ TEST(CounterToSumFilterAttributesWithCardinalityLimit, Double)
             }
             else
             {
-              const auto overflow_it =
-                  md.point_data_attr_[i].attributes.find(sdk::metrics::kAttributesLimitOverflowKey);
+              const auto overflow_it = md.point_data_attr_[i].attributes.find(
+                  sdk::metrics::kAttributesLimitOverflowKey());
               EXPECT_NE(md.point_data_attr_[i].attributes.end(), overflow_it);
               if (overflow_it != md.point_data_attr_[i].attributes.end())
               {

--- a/sdk/test/metrics/sync_instruments_test.cc
+++ b/sdk/test/metrics/sync_instruments_test.cc
@@ -11,17 +11,13 @@
 #include "opentelemetry/common/key_value_iterable_view.h"
 #include "opentelemetry/context/context.h"
 #include "opentelemetry/nostd/utility.h"
-#include "opentelemetry/sdk/instrumentationscope/instrumentation_scope.h"
 #include "opentelemetry/sdk/metrics/instruments.h"
 #include "opentelemetry/sdk/metrics/state/metric_storage.h"
 #include "opentelemetry/sdk/metrics/state/multi_metric_storage.h"
 #include "opentelemetry/sdk/metrics/sync_instruments.h"
 
 using namespace opentelemetry;
-using namespace opentelemetry::sdk::instrumentationscope;
 using namespace opentelemetry::sdk::metrics;
-
-static auto instrumentation_scope = InstrumentationScope::Create("opentelemetry-cpp", "0.1.0");
 
 using M = std::map<std::string, std::string>;
 

--- a/sdk/test/trace/tracer_config_test.cc
+++ b/sdk/test/trace/tracer_config_test.cc
@@ -36,40 +36,65 @@ TEST(TracerConfig, CheckDefaultConfigWorksAccToSpec)
 
 /** Tests to verify the behavior of trace_sdk::TracerConfig::DefaultConfigurator */
 
-static std::pair<opentelemetry::nostd::string_view, opentelemetry::common::AttributeValue> attr1 = {
-    "accept_single_attr", true};
-static std::pair<opentelemetry::nostd::string_view, opentelemetry::common::AttributeValue> attr2 = {
-    "accept_second_attr", "some other attr"};
-static std::pair<opentelemetry::nostd::string_view, opentelemetry::common::AttributeValue> attr3 = {
-    "accept_third_attr", 3};
+static std::pair<opentelemetry::nostd::string_view, opentelemetry::common::AttributeValue> &attr1()
+{
+  static std::pair<opentelemetry::nostd::string_view, opentelemetry::common::AttributeValue> value{
+      "accept_single_attr", true};
+  return value;
+}
+static std::pair<opentelemetry::nostd::string_view, opentelemetry::common::AttributeValue> &attr2()
+{
+  static std::pair<opentelemetry::nostd::string_view, opentelemetry::common::AttributeValue> value{
+      "accept_second_attr", "some other attr"};
+  return value;
+}
+static std::pair<opentelemetry::nostd::string_view, opentelemetry::common::AttributeValue> &attr3()
+{
+  static std::pair<opentelemetry::nostd::string_view, opentelemetry::common::AttributeValue> value{
+      "accept_third_attr", 3};
+  return value;
+}
 
-static instrumentation_scope::InstrumentationScope test_scope_1 =
-    *instrumentation_scope::InstrumentationScope::Create("test_scope_1");
-static instrumentation_scope::InstrumentationScope test_scope_2 =
-    *instrumentation_scope::InstrumentationScope::Create("test_scope_2", "1.0");
-static instrumentation_scope::InstrumentationScope test_scope_3 =
-    *instrumentation_scope::InstrumentationScope::Create(
-        "test_scope_3",
-        "0",
-        "https://opentelemetry.io/schemas/v1.18.0");
-static instrumentation_scope::InstrumentationScope test_scope_4 =
-    *instrumentation_scope::InstrumentationScope::Create("test_scope_4",
-                                                         "0",
-                                                         "https://opentelemetry.io/schemas/v1.18.0",
-                                                         {attr1});
-static instrumentation_scope::InstrumentationScope test_scope_5 =
-    *instrumentation_scope::InstrumentationScope::Create("test_scope_5",
-                                                         "0",
-                                                         "https://opentelemetry.io/schemas/v1.18.0",
-                                                         {attr1, attr2, attr3});
+static instrumentation_scope::InstrumentationScope &test_scope_1()
+{
+  static auto value = *instrumentation_scope::InstrumentationScope::Create("test_scope_1");
+  return value;
+}
+static instrumentation_scope::InstrumentationScope &test_scope_2()
+{
+  static auto value = *instrumentation_scope::InstrumentationScope::Create("test_scope_2", "1.0");
+  return value;
+}
+static instrumentation_scope::InstrumentationScope &test_scope_3()
+{
+  static auto value = *instrumentation_scope::InstrumentationScope::Create(
+      "test_scope_3", "0", "https://opentelemetry.io/schemas/v1.18.0");
+  return value;
+}
+static instrumentation_scope::InstrumentationScope &test_scope_4()
+{
+  static auto value = *instrumentation_scope::InstrumentationScope::Create(
+      "test_scope_4", "0", "https://opentelemetry.io/schemas/v1.18.0", {attr1()});
+  return value;
+}
+static instrumentation_scope::InstrumentationScope &test_scope_5()
+{
+  static auto value = *instrumentation_scope::InstrumentationScope::Create(
+      "test_scope_5", "0", "https://opentelemetry.io/schemas/v1.18.0", {attr1(), attr2(), attr3()});
+  return value;
+}
 
 // This array could also directly contain the reference types, but that  leads to 'uninitialized
 // value was created by heap allocation' errors in Valgrind memcheck. This is a bug in Googletest
 // library, see https://github.com/google/googletest/issues/3805#issuecomment-1397301790 for more
 // details. Using pointers is a workaround to prevent the Valgrind warnings.
-const std::array<instrumentation_scope::InstrumentationScope *, 5> instrumentation_scopes = {
-    &test_scope_1, &test_scope_2, &test_scope_3, &test_scope_4, &test_scope_5,
-};
+static const std::array<instrumentation_scope::InstrumentationScope *, 5> &instrumentation_scopes()
+{
+  static const std::array<instrumentation_scope::InstrumentationScope *, 5> value = {
+      &test_scope_1(), &test_scope_2(), &test_scope_3(), &test_scope_4(), &test_scope_5(),
+  };
+  return value;
+}
 
 namespace
 {
@@ -93,6 +118,6 @@ TEST_P(DefaultTracerConfiguratorTestFixture, VerifyDefaultConfiguratorBehavior)
 
 INSTANTIATE_TEST_SUITE_P(InstrumentationScopes,
                          DefaultTracerConfiguratorTestFixture,
-                         ::testing::ValuesIn(instrumentation_scopes));
+                         ::testing::ValuesIn(instrumentation_scopes()));
 
 }  // namespace

--- a/sdk/test/trace/tracer_config_test.cc
+++ b/sdk/test/trace/tracer_config_test.cc
@@ -36,51 +36,55 @@ TEST(TracerConfig, CheckDefaultConfigWorksAccToSpec)
 
 /** Tests to verify the behavior of trace_sdk::TracerConfig::DefaultConfigurator */
 
-static std::pair<opentelemetry::nostd::string_view, opentelemetry::common::AttributeValue> &attr1()
+static std::pair<opentelemetry::nostd::string_view, opentelemetry::common::AttributeValue> &
+GetAttr1()
 {
   static std::pair<opentelemetry::nostd::string_view, opentelemetry::common::AttributeValue> value{
       "accept_single_attr", true};
   return value;
 }
-static std::pair<opentelemetry::nostd::string_view, opentelemetry::common::AttributeValue> &attr2()
+static std::pair<opentelemetry::nostd::string_view, opentelemetry::common::AttributeValue> &
+GetAttr2()
 {
   static std::pair<opentelemetry::nostd::string_view, opentelemetry::common::AttributeValue> value{
       "accept_second_attr", "some other attr"};
   return value;
 }
-static std::pair<opentelemetry::nostd::string_view, opentelemetry::common::AttributeValue> &attr3()
+static std::pair<opentelemetry::nostd::string_view, opentelemetry::common::AttributeValue> &
+GetAttr3()
 {
   static std::pair<opentelemetry::nostd::string_view, opentelemetry::common::AttributeValue> value{
       "accept_third_attr", 3};
   return value;
 }
 
-static instrumentation_scope::InstrumentationScope &test_scope_1()
+static instrumentation_scope::InstrumentationScope &GetTestScope1()
 {
   static auto value = *instrumentation_scope::InstrumentationScope::Create("test_scope_1");
   return value;
 }
-static instrumentation_scope::InstrumentationScope &test_scope_2()
+static instrumentation_scope::InstrumentationScope &GetTestScope2()
 {
   static auto value = *instrumentation_scope::InstrumentationScope::Create("test_scope_2", "1.0");
   return value;
 }
-static instrumentation_scope::InstrumentationScope &test_scope_3()
+static instrumentation_scope::InstrumentationScope &GetTestScope3()
 {
   static auto value = *instrumentation_scope::InstrumentationScope::Create(
       "test_scope_3", "0", "https://opentelemetry.io/schemas/v1.18.0");
   return value;
 }
-static instrumentation_scope::InstrumentationScope &test_scope_4()
+static instrumentation_scope::InstrumentationScope &GetTestScope4()
 {
   static auto value = *instrumentation_scope::InstrumentationScope::Create(
-      "test_scope_4", "0", "https://opentelemetry.io/schemas/v1.18.0", {attr1()});
+      "test_scope_4", "0", "https://opentelemetry.io/schemas/v1.18.0", {GetAttr1()});
   return value;
 }
-static instrumentation_scope::InstrumentationScope &test_scope_5()
+static instrumentation_scope::InstrumentationScope &GetTestScope5()
 {
   static auto value = *instrumentation_scope::InstrumentationScope::Create(
-      "test_scope_5", "0", "https://opentelemetry.io/schemas/v1.18.0", {attr1(), attr2(), attr3()});
+      "test_scope_5", "0", "https://opentelemetry.io/schemas/v1.18.0",
+      {GetAttr1(), GetAttr2(), GetAttr3()});
   return value;
 }
 
@@ -88,10 +92,11 @@ static instrumentation_scope::InstrumentationScope &test_scope_5()
 // value was created by heap allocation' errors in Valgrind memcheck. This is a bug in Googletest
 // library, see https://github.com/google/googletest/issues/3805#issuecomment-1397301790 for more
 // details. Using pointers is a workaround to prevent the Valgrind warnings.
-static const std::array<instrumentation_scope::InstrumentationScope *, 5> &instrumentation_scopes()
+static const std::array<instrumentation_scope::InstrumentationScope *, 5> &
+GetInstrumentationScopes()
 {
   static const std::array<instrumentation_scope::InstrumentationScope *, 5> value = {
-      &test_scope_1(), &test_scope_2(), &test_scope_3(), &test_scope_4(), &test_scope_5(),
+      &GetTestScope1(), &GetTestScope2(), &GetTestScope3(), &GetTestScope4(), &GetTestScope5(),
   };
   return value;
 }
@@ -118,6 +123,6 @@ TEST_P(DefaultTracerConfiguratorTestFixture, VerifyDefaultConfiguratorBehavior)
 
 INSTANTIATE_TEST_SUITE_P(InstrumentationScopes,
                          DefaultTracerConfiguratorTestFixture,
-                         ::testing::ValuesIn(instrumentation_scopes()));
+                         ::testing::ValuesIn(GetInstrumentationScopes()));
 
 }  // namespace


### PR DESCRIPTION
Fixes #4197

## Changes

Addressing clang-tidy `bugprone-throwing-static-initialization` warnings

Fixes:
  - Replaced `const` with `constexpr` for compile-time constants
  - Replaced `const std::string` with `constexpr const char *`
  - Used `nostd::string_view` for a non-owning view
  - Converted shared objects to static local variables
  - Moved option objects out of namespace scope into `main()` and passed by reference
  - Moved class static member into function scope at use

For significant contributions please make sure you have completed the following items:

* [x] `CHANGELOG.md` updated for non-trivial changes
* [ ] Unit tests have been added
* [x] Changes in public API reviewed