### PR TITLE
[SDK] Span limits configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,11 @@ Increment the:
 * [CMAKE] Fix and test WITH_API_ONLY option
   [#4201](https://github.com/open-telemetry/opentelemetry-cpp/pull/4201)
 
+* [SDK] Span limits can now be configured through the TracerProvider interface
+        and declaritive configuration. When set, limits are enforced by the
+        SpanData and OtlpRecordables recordables used by the standard exporters
+  [#4232](https://github.com/open-telemetry/opentelemetry-cpp/pull/4232)
+
 * [API] Fix `TraceState::IsValidKey()` to comply with the W3C Trace Context
   Level 2, where keys containing `@` and keys with more than 241 characters
   before `@` or more than 14 characters after `@` are now accepted.

--- a/exporters/otlp/include/opentelemetry/exporters/otlp/otlp_grpc_exporter_options.h
+++ b/exporters/otlp/include/opentelemetry/exporters/otlp/otlp_grpc_exporter_options.h
@@ -35,7 +35,11 @@ struct OPENTELEMETRY_EXPORT OtlpGrpcExporterOptions : public OtlpGrpcClientOptio
   OtlpGrpcExporterOptions &operator=(OtlpGrpcExporterOptions &&)      = default;
   ~OtlpGrpcExporterOptions() override;
 
-  /** Collection Limits. No limit by default. */
+  /** Collection Limits. No limit by default.
+   * @deprecated Configure span limits via TracerProviderFactory::Create(), SpanLimitsConfiguration,
+   * or the YAML `tracer_provider.limits` node instead. These fields will be
+   * removed in a future release.
+   */
   std::uint32_t max_attributes           = (std::numeric_limits<std::uint32_t>::max)();
   std::uint32_t max_events               = (std::numeric_limits<std::uint32_t>::max)();
   std::uint32_t max_links                = (std::numeric_limits<std::uint32_t>::max)();

--- a/exporters/otlp/include/opentelemetry/exporters/otlp/otlp_http_exporter_options.h
+++ b/exporters/otlp/include/opentelemetry/exporters/otlp/otlp_http_exporter_options.h
@@ -127,7 +127,11 @@ struct OPENTELEMETRY_EXPORT OtlpHttpExporterOptions
   /** The backoff will be multiplied by this value after each retry attempt. */
   float retry_policy_backoff_multiplier{};
 
-  /** Collection Limits. No limit by default. */
+  /** Collection Limits. No limit by default.
+   * @deprecated Configure span limits via TracerProviderFactory::Create(), SpanLimitsConfiguration,
+   * or the YAML `tracer_provider.limits` node instead. These fields will be
+   * removed in a future release.
+   */
   std::uint32_t max_attributes           = (std::numeric_limits<std::uint32_t>::max)();
   std::uint32_t max_events               = (std::numeric_limits<std::uint32_t>::max)();
   std::uint32_t max_links                = (std::numeric_limits<std::uint32_t>::max)();

--- a/exporters/otlp/include/opentelemetry/exporters/otlp/otlp_recordable.h
+++ b/exporters/otlp/include/opentelemetry/exporters/otlp/otlp_recordable.h
@@ -23,6 +23,7 @@
 #include "opentelemetry/sdk/instrumentationscope/instrumentation_scope.h"
 #include "opentelemetry/sdk/resource/resource.h"
 #include "opentelemetry/sdk/trace/recordable.h"
+#include "opentelemetry/sdk/trace/span_limits.h"
 #include "opentelemetry/trace/span_context.h"
 #include "opentelemetry/trace/span_id.h"
 #include "opentelemetry/trace/span_metadata.h"
@@ -37,17 +38,25 @@ namespace otlp
 class OtlpRecordable final : public opentelemetry::sdk::trace::Recordable
 {
 public:
+  /**
+   * Construct with optional span limits parameters.
+   *
+   * @deprecated Configure span limits via TracerProviderFactory::Create(), SpanLimitsConfiguration,
+   * or the YAML `tracer_provider.limits` node instead. These optional span limit params will be
+   * removed in a future release.
+   */
   explicit OtlpRecordable(
       std::uint32_t max_attributes           = (std::numeric_limits<std::uint32_t>::max)(),
       std::uint32_t max_events               = (std::numeric_limits<std::uint32_t>::max)(),
       std::uint32_t max_links                = (std::numeric_limits<std::uint32_t>::max)(),
       std::uint32_t max_attributes_per_event = (std::numeric_limits<std::uint32_t>::max)(),
       std::uint32_t max_attributes_per_link  = (std::numeric_limits<std::uint32_t>::max)())
-      : max_attributes_(max_attributes),
-        max_events_(max_events),
-        max_links_(max_links),
-        max_attributes_per_event_(max_attributes_per_event),
-        max_attributes_per_link_(max_attributes_per_link)
+      : span_limits_{max_attributes,
+                     (std::numeric_limits<std::size_t>::max)(),
+                     max_events,
+                     max_links,
+                     max_attributes_per_event,
+                     max_attributes_per_link}
   {}
 
   proto::trace::v1::Span &span() noexcept { return span_; }
@@ -92,6 +101,17 @@ public:
 
   void SetDuration(std::chrono::nanoseconds duration) noexcept override;
 
+  /**
+   * Set span limits.
+   *
+   * Until the deprecated OTLP exporter option values are removed, the effective limit for each
+   * field is the minimum (most restrictive) of the deprecated otlp exporter option values (passed
+   * to the constructor) and the values set by calling this method.
+   *
+   * @param limits The span limits to set.
+   */
+  void SetSpanLimits(const opentelemetry::sdk::trace::SpanLimits &limits) noexcept override;
+
   void SetInstrumentationScope(const opentelemetry::sdk::instrumentationscope::InstrumentationScope
                                    &instrumentation_scope) noexcept override;
 
@@ -100,11 +120,8 @@ private:
   const opentelemetry::sdk::resource::Resource *resource_ = nullptr;
   const opentelemetry::sdk::instrumentationscope::InstrumentationScope *instrumentation_scope_ =
       nullptr;
-  std::uint32_t max_attributes_;
-  std::uint32_t max_events_;
-  std::uint32_t max_links_;
-  std::uint32_t max_attributes_per_event_;
-  std::uint32_t max_attributes_per_link_;
+  opentelemetry::sdk::trace::SpanLimits span_limits_{
+      opentelemetry::sdk::trace::SpanLimits::NoLimits()};
 };
 }  // namespace otlp
 }  // namespace exporter

--- a/exporters/otlp/src/otlp_recordable.cc
+++ b/exporters/otlp/src/otlp_recordable.cc
@@ -1,8 +1,9 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-#include <stdint.h>
+#include <algorithm>
 #include <chrono>
+#include <cstdint>
 #include <string>
 
 #include "opentelemetry/common/attribute_value.h"
@@ -15,6 +16,7 @@
 #include "opentelemetry/nostd/string_view.h"
 #include "opentelemetry/sdk/instrumentationscope/instrumentation_scope.h"
 #include "opentelemetry/sdk/resource/resource.h"
+#include "opentelemetry/sdk/trace/span_limits.h"
 #include "opentelemetry/trace/span_context.h"
 #include "opentelemetry/trace/span_id.h"
 #include "opentelemetry/trace/span_metadata.h"
@@ -114,24 +116,40 @@ void OtlpRecordable::SetResource(const sdk::resource::Resource &resource) noexce
   resource_ = &resource;
 }
 
+void OtlpRecordable::SetSpanLimits(const opentelemetry::sdk::trace::SpanLimits &limits) noexcept
+{
+  // Update the span limits to be the minimum of the current limits and the new limits
+  // The initial limits are set on construction from the deprecated span limits otlp options.
+  // TODO: replace with a simple copy once the deprecated options are removed.
+  span_limits_ = {
+      (std::min)(span_limits_.attribute_count_limit, limits.attribute_count_limit),
+      (std::min)(span_limits_.attribute_value_length_limit, limits.attribute_value_length_limit),
+      (std::min)(span_limits_.event_count_limit, limits.event_count_limit),
+      (std::min)(span_limits_.link_count_limit, limits.link_count_limit),
+      (std::min)(span_limits_.event_attribute_count_limit, limits.event_attribute_count_limit),
+      (std::min)(span_limits_.link_attribute_count_limit, limits.link_attribute_count_limit),
+  };
+}
+
 void OtlpRecordable::SetAttribute(nostd::string_view key,
                                   const common::AttributeValue &value) noexcept
 {
-  if (static_cast<uint32_t>(span_.attributes_size()) >= max_attributes_)
+  if (static_cast<std::uint32_t>(span_.attributes_size()) >= span_limits_.attribute_count_limit)
   {
     span_.set_dropped_attributes_count(span_.dropped_attributes_count() + 1);
     return;
   }
 
   auto *attribute = span_.add_attributes();
-  OtlpPopulateAttributeUtils::PopulateAttribute(attribute, key, value, false);
+  OtlpPopulateAttributeUtils::PopulateAttribute(attribute, key, value, false,
+                                                span_limits_.attribute_value_length_limit);
 }
 
 void OtlpRecordable::AddEvent(nostd::string_view name,
                               common::SystemTimestamp timestamp,
                               const common::KeyValueIterable &attributes) noexcept
 {
-  if (static_cast<uint32_t>(span_.events_size()) >= max_events_)
+  if (static_cast<std::uint32_t>(span_.events_size()) >= span_limits_.event_count_limit)
   {
     span_.set_dropped_events_count(span_.dropped_events_count() + 1);
     return;
@@ -142,12 +160,14 @@ void OtlpRecordable::AddEvent(nostd::string_view name,
   event->set_time_unix_nano(timestamp.time_since_epoch().count());
 
   attributes.ForEachKeyValue([&](nostd::string_view key, common::AttributeValue value) noexcept {
-    if (static_cast<uint32_t>(event->attributes_size()) >= max_attributes_per_event_)
+    if (static_cast<std::uint32_t>(event->attributes_size()) >=
+        span_limits_.event_attribute_count_limit)
     {
       event->set_dropped_attributes_count(event->dropped_attributes_count() + 1);
       return true;
     }
-    OtlpPopulateAttributeUtils::PopulateAttribute(event->add_attributes(), key, value, false);
+    OtlpPopulateAttributeUtils::PopulateAttribute(event->add_attributes(), key, value, false,
+                                                  span_limits_.attribute_value_length_limit);
     return true;
   });
 }
@@ -155,7 +175,7 @@ void OtlpRecordable::AddEvent(nostd::string_view name,
 void OtlpRecordable::AddLink(const trace::SpanContext &span_context,
                              const common::KeyValueIterable &attributes) noexcept
 {
-  if (static_cast<uint32_t>(span_.links_size()) >= max_links_)
+  if (static_cast<std::uint32_t>(span_.links_size()) >= span_limits_.link_count_limit)
   {
     span_.set_dropped_links_count(span_.dropped_links_count() + 1);
     return;
@@ -167,12 +187,14 @@ void OtlpRecordable::AddLink(const trace::SpanContext &span_context,
                     trace::SpanId::kSize);
   link->set_trace_state(span_context.trace_state()->ToHeader());
   attributes.ForEachKeyValue([&](nostd::string_view key, common::AttributeValue value) noexcept {
-    if (static_cast<uint32_t>(link->attributes_size()) >= max_attributes_per_link_)
+    if (static_cast<std::uint32_t>(link->attributes_size()) >=
+        span_limits_.link_attribute_count_limit)
     {
       link->set_dropped_attributes_count(link->dropped_attributes_count() + 1);
       return true;
     }
-    OtlpPopulateAttributeUtils::PopulateAttribute(link->add_attributes(), key, value, false);
+    OtlpPopulateAttributeUtils::PopulateAttribute(link->add_attributes(), key, value, false,
+                                                  span_limits_.attribute_value_length_limit);
     return true;
   });
 }

--- a/exporters/otlp/test/otlp_recordable_test.cc
+++ b/exporters/otlp/test/otlp_recordable_test.cc
@@ -872,8 +872,6 @@ TEST(OtlpRecordable, SpanLimitsNoLimitDefault)
 // TODO: remove this test case once the deprecated otlp options span limit fields are removed.
 TEST(OtlpRecordable, SpanLimitsFieldsMerged)
 {
-  constexpr std::uint32_t kMaxCount = 10;
-
   constexpr std::uint32_t kOtlpAttributeCount      = 2;
   constexpr std::uint32_t kOtlpEventCount          = 3;
   constexpr std::uint32_t kOtlpLinkCount           = 4;
@@ -896,7 +894,8 @@ TEST(OtlpRecordable, SpanLimitsFieldsMerged)
   less_restrictive_limits.link_attribute_count_limit   = 7;
   less_restrictive_limits.attribute_value_length_limit = 6;
 
-  auto make_recordable = [&](const trace_sdk::SpanLimits &limits) {
+  auto make_recordable =
+      [&](const trace_sdk::SpanLimits &limits) -> std::unique_ptr<OtlpRecordable> {
     auto recordable =
         std::make_unique<OtlpRecordable>(kOtlpAttributeCount, kOtlpEventCount, kOtlpLinkCount,
                                          kOtlpEventAttributeCount, kOtlpLinkAttributeCount);
@@ -904,7 +903,8 @@ TEST(OtlpRecordable, SpanLimitsFieldsMerged)
     return recordable;
   };
 
-  auto make_attributes = []() {
+  auto make_attributes = []() -> std::map<std::string, int> {
+    constexpr std::uint32_t kMaxCount = 10;
     std::map<std::string, int> attributes;
     for (std::uint32_t i = 0; i < kMaxCount; ++i)
     {

--- a/exporters/otlp/test/otlp_recordable_test.cc
+++ b/exporters/otlp/test/otlp_recordable_test.cc
@@ -24,6 +24,7 @@
 #include "opentelemetry/sdk/instrumentationscope/instrumentation_scope.h"
 #include "opentelemetry/sdk/resource/resource.h"
 #include "opentelemetry/sdk/trace/recordable.h"
+#include "opentelemetry/sdk/trace/span_limits.h"
 #include "opentelemetry/trace/span_context.h"
 #include "opentelemetry/trace/span_id.h"
 #include "opentelemetry/trace/span_metadata.h"
@@ -657,6 +658,7 @@ TEST(OtlpRecordable, SetUint64ArrayOverflowAsStringPerSpec)
   EXPECT_EQ(array_v.values(1).string_value(), std::to_string(overflow_val));
 }
 
+// TODO: remove this test case once the deprecated otlp options span limit fields are removed.
 TEST(OtlpRecordableTest, TestCollectionLimits)
 {
   // Initialize recordable with strict limits:
@@ -698,6 +700,7 @@ TEST(OtlpRecordableTest, TestCollectionLimits)
   EXPECT_EQ(event_list[0].dropped_attributes_count(), 1);
 }
 
+// TODO: remove this test case once the deprecated otlp options span limit fields are removed.
 TEST(OtlpRecordableTest, TestLinkLimits)
 {
   // Limits: Max Links: 2, Max Attributes Per Link: 1
@@ -779,6 +782,275 @@ TEST(OtlpRecordable, PopulateRequestSameScope)
   EXPECT_EQ(req.resource_spans(0).scope_spans(0).spans_size(), 2);
   EXPECT_EQ(req.resource_spans(0).scope_spans(0).scope().name(), "lib");
 }
+
+TEST(OtlpRecordable, SpanLimits)
+{
+  OtlpRecordable data;
+  opentelemetry::sdk::trace::SpanLimits limits;
+  limits.attribute_count_limit        = 1;
+  limits.attribute_value_length_limit = 2;
+  limits.link_count_limit             = 1;
+  limits.link_attribute_count_limit   = 1;
+  limits.event_count_limit            = 1;
+  limits.event_attribute_count_limit  = 1;
+
+  constexpr const char *kKey1   = "one";
+  constexpr const char *kKey2   = "two";
+  constexpr const char *kValue1 = "1234";
+  constexpr const char *kValue2 = "5678";
+
+  std::map<std::string, std::string> attribute_collection{{kKey1, kValue1}, {kKey2, kValue2}};
+
+  const auto &proto_span = data.span();
+
+  data.SetSpanLimits(limits);
+
+  // span attribute count and length limits
+  data.SetAttribute(kKey1, kValue1);
+  data.SetAttribute(kKey2, kValue2);
+
+  EXPECT_EQ(proto_span.attributes_size(), 1);
+  EXPECT_EQ(proto_span.dropped_attributes_count(), 1);
+  EXPECT_EQ(proto_span.attributes(0).value().string_value(), "12");
+
+  // event count and per-event attribute count limits
+  data.AddEvent("event1", std::chrono::system_clock::now(),
+                common::MakeAttributes(attribute_collection));
+  data.AddEvent("event2", std::chrono::system_clock::now(),
+                common::MakeAttributes(attribute_collection));
+
+  ASSERT_EQ(proto_span.events_size(), 1);
+  EXPECT_EQ(proto_span.dropped_events_count(), 1);
+  const auto &event = proto_span.events(0);
+  EXPECT_EQ(event.dropped_attributes_count(), 1);
+  EXPECT_EQ(event.name(), "event1");
+  const auto &event_attributes = event.attributes();
+  EXPECT_EQ(event_attributes.size(), 1);
+  EXPECT_EQ(event_attributes.at(0).value().string_value(), "12");
+
+  // link count and per-link attribute count limits
+  data.AddLink(trace_api::SpanContext(true, false), common::MakeAttributes(attribute_collection));
+  data.AddLink(trace_api::SpanContext(true, false), common::MakeAttributes(attribute_collection));
+  ASSERT_EQ(proto_span.links_size(), 1);
+  EXPECT_EQ(proto_span.dropped_links_count(), 1);
+  const auto &link = proto_span.links(0);
+  EXPECT_EQ(link.dropped_attributes_count(), 1);
+  const auto &link_attributes = link.attributes();
+  EXPECT_EQ(link_attributes.size(), 1);
+  EXPECT_EQ(link_attributes.at(0).value().string_value(), "12");
+}
+
+TEST(OtlpRecordable, SpanLimitsNoLimitDefault)
+{
+  constexpr std::uint32_t kMaxCount = 500;
+  OtlpRecordable recordable;
+  std::map<std::string, std::string> attributes;
+
+  for (std::uint32_t i = 0; i < kMaxCount; ++i)
+  {
+    attributes["attribute_" + std::to_string(i)] = std::to_string(i);
+  }
+
+  for (std::uint32_t i = 0; i < kMaxCount; ++i)
+  {
+    recordable.SetAttribute("attribute_" + std::to_string(i), i);
+    recordable.AddEvent("event_" + std::to_string(i), std::chrono::system_clock::now(),
+                        common::MakeAttributes(attributes));
+    recordable.AddLink(trace::SpanContext::GetInvalid(), common::MakeAttributes(attributes));
+  }
+
+  EXPECT_EQ(recordable.span().attributes_size(), kMaxCount);
+  EXPECT_EQ(recordable.span().dropped_attributes_count(), 0u);
+  EXPECT_EQ(recordable.span().events_size(), kMaxCount);
+  EXPECT_EQ(recordable.span().dropped_events_count(), 0u);
+  EXPECT_EQ(recordable.span().links_size(), kMaxCount);
+  EXPECT_EQ(recordable.span().dropped_links_count(), 0u);
+  EXPECT_EQ(recordable.span().events(0).dropped_attributes_count(), 0u);
+  EXPECT_EQ(recordable.span().links(0).dropped_attributes_count(), 0u);
+}
+
+// TODO: remove this test case once the deprecated otlp options span limit fields are removed.
+TEST(OtlpRecordable, SpanLimitsFieldsMerged)
+{
+  constexpr std::uint32_t kMaxCount = 10;
+
+  constexpr std::uint32_t kOtlpAttributeCount      = 2;
+  constexpr std::uint32_t kOtlpEventCount          = 3;
+  constexpr std::uint32_t kOtlpLinkCount           = 4;
+  constexpr std::uint32_t kOtlpEventAttributeCount = 5;
+  constexpr std::uint32_t kOtlpLinkAttributeCount  = 6;
+
+  trace_sdk::SpanLimits more_restricitve_limits;
+  more_restricitve_limits.attribute_count_limit        = 1;
+  more_restricitve_limits.event_count_limit            = 2;
+  more_restricitve_limits.link_count_limit             = 3;
+  more_restricitve_limits.event_attribute_count_limit  = 4;
+  more_restricitve_limits.link_attribute_count_limit   = 5;
+  more_restricitve_limits.attribute_value_length_limit = 2;
+
+  trace_sdk::SpanLimits less_restricitve_limits;
+  less_restricitve_limits.attribute_count_limit        = 3;
+  less_restricitve_limits.event_count_limit            = 4;
+  less_restricitve_limits.link_count_limit             = 5;
+  less_restricitve_limits.event_attribute_count_limit  = 6;
+  less_restricitve_limits.link_attribute_count_limit   = 7;
+  less_restricitve_limits.attribute_value_length_limit = 6;
+
+  auto make_recordable = [&](const trace_sdk::SpanLimits &limits) {
+    auto recordable =
+        std::make_unique<OtlpRecordable>(kOtlpAttributeCount, kOtlpEventCount, kOtlpLinkCount,
+                                         kOtlpEventAttributeCount, kOtlpLinkAttributeCount);
+    recordable->SetSpanLimits(limits);
+    return recordable;
+  };
+
+  auto make_attributes = []() {
+    std::map<std::string, int> attributes;
+    for (std::uint32_t i = 0; i < kMaxCount; ++i)
+    {
+      attributes["attribute_" + std::to_string(i)] = static_cast<int>(i);
+    }
+    return attributes;
+  };
+
+  const std::map<std::string, int> empty_attributes;
+  const auto event_time = std::chrono::system_clock::time_point{std::chrono::seconds{1000000000}};
+
+  // attribute_count_limit: config limits are more restrictive than the deprecated otlp options.
+  {
+    auto recordable       = make_recordable(more_restricitve_limits);
+    const auto attributes = make_attributes();
+    for (const auto &attr : attributes)
+    {
+      recordable->SetAttribute(attr.first, attr.second);
+    }
+    EXPECT_EQ(recordable->span().attributes_size(),
+              static_cast<int>(more_restricitve_limits.attribute_count_limit));
+    EXPECT_EQ(recordable->span().dropped_attributes_count(),
+              attributes.size() - more_restricitve_limits.attribute_count_limit);
+  }
+  // attribute_count_limit: config limits are less restrictive than the deprecated otlp options.
+  {
+    auto recordable       = make_recordable(less_restricitve_limits);
+    const auto attributes = make_attributes();
+    for (const auto &attr : attributes)
+    {
+      recordable->SetAttribute(attr.first, attr.second);
+    }
+    EXPECT_EQ(recordable->span().attributes_size(), static_cast<int>(kOtlpAttributeCount));
+    EXPECT_EQ(recordable->span().dropped_attributes_count(),
+              attributes.size() - kOtlpAttributeCount);
+  }
+
+  // attribute_value_length_limit: config limits are more restrictive than the deprecated otlp
+  // options.
+  {
+    auto recordable = make_recordable(more_restricitve_limits);
+    recordable->SetAttribute("value", nostd::string_view("abcdefghij"));
+    EXPECT_EQ(recordable->span().attributes(0).value().string_value().size(),
+              more_restricitve_limits.attribute_value_length_limit);
+  }
+  // attribute_value_length_limit: config limits are less restrictive than the deprecated otlp
+  // options.
+  {
+    auto recordable = make_recordable(less_restricitve_limits);
+    recordable->SetAttribute("value", nostd::string_view("abcdefghij"));
+    EXPECT_EQ(recordable->span().attributes(0).value().string_value().size(),
+              less_restricitve_limits.attribute_value_length_limit);
+  }
+
+  // event_count_limit: config limits are more restrictive than the deprecated otlp options.
+  {
+    auto recordable = make_recordable(more_restricitve_limits);
+    recordable->AddEvent("event_one", event_time, common::MakeAttributes(empty_attributes));
+    recordable->AddEvent("event_two", event_time, common::MakeAttributes(empty_attributes));
+    recordable->AddEvent("event_three", event_time, common::MakeAttributes(empty_attributes));
+    EXPECT_EQ(recordable->span().events_size(),
+              static_cast<int>(more_restricitve_limits.event_count_limit));
+    EXPECT_EQ(recordable->span().dropped_events_count(), 1u);
+  }
+  // event_count_limit: config limits are less restrictive than the deprecated otlp options.
+  {
+    auto recordable = make_recordable(less_restricitve_limits);
+    recordable->AddEvent("event_one", event_time, common::MakeAttributes(empty_attributes));
+    recordable->AddEvent("event_two", event_time, common::MakeAttributes(empty_attributes));
+    recordable->AddEvent("event_three", event_time, common::MakeAttributes(empty_attributes));
+    recordable->AddEvent("event_four", event_time, common::MakeAttributes(empty_attributes));
+    EXPECT_EQ(recordable->span().events_size(), static_cast<int>(kOtlpEventCount));
+    EXPECT_EQ(recordable->span().dropped_events_count(), 1u);
+  }
+
+  // link_count_limit: config limits are more restrictive than the deprecated otlp options.
+  {
+    auto recordable = make_recordable(more_restricitve_limits);
+    for (std::uint32_t i = 0; i < kOtlpLinkCount; ++i)
+    {
+      recordable->AddLink(trace::SpanContext::GetInvalid(),
+                          common::MakeAttributes(empty_attributes));
+    }
+    EXPECT_EQ(recordable->span().links_size(),
+              static_cast<int>(more_restricitve_limits.link_count_limit));
+    EXPECT_EQ(recordable->span().dropped_links_count(), 1u);
+  }
+  // link_count_limit: config limits are less restrictive than the deprecated otlp options.
+  {
+    auto recordable = make_recordable(less_restricitve_limits);
+    for (std::uint32_t i = 0; i < less_restricitve_limits.link_count_limit; ++i)
+    {
+      recordable->AddLink(trace::SpanContext::GetInvalid(),
+                          common::MakeAttributes(empty_attributes));
+    }
+    EXPECT_EQ(recordable->span().links_size(), static_cast<int>(kOtlpLinkCount));
+    EXPECT_EQ(recordable->span().dropped_links_count(), 1u);
+  }
+
+  // event_attribute_count_limit: config limits are more restrictive than the deprecated otlp
+  // options.
+  {
+    auto recordable       = make_recordable(more_restricitve_limits);
+    const auto attributes = make_attributes();
+    recordable->AddEvent("test_event", event_time, common::MakeAttributes(attributes));
+    EXPECT_EQ(recordable->span().events(0).attributes_size(),
+              static_cast<int>(more_restricitve_limits.event_attribute_count_limit));
+    EXPECT_EQ(recordable->span().events(0).dropped_attributes_count(),
+              attributes.size() - more_restricitve_limits.event_attribute_count_limit);
+  }
+  // event_attribute_count_limit: config limits are less restrictive than the deprecated otlp
+  // options.
+  {
+    auto recordable       = make_recordable(less_restricitve_limits);
+    const auto attributes = make_attributes();
+    recordable->AddEvent("test_event", event_time, common::MakeAttributes(attributes));
+    EXPECT_EQ(recordable->span().events(0).attributes_size(),
+              static_cast<int>(kOtlpEventAttributeCount));
+    EXPECT_EQ(recordable->span().events(0).dropped_attributes_count(),
+              attributes.size() - kOtlpEventAttributeCount);
+  }
+
+  // link_attribute_count_limit: config limits are more restrictive than the deprecated otlp
+  // options.
+  {
+    auto recordable       = make_recordable(more_restricitve_limits);
+    const auto attributes = make_attributes();
+    recordable->AddLink(trace::SpanContext::GetInvalid(), common::MakeAttributes(attributes));
+    EXPECT_EQ(recordable->span().links(0).attributes_size(),
+              static_cast<int>(more_restricitve_limits.link_attribute_count_limit));
+    EXPECT_EQ(recordable->span().links(0).dropped_attributes_count(),
+              attributes.size() - more_restricitve_limits.link_attribute_count_limit);
+  }
+  // link_attribute_count_limit: config limits are less restrictive than the deprecated otlp
+  // options.
+  {
+    auto recordable       = make_recordable(less_restricitve_limits);
+    const auto attributes = make_attributes();
+    recordable->AddLink(trace::SpanContext::GetInvalid(), common::MakeAttributes(attributes));
+    EXPECT_EQ(recordable->span().links(0).attributes_size(),
+              static_cast<int>(kOtlpLinkAttributeCount));
+    EXPECT_EQ(recordable->span().links(0).dropped_attributes_count(),
+              attributes.size() - kOtlpLinkAttributeCount);
+  }
+}
+
 }  // namespace otlp
 }  // namespace exporter
 OPENTELEMETRY_END_NAMESPACE

--- a/exporters/otlp/test/otlp_recordable_test.cc
+++ b/exporters/otlp/test/otlp_recordable_test.cc
@@ -880,21 +880,21 @@ TEST(OtlpRecordable, SpanLimitsFieldsMerged)
   constexpr std::uint32_t kOtlpEventAttributeCount = 5;
   constexpr std::uint32_t kOtlpLinkAttributeCount  = 6;
 
-  trace_sdk::SpanLimits more_restricitve_limits;
-  more_restricitve_limits.attribute_count_limit        = 1;
-  more_restricitve_limits.event_count_limit            = 2;
-  more_restricitve_limits.link_count_limit             = 3;
-  more_restricitve_limits.event_attribute_count_limit  = 4;
-  more_restricitve_limits.link_attribute_count_limit   = 5;
-  more_restricitve_limits.attribute_value_length_limit = 2;
+  trace_sdk::SpanLimits more_restrictive_limits;
+  more_restrictive_limits.attribute_count_limit        = 1;
+  more_restrictive_limits.event_count_limit            = 2;
+  more_restrictive_limits.link_count_limit             = 3;
+  more_restrictive_limits.event_attribute_count_limit  = 4;
+  more_restrictive_limits.link_attribute_count_limit   = 5;
+  more_restrictive_limits.attribute_value_length_limit = 2;
 
-  trace_sdk::SpanLimits less_restricitve_limits;
-  less_restricitve_limits.attribute_count_limit        = 3;
-  less_restricitve_limits.event_count_limit            = 4;
-  less_restricitve_limits.link_count_limit             = 5;
-  less_restricitve_limits.event_attribute_count_limit  = 6;
-  less_restricitve_limits.link_attribute_count_limit   = 7;
-  less_restricitve_limits.attribute_value_length_limit = 6;
+  trace_sdk::SpanLimits less_restrictive_limits;
+  less_restrictive_limits.attribute_count_limit        = 3;
+  less_restrictive_limits.event_count_limit            = 4;
+  less_restrictive_limits.link_count_limit             = 5;
+  less_restrictive_limits.event_attribute_count_limit  = 6;
+  less_restrictive_limits.link_attribute_count_limit   = 7;
+  less_restrictive_limits.attribute_value_length_limit = 6;
 
   auto make_recordable = [&](const trace_sdk::SpanLimits &limits) {
     auto recordable =
@@ -918,20 +918,20 @@ TEST(OtlpRecordable, SpanLimitsFieldsMerged)
 
   // attribute_count_limit: config limits are more restrictive than the deprecated otlp options.
   {
-    auto recordable       = make_recordable(more_restricitve_limits);
+    auto recordable       = make_recordable(more_restrictive_limits);
     const auto attributes = make_attributes();
     for (const auto &attr : attributes)
     {
       recordable->SetAttribute(attr.first, attr.second);
     }
     EXPECT_EQ(recordable->span().attributes_size(),
-              static_cast<int>(more_restricitve_limits.attribute_count_limit));
+              static_cast<int>(more_restrictive_limits.attribute_count_limit));
     EXPECT_EQ(recordable->span().dropped_attributes_count(),
-              attributes.size() - more_restricitve_limits.attribute_count_limit);
+              attributes.size() - more_restrictive_limits.attribute_count_limit);
   }
   // attribute_count_limit: config limits are less restrictive than the deprecated otlp options.
   {
-    auto recordable       = make_recordable(less_restricitve_limits);
+    auto recordable       = make_recordable(less_restrictive_limits);
     const auto attributes = make_attributes();
     for (const auto &attr : attributes)
     {
@@ -945,33 +945,33 @@ TEST(OtlpRecordable, SpanLimitsFieldsMerged)
   // attribute_value_length_limit: config limits are more restrictive than the deprecated otlp
   // options.
   {
-    auto recordable = make_recordable(more_restricitve_limits);
+    auto recordable = make_recordable(more_restrictive_limits);
     recordable->SetAttribute("value", nostd::string_view("abcdefghij"));
     EXPECT_EQ(recordable->span().attributes(0).value().string_value().size(),
-              more_restricitve_limits.attribute_value_length_limit);
+              more_restrictive_limits.attribute_value_length_limit);
   }
   // attribute_value_length_limit: config limits are less restrictive than the deprecated otlp
   // options.
   {
-    auto recordable = make_recordable(less_restricitve_limits);
+    auto recordable = make_recordable(less_restrictive_limits);
     recordable->SetAttribute("value", nostd::string_view("abcdefghij"));
     EXPECT_EQ(recordable->span().attributes(0).value().string_value().size(),
-              less_restricitve_limits.attribute_value_length_limit);
+              less_restrictive_limits.attribute_value_length_limit);
   }
 
   // event_count_limit: config limits are more restrictive than the deprecated otlp options.
   {
-    auto recordable = make_recordable(more_restricitve_limits);
+    auto recordable = make_recordable(more_restrictive_limits);
     recordable->AddEvent("event_one", event_time, common::MakeAttributes(empty_attributes));
     recordable->AddEvent("event_two", event_time, common::MakeAttributes(empty_attributes));
     recordable->AddEvent("event_three", event_time, common::MakeAttributes(empty_attributes));
     EXPECT_EQ(recordable->span().events_size(),
-              static_cast<int>(more_restricitve_limits.event_count_limit));
+              static_cast<int>(more_restrictive_limits.event_count_limit));
     EXPECT_EQ(recordable->span().dropped_events_count(), 1u);
   }
   // event_count_limit: config limits are less restrictive than the deprecated otlp options.
   {
-    auto recordable = make_recordable(less_restricitve_limits);
+    auto recordable = make_recordable(less_restrictive_limits);
     recordable->AddEvent("event_one", event_time, common::MakeAttributes(empty_attributes));
     recordable->AddEvent("event_two", event_time, common::MakeAttributes(empty_attributes));
     recordable->AddEvent("event_three", event_time, common::MakeAttributes(empty_attributes));
@@ -982,20 +982,20 @@ TEST(OtlpRecordable, SpanLimitsFieldsMerged)
 
   // link_count_limit: config limits are more restrictive than the deprecated otlp options.
   {
-    auto recordable = make_recordable(more_restricitve_limits);
+    auto recordable = make_recordable(more_restrictive_limits);
     for (std::uint32_t i = 0; i < kOtlpLinkCount; ++i)
     {
       recordable->AddLink(trace::SpanContext::GetInvalid(),
                           common::MakeAttributes(empty_attributes));
     }
     EXPECT_EQ(recordable->span().links_size(),
-              static_cast<int>(more_restricitve_limits.link_count_limit));
+              static_cast<int>(more_restrictive_limits.link_count_limit));
     EXPECT_EQ(recordable->span().dropped_links_count(), 1u);
   }
   // link_count_limit: config limits are less restrictive than the deprecated otlp options.
   {
-    auto recordable = make_recordable(less_restricitve_limits);
-    for (std::uint32_t i = 0; i < less_restricitve_limits.link_count_limit; ++i)
+    auto recordable = make_recordable(less_restrictive_limits);
+    for (std::uint32_t i = 0; i < less_restrictive_limits.link_count_limit; ++i)
     {
       recordable->AddLink(trace::SpanContext::GetInvalid(),
                           common::MakeAttributes(empty_attributes));
@@ -1007,18 +1007,18 @@ TEST(OtlpRecordable, SpanLimitsFieldsMerged)
   // event_attribute_count_limit: config limits are more restrictive than the deprecated otlp
   // options.
   {
-    auto recordable       = make_recordable(more_restricitve_limits);
+    auto recordable       = make_recordable(more_restrictive_limits);
     const auto attributes = make_attributes();
     recordable->AddEvent("test_event", event_time, common::MakeAttributes(attributes));
     EXPECT_EQ(recordable->span().events(0).attributes_size(),
-              static_cast<int>(more_restricitve_limits.event_attribute_count_limit));
+              static_cast<int>(more_restrictive_limits.event_attribute_count_limit));
     EXPECT_EQ(recordable->span().events(0).dropped_attributes_count(),
-              attributes.size() - more_restricitve_limits.event_attribute_count_limit);
+              attributes.size() - more_restrictive_limits.event_attribute_count_limit);
   }
   // event_attribute_count_limit: config limits are less restrictive than the deprecated otlp
   // options.
   {
-    auto recordable       = make_recordable(less_restricitve_limits);
+    auto recordable       = make_recordable(less_restrictive_limits);
     const auto attributes = make_attributes();
     recordable->AddEvent("test_event", event_time, common::MakeAttributes(attributes));
     EXPECT_EQ(recordable->span().events(0).attributes_size(),
@@ -1030,18 +1030,18 @@ TEST(OtlpRecordable, SpanLimitsFieldsMerged)
   // link_attribute_count_limit: config limits are more restrictive than the deprecated otlp
   // options.
   {
-    auto recordable       = make_recordable(more_restricitve_limits);
+    auto recordable       = make_recordable(more_restrictive_limits);
     const auto attributes = make_attributes();
     recordable->AddLink(trace::SpanContext::GetInvalid(), common::MakeAttributes(attributes));
     EXPECT_EQ(recordable->span().links(0).attributes_size(),
-              static_cast<int>(more_restricitve_limits.link_attribute_count_limit));
+              static_cast<int>(more_restrictive_limits.link_attribute_count_limit));
     EXPECT_EQ(recordable->span().links(0).dropped_attributes_count(),
-              attributes.size() - more_restricitve_limits.link_attribute_count_limit);
+              attributes.size() - more_restrictive_limits.link_attribute_count_limit);
   }
   // link_attribute_count_limit: config limits are less restrictive than the deprecated otlp
   // options.
   {
-    auto recordable       = make_recordable(less_restricitve_limits);
+    auto recordable       = make_recordable(less_restrictive_limits);
     const auto attributes = make_attributes();
     recordable->AddLink(trace::SpanContext::GetInvalid(), common::MakeAttributes(attributes));
     EXPECT_EQ(recordable->span().links(0).attributes_size(),

--- a/sdk/include/opentelemetry/sdk/common/attribute_utils.h
+++ b/sdk/include/opentelemetry/sdk/common/attribute_utils.h
@@ -289,7 +289,7 @@ struct AttributeEqualToVisitor
  * @return A pair of an iterator to the element and a bool (true if the insertion took place).
  */
 template <typename Map, typename Value>
-OPENTELEMETRY_MAYBE_UNUSED inline std::pair<typename Map::iterator, bool>
+inline std::pair<typename Map::iterator, bool>
 AttributeInsertOrAssign(Map &map, opentelemetry::nostd::string_view key, Value &&value) noexcept
 {
 #if __cplusplus >= 201703L
@@ -388,7 +388,7 @@ public:
   }
 
   // Convert non-owning key-value to owning std::string(key) and OwnedAttributeValue(value)
-  void SetAttribute(nostd::string_view key,
+  bool SetAttribute(nostd::string_view key,
                     const opentelemetry::common::AttributeValue &value,
                     std::size_t max_length = (std::numeric_limits<std::size_t>::max)()) noexcept
   {
@@ -397,7 +397,9 @@ public:
     if (result.second)
     {
       AttributeInsertOrAssign(*this, key, std::move(result.first));
+      return true;
     }
+    return false;
   }
 
   // Compare the attributes of this map with another KeyValueIterable

--- a/sdk/include/opentelemetry/sdk/common/attribute_utils.h
+++ b/sdk/include/opentelemetry/sdk/common/attribute_utils.h
@@ -14,16 +14,16 @@
 #include <utility>
 #include <vector>
 
-#if OPENTELEMETRY_HAVE_EXCEPTIONS
-#  include <new>
-#endif
-
 #include "opentelemetry/common/attribute_value.h"
 #include "opentelemetry/common/key_value_iterable.h"
 #include "opentelemetry/nostd/span.h"
 #include "opentelemetry/nostd/string_view.h"
 #include "opentelemetry/nostd/variant.h"
 #include "opentelemetry/version.h"
+
+#if OPENTELEMETRY_HAVE_EXCEPTIONS
+#  include <new>
+#endif
 
 OPENTELEMETRY_BEGIN_NAMESPACE
 namespace sdk
@@ -313,8 +313,8 @@ template <typename Visitor, typename Variant>
 inline auto VisitVariant(Visitor &&visitor, const Variant &value) noexcept
     -> std::pair<decltype(opentelemetry::nostd::visit(std::forward<Visitor>(visitor), value)), bool>
 {
-  using ReturnType = decltype(opentelemetry::nostd::visit(std::forward<Visitor>(visitor), value));
 #if OPENTELEMETRY_HAVE_EXCEPTIONS
+  using ReturnType = decltype(opentelemetry::nostd::visit(std::forward<Visitor>(visitor), value));
   try
   {
 #endif

--- a/sdk/include/opentelemetry/sdk/common/attribute_utils.h
+++ b/sdk/include/opentelemetry/sdk/common/attribute_utils.h
@@ -14,6 +14,10 @@
 #include <utility>
 #include <vector>
 
+#if OPENTELEMETRY_HAVE_EXCEPTIONS
+#  include <new>
+#endif
+
 #include "opentelemetry/common/attribute_value.h"
 #include "opentelemetry/common/key_value_iterable.h"
 #include "opentelemetry/nostd/span.h"
@@ -277,6 +281,62 @@ struct AttributeEqualToVisitor
 };
 
 /**
+ * Insert or assign a key-value pair into a map using map.insert_or_assign if available, or
+ * map.emplace otherwise.
+ * @param map The map to insert or assign the key-value pair into.
+ * @param key The key to insert or assign.
+ * @param value The value to insert or assign.
+ * @return A pair of an iterator to the element and a bool (true if the insertion took place).
+ */
+template <typename Map, typename Value>
+OPENTELEMETRY_MAYBE_UNUSED inline std::pair<typename Map::iterator, bool>
+AttributeInsertOrAssign(Map &map, opentelemetry::nostd::string_view key, Value &&value) noexcept
+{
+#if __cplusplus >= 201703L
+  // Use insert_or_assign if C++17 is available
+  return map.insert_or_assign(std::string(key), std::forward<Value>(value));
+#else
+  auto result          = map.emplace(std::string(key), typename Map::mapped_type{});
+  result.first->second = std::forward<Value>(value);
+  return result;
+#endif
+}
+
+/**
+ * VisitVariant
+ *
+ * Invokes nostd::visit(visitor, value) with exception-safe handling.
+ * Returns pair<ReturnType, bool>: second=true on success, false if an exception was caught
+ * On exception the first element is default-constructed.
+ */
+template <typename Visitor, typename Variant>
+inline auto VisitVariant(Visitor &&visitor, const Variant &value) noexcept
+    -> std::pair<decltype(opentelemetry::nostd::visit(std::forward<Visitor>(visitor), value)), bool>
+{
+  using ReturnType = decltype(opentelemetry::nostd::visit(std::forward<Visitor>(visitor), value));
+#if OPENTELEMETRY_HAVE_EXCEPTIONS
+  try
+  {
+#endif
+    return {opentelemetry::nostd::visit(std::forward<Visitor>(visitor), value), true};
+#if OPENTELEMETRY_HAVE_EXCEPTIONS
+  }
+#  if defined(OPENTELEMETRY_HAVE_STD_VARIANT)
+  catch (const std::bad_variant_access &)
+#  else
+  catch (const opentelemetry::nostd::bad_variant_access &)
+#  endif
+  {
+    return {ReturnType{}, false};
+  }
+  catch (const std::bad_alloc &)
+  {
+    return {ReturnType{}, false};
+  }
+#endif
+}
+
+/**
  * Class for storing attributes.
  */
 class AttributeMap : public std::unordered_map<std::string, OwnedAttributeValue>
@@ -329,9 +389,15 @@ public:
 
   // Convert non-owning key-value to owning std::string(key) and OwnedAttributeValue(value)
   void SetAttribute(nostd::string_view key,
-                    const opentelemetry::common::AttributeValue &value) noexcept
+                    const opentelemetry::common::AttributeValue &value,
+                    std::size_t max_length = (std::numeric_limits<std::size_t>::max)()) noexcept
   {
-    (*this)[std::string(key)] = nostd::visit(AttributeConverter(), value);
+    std::pair<OwnedAttributeValue, bool> result =
+        VisitVariant(AttributeConverter(max_length), value);
+    if (result.second)
+    {
+      AttributeInsertOrAssign(*this, key, std::move(result.first));
+    }
   }
 
   // Compare the attributes of this map with another KeyValueIterable
@@ -403,9 +469,15 @@ public:
 
   // Convert non-owning key-value to owning std::string(key) and OwnedAttributeValue(value)
   void SetAttribute(nostd::string_view key,
-                    const opentelemetry::common::AttributeValue &value) noexcept
+                    const opentelemetry::common::AttributeValue &value,
+                    std::size_t max_length = (std::numeric_limits<std::size_t>::max)()) noexcept
   {
-    (*this)[std::string(key)] = nostd::visit(AttributeConverter(), value);
+    std::pair<OwnedAttributeValue, bool> result =
+        VisitVariant(AttributeConverter(max_length), value);
+    if (result.second)
+    {
+      AttributeInsertOrAssign(*this, key, std::move(result.first));
+    }
   }
 };
 

--- a/sdk/include/opentelemetry/sdk/configuration/span_limits_configuration.h
+++ b/sdk/include/opentelemetry/sdk/configuration/span_limits_configuration.h
@@ -17,11 +17,11 @@ class SpanLimitsConfiguration
 {
 public:
   std::size_t attribute_value_length_limit;
-  std::size_t attribute_count_limit;
-  std::size_t event_count_limit;
-  std::size_t link_count_limit;
-  std::size_t event_attribute_count_limit;
-  std::size_t link_attribute_count_limit;
+  std::uint32_t attribute_count_limit;
+  std::uint32_t event_count_limit;
+  std::uint32_t link_count_limit;
+  std::uint32_t event_attribute_count_limit;
+  std::uint32_t link_attribute_count_limit;
 };
 
 }  // namespace configuration

--- a/sdk/include/opentelemetry/sdk/trace/multi_recordable.h
+++ b/sdk/include/opentelemetry/sdk/trace/multi_recordable.h
@@ -58,6 +58,8 @@ public:
 
   void SetDuration(std::chrono::nanoseconds duration) noexcept override;
 
+  void SetSpanLimits(const SpanLimits &limits) noexcept override;
+
   void SetInstrumentationScope(const InstrumentationScope &instrumentation_scope) noexcept override;
 
 private:

--- a/sdk/include/opentelemetry/sdk/trace/recordable.h
+++ b/sdk/include/opentelemetry/sdk/trace/recordable.h
@@ -175,7 +175,6 @@ public:
   /**
    * Set the span limits for the span.
    * This method must be called before any SetAttribute / AddEvent / AddLink call.
-   * @param limits the span limits to set
    */
   virtual void SetSpanLimits(const SpanLimits & /* limits */) noexcept {}
 

--- a/sdk/include/opentelemetry/sdk/trace/recordable.h
+++ b/sdk/include/opentelemetry/sdk/trace/recordable.h
@@ -10,6 +10,7 @@
 #include "opentelemetry/nostd/string_view.h"
 #include "opentelemetry/sdk/common/empty_attributes.h"
 #include "opentelemetry/sdk/instrumentationscope/instrumentation_scope.h"
+#include "opentelemetry/sdk/trace/span_limits.h"
 #include "opentelemetry/trace/span_context.h"
 #include "opentelemetry/trace/span_id.h"
 #include "opentelemetry/trace/span_metadata.h"
@@ -170,6 +171,13 @@ public:
    * @param duration the duration to set
    */
   virtual void SetDuration(std::chrono::nanoseconds duration) noexcept = 0;
+
+  /**
+   * Set the span limits for the span.
+   * This method must be called before any SetAttribute / AddEvent / AddLink call.
+   * @param limits the span limits to set
+   */
+  virtual void SetSpanLimits(const SpanLimits & /* limits */) noexcept {}
 
   /**
    * Get the SpanData object for this Recordable.

--- a/sdk/include/opentelemetry/sdk/trace/span_data.h
+++ b/sdk/include/opentelemetry/sdk/trace/span_data.h
@@ -4,6 +4,7 @@
 #pragma once
 
 #include <chrono>
+#include <limits>
 #include <map>
 #include <memory>
 #include <string>
@@ -20,6 +21,7 @@
 #include "opentelemetry/sdk/instrumentationscope/instrumentation_scope.h"
 #include "opentelemetry/sdk/resource/resource.h"
 #include "opentelemetry/sdk/trace/recordable.h"
+#include "opentelemetry/sdk/trace/span_limits.h"
 #include "opentelemetry/trace/span_context.h"
 #include "opentelemetry/trace/span_id.h"
 #include "opentelemetry/trace/span_metadata.h"
@@ -38,9 +40,12 @@ namespace trace
 class SpanDataEvent
 {
 public:
-  SpanDataEvent(std::string name,
-                opentelemetry::common::SystemTimestamp timestamp,
-                const opentelemetry::common::KeyValueIterable &attributes);
+  SpanDataEvent(
+      std::string name,
+      opentelemetry::common::SystemTimestamp timestamp,
+      const opentelemetry::common::KeyValueIterable &attributes,
+      std::uint32_t attribute_count_limit      = (std::numeric_limits<std::uint32_t>::max)(),
+      std::size_t attribute_value_length_limit = (std::numeric_limits<std::size_t>::max)());
 
   /**
    * Get the name for this event
@@ -61,10 +66,17 @@ public:
   const std::unordered_map<std::string, opentelemetry::sdk::common::OwnedAttributeValue> &
   GetAttributes() const noexcept;
 
+  /**
+   * Get the number of attributes dropped due to the per-event attribute count limit.
+   * @return the number of attributes dropped
+   */
+  std::uint32_t GetDroppedAttributesCount() const noexcept { return dropped_attributes_count_; }
+
 private:
   std::string name_;
   opentelemetry::common::SystemTimestamp timestamp_;
   opentelemetry::sdk::common::AttributeMap attribute_map_;
+  std::uint32_t dropped_attributes_count_{0};
 };
 
 /**
@@ -73,8 +85,11 @@ private:
 class SpanDataLink
 {
 public:
-  SpanDataLink(opentelemetry::trace::SpanContext span_context,
-               const opentelemetry::common::KeyValueIterable &attributes);
+  SpanDataLink(
+      opentelemetry::trace::SpanContext span_context,
+      const opentelemetry::common::KeyValueIterable &attributes,
+      std::uint32_t attribute_count_limit      = (std::numeric_limits<std::uint32_t>::max)(),
+      std::size_t attribute_value_length_limit = (std::numeric_limits<std::size_t>::max)());
 
   /**
    * Get the attributes for this link
@@ -89,9 +104,17 @@ public:
    */
   const opentelemetry::trace::SpanContext &GetSpanContext() const noexcept { return span_context_; }
 
+  /**
+   * Get the number of attributes dropped due to the per-link
+   * attribute count limit.
+   * @return the number of attributes dropped
+   */
+  std::uint32_t GetDroppedAttributesCount() const noexcept { return dropped_attributes_count_; }
+
 private:
   opentelemetry::trace::SpanContext span_context_;
   opentelemetry::sdk::common::AttributeMap attribute_map_;
+  std::uint32_t dropped_attributes_count_{0};
 };
 
 /**
@@ -235,7 +258,15 @@ public:
 
   void SetDuration(std::chrono::nanoseconds duration) noexcept override;
 
+  void SetSpanLimits(const SpanLimits &limits) noexcept override;
+
   void SetInstrumentationScope(const InstrumentationScope &instrumentation_scope) noexcept override;
+
+  std::uint32_t GetDroppedAttributesCount() const noexcept { return dropped_attributes_count_; }
+
+  std::uint32_t GetDroppedEventsCount() const noexcept { return dropped_events_count_; }
+
+  std::uint32_t GetDroppedLinksCount() const noexcept { return dropped_links_count_; }
 
 private:
   opentelemetry::trace::SpanContext span_context_{false, false};
@@ -252,6 +283,10 @@ private:
   opentelemetry::trace::SpanKind span_kind_{opentelemetry::trace::SpanKind::kInternal};
   const opentelemetry::sdk::resource::Resource *resource_{nullptr};
   const InstrumentationScope *instrumentation_scope_{nullptr};
+  SpanLimits limits_{SpanLimits::NoLimits()};
+  std::uint32_t dropped_attributes_count_{0};
+  std::uint32_t dropped_events_count_{0};
+  std::uint32_t dropped_links_count_{0};
 };
 }  // namespace trace
 }  // namespace sdk

--- a/sdk/include/opentelemetry/sdk/trace/span_limits.h
+++ b/sdk/include/opentelemetry/sdk/trace/span_limits.h
@@ -32,7 +32,7 @@ struct SpanLimits
   /// Maximum number of attributes per span.
   std::uint32_t attribute_count_limit{kDefaultAttributeCountLimit};
 
-  /// Maximum byte length of string and byte array attribute values.
+  /// Maximum allowed attribute value length (applies to string values and byte arrays)
   std::size_t attribute_value_length_limit{kDefaultAttributeValueLengthLimit};
 
   /// Maximum number of events per span.

--- a/sdk/include/opentelemetry/sdk/trace/span_limits.h
+++ b/sdk/include/opentelemetry/sdk/trace/span_limits.h
@@ -1,0 +1,68 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+#include <limits>
+
+#include "opentelemetry/version.h"
+
+OPENTELEMETRY_BEGIN_NAMESPACE
+namespace sdk
+{
+namespace trace
+{
+
+/**
+ * Span limits set on the TracerProvider and used by supporting recordables.
+ * See https://opentelemetry.io/docs/specs/otel/trace/sdk/#span-limits.
+ */
+struct SpanLimits
+{
+  static constexpr std::uint32_t kDefaultAttributeCountLimit      = 128;
+  static constexpr std::uint32_t kDefaultEventCountLimit          = 128;
+  static constexpr std::uint32_t kDefaultLinkCountLimit           = 128;
+  static constexpr std::uint32_t kDefaultEventAttributeCountLimit = 128;
+  static constexpr std::uint32_t kDefaultLinkAttributeCountLimit  = 128;
+  static constexpr std::size_t kDefaultAttributeValueLengthLimit =
+      (std::numeric_limits<std::size_t>::max)();
+
+  /// Maximum number of attributes per span.
+  std::uint32_t attribute_count_limit{kDefaultAttributeCountLimit};
+
+  /// Maximum byte length of string and byte array attribute values.
+  std::size_t attribute_value_length_limit{kDefaultAttributeValueLengthLimit};
+
+  /// Maximum number of events per span.
+  std::uint32_t event_count_limit{kDefaultEventCountLimit};
+
+  /// Maximum number of links per span.
+  std::uint32_t link_count_limit{kDefaultLinkCountLimit};
+
+  /// Maximum number of attributes per span event.
+  std::uint32_t event_attribute_count_limit{kDefaultEventAttributeCountLimit};
+
+  /// Maximum number of attributes per span link.
+  std::uint32_t link_attribute_count_limit{kDefaultLinkAttributeCountLimit};
+
+  /**
+   * Limit values that impose no cap on any field
+   */
+  static constexpr SpanLimits NoLimits() noexcept
+  {
+    SpanLimits limits;
+    limits.attribute_count_limit        = (std::numeric_limits<std::uint32_t>::max)();
+    limits.attribute_value_length_limit = (std::numeric_limits<std::size_t>::max)();
+    limits.event_count_limit            = (std::numeric_limits<std::uint32_t>::max)();
+    limits.link_count_limit             = (std::numeric_limits<std::uint32_t>::max)();
+    limits.event_attribute_count_limit  = (std::numeric_limits<std::uint32_t>::max)();
+    limits.link_attribute_count_limit   = (std::numeric_limits<std::uint32_t>::max)();
+    return limits;
+  }
+};
+
+}  // namespace trace
+}  // namespace sdk
+OPENTELEMETRY_END_NAMESPACE

--- a/sdk/include/opentelemetry/sdk/trace/tracer.h
+++ b/sdk/include/opentelemetry/sdk/trace/tracer.h
@@ -15,6 +15,7 @@
 #include "opentelemetry/sdk/trace/id_generator.h"
 #include "opentelemetry/sdk/trace/processor.h"
 #include "opentelemetry/sdk/trace/sampler.h"
+#include "opentelemetry/sdk/trace/span_limits.h"
 #include "opentelemetry/sdk/trace/tracer_config.h"
 #include "opentelemetry/sdk/trace/tracer_context.h"
 #include "opentelemetry/trace/noop.h"
@@ -82,6 +83,9 @@ public:
 
   /** Returns the configured span processor. */
   SpanProcessor &GetProcessor() noexcept { return context_->GetProcessor(); }
+
+  /** Returns the configured span limits. */
+  const SpanLimits &GetSpanLimits() const noexcept { return context_->GetSpanLimits(); }
 
   /** Returns the configured Id generator */
   IdGenerator &GetIdGenerator() const noexcept { return context_->GetIdGenerator(); }

--- a/sdk/include/opentelemetry/sdk/trace/tracer_context.h
+++ b/sdk/include/opentelemetry/sdk/trace/tracer_context.h
@@ -14,6 +14,7 @@
 #include "opentelemetry/sdk/trace/random_id_generator.h"
 #include "opentelemetry/sdk/trace/sampler.h"
 #include "opentelemetry/sdk/trace/samplers/always_on.h"
+#include "opentelemetry/sdk/trace/span_limits.h"
 #include "opentelemetry/sdk/trace/tracer_config.h"
 #include "opentelemetry/version.h"
 
@@ -50,7 +51,8 @@ public:
           std::make_unique<instrumentationscope::ScopeConfigurator<TracerConfig>>(
               instrumentationscope::ScopeConfigurator<TracerConfig>::Builder(
                   TracerConfig::Default())
-                  .Build())) noexcept;
+                  .Build()),
+      SpanLimits span_limits = SpanLimits::NoLimits()) noexcept;
 
   TracerContext(const TracerContext &)            = delete;
   TracerContext(TracerContext &&)                 = delete;
@@ -103,6 +105,12 @@ public:
   opentelemetry::sdk::trace::IdGenerator &GetIdGenerator() const noexcept;
 
   /**
+   * Obtain the SpanLimits associated with this tracer context.
+   * @return The SpanLimits for this tracer context.
+   */
+  const SpanLimits &GetSpanLimits() const noexcept;
+
+  /**
    * Replace the TracerConfigurator for this context.
    *
    * Note: This method is not thread safe.
@@ -129,6 +137,7 @@ private:
   std::unique_ptr<IdGenerator> id_generator_;
   std::unique_ptr<SpanProcessor> processor_;
   std::unique_ptr<instrumentationscope::ScopeConfigurator<TracerConfig>> tracer_configurator_;
+  SpanLimits span_limits_;
 };
 
 }  // namespace trace

--- a/sdk/include/opentelemetry/sdk/trace/tracer_provider.h
+++ b/sdk/include/opentelemetry/sdk/trace/tracer_provider.h
@@ -15,6 +15,7 @@
 #include "opentelemetry/sdk/trace/random_id_generator.h"
 #include "opentelemetry/sdk/trace/sampler.h"
 #include "opentelemetry/sdk/trace/samplers/always_on.h"
+#include "opentelemetry/sdk/trace/span_limits.h"
 #include "opentelemetry/sdk/trace/tracer.h"
 #include "opentelemetry/sdk/trace/tracer_context.h"
 #include "opentelemetry/trace/tracer.h"
@@ -41,6 +42,7 @@ public:
    * not be a nullptr
    * @param tracer_configurator Provides access to a function that computes the TracerConfig for
    * Tracers provided by this TracerProvider.
+   * @param span_limits The span limits for this tracer provider.
    */
   explicit TracerProvider(
       std::unique_ptr<SpanProcessor> processor,
@@ -53,7 +55,8 @@ public:
           std::make_unique<instrumentationscope::ScopeConfigurator<TracerConfig>>(
               instrumentationscope::ScopeConfigurator<TracerConfig>::Builder(
                   TracerConfig::Default())
-                  .Build())) noexcept;
+                  .Build()),
+      SpanLimits span_limits = SpanLimits::NoLimits()) noexcept;
 
   explicit TracerProvider(
       std::vector<std::unique_ptr<SpanProcessor>> &&processors,
@@ -66,7 +69,8 @@ public:
           std::make_unique<instrumentationscope::ScopeConfigurator<TracerConfig>>(
               instrumentationscope::ScopeConfigurator<TracerConfig>::Builder(
                   TracerConfig::Default())
-                  .Build())) noexcept;
+                  .Build()),
+      SpanLimits span_limits = SpanLimits::NoLimits()) noexcept;
 
   /**
    * Initialize a new tracer provider with a specified context
@@ -129,6 +133,12 @@ public:
    * @return The resource for this tracer provider.
    */
   const opentelemetry::sdk::resource::Resource &GetResource() const noexcept;
+
+  /**
+   * Obtain the span limits configured for this tracer provider.
+   * @return The SpanLimits for this tracer provider.
+   */
+  const opentelemetry::sdk::trace::SpanLimits &GetSpanLimits() const noexcept;
 
   /**
    * Shutdown the span processor associated with this tracer provider.

--- a/sdk/include/opentelemetry/sdk/trace/tracer_provider_factory.h
+++ b/sdk/include/opentelemetry/sdk/trace/tracer_provider_factory.h
@@ -10,6 +10,7 @@
 #include "opentelemetry/sdk/trace/id_generator.h"
 #include "opentelemetry/sdk/trace/processor.h"
 #include "opentelemetry/sdk/trace/sampler.h"
+#include "opentelemetry/sdk/trace/span_limits.h"
 #include "opentelemetry/sdk/trace/tracer_context.h"
 #include "opentelemetry/sdk/trace/tracer_provider.h"
 #include "opentelemetry/trace/tracer_provider.h"
@@ -55,6 +56,14 @@ public:
       std::unique_ptr<IdGenerator> id_generator,
       std::unique_ptr<instrumentationscope::ScopeConfigurator<TracerConfig>> tracer_configurator);
 
+  static std::unique_ptr<opentelemetry::sdk::trace::TracerProvider> Create(
+      std::unique_ptr<SpanProcessor> processor,
+      const opentelemetry::sdk::resource::Resource &resource,
+      std::unique_ptr<Sampler> sampler,
+      std::unique_ptr<IdGenerator> id_generator,
+      std::unique_ptr<instrumentationscope::ScopeConfigurator<TracerConfig>> tracer_configurator,
+      SpanLimits span_limits);
+
   /* Series of creator methods with a vector of processors. */
 
   static std::unique_ptr<opentelemetry::sdk::trace::TracerProvider> Create(
@@ -81,6 +90,14 @@ public:
       std::unique_ptr<Sampler> sampler,
       std::unique_ptr<IdGenerator> id_generator,
       std::unique_ptr<instrumentationscope::ScopeConfigurator<TracerConfig>> tracer_configurator);
+
+  static std::unique_ptr<opentelemetry::sdk::trace::TracerProvider> Create(
+      std::vector<std::unique_ptr<SpanProcessor>> &&processors,
+      const opentelemetry::sdk::resource::Resource &resource,
+      std::unique_ptr<Sampler> sampler,
+      std::unique_ptr<IdGenerator> id_generator,
+      std::unique_ptr<instrumentationscope::ScopeConfigurator<TracerConfig>> tracer_configurator,
+      SpanLimits span_limits);
 
   /* Create with a tracer context. */
 

--- a/sdk/src/configuration/configuration_parser.cc
+++ b/sdk/src/configuration/configuration_parser.cc
@@ -1,11 +1,11 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-#include <stddef.h>
-#include <stdint.h>
 #include <stdio.h>
 #include <cstddef>
+#include <cstdint>
 #include <fstream>
+#include <limits>
 #include <map>
 #include <memory>
 #include <string>

--- a/sdk/src/configuration/configuration_parser.cc
+++ b/sdk/src/configuration/configuration_parser.cc
@@ -1596,12 +1596,22 @@ std::unique_ptr<SpanLimitsConfiguration> ConfigurationParser::ParseSpanLimitsCon
 {
   auto model = std::make_unique<SpanLimitsConfiguration>();
 
+  const auto get_valid_uint32 = [&node](const std::string &name, std::size_t default_value) {
+    std::size_t value = node->GetInteger(name, default_value);
+    if (value > std::numeric_limits<std::uint32_t>::max())
+    {
+      std::string message = "Invalid value for " + name + ": " + std::to_string(value);
+      throw InvalidSchemaException(node->Location(), message);
+    }
+    return static_cast<uint32_t>(value);
+  };
+
   model->attribute_value_length_limit = node->GetInteger("attribute_value_length_limit", 4096);
-  model->attribute_count_limit        = node->GetInteger("attribute_count_limit", 128);
-  model->event_count_limit            = node->GetInteger("event_count_limit", 128);
-  model->link_count_limit             = node->GetInteger("link_count_limit", 128);
-  model->event_attribute_count_limit  = node->GetInteger("event_attribute_count_limit", 128);
-  model->link_attribute_count_limit   = node->GetInteger("link_attribute_count_limit", 128);
+  model->attribute_count_limit        = get_valid_uint32("attribute_count_limit", 128);
+  model->event_count_limit            = get_valid_uint32("event_count_limit", 128);
+  model->link_count_limit             = get_valid_uint32("link_count_limit", 128);
+  model->event_attribute_count_limit  = get_valid_uint32("event_attribute_count_limit", 128);
+  model->link_attribute_count_limit   = get_valid_uint32("link_attribute_count_limit", 128);
 
   return model;
 }

--- a/sdk/src/configuration/sdk_builder.cc
+++ b/sdk/src/configuration/sdk_builder.cc
@@ -1173,14 +1173,11 @@ std::unique_ptr<opentelemetry::sdk::trace::TracerProvider> SdkBuilder::CreateTra
   if (model->limits)
   {
     span_limits.attribute_value_length_limit = model->limits->attribute_value_length_limit;
-    span_limits.attribute_count_limit =
-        static_cast<std::uint32_t>(model->limits->attribute_count_limit);
-    span_limits.event_count_limit = static_cast<std::uint32_t>(model->limits->event_count_limit);
-    span_limits.link_count_limit  = static_cast<std::uint32_t>(model->limits->link_count_limit);
-    span_limits.event_attribute_count_limit =
-        static_cast<std::uint32_t>(model->limits->event_attribute_count_limit);
-    span_limits.link_attribute_count_limit =
-        static_cast<std::uint32_t>(model->limits->link_attribute_count_limit);
+    span_limits.attribute_count_limit        = model->limits->attribute_count_limit;
+    span_limits.event_count_limit            = model->limits->event_count_limit;
+    span_limits.link_count_limit             = model->limits->link_count_limit;
+    span_limits.event_attribute_count_limit  = model->limits->event_attribute_count_limit;
+    span_limits.link_attribute_count_limit   = model->limits->link_attribute_count_limit;
   }
 
   if (model->tracer_configurator)

--- a/sdk/src/configuration/sdk_builder.cc
+++ b/sdk/src/configuration/sdk_builder.cc
@@ -1,9 +1,9 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-#include <stddef.h>
-#include <stdint.h>
 #include <chrono>
+#include <cstddef>
+#include <cstdint>
 #include <functional>
 #include <map>
 #include <memory>
@@ -115,6 +115,7 @@
 #include "opentelemetry/sdk/configuration/simple_span_processor_configuration.h"
 #include "opentelemetry/sdk/configuration/span_exporter_configuration.h"
 #include "opentelemetry/sdk/configuration/span_exporter_configuration_visitor.h"
+#include "opentelemetry/sdk/configuration/span_limits_configuration.h"
 #include "opentelemetry/sdk/configuration/span_processor_configuration.h"
 #include "opentelemetry/sdk/configuration/span_processor_configuration_visitor.h"
 #include "opentelemetry/sdk/configuration/string_array_attribute_value_configuration.h"
@@ -172,6 +173,7 @@
 #include "opentelemetry/sdk/trace/samplers/parent_factory.h"
 #include "opentelemetry/sdk/trace/samplers/trace_id_ratio_factory.h"
 #include "opentelemetry/sdk/trace/simple_processor_factory.h"
+#include "opentelemetry/sdk/trace/span_limits.h"
 #include "opentelemetry/sdk/trace/tracer_config.h"
 #include "opentelemetry/sdk/trace/tracer_provider.h"
 #include "opentelemetry/sdk/trace/tracer_provider_factory.h"
@@ -1104,20 +1106,41 @@ std::unique_ptr<opentelemetry::sdk::trace::TracerProvider> SdkBuilder::CreateTra
     sdk_processors.push_back(CreateSpanProcessor(processor_model));
   }
 
-  // FIXME-SDK: https://github.com/open-telemetry/opentelemetry-cpp/issues/3303
-  // FIXME-SDK: use limits, id_generator, ...
+  opentelemetry::sdk::trace::SpanLimits span_limits;
+  if (model->limits)
+  {
+    span_limits.attribute_value_length_limit = model->limits->attribute_value_length_limit;
+    span_limits.attribute_count_limit =
+        static_cast<std::uint32_t>(model->limits->attribute_count_limit);
+    span_limits.event_count_limit = static_cast<std::uint32_t>(model->limits->event_count_limit);
+    span_limits.link_count_limit  = static_cast<std::uint32_t>(model->limits->link_count_limit);
+    span_limits.event_attribute_count_limit =
+        static_cast<std::uint32_t>(model->limits->event_attribute_count_limit);
+    span_limits.link_attribute_count_limit =
+        static_cast<std::uint32_t>(model->limits->link_attribute_count_limit);
+  }
+
   if (model->tracer_configurator)
   {
     auto tracer_configurator = CreateTracerConfigurator(model->tracer_configurator);
     auto id_generator        = opentelemetry::sdk::trace::RandomIdGeneratorFactory::Create();
     sdk                      = opentelemetry::sdk::trace::TracerProviderFactory::Create(
         std::move(sdk_processors), resource, std::move(sampler), std::move(id_generator),
-        std::move(tracer_configurator));
+        std::move(tracer_configurator), span_limits);
   }
   else
   {
-    sdk = opentelemetry::sdk::trace::TracerProviderFactory::Create(std::move(sdk_processors),
-                                                                   resource, std::move(sampler));
+    auto id_generator = opentelemetry::sdk::trace::RandomIdGeneratorFactory::Create();
+    auto tracer_configurator =
+        std::make_unique<opentelemetry::sdk::instrumentationscope::ScopeConfigurator<
+            opentelemetry::sdk::trace::TracerConfig>>(
+            opentelemetry::sdk::instrumentationscope::
+                ScopeConfigurator<opentelemetry::sdk::trace::TracerConfig>::Builder(
+                    opentelemetry::sdk::trace::TracerConfig::Default())
+                    .Build());
+    sdk = opentelemetry::sdk::trace::TracerProviderFactory::Create(
+        std::move(sdk_processors), resource, std::move(sampler), std::move(id_generator),
+        std::move(tracer_configurator), span_limits);
   }
 
   return sdk;

--- a/sdk/src/trace/multi_recordable.cc
+++ b/sdk/src/trace/multi_recordable.cc
@@ -69,6 +69,14 @@ void MultiRecordable::SetIdentity(const opentelemetry::trace::SpanContext &span_
   }
 }
 
+void MultiRecordable::SetSpanLimits(const SpanLimits &limits) noexcept
+{
+  for (auto &recordable : recordables_)
+  {
+    recordable.second->SetSpanLimits(limits);
+  }
+}
+
 void MultiRecordable::SetAttribute(nostd::string_view key,
                                    const opentelemetry::common::AttributeValue &value) noexcept
 {

--- a/sdk/src/trace/span.cc
+++ b/sdk/src/trace/span.cc
@@ -66,6 +66,7 @@ Span::Span(std::shared_ptr<Tracer> &&tracer,
   {
     return;
   }
+  recordable_->SetSpanLimits(tracer_->GetSpanLimits());
   recordable_->SetName(name);
   recordable_->SetInstrumentationScope(tracer_->GetInstrumentationScope());
   recordable_->SetIdentity(*span_context_, parent_span_context.IsValid()

--- a/sdk/src/trace/span_data.cc
+++ b/sdk/src/trace/span_data.cc
@@ -59,6 +59,7 @@ bool SetAttributeImpl(opentelemetry::sdk::common::AttributeMap &attribute_map,
       return false;  // There was an exception converting the value. Skip this attribute.
     }
     it->second = std::move(convert_result.first);
+    return true;
   }
   // The map is under the limit. Set the attribute (insert or assign).
   return attribute_map.SetAttribute(key, value, attribute_value_length_limit);

--- a/sdk/src/trace/span_data.cc
+++ b/sdk/src/trace/span_data.cc
@@ -67,7 +67,7 @@ opentelemetry::sdk::common::AttributeMap PopulateAttributeMap(
             map, key, std::move(convert_result.first));
         if (result.second)
         {
-          ++inserted; // A unique key was inserted.  
+          ++inserted;  // A unique key was inserted.
         }
         return true;
       });

--- a/sdk/src/trace/span_data.cc
+++ b/sdk/src/trace/span_data.cc
@@ -36,49 +36,56 @@ namespace trace
 namespace
 {
 
-// Populate from attributes enforcing count and value-length limits.
-opentelemetry::sdk::common::AttributeMap PopulateAttributeMap(
+bool SetAttributeImpl(opentelemetry::sdk::common::AttributeMap &attribute_map,
+                      nostd::string_view key,
+                      const opentelemetry::common::AttributeValue &value,
+                      std::uint32_t attribute_count_limit,
+                      std::size_t attribute_value_length_limit) noexcept
+{
+  if (attribute_map.size() >= attribute_count_limit)
+  {
+    // The map is at the limit. Can only update existing keys.
+    auto it = attribute_map.find(std::string(key));
+    if (it == attribute_map.end())
+    {
+      return false;  // The key is not in the map. Cannot add new attributes.
+    }
+    // try to convert the value and assign it to overwrite the existing value
+    opentelemetry::sdk::common::AttributeConverter converter(attribute_value_length_limit);
+    std::pair<opentelemetry::sdk::common::OwnedAttributeValue, bool> convert_result =
+        opentelemetry::sdk::common::VisitVariant(converter, value);
+    if (!convert_result.second)
+    {
+      return false;  // There was an exception converting the value. Skip this attribute.
+    }
+    it->second = std::move(convert_result.first);
+  }
+  // The map is under the limit. Set the attribute (insert or assign).
+  return attribute_map.SetAttribute(key, value, attribute_value_length_limit);
+}
+
+// Create the attribute map from KeyValueIterable attributes enforcing count and value-length
+// limits.
+opentelemetry::sdk::common::AttributeMap CreateAttributeMap(
     const opentelemetry::common::KeyValueIterable &attributes,
-    std::uint32_t count_limit,
-    std::size_t value_length_limit)
+    std::uint32_t attribute_count_limit,
+    std::size_t attribute_value_length_limit,
+    std::uint32_t &dropped_count)
 {
   opentelemetry::sdk::common::AttributeMap map;
-  map.reserve((std::min)(static_cast<std::size_t>(count_limit), attributes.size()));
-
+  map.reserve((std::min)(static_cast<std::size_t>(attribute_count_limit), attributes.size()));
+  dropped_count = 0;
   // Insert attributes until the count limit of unique keys is reached.
-  std::uint32_t inserted = 0;
   attributes.ForEachKeyValue(
-      [count_limit, value_length_limit, &map, &inserted](
+      [attribute_count_limit, attribute_value_length_limit, &map, &dropped_count](
           nostd::string_view key, const opentelemetry::common::AttributeValue &value) noexcept {
-        if (inserted >= count_limit)
+        if (!SetAttributeImpl(map, key, value, attribute_count_limit, attribute_value_length_limit))
         {
-          return false;  // The attribute count limit has been reached. Stop iterating.
-        }
-
-        std::pair<opentelemetry::sdk::common::OwnedAttributeValue, bool> convert_result =
-            opentelemetry::sdk::common::VisitVariant(
-                opentelemetry::sdk::common::AttributeConverter(value_length_limit), value);
-        if (!convert_result.second)
-        {
-          return true;  // There was an exception converting. Skip this attribute and continue.
-        }
-
-        auto result = opentelemetry::sdk::common::AttributeInsertOrAssign(
-            map, key, std::move(convert_result.first));
-        if (result.second)
-        {
-          ++inserted;  // A unique key was inserted.
+          ++dropped_count;
         }
         return true;
       });
   return map;
-}
-
-std::uint32_t CountDroppedAttributes(const opentelemetry::common::KeyValueIterable &attributes,
-                                     std::uint32_t count_limit)
-{
-  const std::size_t total = attributes.size();
-  return static_cast<std::uint32_t>(total > count_limit ? total - count_limit : 0);
 }
 
 }  // namespace
@@ -88,12 +95,11 @@ SpanDataEvent::SpanDataEvent(std::string name,
                              const opentelemetry::common::KeyValueIterable &attributes,
                              std::uint32_t attribute_count_limit,
                              std::size_t attribute_value_length_limit)
-    : name_(std::move(name)),
-      timestamp_(timestamp),
-      attribute_map_(
-          PopulateAttributeMap(attributes, attribute_count_limit, attribute_value_length_limit)),
-      dropped_attributes_count_(CountDroppedAttributes(attributes, attribute_count_limit))
-{}
+    : name_(std::move(name)), timestamp_(timestamp)
+{
+  attribute_map_ = CreateAttributeMap(attributes, attribute_count_limit,
+                                      attribute_value_length_limit, dropped_attributes_count_);
+}
 
 const std::unordered_map<std::string, opentelemetry::sdk::common::OwnedAttributeValue> &
 SpanDataEvent::GetAttributes() const noexcept
@@ -105,11 +111,11 @@ SpanDataLink::SpanDataLink(opentelemetry::trace::SpanContext span_context,
                            const opentelemetry::common::KeyValueIterable &attributes,
                            std::uint32_t attribute_count_limit,
                            std::size_t attribute_value_length_limit)
-    : span_context_(std::move(span_context)),
-      attribute_map_(
-          PopulateAttributeMap(attributes, attribute_count_limit, attribute_value_length_limit)),
-      dropped_attributes_count_(CountDroppedAttributes(attributes, attribute_count_limit))
-{}
+    : span_context_(std::move(span_context))
+{
+  attribute_map_ = CreateAttributeMap(attributes, attribute_count_limit,
+                                      attribute_value_length_limit, dropped_attributes_count_);
+}
 
 const std::unordered_map<std::string, opentelemetry::sdk::common::OwnedAttributeValue> &
 SpanDataLink::GetAttributes() const noexcept
@@ -160,30 +166,11 @@ void SpanData::SetIdentity(const opentelemetry::trace::SpanContext &span_context
 void SpanData::SetAttribute(nostd::string_view key,
                             const opentelemetry::common::AttributeValue &value) noexcept
 {
-  if (attribute_map_.size() >= limits_.attribute_count_limit)
+  if (!SetAttributeImpl(attribute_map_, key, value, limits_.attribute_count_limit,
+                        limits_.attribute_value_length_limit))
   {
-    // The map is at the limit. Can only update existing keys.
-    auto it = attribute_map_.find(std::string(key));
-    if (it == attribute_map_.end())
-    {
-      ++dropped_attributes_count_;
-      return;
-    }
-    // try to convert the value.
-    std::pair<opentelemetry::sdk::common::OwnedAttributeValue, bool> convert_result =
-        opentelemetry::sdk::common::VisitVariant(
-            opentelemetry::sdk::common::AttributeConverter(limits_.attribute_value_length_limit),
-            value);
-    if (!convert_result.second)
-    {
-      return;  // There was an exception converting the value. Skip this attribute.
-    }
-    it->second = std::move(convert_result.first);
-    return;
+    ++dropped_attributes_count_;
   }
-
-  // The map is under the limit. Set the attribute (insert or assign).
-  attribute_map_.SetAttribute(key, value, limits_.attribute_value_length_limit);
 }
 
 void SpanData::AddEvent(nostd::string_view name,

--- a/sdk/src/trace/span_data.cc
+++ b/sdk/src/trace/span_data.cc
@@ -1,7 +1,10 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
+#include <algorithm>
 #include <chrono>
+#include <cstddef>
+#include <cstdint>
 #include <memory>
 #include <string>
 #include <unordered_map>
@@ -11,11 +14,14 @@
 #include "opentelemetry/common/attribute_value.h"
 #include "opentelemetry/common/key_value_iterable.h"
 #include "opentelemetry/common/timestamp.h"
+#include "opentelemetry/nostd/function_ref.h"
 #include "opentelemetry/nostd/string_view.h"
+#include "opentelemetry/nostd/variant.h"
 #include "opentelemetry/sdk/common/attribute_utils.h"
 #include "opentelemetry/sdk/instrumentationscope/instrumentation_scope.h"
 #include "opentelemetry/sdk/resource/resource.h"
 #include "opentelemetry/sdk/trace/span_data.h"
+#include "opentelemetry/sdk/trace/span_limits.h"
 #include "opentelemetry/trace/span_context.h"
 #include "opentelemetry/trace/span_id.h"
 #include "opentelemetry/trace/trace_flags.h"
@@ -27,10 +33,66 @@ namespace sdk
 namespace trace
 {
 
+namespace
+{
+
+// Populate from attributes enforcing count and value-length limits.
+opentelemetry::sdk::common::AttributeMap PopulateAttributeMap(
+    const opentelemetry::common::KeyValueIterable &attributes,
+    std::uint32_t count_limit,
+    std::size_t value_length_limit)
+{
+  opentelemetry::sdk::common::AttributeMap map;
+  map.reserve((std::min)(static_cast<std::size_t>(count_limit), attributes.size()));
+
+  // Insert attributes until the count limit of unique keys is reached.
+  std::uint32_t inserted = 0;
+  attributes.ForEachKeyValue(
+      [count_limit, value_length_limit, &map, &inserted](
+          nostd::string_view key, const opentelemetry::common::AttributeValue &value) noexcept {
+        if (inserted >= count_limit)
+        {
+          return false;  // The attribute count limit has been reached. Stop iterating.
+        }
+
+        std::pair<opentelemetry::sdk::common::OwnedAttributeValue, bool> convert_result =
+            opentelemetry::sdk::common::VisitVariant(
+                opentelemetry::sdk::common::AttributeConverter(value_length_limit), value);
+        if (!convert_result.second)
+        {
+          return true;  // There was an exception converting. Skip this attribute and continue.
+        }
+
+        auto result = opentelemetry::sdk::common::AttributeInsertOrAssign(
+            map, key, std::move(convert_result.first));
+        if (result.second)
+        {
+          ++inserted; // A unique key was inserted.  
+        }
+        return true;
+      });
+  return map;
+}
+
+std::uint32_t CountDroppedAttributes(const opentelemetry::common::KeyValueIterable &attributes,
+                                     std::uint32_t count_limit)
+{
+  const std::size_t total = attributes.size();
+  return static_cast<std::uint32_t>(total > count_limit ? total - count_limit : 0);
+}
+
+}  // namespace
+
 SpanDataEvent::SpanDataEvent(std::string name,
                              opentelemetry::common::SystemTimestamp timestamp,
-                             const opentelemetry::common::KeyValueIterable &attributes)
-    : name_(std::move(name)), timestamp_(timestamp), attribute_map_(attributes)
+                             const opentelemetry::common::KeyValueIterable &attributes,
+                             std::uint32_t attribute_count_limit,
+                             std::size_t attribute_value_length_limit)
+    : name_(std::move(name)),
+      timestamp_(timestamp),
+      attribute_map_(
+          PopulateAttributeMap(attributes, attribute_count_limit, attribute_value_length_limit)),
+      dropped_attributes_count_(CountDroppedAttributes(attributes, attribute_count_limit))
 {}
 
 const std::unordered_map<std::string, opentelemetry::sdk::common::OwnedAttributeValue> &
@@ -40,8 +102,13 @@ SpanDataEvent::GetAttributes() const noexcept
 }
 
 SpanDataLink::SpanDataLink(opentelemetry::trace::SpanContext span_context,
-                           const opentelemetry::common::KeyValueIterable &attributes)
-    : span_context_(std::move(span_context)), attribute_map_(attributes)
+                           const opentelemetry::common::KeyValueIterable &attributes,
+                           std::uint32_t attribute_count_limit,
+                           std::size_t attribute_value_length_limit)
+    : span_context_(std::move(span_context)),
+      attribute_map_(
+          PopulateAttributeMap(attributes, attribute_count_limit, attribute_value_length_limit)),
+      dropped_attributes_count_(CountDroppedAttributes(attributes, attribute_count_limit))
 {}
 
 const std::unordered_map<std::string, opentelemetry::sdk::common::OwnedAttributeValue> &
@@ -93,22 +160,60 @@ void SpanData::SetIdentity(const opentelemetry::trace::SpanContext &span_context
 void SpanData::SetAttribute(nostd::string_view key,
                             const opentelemetry::common::AttributeValue &value) noexcept
 {
-  attribute_map_.SetAttribute(key, value);
+  if (attribute_map_.size() >= limits_.attribute_count_limit)
+  {
+    // The map is at the limit. Can only update existing keys.
+    auto it = attribute_map_.find(std::string(key));
+    if (it == attribute_map_.end())
+    {
+      ++dropped_attributes_count_;
+      return;
+    }
+    // try to convert the value.
+    std::pair<opentelemetry::sdk::common::OwnedAttributeValue, bool> convert_result =
+        opentelemetry::sdk::common::VisitVariant(
+            opentelemetry::sdk::common::AttributeConverter(limits_.attribute_value_length_limit),
+            value);
+    if (!convert_result.second)
+    {
+      return;  // There was an exception converting the value. Skip this attribute.
+    }
+    it->second = std::move(convert_result.first);
+    return;
+  }
+
+  // The map is under the limit. Set the attribute (insert or assign).
+  attribute_map_.SetAttribute(key, value, limits_.attribute_value_length_limit);
 }
 
 void SpanData::AddEvent(nostd::string_view name,
                         opentelemetry::common::SystemTimestamp timestamp,
                         const opentelemetry::common::KeyValueIterable &attributes) noexcept
 {
-  SpanDataEvent event(std::string(name), timestamp, attributes);
-  events_.push_back(event);
+  if (events_.size() >= limits_.event_count_limit)
+  {
+    ++dropped_events_count_;
+    return;
+  }
+  events_.emplace_back(std::string(name), timestamp, attributes,
+                       limits_.event_attribute_count_limit, limits_.attribute_value_length_limit);
 }
 
 void SpanData::AddLink(const opentelemetry::trace::SpanContext &span_context,
                        const opentelemetry::common::KeyValueIterable &attributes) noexcept
 {
-  SpanDataLink link(span_context, attributes);
-  links_.push_back(link);
+  if (links_.size() >= limits_.link_count_limit)
+  {
+    ++dropped_links_count_;
+    return;
+  }
+  links_.emplace_back(span_context, attributes, limits_.link_attribute_count_limit,
+                      limits_.attribute_value_length_limit);
+}
+
+void SpanData::SetSpanLimits(const SpanLimits &limits) noexcept
+{
+  limits_ = limits;
 }
 
 void SpanData::SetStatus(opentelemetry::trace::StatusCode code,

--- a/sdk/src/trace/tracer_context.cc
+++ b/sdk/src/trace/tracer_context.cc
@@ -13,6 +13,7 @@
 #include "opentelemetry/sdk/trace/multi_span_processor.h"
 #include "opentelemetry/sdk/trace/processor.h"
 #include "opentelemetry/sdk/trace/sampler.h"
+#include "opentelemetry/sdk/trace/span_limits.h"
 #include "opentelemetry/sdk/trace/tracer_config.h"
 #include "opentelemetry/sdk/trace/tracer_context.h"
 #include "opentelemetry/version.h"
@@ -24,17 +25,19 @@ namespace trace
 {
 namespace resource = opentelemetry::sdk::resource;
 
-TracerContext::TracerContext(std::vector<std::unique_ptr<SpanProcessor>> &&processors,
-                             const resource::Resource &resource,
-                             std::unique_ptr<Sampler> sampler,
-                             std::unique_ptr<IdGenerator> id_generator,
-                             std::unique_ptr<instrumentationscope::ScopeConfigurator<TracerConfig>>
-                                 tracer_configurator) noexcept
+TracerContext::TracerContext(
+    std::vector<std::unique_ptr<SpanProcessor>> &&processors,
+    const resource::Resource &resource,
+    std::unique_ptr<Sampler> sampler,
+    std::unique_ptr<IdGenerator> id_generator,
+    std::unique_ptr<instrumentationscope::ScopeConfigurator<TracerConfig>> tracer_configurator,
+    SpanLimits span_limits) noexcept
     : resource_(resource),
       sampler_(std::move(sampler)),
       id_generator_(std::move(id_generator)),
       processor_(std::unique_ptr<SpanProcessor>(new MultiSpanProcessor(std::move(processors)))),
-      tracer_configurator_(std::move(tracer_configurator))
+      tracer_configurator_(std::move(tracer_configurator)),
+      span_limits_(span_limits)
 {}
 
 Sampler &TracerContext::GetSampler() const noexcept
@@ -58,9 +61,13 @@ opentelemetry::sdk::trace::IdGenerator &TracerContext::GetIdGenerator() const no
   return *id_generator_;
 }
 
+const SpanLimits &TracerContext::GetSpanLimits() const noexcept
+{
+  return span_limits_;
+}
+
 void TracerContext::AddProcessor(std::unique_ptr<SpanProcessor> processor) noexcept
 {
-
   auto multi_processor = static_cast<MultiSpanProcessor *>(processor_.get());
   multi_processor->AddProcessor(std::move(processor));
 }

--- a/sdk/src/trace/tracer_provider.cc
+++ b/sdk/src/trace/tracer_provider.cc
@@ -16,6 +16,7 @@
 #include "opentelemetry/sdk/trace/id_generator.h"
 #include "opentelemetry/sdk/trace/processor.h"
 #include "opentelemetry/sdk/trace/sampler.h"
+#include "opentelemetry/sdk/trace/span_limits.h"
 #include "opentelemetry/sdk/trace/tracer.h"
 #include "opentelemetry/sdk/trace/tracer_config.h"
 #include "opentelemetry/sdk/trace/tracer_context.h"
@@ -41,14 +42,14 @@ TracerProvider::TracerProvider(
     const resource::Resource &resource,
     std::unique_ptr<Sampler> sampler,
     std::unique_ptr<IdGenerator> id_generator,
-    std::unique_ptr<instrumentationscope::ScopeConfigurator<TracerConfig>>
-        tracer_configurator) noexcept
+    std::unique_ptr<instrumentationscope::ScopeConfigurator<TracerConfig>> tracer_configurator,
+    SpanLimits span_limits) noexcept
 {
   std::vector<std::unique_ptr<SpanProcessor>> processors;
   processors.push_back(std::move(processor));
-  context_ =
-      std::make_shared<TracerContext>(std::move(processors), resource, std::move(sampler),
-                                      std::move(id_generator), std::move(tracer_configurator));
+  context_ = std::make_shared<TracerContext>(std::move(processors), resource, std::move(sampler),
+                                             std::move(id_generator),
+                                             std::move(tracer_configurator), span_limits);
 }
 
 TracerProvider::TracerProvider(
@@ -56,13 +57,14 @@ TracerProvider::TracerProvider(
     const resource::Resource &resource,
     std::unique_ptr<Sampler> sampler,
     std::unique_ptr<IdGenerator> id_generator,
-    std::unique_ptr<instrumentationscope::ScopeConfigurator<TracerConfig>>
-        tracer_configurator) noexcept
+    std::unique_ptr<instrumentationscope::ScopeConfigurator<TracerConfig>> tracer_configurator,
+    SpanLimits span_limits) noexcept
     : context_(std::make_shared<TracerContext>(std::move(processors),
                                                resource,
                                                std::move(sampler),
                                                std::move(id_generator),
-                                               std::move(tracer_configurator)))
+                                               std::move(tracer_configurator),
+                                               span_limits))
 {}
 
 TracerProvider::~TracerProvider()
@@ -161,6 +163,11 @@ void TracerProvider::UpdateTracerConfigurator(
 const resource::Resource &TracerProvider::GetResource() const noexcept
 {
   return context_->GetResource();
+}
+
+const opentelemetry::sdk::trace::SpanLimits &TracerProvider::GetSpanLimits() const noexcept
+{
+  return context_->GetSpanLimits();
 }
 
 bool TracerProvider::Shutdown(std::chrono::microseconds timeout) noexcept

--- a/sdk/src/trace/tracer_provider_factory.cc
+++ b/sdk/src/trace/tracer_provider_factory.cc
@@ -12,6 +12,7 @@
 #include "opentelemetry/sdk/trace/random_id_generator_factory.h"
 #include "opentelemetry/sdk/trace/sampler.h"
 #include "opentelemetry/sdk/trace/samplers/always_on_factory.h"
+#include "opentelemetry/sdk/trace/span_limits.h"
 #include "opentelemetry/sdk/trace/tracer_config.h"
 #include "opentelemetry/sdk/trace/tracer_context.h"
 #include "opentelemetry/sdk/trace/tracer_provider.h"
@@ -69,10 +70,22 @@ std::unique_ptr<opentelemetry::sdk::trace::TracerProvider> TracerProviderFactory
     std::unique_ptr<IdGenerator> id_generator,
     std::unique_ptr<instrumentationscope::ScopeConfigurator<TracerConfig>> tracer_configurator)
 {
+  return Create(std::move(processor), resource, std::move(sampler), std::move(id_generator),
+                std::move(tracer_configurator), SpanLimits::NoLimits());
+}
+
+std::unique_ptr<opentelemetry::sdk::trace::TracerProvider> TracerProviderFactory::Create(
+    std::unique_ptr<SpanProcessor> processor,
+    const opentelemetry::sdk::resource::Resource &resource,
+    std::unique_ptr<Sampler> sampler,
+    std::unique_ptr<IdGenerator> id_generator,
+    std::unique_ptr<instrumentationscope::ScopeConfigurator<TracerConfig>> tracer_configurator,
+    SpanLimits span_limits)
+{
   std::unique_ptr<opentelemetry::sdk::trace::TracerProvider> provider(
       new opentelemetry::sdk::trace::TracerProvider(std::move(processor), resource,
                                                     std::move(sampler), std::move(id_generator),
-                                                    std::move(tracer_configurator)));
+                                                    std::move(tracer_configurator), span_limits));
   return provider;
 }
 
@@ -121,10 +134,22 @@ std::unique_ptr<opentelemetry::sdk::trace::TracerProvider> TracerProviderFactory
     std::unique_ptr<IdGenerator> id_generator,
     std::unique_ptr<instrumentationscope::ScopeConfigurator<TracerConfig>> tracer_configurator)
 {
+  return Create(std::move(processors), resource, std::move(sampler), std::move(id_generator),
+                std::move(tracer_configurator), SpanLimits::NoLimits());
+}
+
+std::unique_ptr<opentelemetry::sdk::trace::TracerProvider> TracerProviderFactory::Create(
+    std::vector<std::unique_ptr<SpanProcessor>> &&processors,
+    const opentelemetry::sdk::resource::Resource &resource,
+    std::unique_ptr<Sampler> sampler,
+    std::unique_ptr<IdGenerator> id_generator,
+    std::unique_ptr<instrumentationscope::ScopeConfigurator<TracerConfig>> tracer_configurator,
+    SpanLimits span_limits)
+{
   std::unique_ptr<opentelemetry::sdk::trace::TracerProvider> provider(
       new opentelemetry::sdk::trace::TracerProvider(std::move(processors), resource,
                                                     std::move(sampler), std::move(id_generator),
-                                                    std::move(tracer_configurator)));
+                                                    std::move(tracer_configurator), span_limits));
   return provider;
 }
 

--- a/sdk/test/common/attribute_utils_test.cc
+++ b/sdk/test/common/attribute_utils_test.cc
@@ -195,6 +195,26 @@ TEST(AttributeMapTest, EqualTo)
   EXPECT_FALSE(attribute_map.EqualTo(kv_iterable_different_all));
 }
 
+TEST(AttributeMapTest, SetAttributeTruncation)
+{
+  opentelemetry::sdk::common::AttributeMap attribute_map;
+  opentelemetry::nostd::string_view value("abcdefghijk");
+  attribute_map.SetAttribute("key", value, 5);
+  auto stored_value = attribute_map.GetAttributes().at("key");
+  auto string_value = opentelemetry::nostd::get<std::string>(stored_value);
+  EXPECT_EQ(string_value, "abcde");
+}
+
+TEST(OrderedAttributeMapTest, SetAttributeTruncation)
+{
+  opentelemetry::sdk::common::OrderedAttributeMap attribute_map;
+  opentelemetry::nostd::string_view value("abcdefghijk");
+  attribute_map.SetAttribute("key", value, 5);
+  auto stored_value = attribute_map.GetAttributes().at("key");
+  auto string_value = opentelemetry::nostd::get<std::string>(stored_value);
+  EXPECT_EQ(string_value, "abcde");
+}
+
 // ---------------------------------------------------------------------------
 // AttributeConverter truncation
 // ---------------------------------------------------------------------------

--- a/sdk/test/configuration/BUILD
+++ b/sdk/test/configuration/BUILD
@@ -4,6 +4,26 @@
 load("@rules_cc//cc:cc_test.bzl", "cc_test")
 
 cc_test(
+    name = "sdk_builder_test",
+    srcs = [
+        "sdk_builder_test.cc",
+    ],
+    tags = [
+        "test",
+        "trace",
+    ],
+    deps = [
+        "//sdk:headers",
+        "//sdk/src/configuration",
+        "//sdk/src/logs",
+        "//sdk/src/metrics",
+        "//sdk/src/resource",
+        "//sdk/src/trace",
+        "@com_google_googletest//:gtest_main",
+    ],
+)
+
+cc_test(
     name = "yaml_logs_test",
     srcs = [
         "yaml_logs_test.cc",

--- a/sdk/test/configuration/CMakeLists.txt
+++ b/sdk/test/configuration/CMakeLists.txt
@@ -3,6 +3,7 @@
 
 foreach(
   testname
+  sdk_builder_test
   yaml_logs_test
   yaml_metrics_test
   yaml_propagator_test

--- a/sdk/test/configuration/sdk_builder_test.cc
+++ b/sdk/test/configuration/sdk_builder_test.cc
@@ -1,0 +1,68 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+#include <gtest/gtest.h>
+#include <memory>
+#include <string>
+
+#include "opentelemetry/sdk/configuration/registry.h"
+#include "opentelemetry/sdk/configuration/sdk_builder.h"
+#include "opentelemetry/sdk/configuration/span_limits_configuration.h"
+#include "opentelemetry/sdk/configuration/tracer_provider_configuration.h"
+#include "opentelemetry/sdk/resource/resource.h"
+#include "opentelemetry/sdk/trace/span_limits.h"
+#include "opentelemetry/sdk/trace/tracer_provider.h"
+
+using opentelemetry::sdk::configuration::Registry;
+using opentelemetry::sdk::configuration::SdkBuilder;
+using opentelemetry::sdk::configuration::SpanLimitsConfiguration;
+using opentelemetry::sdk::configuration::TracerProviderConfiguration;
+
+TEST(SdkBuilder, SpanLimitsDefaults)
+{
+  auto model    = std::make_unique<TracerProviderConfiguration>();
+  model->limits = nullptr;
+
+  SdkBuilder builder(std::make_shared<Registry>());
+  auto resource = opentelemetry::sdk::resource::Resource::Create({});
+  auto provider = builder.CreateTracerProvider(model, resource);
+  ASSERT_NE(provider, nullptr);
+
+  auto limits = provider->GetSpanLimits();
+  EXPECT_EQ(limits.attribute_count_limit,
+            opentelemetry::sdk::trace::SpanLimits::kDefaultAttributeCountLimit);
+  EXPECT_EQ(limits.event_count_limit,
+            opentelemetry::sdk::trace::SpanLimits::kDefaultEventCountLimit);
+  EXPECT_EQ(limits.link_count_limit, opentelemetry::sdk::trace::SpanLimits::kDefaultLinkCountLimit);
+  EXPECT_EQ(limits.event_attribute_count_limit,
+            opentelemetry::sdk::trace::SpanLimits::kDefaultEventAttributeCountLimit);
+  EXPECT_EQ(limits.link_attribute_count_limit,
+            opentelemetry::sdk::trace::SpanLimits::kDefaultLinkAttributeCountLimit);
+  EXPECT_EQ(limits.attribute_value_length_limit,
+            opentelemetry::sdk::trace::SpanLimits::kDefaultAttributeValueLengthLimit);
+}
+
+TEST(SdkBuilder, SpanLimitsConfiguration)
+{
+  auto model                                  = std::make_unique<TracerProviderConfiguration>();
+  model->limits                               = std::make_unique<SpanLimitsConfiguration>();
+  model->limits->attribute_value_length_limit = 1111;
+  model->limits->attribute_count_limit        = 2222;
+  model->limits->event_count_limit            = 3333;
+  model->limits->link_count_limit             = 4444;
+  model->limits->event_attribute_count_limit  = 5555;
+  model->limits->link_attribute_count_limit   = 6666;
+
+  SdkBuilder builder(std::make_shared<Registry>());
+  auto resource = opentelemetry::sdk::resource::Resource::Create({});
+  auto provider = builder.CreateTracerProvider(model, resource);
+  ASSERT_NE(provider, nullptr);
+
+  auto limits = provider->GetSpanLimits();
+  EXPECT_EQ(limits.attribute_value_length_limit, model->limits->attribute_value_length_limit);
+  EXPECT_EQ(limits.attribute_count_limit, model->limits->attribute_count_limit);
+  EXPECT_EQ(limits.event_count_limit, model->limits->event_count_limit);
+  EXPECT_EQ(limits.link_count_limit, model->limits->link_count_limit);
+  EXPECT_EQ(limits.event_attribute_count_limit, model->limits->event_attribute_count_limit);
+  EXPECT_EQ(limits.link_attribute_count_limit, model->limits->link_attribute_count_limit);
+}

--- a/sdk/test/configuration/sdk_builder_test.cc
+++ b/sdk/test/configuration/sdk_builder_test.cc
@@ -28,18 +28,15 @@ TEST(SdkBuilder, SpanLimitsDefaults)
   auto provider = builder.CreateTracerProvider(model, resource);
   ASSERT_NE(provider, nullptr);
 
-  auto limits = provider->GetSpanLimits();
-  EXPECT_EQ(limits.attribute_count_limit,
-            opentelemetry::sdk::trace::SpanLimits::kDefaultAttributeCountLimit);
-  EXPECT_EQ(limits.event_count_limit,
-            opentelemetry::sdk::trace::SpanLimits::kDefaultEventCountLimit);
-  EXPECT_EQ(limits.link_count_limit, opentelemetry::sdk::trace::SpanLimits::kDefaultLinkCountLimit);
-  EXPECT_EQ(limits.event_attribute_count_limit,
-            opentelemetry::sdk::trace::SpanLimits::kDefaultEventAttributeCountLimit);
-  EXPECT_EQ(limits.link_attribute_count_limit,
-            opentelemetry::sdk::trace::SpanLimits::kDefaultLinkAttributeCountLimit);
-  EXPECT_EQ(limits.attribute_value_length_limit,
-            opentelemetry::sdk::trace::SpanLimits::kDefaultAttributeValueLengthLimit);
+  const auto limits         = provider->GetSpanLimits();
+  const auto default_limits = opentelemetry::sdk::trace::SpanLimits{};
+
+  EXPECT_EQ(limits.attribute_count_limit, default_limits.attribute_count_limit);
+  EXPECT_EQ(limits.event_count_limit, default_limits.event_count_limit);
+  EXPECT_EQ(limits.link_count_limit, default_limits.link_count_limit);
+  EXPECT_EQ(limits.event_attribute_count_limit, default_limits.event_attribute_count_limit);
+  EXPECT_EQ(limits.link_attribute_count_limit, default_limits.link_attribute_count_limit);
+  EXPECT_EQ(limits.attribute_value_length_limit, default_limits.attribute_value_length_limit);
 }
 
 TEST(SdkBuilder, SpanLimitsConfiguration)

--- a/sdk/test/configuration/yaml_trace_test.cc
+++ b/sdk/test/configuration/yaml_trace_test.cc
@@ -18,7 +18,6 @@
 #include "opentelemetry/sdk/configuration/grpc_tls_configuration.h"
 #include "opentelemetry/sdk/configuration/headers_configuration.h"
 #include "opentelemetry/sdk/configuration/http_tls_configuration.h"
-#include "opentelemetry/sdk/configuration/invalid_schema_exception.h"
 #include "opentelemetry/sdk/configuration/jaeger_remote_sampler_configuration.h"
 #include "opentelemetry/sdk/configuration/otlp_file_span_exporter_configuration.h"
 #include "opentelemetry/sdk/configuration/otlp_grpc_span_exporter_configuration.h"

--- a/sdk/test/configuration/yaml_trace_test.cc
+++ b/sdk/test/configuration/yaml_trace_test.cc
@@ -18,6 +18,7 @@
 #include "opentelemetry/sdk/configuration/grpc_tls_configuration.h"
 #include "opentelemetry/sdk/configuration/headers_configuration.h"
 #include "opentelemetry/sdk/configuration/http_tls_configuration.h"
+#include "opentelemetry/sdk/configuration/invalid_schema_exception.h"
 #include "opentelemetry/sdk/configuration/jaeger_remote_sampler_configuration.h"
 #include "opentelemetry/sdk/configuration/otlp_file_span_exporter_configuration.h"
 #include "opentelemetry/sdk/configuration/otlp_grpc_span_exporter_configuration.h"
@@ -591,6 +592,79 @@ tracer_provider:
   ASSERT_EQ(config->tracer_provider->limits->link_count_limit, 4444);
   ASSERT_EQ(config->tracer_provider->limits->event_attribute_count_limit, 5555);
   ASSERT_EQ(config->tracer_provider->limits->link_attribute_count_limit, 6666);
+}
+
+TEST(YamlTrace, limits_with_invalid_values)
+{
+  std::string invalid_attribute_count_yaml = R"(
+file_format: "1.0-trace"
+tracer_provider:
+  processors:
+    - simple:
+        exporter:
+          console:
+  limits:
+    attribute_count_limit: 4294967296
+)";
+
+  std::string invalid_event_count_yaml = R"(
+file_format: "1.0-trace"
+tracer_provider:
+  processors:
+    - simple:
+        exporter:
+          console:
+  limits:
+    event_count_limit: 4294967296
+)";
+
+  std::string invalid_link_count_yaml = R"(
+file_format: "1.0-trace"
+tracer_provider:
+  processors:
+    - simple:
+        exporter:
+          console:
+  limits:
+    link_count_limit: 4294967296
+)";
+
+  std::string invalid_event_attribute_count_yaml = R"(
+file_format: "1.0-trace"
+tracer_provider:
+  processors:
+    - simple:
+        exporter:
+          console:
+  limits:
+    event_attribute_count_limit: 4294967296
+)";
+
+  std::string invalid_link_attribute_count_yaml = R"(
+file_format: "1.0-trace"
+tracer_provider:
+  processors:
+    - simple:
+        exporter:
+          console:
+  limits:
+    link_attribute_count_limit: 4294967296
+)";
+
+  auto config = DoParse(invalid_attribute_count_yaml);
+  EXPECT_TRUE(config == nullptr);
+
+  config = DoParse(invalid_event_count_yaml);
+  EXPECT_TRUE(config == nullptr);
+
+  config = DoParse(invalid_link_count_yaml);
+  EXPECT_TRUE(config == nullptr);
+
+  config = DoParse(invalid_event_attribute_count_yaml);
+  EXPECT_TRUE(config == nullptr);
+
+  config = DoParse(invalid_link_attribute_count_yaml);
+  EXPECT_TRUE(config == nullptr);
 }
 
 TEST(YamlTrace, no_sampler)

--- a/sdk/test/trace/span_data_test.cc
+++ b/sdk/test/trace/span_data_test.cc
@@ -7,6 +7,7 @@
 #include <map>
 #include <string>
 #include <unordered_map>
+#include <utility>
 #include <vector>
 
 #include "opentelemetry/common/key_value_iterable_view.h"
@@ -16,6 +17,7 @@
 #include "opentelemetry/nostd/variant.h"
 #include "opentelemetry/sdk/resource/resource.h"
 #include "opentelemetry/sdk/trace/span_data.h"
+#include "opentelemetry/sdk/trace/span_limits.h"
 #include "opentelemetry/trace/span_context.h"
 #include "opentelemetry/trace/span_id.h"
 #include "opentelemetry/trace/span_metadata.h"
@@ -148,4 +150,141 @@ TEST(SpanData, Links)
     EXPECT_EQ(opentelemetry::nostd::get<int64_t>(data.GetLinks().at(0).GetAttributes().at(keys[i])),
               values[i]);
   }
+}
+
+TEST(SpanData, SpanLimits)
+{
+  SpanData recordable;
+  opentelemetry::sdk::trace::SpanLimits limits;
+  limits.attribute_count_limit        = 1;
+  limits.attribute_value_length_limit = 2;
+  limits.link_count_limit             = 1;
+  limits.link_attribute_count_limit   = 1;
+  limits.event_count_limit            = 1;
+  limits.event_attribute_count_limit  = 1;
+
+  constexpr const char *kKey1   = "one";
+  constexpr const char *kKey2   = "two";
+  constexpr const char *kValue1 = "1234";
+  constexpr const char *kValue2 = "5678";
+
+  std::map<std::string, std::string> attribute_collection{{kKey1, kValue1}, {kKey2, kValue2}};
+
+  recordable.SetSpanLimits(limits);
+
+  // span attribute count and length limits
+  recordable.SetAttribute(kKey1, kValue1);
+  recordable.SetAttribute(kKey2, kValue2);
+
+  EXPECT_EQ(recordable.GetAttributes().size(), 1);
+  EXPECT_EQ(recordable.GetDroppedAttributesCount(), 1);
+  EXPECT_EQ(opentelemetry::nostd::get<std::string>(recordable.GetAttributes().at(kKey1)), "12");
+
+  // event count and per-event attribute count limits
+  recordable.AddEvent("event1", std::chrono::system_clock::now(),
+                      common::MakeAttributes(attribute_collection));
+  recordable.AddEvent("event2", std::chrono::system_clock::now(),
+                      common::MakeAttributes(attribute_collection));
+
+  ASSERT_EQ(recordable.GetEvents().size(), 1);
+  EXPECT_EQ(recordable.GetDroppedEventsCount(), 1);
+  const auto event = recordable.GetEvents().at(0);
+  EXPECT_EQ(event.GetDroppedAttributesCount(), 1);
+  EXPECT_EQ(event.GetName(), "event1");
+  const auto &event_attributes = event.GetAttributes();
+  EXPECT_EQ(event_attributes.size(), 1);
+  EXPECT_EQ(opentelemetry::nostd::get<std::string>(event_attributes.at(kKey1)), "12");
+
+  // link count and per-link attribute count limits
+  recordable.AddLink(trace_api::SpanContext::GetInvalid(),
+                     common::MakeAttributes(attribute_collection));
+  recordable.AddLink(trace_api::SpanContext::GetInvalid(),
+                     common::MakeAttributes(attribute_collection));
+  ASSERT_EQ(recordable.GetLinks().size(), 1);
+  EXPECT_EQ(recordable.GetDroppedLinksCount(), 1);
+  const auto link = recordable.GetLinks().at(0);
+  EXPECT_EQ(link.GetDroppedAttributesCount(), 1);
+  const auto &link_attributes = link.GetAttributes();
+  EXPECT_EQ(link_attributes.size(), 1);
+  EXPECT_EQ(opentelemetry::nostd::get<std::string>(link_attributes.at(kKey1)), "12");
+}
+
+TEST(SpanData, SpanLimitsNoLimitDefault)
+{
+  constexpr std::uint32_t kMaxCount = 500;
+  SpanData recordable;
+  std::map<std::string, std::string> attributes;
+
+  for (std::uint32_t i = 0; i < kMaxCount; ++i)
+  {
+    attributes["attribute_" + std::to_string(i)] = std::to_string(i);
+  }
+
+  for (std::uint32_t i = 0; i < kMaxCount; ++i)
+  {
+    recordable.SetAttribute("attribute_" + std::to_string(i), i);
+    recordable.AddEvent("event_" + std::to_string(i), std::chrono::system_clock::now(),
+                        common::MakeAttributes(attributes));
+    recordable.AddLink(trace_api::SpanContext::GetInvalid(), common::MakeAttributes(attributes));
+  }
+
+  EXPECT_EQ(recordable.GetAttributes().size(), kMaxCount);
+  EXPECT_EQ(recordable.GetDroppedAttributesCount(), 0u);
+  EXPECT_EQ(recordable.GetEvents().size(), kMaxCount);
+  EXPECT_EQ(recordable.GetDroppedEventsCount(), 0u);
+  EXPECT_EQ(recordable.GetLinks().size(), kMaxCount);
+  EXPECT_EQ(recordable.GetDroppedLinksCount(), 0u);
+  EXPECT_EQ(recordable.GetEvents().at(0).GetDroppedAttributesCount(), 0u);
+  EXPECT_EQ(recordable.GetLinks().at(0).GetDroppedAttributesCount(), 0u);
+}
+
+TEST(SpanData, SpanLimitsDuplicateAttributeKeys)
+{
+  SpanData recordable;
+  opentelemetry::sdk::trace::SpanLimits limits;
+  limits.attribute_count_limit        = 2;
+  limits.attribute_value_length_limit = 2;
+  limits.link_count_limit             = 1;
+  limits.link_attribute_count_limit   = 2;
+  limits.event_count_limit            = 1;
+  limits.event_attribute_count_limit  = 2;
+
+  // Create three attributes. One has a duplicate key.
+  std::vector<std::pair<std::string, std::string>> attributes{
+      {"attribute_one", "AA"}, {"attribute_two", "BB"}, {"attribute_one", "CC"}};
+
+  for (const auto &keyvalue : attributes)
+  {
+    recordable.SetAttribute(keyvalue.first, keyvalue.second);
+  }
+
+  recordable.AddEvent("event", std::chrono::system_clock::now(),
+                      common::MakeAttributes(attributes));
+
+  recordable.AddLink(trace_api::SpanContext::GetInvalid(), common::MakeAttributes(attributes));
+
+  EXPECT_EQ(recordable.GetAttributes().size(), 2u);
+  EXPECT_EQ(recordable.GetDroppedAttributesCount(), 0u);
+  EXPECT_EQ(opentelemetry::nostd::get<std::string>(recordable.GetAttributes().at("attribute_one")),
+            "CC");
+  EXPECT_EQ(opentelemetry::nostd::get<std::string>(recordable.GetAttributes().at("attribute_two")),
+            "BB");
+
+  EXPECT_EQ(recordable.GetEvents().size(), 1u);
+  EXPECT_EQ(recordable.GetDroppedEventsCount(), 0u);
+  const auto &event = recordable.GetEvents().at(0);
+  EXPECT_EQ(event.GetAttributes().size(), 2u);
+  EXPECT_EQ(event.GetDroppedAttributesCount(), 0u);
+  EXPECT_EQ(opentelemetry::nostd::get<std::string>(event.GetAttributes().at("attribute_one")),
+            "CC");
+  EXPECT_EQ(opentelemetry::nostd::get<std::string>(event.GetAttributes().at("attribute_two")),
+            "BB");
+
+  EXPECT_EQ(recordable.GetLinks().size(), 1u);
+  EXPECT_EQ(recordable.GetDroppedLinksCount(), 0u);
+  const auto &link = recordable.GetLinks().at(0);
+  EXPECT_EQ(link.GetAttributes().size(), 2u);
+  EXPECT_EQ(link.GetDroppedAttributesCount(), 0u);
+  EXPECT_EQ(opentelemetry::nostd::get<std::string>(link.GetAttributes().at("attribute_one")), "CC");
+  EXPECT_EQ(opentelemetry::nostd::get<std::string>(link.GetAttributes().at("attribute_two")), "BB");
 }

--- a/sdk/test/trace/span_data_test.cc
+++ b/sdk/test/trace/span_data_test.cc
@@ -167,6 +167,7 @@ TEST(SpanData, SpanLimits)
   constexpr const char *kKey2   = "two";
   constexpr const char *kValue1 = "1234";
   constexpr const char *kValue2 = "5678";
+  constexpr const char *kValue3 = "9012";
 
   std::map<std::string, std::string> attribute_collection{{kKey1, kValue1}, {kKey2, kValue2}};
 
@@ -175,10 +176,11 @@ TEST(SpanData, SpanLimits)
   // span attribute count and length limits
   recordable.SetAttribute(kKey1, kValue1);
   recordable.SetAttribute(kKey2, kValue2);
+  recordable.SetAttribute(kKey1, kValue3);  // overwrite existing attribute
 
   EXPECT_EQ(recordable.GetAttributes().size(), 1);
   EXPECT_EQ(recordable.GetDroppedAttributesCount(), 1);
-  EXPECT_EQ(opentelemetry::nostd::get<std::string>(recordable.GetAttributes().at(kKey1)), "12");
+  EXPECT_EQ(opentelemetry::nostd::get<std::string>(recordable.GetAttributes().at(kKey1)), "90");
 
   // event count and per-event attribute count limits
   recordable.AddEvent("event1", std::chrono::system_clock::now(),

--- a/sdk/test/trace/span_data_test.cc
+++ b/sdk/test/trace/span_data_test.cc
@@ -251,6 +251,8 @@ TEST(SpanData, SpanLimitsDuplicateAttributeKeys)
   limits.event_count_limit            = 1;
   limits.event_attribute_count_limit  = 2;
 
+  recordable.SetSpanLimits(limits);
+
   // Create three attributes. One has a duplicate key.
   std::vector<std::pair<std::string, std::string>> attributes{
       {"attribute_one", "AA"}, {"attribute_two", "BB"}, {"attribute_one", "CC"}};

--- a/sdk/test/trace/tracer_provider_test.cc
+++ b/sdk/test/trace/tracer_provider_test.cc
@@ -38,7 +38,6 @@
 #include "opentelemetry/trace/tracer.h"
 
 #if OPENTELEMETRY_ABI_VERSION_NO >= 2
-#  include <stdint.h>
 #  include <initializer_list>
 #  include <map>
 #  include <unordered_map>

--- a/sdk/test/trace/tracer_provider_test.cc
+++ b/sdk/test/trace/tracer_provider_test.cc
@@ -2,13 +2,15 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include <gtest/gtest.h>
+#include <atomic>
+#include <cstddef>
+#include <cstdint>
+#include <future>
+#include <limits>
 #include <string>
+#include <thread>
 #include <utility>
 #include <vector>
-
-#include <atomic>
-#include <future>
-#include <thread>
 
 #include "opentelemetry/common/macros.h"
 #include "opentelemetry/exporters/memory/in_memory_span_exporter.h"
@@ -26,6 +28,7 @@
 #include "opentelemetry/sdk/trace/samplers/always_on.h"
 #include "opentelemetry/sdk/trace/simple_processor.h"
 #include "opentelemetry/sdk/trace/simple_processor_factory.h"
+#include "opentelemetry/sdk/trace/span_limits.h"
 #include "opentelemetry/sdk/trace/tracer.h"
 #include "opentelemetry/sdk/trace/tracer_config.h"
 #include "opentelemetry/sdk/trace/tracer_context.h"
@@ -517,4 +520,67 @@ TEST(TracerProvider, UpdateTracerConfiguratorConcurrentStartSpan)
 #if OPENTELEMETRY_ABI_VERSION_NO >= 2
   EXPECT_TRUE(tracer->Enabled());
 #endif
+}
+
+TEST(TracerProvider, SpanLimitsSpecDefaults)
+{
+  SpanLimits limits;
+  EXPECT_EQ(limits.attribute_count_limit, 128u);
+  EXPECT_EQ(limits.event_count_limit, 128u);
+  EXPECT_EQ(limits.link_count_limit, 128u);
+  EXPECT_EQ(limits.event_attribute_count_limit, 128u);
+  EXPECT_EQ(limits.link_attribute_count_limit, 128u);
+  EXPECT_EQ(limits.attribute_value_length_limit, (std::numeric_limits<std::size_t>::max)());
+}
+
+TEST(TracerProvider, SpanLimitsNoLimits)
+{
+  SpanLimits limits = SpanLimits::NoLimits();
+  EXPECT_EQ(limits.attribute_count_limit, (std::numeric_limits<std::uint32_t>::max)());
+  EXPECT_EQ(limits.attribute_value_length_limit, (std::numeric_limits<std::size_t>::max)());
+  EXPECT_EQ(limits.event_count_limit, (std::numeric_limits<std::uint32_t>::max)());
+  EXPECT_EQ(limits.link_count_limit, (std::numeric_limits<std::uint32_t>::max)());
+  EXPECT_EQ(limits.event_attribute_count_limit, (std::numeric_limits<std::uint32_t>::max)());
+  EXPECT_EQ(limits.link_attribute_count_limit, (std::numeric_limits<std::uint32_t>::max)());
+}
+
+TEST(TracerProvider, SpanLimitsTracerProviderFactoryCreate)
+{
+  SpanLimits limits;
+  limits.attribute_count_limit        = 5;
+  limits.attribute_value_length_limit = 10;
+  limits.event_count_limit            = 3;
+  limits.link_count_limit             = 2;
+  limits.event_attribute_count_limit  = 4;
+  limits.link_attribute_count_limit   = 4;
+
+  auto provider = TracerProviderFactory::Create(
+      std::make_unique<SimpleSpanProcessor>(nullptr), Resource::Create({}),
+      std::make_unique<AlwaysOnSampler>(), std::make_unique<RandomIdGenerator>(),
+      std::make_unique<ScopeConfigurator<TracerConfig>>(
+          ScopeConfigurator<TracerConfig>::Builder(TracerConfig::Default()).Build()),
+      limits);
+
+  const auto &stored = provider->GetSpanLimits();
+  EXPECT_EQ(stored.attribute_count_limit, limits.attribute_count_limit);
+  EXPECT_EQ(stored.attribute_value_length_limit, limits.attribute_value_length_limit);
+  EXPECT_EQ(stored.event_count_limit, limits.event_count_limit);
+  EXPECT_EQ(stored.link_count_limit, limits.link_count_limit);
+  EXPECT_EQ(stored.event_attribute_count_limit, limits.event_attribute_count_limit);
+  EXPECT_EQ(stored.link_attribute_count_limit, limits.link_attribute_count_limit);
+}
+
+TEST(TracerProvider, SpanLimitsTracerProviderFactoryCreateDefault)
+{
+  auto provider = TracerProviderFactory::Create(std::make_unique<SimpleSpanProcessor>(nullptr));
+
+  const auto no_limits = SpanLimits::NoLimits();
+
+  const auto &limits = provider->GetSpanLimits();
+  EXPECT_EQ(limits.attribute_count_limit, no_limits.attribute_count_limit);
+  EXPECT_EQ(limits.event_count_limit, no_limits.event_count_limit);
+  EXPECT_EQ(limits.link_count_limit, no_limits.link_count_limit);
+  EXPECT_EQ(limits.event_attribute_count_limit, no_limits.event_attribute_count_limit);
+  EXPECT_EQ(limits.link_attribute_count_limit, no_limits.link_attribute_count_limit);
+  EXPECT_EQ(limits.attribute_value_length_limit, no_limits.attribute_value_length_limit);
 }

--- a/sdk/test/trace/tracer_test.cc
+++ b/sdk/test/trace/tracer_test.cc
@@ -38,6 +38,7 @@
 #include "opentelemetry/sdk/trace/samplers/parent.h"
 #include "opentelemetry/sdk/trace/simple_processor.h"
 #include "opentelemetry/sdk/trace/span_data.h"
+#include "opentelemetry/sdk/trace/span_limits.h"
 #include "opentelemetry/sdk/trace/tracer.h"
 #include "opentelemetry/sdk/trace/tracer_config.h"
 #include "opentelemetry/sdk/trace/tracer_context.h"
@@ -188,7 +189,8 @@ std::shared_ptr<opentelemetry::trace::Tracer> initTracer(
     IdGenerator *id_generator = new RandomIdGenerator,
     const ScopeConfigurator<TracerConfig> &tracer_configurator =
         ScopeConfigurator<TracerConfig>::Builder(TracerConfig::Default()).Build(),
-    std::unique_ptr<InstrumentationScope> scope = InstrumentationScope::Create(""))
+    std::unique_ptr<InstrumentationScope> scope       = InstrumentationScope::Create(""),
+    opentelemetry::sdk::trace::SpanLimits span_limits = SpanLimits::NoLimits())
 {
   auto processor = std::unique_ptr<SpanProcessor>(new SimpleSpanProcessor(std::move(exporter)));
   std::vector<std::unique_ptr<SpanProcessor>> processors;
@@ -197,7 +199,7 @@ std::shared_ptr<opentelemetry::trace::Tracer> initTracer(
   auto context  = std::make_shared<TracerContext>(
       std::move(processors), resource, std::unique_ptr<Sampler>(sampler),
       std::unique_ptr<IdGenerator>(id_generator),
-      std::make_unique<ScopeConfigurator<TracerConfig>>(tracer_configurator));
+      std::make_unique<ScopeConfigurator<TracerConfig>>(tracer_configurator), span_limits);
   return std::shared_ptr<opentelemetry::trace::Tracer>(new Tracer(context, std::move(scope)));
 }
 
@@ -1481,4 +1483,52 @@ TEST(Tracer, SpanSamplerDecision)
     }
   }
   EXPECT_EQ(3, span_data->GetSpans().size());
+}
+
+TEST(Tracer, SpanLimits)
+{
+  opentelemetry::sdk::trace::SpanLimits limits;
+  limits.attribute_count_limit        = 2;
+  limits.attribute_value_length_limit = 5;
+  limits.event_count_limit            = 2;
+  limits.event_attribute_count_limit  = 2;
+
+  InMemorySpanExporter *exporter              = new InMemorySpanExporter();
+  std::shared_ptr<InMemorySpanData> span_data = exporter->GetData();
+  auto tracer                                 = initTracer(
+      std::unique_ptr<SpanExporter>{exporter}, new AlwaysOnSampler(), new RandomIdGenerator,
+      ScopeConfigurator<TracerConfig>::Builder(TracerConfig::Default()).Build(),
+      InstrumentationScope::Create(""), limits);
+
+  std::vector<std::pair<std::string, std::string>> attributes = {
+      {"one", "1_value"}, {"two", "2_value"}, {"three", "3_value"}};
+
+  {
+    auto span = tracer->StartSpan("span_with_limits", attributes);
+    span->SetAttribute("four", "4_value");
+    span->AddEvent("event1", attributes);
+    span->AddEvent("event2", attributes);
+    span->AddEvent("event3", attributes);
+    span->End();
+  }
+
+  const auto span_batch = span_data->GetSpans();
+  ASSERT_EQ(1, span_batch.size());
+
+  const auto &recordable = span_batch.at(0);
+
+  ASSERT_EQ(limits.attribute_count_limit, recordable->GetAttributes().size());
+  EXPECT_EQ(limits.attribute_value_length_limit,
+            nostd::get<std::string>(recordable->GetAttributes().at("one")).size());
+  EXPECT_EQ("1_val", nostd::get<std::string>(recordable->GetAttributes().at("one")));
+  EXPECT_EQ("2_val", nostd::get<std::string>(recordable->GetAttributes().at("two")));
+
+  const auto &events = recordable->GetEvents();
+  ASSERT_EQ(limits.event_count_limit, events.size());
+  EXPECT_EQ("event1", events.at(0).GetName());
+  EXPECT_EQ("event2", events.at(1).GetName());
+  EXPECT_EQ(limits.event_attribute_count_limit, events.at(0).GetAttributes().size());
+  EXPECT_EQ(limits.event_attribute_count_limit, events.at(1).GetAttributes().size());
+  EXPECT_EQ(limits.attribute_value_length_limit,
+            nostd::get<std::string>(events.at(0).GetAttributes().at("one")).size());
 }


### PR DESCRIPTION
Fixes #4046 

Add support for programmatic and yaml configuration of span limits through the TracerProvider. Apply span limits on the SpanData recordable and update the OtlpRecordable to use the configured limits (deprecating the limits set in otlp exporter options classes). 

## Changes

- Adds SpanLimits to the TracerProvider
- Updates the sdk builder to configure the span limits and test
- Adds span limit support in SpanData and OtlpRecordable with tests
- Adds tests to the TracerProvider, Tracer, SpanData, and OtlpRecordable
- (TODO) Deprecates the OtlpGrpcExporterOptions and OltpHttpExporterOptions span limit fields 

For significant contributions please make sure you have completed the following items:

* [x] `CHANGELOG.md` updated for non-trivial changes
* [x] Unit tests have been added
* [ ] Changes in public API reviewed