### PR TITLE
[ETW] Make spans own their names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ Increment the:
 ## [Unreleased]
 
 * [ETW] Ensure spans own their names until they are ended
+  [#4247](https://github.com/open-telemetry/opentelemetry-cpp/pull/4247)
 
 * [SDK] Apply metric cardinality limits to non-overflow attribute sets and
   reserve the overflow point separately.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ Increment the:
 
 ## [Unreleased]
 
+* [ETW] Ensure spans own their names until they are ended
+
 * [SDK] Apply metric cardinality limits to non-overflow attribute sets and
   reserve the overflow point separately.
   [#4236](https://github.com/open-telemetry/opentelemetry-cpp/pull/4236)

--- a/exporters/etw/include/opentelemetry/exporters/etw/etw_tracer.h
+++ b/exporters/etw/include/opentelemetry/exporters/etw/etw_tracer.h
@@ -788,7 +788,7 @@ protected:
   /**
    * @brief Span name.
    */
-  nostd::string_view name_;
+  std::string name_;
 
   /**
    * @brief Attribute indicating that the span has ended.
@@ -852,7 +852,7 @@ public:
    * @brief Get Span Name.
    * @return Span Name.
    */
-  nostd::string_view GetName() const { return name_; }
+  nostd::string_view GetName() const { return nostd::string_view{name_.data(), name_.size()}; }
 
   /**
    * @brief Span constructor
@@ -870,10 +870,10 @@ public:
       : opentelemetry::trace::Span(),
         start_time_(std::chrono::system_clock::now()),
         owner_(owner),
+        name_(name.data(), name.size()),
         context_(std::move(spanContext)),
         parent_(parent)
   {
-    name_ = name;
     UNREFERENCED_PARAMETER(options);
   }
 

--- a/exporters/etw/test/etw_tracer_test.cc
+++ b/exporters/etw/test/etw_tracer_test.cc
@@ -503,6 +503,20 @@ TEST(ETWTracer, AlwayOffTailSampler)
   auto tracer = tp.GetTracer(providerName);
 }
 
+TEST(ETWTracer, SpanOwnsName)
+{
+  exporter::etw::TracerProvider tp;
+  auto tracer = tp.GetTracer("SpanOwnsName");
+  std::string name = "original";
+  auto span = tracer->StartSpan(name);
+
+  name[0] = 'X';
+
+  auto etw_span = static_cast<exporter::etw::Span *>(span.get());
+  EXPECT_EQ(etw_span->GetName(), "original");
+  span->End();
+}
+
 TEST(ETWTracer, CustomIdGenerator)
 {
   std::string providerName = kGlobalProviderName; // supply unique instrumentation name here


### PR DESCRIPTION
Fixes #4246 

## Changes

- Store the ETW span name as an owned `std::string` instead of retaining the caller-provided `nostd::string_view`.
- Preserve the original span name when the caller modifies or destroys its source buffer before `Span::End()`.
- Add a regression test covering mutation of the caller-owned name after `StartSpan()`.

For significant contributions please make sure you have completed the following items:

* [x] `CHANGELOG.md` updated for non-trivial changes
* [x] Unit tests have been added
* [ ] Changes in public API reviewed