### PR TITLE
[CODE HEALTH] Move api/test and sdk/test classes into anonymous namespace

### DIFF
--- a/.github/workflows/clang-tidy.yaml
+++ b/.github/workflows/clang-tidy.yaml
@@ -17,9 +17,9 @@ jobs:
       matrix:
         include:
           - cmake_options: all-options-abiv1-preview
-            warning_limit: 309
+            warning_limit: 278
           - cmake_options: all-options-abiv2-preview
-            warning_limit: 319
+            warning_limit: 288
     env:
       CC: /usr/bin/clang-22
       CXX: /usr/bin/clang++-22

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,9 @@ Increment the:
 
 ## [Unreleased]
 
+* [CODE HEALTH] Move api/test and sdk/test classes into anonymous namespace
+  [#4217](https://github.com/open-telemetry/opentelemetry-cpp/pull/4217)
+
 * [CMAKE] Fix and test WITH_API_ONLY option
   [#4201](https://github.com/open-telemetry/opentelemetry-cpp/pull/4201)
 

--- a/api/test/nostd/shared_ptr_test.cc
+++ b/api/test/nostd/shared_ptr_test.cc
@@ -13,6 +13,9 @@
 
 using opentelemetry::nostd::shared_ptr;
 
+namespace
+{
+
 class A
 {
 public:
@@ -237,3 +240,5 @@ TEST(SharedPtrTest, Sort)
 {
   SharedPtrTest_Sort();
 }
+
+}  // namespace

--- a/api/test/nostd/unique_ptr_test.cc
+++ b/api/test/nostd/unique_ptr_test.cc
@@ -10,6 +10,9 @@
 
 using opentelemetry::nostd::unique_ptr;
 
+namespace
+{
+
 class A
 {
 public:
@@ -174,3 +177,5 @@ TEST(UniquePtrTest, Comparison)
   EXPECT_EQ(ptr3, nullptr);
   EXPECT_EQ(nullptr, ptr3);
 }
+
+}  // namespace

--- a/api/test/nostd/variant_test.cc
+++ b/api/test/nostd/variant_test.cc
@@ -8,6 +8,9 @@
 
 namespace nostd = opentelemetry::nostd;
 
+namespace
+{
+
 class DestroyCounter
 {
 public:
@@ -120,3 +123,5 @@ TEST(VariantTest, Construction)
   nostd::variant<bool, const char *, std::string> v{"abc"};
   EXPECT_EQ(v.index(), 1);
 }
+
+}  // namespace

--- a/api/test/singleton/singleton_test.cc
+++ b/api/test/singleton/singleton_test.cc
@@ -163,6 +163,9 @@ static void reset_counts()
   unknown_span_count = 0;
 }
 
+namespace
+{
+
 class MyTracer : public trace::Tracer
 {
 public:
@@ -458,3 +461,5 @@ TEST(SingletonTest, Uniqueness)
   EXPECT_EQ(span_h_f2_count, 0);
   EXPECT_EQ(unknown_span_count, 0);
 }
+
+}  // namespace

--- a/sdk/test/common/global_log_handle_test.cc
+++ b/sdk/test/common/global_log_handle_test.cc
@@ -10,6 +10,9 @@
 #include "opentelemetry/sdk/common/attribute_utils.h"
 #include "opentelemetry/sdk/common/global_log_handler.h"
 
+namespace
+{
+
 class CustomLogHandler : public opentelemetry::sdk::common::internal_log::LogHandler
 {
 public:
@@ -76,3 +79,5 @@ TEST(GlobalLogHandleTest, CustomLogHandler)
   opentelemetry::sdk::common::internal_log::GlobalLogHandler::SetLogHandler(backup_log_handle);
   opentelemetry::sdk::common::internal_log::GlobalLogHandler::SetLogLevel(backup_log_level);
 }
+
+}  // namespace

--- a/sdk/test/logs/batch_log_record_processor_test.cc
+++ b/sdk/test/logs/batch_log_record_processor_test.cc
@@ -36,6 +36,9 @@ using namespace opentelemetry::sdk::common;
 
 namespace nostd = opentelemetry::nostd;
 
+namespace
+{
+
 class MockLogRecordable final : public opentelemetry::sdk::logs::Recordable
 {
 public:
@@ -474,3 +477,5 @@ TEST_F(BatchLogRecordProcessorTest, TestOptionsReadFromMultipleEnvVars)
   unsetenv("OTEL_BLRP_EXPORT_TIMEOUT");
   unsetenv("OTEL_BLRP_MAX_EXPORT_BATCH_SIZE");
 }
+
+}  // namespace

--- a/sdk/test/logs/log_record_test.cc
+++ b/sdk/test/logs/log_record_test.cc
@@ -85,6 +85,9 @@ TEST(ReadWriteLogRecord, SetAndGet)
   ASSERT_EQ(record.GetTimestamp().time_since_epoch(), now.time_since_epoch());
 }
 
+namespace
+{
+
 // Define a basic Logger class
 class TestBodyLogger : public opentelemetry::logs::Logger
 {
@@ -343,3 +346,5 @@ TEST(LogBody, BodyConversation)
     }
   }
 }
+
+}  // namespace

--- a/sdk/test/logs/logger_config_test.cc
+++ b/sdk/test/logs/logger_config_test.cc
@@ -89,6 +89,9 @@ const std::array<instrumentation_scope::InstrumentationScope *, 5> instrumentati
     &test_scope_1, &test_scope_2, &test_scope_3, &test_scope_4, &test_scope_5,
 };
 
+namespace
+{
+
 // Test fixture for VerifyDefaultConfiguratorBehavior
 class DefaultLoggerConfiguratorTestFixture
     : public ::testing::TestWithParam<instrumentation_scope::InstrumentationScope *>
@@ -125,3 +128,5 @@ TEST(LoggerConfig, ScopeConfiguratorPreservesCustomConfig)
 INSTANTIATE_TEST_SUITE_P(InstrumentationScopes,
                          DefaultLoggerConfiguratorTestFixture,
                          ::testing::ValuesIn(instrumentation_scopes));
+
+}  // namespace

--- a/sdk/test/metrics/attributes_hashmap_test.cc
+++ b/sdk/test/metrics/attributes_hashmap_test.cc
@@ -82,6 +82,9 @@ TEST(AttributesHashMap, BasicTests)
   EXPECT_EQ(count, hash_map.Size());
 }
 
+namespace
+{
+
 class MetricAttributeMapHashForCollision
 {
 public:
@@ -223,3 +226,5 @@ TEST(AttributesHashMap, OverflowCardinalityLimitBehavior)
     EXPECT_NE(map_copy.Get(attr), nullptr);
   }
 }
+
+}  // namespace

--- a/sdk/test/metrics/cardinality_limit_test.cc
+++ b/sdk/test/metrics/cardinality_limit_test.cc
@@ -101,6 +101,9 @@ TEST(CardinalityLimit, AttributesHashMapBasicTests)
   }
 }
 
+namespace
+{
+
 class WritableMetricStorageCardinalityLimitTestFixture
     : public ::testing::TestWithParam<AggregationTemporality>
 {};
@@ -183,3 +186,5 @@ TEST(CardinalityLimitOverflowAttribute, MatchesSpecLiteral)
   EXPECT_EQ(entry.first, "otel.metric.overflow");
   EXPECT_EQ(nostd::get<bool>(entry.second), true);
 }
+
+}  // namespace

--- a/sdk/test/metrics/circular_buffer_counter_test.cc
+++ b/sdk/test/metrics/circular_buffer_counter_test.cc
@@ -10,6 +10,9 @@
 
 using namespace opentelemetry::sdk::metrics;
 
+namespace
+{
+
 class AdaptingIntegerArrayTest : public testing::TestWithParam<uint64_t>
 {};
 
@@ -149,3 +152,5 @@ TEST(AdaptingCircularBufferCounterTest, Clear)
   counter.Clear();
   EXPECT_TRUE(counter.Empty());
 }
+
+}  // namespace

--- a/sdk/test/metrics/meter_config_test.cc
+++ b/sdk/test/metrics/meter_config_test.cc
@@ -71,6 +71,9 @@ const std::array<instrumentation_scope::InstrumentationScope *, 5> instrumentati
     &test_scope_1, &test_scope_2, &test_scope_3, &test_scope_4, &test_scope_5,
 };
 
+namespace
+{
+
 // Test fixture for VerifyDefaultConfiguratorBehavior
 class DefaultMeterConfiguratorTestFixture
     : public ::testing::TestWithParam<instrumentation_scope::InstrumentationScope *>
@@ -91,3 +94,5 @@ TEST_P(DefaultMeterConfiguratorTestFixture, VerifyDefaultConfiguratorBehavior)
 INSTANTIATE_TEST_SUITE_P(InstrumentationScopes,
                          DefaultMeterConfiguratorTestFixture,
                          ::testing::ValuesIn(instrumentation_scopes));
+
+}  // namespace

--- a/sdk/test/metrics/metric_test_stress.cc
+++ b/sdk/test/metrics/metric_test_stress.cc
@@ -35,6 +35,9 @@ using namespace opentelemetry;
 using namespace opentelemetry::sdk::instrumentationscope;
 using namespace opentelemetry::sdk::metrics;
 
+namespace
+{
+
 class MockMetricExporterForStress : public opentelemetry::sdk::metrics::PushMetricExporter
 {
 public:
@@ -175,3 +178,5 @@ TEST(HistogramStress, UnsignedInt64)
   ASSERT_EQ(expected_count, collected_count);
   ASSERT_EQ(*expected_sum, collected_sum);
 }
+
+}  // namespace

--- a/sdk/test/metrics/multi_metric_storage_test.cc
+++ b/sdk/test/metrics/multi_metric_storage_test.cc
@@ -14,6 +14,9 @@
 using namespace opentelemetry;
 using namespace opentelemetry::sdk::metrics;
 
+namespace
+{
+
 class TestMetricStorage : public SyncWritableMetricStorage
 {
 public:
@@ -62,3 +65,5 @@ TEST(MultiMetricStorageTest, BasicTests)
   EXPECT_EQ(static_cast<TestMetricStorage *>(storage.get())->num_calls_long, 3);
   EXPECT_EQ(static_cast<TestMetricStorage *>(storage.get())->num_calls_double, 1);
 }
+
+}  // namespace

--- a/sdk/test/metrics/periodic_exporting_metric_reader_test.cc
+++ b/sdk/test/metrics/periodic_exporting_metric_reader_test.cc
@@ -29,6 +29,9 @@ using namespace opentelemetry;
 using namespace opentelemetry::sdk::instrumentationscope;
 using namespace opentelemetry::sdk::metrics;
 
+namespace
+{
+
 class MockPushMetricExporter : public PushMetricExporter
 {
 public:
@@ -168,3 +171,5 @@ TEST(PeriodicExportingMetricReaderOptions, UsesDefault)
   EXPECT_EQ(options.export_interval_millis, std::chrono::milliseconds(60000));
   EXPECT_EQ(options.export_timeout_millis, std::chrono::milliseconds(30000));
 }
+
+}  // namespace

--- a/sdk/test/metrics/sum_aggregation_test.cc
+++ b/sdk/test/metrics/sum_aggregation_test.cc
@@ -414,6 +414,9 @@ TEST(CounterToSumFilterAttributesWithCardinalityLimit, Double)
   }
 }
 
+namespace
+{
+
 class UpDownCounterToSumFixture : public ::testing::TestWithParam<bool>
 {};
 
@@ -471,3 +474,5 @@ INSTANTIATE_TEST_SUITE_P(UpDownCounterToSum,
                          UpDownCounterToSumFixture,
                          ::testing::Values(true, false));
 #endif
+
+}  // namespace

--- a/sdk/test/metrics/sync_metric_storage_histogram_test.cc
+++ b/sdk/test/metrics/sync_metric_storage_histogram_test.cc
@@ -34,6 +34,9 @@
 using namespace opentelemetry::sdk::metrics;
 using namespace opentelemetry::common;
 
+namespace
+{
+
 class WritableMetricStorageHistogramTestFixture
     : public ::testing::TestWithParam<AggregationTemporality>
 {};
@@ -538,3 +541,5 @@ INSTANTIATE_TEST_SUITE_P(WritableMetricStorageHistogramTestBase2ExponentialDoubl
                          WritableMetricStorageHistogramTestFixture,
                          ::testing::Values(AggregationTemporality::kCumulative,
                                            AggregationTemporality::kDelta));
+
+}  // namespace

--- a/sdk/test/resource/resource_test.cc
+++ b/sdk/test/resource/resource_test.cc
@@ -27,6 +27,9 @@ using namespace opentelemetry::sdk::resource;
 namespace nostd   = opentelemetry::nostd;
 namespace semconv = opentelemetry::semconv;
 
+namespace
+{
+
 class TestResource : public Resource
 {
 public:
@@ -292,3 +295,5 @@ TEST(ResourceTest, DerivedResourceDetector)
   EXPECT_EQ(resource.GetSchemaURL(), detector.schema_url);
   EXPECT_TRUE(received_attributes.find("key") != received_attributes.end());
 }
+
+}  // namespace

--- a/sdk/test/trace/simple_processor_test.cc
+++ b/sdk/test/trace/simple_processor_test.cc
@@ -42,6 +42,9 @@ TEST(SimpleProcessor, ToInMemorySpanExporter)
   EXPECT_TRUE(processor.Shutdown());
 }
 
+namespace
+{
+
 // An exporter that does nothing but record (and give back ) the # of times Shutdown was called.
 class RecordShutdownExporter final : public SpanExporter
 {
@@ -141,3 +144,5 @@ TEST(SimpleSpanProcessor, ForceFlushFail)
       std::unique_ptr<SpanExporter>{new FailShutDownForceFlushExporter()});
   EXPECT_EQ(false, processor.ForceFlush());
 }
+
+}  // namespace

--- a/sdk/test/trace/tracer_config_test.cc
+++ b/sdk/test/trace/tracer_config_test.cc
@@ -71,6 +71,9 @@ const std::array<instrumentation_scope::InstrumentationScope *, 5> instrumentati
     &test_scope_1, &test_scope_2, &test_scope_3, &test_scope_4, &test_scope_5,
 };
 
+namespace
+{
+
 // Test fixture for VerifyDefaultConfiguratorBehavior
 class DefaultTracerConfiguratorTestFixture
     : public ::testing::TestWithParam<instrumentation_scope::InstrumentationScope *>
@@ -91,3 +94,5 @@ TEST_P(DefaultTracerConfiguratorTestFixture, VerifyDefaultConfiguratorBehavior)
 INSTANTIATE_TEST_SUITE_P(InstrumentationScopes,
                          DefaultTracerConfiguratorTestFixture,
                          ::testing::ValuesIn(instrumentation_scopes));
+
+}  // namespace


### PR DESCRIPTION
## Changes

Part of #4196 (and #2053). Wraps file-local test helper classes in an anonymous namespace to enforce internal linkage, resolving the `misc-use-internal-linkage` warnings across 20 files under `api/test` and `sdk/test`. This follows the same approach as #4199 and #4200.

To keep the review manageable, this is the first batch. The remaining files (under `exporters`, `ext`, and `functional`, plus a few that need manual handling due to existing or nested namespaces) will follow in later batches. The files that overlap with my other open code-health PRs (#4215, #4216) are also deferred to avoid conflicts.

Four metrics tests that share the `WritableMetricStorageTestFixture` fixture (async_metric_storage_test and the sync_metric_storage counter/gauge/up_down_counter tests) are also deferred. They are linked together into `//sdk/test/metrics:all_tests`, and moving same-named fixtures into per-file anonymous namespaces makes gtest treat them as a redefinition of one test suite. They will be handled in a follow-up that renames the fixtures or shares one via a header.

### Verification
- Compiles clean (clang-22, abiv2 preset); a local clang-tidy run confirms the 31 warnings on these 20 files are resolved with no new warnings, and the code still builds.
- clang-format clean on all changed files.
- `warning_limit` lowered from 309/319 to 278/288 (the current baseline minus the 31 resolved here).

Note: this touches the same `warning_limit` line as #4215 and #4216. Whichever of these merges first, I will rebase the others accordingly (the final limit after all three is lower).
