### PR TITLE
[CODE HEALTH] Move otlp, zipkin and prometheus test classes into anonymous namespace

### DIFF
--- a/.github/workflows/clang-tidy.yaml
+++ b/.github/workflows/clang-tidy.yaml
@@ -17,9 +17,9 @@ jobs:
       matrix:
         include:
           - cmake_options: all-options-abiv1-preview
-            warning_limit: 235
+            warning_limit: 216
           - cmake_options: all-options-abiv2-preview
-            warning_limit: 245
+            warning_limit: 226
     env:
       CC: /usr/bin/clang-22
       CXX: /usr/bin/clang++-22

--- a/.github/workflows/clang-tidy.yaml
+++ b/.github/workflows/clang-tidy.yaml
@@ -17,9 +17,9 @@ jobs:
       matrix:
         include:
           - cmake_options: all-options-abiv1-preview
-            warning_limit: 216
+            warning_limit: 137
           - cmake_options: all-options-abiv2-preview
-            warning_limit: 226
+            warning_limit: 145
     env:
       CC: /usr/bin/clang-22
       CXX: /usr/bin/clang++-22

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,9 @@ Increment the:
 
 ## [Unreleased]
 
+* [CODE HEALTH] Move otlp, zipkin and prometheus test classes into anonymous namespace
+  [#4231](https://github.com/open-telemetry/opentelemetry-cpp/pull/4231)
+
 * [CODE HEALTH] Move ext and exporters test classes into anonymous namespace
   [#4225](https://github.com/open-telemetry/opentelemetry-cpp/pull/4225)
 

--- a/exporters/otlp/test/otlp_file_client_test.cc
+++ b/exporters/otlp/test/otlp_file_client_test.cc
@@ -57,6 +57,8 @@ namespace otlp
 
 namespace resource = opentelemetry::sdk::resource;
 
+namespace
+{
 class ProtobufGlobalSymbolGuard
 {
 public:
@@ -67,6 +69,7 @@ public:
   ProtobufGlobalSymbolGuard(ProtobufGlobalSymbolGuard &&)                 = delete;
   ProtobufGlobalSymbolGuard &operator=(ProtobufGlobalSymbolGuard &&)      = delete;
 };
+}  // namespace
 
 static std::tm GetLocalTime(std::chrono::system_clock::time_point tp)
 {

--- a/exporters/otlp/test/otlp_file_exporter_test.cc
+++ b/exporters/otlp/test/otlp_file_exporter_test.cc
@@ -59,6 +59,8 @@ namespace otlp
 namespace trace_api = opentelemetry::trace;
 namespace resource  = opentelemetry::sdk::resource;
 
+namespace
+{
 class ProtobufGlobalSymbolGuard
 {
 public:
@@ -69,6 +71,7 @@ public:
   ProtobufGlobalSymbolGuard(ProtobufGlobalSymbolGuard &&)                 = delete;
   ProtobufGlobalSymbolGuard &operator=(ProtobufGlobalSymbolGuard &&)      = delete;
 };
+}  // namespace
 
 template <class T, size_t N>
 static nostd::span<T, N> MakeSpan(T (&array)[N])
@@ -76,6 +79,8 @@ static nostd::span<T, N> MakeSpan(T (&array)[N])
   return nostd::span<T, N>(array);
 }
 
+namespace
+{
 class OtlpFileExporterTestPeer : public ::testing::Test
 {
 public:
@@ -183,6 +188,7 @@ public:
     }
   }
 };
+}  // namespace
 
 TEST(OtlpFileExporterTest, Shutdown)
 {

--- a/exporters/otlp/test/otlp_file_log_record_exporter_test.cc
+++ b/exporters/otlp/test/otlp_file_log_record_exporter_test.cc
@@ -45,6 +45,8 @@ namespace exporter
 namespace otlp
 {
 
+namespace
+{
 class ProtobufGlobalSymbolGuard
 {
 public:
@@ -55,6 +57,7 @@ public:
   ProtobufGlobalSymbolGuard(ProtobufGlobalSymbolGuard &&)                 = delete;
   ProtobufGlobalSymbolGuard &operator=(ProtobufGlobalSymbolGuard &&)      = delete;
 };
+}  // namespace
 
 template <class T, size_t N>
 static nostd::span<T, N> MakeSpan(T (&array)[N])
@@ -62,6 +65,8 @@ static nostd::span<T, N> MakeSpan(T (&array)[N])
   return nostd::span<T, N>(array);
 }
 
+namespace
+{
 class OtlpFileLogRecordExporterTestPeer : public ::testing::Test
 {
 public:
@@ -168,6 +173,7 @@ public:
     }
   }
 };
+}  // namespace
 
 TEST(OtlpFileLogRecordExporterTest, Shutdown)
 {

--- a/exporters/otlp/test/otlp_file_metric_exporter_test.cc
+++ b/exporters/otlp/test/otlp_file_metric_exporter_test.cc
@@ -43,6 +43,8 @@ namespace exporter
 namespace otlp
 {
 
+namespace
+{
 class ProtobufGlobalSymbolGuard
 {
 public:
@@ -53,6 +55,7 @@ public:
   ProtobufGlobalSymbolGuard(ProtobufGlobalSymbolGuard &&)                 = delete;
   ProtobufGlobalSymbolGuard &operator=(ProtobufGlobalSymbolGuard &&)      = delete;
 };
+}  // namespace
 
 template <class IntegerType>
 static IntegerType JsonToInteger(const nlohmann::json &value)

--- a/exporters/otlp/test/otlp_grpc_exporter_test.cc
+++ b/exporters/otlp/test/otlp_grpc_exporter_test.cc
@@ -453,6 +453,8 @@ TEST_F(OtlpGrpcExporterTestPeer, ConfigRetryGenericValuesFromEnv)
 #  endif  // NO_GETENV
 
 #  ifdef ENABLE_OTLP_RETRY_PREVIEW
+namespace
+{
 struct TestTraceService : public opentelemetry::proto::collector::trace::v1::TraceService::Service
 {
   TestTraceService(const std::vector<grpc::StatusCode> &status_codes) : status_codes_(status_codes)
@@ -471,12 +473,16 @@ struct TestTraceService : public opentelemetry::proto::collector::trace::v1::Tra
   size_t index_         = 0UL;
   std::vector<grpc::StatusCode> status_codes_;
 };
+}  // namespace
 
 using StatusCodeVector = std::vector<grpc::StatusCode>;
 
+namespace
+{
 class OtlpGrpcExporterRetryIntegrationTests
     : public ::testing::TestWithParam<std::tuple<bool, StatusCodeVector, std::size_t>>
 {};
+}  // namespace
 
 INSTANTIATE_TEST_SUITE_P(
     StatusCodes,

--- a/exporters/otlp/test/otlp_http_exporter_test.cc
+++ b/exporters/otlp/test/otlp_http_exporter_test.cc
@@ -777,9 +777,12 @@ TEST_F(OtlpHttpExporterTestPeer, ConfigRetryGenericValuesFromEnv)
 #  ifdef ENABLE_OTLP_RETRY_PREVIEW
 using StatusCodeVector = std::vector<int>;
 
+namespace
+{
 class OtlpHttpExporterRetryIntegrationTests
     : public ::testing::TestWithParam<std::tuple<bool, StatusCodeVector, std::size_t>>
 {};
+}  // namespace
 
 INSTANTIATE_TEST_SUITE_P(StatusCodes,
                          OtlpHttpExporterRetryIntegrationTests,

--- a/exporters/otlp/test/otlp_log_recordable_test.cc
+++ b/exporters/otlp/test/otlp_log_recordable_test.cc
@@ -254,11 +254,14 @@ TEST(OtlpLogRecordable, SetEventName)
  * unsigned int, and uint64_t. To avoid writing test cases for each, we can
  * use a template approach to test all int types.
  */
+namespace
+{
 template <typename T>
 struct OtlpLogRecordableIntAttributeTest : public testing::Test
 {
   using IntParamType = T;
 };
+}  // namespace
 
 using IntTypes = testing::Types<int, int64_t, unsigned int, uint64_t>;
 TYPED_TEST_SUITE(OtlpLogRecordableIntAttributeTest, IntTypes);

--- a/exporters/otlp/test/otlp_recordable_test.cc
+++ b/exporters/otlp/test/otlp_recordable_test.cc
@@ -548,11 +548,14 @@ TEST(OtlpRecordable, PopulateRequestMissing)
   }
 }
 
+namespace
+{
 template <typename T>
 struct EmptyArrayAttributeTest : public testing::Test
 {
   using ElementType = T;
 };
+}  // namespace
 
 using ArrayElementTypes =
     testing::Types<bool, double, nostd::string_view, uint8_t, int, int64_t, unsigned int, uint64_t>;
@@ -576,11 +579,14 @@ TYPED_TEST(EmptyArrayAttributeTest, SetEmptyArrayAttribute)
  * unsigned int, and uint64_t. To avoid writing test cases for each, we can
  * use a template approach to test all int types.
  */
+namespace
+{
 template <typename T>
 struct IntAttributeTest : public testing::Test
 {
   using IntParamType = T;
 };
+}  // namespace
 
 using IntTypes = testing::Types<int, int64_t, unsigned int, uint64_t>;
 TYPED_TEST_SUITE(IntAttributeTest, IntTypes);

--- a/exporters/prometheus/test/collector_test.cc
+++ b/exporters/prometheus/test/collector_test.cc
@@ -20,6 +20,8 @@ using opentelemetry::exporter::metrics::PrometheusCollector;
 using opentelemetry::sdk::metrics::MetricProducer;
 using opentelemetry::sdk::metrics::ResourceMetrics;
 
+namespace
+{
 class MockMetricProducer : public MetricProducer
 {
   TestDataPoints test_data_points_;
@@ -43,7 +45,10 @@ private:
   std::chrono::microseconds sleep_ms_;
   size_t data_sent_size_{0};
 };
+}  // namespace
 
+namespace
+{
 class MockMetricReader : public opentelemetry::sdk::metrics::MetricReader
 {
 public:
@@ -61,6 +66,7 @@ private:
 
   void OnInitialized() noexcept override {}
 };
+}  // namespace
 
 // ==================== Test for addMetricsData() function ======================
 

--- a/exporters/prometheus/test/exporter_utils_test.cc
+++ b/exporters/prometheus/test/exporter_utils_test.cc
@@ -286,6 +286,8 @@ TEST(PrometheusExporterUtils, TranslateToPrometheusHistogramNormal)
   ASSERT_EQ(checked_label_num, 3);
 }
 
+namespace
+{
 class SanitizeTest : public ::testing::Test
 {
   Resource resource_ = Resource::Create({});
@@ -308,6 +310,7 @@ protected:
     EXPECT_EQ(result.begin()->metric.begin()->label.begin()->name, sanitized);
   }
 };
+}  // namespace
 
 TEST_F(SanitizeTest, Label)
 {
@@ -321,6 +324,8 @@ TEST_F(SanitizeTest, Label)
 
 TEST_F(SanitizeTest, Name) {}
 
+namespace
+{
 class AttributeCollisionTest : public ::testing::Test
 {
   Resource resource_ = Resource::Create(ResourceAttributes{});
@@ -356,6 +361,7 @@ protected:
     }
   }
 };
+}  // namespace
 
 TEST_F(AttributeCollisionTest, SeparatesDistinctKeys)
 {

--- a/exporters/zipkin/test/zipkin_exporter_test.cc
+++ b/exporters/zipkin/test/zipkin_exporter_test.cc
@@ -60,6 +60,8 @@ public:
   }
 };
 
+namespace
+{
 class MockHttpClient : public opentelemetry::ext::http::client::HttpClientSync
 {
 public:
@@ -80,7 +82,10 @@ public:
                const ext::http::client::Compression &),
               (noexcept, override));
 };
+}  // namespace
 
+namespace
+{
 class IsValidMessageMatcher
 {
 public:
@@ -102,6 +107,7 @@ public:
 private:
   std::string trace_id_;
 };
+}  // namespace
 
 static PolymorphicMatcher<IsValidMessageMatcher> IsValidMessage(const std::string &trace_id)
 {

--- a/exporters/zipkin/test/zipkin_recordable_test.cc
+++ b/exporters/zipkin/test/zipkin_recordable_test.cc
@@ -268,11 +268,14 @@ TEST(ZipkinSpanRecordable, SetResource)
  * unsigned int, and uint64_t. To avoid writing test cases for each, we can
  * use a template approach to test all int types.
  */
+namespace
+{
 template <typename T>
 struct ZipkinIntAttributeTest : public testing::Test
 {
   using IntParamType = T;
 };
+}  // namespace
 
 using IntTypes = testing::Types<int, int64_t, unsigned int, uint64_t>;
 TYPED_TEST_SUITE(ZipkinIntAttributeTest, IntTypes);


### PR DESCRIPTION
Finishes the misc-use-internal-linkage cleanup from #4196, covering the otlp, zipkin and prometheus exporter test files thc1006 handed off after #4225.

Moves the flagged test fixtures and helper classes into anonymous namespaces to give them internal linkage. The friend-declared exporter TestPeer classes are not flagged and are left in place, since moving them would break the friend relationship with the production exporters.

Verified on an Ubuntu 24.04 + clang-tidy-22 build (the same preset the CI job uses): all 19 misc-use-internal-linkage warnings in these files are cleared, the affected test targets compile and link, and clang-format is clean. Lowered the warning_limit by 19 for both ABI presets.

Part of #4196.