### PR TITLE
[METRICS SDK] Apply cardinality limits only to non-overflow attributesets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,9 @@ Increment the:
 
 ## [Unreleased]
 
+* [SDK] Apply metric cardinality limits to non-overflow attribute sets and
+  reserve the overflow point separately.
+
 * [CODE HEALTH] Move ext and exporters test classes into anonymous namespace
   [#4225](https://github.com/open-telemetry/opentelemetry-cpp/pull/4225)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ Increment the:
 
 * [SDK] Apply metric cardinality limits to non-overflow attribute sets and
   reserve the overflow point separately.
+  [#4236](https://github.com/open-telemetry/opentelemetry-cpp/pull/4236)
 
 * [CODE HEALTH] Move ext and exporters test classes into anonymous namespace
   [#4225](https://github.com/open-telemetry/opentelemetry-cpp/pull/4225)

--- a/sdk/include/opentelemetry/sdk/metrics/state/attributes_hashmap.h
+++ b/sdk/include/opentelemetry/sdk/metrics/state/attributes_hashmap.h
@@ -215,18 +215,11 @@ private:
     {
       return true;
     }
-    // Determine if overflow entry already exists.
-    bool has_overflow = (hash_map_.find(GetOverflowAttributes()) != hash_map_.end());
-    // If overflow already present, total size already includes it; trigger overflow
-    // when current size (including overflow) is >= limit.
-    if (has_overflow)
-    {
-      return hash_map_.size() >= attributes_limit_;
-    }
-    // If overflow not present yet, simulate adding a new distinct key. If that
-    // would exceed the limit, we redirect to overflow instead of creating a
-    // new real attribute entry.
-    return (hash_map_.size() + 1) >= attributes_limit_;
+    // The configured limit applies to distinct non-overflow attribute sets.
+    // The overflow point is an additional reserved entry.
+    const bool has_overflow        = (hash_map_.find(GetOverflowAttributes()) != hash_map_.end());
+    const size_t non_overflow_size = hash_map_.size() - (has_overflow ? 1 : 0);
+    return non_overflow_size >= attributes_limit_;
   }
 };
 

--- a/sdk/include/opentelemetry/sdk/metrics/state/sync_metric_storage.h
+++ b/sdk/include/opentelemetry/sdk/metrics/state/sync_metric_storage.h
@@ -275,12 +275,10 @@ private:
     }
     const size_t limit      = aggregation_config_->cardinality_limit_;
     const bool has_overflow = active_keys_.find(GetOverflowAttributes()) != active_keys_.end();
-    // Mirror AttributesHashMap::IsOverflowAttributes() exactly. When the
-    // overflow slot is already counted in active_keys_, only route to
-    // overflow when total active keys reach the limit. Otherwise simulate
-    // adding the overflow slot too, matching the (size + 1) >= limit branch.
-    const bool would_overflow =
-        has_overflow ? (active_keys_.size() >= limit) : (active_keys_.size() + 1 >= limit);
+    // Mirror AttributesHashMap::IsOverflowAttributes() exactly. The configured
+    // limit applies to non-overflow attribute sets, while overflow is reserved.
+    const size_t non_overflow_size = active_keys_.size() - (has_overflow ? 1 : 0);
+    const bool would_overflow      = non_overflow_size >= limit;
     if (would_overflow)
     {
       active_keys_.insert(GetOverflowAttributes());

--- a/sdk/test/metrics/attributes_hashmap_test.cc
+++ b/sdk/test/metrics/attributes_hashmap_test.cc
@@ -183,6 +183,7 @@ TEST(AttributesHashMap, OverflowCardinalityLimitBehavior)
 
   // Size should be exactly 'limit' (no overflow yet)
   EXPECT_EQ(map.Size(), limit);
+  EXPECT_EQ(map.Get(GetOverflowAttributes()), nullptr);
 
   // Insert one more distinct attribute; this should not increase the real attributes count
   MetricAttributes overflow_trigger = {{"k", "overflow"}};
@@ -190,9 +191,9 @@ TEST(AttributesHashMap, OverflowCardinalityLimitBehavior)
                       []() { return std::unique_ptr<Aggregation>(new DropAggregation()); })
       ->Aggregate(static_cast<int64_t>(1));
 
-  EXPECT_EQ(map.Size(), limit);
+  EXPECT_EQ(map.Size(), limit + 1);
 
-  // Insert several more unique attributes - size must remain constant (limit)
+  // Insert several more unique attributes - size must remain constant (limit + overflow)
   for (size_t i = 0; i < limit - 1; ++i)
   {
     MetricAttributes extra_attr = {{"k", std::string("extra") + std::to_string(i)}};
@@ -200,13 +201,13 @@ TEST(AttributesHashMap, OverflowCardinalityLimitBehavior)
                         []() { return std::unique_ptr<Aggregation>(new DropAggregation()); })
         ->Aggregate(static_cast<int64_t>(1));
   }
-  EXPECT_EQ(map.Size(), limit);
+  EXPECT_EQ(map.Size(), limit + 1);
 
   // Ensure overflow key was actually created and accessible via Get
   EXPECT_NE(map.Get(GetOverflowAttributes()), nullptr);
 
   // Ensure original real attributes still present
-  for (size_t i = 0; i < limit - 1; ++i)
+  for (size_t i = 0; i < limit; ++i)
   {
     MetricAttributes attr = {{"k", std::to_string(i)}};
     EXPECT_NE(map.Get(attr), nullptr);
@@ -220,7 +221,7 @@ TEST(AttributesHashMap, OverflowCardinalityLimitBehavior)
   });
   EXPECT_EQ(map_copy.Size(), map.Size());
   EXPECT_NE(map_copy.Get(GetOverflowAttributes()), nullptr);
-  for (size_t i = 0; i < limit - 1; ++i)
+  for (size_t i = 0; i < limit; ++i)
   {
     MetricAttributes attr = {{"k", std::to_string(i)}};
     EXPECT_NE(map_copy.Get(attr), nullptr);

--- a/sdk/test/metrics/bound_sync_instruments_test.cc
+++ b/sdk/test/metrics/bound_sync_instruments_test.cc
@@ -638,8 +638,7 @@ TEST(BoundSyncInstruments, BoundAndUnboundShareDatapoint)
 //    multiple overflow-bound handles aggregate into the same overflow datapoint.
 TEST(BoundSyncInstruments, BindingAtOverflowGoesToOverflowBucket)
 {
-  // limit = 3: two real distinct keys are admitted; the third new distinct
-  // key overflows because the overflow attribute set itself consumes a slot.
+  // limit = 3: three real distinct keys are admitted; the fourth overflows.
   StorageHolder holder(InstrumentType::kCounter, InstrumentValueType::kLong, 3);
 
   M a1    = {{"k", "1"}};
@@ -658,7 +657,7 @@ TEST(BoundSyncInstruments, BindingAtOverflowGoesToOverflowBucket)
   auto b4 = holder->Bind(KeyValueIterableView<M>(a4));
   b4->RecordLong(50);
 
-  // Overflow datapoint must equal sum of the overflow-bound writes (100 + 50).
+  // Overflow datapoint contains only the fourth bound write.
   std::shared_ptr<CollectorHandle> collector(
       new MockCollectorHandle(AggregationTemporality::kDelta));
   std::vector<std::shared_ptr<CollectorHandle>> collectors{collector};
@@ -678,7 +677,7 @@ TEST(BoundSyncInstruments, BindingAtOverflowGoesToOverflowBucket)
                     return true;
                   });
   EXPECT_TRUE(seen);
-  EXPECT_EQ(ov_value, 150);
+  EXPECT_EQ(ov_value, 50);
 }
 
 // 7) Noop bound instruments compile and no-op.
@@ -761,7 +760,7 @@ TEST(BoundSyncInstruments, DroppedBoundEntriesAreGarbageCollected)
     h->RecordLong(1);
     handles.push_back(h);
   }
-  // Expect no overflow yet (3 + 1 < 5).
+  // Expect no overflow yet (3 < 5).
   EXPECT_FALSE(HasOverflowPoint(*holder, AggregationTemporality::kDelta));
 }
 
@@ -769,14 +768,12 @@ TEST(BoundSyncInstruments, DroppedBoundEntriesAreGarbageCollected)
 // Bind() to reuse it without consuming new cardinality.
 TEST(BoundSyncInstruments, BindOnExistingUnboundKeyDoesNotOverflow)
 {
-  // limit = 3: two real keys are admitted; a third new distinct key would
-  // overflow (overflow itself consumes a slot).
+  // limit = 3: three real keys are admitted; a fourth new distinct key would overflow.
   StorageHolder holder(InstrumentType::kCounter, InstrumentValueType::kLong, 3);
 
   M a1 = {{"k", "1"}};
   M a2 = {{"k", "2"}};
-  // Two distinct unbound keys consume the two admitted slots (limit=3 with
-  // overflow consuming a slot leaves room for two real keys).
+  // Two distinct unbound keys consume two of the three admitted slots.
   holder->RecordLong(10, KeyValueIterableView<M>(a1), opentelemetry::context::Context{});
   holder->RecordLong(20, KeyValueIterableView<M>(a2), opentelemetry::context::Context{});
 
@@ -863,9 +860,9 @@ TEST(BoundSyncInstruments, UnboundOnExistingBoundKeyDoesNotOverflow)
 // unbound keys correctly overflow.
 TEST(BoundSyncInstruments, RetainedBoundEntriesCountAfterDeltaCollect)
 {
-  StorageHolder holder(InstrumentType::kCounter, InstrumentValueType::kLong, 3);
+  StorageHolder holder(InstrumentType::kCounter, InstrumentValueType::kLong, 2);
 
-  // Two bound keys consume the two real admitted slots (overflow takes the 3rd).
+  // Two bound keys consume the two admitted slots.
   M a1    = {{"bound", "1"}};
   M a2    = {{"bound", "2"}};
   auto b1 = holder->Bind(KeyValueIterableView<M>(a1));
@@ -886,7 +883,7 @@ TEST(BoundSyncInstruments, RetainedBoundEntriesCountAfterDeltaCollect)
 // Strengthened: assert the overflow datapoint VALUE, not just its presence.
 TEST(BoundSyncInstruments, RetainedBoundEntriesOverflowValue)
 {
-  StorageHolder holder(InstrumentType::kCounter, InstrumentValueType::kLong, 3);
+  StorageHolder holder(InstrumentType::kCounter, InstrumentValueType::kLong, 2);
   M a1    = {{"bound", "1"}};
   M a2    = {{"bound", "2"}};
   auto b1 = holder->Bind(KeyValueIterableView<M>(a1));
@@ -917,12 +914,11 @@ TEST(BoundSyncInstruments, RetainedBoundEntriesOverflowValue)
 }
 
 // No-attribute unbound RecordLong must follow the unified cardinality policy.
-// With limit=3, two real distinct bound keys are admitted; the empty-attr
-// unbound write would be a third new key and routes to overflow (overflow
-// itself consumes a slot).
+// With limit=2, two real distinct bound keys are admitted; the empty-attr
+// unbound write is a third new key and routes to overflow.
 TEST(BoundSyncInstruments, NoAttributeUnboundFollowsUnifiedPolicyLong)
 {
-  StorageHolder holder(InstrumentType::kCounter, InstrumentValueType::kLong, 3);
+  StorageHolder holder(InstrumentType::kCounter, InstrumentValueType::kLong, 2);
   M a1    = {{"k", "1"}};
   M a2    = {{"k", "2"}};
   auto b1 = holder->Bind(KeyValueIterableView<M>(a1));
@@ -954,7 +950,7 @@ TEST(BoundSyncInstruments, NoAttributeUnboundFollowsUnifiedPolicyLong)
 // Same coverage for double counter no-attribute path.
 TEST(BoundSyncInstruments, NoAttributeUnboundFollowsUnifiedPolicyDouble)
 {
-  StorageHolder holder(InstrumentType::kCounter, InstrumentValueType::kDouble, 3);
+  StorageHolder holder(InstrumentType::kCounter, InstrumentValueType::kDouble, 2);
   M a1    = {{"k", "1"}};
   M a2    = {{"k", "2"}};
   auto b1 = holder->Bind(KeyValueIterableView<M>(a1));
@@ -1042,7 +1038,7 @@ TEST(BoundSyncInstruments, DirtyDroppedBoundEntriesReleaseCardinality)
 {
   StorageHolder holder(InstrumentType::kCounter, InstrumentValueType::kLong, 3);
 
-  // Bind two distinct keys (consume the two real admitted slots), record so
+  // Bind two distinct keys, record so
   // they're dirty, then drop the handles BEFORE Collect(). The pre-rotation
   // GC cannot remove them (they're dirty); rotation flushes their data; the
   // post-rotation cleanup must release their slots.
@@ -1076,36 +1072,36 @@ TEST(BoundSyncInstruments, OverflowParityAllowsFillingRemainingSlot)
 {
   StorageHolder holder(InstrumentType::kCounter, InstrumentValueType::kLong, 3);
 
-  // Trigger overflow first: bind k1, k2, then k3 (which routes to overflow,
-  // so bound_entries_ ends up with k1, k2, and the overflow entry).
+  // Trigger overflow first: bind k1, k2, k3, then k4, which routes to overflow.
   M a1     = {{"k", "1"}};
   M a2     = {{"k", "2"}};
   M a3     = {{"k", "3"}};
+  M a4     = {{"k", "4"}};
   auto b1  = holder->Bind(KeyValueIterableView<M>(a1));
   auto b2  = holder->Bind(KeyValueIterableView<M>(a2));
-  auto bov = holder->Bind(KeyValueIterableView<M>(a3));  // routes to overflow
+  auto b3  = holder->Bind(KeyValueIterableView<M>(a3));
+  auto bov = holder->Bind(KeyValueIterableView<M>(a4));  // routes to overflow
   b1->RecordLong(1);
   b2->RecordLong(1);
+  b3->RecordLong(1);
   bov->RecordLong(100);
 
   // Drop k1 only. After Collect(), the M1 cleanup releases its slot, leaving
-  // active_keys_ = { k2, overflow }. With limit=3, has_overflow=true and
-  // active_keys_.size()==2, the existing AttributesHashMap semantics admit
-  // one more real key. The pre-fix preview path would have routed it to
-  // overflow (off-by-one). After M2, it must be admitted.
+  // active_keys_ = { k2, k3, overflow }. With limit=3, the existing
+  // AttributesHashMap semantics admit one more real key.
   b1.reset();
-  EXPECT_EQ(CollectAndCountPoints(*holder, AggregationTemporality::kDelta), 3u);
+  EXPECT_EQ(CollectAndCountPoints(*holder, AggregationTemporality::kDelta), 4u);
 
   // Fresh real key in the next interval must be admitted, not routed to overflow.
-  M a4 = {{"fresh", "key"}};
-  holder->RecordLong(42, KeyValueIterableView<M>(a4), opentelemetry::context::Context{});
+  M a5 = {{"fresh", "key"}};
+  holder->RecordLong(42, KeyValueIterableView<M>(a5), opentelemetry::context::Context{});
 
   std::shared_ptr<CollectorHandle> collector(
       new MockCollectorHandle(AggregationTemporality::kDelta));
   std::vector<std::shared_ptr<CollectorHandle>> collectors{collector};
   bool overflow_seen = false;
-  bool a4_seen       = false;
-  int64_t a4_value   = 0;
+  bool a5_seen       = false;
+  int64_t a5_value   = 0;
   holder->Collect(collector.get(), collectors, std::chrono::system_clock::now(),
                   std::chrono::system_clock::now(), [&](const MetricData &md) {
                     for (const auto &p : md.point_data_attr_)
@@ -1118,15 +1114,15 @@ TEST(BoundSyncInstruments, OverflowParityAllowsFillingRemainingSlot)
                       if (it != p.attributes.end() &&
                           opentelemetry::nostd::get<std::string>(it->second) == "key")
                       {
-                        a4_seen        = true;
+                        a5_seen        = true;
                         const auto &sp = opentelemetry::nostd::get<SumPointData>(p.point_data);
-                        a4_value       = opentelemetry::nostd::get<int64_t>(sp.value_);
+                        a5_value       = opentelemetry::nostd::get<int64_t>(sp.value_);
                       }
                     }
                     return true;
                   });
-  EXPECT_TRUE(a4_seen);
-  EXPECT_EQ(a4_value, 42);
+  EXPECT_TRUE(a5_seen);
+  EXPECT_EQ(a5_value, 42);
   EXPECT_FALSE(overflow_seen);
 }
 

--- a/sdk/test/metrics/cardinality_limit_test.cc
+++ b/sdk/test/metrics/cardinality_limit_test.cc
@@ -47,7 +47,7 @@ TEST(CardinalityLimit, AttributesHashMapBasicTests)
       []() -> std::unique_ptr<Aggregation> {
     return std::unique_ptr<Aggregation>(new LongSumAggregation(true));
   };
-  // add 10 unique metric points. 9 should be added to hashmap, 10th should be overflow.
+  // Add 10 unique metric points. All should be independently aggregated without overflow.
   int64_t record_value = 100;
   for (auto i = 0; i < 10; i++)
   {
@@ -56,15 +56,16 @@ TEST(CardinalityLimit, AttributesHashMapBasicTests)
         ->Aggregate(record_value);
   }
   EXPECT_EQ(hash_map.Size(), 10);
+  EXPECT_EQ(hash_map.Get(GetOverflowAttributes()), nullptr);
   // add 5 unique metric points above limit, they all should get consolidated as single
-  // overflowmetric point.
+  // overflow metric point.
   for (auto i = 10; i < 15; i++)
   {
     FilteredOrderedAttributeMap attributes = {{"key", std::to_string(i)}};
     static_cast<LongSumAggregation *>(hash_map.GetOrSetDefault(attributes, aggregation_callback))
         ->Aggregate(record_value);
   }
-  EXPECT_EQ(hash_map.Size(), 10);  // only one more metric point should be added as overflow.
+  EXPECT_EQ(hash_map.Size(), 11);  // one additional metric point should be added as overflow.
   // record 5 more measurements to already existing (and not-overflow) metric points. They
   // should get aggregated to these existing metric points.
   for (auto i = 0; i < 5; i++)
@@ -73,16 +74,16 @@ TEST(CardinalityLimit, AttributesHashMapBasicTests)
     static_cast<LongSumAggregation *>(hash_map.GetOrSetDefault(attributes, aggregation_callback))
         ->Aggregate(record_value);
   }
-  EXPECT_EQ(hash_map.Size(), 10);  // no new metric point added
+  EXPECT_EQ(hash_map.Size(), 11);  // no new metric point added
 
   // get the overflow metric point
   auto agg1 = hash_map.GetOrSetDefault(GetOverflowAttributes(), aggregation_callback);
   EXPECT_NE(agg1, nullptr);
   auto sum_agg1 = static_cast<LongSumAggregation *>(agg1);
   EXPECT_EQ(nostd::get<int64_t>(nostd::get<SumPointData>(sum_agg1->ToPoint()).value_),
-            record_value * 6);  // 1 from previous 10, 5 from current 5.
+            record_value * 5);
   // get remaining metric points
-  for (auto i = 0; i < 9; i++)
+  for (auto i = 0; i < 10; i++)
   {
     FilteredOrderedAttributeMap attributes = {{"key", std::to_string(i)}};
     auto agg2 = hash_map.GetOrSetDefault(attributes, aggregation_callback);
@@ -125,7 +126,7 @@ TEST_P(WritableMetricStorageCardinalityLimitTestFixture, LongCounterSumAggregati
                             &aggConfig);
 
   int64_t record_value = 100;
-  // add 9 unique metric points, and 6 more above limit.
+  // Add 10 unique metric points, and 5 more above limit.
   for (auto i = 0; i < 15; i++)
   {
     std::map<std::string, std::string> attributes = {{"key", std::to_string(i)}};
@@ -154,13 +155,13 @@ TEST_P(WritableMetricStorageCardinalityLimitTestFixture, LongCounterSumAggregati
             // value `true`.
             EXPECT_EQ(data_attr.attributes.size(), 1u);
             EXPECT_EQ(nostd::get<bool>(data_attr.attributes.begin()->second), true);
-            EXPECT_EQ(nostd::get<int64_t>(data.value_), record_value * 6);
+            EXPECT_EQ(nostd::get<int64_t>(data.value_), record_value * 5);
             overflow_present = true;
           }
         }
         return true;
       });
-  EXPECT_EQ(count_attributes, attributes_limit);
+  EXPECT_EQ(count_attributes, attributes_limit + 1);
   EXPECT_EQ(overflow_present, true);
 }
 INSTANTIATE_TEST_SUITE_P(All,

--- a/sdk/test/metrics/sum_aggregation_test.cc
+++ b/sdk/test/metrics/sum_aggregation_test.cc
@@ -194,7 +194,7 @@ TEST(HistogramToSumFilterAttributesWithCardinalityLimit, Double)
       {
         for (const MetricData &md : smd.metric_data_)
         {
-          EXPECT_EQ(cardinality_limit, md.point_data_attr_.size());
+          EXPECT_EQ(cardinality_limit + 1, md.point_data_attr_.size());
           for (size_t i = 0; i < md.point_data_attr_.size(); i++)
           {
             EXPECT_EQ(1, md.point_data_attr_[i].attributes.size());
@@ -378,11 +378,8 @@ TEST(CounterToSumFilterAttributesWithCardinalityLimit, Double)
         for (const MetricData &md : smd.metric_data_)
         {
           // When the number of unique attribute sets exceeds the cardinality limit, the
-          // implementation emits up to (cardinality_limit - 1) unique sets and one overflow set,
-          // resulting in a total of cardinality_limit sets. This test checks that the number of
-          // emitted attribute sets is within the expected range, accounting for the overflow
-          // behavior.
-          EXPECT_EQ(cardinality_limit, md.point_data_attr_.size());
+          // implementation emits cardinality_limit unique sets and one overflow set.
+          EXPECT_EQ(cardinality_limit + 1, md.point_data_attr_.size());
           for (size_t i = 0; i < md.point_data_attr_.size(); i++)
           {
             EXPECT_EQ(1, md.point_data_attr_[i].attributes.size());


### PR DESCRIPTION
Fixes #4235 

## Changes

Fix metric cardinality enforcement to admit up to the configured number of distinct non-overflow attribute sets before routing additional measurements to the overflow point. The overflow point is now reserved separately instead of consuming one slot from the configured limit.

Apply the same accounting to ABI v2 bound synchronous instruments, update direct and integration tests to cover the exact-limit and overflow cases, and document the behavior change in the changelog.

This aligns the SDK with the Metrics specification guarantee that overflow must not occur when the number of distinct non-overflow attribute sets is less than or equal to the configured limit.

For significant contributions please make sure you have completed the following items:

* [x] `CHANGELOG.md` updated for non-trivial changes
* [x] Unit tests have been added
* [ ] Changes in public API reviewed