### PR TITLE
[SDK] Fix yaml configuration of the logger configurator

### DIFF
--- a/sdk/src/configuration/sdk_builder.cc
+++ b/sdk/src/configuration/sdk_builder.cc
@@ -16,6 +16,7 @@
 #include "opentelemetry/common/kv_properties.h"
 #include "opentelemetry/context/propagation/composite_propagator.h"
 #include "opentelemetry/context/propagation/text_map_propagator.h"
+#include "opentelemetry/logs/severity.h"
 #include "opentelemetry/nostd/span.h"
 #include "opentelemetry/nostd/string_view.h"
 #include "opentelemetry/sdk/common/global_log_handler.h"
@@ -192,6 +193,68 @@ using common::WildcardMatch;
 
 namespace
 {
+
+static opentelemetry::logs::Severity ToLogSeverity(
+    opentelemetry::sdk::configuration::SeverityNumber severity_number)
+{
+  // Convert configuration::SeverityNumber to opentelemetry::logs::Severity
+  // The configuration::SeverityNumber enum values do not match the opentelemetry::logs::Severity
+  // enum values use a switch statement for conversion.
+  switch (severity_number)
+  {
+    case SeverityNumber::trace:
+      return opentelemetry::logs::Severity::kTrace;
+    case SeverityNumber::trace2:
+      return opentelemetry::logs::Severity::kTrace2;
+    case SeverityNumber::trace3:
+      return opentelemetry::logs::Severity::kTrace3;
+    case SeverityNumber::trace4:
+      return opentelemetry::logs::Severity::kTrace4;
+    case SeverityNumber::debug:
+      return opentelemetry::logs::Severity::kDebug;
+    case SeverityNumber::debug2:
+      return opentelemetry::logs::Severity::kDebug2;
+    case SeverityNumber::debug3:
+      return opentelemetry::logs::Severity::kDebug3;
+    case SeverityNumber::debug4:
+      return opentelemetry::logs::Severity::kDebug4;
+    case SeverityNumber::info:
+      return opentelemetry::logs::Severity::kInfo;
+    case SeverityNumber::info2:
+      return opentelemetry::logs::Severity::kInfo2;
+    case SeverityNumber::info3:
+      return opentelemetry::logs::Severity::kInfo3;
+    case SeverityNumber::info4:
+      return opentelemetry::logs::Severity::kInfo4;
+    case SeverityNumber::warn:
+      return opentelemetry::logs::Severity::kWarn;
+    case SeverityNumber::warn2:
+      return opentelemetry::logs::Severity::kWarn2;
+    case SeverityNumber::warn3:
+      return opentelemetry::logs::Severity::kWarn3;
+    case SeverityNumber::warn4:
+      return opentelemetry::logs::Severity::kWarn4;
+    case SeverityNumber::error:
+      return opentelemetry::logs::Severity::kError;
+    case SeverityNumber::error2:
+      return opentelemetry::logs::Severity::kError2;
+    case SeverityNumber::error3:
+      return opentelemetry::logs::Severity::kError3;
+    case SeverityNumber::error4:
+      return opentelemetry::logs::Severity::kError4;
+    case SeverityNumber::fatal:
+      return opentelemetry::logs::Severity::kFatal;
+    case SeverityNumber::fatal2:
+      return opentelemetry::logs::Severity::kFatal2;
+    case SeverityNumber::fatal3:
+      return opentelemetry::logs::Severity::kFatal3;
+    case SeverityNumber::fatal4:
+      return opentelemetry::logs::Severity::kFatal4;
+    default:
+      break;
+  }
+  return opentelemetry::logs::Severity::kInvalid;
+}
 
 class ResourceAttributeValueSetter
     : public opentelemetry::sdk::configuration::AttributeValueConfigurationVisitor
@@ -1876,15 +1939,17 @@ SdkBuilder::CreateLoggerConfigurator(
   using opentelemetry::sdk::instrumentationscope::ScopeConfigurator;
   using opentelemetry::sdk::logs::LoggerConfig;
 
-  LoggerConfig default_config =
-      model->default_config.enabled ? LoggerConfig::Enabled() : LoggerConfig::Disabled();
+  LoggerConfig default_config = LoggerConfig::Create(
+      model->default_config.enabled, ToLogSeverity(model->default_config.minimum_severity),
+      model->default_config.trace_based);
 
   auto builder = ScopeConfigurator<LoggerConfig>::Builder(default_config);
 
   for (const auto &entry : model->loggers)
   {
     LoggerConfig entry_config =
-        entry.config.enabled ? LoggerConfig::Enabled() : LoggerConfig::Disabled();
+        LoggerConfig::Create(entry.config.enabled, ToLogSeverity(entry.config.minimum_severity),
+                             entry.config.trace_based);
     std::string pattern = entry.name;
     builder.AddCondition(
         [pattern](const InstrumentationScope &scope) {

--- a/sdk/test/configuration/BUILD
+++ b/sdk/test/configuration/BUILD
@@ -4,6 +4,26 @@
 load("@rules_cc//cc:cc_test.bzl", "cc_test")
 
 cc_test(
+    name = "sdk_builder_test",
+    srcs = [
+        "sdk_builder_test.cc",
+    ],
+    tags = [
+        "test",
+        "yaml",
+    ],
+    deps = [
+        "//sdk:headers",
+        "//sdk/src/configuration",
+        "//sdk/src/logs",
+        "//sdk/src/metrics",
+        "//sdk/src/resource",
+        "//sdk/src/trace",
+        "@com_google_googletest//:gtest_main",
+    ],
+)
+
+cc_test(
     name = "yaml_logs_test",
     srcs = [
         "yaml_logs_test.cc",

--- a/sdk/test/configuration/CMakeLists.txt
+++ b/sdk/test/configuration/CMakeLists.txt
@@ -3,6 +3,7 @@
 
 foreach(
   testname
+  sdk_builder_test
   yaml_logs_test
   yaml_metrics_test
   yaml_propagator_test

--- a/sdk/test/configuration/sdk_builder_test.cc
+++ b/sdk/test/configuration/sdk_builder_test.cc
@@ -1,0 +1,74 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+#include <gtest/gtest.h>
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "opentelemetry/logs/severity.h"
+#include "opentelemetry/sdk/configuration/logger_config_configuration.h"
+#include "opentelemetry/sdk/configuration/logger_configurator_configuration.h"
+#include "opentelemetry/sdk/configuration/logger_matcher_and_config_configuration.h"
+#include "opentelemetry/sdk/configuration/registry.h"
+#include "opentelemetry/sdk/configuration/sdk_builder.h"
+#include "opentelemetry/sdk/configuration/severity_number.h"
+#include "opentelemetry/sdk/instrumentationscope/instrumentation_scope.h"
+#include "opentelemetry/sdk/instrumentationscope/scope_configurator.h"
+#include "opentelemetry/sdk/logs/logger_config.h"
+
+namespace config_sdk = opentelemetry::sdk::configuration;
+namespace scope_sdk  = opentelemetry::sdk::instrumentationscope;
+namespace logs_sdk   = opentelemetry::sdk::logs;
+
+TEST(SdkBuilder, CreateLoggerConfigurator)
+{
+  config_sdk::LoggerConfigConfiguration default_config;
+  default_config.enabled          = true;
+  default_config.minimum_severity = config_sdk::SeverityNumber::warn;
+  default_config.trace_based      = false;
+
+  config_sdk::LoggerMatcherAndConfigConfiguration matcher1;
+  matcher1.name                    = "enabled_minsev_error_not_trace_based";
+  matcher1.config.enabled          = true;
+  matcher1.config.minimum_severity = config_sdk::SeverityNumber::error3;
+  matcher1.config.trace_based      = false;
+
+  config_sdk::LoggerMatcherAndConfigConfiguration matcher2;
+  matcher2.name                    = "disabled_minsev_info_trace_based";
+  matcher2.config.enabled          = false;
+  matcher2.config.minimum_severity = config_sdk::SeverityNumber::debug;
+  matcher2.config.trace_based      = true;
+
+  auto model            = std::make_unique<config_sdk::LoggerConfiguratorConfiguration>();
+  model->default_config = default_config;
+  model->loggers.push_back(matcher1);
+  model->loggers.push_back(matcher2);
+
+  config_sdk::SdkBuilder builder(std::make_shared<config_sdk::Registry>());
+
+  auto logger_configurator = builder.CreateLoggerConfigurator(model);
+  ASSERT_NE(logger_configurator, nullptr);
+
+  auto default_scope = scope_sdk::InstrumentationScope::Create("default_scope");
+  logs_sdk::LoggerConfig sdk_logger_config_default =
+      logger_configurator->ComputeConfig(*default_scope);
+
+  auto scope_1 = scope_sdk::InstrumentationScope::Create(matcher1.name);
+  logs_sdk::LoggerConfig sdk_logger_config_1 = logger_configurator->ComputeConfig(*scope_1);
+
+  auto scope_2 = scope_sdk::InstrumentationScope::Create(matcher2.name);
+  logs_sdk::LoggerConfig sdk_logger_config_2 = logger_configurator->ComputeConfig(*scope_2);
+
+  EXPECT_TRUE(sdk_logger_config_default.IsEnabled());
+  EXPECT_EQ(sdk_logger_config_default.GetMinimumSeverity(), opentelemetry::logs::Severity::kWarn);
+  EXPECT_FALSE(sdk_logger_config_default.IsTraceBased());
+
+  EXPECT_TRUE(sdk_logger_config_1.IsEnabled());
+  EXPECT_EQ(sdk_logger_config_1.GetMinimumSeverity(), opentelemetry::logs::Severity::kError3);
+  EXPECT_FALSE(sdk_logger_config_1.IsTraceBased());
+
+  EXPECT_FALSE(sdk_logger_config_2.IsEnabled());
+  EXPECT_EQ(sdk_logger_config_2.GetMinimumSeverity(), opentelemetry::logs::Severity::kDebug);
+  EXPECT_TRUE(sdk_logger_config_2.IsTraceBased());
+}


### PR DESCRIPTION
Fixes # (issue)

The yaml configuration of the LoggerConfigurator only respects the enabled property and ignores minimum severity and trace based. This PR fixes the SDK builder to configure all properties of the LoggerConfig. 

## Changes

- Update the CreateLoggerConfigurator method of SdkBuilder to use the LoggerConfig::Create method. 
- Add an SdkBuilder test to verify the default and scope specific logger configs have all properties set as configured. 

For significant contributions please make sure you have completed the following items:

* [ ] `CHANGELOG.md` updated for non-trivial changes
* [ ] Unit tests have been added
* [ ] Changes in public API reviewed