### PR TITLE
[CI] Add `modernize-` and `cppcoreguidelines-pro-` checks to clang-tidy

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -63,6 +63,6 @@ Checks: >
   -modernize-pass-by-value,
   -modernize-use-equals-default,
   -modernize-use-equals-delete,
-  -modernize-make-unique, 
+  -modernize-make-unique,
   -modernize-make-shared,
 

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,5 +1,6 @@
 # Copyright The OpenTelemetry Authors
 # SPDX-License-Identifier: Apache-2.0
+#
 
 Checks: >
   -*,
@@ -38,4 +39,30 @@ Checks: >
   -cppcoreguidelines-macro-usage,
   -cppcoreguidelines-non-private-member-variables-in-classes,
   -cppcoreguidelines-avoid-non-const-global-variables,
-  -cppcoreguidelines-pro-*
+  -cppcoreguidelines-pro-bounds-array-to-pointer-decay,
+  -cppcoreguidelines-pro-bounds-avoid-unchecked-container-access,
+  -cppcoreguidelines-pro-bounds-constant-array-index,
+  -cppcoreguidelines-pro-bounds-pointer-arithmetic,
+  -cppcoreguidelines-pro-type-reinterpret-cast,
+  -cppcoreguidelines-pro-type-static-cast-downcast,
+  -cppcoreguidelines-pro-type-union-access,
+  -cppcoreguidelines-pro-type-vararg,
+  modernize-*,
+  -modernize-avoid-c-arrays,
+  -modernize-concat-nested-namespaces,
+  -modernize-macro-to-enum,
+  -modernize-raw-string-literal,
+  -modernize-return-braced-init-list,
+  -modernize-type-traits,
+  -modernize-use-auto,
+  -modernize-use-nodiscard,
+  -modernize-use-scoped-lock,
+  -modernize-use-trailing-return-type,
+  -modernize-deprecated-headers,
+  -modernize-loop-convert,
+  -modernize-pass-by-value,
+  -modernize-use-equals-default,
+  -modernize-use-equals-delete,
+  -modernize-make-unique, 
+  -modernize-make-shared,
+

--- a/.github/workflows/clang-tidy.yaml
+++ b/.github/workflows/clang-tidy.yaml
@@ -17,9 +17,9 @@ jobs:
       matrix:
         include:
           - cmake_options: all-options-abiv1-preview
-            warning_limit: 137
+            warning_limit: 216
           - cmake_options: all-options-abiv2-preview
-            warning_limit: 145
+            warning_limit: 226
     env:
       CC: /usr/bin/clang-22
       CXX: /usr/bin/clang++-22


### PR DESCRIPTION
Fixes # (issue)

Adds new clang-tidy checks from `modernize-` and `cppcoreguidelines-pro-`. 

Many of the checks in these groups are disabled and may be enabled in future PRs. The following new checks are enabled and mostly catch issues impacting correctness and performance. 

| Check | Count |
|---|---|
| cppcoreguidelines-pro-type-member-init | 38 |
| modernize-use-emplace | 20 |
| cppcoreguidelines-pro-type-const-cast | 10 |
| google-readability-casting,modernize-avoid-c-style-cast | 7 |
| modernize-use-using | 6 |
| modernize-use-bool-literals | 4 |
| modernize-use-nullptr | 1 |

## Changes

- updated clang-tidy file to evaluate  `modernize-` and `cppcoreguidelines-pro-` checks with many disabled for now
- update the warnings limits in CI

For significant contributions please make sure you have completed the following items:

* [ ] `CHANGELOG.md` updated for non-trivial changes
* [ ] Unit tests have been added
* [ ] Changes in public API reviewed