### PR TITLE
[BUILD] add missing link dependency for bazel

### DIFF
--- a/exporters/otlp/BUILD
+++ b/exporters/otlp/BUILD
@@ -47,9 +47,9 @@ cc_library(
     deps = [
         ":otlp_utf8_validity",
         "//sdk/src/logs",
+        "//sdk/src/metrics",
         "//sdk/src/resource",
         "//sdk/src/trace",
-        "//sdk/src/metrics",
         "@com_github_opentelemetry_proto//:logs_service_proto_cc",
         "@com_github_opentelemetry_proto//:metrics_service_proto_cc",
         "@com_github_opentelemetry_proto//:trace_service_proto_cc",

--- a/exporters/otlp/BUILD
+++ b/exporters/otlp/BUILD
@@ -49,6 +49,7 @@ cc_library(
         "//sdk/src/logs",
         "//sdk/src/resource",
         "//sdk/src/trace",
+        "//sdk/src/metrics",
         "@com_github_opentelemetry_proto//:logs_service_proto_cc",
         "@com_github_opentelemetry_proto//:metrics_service_proto_cc",
         "@com_github_opentelemetry_proto//:trace_service_proto_cc",

--- a/exporters/prometheus/BUILD
+++ b/exporters/prometheus/BUILD
@@ -58,6 +58,7 @@ cc_library(
     deps = [
         "//api",
         "//sdk:headers",
+        "//sdk/src/metrics",
         "@com_github_jupp0r_prometheus_cpp//core",
         "@com_github_jupp0r_prometheus_cpp//pull",
     ],


### PR DESCRIPTION
This adds the `//sdk/src/metrics` link dependency for two libraries that need to use `AdaptingCircularBufferCounter` for `Base2ExponentialHistogramPointData`.

Fixes #4219.

## Changes

Added the missing dependencies. Verified in our builds that the `otlp_recordable` no longer brings unresolved symbols into the build.

For significant contributions please make sure you have completed the following items:

* [ ] `CHANGELOG.md` updated for non-trivial changes
* [ ] Unit tests have been added
* [ ] Changes in public API reviewed