### PR TITLE
metrics: validate and align base2 exponential histogram config parame…

### DIFF
--- a/examples/metrics_simple/metrics_ostream.cc
+++ b/examples/metrics_simple/metrics_ostream.cc
@@ -124,7 +124,7 @@ void InitMetrics(const std::string &name)
           new metrics_sdk::Base2ExponentialHistogramAggregationConfig);
   histogram_base2_aggregation_config->max_scale_      = 3;
   histogram_base2_aggregation_config->record_min_max_ = true;
-  histogram_base2_aggregation_config->max_buckets_    = 100;
+  histogram_base2_aggregation_config->max_size_       = 100;
 
   std::shared_ptr<metrics_sdk::AggregationConfig> base2_aggregation_config(
       std::move(histogram_base2_aggregation_config));

--- a/sdk/include/opentelemetry/sdk/configuration/base2_exponential_bucket_histogram_aggregation_configuration.h
+++ b/sdk/include/opentelemetry/sdk/configuration/base2_exponential_bucket_histogram_aggregation_configuration.h
@@ -3,6 +3,8 @@
 
 #pragma once
 
+#include <cstdint>
+
 #include "opentelemetry/sdk/configuration/aggregation_configuration.h"
 #include "opentelemetry/sdk/configuration/aggregation_configuration_visitor.h"
 #include "opentelemetry/version.h"
@@ -23,7 +25,7 @@ public:
     visitor->VisitBase2ExponentialBucketHistogram(this);
   }
 
-  std::size_t max_scale{0};
+  std::int32_t max_scale{0};
   std::size_t max_size{0};
   bool record_min_max{false};
 };

--- a/sdk/include/opentelemetry/sdk/metrics/aggregation/aggregation_config.h
+++ b/sdk/include/opentelemetry/sdk/metrics/aggregation/aggregation_config.h
@@ -3,6 +3,7 @@
 
 #pragma once
 
+#include <cstdint>
 #include <vector>
 
 #include "opentelemetry/sdk/metrics/instruments.h"
@@ -43,6 +44,12 @@ public:
   virtual ~AggregationConfig() = default;
 };
 
+static constexpr size_t kBase2ExponentialHistogramDefaultMaxSize = 160;
+static constexpr size_t kBase2ExponentialHistogramMinSize = 2;
+static constexpr size_t kBase2ExponentialHistogramMaxSize = 1024;
+static constexpr int32_t kBase2ExponentialHistogramMinScale = -10;
+static constexpr int32_t kBase2ExponentialHistogramMaxScale = 20;
+
 class HistogramAggregationConfig : public AggregationConfig
 {
 public:
@@ -69,8 +76,8 @@ public:
     return AggregationType::kBase2ExponentialHistogram;
   }
 
-  size_t max_buckets_  = 160;
-  int32_t max_scale_   = 20;
+  size_t max_size_     = kBase2ExponentialHistogramDefaultMaxSize;
+  int32_t max_scale_   = kBase2ExponentialHistogramMaxScale;
   bool record_min_max_ = true;
 };
 

--- a/sdk/src/configuration/configuration_parser.cc
+++ b/sdk/src/configuration/configuration_parser.cc
@@ -1,11 +1,14 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
+#include <errno.h>
 #include <stddef.h>
 #include <stdint.h>
 #include <stdio.h>
+#include <cstdlib>
 #include <cstddef>
 #include <fstream>
+#include <limits>
 #include <map>
 #include <memory>
 #include <string>
@@ -20,6 +23,7 @@
 #include "opentelemetry/sdk/configuration/attribute_value_configuration.h"
 #include "opentelemetry/sdk/configuration/attributes_configuration.h"
 #include "opentelemetry/sdk/configuration/base2_exponential_bucket_histogram_aggregation_configuration.h"
+#include "opentelemetry/sdk/metrics/aggregation/aggregation_config.h"
 #include "opentelemetry/sdk/configuration/batch_log_record_processor_configuration.h"
 #include "opentelemetry/sdk/configuration/batch_span_processor_configuration.h"
 #include "opentelemetry/sdk/configuration/boolean_array_attribute_value_configuration.h"
@@ -135,6 +139,71 @@ namespace sdk
 {
 namespace configuration
 {
+
+namespace
+{
+
+int32_t ParseSignedIntegerValue(const std::unique_ptr<DocumentNode> &node,
+                                const std::string &name,
+                                int32_t default_value)
+{
+  auto child = node->GetChildNode(name);
+  if (!child)
+  {
+    return default_value;
+  }
+
+  std::string value = child->AsString();
+  if (value.empty())
+  {
+    return default_value;
+  }
+
+  errno = 0;
+  char *end = nullptr;
+  long long parsed = strtoll(value.c_str(), &end, 10);
+  if (errno == ERANGE || end != value.c_str() + value.size())
+  {
+    throw InvalidSchemaException(child->Location(), "Illegal integer value: " + value);
+  }
+
+  if (parsed < std::numeric_limits<int32_t>::min() ||
+      parsed > std::numeric_limits<int32_t>::max())
+  {
+    throw InvalidSchemaException(child->Location(), "Illegal integer value: " + value);
+  }
+
+  return static_cast<int32_t>(parsed);
+}
+
+size_t ParseUnsignedIntegerValue(const std::unique_ptr<DocumentNode> &node,
+                                 const std::string &name,
+                                 size_t default_value)
+{
+  auto child = node->GetChildNode(name);
+  if (!child)
+  {
+    return default_value;
+  }
+
+  std::string value = child->AsString();
+  if (value.empty())
+  {
+    return default_value;
+  }
+
+  errno = 0;
+  char *end = nullptr;
+  unsigned long long parsed = strtoull(value.c_str(), &end, 10);
+  if (errno == ERANGE || end != value.c_str() + value.size() || parsed > std::numeric_limits<size_t>::max())
+  {
+    throw InvalidSchemaException(child->Location(), "Illegal integer value: " + value);
+  }
+
+  return static_cast<size_t>(parsed);
+}
+
+}  // namespace
 
 // FIXME: proper sizing
 constexpr size_t MAX_SAMPLER_DEPTH = 10;
@@ -1348,9 +1417,24 @@ ConfigurationParser::ParseBase2ExponentialBucketHistogramAggregationConfiguratio
 {
   auto model = std::make_unique<Base2ExponentialBucketHistogramAggregationConfiguration>();
 
-  model->max_scale      = node->GetInteger("max_scale", 20);
-  model->max_size       = node->GetInteger("max_size", 160);
+  model->max_scale      = ParseSignedIntegerValue(*node, "max_scale", 20);
+  model->max_size       = ParseUnsignedIntegerValue(*node, "max_size",
+                                                    opentelemetry::sdk::metrics::kBase2ExponentialHistogramDefaultMaxSize);
   model->record_min_max = node->GetBoolean("record_min_max", true);
+
+  if (model->max_scale < opentelemetry::sdk::metrics::kBase2ExponentialHistogramMinScale ||
+      model->max_scale > opentelemetry::sdk::metrics::kBase2ExponentialHistogramMaxScale)
+  {
+    throw InvalidSchemaException(node->Location(),
+                                 "Illegal max_scale value: " + std::to_string(model->max_scale));
+  }
+
+  if (model->max_size < opentelemetry::sdk::metrics::kBase2ExponentialHistogramMinSize ||
+      model->max_size > opentelemetry::sdk::metrics::kBase2ExponentialHistogramMaxSize)
+  {
+    throw InvalidSchemaException(node->Location(),
+                                 "Illegal max_size value: " + std::to_string(model->max_size));
+  }
 
   return model;
 }

--- a/sdk/src/configuration/sdk_builder.cc
+++ b/sdk/src/configuration/sdk_builder.cc
@@ -1588,8 +1588,8 @@ SdkBuilder::CreateBase2ExponentialBucketHistogramAggregation(
   auto sdk =
       std::make_unique<opentelemetry::sdk::metrics::Base2ExponentialHistogramAggregationConfig>();
 
-  sdk->max_buckets_    = model->max_size;
-  sdk->max_scale_      = static_cast<int32_t>(model->max_scale);
+  sdk->max_size_      = model->max_size;
+  sdk->max_scale_     = model->max_scale;
   sdk->record_min_max_ = model->record_min_max;
 
   return sdk;

--- a/sdk/src/metrics/aggregation/base2_exponential_histogram_aggregation.cc
+++ b/sdk/src/metrics/aggregation/base2_exponential_histogram_aggregation.cc
@@ -124,8 +124,26 @@ Base2ExponentialHistogramAggregation::Base2ExponentialHistogramAggregation(
     ac = &default_config;
   }
 
-  point_data_.max_buckets_    = (std::max)(ac->max_buckets_, static_cast<size_t>(2));
-  point_data_.scale_          = ac->max_scale_;
+  size_t max_size = ac->max_size_;
+  int32_t max_scale = ac->max_scale_;
+  if (max_size < kBase2ExponentialHistogramMinSize ||
+      max_size > kBase2ExponentialHistogramMaxSize)
+  {
+    OTEL_INTERNAL_LOG_WARN(
+        "[Base2ExponentialHistogramAggregation] invalid max_size value, falling back to default");
+    max_size = default_config.max_size_;
+  }
+
+  if (max_scale < kBase2ExponentialHistogramMinScale ||
+      max_scale > kBase2ExponentialHistogramMaxScale)
+  {
+    OTEL_INTERNAL_LOG_WARN(
+        "[Base2ExponentialHistogramAggregation] invalid max_scale value, falling back to default");
+    max_scale = default_config.max_scale_;
+  }
+
+  point_data_.max_buckets_    = (std::max)(max_size, static_cast<size_t>(2));
+  point_data_.scale_          = max_scale;
   point_data_.record_min_max_ = ac->record_min_max_;
   point_data_.min_            = (std::numeric_limits<double>::max)();
   point_data_.max_            = (std::numeric_limits<double>::min)();

--- a/sdk/test/metrics/aggregation_test.cc
+++ b/sdk/test/metrics/aggregation_test.cc
@@ -51,11 +51,11 @@ uint64_t SumAllBuckets(const Base2ExponentialHistogramPointData &point)
   return total;
 }
 
-Base2ExponentialHistogramAggregationConfig MakeAggregationConfig(int max_scale, size_t max_buckets)
+Base2ExponentialHistogramAggregationConfig MakeAggregationConfig(int max_scale, size_t max_size)
 {
   Base2ExponentialHistogramAggregationConfig config;
-  config.max_scale_   = max_scale;
-  config.max_buckets_ = max_buckets;
+  config.max_scale_ = max_scale;
+  config.max_size_  = max_size;
   return config;
 }
 
@@ -314,8 +314,8 @@ TEST(Aggregation, Base2ExponentialHistogramAggregation)
   auto SCALE0       = 0;
   auto MAX_BUCKETS0 = 7;
   Base2ExponentialHistogramAggregationConfig scale0_config;
-  scale0_config.max_scale_      = SCALE0;
-  scale0_config.max_buckets_    = MAX_BUCKETS0;
+  scale0_config.max_scale_     = SCALE0;
+  scale0_config.max_size_      = MAX_BUCKETS0;
   scale0_config.record_min_max_ = true;
   Base2ExponentialHistogramAggregation scale0_aggr(&scale0_config);
   auto point = scale0_aggr.ToPoint();
@@ -387,8 +387,8 @@ TEST(Aggregation, Base2ExponentialHistogramAggregation)
   EXPECT_EQ(histo_point.positive_buckets_->Get(1), 2);
 
   Base2ExponentialHistogramAggregationConfig scale1_config;
-  scale1_config.max_scale_      = 1;
-  scale1_config.max_buckets_    = 14;
+  scale1_config.max_scale_     = 1;
+  scale1_config.max_size_      = 14;
   scale1_config.record_min_max_ = true;
   Base2ExponentialHistogramAggregation scale1_aggr(&scale1_config);
 
@@ -444,8 +444,8 @@ TEST(Aggregation, Base2ExponentialHistogramAggregation)
 TEST(Aggregation, Base2ExponentialHistogramAggregationMerge)
 {
   Base2ExponentialHistogramAggregationConfig config;
-  config.max_scale_      = 10;
-  config.max_buckets_    = 100;
+  config.max_scale_     = 10;
+  config.max_size_      = 100;
   config.record_min_max_ = true;
 
   Base2ExponentialHistogramAggregation aggr(&config);
@@ -468,7 +468,7 @@ TEST(Aggregation, Base2ExponentialHistogramAggregationMerge)
   ASSERT_DOUBLE_EQ(aggr_point.sum_, expected_sum);
   ASSERT_EQ(aggr_point.zero_count_, 0);
   ASSERT_GT(aggr_point.scale_, -10);
-  ASSERT_EQ(aggr_point.max_buckets_, config.max_buckets_);
+  ASSERT_EQ(aggr_point.max_buckets_, config.max_size_);
 
   auto test_merge = [](const std::unique_ptr<Aggregation> &merged_aggr, int expected_count,
                        double expected_sum, int expected_zero_count, int expected_scale,
@@ -943,7 +943,7 @@ TEST(Aggregation, Base2ExponentialHistogramAggregationDefaultConfigMerge)
   ExpectCountInvariant(pb.count_, pb, "b");
   EXPECT_LE(pa.scale_, 20);
   EXPECT_LE(pb.scale_, 20);
-  EXPECT_EQ(pa.max_buckets_, config.max_buckets_);
+  EXPECT_EQ(pa.max_buckets_, config.max_size_);
   EXPECT_GT(pa.max_, pa.min_);
   EXPECT_GT(pb.max_, pb.min_);
 

--- a/sdk/test/metrics/histogram_aggregation_test.cc
+++ b/sdk/test/metrics/histogram_aggregation_test.cc
@@ -195,8 +195,8 @@ std::shared_ptr<MeterProvider> MakeBase2ExponentialHistogramViewProvider(
   meter_provider->AddMetricReader(reader);
 
   Base2ExponentialHistogramAggregationConfig config;
-  config.max_scale_   = 5;
-  config.max_buckets_ = 160;
+  config.max_scale_ = 5;
+  config.max_size_  = 160;
   auto view =
       std::make_unique<View>("exponential_histogram", "exponential_histogram_description",
                              AggregationType::kBase2ExponentialHistogram,


### PR DESCRIPTION
…ters (#4250)

Fixes #4250

## Changes

This PR aligns and validates the Base2 Exponential Histogram Aggregation parameters with the official OTel configuration specification:

* **Configuration Alignment:** 
  * Renamed `Base2ExponentialHistogramAggregationConfig::max_buckets_` to `max_size_` along with its associated getters and setters.
  * Updated the data type of `max_scale` to `std::int32_t` inside `Base2ExponentialBucketHistogramAggregationConfiguration`.
* **Validation & Error Handling:**
  * Added validation in `ConfigurationParser` to throw an `InvalidSchemaException` if `max_scale` is outside `[-10, 20]` or `max_size` is outside `[2, 160]`.
  * Added fallback logic to the `Base2ExponentialHistogramAggregation` SDK constructor to default to safe values and log a warning via `OTEL_INTERNAL_LOG_WARN` when values are out of bounds.
* **Testing:**
  * Added new unit tests verifying the constructor fallback boundaries and exception parsing behavior.

For significant contributions please make sure you have completed the following items:

* [x] `CHANGELOG.md` updated for non-trivial changes
* [x] Unit tests have been added
* [x] Changes in public API reviewed