### PR TITLE
[SDK] Read span limits from environment variables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,12 @@ Increment the:
 
 ## [Unreleased]
 
+* [SDK] Read span limits from the environment variables defined in the
+        specification (OTEL_SPAN_ATTRIBUTE_COUNT_LIMIT, OTEL_SPAN_EVENT_COUNT_LIMIT,
+        OTEL_SPAN_LINK_COUNT_LIMIT, ...) in the TracerProviderFactory overloads
+        that do not receive explicit SpanLimits
+  [#4258](https://github.com/open-telemetry/opentelemetry-cpp/pull/4258)
+
 * docs: update supported development platforms
   [#4260](https://github.com/open-telemetry/opentelemetry-cpp/pull/4260)
 

--- a/sdk/include/opentelemetry/sdk/trace/span_limits.h
+++ b/sdk/include/opentelemetry/sdk/trace/span_limits.h
@@ -63,6 +63,24 @@ struct SpanLimits
   }
 };
 
+namespace span_limits_env
+{
+
+/**
+ * @brief Returns span limits read from the environment variables defined in the
+ * OpenTelemetry specification
+ * (https://opentelemetry.io/docs/specs/otel/configuration/sdk-environment-variables/#span-limits).
+ *
+ * A field whose environment variable is not set keeps its SpanLimits::NoLimits() value, so with
+ * no variables set the result equals SpanLimits::NoLimits() and SDK behavior is unchanged. The
+ * span-specific variables (OTEL_SPAN_ATTRIBUTE_VALUE_LENGTH_LIMIT,
+ * OTEL_SPAN_ATTRIBUTE_COUNT_LIMIT) take precedence over the general ones
+ * (OTEL_ATTRIBUTE_VALUE_LENGTH_LIMIT, OTEL_ATTRIBUTE_COUNT_LIMIT).
+ */
+OPENTELEMETRY_EXPORT SpanLimits GetSpanLimitsFromEnv();
+
+}  // namespace span_limits_env
+
 }  // namespace trace
 }  // namespace sdk
 OPENTELEMETRY_END_NAMESPACE

--- a/sdk/include/opentelemetry/sdk/trace/span_limits.h
+++ b/sdk/include/opentelemetry/sdk/trace/span_limits.h
@@ -71,13 +71,15 @@ namespace span_limits_env
  * OpenTelemetry specification
  * (https://opentelemetry.io/docs/specs/otel/configuration/sdk-environment-variables/#span-limits).
  *
- * A field whose environment variable is not set keeps its SpanLimits::NoLimits() value, so with
- * no variables set the result equals SpanLimits::NoLimits() and SDK behavior is unchanged. The
+ * A field whose environment variable is not set keeps its value from @p defaults, so with no
+ * variables set the result equals @p defaults. The default of SpanLimits::NoLimits() leaves SDK
+ * behavior unchanged; pass SpanLimits{} to fall back to the specification defaults instead. The
  * span-specific variables (OTEL_SPAN_ATTRIBUTE_VALUE_LENGTH_LIMIT,
  * OTEL_SPAN_ATTRIBUTE_COUNT_LIMIT) take precedence over the general ones
  * (OTEL_ATTRIBUTE_VALUE_LENGTH_LIMIT, OTEL_ATTRIBUTE_COUNT_LIMIT).
  */
-OPENTELEMETRY_EXPORT SpanLimits GetSpanLimitsFromEnv();
+OPENTELEMETRY_EXPORT SpanLimits
+GetSpanLimitsFromEnv(const SpanLimits &defaults = SpanLimits::NoLimits());
 
 }  // namespace span_limits_env
 

--- a/sdk/src/trace/BUILD
+++ b/sdk/src/trace/BUILD
@@ -15,6 +15,7 @@ cc_library(
         "//sdk:headers",
         "//sdk/src/common:disabled",
         "//sdk/src/common:empty_attributes",
+        "//sdk/src/common:env_variables",
         "//sdk/src/common:global_log_handler",
         "//sdk/src/common:random",
         "//sdk/src/resource",

--- a/sdk/src/trace/CMakeLists.txt
+++ b/sdk/src/trace/CMakeLists.txt
@@ -16,6 +16,7 @@ add_library(
   batch_span_processor_options.cc
   simple_processor_factory.cc
   span_data.cc
+  span_limits.cc
   samplers/always_on_factory.cc
   samplers/always_off_factory.cc
   samplers/parent.cc

--- a/sdk/src/trace/span_limits.cc
+++ b/sdk/src/trace/span_limits.cc
@@ -51,9 +51,9 @@ void UpdateFromEnv(const char *env_var_name, std::size_t &limit)
 
 }  // namespace
 
-SpanLimits GetSpanLimitsFromEnv()
+SpanLimits GetSpanLimitsFromEnv(const SpanLimits &defaults)
 {
-  SpanLimits limits = SpanLimits::NoLimits();
+  SpanLimits limits = defaults;
 
   // General attribute limits first; the span-specific variables below take precedence.
   UpdateFromEnv(kAttributeValueLengthLimitEnv, limits.attribute_value_length_limit);

--- a/sdk/src/trace/span_limits.cc
+++ b/sdk/src/trace/span_limits.cc
@@ -1,0 +1,75 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+#include <cstddef>
+#include <cstdint>
+
+#include "opentelemetry/sdk/common/env_variables.h"
+#include "opentelemetry/sdk/trace/span_limits.h"
+#include "opentelemetry/version.h"
+
+OPENTELEMETRY_BEGIN_NAMESPACE
+namespace sdk
+{
+namespace trace
+{
+namespace span_limits_env
+{
+
+// Environment variable names, see
+// https://opentelemetry.io/docs/specs/otel/configuration/sdk-environment-variables/#span-limits
+static constexpr const char *kAttributeValueLengthLimitEnv = "OTEL_ATTRIBUTE_VALUE_LENGTH_LIMIT";
+static constexpr const char *kAttributeCountLimitEnv       = "OTEL_ATTRIBUTE_COUNT_LIMIT";
+static constexpr const char *kSpanAttributeValueLengthLimitEnv =
+    "OTEL_SPAN_ATTRIBUTE_VALUE_LENGTH_LIMIT";
+static constexpr const char *kSpanAttributeCountLimitEnv  = "OTEL_SPAN_ATTRIBUTE_COUNT_LIMIT";
+static constexpr const char *kSpanEventCountLimitEnv      = "OTEL_SPAN_EVENT_COUNT_LIMIT";
+static constexpr const char *kSpanLinkCountLimitEnv       = "OTEL_SPAN_LINK_COUNT_LIMIT";
+static constexpr const char *kEventAttributeCountLimitEnv = "OTEL_EVENT_ATTRIBUTE_COUNT_LIMIT";
+static constexpr const char *kLinkAttributeCountLimitEnv  = "OTEL_LINK_ATTRIBUTE_COUNT_LIMIT";
+
+namespace
+{
+
+void UpdateFromEnv(const char *env_var_name, std::uint32_t &limit)
+{
+  std::uint32_t value{};
+  if (opentelemetry::sdk::common::GetUintEnvironmentVariable(env_var_name, value))
+  {
+    limit = value;
+  }
+}
+
+void UpdateFromEnv(const char *env_var_name, std::size_t &limit)
+{
+  std::uint32_t value{};
+  if (opentelemetry::sdk::common::GetUintEnvironmentVariable(env_var_name, value))
+  {
+    limit = static_cast<std::size_t>(value);
+  }
+}
+
+}  // namespace
+
+SpanLimits GetSpanLimitsFromEnv()
+{
+  SpanLimits limits = SpanLimits::NoLimits();
+
+  // General attribute limits first; the span-specific variables below take precedence.
+  UpdateFromEnv(kAttributeValueLengthLimitEnv, limits.attribute_value_length_limit);
+  UpdateFromEnv(kAttributeCountLimitEnv, limits.attribute_count_limit);
+
+  UpdateFromEnv(kSpanAttributeValueLengthLimitEnv, limits.attribute_value_length_limit);
+  UpdateFromEnv(kSpanAttributeCountLimitEnv, limits.attribute_count_limit);
+  UpdateFromEnv(kSpanEventCountLimitEnv, limits.event_count_limit);
+  UpdateFromEnv(kSpanLinkCountLimitEnv, limits.link_count_limit);
+  UpdateFromEnv(kEventAttributeCountLimitEnv, limits.event_attribute_count_limit);
+  UpdateFromEnv(kLinkAttributeCountLimitEnv, limits.link_attribute_count_limit);
+
+  return limits;
+}
+
+}  // namespace span_limits_env
+}  // namespace trace
+}  // namespace sdk
+OPENTELEMETRY_END_NAMESPACE

--- a/sdk/src/trace/tracer_provider_factory.cc
+++ b/sdk/src/trace/tracer_provider_factory.cc
@@ -71,7 +71,7 @@ std::unique_ptr<opentelemetry::sdk::trace::TracerProvider> TracerProviderFactory
     std::unique_ptr<instrumentationscope::ScopeConfigurator<TracerConfig>> tracer_configurator)
 {
   return Create(std::move(processor), resource, std::move(sampler), std::move(id_generator),
-                std::move(tracer_configurator), SpanLimits::NoLimits());
+                std::move(tracer_configurator), span_limits_env::GetSpanLimitsFromEnv());
 }
 
 std::unique_ptr<opentelemetry::sdk::trace::TracerProvider> TracerProviderFactory::Create(
@@ -135,7 +135,7 @@ std::unique_ptr<opentelemetry::sdk::trace::TracerProvider> TracerProviderFactory
     std::unique_ptr<instrumentationscope::ScopeConfigurator<TracerConfig>> tracer_configurator)
 {
   return Create(std::move(processors), resource, std::move(sampler), std::move(id_generator),
-                std::move(tracer_configurator), SpanLimits::NoLimits());
+                std::move(tracer_configurator), span_limits_env::GetSpanLimitsFromEnv());
 }
 
 std::unique_ptr<opentelemetry::sdk::trace::TracerProvider> TracerProviderFactory::Create(

--- a/sdk/test/trace/tracer_provider_test.cc
+++ b/sdk/test/trace/tracer_provider_test.cc
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include <gtest/gtest.h>
+#include <stdlib.h>
 #include <atomic>
 #include <cstddef>
 #include <cstdint>
@@ -36,6 +37,12 @@
 #include "opentelemetry/sdk/trace/tracer_provider_factory.h"
 #include "opentelemetry/trace/span.h"
 #include "opentelemetry/trace/tracer.h"
+
+#if defined(_MSC_VER)
+#  include "opentelemetry/sdk/common/env_variables.h"
+using opentelemetry::sdk::common::setenv;
+using opentelemetry::sdk::common::unsetenv;
+#endif
 
 #if OPENTELEMETRY_ABI_VERSION_NO >= 2
 #  include <initializer_list>
@@ -567,6 +574,102 @@ TEST(TracerProvider, SpanLimitsTracerProviderFactoryCreate)
   EXPECT_EQ(stored.link_count_limit, limits.link_count_limit);
   EXPECT_EQ(stored.event_attribute_count_limit, limits.event_attribute_count_limit);
   EXPECT_EQ(stored.link_attribute_count_limit, limits.link_attribute_count_limit);
+}
+
+namespace
+{
+
+void UnsetSpanLimitsEnv()
+{
+  unsetenv("OTEL_ATTRIBUTE_VALUE_LENGTH_LIMIT");
+  unsetenv("OTEL_ATTRIBUTE_COUNT_LIMIT");
+  unsetenv("OTEL_SPAN_ATTRIBUTE_VALUE_LENGTH_LIMIT");
+  unsetenv("OTEL_SPAN_ATTRIBUTE_COUNT_LIMIT");
+  unsetenv("OTEL_SPAN_EVENT_COUNT_LIMIT");
+  unsetenv("OTEL_SPAN_LINK_COUNT_LIMIT");
+  unsetenv("OTEL_EVENT_ATTRIBUTE_COUNT_LIMIT");
+  unsetenv("OTEL_LINK_ATTRIBUTE_COUNT_LIMIT");
+}
+
+}  // namespace
+
+TEST(TracerProvider, SpanLimitsFromEnvUnsetIsNoLimits)
+{
+  UnsetSpanLimitsEnv();
+
+  const SpanLimits limits    = span_limits_env::GetSpanLimitsFromEnv();
+  const SpanLimits no_limits = SpanLimits::NoLimits();
+  EXPECT_EQ(limits.attribute_count_limit, no_limits.attribute_count_limit);
+  EXPECT_EQ(limits.attribute_value_length_limit, no_limits.attribute_value_length_limit);
+  EXPECT_EQ(limits.event_count_limit, no_limits.event_count_limit);
+  EXPECT_EQ(limits.link_count_limit, no_limits.link_count_limit);
+  EXPECT_EQ(limits.event_attribute_count_limit, no_limits.event_attribute_count_limit);
+  EXPECT_EQ(limits.link_attribute_count_limit, no_limits.link_attribute_count_limit);
+}
+
+TEST(TracerProvider, SpanLimitsFromEnvReadsVariables)
+{
+  UnsetSpanLimitsEnv();
+  setenv("OTEL_SPAN_ATTRIBUTE_VALUE_LENGTH_LIMIT", "100", 1);
+  setenv("OTEL_SPAN_ATTRIBUTE_COUNT_LIMIT", "5", 1);
+  setenv("OTEL_SPAN_EVENT_COUNT_LIMIT", "3", 1);
+  setenv("OTEL_SPAN_LINK_COUNT_LIMIT", "2", 1);
+  setenv("OTEL_EVENT_ATTRIBUTE_COUNT_LIMIT", "4", 1);
+  setenv("OTEL_LINK_ATTRIBUTE_COUNT_LIMIT", "6", 1);
+
+  const SpanLimits limits = span_limits_env::GetSpanLimitsFromEnv();
+  EXPECT_EQ(limits.attribute_value_length_limit, 100u);
+  EXPECT_EQ(limits.attribute_count_limit, 5u);
+  EXPECT_EQ(limits.event_count_limit, 3u);
+  EXPECT_EQ(limits.link_count_limit, 2u);
+  EXPECT_EQ(limits.event_attribute_count_limit, 4u);
+  EXPECT_EQ(limits.link_attribute_count_limit, 6u);
+
+  UnsetSpanLimitsEnv();
+}
+
+TEST(TracerProvider, SpanLimitsFromEnvGeneralAttributeVariablesApply)
+{
+  UnsetSpanLimitsEnv();
+  setenv("OTEL_ATTRIBUTE_VALUE_LENGTH_LIMIT", "50", 1);
+  setenv("OTEL_ATTRIBUTE_COUNT_LIMIT", "10", 1);
+
+  const SpanLimits limits = span_limits_env::GetSpanLimitsFromEnv();
+  EXPECT_EQ(limits.attribute_value_length_limit, 50u);
+  EXPECT_EQ(limits.attribute_count_limit, 10u);
+  EXPECT_EQ(limits.event_count_limit, (std::numeric_limits<std::uint32_t>::max)());
+
+  UnsetSpanLimitsEnv();
+}
+
+TEST(TracerProvider, SpanLimitsFromEnvSpanSpecificTakesPrecedence)
+{
+  UnsetSpanLimitsEnv();
+  setenv("OTEL_ATTRIBUTE_VALUE_LENGTH_LIMIT", "50", 1);
+  setenv("OTEL_ATTRIBUTE_COUNT_LIMIT", "10", 1);
+  setenv("OTEL_SPAN_ATTRIBUTE_VALUE_LENGTH_LIMIT", "100", 1);
+  setenv("OTEL_SPAN_ATTRIBUTE_COUNT_LIMIT", "20", 1);
+
+  const SpanLimits limits = span_limits_env::GetSpanLimitsFromEnv();
+  EXPECT_EQ(limits.attribute_value_length_limit, 100u);
+  EXPECT_EQ(limits.attribute_count_limit, 20u);
+
+  UnsetSpanLimitsEnv();
+}
+
+TEST(TracerProvider, SpanLimitsTracerProviderFactoryCreateDefaultReadsEnv)
+{
+  UnsetSpanLimitsEnv();
+  setenv("OTEL_SPAN_EVENT_COUNT_LIMIT", "42", 1);
+
+  auto provider = TracerProviderFactory::Create(std::make_unique<SimpleSpanProcessor>(nullptr));
+
+  const auto &limits = provider->GetSpanLimits();
+  EXPECT_EQ(limits.event_count_limit, 42u);
+  EXPECT_EQ(limits.attribute_count_limit, (std::numeric_limits<std::uint32_t>::max)());
+  EXPECT_EQ(limits.link_count_limit, (std::numeric_limits<std::uint32_t>::max)());
+
+  UnsetSpanLimitsEnv();
 }
 
 TEST(TracerProvider, SpanLimitsTracerProviderFactoryCreateDefault)

--- a/sdk/test/trace/tracer_provider_test.cc
+++ b/sdk/test/trace/tracer_provider_test.cc
@@ -635,8 +635,8 @@ TEST(TracerProvider, SpanLimitsFromEnvCustomFallbackDefaults)
 
   const SpanLimits limits = span_limits_env::GetSpanLimitsFromEnv(SpanLimits{});
   EXPECT_EQ(limits.event_count_limit, 42u);
-  EXPECT_EQ(limits.attribute_count_limit, SpanLimits::kDefaultAttributeCountLimit);
-  EXPECT_EQ(limits.link_count_limit, SpanLimits::kDefaultLinkCountLimit);
+  EXPECT_EQ(limits.attribute_count_limit, 128u);
+  EXPECT_EQ(limits.link_count_limit, 128u);
 
   UnsetSpanLimitsEnv();
 }

--- a/sdk/test/trace/tracer_provider_test.cc
+++ b/sdk/test/trace/tracer_provider_test.cc
@@ -628,6 +628,19 @@ TEST(TracerProvider, SpanLimitsFromEnvReadsVariables)
   UnsetSpanLimitsEnv();
 }
 
+TEST(TracerProvider, SpanLimitsFromEnvCustomFallbackDefaults)
+{
+  UnsetSpanLimitsEnv();
+  setenv("OTEL_SPAN_EVENT_COUNT_LIMIT", "42", 1);
+
+  const SpanLimits limits = span_limits_env::GetSpanLimitsFromEnv(SpanLimits{});
+  EXPECT_EQ(limits.event_count_limit, 42u);
+  EXPECT_EQ(limits.attribute_count_limit, SpanLimits::kDefaultAttributeCountLimit);
+  EXPECT_EQ(limits.link_count_limit, SpanLimits::kDefaultLinkCountLimit);
+
+  UnsetSpanLimitsEnv();
+}
+
 TEST(TracerProvider, SpanLimitsFromEnvGeneralAttributeVariablesApply)
 {
   UnsetSpanLimitsEnv();


### PR DESCRIPTION
Fixes #4257

## Changes

Adds `span_limits_env::GetSpanLimitsFromEnv()`, which builds a `SpanLimits` from the [environment variables defined in the specification](https://opentelemetry.io/docs/specs/otel/configuration/sdk-environment-variables/#span-limits), and uses it as the default in the `TracerProviderFactory::Create` overloads that previously defaulted to `SpanLimits::NoLimits()`. The implementation mirrors the existing `batch_span_processor_options_env` pattern (`OTEL_BSP_*`).

Semantics, chosen to preserve the backward-compatible default established in #4232:

- A field whose environment variable is unset keeps its `SpanLimits::NoLimits()` value — with no variables set, `GetSpanLimitsFromEnv() == SpanLimits::NoLimits()` and SDK behavior is unchanged.
- Supported variables: `OTEL_SPAN_ATTRIBUTE_VALUE_LENGTH_LIMIT`, `OTEL_SPAN_ATTRIBUTE_COUNT_LIMIT`, `OTEL_SPAN_EVENT_COUNT_LIMIT`, `OTEL_SPAN_LINK_COUNT_LIMIT`, `OTEL_EVENT_ATTRIBUTE_COUNT_LIMIT`, `OTEL_LINK_ATTRIBUTE_COUNT_LIMIT`, plus the general `OTEL_ATTRIBUTE_VALUE_LENGTH_LIMIT` / `OTEL_ATTRIBUTE_COUNT_LIMIT`, with the span-specific variables taking precedence per the spec.
- Explicitly passed `SpanLimits` (programmatic, or declarative configuration through the sdk builder) continue to take precedence over the environment, matching the spec's configuration-precedence order.

Follow-up once merged: flip the C++ cells of the span-limit env-variable rows in the [spec compliance matrix](https://github.com/open-telemetry/opentelemetry-specification/blob/main/spec-compliance-matrix.md#environment-variables) (separate PR to the specification repo).

For significant contributions please make sure you have completed the following items:

* [x] `CHANGELOG.md` updated for non-trivial changes
* [x] Unit tests have been added
* [x] Changes in public API reviewed