### PR TITLE
[CONFIGURATION] Define and set spec default values in configuration objects

### DIFF
--- a/sdk/include/opentelemetry/sdk/configuration/attribute_limits_configuration.h
+++ b/sdk/include/opentelemetry/sdk/configuration/attribute_limits_configuration.h
@@ -18,8 +18,12 @@ namespace configuration
 class AttributeLimitsConfiguration
 {
 public:
-  std::size_t attribute_value_length_limit;
-  std::size_t attribute_count_limit;
+  // TODO: spec default is no limit, using 4096 to preserve original behavior
+  static constexpr std::size_t kDefaultAttributeValueLengthLimit = 4096;
+  static constexpr std::size_t kDefaultAttributeCountLimit       = 128;
+
+  std::size_t attribute_value_length_limit{kDefaultAttributeValueLengthLimit};
+  std::size_t attribute_count_limit{kDefaultAttributeCountLimit};
 };
 
 }  // namespace configuration

--- a/sdk/include/opentelemetry/sdk/configuration/base2_exponential_bucket_histogram_aggregation_configuration.h
+++ b/sdk/include/opentelemetry/sdk/configuration/base2_exponential_bucket_histogram_aggregation_configuration.h
@@ -3,6 +3,8 @@
 
 #pragma once
 
+#include <cstddef>
+
 #include "opentelemetry/sdk/configuration/aggregation_configuration.h"
 #include "opentelemetry/sdk/configuration/aggregation_configuration_visitor.h"
 #include "opentelemetry/version.h"
@@ -18,14 +20,21 @@ namespace configuration
 class Base2ExponentialBucketHistogramAggregationConfiguration : public AggregationConfiguration
 {
 public:
+  // TODO: max_scale range is [-10, 20]. Negative values require GetSignedInteger in the parser and
+  // changing the type of max_scale to an int32_t to match the
+  // Base2ExponentialHistogramAggregationConfig.
+  static constexpr std::size_t kDefaultMaxScale = 20;  // schema: minimum -10, maximum 20
+  static constexpr std::size_t kDefaultMaxSize  = 160;
+  static constexpr bool kDefaultRecordMinMax    = true;
+
   void Accept(AggregationConfigurationVisitor *visitor) const override
   {
     visitor->VisitBase2ExponentialBucketHistogram(this);
   }
 
-  std::size_t max_scale{0};
-  std::size_t max_size{0};
-  bool record_min_max{false};
+  std::size_t max_scale{kDefaultMaxScale};
+  std::size_t max_size{kDefaultMaxSize};
+  bool record_min_max{kDefaultRecordMinMax};
 };
 
 }  // namespace configuration

--- a/sdk/include/opentelemetry/sdk/configuration/batch_log_record_processor_configuration.h
+++ b/sdk/include/opentelemetry/sdk/configuration/batch_log_record_processor_configuration.h
@@ -3,6 +3,7 @@
 
 #pragma once
 
+#include <cstddef>
 #include <memory>
 
 #include "opentelemetry/sdk/configuration/log_record_exporter_configuration.h"
@@ -21,15 +22,21 @@ namespace configuration
 class BatchLogRecordProcessorConfiguration : public LogRecordProcessorConfiguration
 {
 public:
+  // TODO: spec default is 1000ms for schedule_delay, using 5000ms to preserve original behavior
+  static constexpr std::size_t kDefaultScheduleDelayMs    = 5000;
+  static constexpr std::size_t kDefaultExportTimeoutMs    = 30000;
+  static constexpr std::size_t kDefaultMaxQueueSize       = 2048;
+  static constexpr std::size_t kDefaultMaxExportBatchSize = 512;
+
   void Accept(LogRecordProcessorConfigurationVisitor *visitor) const override
   {
     visitor->VisitBatch(this);
   }
 
-  std::size_t schedule_delay{0};
-  std::size_t export_timeout{0};
-  std::size_t max_queue_size{0};
-  std::size_t max_export_batch_size{0};
+  std::size_t schedule_delay{kDefaultScheduleDelayMs};
+  std::size_t export_timeout{kDefaultExportTimeoutMs};
+  std::size_t max_queue_size{kDefaultMaxQueueSize};
+  std::size_t max_export_batch_size{kDefaultMaxExportBatchSize};
   std::unique_ptr<LogRecordExporterConfiguration> exporter;
 };
 

--- a/sdk/include/opentelemetry/sdk/configuration/batch_span_processor_configuration.h
+++ b/sdk/include/opentelemetry/sdk/configuration/batch_span_processor_configuration.h
@@ -3,6 +3,7 @@
 
 #pragma once
 
+#include <cstddef>
 #include <memory>
 
 #include "opentelemetry/sdk/configuration/span_exporter_configuration.h"
@@ -21,15 +22,20 @@ namespace configuration
 class BatchSpanProcessorConfiguration : public SpanProcessorConfiguration
 {
 public:
+  static constexpr std::size_t kDefaultScheduleDelayMs    = 5000;
+  static constexpr std::size_t kDefaultExportTimeoutMs    = 30000;
+  static constexpr std::size_t kDefaultMaxQueueSize       = 2048;
+  static constexpr std::size_t kDefaultMaxExportBatchSize = 512;
+
   void Accept(SpanProcessorConfigurationVisitor *visitor) const override
   {
     visitor->VisitBatch(this);
   }
 
-  std::size_t schedule_delay{0};
-  std::size_t export_timeout{0};
-  std::size_t max_queue_size{0};
-  std::size_t max_export_batch_size{0};
+  std::size_t schedule_delay{kDefaultScheduleDelayMs};
+  std::size_t export_timeout{kDefaultExportTimeoutMs};
+  std::size_t max_queue_size{kDefaultMaxQueueSize};
+  std::size_t max_export_batch_size{kDefaultMaxExportBatchSize};
   std::unique_ptr<SpanExporterConfiguration> exporter;
 };
 

--- a/sdk/include/opentelemetry/sdk/configuration/boolean_attribute_value_configuration.h
+++ b/sdk/include/opentelemetry/sdk/configuration/boolean_attribute_value_configuration.h
@@ -23,7 +23,7 @@ public:
     visitor->VisitBoolean(this);
   }
 
-  bool value;
+  bool value{false};
 };
 
 }  // namespace configuration

--- a/sdk/include/opentelemetry/sdk/configuration/cardinality_limits_configuration.h
+++ b/sdk/include/opentelemetry/sdk/configuration/cardinality_limits_configuration.h
@@ -18,15 +18,19 @@ namespace configuration
 class CardinalityLimitsConfiguration
 {
 public:
-  std::size_t default_limit;
-  // For all limits, 0 means unset, use default_limit
-  std::size_t counter;
-  std::size_t gauge;
-  std::size_t histogram;
-  std::size_t observable_counter;
-  std::size_t observable_gauge;
-  std::size_t observable_up_down_counter;
-  std::size_t up_down_counter;
+  static constexpr std::size_t kDefaultLimit = 2000;
+  // 0 is a sentinel: inherit from default_limit (schema exclusiveMinimum: 0)
+  static constexpr std::size_t kInheritDefault = 0;
+
+  std::size_t default_limit{kDefaultLimit};
+  // For all limits, kInheritDefault means unset, use default_limit
+  std::size_t counter{kInheritDefault};
+  std::size_t gauge{kInheritDefault};
+  std::size_t histogram{kInheritDefault};
+  std::size_t observable_counter{kInheritDefault};
+  std::size_t observable_gauge{kInheritDefault};
+  std::size_t observable_up_down_counter{kInheritDefault};
+  std::size_t up_down_counter{kInheritDefault};
 };
 
 }  // namespace configuration

--- a/sdk/include/opentelemetry/sdk/configuration/composable_probability_sampler_configuration.h
+++ b/sdk/include/opentelemetry/sdk/configuration/composable_probability_sampler_configuration.h
@@ -15,8 +15,10 @@ namespace configuration
 class ComposableProbabilitySamplerConfiguration : public ComposableSamplerConfiguration
 {
 public:
+  static constexpr double kDefaultRatio = 1.0;
+
   ComposableProbabilitySamplerConfiguration() = default;
-  double ratio{1.0};
+  double ratio{kDefaultRatio};
   void Accept(SamplerConfigurationVisitor *visitor) const override;
 };
 

--- a/sdk/include/opentelemetry/sdk/configuration/configuration.h
+++ b/sdk/include/opentelemetry/sdk/configuration/configuration.h
@@ -58,7 +58,8 @@ namespace configuration
 class Configuration
 {
 public:
-  Configuration(std::unique_ptr<Document> doc) : doc_(std::move(doc)) {}
+  Configuration() = default;
+  explicit Configuration(std::unique_ptr<Document> doc) : doc_(std::move(doc)) {}
   Configuration(Configuration &&)                      = delete;
   Configuration(const Configuration &)                 = delete;
   Configuration &operator=(Configuration &&)           = delete;

--- a/sdk/include/opentelemetry/sdk/configuration/configuration_parser.h
+++ b/sdk/include/opentelemetry/sdk/configuration/configuration_parser.h
@@ -474,8 +474,8 @@ public:
 
 private:
   std::string version_;
-  int version_major_;
-  int version_minor_;
+  int version_major_{};
+  int version_minor_{};
 };
 
 }  // namespace configuration

--- a/sdk/include/opentelemetry/sdk/configuration/console_push_metric_exporter_configuration.h
+++ b/sdk/include/opentelemetry/sdk/configuration/console_push_metric_exporter_configuration.h
@@ -21,14 +21,18 @@ namespace configuration
 class ConsolePushMetricExporterConfiguration : public PushMetricExporterConfiguration
 {
 public:
+  static constexpr TemporalityPreference kDefaultTemporalityPreference =
+      TemporalityPreference::cumulative;
+  static constexpr DefaultHistogramAggregation kDefaultHistogramAggregation =
+      DefaultHistogramAggregation::explicit_bucket_histogram;
+
   void Accept(PushMetricExporterConfigurationVisitor *visitor) const override
   {
     visitor->VisitConsole(this);
   }
 
-  TemporalityPreference temporality_preference{TemporalityPreference::cumulative};
-  DefaultHistogramAggregation default_histogram_aggregation{
-      DefaultHistogramAggregation::explicit_bucket_histogram};
+  TemporalityPreference temporality_preference{kDefaultTemporalityPreference};
+  DefaultHistogramAggregation default_histogram_aggregation{kDefaultHistogramAggregation};
 };
 
 }  // namespace configuration

--- a/sdk/include/opentelemetry/sdk/configuration/document_node.h
+++ b/sdk/include/opentelemetry/sdk/configuration/document_node.h
@@ -178,9 +178,9 @@ private:
 class DocumentNodeLocation
 {
 public:
-  size_t offset;
-  size_t line;
-  size_t col;
+  std::size_t offset{};
+  std::size_t line{};
+  std::size_t col{};
   std::string filename;
 
   std::string ToString() const;

--- a/sdk/include/opentelemetry/sdk/configuration/double_attribute_value_configuration.h
+++ b/sdk/include/opentelemetry/sdk/configuration/double_attribute_value_configuration.h
@@ -23,7 +23,7 @@ public:
     visitor->VisitDouble(this);
   }
 
-  double value;
+  double value{0.0};
 };
 
 }  // namespace configuration

--- a/sdk/include/opentelemetry/sdk/configuration/explicit_bucket_histogram_aggregation_configuration.h
+++ b/sdk/include/opentelemetry/sdk/configuration/explicit_bucket_histogram_aggregation_configuration.h
@@ -20,13 +20,16 @@ namespace configuration
 class ExplicitBucketHistogramAggregationConfiguration : public AggregationConfiguration
 {
 public:
+  // empty boundaries means use the SDK spec default ([0, 5, 10, ...])
+  static constexpr bool kDefaultRecordMinMax = true;
+
   void Accept(AggregationConfigurationVisitor *visitor) const override
   {
     visitor->VisitExplicitBucketHistogram(this);
   }
 
   std::vector<double> boundaries;
-  bool record_min_max{false};
+  bool record_min_max{kDefaultRecordMinMax};
 };
 
 }  // namespace configuration

--- a/sdk/include/opentelemetry/sdk/configuration/grpc_tls_configuration.h
+++ b/sdk/include/opentelemetry/sdk/configuration/grpc_tls_configuration.h
@@ -19,10 +19,12 @@ namespace configuration
 class GrpcTlsConfiguration
 {
 public:
+  static constexpr bool kDefaultInsecure = false;
+
   std::string ca_file;
   std::string key_file;
   std::string cert_file;
-  bool insecure{false};
+  bool insecure{kDefaultInsecure};
 };
 
 }  // namespace configuration

--- a/sdk/include/opentelemetry/sdk/configuration/integer_attribute_value_configuration.h
+++ b/sdk/include/opentelemetry/sdk/configuration/integer_attribute_value_configuration.h
@@ -25,7 +25,7 @@ public:
     visitor->VisitInteger(this);
   }
 
-  int64_t value;
+  std::int64_t value{0};
 };
 
 }  // namespace configuration

--- a/sdk/include/opentelemetry/sdk/configuration/jaeger_remote_sampler_configuration.h
+++ b/sdk/include/opentelemetry/sdk/configuration/jaeger_remote_sampler_configuration.h
@@ -3,6 +3,7 @@
 
 #pragma once
 
+#include <cstddef>
 #include <memory>
 #include <string>
 
@@ -21,13 +22,15 @@ namespace configuration
 class JaegerRemoteSamplerConfiguration : public SamplerConfiguration
 {
 public:
+  static constexpr std::size_t kDefaultIntervalMs = 60000;
+
   void Accept(SamplerConfigurationVisitor *visitor) const override
   {
     visitor->VisitJaegerRemote(this);
   }
 
   std::string endpoint;
-  std::size_t interval{0};
+  std::size_t interval{kDefaultIntervalMs};
   std::unique_ptr<SamplerConfiguration> initial_sampler;
 };
 

--- a/sdk/include/opentelemetry/sdk/configuration/log_record_limits_configuration.h
+++ b/sdk/include/opentelemetry/sdk/configuration/log_record_limits_configuration.h
@@ -3,6 +3,8 @@
 
 #pragma once
 
+#include <cstddef>
+
 #include "opentelemetry/version.h"
 
 OPENTELEMETRY_BEGIN_NAMESPACE
@@ -16,8 +18,12 @@ namespace configuration
 class LogRecordLimitsConfiguration
 {
 public:
-  std::size_t attribute_value_length_limit;
-  std::size_t attribute_count_limit;
+  // TODO: spec default is no limit, using 4096 to preserve original behavior
+  static constexpr std::size_t kDefaultAttributeValueLengthLimit = 4096;
+  static constexpr std::size_t kDefaultAttributeCountLimit       = 128;
+
+  std::size_t attribute_value_length_limit{kDefaultAttributeValueLengthLimit};
+  std::size_t attribute_count_limit{kDefaultAttributeCountLimit};
 };
 
 }  // namespace configuration

--- a/sdk/include/opentelemetry/sdk/configuration/logger_config_configuration.h
+++ b/sdk/include/opentelemetry/sdk/configuration/logger_config_configuration.h
@@ -17,9 +17,13 @@ namespace configuration
 class LoggerConfigConfiguration
 {
 public:
-  bool enabled{true};
-  SeverityNumber minimum_severity{SeverityNumber::trace};
-  bool trace_based{false};
+  static constexpr bool kDefaultEnabled                   = true;
+  static constexpr SeverityNumber kDefaultMinimumSeverity = SeverityNumber::trace;
+  static constexpr bool kDefaultTraceBased                = false;
+
+  bool enabled{kDefaultEnabled};
+  SeverityNumber minimum_severity{kDefaultMinimumSeverity};
+  bool trace_based{kDefaultTraceBased};
 };
 
 }  // namespace configuration

--- a/sdk/include/opentelemetry/sdk/configuration/meter_provider_configuration.h
+++ b/sdk/include/opentelemetry/sdk/configuration/meter_provider_configuration.h
@@ -25,7 +25,7 @@ class MeterProviderConfiguration
 public:
   std::vector<std::unique_ptr<MetricReaderConfiguration>> readers;
   std::vector<std::unique_ptr<ViewConfiguration>> views;
-  ExemplarFilter exemplar_filter = ExemplarFilter::trace_based;
+  ExemplarFilter exemplar_filter{ExemplarFilter::trace_based};
   std::unique_ptr<MeterConfiguratorConfiguration> meter_configurator;
 };
 

--- a/sdk/include/opentelemetry/sdk/configuration/otlp_file_push_metric_exporter_configuration.h
+++ b/sdk/include/opentelemetry/sdk/configuration/otlp_file_push_metric_exporter_configuration.h
@@ -23,15 +23,19 @@ namespace configuration
 class OtlpFilePushMetricExporterConfiguration : public PushMetricExporterConfiguration
 {
 public:
+  static constexpr TemporalityPreference kDefaultTemporalityPreference =
+      TemporalityPreference::cumulative;
+  static constexpr DefaultHistogramAggregation kDefaultHistogramAggregation =
+      DefaultHistogramAggregation::explicit_bucket_histogram;
+
   void Accept(PushMetricExporterConfigurationVisitor *visitor) const override
   {
     visitor->VisitOtlpFile(this);
   }
 
   std::string output_stream;
-  TemporalityPreference temporality_preference{TemporalityPreference::cumulative};
-  DefaultHistogramAggregation default_histogram_aggregation{
-      DefaultHistogramAggregation::explicit_bucket_histogram};
+  TemporalityPreference temporality_preference{kDefaultTemporalityPreference};
+  DefaultHistogramAggregation default_histogram_aggregation{kDefaultHistogramAggregation};
 };
 
 }  // namespace configuration

--- a/sdk/include/opentelemetry/sdk/configuration/otlp_grpc_log_record_exporter_configuration.h
+++ b/sdk/include/opentelemetry/sdk/configuration/otlp_grpc_log_record_exporter_configuration.h
@@ -3,6 +3,7 @@
 
 #pragma once
 
+#include <cstddef>
 #include <memory>
 #include <string>
 
@@ -23,6 +24,8 @@ namespace configuration
 class OtlpGrpcLogRecordExporterConfiguration : public LogRecordExporterConfiguration
 {
 public:
+  static constexpr std::size_t kDefaultTimeoutMs = 10000;
+
   void Accept(LogRecordExporterConfigurationVisitor *visitor) const override
   {
     visitor->VisitOtlpGrpc(this);
@@ -33,7 +36,7 @@ public:
   std::unique_ptr<HeadersConfiguration> headers;
   std::string headers_list;
   std::string compression;
-  std::size_t timeout{0};
+  std::size_t timeout{kDefaultTimeoutMs};
 };
 
 }  // namespace configuration

--- a/sdk/include/opentelemetry/sdk/configuration/otlp_grpc_push_metric_exporter_configuration.h
+++ b/sdk/include/opentelemetry/sdk/configuration/otlp_grpc_push_metric_exporter_configuration.h
@@ -3,6 +3,7 @@
 
 #pragma once
 
+#include <cstddef>
 #include <memory>
 #include <string>
 
@@ -25,6 +26,12 @@ namespace configuration
 class OtlpGrpcPushMetricExporterConfiguration : public PushMetricExporterConfiguration
 {
 public:
+  static constexpr std::size_t kDefaultTimeoutMs = 10000;
+  static constexpr TemporalityPreference kDefaultTemporalityPreference =
+      TemporalityPreference::cumulative;
+  static constexpr DefaultHistogramAggregation kDefaultHistogramAggregation =
+      DefaultHistogramAggregation::explicit_bucket_histogram;
+
   void Accept(PushMetricExporterConfigurationVisitor *visitor) const override
   {
     visitor->VisitOtlpGrpc(this);
@@ -35,10 +42,9 @@ public:
   std::unique_ptr<HeadersConfiguration> headers;
   std::string headers_list;
   std::string compression;
-  std::size_t timeout{0};
-  TemporalityPreference temporality_preference{TemporalityPreference::cumulative};
-  DefaultHistogramAggregation default_histogram_aggregation{
-      DefaultHistogramAggregation::explicit_bucket_histogram};
+  std::size_t timeout{kDefaultTimeoutMs};
+  TemporalityPreference temporality_preference{kDefaultTemporalityPreference};
+  DefaultHistogramAggregation default_histogram_aggregation{kDefaultHistogramAggregation};
 };
 
 }  // namespace configuration

--- a/sdk/include/opentelemetry/sdk/configuration/otlp_grpc_span_exporter_configuration.h
+++ b/sdk/include/opentelemetry/sdk/configuration/otlp_grpc_span_exporter_configuration.h
@@ -3,6 +3,7 @@
 
 #pragma once
 
+#include <cstddef>
 #include <memory>
 #include <string>
 
@@ -23,6 +24,8 @@ namespace configuration
 class OtlpGrpcSpanExporterConfiguration : public SpanExporterConfiguration
 {
 public:
+  static constexpr std::size_t kDefaultTimeoutMs = 10000;
+
   void Accept(SpanExporterConfigurationVisitor *visitor) const override
   {
     visitor->VisitOtlpGrpc(this);
@@ -33,7 +36,7 @@ public:
   std::unique_ptr<HeadersConfiguration> headers;
   std::string headers_list;
   std::string compression;
-  std::size_t timeout{0};
+  std::size_t timeout{kDefaultTimeoutMs};
 };
 
 }  // namespace configuration

--- a/sdk/include/opentelemetry/sdk/configuration/otlp_http_log_record_exporter_configuration.h
+++ b/sdk/include/opentelemetry/sdk/configuration/otlp_http_log_record_exporter_configuration.h
@@ -3,6 +3,7 @@
 
 #pragma once
 
+#include <cstddef>
 #include <memory>
 #include <string>
 
@@ -24,6 +25,8 @@ namespace configuration
 class OtlpHttpLogRecordExporterConfiguration : public LogRecordExporterConfiguration
 {
 public:
+  static constexpr std::size_t kDefaultTimeoutMs = 10000;
+
   void Accept(LogRecordExporterConfigurationVisitor *visitor) const override
   {
     visitor->VisitOtlpHttp(this);
@@ -34,7 +37,7 @@ public:
   std::unique_ptr<HeadersConfiguration> headers;
   std::string headers_list;
   std::string compression;
-  std::size_t timeout{0};
+  std::size_t timeout{kDefaultTimeoutMs};
   OtlpHttpEncoding encoding{OtlpHttpEncoding::protobuf};
 };
 

--- a/sdk/include/opentelemetry/sdk/configuration/otlp_http_push_metric_exporter_configuration.h
+++ b/sdk/include/opentelemetry/sdk/configuration/otlp_http_push_metric_exporter_configuration.h
@@ -3,6 +3,7 @@
 
 #pragma once
 
+#include <cstddef>
 #include <memory>
 #include <string>
 
@@ -26,6 +27,12 @@ namespace configuration
 class OtlpHttpPushMetricExporterConfiguration : public PushMetricExporterConfiguration
 {
 public:
+  static constexpr std::size_t kDefaultTimeoutMs = 10000;
+  static constexpr TemporalityPreference kDefaultTemporalityPreference =
+      TemporalityPreference::cumulative;
+  static constexpr DefaultHistogramAggregation kDefaultHistogramAggregation =
+      DefaultHistogramAggregation::explicit_bucket_histogram;
+
   void Accept(PushMetricExporterConfigurationVisitor *visitor) const override
   {
     visitor->VisitOtlpHttp(this);
@@ -36,11 +43,10 @@ public:
   std::unique_ptr<HeadersConfiguration> headers;
   std::string headers_list;
   std::string compression;
-  std::size_t timeout{0};
+  std::size_t timeout{kDefaultTimeoutMs};
   OtlpHttpEncoding encoding{OtlpHttpEncoding::protobuf};
-  TemporalityPreference temporality_preference{TemporalityPreference::cumulative};
-  DefaultHistogramAggregation default_histogram_aggregation{
-      DefaultHistogramAggregation::explicit_bucket_histogram};
+  TemporalityPreference temporality_preference{kDefaultTemporalityPreference};
+  DefaultHistogramAggregation default_histogram_aggregation{kDefaultHistogramAggregation};
 };
 
 }  // namespace configuration

--- a/sdk/include/opentelemetry/sdk/configuration/otlp_http_span_exporter_configuration.h
+++ b/sdk/include/opentelemetry/sdk/configuration/otlp_http_span_exporter_configuration.h
@@ -3,6 +3,7 @@
 
 #pragma once
 
+#include <cstddef>
 #include <memory>
 #include <string>
 
@@ -24,6 +25,8 @@ namespace configuration
 class OtlpHttpSpanExporterConfiguration : public SpanExporterConfiguration
 {
 public:
+  static constexpr std::size_t kDefaultTimeoutMs = 10000;
+
   void Accept(SpanExporterConfigurationVisitor *visitor) const override
   {
     visitor->VisitOtlpHttp(this);
@@ -34,7 +37,7 @@ public:
   std::unique_ptr<HeadersConfiguration> headers;
   std::string headers_list;
   std::string compression;
-  std::size_t timeout{0};
+  std::size_t timeout{kDefaultTimeoutMs};
   OtlpHttpEncoding encoding{OtlpHttpEncoding::protobuf};
 };
 

--- a/sdk/include/opentelemetry/sdk/configuration/periodic_metric_reader_configuration.h
+++ b/sdk/include/opentelemetry/sdk/configuration/periodic_metric_reader_configuration.h
@@ -3,6 +3,7 @@
 
 #pragma once
 
+#include <cstddef>
 #include <memory>
 #include <vector>
 
@@ -24,13 +25,17 @@ namespace configuration
 class PeriodicMetricReaderConfiguration : public MetricReaderConfiguration
 {
 public:
+  // TODO: spec default is 60000ms for interval, using 5000ms to preserve original behavior
+  static constexpr std::size_t kDefaultIntervalMs = 5000;
+  static constexpr std::size_t kDefaultTimeoutMs  = 30000;
+
   void Accept(MetricReaderConfigurationVisitor *visitor) const override
   {
     visitor->VisitPeriodic(this);
   }
 
-  std::size_t interval{0};
-  std::size_t timeout{0};
+  std::size_t interval{kDefaultIntervalMs};
+  std::size_t timeout{kDefaultTimeoutMs};
   std::unique_ptr<PushMetricExporterConfiguration> exporter;
   std::vector<std::unique_ptr<MetricProducerConfiguration>> producers;
   std::unique_ptr<CardinalityLimitsConfiguration> cardinality_limits;

--- a/sdk/include/opentelemetry/sdk/configuration/prometheus_pull_metric_exporter_configuration.h
+++ b/sdk/include/opentelemetry/sdk/configuration/prometheus_pull_metric_exporter_configuration.h
@@ -3,6 +3,7 @@
 
 #pragma once
 
+#include <cstddef>
 #include <string>
 
 #include "opentelemetry/sdk/configuration/headers_configuration.h"
@@ -23,17 +24,24 @@ namespace configuration
 class PrometheusPullMetricExporterConfiguration : public PullMetricExporterConfiguration
 {
 public:
+  static constexpr const char *kDefaultHost       = "localhost";
+  static constexpr std::size_t kDefaultPort       = 9464;
+  static constexpr bool kDefaultWithoutScopeInfo  = false;  // schema: scope_info_enabled=true
+  static constexpr bool kDefaultWithoutTargetInfo = false;  // schema: target_info_enabled=true
+  static constexpr TranslationStrategy kDefaultTranslationStrategy =
+      TranslationStrategy::UnderscoreEscapingWithSuffixes;
+
   void Accept(PullMetricExporterConfigurationVisitor *visitor) const override
   {
     visitor->VisitPrometheus(this);
   }
 
-  std::string host;
-  std::size_t port{0};
-  bool without_scope_info{false};
-  bool without_target_info{false};
+  std::string host{kDefaultHost};
+  std::size_t port{kDefaultPort};
+  bool without_scope_info{kDefaultWithoutScopeInfo};
+  bool without_target_info{kDefaultWithoutTargetInfo};
   std::unique_ptr<IncludeExcludeConfiguration> with_resource_constant_labels;
-  TranslationStrategy translation_strategy;
+  TranslationStrategy translation_strategy{kDefaultTranslationStrategy};
 };
 
 }  // namespace configuration

--- a/sdk/include/opentelemetry/sdk/configuration/ryml_document_node.h
+++ b/sdk/include/opentelemetry/sdk/configuration/ryml_document_node.h
@@ -70,7 +70,7 @@ private:
 
   const RymlDocument *doc_;
   ryml::ConstNodeRef node_;
-  std::size_t depth_;
+  std::size_t depth_{};
 };
 
 class RymlDocumentNodeConstIteratorImpl : public DocumentNodeConstIteratorImpl

--- a/sdk/include/opentelemetry/sdk/configuration/span_limits_configuration.h
+++ b/sdk/include/opentelemetry/sdk/configuration/span_limits_configuration.h
@@ -3,6 +3,8 @@
 
 #pragma once
 
+#include <cstddef>
+
 #include "opentelemetry/version.h"
 
 OPENTELEMETRY_BEGIN_NAMESPACE
@@ -16,12 +18,20 @@ namespace configuration
 class SpanLimitsConfiguration
 {
 public:
-  std::size_t attribute_value_length_limit;
-  std::size_t attribute_count_limit;
-  std::size_t event_count_limit;
-  std::size_t link_count_limit;
-  std::size_t event_attribute_count_limit;
-  std::size_t link_attribute_count_limit;
+  // TODO: spec default is no limit, using 4096 to preserve original behavior
+  static constexpr std::size_t kDefaultAttributeValueLengthLimit = 4096;
+  static constexpr std::size_t kDefaultAttributeCountLimit       = 128;
+  static constexpr std::size_t kDefaultEventCountLimit           = 128;
+  static constexpr std::size_t kDefaultLinkCountLimit            = 128;
+  static constexpr std::size_t kDefaultEventAttributeCountLimit  = 128;
+  static constexpr std::size_t kDefaultLinkAttributeCountLimit   = 128;
+
+  std::size_t attribute_value_length_limit{kDefaultAttributeValueLengthLimit};
+  std::size_t attribute_count_limit{kDefaultAttributeCountLimit};
+  std::size_t event_count_limit{kDefaultEventCountLimit};
+  std::size_t link_count_limit{kDefaultLinkCountLimit};
+  std::size_t event_attribute_count_limit{kDefaultEventAttributeCountLimit};
+  std::size_t link_attribute_count_limit{kDefaultLinkAttributeCountLimit};
 };
 
 }  // namespace configuration

--- a/sdk/include/opentelemetry/sdk/configuration/trace_id_ratio_based_sampler_configuration.h
+++ b/sdk/include/opentelemetry/sdk/configuration/trace_id_ratio_based_sampler_configuration.h
@@ -18,12 +18,15 @@ namespace configuration
 class TraceIdRatioBasedSamplerConfiguration : public SamplerConfiguration
 {
 public:
+  // TODO: spec default is 1.0, using 0.0 to preserve original behavior
+  static constexpr double kDefaultRatio = 0.0;
+
   void Accept(SamplerConfigurationVisitor *visitor) const override
   {
     visitor->VisitTraceIdRatioBased(this);
   }
 
-  double ratio{0.0};
+  double ratio{kDefaultRatio};
 };
 
 }  // namespace configuration

--- a/sdk/include/opentelemetry/sdk/configuration/view_stream_configuration.h
+++ b/sdk/include/opentelemetry/sdk/configuration/view_stream_configuration.h
@@ -3,6 +3,7 @@
 
 #pragma once
 
+#include <cstddef>
 #include <memory>
 #include <string>
 #include <vector>
@@ -22,10 +23,13 @@ namespace configuration
 class ViewStreamConfiguration
 {
 public:
+  // 0 is a sentinel: inherit cardinality limit from the metric reader (schema exclusiveMinimum: 0)
+  static constexpr std::size_t kInheritFromReader = 0;
+
   std::string name;
   std::string description;
   std::unique_ptr<AggregationConfiguration> aggregation;
-  std::size_t aggregation_cardinality_limit;
+  std::size_t aggregation_cardinality_limit{kInheritFromReader};
   std::unique_ptr<IncludeExcludeConfiguration> attribute_keys;
 };
 

--- a/sdk/src/configuration/configuration_parser.cc
+++ b/sdk/src/configuration/configuration_parser.cc
@@ -356,10 +356,13 @@ std::unique_ptr<AttributeLimitsConfiguration>
 ConfigurationParser::ParseAttributeLimitsConfiguration(
     const std::unique_ptr<DocumentNode> &node) const
 {
-  auto model = std::make_unique<AttributeLimitsConfiguration>();
+  using Config = AttributeLimitsConfiguration;
+  auto model   = std::make_unique<AttributeLimitsConfiguration>();
 
-  model->attribute_value_length_limit = node->GetInteger("attribute_value_length_limit", 4096);
-  model->attribute_count_limit        = node->GetInteger("attribute_count_limit", 128);
+  model->attribute_value_length_limit =
+      node->GetInteger("attribute_value_length_limit", Config::kDefaultAttributeValueLengthLimit);
+  model->attribute_count_limit =
+      node->GetInteger("attribute_count_limit", Config::kDefaultAttributeCountLimit);
 
   return model;
 }
@@ -379,12 +382,13 @@ std::unique_ptr<HttpTlsConfiguration> ConfigurationParser::ParseHttpTlsConfigura
 std::unique_ptr<GrpcTlsConfiguration> ConfigurationParser::ParseGrpcTlsConfiguration(
     const std::unique_ptr<DocumentNode> &node) const
 {
-  auto model = std::make_unique<GrpcTlsConfiguration>();
+  using Config = GrpcTlsConfiguration;
+  auto model   = std::make_unique<GrpcTlsConfiguration>();
 
   model->ca_file   = node->GetString("ca_file", "");
   model->key_file  = node->GetString("key_file", "");
   model->cert_file = node->GetString("cert_file", "");
-  model->insecure  = node->GetBoolean("insecure", false);
+  model->insecure  = node->GetBoolean("insecure", Config::kDefaultInsecure);
 
   return model;
 }
@@ -393,7 +397,8 @@ std::unique_ptr<OtlpHttpLogRecordExporterConfiguration>
 ConfigurationParser::ParseOtlpHttpLogRecordExporterConfiguration(
     const std::unique_ptr<DocumentNode> &node) const
 {
-  auto model = std::make_unique<OtlpHttpLogRecordExporterConfiguration>();
+  using Config = OtlpHttpLogRecordExporterConfiguration;
+  auto model   = std::make_unique<OtlpHttpLogRecordExporterConfiguration>();
   std::unique_ptr<DocumentNode> child;
 
   model->endpoint = node->GetRequiredString("endpoint");
@@ -412,7 +417,7 @@ ConfigurationParser::ParseOtlpHttpLogRecordExporterConfiguration(
 
   model->headers_list = node->GetString("headers_list", "");
   model->compression  = node->GetString("compression", "");
-  model->timeout      = node->GetInteger("timeout", 10000);
+  model->timeout      = node->GetInteger("timeout", Config::kDefaultTimeoutMs);
 
   const std::string encoding = node->GetString("encoding", "protobuf");
   model->encoding            = ParseOtlpHttpEncoding(node, encoding);
@@ -424,7 +429,8 @@ std::unique_ptr<OtlpGrpcLogRecordExporterConfiguration>
 ConfigurationParser::ParseOtlpGrpcLogRecordExporterConfiguration(
     const std::unique_ptr<DocumentNode> &node) const
 {
-  auto model = std::make_unique<OtlpGrpcLogRecordExporterConfiguration>();
+  using Config = OtlpGrpcLogRecordExporterConfiguration;
+  auto model   = std::make_unique<OtlpGrpcLogRecordExporterConfiguration>();
   std::unique_ptr<DocumentNode> child;
 
   model->endpoint = node->GetRequiredString("endpoint");
@@ -443,7 +449,7 @@ ConfigurationParser::ParseOtlpGrpcLogRecordExporterConfiguration(
 
   model->headers_list = node->GetString("headers_list", "");
   model->compression  = node->GetString("compression", "");
-  model->timeout      = node->GetInteger("timeout", 10000);
+  model->timeout      = node->GetInteger("timeout", Config::kDefaultTimeoutMs);
 
   return model;
 }
@@ -534,13 +540,15 @@ std::unique_ptr<BatchLogRecordProcessorConfiguration>
 ConfigurationParser::ParseBatchLogRecordProcessorConfiguration(
     const std::unique_ptr<DocumentNode> &node) const
 {
-  auto model = std::make_unique<BatchLogRecordProcessorConfiguration>();
+  using Config = BatchLogRecordProcessorConfiguration;
+  auto model   = std::make_unique<BatchLogRecordProcessorConfiguration>();
   std::unique_ptr<DocumentNode> child;
 
-  model->schedule_delay        = node->GetInteger("schedule_delay", 5000);
-  model->export_timeout        = node->GetInteger("export_timeout", 30000);
-  model->max_queue_size        = node->GetInteger("max_queue_size", 2048);
-  model->max_export_batch_size = node->GetInteger("max_export_batch_size", 512);
+  model->schedule_delay = node->GetInteger("schedule_delay", Config::kDefaultScheduleDelayMs);
+  model->export_timeout = node->GetInteger("export_timeout", Config::kDefaultExportTimeoutMs);
+  model->max_queue_size = node->GetInteger("max_queue_size", Config::kDefaultMaxQueueSize);
+  model->max_export_batch_size =
+      node->GetInteger("max_export_batch_size", Config::kDefaultMaxExportBatchSize);
 
   child           = node->GetRequiredChildNode("exporter");
   model->exporter = ParseLogRecordExporterConfiguration(child);
@@ -618,10 +626,13 @@ std::unique_ptr<LogRecordLimitsConfiguration>
 ConfigurationParser::ParseLogRecordLimitsConfiguration(
     const std::unique_ptr<DocumentNode> &node) const
 {
-  auto model = std::make_unique<LogRecordLimitsConfiguration>();
+  using Config = LogRecordLimitsConfiguration;
+  auto model   = std::make_unique<LogRecordLimitsConfiguration>();
 
-  model->attribute_value_length_limit = node->GetInteger("attribute_value_length_limit", 4096);
-  model->attribute_count_limit        = node->GetInteger("attribute_count_limit", 128);
+  model->attribute_value_length_limit =
+      node->GetInteger("attribute_value_length_limit", Config::kDefaultAttributeValueLengthLimit);
+  model->attribute_count_limit =
+      node->GetInteger("attribute_count_limit", Config::kDefaultAttributeCountLimit);
 
   return model;
 }
@@ -629,13 +640,14 @@ ConfigurationParser::ParseLogRecordLimitsConfiguration(
 LoggerConfigConfiguration ConfigurationParser::ParseLoggerConfigConfiguration(
     const std::unique_ptr<DocumentNode> &node) const
 {
-  LoggerConfigConfiguration model;
-  model.enabled = node->GetBoolean("enabled", true);
+  using Config = LoggerConfigConfiguration;
+  Config model;
+  model.enabled = node->GetBoolean("enabled", Config::kDefaultEnabled);
 
   const std::string minimum_severity_str = node->GetString("minimum_severity", "trace");
   model.minimum_severity                 = ParseSeverityNumber(node, minimum_severity_str);
 
-  model.trace_based = node->GetBoolean("trace_based", false);
+  model.trace_based = node->GetBoolean("trace_based", Config::kDefaultTraceBased);
 
   return model;
 }
@@ -756,7 +768,8 @@ std::unique_ptr<OtlpHttpPushMetricExporterConfiguration>
 ConfigurationParser::ParseOtlpHttpPushMetricExporterConfiguration(
     const std::unique_ptr<DocumentNode> &node) const
 {
-  auto model = std::make_unique<OtlpHttpPushMetricExporterConfiguration>();
+  using Config = OtlpHttpPushMetricExporterConfiguration;
+  auto model   = std::make_unique<OtlpHttpPushMetricExporterConfiguration>();
   std::unique_ptr<DocumentNode> child;
 
   model->endpoint = node->GetRequiredString("endpoint");
@@ -775,7 +788,7 @@ ConfigurationParser::ParseOtlpHttpPushMetricExporterConfiguration(
 
   model->headers_list = node->GetString("headers_list", "");
   model->compression  = node->GetString("compression", "");
-  model->timeout      = node->GetInteger("timeout", 10000);
+  model->timeout      = node->GetInteger("timeout", Config::kDefaultTimeoutMs);
 
   const std::string temporality_preference =
       node->GetString("temporality_preference", "cumulative");
@@ -796,7 +809,8 @@ std::unique_ptr<OtlpGrpcPushMetricExporterConfiguration>
 ConfigurationParser::ParseOtlpGrpcPushMetricExporterConfiguration(
     const std::unique_ptr<DocumentNode> &node) const
 {
-  auto model = std::make_unique<OtlpGrpcPushMetricExporterConfiguration>();
+  using Config = OtlpGrpcPushMetricExporterConfiguration;
+  auto model   = std::make_unique<OtlpGrpcPushMetricExporterConfiguration>();
   std::unique_ptr<DocumentNode> child;
 
   model->endpoint = node->GetRequiredString("endpoint");
@@ -815,7 +829,7 @@ ConfigurationParser::ParseOtlpGrpcPushMetricExporterConfiguration(
 
   model->headers_list = node->GetString("headers_list", "");
   model->compression  = node->GetString("compression", "");
-  model->timeout      = node->GetInteger("timeout", 10000);
+  model->timeout      = node->GetInteger("timeout", Config::kDefaultTimeoutMs);
 
   const std::string temporality_preference =
       node->GetString("temporality_preference", "cumulative");
@@ -901,13 +915,16 @@ std::unique_ptr<PrometheusPullMetricExporterConfiguration>
 ConfigurationParser::ParsePrometheusPullMetricExporterConfiguration(
     const std::unique_ptr<DocumentNode> &node) const
 {
-  auto model = std::make_unique<PrometheusPullMetricExporterConfiguration>();
+  using Config = PrometheusPullMetricExporterConfiguration;
+  auto model   = std::make_unique<PrometheusPullMetricExporterConfiguration>();
   std::unique_ptr<DocumentNode> child;
 
-  model->host                = node->GetString("host", "localhost");
-  model->port                = node->GetInteger("port", 9464);
-  model->without_scope_info  = node->GetBoolean("without_scope_info", false);
-  model->without_target_info = node->GetBoolean("without_target_info", false);
+  model->host = node->GetString("host", Config::kDefaultHost);
+  model->port = node->GetInteger("port", Config::kDefaultPort);
+  model->without_scope_info =
+      node->GetBoolean("without_scope_info", Config::kDefaultWithoutScopeInfo);
+  model->without_target_info =
+      node->GetBoolean("without_target_info", Config::kDefaultWithoutTargetInfo);
 
   child = node->GetChildNode("with_resource_constant_labels");
   if (child)
@@ -1093,16 +1110,18 @@ std::unique_ptr<CardinalityLimitsConfiguration>
 ConfigurationParser::ParseCardinalityLimitsConfiguration(
     const std::unique_ptr<DocumentNode> &node) const
 {
-  auto model = std::make_unique<CardinalityLimitsConfiguration>();
+  using Config = CardinalityLimitsConfiguration;
+  auto model   = std::make_unique<CardinalityLimitsConfiguration>();
 
-  model->default_limit              = node->GetInteger("default", 2000);
-  model->counter                    = node->GetInteger("counter", 0);
-  model->gauge                      = node->GetInteger("gauge", 0);
-  model->histogram                  = node->GetInteger("histogram", 0);
-  model->observable_counter         = node->GetInteger("observable_counter", 0);
-  model->observable_gauge           = node->GetInteger("observable_gauge", 0);
-  model->observable_up_down_counter = node->GetInteger("observable_up_down_counter", 0);
-  model->up_down_counter            = node->GetInteger("up_down_counter", 0);
+  model->default_limit      = node->GetInteger("default", Config::kDefaultLimit);
+  model->counter            = node->GetInteger("counter", Config::kInheritDefault);
+  model->gauge              = node->GetInteger("gauge", Config::kInheritDefault);
+  model->histogram          = node->GetInteger("histogram", Config::kInheritDefault);
+  model->observable_counter = node->GetInteger("observable_counter", Config::kInheritDefault);
+  model->observable_gauge   = node->GetInteger("observable_gauge", Config::kInheritDefault);
+  model->observable_up_down_counter =
+      node->GetInteger("observable_up_down_counter", Config::kInheritDefault);
+  model->up_down_counter = node->GetInteger("up_down_counter", Config::kInheritDefault);
 
   return model;
 }
@@ -1111,11 +1130,12 @@ std::unique_ptr<PeriodicMetricReaderConfiguration>
 ConfigurationParser::ParsePeriodicMetricReaderConfiguration(
     const std::unique_ptr<DocumentNode> &node) const
 {
-  auto model = std::make_unique<PeriodicMetricReaderConfiguration>();
+  using Config = PeriodicMetricReaderConfiguration;
+  auto model   = std::make_unique<PeriodicMetricReaderConfiguration>();
   std::unique_ptr<DocumentNode> child;
 
-  model->interval = node->GetInteger("interval", 5000);
-  model->timeout  = node->GetInteger("timeout", 30000);
+  model->interval = node->GetInteger("interval", Config::kDefaultIntervalMs);
+  model->timeout  = node->GetInteger("timeout", Config::kDefaultTimeoutMs);
 
   child           = node->GetRequiredChildNode("exporter");
   model->exporter = ParsePushMetricExporterConfiguration(child);
@@ -1320,7 +1340,8 @@ std::unique_ptr<ExplicitBucketHistogramAggregationConfiguration>
 ConfigurationParser::ParseExplicitBucketHistogramAggregationConfiguration(
     const std::unique_ptr<DocumentNode> &node) const
 {
-  auto model = std::make_unique<ExplicitBucketHistogramAggregationConfiguration>();
+  using Config = ExplicitBucketHistogramAggregationConfiguration;
+  auto model   = std::make_unique<ExplicitBucketHistogramAggregationConfiguration>();
   std::unique_ptr<DocumentNode> child;
 
   child = node->GetChildNode("boundaries");
@@ -1337,7 +1358,7 @@ ConfigurationParser::ParseExplicitBucketHistogramAggregationConfiguration(
     }
   }
 
-  model->record_min_max = node->GetBoolean("record_min_max", true);
+  model->record_min_max = node->GetBoolean("record_min_max", Config::kDefaultRecordMinMax);
 
   return model;
 }
@@ -1346,11 +1367,12 @@ std::unique_ptr<Base2ExponentialBucketHistogramAggregationConfiguration>
 ConfigurationParser::ParseBase2ExponentialBucketHistogramAggregationConfiguration(
     const std::unique_ptr<DocumentNode> &node) const
 {
-  auto model = std::make_unique<Base2ExponentialBucketHistogramAggregationConfiguration>();
+  using Config = Base2ExponentialBucketHistogramAggregationConfiguration;
+  auto model   = std::make_unique<Base2ExponentialBucketHistogramAggregationConfiguration>();
 
-  model->max_scale      = node->GetInteger("max_scale", 20);
-  model->max_size       = node->GetInteger("max_size", 160);
-  model->record_min_max = node->GetBoolean("record_min_max", true);
+  model->max_scale      = node->GetInteger("max_scale", Config::kDefaultMaxScale);
+  model->max_size       = node->GetInteger("max_size", Config::kDefaultMaxSize);
+  model->record_min_max = node->GetBoolean("record_min_max", Config::kDefaultRecordMinMax);
 
   return model;
 }
@@ -1427,12 +1449,14 @@ std::unique_ptr<AggregationConfiguration> ConfigurationParser::ParseAggregationC
 std::unique_ptr<ViewStreamConfiguration> ConfigurationParser::ParseViewStreamConfiguration(
     const std::unique_ptr<DocumentNode> &node) const
 {
-  auto model = std::make_unique<ViewStreamConfiguration>();
+  using Config = ViewStreamConfiguration;
+  auto model   = std::make_unique<ViewStreamConfiguration>();
   std::unique_ptr<DocumentNode> child;
 
-  model->name                          = node->GetString("name", "");
-  model->description                   = node->GetString("description", "");
-  model->aggregation_cardinality_limit = node->GetInteger("aggregation_cardinality_limit", 0);
+  model->name        = node->GetString("name", "");
+  model->description = node->GetString("description", "");
+  model->aggregation_cardinality_limit =
+      node->GetInteger("aggregation_cardinality_limit", Config::kInheritFromReader);
 
   child = node->GetChildNode("aggregation");
   if (child)
@@ -1594,14 +1618,19 @@ std::unique_ptr<PropagatorConfiguration> ConfigurationParser::ParsePropagatorCon
 std::unique_ptr<SpanLimitsConfiguration> ConfigurationParser::ParseSpanLimitsConfiguration(
     const std::unique_ptr<DocumentNode> &node) const
 {
-  auto model = std::make_unique<SpanLimitsConfiguration>();
+  using Config = SpanLimitsConfiguration;
+  auto model   = std::make_unique<SpanLimitsConfiguration>();
 
-  model->attribute_value_length_limit = node->GetInteger("attribute_value_length_limit", 4096);
-  model->attribute_count_limit        = node->GetInteger("attribute_count_limit", 128);
-  model->event_count_limit            = node->GetInteger("event_count_limit", 128);
-  model->link_count_limit             = node->GetInteger("link_count_limit", 128);
-  model->event_attribute_count_limit  = node->GetInteger("event_attribute_count_limit", 128);
-  model->link_attribute_count_limit   = node->GetInteger("link_attribute_count_limit", 128);
+  model->attribute_value_length_limit =
+      node->GetInteger("attribute_value_length_limit", Config::kDefaultAttributeValueLengthLimit);
+  model->attribute_count_limit =
+      node->GetInteger("attribute_count_limit", Config::kDefaultAttributeCountLimit);
+  model->event_count_limit = node->GetInteger("event_count_limit", Config::kDefaultEventCountLimit);
+  model->link_count_limit  = node->GetInteger("link_count_limit", Config::kDefaultLinkCountLimit);
+  model->event_attribute_count_limit =
+      node->GetInteger("event_attribute_count_limit", Config::kDefaultEventAttributeCountLimit);
+  model->link_attribute_count_limit =
+      node->GetInteger("link_attribute_count_limit", Config::kDefaultLinkAttributeCountLimit);
 
   return model;
 }
@@ -1632,6 +1661,8 @@ ConfigurationParser::ParseJaegerRemoteSamplerConfiguration(
     const std::unique_ptr<DocumentNode> &node,
     size_t depth) const
 {
+  using Config = JaegerRemoteSamplerConfiguration;
+
   auto model = std::make_unique<JaegerRemoteSamplerConfiguration>();
   std::unique_ptr<DocumentNode> child;
 
@@ -1640,7 +1671,7 @@ ConfigurationParser::ParseJaegerRemoteSamplerConfiguration(
   OTEL_INTERNAL_LOG_ERROR("JaegerRemoteSamplerConfiguration: FIXME");
 
   model->endpoint = node->GetString("endpoint", "FIXME");
-  model->interval = node->GetInteger("interval", 0);
+  model->interval = node->GetInteger("interval", Config::kDefaultIntervalMs);
 
   child = node->GetChildNode("initial_sampler");
   if (child)
@@ -1703,10 +1734,11 @@ ConfigurationParser::ParseTraceIdRatioBasedSamplerConfiguration(
     const std::unique_ptr<DocumentNode> &node,
     size_t /* depth */) const
 {
-  auto model = std::make_unique<TraceIdRatioBasedSamplerConfiguration>();
+  using Config = TraceIdRatioBasedSamplerConfiguration;
+  auto model   = std::make_unique<TraceIdRatioBasedSamplerConfiguration>();
   std::unique_ptr<DocumentNode> child;
 
-  model->ratio = node->GetDouble("ratio", 0);
+  model->ratio = node->GetDouble("ratio", Config::kDefaultRatio);
 
   return model;
 }
@@ -1732,8 +1764,9 @@ ConfigurationParser::ParseComposableProbabilitySamplerConfiguration(
     const std::unique_ptr<DocumentNode> &node,
     size_t /* depth */) const
 {
+  using Config = ComposableProbabilitySamplerConfiguration;
   auto model   = std::make_unique<ComposableProbabilitySamplerConfiguration>();
-  model->ratio = node->GetDouble("ratio", 1.0);
+  model->ratio = node->GetDouble("ratio", Config::kDefaultRatio);
   return model;
 }
 
@@ -2009,7 +2042,8 @@ std::unique_ptr<OtlpHttpSpanExporterConfiguration>
 ConfigurationParser::ParseOtlpHttpSpanExporterConfiguration(
     const std::unique_ptr<DocumentNode> &node) const
 {
-  auto model = std::make_unique<OtlpHttpSpanExporterConfiguration>();
+  using Config = OtlpHttpSpanExporterConfiguration;
+  auto model   = std::make_unique<OtlpHttpSpanExporterConfiguration>();
   std::unique_ptr<DocumentNode> child;
 
   model->endpoint = node->GetRequiredString("endpoint");
@@ -2028,7 +2062,7 @@ ConfigurationParser::ParseOtlpHttpSpanExporterConfiguration(
 
   model->headers_list = node->GetString("headers_list", "");
   model->compression  = node->GetString("compression", "");
-  model->timeout      = node->GetInteger("timeout", 10000);
+  model->timeout      = node->GetInteger("timeout", Config::kDefaultTimeoutMs);
 
   const std::string encoding = node->GetString("encoding", "protobuf");
   model->encoding            = ParseOtlpHttpEncoding(node, encoding);
@@ -2040,7 +2074,8 @@ std::unique_ptr<OtlpGrpcSpanExporterConfiguration>
 ConfigurationParser::ParseOtlpGrpcSpanExporterConfiguration(
     const std::unique_ptr<DocumentNode> &node) const
 {
-  auto model = std::make_unique<OtlpGrpcSpanExporterConfiguration>();
+  using Config = OtlpGrpcSpanExporterConfiguration;
+  auto model   = std::make_unique<OtlpGrpcSpanExporterConfiguration>();
   std::unique_ptr<DocumentNode> child;
 
   model->endpoint = node->GetRequiredString("endpoint");
@@ -2059,7 +2094,7 @@ ConfigurationParser::ParseOtlpGrpcSpanExporterConfiguration(
 
   model->headers_list = node->GetString("headers_list", "");
   model->compression  = node->GetString("compression", "");
-  model->timeout      = node->GetInteger("timeout", 10000);
+  model->timeout      = node->GetInteger("timeout", Config::kDefaultTimeoutMs);
 
   return model;
 }
@@ -2149,13 +2184,15 @@ std::unique_ptr<BatchSpanProcessorConfiguration>
 ConfigurationParser::ParseBatchSpanProcessorConfiguration(
     const std::unique_ptr<DocumentNode> &node) const
 {
-  auto model = std::make_unique<BatchSpanProcessorConfiguration>();
+  using Config = BatchSpanProcessorConfiguration;
+  auto model   = std::make_unique<BatchSpanProcessorConfiguration>();
   std::unique_ptr<DocumentNode> child;
 
-  model->schedule_delay        = node->GetInteger("schedule_delay", 5000);
-  model->export_timeout        = node->GetInteger("export_timeout", 30000);
-  model->max_queue_size        = node->GetInteger("max_queue_size", 2048);
-  model->max_export_batch_size = node->GetInteger("max_export_batch_size", 512);
+  model->schedule_delay = node->GetInteger("schedule_delay", Config::kDefaultScheduleDelayMs);
+  model->export_timeout = node->GetInteger("export_timeout", Config::kDefaultExportTimeoutMs);
+  model->max_queue_size = node->GetInteger("max_queue_size", Config::kDefaultMaxQueueSize);
+  model->max_export_batch_size =
+      node->GetInteger("max_export_batch_size", Config::kDefaultMaxExportBatchSize);
 
   child           = node->GetRequiredChildNode("exporter");
   model->exporter = ParseSpanExporterConfiguration(child);


### PR DESCRIPTION
Contributes to https://github.com/open-telemetry/opentelemetry-cpp/issues/4134


The configuration spec defines default values through `defaultBehavior` annotations and the in-memory configuration model must set the defaults. 

https://opentelemetry.io/docs/specs/otel/configuration/sdk/#in-memory-configuration-model

> If a property is present and the value is null, Create MUST use the nullBehavior, or defaultBehavior if nullBehavior is not set.

These values are currently only applied in the yaml parser and the configuration c++ objects for the in-memory model are left uninitialized. This PR moves the spec defaults from the parser into constants in each configuration object and initializes all members of the objects. 

See the schemas for the `defaultBehavior` annotations:
- https://github.com/open-telemetry/opentelemetry-configuration/blob/main/schema/logger_provider.yaml
- https://github.com/open-telemetry/opentelemetry-configuration/blob/main/schema/tracer_provider.yaml
- https://github.com/open-telemetry/opentelemetry-configuration/blob/main/schema/meter_provider.yaml

## Changes

- Adds the spec defaults parameter values as constants to the configuration classes 
- Initialize all arithmetic members of the configuration classes to the spec defaults
    - Adds TODO comments where the current default is not aligned with the spec. 
- Use the configuration class constants in the parser.  
   

For significant contributions please make sure you have completed the following items:

* [ ] `CHANGELOG.md` updated for non-trivial changes
* [ ] Unit tests have been added
* [ ] Changes in public API reviewed