### PR TITLE
[METRICS SDK] Use std::mutex for SyncMetricStorage record-path lock

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,15 @@ Increment the:
 
 ## [Unreleased]
 
+* [METRICS SDK] Fix Windows metrics tail latency on the synchronous record path:
+  `SyncMetricStorage::attribute_hashmap_lock_` now uses `std::mutex` instead of
+  `common::SpinLockMutex`. The spin lock's final `sleep_for(1ms)` back-off is
+  rounded up to the Windows timer quantum (~15.6 ms), so a waiter contending
+  on a hot instrument could stall for a full quantum, inflating tail latency.
+  `std::mutex` blocks the waiter instead. Only this one contended lock changes;
+  the API `SpinLockMutex` and all other SDK locks are unchanged.
+  [#4245](https://github.com/open-telemetry/opentelemetry-cpp/pull/4245)
+
 * [OTLP/HTTP] Honor `Retry-After` response header when retrying exports,
   supporting both delay-seconds and HTTP-date formats per RFC 7231 §7.1.3.
   [#4172](https://github.com/open-telemetry/opentelemetry-cpp/issues/4172)

--- a/sdk/include/opentelemetry/sdk/metrics/state/sync_metric_storage.h
+++ b/sdk/include/opentelemetry/sdk/metrics/state/sync_metric_storage.h
@@ -103,7 +103,7 @@ public:
     }
 #endif
     static MetricAttributes attr = MetricAttributes{};
-    std::lock_guard<opentelemetry::common::SpinLockMutex> guard(attribute_hashmap_lock_);
+    std::lock_guard<std::mutex> guard(attribute_hashmap_lock_);
 #ifdef OPENTELEMETRY_HAVE_METRICS_BOUND_INSTRUMENTS_PREVIEW
     MetricAttributes resolved = ResolveCardinality(attr);
     attributes_hashmap_->GetOrSetDefault(std::move(resolved), create_default_aggregation_)
@@ -131,7 +131,7 @@ public:
 #endif
 
     MetricAttributes attr{attributes, attributes_processor_.get()};
-    std::lock_guard<opentelemetry::common::SpinLockMutex> guard(attribute_hashmap_lock_);
+    std::lock_guard<std::mutex> guard(attribute_hashmap_lock_);
 #ifdef OPENTELEMETRY_HAVE_METRICS_BOUND_INSTRUMENTS_PREVIEW
     // Resolve via the unified cardinality policy so unbound and bound paths
     // share one combined limit (see ResolveCardinality()).
@@ -161,7 +161,7 @@ public:
     }
 #endif
     static MetricAttributes attr = MetricAttributes{};
-    std::lock_guard<opentelemetry::common::SpinLockMutex> guard(attribute_hashmap_lock_);
+    std::lock_guard<std::mutex> guard(attribute_hashmap_lock_);
 #ifdef OPENTELEMETRY_HAVE_METRICS_BOUND_INSTRUMENTS_PREVIEW
     MetricAttributes resolved = ResolveCardinality(attr);
     attributes_hashmap_->GetOrSetDefault(std::move(resolved), create_default_aggregation_)
@@ -188,7 +188,7 @@ public:
     }
 #endif
     MetricAttributes attr{attributes, attributes_processor_.get()};
-    std::lock_guard<opentelemetry::common::SpinLockMutex> guard(attribute_hashmap_lock_);
+    std::lock_guard<std::mutex> guard(attribute_hashmap_lock_);
 #ifdef OPENTELEMETRY_HAVE_METRICS_BOUND_INSTRUMENTS_PREVIEW
     MetricAttributes resolved = ResolveCardinality(std::move(attr));
     // cppcheck-suppress accessMoved
@@ -300,7 +300,7 @@ private:
   nostd::shared_ptr<ExemplarReservoir> exemplar_reservoir_;
 #endif
   TemporalMetricStorage temporal_metric_storage_;
-  opentelemetry::common::SpinLockMutex attribute_hashmap_lock_;
+  std::mutex attribute_hashmap_lock_;
 #ifdef OPENTELEMETRY_HAVE_METRICS_BOUND_INSTRUMENTS_PREVIEW
   // NOTE: ENABLE_METRICS_BOUND_INSTRUMENTS_PREVIEW changes the layout and
   // vtable of SyncMetricStorage (these conditional members and the virtual

--- a/sdk/src/metrics/state/sync_metric_storage.cc
+++ b/sdk/src/metrics/state/sync_metric_storage.cc
@@ -5,7 +5,6 @@
 #include <mutex>
 #include <utility>
 
-#include "opentelemetry/common/spin_lock_mutex.h"
 #include "opentelemetry/common/timestamp.h"
 #include "opentelemetry/nostd/function_ref.h"
 #include "opentelemetry/nostd/span.h"
@@ -23,6 +22,7 @@
 #  include <unordered_set>
 #  include <vector>
 
+#  include "opentelemetry/common/spin_lock_mutex.h"
 #  include "opentelemetry/sdk/common/global_log_handler.h"
 #  include "opentelemetry/sdk/metrics/aggregation/aggregation.h"
 #  include "opentelemetry/sdk/metrics/data/exemplar_data.h"
@@ -51,7 +51,7 @@ bool SyncMetricStorage::Collect(CollectorHandle *collector,
   std::vector<std::shared_ptr<BoundEntry>> entry_snapshot;
 #endif
   {
-    std::lock_guard<opentelemetry::common::SpinLockMutex> guard(attribute_hashmap_lock_);
+    std::lock_guard<std::mutex> guard(attribute_hashmap_lock_);
     delta_metrics = std::move(attributes_hashmap_);
     attributes_hashmap_.reset(new AttributesHashMap(aggregation_config_->cardinality_limit_));
 #ifdef OPENTELEMETRY_HAVE_METRICS_BOUND_INSTRUMENTS_PREVIEW
@@ -142,7 +142,7 @@ bool SyncMetricStorage::Collect(CollectorHandle *collector,
   // Drop snapshot refs so use_count reflects only storage + user holders.
   entry_snapshot.clear();
   {
-    std::lock_guard<opentelemetry::common::SpinLockMutex> guard(attribute_hashmap_lock_);
+    std::lock_guard<std::mutex> guard(attribute_hashmap_lock_);
     for (const auto &k : snapshot_keys)
     {
       auto it = bound_entries_.find(k);
@@ -189,7 +189,7 @@ std::shared_ptr<BoundSyncWritableMetricStorage> SyncMetricStorage::Bind(
   // Filter attributes once, at bind time.
   MetricAttributes filtered{attributes, attributes_processor_.get()};
 
-  std::lock_guard<opentelemetry::common::SpinLockMutex> guard(attribute_hashmap_lock_);
+  std::lock_guard<std::mutex> guard(attribute_hashmap_lock_);
 
   // Dedupe: same post-filter attribute set returns the same bound entry.
   auto it = bound_entries_.find(filtered);


### PR DESCRIPTION
## Problem

On Windows, `SpinLockMutex::lock()` falls through to
`std::this_thread::sleep_for(std::chrono::milliseconds(1))` as its final
back-off step. Windows rounds sleep durations up to the current system timer
resolution, which defaults to **~15.6 ms**. So a thread that loses the lock race
does not sleep ~1 ms — it parks for a **full timer quantum (~15.6 ms)**.

Under sustained contention on a single instrument (for example a hot histogram
recorded from many threads via `SyncMetricStorage`, which holds a per-stream
`SpinLockMutex`), this produces a large tail latency: the median `Record()` is a
few microseconds but **p99 jumps to ~15 ms**.

## Root cause

`sleep_for(1ms)` is not 1 ms on Windows. The intended sub-millisecond
incremental back-off becomes a ~15.6 ms stall whenever a waiter reaches the
sleep phase.

## Fix

Exploring options — see comment below for the two approaches and benchmarks; open to maintainer preference.

## Measurements

Windows 11, 6 threads hammering one histogram at ~2000 rec/s, default 15.6 ms
timer:

| build | p50 | p99 | records >= 5 ms |
|---|---|---|---|
| SpinLock (`sleep_for`) | few us | ~15 ms | ~52% |

## Notes

- Header-only change in the API; no ABI break (same size class, same public
  surface).
- `timeBeginPeriod(1)` mitigates the symptom globally but is a process-wide side
  effect, not a library-level fix.
