### PR TITLE
[CODE HEALTH] Fix clang-tidy misc-override-with-different-visibility warnings

### DIFF
--- a/.github/workflows/clang-tidy.yaml
+++ b/.github/workflows/clang-tidy.yaml
@@ -17,9 +17,9 @@ jobs:
       matrix:
         include:
           - cmake_options: all-options-abiv1-preview
-            warning_limit: 309
+            warning_limit: 280
           - cmake_options: all-options-abiv2-preview
-            warning_limit: 319
+            warning_limit: 288
     env:
       CC: /usr/bin/clang-22
       CXX: /usr/bin/clang++-22

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,9 @@ Increment the:
 
 ## [Unreleased]
 
+* [CODE HEALTH] Fix clang-tidy misc-override-with-different-visibility warnings
+  [#4215](https://github.com/open-telemetry/opentelemetry-cpp/pull/4215)
+
 * [CMAKE] Fix and test WITH_API_ONLY option
   [#4201](https://github.com/open-telemetry/opentelemetry-cpp/pull/4201)
 

--- a/api/include/opentelemetry/trace/propagation/http_trace_context.h
+++ b/api/include/opentelemetry/trace/propagation/http_trace_context.h
@@ -191,6 +191,7 @@ private:
     return ExtractContextFromTraceHeaders(trace_parent, trace_state);
   }
 
+public:
   bool Fields(nostd::function_ref<bool(nostd::string_view)> callback) const noexcept override
   {
     return (callback(kTraceParent) && callback(kTraceState));

--- a/api/test/logs/logger_test.cc
+++ b/api/test/logs/logger_test.cc
@@ -263,6 +263,7 @@ TEST(Logger, EventLogMethodOverloads)
 // Define a basic Logger class
 class TestLogger : public Logger
 {
+public:
   const nostd::string_view GetName() noexcept override { return "test logger"; }
 
   using Logger::CreateLogRecord;
@@ -459,6 +460,7 @@ private:
 // Define a basic LoggerProvider class that returns an instance of the logger class defined above
 class TestProvider : public LoggerProvider
 {
+public:
   nostd::shared_ptr<Logger> GetLogger(nostd::string_view /* logger_name */,
                                       nostd::string_view /* library_name */,
                                       nostd::string_view /* library_version */,

--- a/api/test/logs/provider_test.cc
+++ b/api/test/logs/provider_test.cc
@@ -30,6 +30,7 @@ namespace nostd = opentelemetry::nostd;
 
 class TestProvider : public LoggerProvider
 {
+public:
   nostd::shared_ptr<Logger> GetLogger(
       nostd::string_view /* logger_name */,
       nostd::string_view /* library_name */,

--- a/api/test/trace/provider_test.cc
+++ b/api/test/trace/provider_test.cc
@@ -17,7 +17,7 @@ namespace nostd = opentelemetry::nostd;
 
 class TestProvider : public TracerProvider
 {
-
+public:
 #if OPENTELEMETRY_ABI_VERSION_NO >= 2
   nostd::shared_ptr<Tracer> GetTracer(
       nostd::string_view /* name */,

--- a/examples/configuration/custom_pull_metric_exporter.h
+++ b/examples/configuration/custom_pull_metric_exporter.h
@@ -21,12 +21,12 @@ public:
   opentelemetry::sdk::metrics::AggregationTemporality GetAggregationTemporality(
       opentelemetry::sdk::metrics::InstrumentType instrument_type) const noexcept override;
 
+private:
   bool OnForceFlush(std::chrono::microseconds timeout) noexcept override;
 
   bool OnShutDown(std::chrono::microseconds timeout) noexcept override;
 
   void OnInitialized() noexcept override;
 
-private:
   std::string comment_;
 };

--- a/ext/test/http/curl_http_test.cc
+++ b/ext/test/http/curl_http_test.cc
@@ -72,6 +72,7 @@ public:
 
 class GetEventHandler : public CustomEventHandler
 {
+public:
   void OnResponse(http_client::Response &response) noexcept override
   {
     ASSERT_EQ(200, response.GetStatusCode());
@@ -83,6 +84,7 @@ class GetEventHandler : public CustomEventHandler
 
 class PostEventHandler : public CustomEventHandler
 {
+public:
   void OnResponse(http_client::Response &response) noexcept override
   {
     ASSERT_EQ(200, response.GetStatusCode());
@@ -120,6 +122,7 @@ private:
 
 class RetryEventHandler : public CustomEventHandler
 {
+public:
   void OnResponse(http_client::Response &response) noexcept override
   {
     ASSERT_EQ(429, response.GetStatusCode());
@@ -145,6 +148,7 @@ protected:
 public:
   BasicCurlHttpTests() : is_setup_(false), is_running_(false) {}
 
+protected:
   void SetUp() override
   {
     if (is_setup_.exchange(true))
@@ -173,6 +177,7 @@ public:
     is_running_ = false;
   }
 
+public:
   int onHttpRequest(HTTP_SERVER_NS::HttpRequest const &request,
                     HTTP_SERVER_NS::HttpResponse &response) override
   {

--- a/sdk/include/opentelemetry/sdk/logs/logger.h
+++ b/sdk/include/opentelemetry/sdk/logs/logger.h
@@ -72,7 +72,7 @@ public:
     return GetInstrumentationScope();
   }
 
-private:
+protected:
   bool EnabledImplementation(opentelemetry::logs::Severity severity,
                              const opentelemetry::logs::EventId &event_id) const noexcept override;
 
@@ -89,6 +89,8 @@ private:
                              opentelemetry::logs::Severity severity,
                              const opentelemetry::logs::EventId &event_id) const noexcept override;
 #endif  // OPENTELEMETRY_ABI_VERSION_NO >= 2
+
+private:
   // The name of this logger
   std::string logger_name_;
 

--- a/sdk/include/opentelemetry/sdk/metrics/exemplar/aligned_histogram_bucket_exemplar_reservoir.h
+++ b/sdk/include/opentelemetry/sdk/metrics/exemplar/aligned_histogram_bucket_exemplar_reservoir.h
@@ -75,11 +75,13 @@ public:
       return static_cast<int>(max_size);
     }
 
-  private:
+  public:
     void reset() override
     {
       // Do nothing
     }
+
+  private:
     std::vector<double> boundaries_;
   };
 };

--- a/sdk/include/opentelemetry/sdk/metrics/view/predicate.h
+++ b/sdk/include/opentelemetry/sdk/metrics/view/predicate.h
@@ -75,11 +75,13 @@ private:
 
 class MatchEverythingPattern : public Predicate
 {
+public:
   bool Match(opentelemetry::nostd::string_view /* str */) const noexcept override { return true; }
 };
 
 class MatchNothingPattern : public Predicate
 {
+public:
   bool Match(opentelemetry::nostd::string_view /* str */) const noexcept override { return false; }
 };
 }  // namespace metrics

--- a/sdk/test/logs/logger_provider_sdk_test.cc
+++ b/sdk/test/logs/logger_provider_sdk_test.cc
@@ -242,6 +242,7 @@ public:
 
 class DummyProcessor : public LogRecordProcessor
 {
+public:
   std::unique_ptr<Recordable> MakeRecordable() noexcept override
   {
     return std::unique_ptr<Recordable>(new DummyLogRecordable());

--- a/sdk/test/logs/logger_provider_set_test.cc
+++ b/sdk/test/logs/logger_provider_set_test.cc
@@ -30,6 +30,7 @@ namespace logs_sdk = opentelemetry::sdk::logs;
 
 class TestProvider : public LoggerProvider
 {
+public:
   nostd::shared_ptr<Logger> GetLogger(
       nostd::string_view /* logger_name */,
       nostd::string_view /* library_name */,

--- a/sdk/test/metrics/common.h
+++ b/sdk/test/metrics/common.h
@@ -42,13 +42,13 @@ public:
   opentelemetry::sdk::metrics::AggregationTemporality GetAggregationTemporality(
       opentelemetry::sdk::metrics::InstrumentType) const noexcept override;
 
+private:
   bool OnForceFlush(std::chrono::microseconds) noexcept override;
 
   bool OnShutDown(std::chrono::microseconds) noexcept override;
 
   void OnInitialized() noexcept override;
 
-private:
   std::unique_ptr<opentelemetry::sdk::metrics::PushMetricExporter> exporter_;
 };
 

--- a/sdk/test/trace/tracer_provider_set_test.cc
+++ b/sdk/test/trace/tracer_provider_set_test.cc
@@ -26,7 +26,7 @@ namespace trace_sdk = opentelemetry::sdk::trace;
 
 class TestProvider : public TracerProvider
 {
-
+public:
 #if OPENTELEMETRY_ABI_VERSION_NO >= 2
   nostd::shared_ptr<Tracer> GetTracer(
       nostd::string_view /* name */,


### PR DESCRIPTION
Contributes to #4195

## Changes

Fixes a subset of #4195 by aligning the visibility of virtual function overrides with their base-class declaration, which is the fix the `misc-override-with-different-visibility` check asks for (per the [check documentation](https://clang.llvm.org/extra/clang-tidy/checks/misc/override-with-different-visibility.html)).

This PR resolves 31 of the 36 reported warnings across 13 files. The remaining 5 warnings (in `ext/include/opentelemetry/ext/http/server/http_server.h` and `socket_tools.h`) arise from `private`/`protected` inheritance of `SocketTools::Reactor::SocketCallback` and need a different, more careful change; they are deferred to a follow-up PR to keep this one reviewable.

### Fix pattern
- Base `public` -> derived override made `public` (widening; e.g. test mocks of `GetLogger`/`GetTracer`, `Predicate::Match`, `Fields`)
- Base `protected` -> derived override made `protected` (e.g. `sdk::logs::Logger::EnabledImplementation`, gtest `SetUp`/`TearDown`)
- Base `private` (NVI) -> derived override made `private` (e.g. `MetricReader::OnForceFlush`/`OnShutDown`/`OnInitialized`)

No behavior change: only access specifiers on overrides are adjusted; `.cc` definitions do not restate visibility.

### Verification
- Built all affected test and example targets locally (clang-22, ABI v1 and v2 presets); all compile and link.
- clang-format clean on all changed files.
- The `warning_limit` in `.github/workflows/clang-tidy.yaml` is lowered accordingly (abiv1: 309 -> 280, abiv2: 319 -> 288), derived from the current CI baseline minus the 29 (abiv1) / 31 (abiv2) warnings resolved here.