### PR TITLE
[CMAKE] Upgrade to protobuf 35.1 and grpc 1.82.1

### DIFF
--- a/cmake/grpc.cmake
+++ b/cmake/grpc.cmake
@@ -23,7 +23,6 @@ if(NOT gRPC_FOUND)
           "third_party/abseil-cpp"
           "third_party/protobuf"
           "third_party/cares/cares"
-          "third_party/boringssl-with-bazel"
       )
   set(gRPC_PROVIDER "fetch_repository")
 
@@ -38,6 +37,7 @@ if(NOT gRPC_FOUND)
   set(gRPC_BUILD_GRPC_PYTHON_PLUGIN OFF CACHE BOOL "" FORCE)
   set(gRPC_BUILD_GRPC_RUBY_PLUGIN OFF CACHE BOOL "" FORCE)
   set(gRPC_BUILD_GRPCPP_OTEL_PLUGIN OFF CACHE BOOL "" FORCE)
+  set(gRPC_SSL_PROVIDER "package" CACHE STRING "" FORCE)
   set(gRPC_ZLIB_PROVIDER "package" CACHE STRING "" FORCE)
   set(gRPC_RE2_PROVIDER "module"  CACHE STRING "" FORCE)
   set(RE2_BUILD_TESTING OFF CACHE BOOL "" FORCE)

--- a/exporters/otlp/test/otlp_http_exporter_test.cc
+++ b/exporters/otlp/test/otlp_http_exporter_test.cc
@@ -423,9 +423,14 @@ public:
             [&mock_session, report_trace_id, &received_trace_id_counter](
                 const std::shared_ptr<opentelemetry::ext::http::client::EventHandler> &callback) {
               opentelemetry::proto::collector::trace::v1::ExportTraceServiceRequest request_body;
-              request_body.ParseFromArray(
+              const bool parsed = request_body.ParseFromArray(
                   &mock_session->GetRequest()->body_[0],
                   static_cast<int>(mock_session->GetRequest()->body_.size()));
+              EXPECT_TRUE(parsed);
+              if (!parsed)
+              {
+                return;
+              }
               if (request_body.resource_spans_size() == 0 ||
                   request_body.resource_spans(0).scope_spans_size() == 0 ||
                   request_body.resource_spans(0).scope_spans(0).spans_size() == 0)
@@ -520,9 +525,14 @@ public:
             [&mock_session, report_trace_id, &received_trace_id_counter](
                 const std::shared_ptr<opentelemetry::ext::http::client::EventHandler> &callback) {
               opentelemetry::proto::collector::trace::v1::ExportTraceServiceRequest request_body;
-              request_body.ParseFromArray(
+              const bool parsed = request_body.ParseFromArray(
                   &mock_session->GetRequest()->body_[0],
                   static_cast<int>(mock_session->GetRequest()->body_.size()));
+              EXPECT_TRUE(parsed);
+              if (!parsed)
+              {
+                return;
+              }
               if (request_body.resource_spans_size() == 0 ||
                   request_body.resource_spans(0).scope_spans_size() == 0 ||
                   request_body.resource_spans(0).scope_spans(0).spans_size() == 0)

--- a/exporters/otlp/test/otlp_http_log_record_exporter_test.cc
+++ b/exporters/otlp/test/otlp_http_log_record_exporter_test.cc
@@ -462,9 +462,14 @@ public:
             [&mock_session, report_trace_id, report_span_id, &received_record_counter](
                 const std::shared_ptr<opentelemetry::ext::http::client::EventHandler> &callback) {
               opentelemetry::proto::collector::logs::v1::ExportLogsServiceRequest request_body;
-              request_body.ParseFromArray(
+              const bool parsed = request_body.ParseFromArray(
                   &mock_session->GetRequest()->body_[0],
                   static_cast<int>(mock_session->GetRequest()->body_.size()));
+              EXPECT_TRUE(parsed);
+              if (!parsed)
+              {
+                return;
+              }
               if (request_body.resource_logs_size() == 0 ||
                   request_body.resource_logs(0).scope_logs_size() == 0 ||
                   request_body.resource_logs(0).scope_logs(0).log_records_size() == 0)
@@ -590,9 +595,14 @@ public:
             [&mock_session, report_trace_id, report_span_id, schema_url, &received_record_counter](
                 const std::shared_ptr<opentelemetry::ext::http::client::EventHandler> &callback) {
               opentelemetry::proto::collector::logs::v1::ExportLogsServiceRequest request_body;
-              request_body.ParseFromArray(
+              const bool parsed = request_body.ParseFromArray(
                   &mock_session->GetRequest()->body_[0],
                   static_cast<int>(mock_session->GetRequest()->body_.size()));
+              EXPECT_TRUE(parsed);
+              if (!parsed)
+              {
+                return;
+              }
               if (request_body.resource_logs_size() == 0 ||
                   request_body.resource_logs(0).scope_logs_size() == 0 ||
                   request_body.resource_logs(0).scope_logs(0).log_records_size() == 0)

--- a/exporters/otlp/test/otlp_http_metric_exporter_test.cc
+++ b/exporters/otlp/test/otlp_http_metric_exporter_test.cc
@@ -301,8 +301,14 @@ public:
                             const std::shared_ptr<opentelemetry::ext::http::client::EventHandler>
                                 &callback) {
           opentelemetry::proto::collector::metrics::v1::ExportMetricsServiceRequest request_body;
-          request_body.ParseFromArray(&mock_session->GetRequest()->body_[0],
-                                      static_cast<int>(mock_session->GetRequest()->body_.size()));
+          const bool parsed = request_body.ParseFromArray(
+              &mock_session->GetRequest()->body_[0],
+              static_cast<int>(mock_session->GetRequest()->body_.size()));
+          EXPECT_TRUE(parsed);
+          if (!parsed)
+          {
+            return;
+          }
           if (request_body.resource_metrics_size() == 0 ||
               request_body.resource_metrics(0).scope_metrics_size() == 0 ||
               request_body.resource_metrics(0).scope_metrics(0).metrics_size() == 0)
@@ -522,8 +528,14 @@ public:
                             const std::shared_ptr<opentelemetry::ext::http::client::EventHandler>
                                 &callback) {
           opentelemetry::proto::collector::metrics::v1::ExportMetricsServiceRequest request_body;
-          request_body.ParseFromArray(&mock_session->GetRequest()->body_[0],
-                                      static_cast<int>(mock_session->GetRequest()->body_.size()));
+          const bool parsed = request_body.ParseFromArray(
+              &mock_session->GetRequest()->body_[0],
+              static_cast<int>(mock_session->GetRequest()->body_.size()));
+          EXPECT_TRUE(parsed);
+          if (!parsed)
+          {
+            return;
+          }
           if (request_body.resource_metrics_size() == 0 ||
               request_body.resource_metrics(0).scope_metrics_size() == 0 ||
               request_body.resource_metrics(0).scope_metrics(0).metrics_size() == 0)
@@ -788,8 +800,14 @@ public:
                             const std::shared_ptr<opentelemetry::ext::http::client::EventHandler>
                                 &callback) {
           opentelemetry::proto::collector::metrics::v1::ExportMetricsServiceRequest request_body;
-          request_body.ParseFromArray(&mock_session->GetRequest()->body_[0],
-                                      static_cast<int>(mock_session->GetRequest()->body_.size()));
+          const bool parsed = request_body.ParseFromArray(
+              &mock_session->GetRequest()->body_[0],
+              static_cast<int>(mock_session->GetRequest()->body_.size()));
+          EXPECT_TRUE(parsed);
+          if (!parsed)
+          {
+            return;
+          }
           if (request_body.resource_metrics_size() == 0 ||
               request_body.resource_metrics(0).scope_metrics_size() == 0 ||
               request_body.resource_metrics(0).scope_metrics(0).metrics_size() == 0)

--- a/install/cmake/CMakeLists.txt
+++ b/install/cmake/CMakeLists.txt
@@ -223,7 +223,6 @@ if(grpc IN_LIST _THIRDPARTY_PACKAGE_LIST)
     GIT_TAG ${grpc_GIT_TAG}
     GIT_SHALLOW ON
     GIT_SUBMODULES "third_party/re2" "third_party/cares/cares"
-                   "third_party/boringssl-with-bazel"
     PREFIX ${CMAKE_BINARY_DIR}/external/grpc
     INSTALL_DIR ${CMAKE_INSTALL_PREFIX}
     CMAKE_ARGS "${CMAKE_OPTIONS}"
@@ -238,6 +237,7 @@ if(grpc IN_LIST _THIRDPARTY_PACKAGE_LIST)
                "-DgRPC_BUILD_GRPC_RUBY_PLUGIN=OFF"
                "-DgRPC_BUILD_GRPCPP_OTEL_PLUGIN=OFF"
                "-DRE2_BUILD_TESTING=OFF"
+               "-DgRPC_SSL_PROVIDER=package"
                "-DgRPC_ZLIB_PROVIDER=package"
                "-DgRPC_PROTOBUF_PROVIDER=package"
                "-DgRPC_PROTOBUF_PACKAGE_TYPE=CONFIG"

--- a/install/cmake/third_party_latest
+++ b/install/cmake/third_party_latest
@@ -7,8 +7,8 @@
 abseil=20250512.1
 zlib=v1.3.2
 curl=curl-8_21_0
-protobuf=v33.6
-grpc=v1.81.1
+protobuf=v35.1
+grpc=v1.82.1
 benchmark=v1.9.4
 googletest=v1.17.0
 ms-gsl=v4.2.1

--- a/third_party_release
+++ b/third_party_release
@@ -16,8 +16,8 @@
 abseil=20250512.1
 zlib=v1.3.2
 curl=curl-8_21_0
-protobuf=v33.6
-grpc=v1.81.1
+protobuf=v35.1
+grpc=v1.82.1
 benchmark=v1.9.4
 googletest=v1.17.0
 ms-gsl=v4.2.1


### PR DESCRIPTION
Fixes # (issue)

## Changes

- Upgrade the CMake build to protobuf 35.1 and grpc 1.82.1
- Fix warnings from ParseFromArray which had the [[nodiscard]] attribute added.
- Fix Curl incorrectly finding Borring SSL installed by gRPC after the upgrade by using system OpenSSL for curl and gRPC. 

For significant contributions please make sure you have completed the following items:

* [ ] `CHANGELOG.md` updated for non-trivial changes
* [ ] Unit tests have been added
* [ ] Changes in public API reviewed