### PR TITLE
[SDK] Rename ComposableTraceIdRatioBasedSampler to ComposableProbabilitySampler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -115,9 +115,13 @@ Increment the:
   [#4144](https://github.com/open-telemetry/opentelemetry-cpp/pull/4144)
 
 * [SDK] Add ComposableSampler and CompositeSampler with the consistent
-  probability sampling variants (AlwaysOn, AlwaysOff, TraceIdRatioBased,
+  probability sampling variants (AlwaysOn, AlwaysOff, ComposableProbability,
   ParentThreshold, RuleBased)
   [#4028](https://github.com/open-telemetry/opentelemetry-cpp/issues/4028)
+
+* [SDK] Rename ComposableTraceIdRatioBasedSampler to ComposableProbabilitySampler
+  to align with the OpenTelemetry specification
+  [#4161](https://github.com/open-telemetry/opentelemetry-cpp/issues/4161)
 
 * [BUILD] Fix protobuf build failure
   [#4154](https://github.com/open-telemetry/opentelemetry-cpp/pull/4154)

--- a/sdk/include/opentelemetry/sdk/trace/samplers/composable_probability.h
+++ b/sdk/include/opentelemetry/sdk/trace/samplers/composable_probability.h
@@ -16,7 +16,7 @@ namespace trace
 {
 
 /**
- * ComposableTraceIdRatioBasedSampler samples a configurable fraction of traces
+ * ComposableProbabilitySampler samples a configurable fraction of traces
  * using consistent probability sampling. It corresponds to the specification's
  * ComposableProbability sampler and the ComposableProbabilitySamplerConfiguration
  * config model.
@@ -24,10 +24,10 @@ namespace trace
  * The ratio maps to a 56-bit rejection threshold. A ratio of 0 drops every span
  * (an unreliable, non-probabilistic intent, equivalent to ComposableAlwaysOff).
  */
-class ComposableTraceIdRatioBasedSampler : public ComposableSampler
+class ComposableProbabilitySampler : public ComposableSampler
 {
 public:
-  explicit ComposableTraceIdRatioBasedSampler(double ratio);
+  explicit ComposableProbabilitySampler(double ratio);
 
   SamplingIntent GetSamplingIntent(
       const opentelemetry::trace::SpanContext &parent_context,

--- a/sdk/src/trace/CMakeLists.txt
+++ b/sdk/src/trace/CMakeLists.txt
@@ -25,7 +25,7 @@ add_library(
   samplers/ot_trace_state.cc
   samplers/composite_sampler.cc
   samplers/composite_sampler_factory.cc
-  samplers/composable_trace_id_ratio.cc
+  samplers/composable_probability.cc
   samplers/composable_parent_threshold.cc
   samplers/composable_rule_based.cc
   multi_recordable.cc

--- a/sdk/src/trace/samplers/composable_probability.cc
+++ b/sdk/src/trace/samplers/composable_probability.cc
@@ -1,7 +1,7 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-#include "opentelemetry/sdk/trace/samplers/composable_trace_id_ratio.h"
+#include "opentelemetry/sdk/trace/samplers/composable_probability.h"
 
 #include <cstdint>
 #include <string>
@@ -18,7 +18,7 @@ namespace sdk
 namespace trace
 {
 
-ComposableTraceIdRatioBasedSampler::ComposableTraceIdRatioBasedSampler(double ratio)
+ComposableProbabilitySampler::ComposableProbabilitySampler(double ratio)
 {
   if (ratio > 1.0)
   {
@@ -33,10 +33,10 @@ ComposableTraceIdRatioBasedSampler::ComposableTraceIdRatioBasedSampler(double ra
   // this to behave like ComposableAlwaysOff: a non-probabilistic drop.
   has_threshold_ = threshold < kMaxThreshold;
   threshold_     = has_threshold_ ? threshold : 0;
-  description_   = "ComposableTraceIdRatioBasedSampler{" + std::to_string(ratio) + "}";
+  description_   = "ComposableProbabilitySampler{" + std::to_string(ratio) + "}";
 }
 
-SamplingIntent ComposableTraceIdRatioBasedSampler::GetSamplingIntent(
+SamplingIntent ComposableProbabilitySampler::GetSamplingIntent(
     const opentelemetry::trace::SpanContext & /* parent_context */,
     opentelemetry::trace::TraceId /* trace_id */,
     nostd::string_view /* name */,
@@ -51,7 +51,7 @@ SamplingIntent ComposableTraceIdRatioBasedSampler::GetSamplingIntent(
   return intent;
 }
 
-nostd::string_view ComposableTraceIdRatioBasedSampler::GetDescription() const noexcept
+nostd::string_view ComposableProbabilitySampler::GetDescription() const noexcept
 {
   return description_;
 }

--- a/sdk/test/trace/composable_sampler_test.cc
+++ b/sdk/test/trace/composable_sampler_test.cc
@@ -20,9 +20,9 @@
 #include "opentelemetry/sdk/trace/samplers/composable_always_off.h"
 #include "opentelemetry/sdk/trace/samplers/composable_always_on.h"
 #include "opentelemetry/sdk/trace/samplers/composable_parent_threshold.h"
+#include "opentelemetry/sdk/trace/samplers/composable_probability.h"
 #include "opentelemetry/sdk/trace/samplers/composable_rule_based.h"
 #include "opentelemetry/sdk/trace/samplers/composable_sampler.h"
-#include "opentelemetry/sdk/trace/samplers/composable_trace_id_ratio.h"
 #include "opentelemetry/sdk/trace/samplers/composite_sampler.h"
 #include "opentelemetry/sdk/trace/samplers/composite_sampler_factory.h"
 #include "opentelemetry/sdk/trace/samplers/predicate.h"
@@ -40,9 +40,9 @@ namespace common    = opentelemetry::common;
 using opentelemetry::sdk::trace::ComposableAlwaysOffSampler;
 using opentelemetry::sdk::trace::ComposableAlwaysOnSampler;
 using opentelemetry::sdk::trace::ComposableParentThresholdSampler;
+using opentelemetry::sdk::trace::ComposableProbabilitySampler;
 using opentelemetry::sdk::trace::ComposableRuleBasedSampler;
 using opentelemetry::sdk::trace::ComposableSampler;
-using opentelemetry::sdk::trace::ComposableTraceIdRatioBasedSampler;
 using opentelemetry::sdk::trace::CompositeSampler;
 using opentelemetry::sdk::trace::CompositeSamplerFactory;
 using opentelemetry::sdk::trace::Decision;
@@ -207,12 +207,11 @@ TEST(ComposableSampler, AlwaysOffDrops)
 TEST(ComposableSampler, TraceIdRatioBoundaries)
 {
   auto always =
-      CompositeSamplerFactory::Create(std::make_shared<ComposableTraceIdRatioBasedSampler>(1.0));
+      CompositeSamplerFactory::Create(std::make_shared<ComposableProbabilitySampler>(1.0));
   EXPECT_EQ(Decision::RECORD_AND_SAMPLE,
             Sample(*always, trace_api::SpanContext::GetInvalid(), MakeTraceId(0x00)));
 
-  auto never =
-      CompositeSamplerFactory::Create(std::make_shared<ComposableTraceIdRatioBasedSampler>(0.0));
+  auto never = CompositeSamplerFactory::Create(std::make_shared<ComposableProbabilitySampler>(0.0));
   EXPECT_EQ(Decision::DROP,
             Sample(*never, trace_api::SpanContext::GetInvalid(), MakeTraceId(0xFF)));
 }
@@ -220,7 +219,7 @@ TEST(ComposableSampler, TraceIdRatioBoundaries)
 TEST(ComposableSampler, TraceIdRatioUsesTraceRandomness)
 {
   auto sampler =
-      CompositeSamplerFactory::Create(std::make_shared<ComposableTraceIdRatioBasedSampler>(0.5));
+      CompositeSamplerFactory::Create(std::make_shared<ComposableProbabilitySampler>(0.5));
 
   // Threshold for p=0.5 is 2^55, encoded as th:8. Maximum randomness keeps.
   opentelemetry::sdk::trace::SamplingResult kept;
@@ -236,7 +235,7 @@ TEST(ComposableSampler, TraceIdRatioUsesTraceRandomness)
 TEST(ComposableSampler, ExplicitRandomnessOverridesTraceId)
 {
   auto sampler =
-      CompositeSamplerFactory::Create(std::make_shared<ComposableTraceIdRatioBasedSampler>(0.5));
+      CompositeSamplerFactory::Create(std::make_shared<ComposableProbabilitySampler>(0.5));
 
   // rv present and at maximum: keep regardless of the (zero) trace id bits, and
   // the explicit randomness must be preserved in the outgoing tracestate.
@@ -315,8 +314,8 @@ TEST(ComposableSampler, RuleBasedNoMatchDrops)
 
 TEST(ComposableSampler, Descriptions)
 {
-  ComposableTraceIdRatioBasedSampler ratio(0.5);
-  EXPECT_EQ("ComposableTraceIdRatioBasedSampler{0.500000}", std::string(ratio.GetDescription()));
+  ComposableProbabilitySampler ratio(0.5);
+  EXPECT_EQ("ComposableProbabilitySampler{0.500000}", std::string(ratio.GetDescription()));
 
   CompositeSampler composite(std::make_shared<ComposableAlwaysOnSampler>());
   EXPECT_EQ("CompositeSampler{ComposableAlwaysOnSampler}", std::string(composite.GetDescription()));
@@ -365,13 +364,12 @@ TEST(ComposableSampler, DropsTrailingSubkeysOverSizeLimit)
 
 TEST(ComposableSampler, RatioClampedToValidRange)
 {
-  auto over =
-      CompositeSamplerFactory::Create(std::make_shared<ComposableTraceIdRatioBasedSampler>(2.0));
+  auto over = CompositeSamplerFactory::Create(std::make_shared<ComposableProbabilitySampler>(2.0));
   EXPECT_EQ(Decision::RECORD_AND_SAMPLE,
             Sample(*over, trace_api::SpanContext::GetInvalid(), MakeTraceId(0x00)));
 
   auto under =
-      CompositeSamplerFactory::Create(std::make_shared<ComposableTraceIdRatioBasedSampler>(-1.0));
+      CompositeSamplerFactory::Create(std::make_shared<ComposableProbabilitySampler>(-1.0));
   EXPECT_EQ(Decision::DROP,
             Sample(*under, trace_api::SpanContext::GetInvalid(), MakeTraceId(0xFF)));
 }


### PR DESCRIPTION
Fixes #4161

## Changes

Renames ComposableTraceIdRatioBasedSampler to ComposableProbabilitySampler to align with the OpenTelemetry specification, which defines the ComposableProbability sampler as a replacement for the deprecated TraceIdRatio sampler.

- Renamed class, header, and source file
- Updated description string and test references
- Updated CHANGELOG

The configuration model (ComposableProbabilitySamplerConfiguration, VisitComposableProbability, YAML key "probability") was already using the correct spec name and requires no changes.

* [x] CHANGELOG.md updated for non-trivial changes
* [x] Unit tests have been added
* [x] Changes in public API reviewed