### PR TITLE
[CODE HEALTH] Fix more clang tidy warnings (member initialization) 

### DIFF
--- a/.github/workflows/clang-tidy.yaml
+++ b/.github/workflows/clang-tidy.yaml
@@ -17,9 +17,9 @@ jobs:
       matrix:
         include:
           - cmake_options: all-options-abiv1-preview
-            warning_limit: 216
+            warning_limit: 163
           - cmake_options: all-options-abiv2-preview
-            warning_limit: 226
+            warning_limit: 173
     env:
       CC: /usr/bin/clang-22
       CXX: /usr/bin/clang++-22

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,9 @@ Increment the:
 
 ## [Unreleased]
 
+* [CODE HEALTH] Fix more clang tidy warnings (member initialization)
+  [#4270](https://github.com/open-telemetry/opentelemetry-cpp/pull/4270)
+
 * docs: update supported development platforms
   [#4260](https://github.com/open-telemetry/opentelemetry-cpp/pull/4260)
 

--- a/api/include/opentelemetry/baggage/baggage.h
+++ b/api/include/opentelemetry/baggage/baggage.h
@@ -142,7 +142,7 @@ public:
         value    = value.substr(0, metadata_separator);
       }
 
-      bool err       = 0;
+      bool err       = false;
       auto key_str   = UrlDecode(common::StringUtil::Trim(key), err);
       auto value_str = UrlDecode(common::StringUtil::Trim(value), err);
 
@@ -264,7 +264,7 @@ private:
       {
         if (i + 2 >= str.size() || !IsHex(str[i + 1]) || !IsHex(str[i + 2]))
         {
-          err = 1;
+          err = true;
           return "";
         }
         ret.push_back(static_cast<char>(from_hex(str[i + 1]) << 4 | from_hex(str[i + 2])));
@@ -286,7 +286,7 @@ private:
       }
       else
       {
-        err = 1;
+        err = true;
         return "";
       }
     }

--- a/api/include/opentelemetry/trace/span_id.h
+++ b/api/include/opentelemetry/trace/span_id.h
@@ -20,7 +20,7 @@ public:
   static constexpr size_t kSize = 8;
 
   // An invalid SpanId (all zeros).
-  SpanId() noexcept : rep_{0} {}
+  SpanId() noexcept = default;
 
   // Creates a SpanId with the given ID.
   explicit SpanId(nostd::span<const uint8_t, kSize> id) noexcept { memcpy(rep_, id.data(), kSize); }
@@ -60,7 +60,7 @@ public:
   }
 
 private:
-  uint8_t rep_[kSize];
+  uint8_t rep_[kSize]{};
 };
 
 }  // namespace trace

--- a/api/include/opentelemetry/trace/trace_id.h
+++ b/api/include/opentelemetry/trace/trace_id.h
@@ -23,7 +23,7 @@ public:
   static constexpr size_t kSize = 16;
 
   // An invalid TraceId (all zeros).
-  TraceId() noexcept : rep_{0} {}
+  TraceId() noexcept = default;
 
   // Creates a TraceId with the given ID.
   explicit TraceId(nostd::span<const uint8_t, kSize> id) noexcept
@@ -65,7 +65,7 @@ public:
   }
 
 private:
-  uint8_t rep_[kSize];
+  uint8_t rep_[kSize]{};
 };
 
 }  // namespace trace

--- a/examples/http/server.cc
+++ b/examples/http/server.cc
@@ -107,7 +107,7 @@ int main(int argc, char *argv[])
   Scope scope(root_span);
   http_server.Start();
   std::cout << "Server is running..Press ctrl-c to exit...\n";
-  while (1)
+  while (true)
   {
     std::this_thread::sleep_for(std::chrono::seconds(100));
   }

--- a/exporters/otlp/include/opentelemetry/exporters/otlp/otlp_grpc_client_options.h
+++ b/exporters/otlp/include/opentelemetry/exporters/otlp/otlp_grpc_client_options.h
@@ -61,7 +61,7 @@ struct OtlpGrpcClientOptions
 #endif
 
   /** Export timeout. */
-  std::chrono::system_clock::duration timeout;
+  std::chrono::system_clock::duration timeout{};
 
   /** Additional HTTP headers. */
   OtlpHeaders metadata;

--- a/exporters/otlp/include/opentelemetry/exporters/otlp/otlp_grpc_metric_exporter_options.h
+++ b/exporters/otlp/include/opentelemetry/exporters/otlp/otlp_grpc_metric_exporter_options.h
@@ -36,7 +36,7 @@ struct OPENTELEMETRY_EXPORT OtlpGrpcMetricExporterOptions : public OtlpGrpcClien
 
   /** Preferred Aggregation Temporality. */
   PreferredAggregationTemporality aggregation_temporality{
-      PreferredAggregationTemporality::kUnspecified};
+      PreferredAggregationTemporality::kCumulative};
 };
 
 }  // namespace otlp

--- a/exporters/otlp/include/opentelemetry/exporters/otlp/otlp_grpc_metric_exporter_options.h
+++ b/exporters/otlp/include/opentelemetry/exporters/otlp/otlp_grpc_metric_exporter_options.h
@@ -35,7 +35,8 @@ struct OPENTELEMETRY_EXPORT OtlpGrpcMetricExporterOptions : public OtlpGrpcClien
   ~OtlpGrpcMetricExporterOptions() override;
 
   /** Preferred Aggregation Temporality. */
-  PreferredAggregationTemporality aggregation_temporality;
+  PreferredAggregationTemporality aggregation_temporality{
+      PreferredAggregationTemporality::kUnspecified};
 };
 
 }  // namespace otlp

--- a/exporters/otlp/include/opentelemetry/exporters/otlp/otlp_http_client.h
+++ b/exporters/otlp/include/opentelemetry/exporters/otlp/otlp_http_client.h
@@ -72,7 +72,7 @@ struct OtlpHttpClientOptions
   // Whether to print the status of the HTTP client in the console
   bool console_debug = false;
 
-  std::chrono::system_clock::duration timeout;
+  std::chrono::system_clock::duration timeout{};
 
   // Additional HTTP headers
   OtlpHeaders http_headers;

--- a/exporters/otlp/include/opentelemetry/exporters/otlp/otlp_http_exporter_options.h
+++ b/exporters/otlp/include/opentelemetry/exporters/otlp/otlp_http_exporter_options.h
@@ -60,27 +60,27 @@ struct OPENTELEMETRY_EXPORT OtlpHttpExporterOptions
   /**
     Use json names (true) or protobuf field names (false) to set the json key.
   */
-  bool use_json_name;
+  bool use_json_name{false};
 
   /** Print debug messages. */
-  bool console_debug;
+  bool console_debug{false};
 
   /** Export timeout. */
-  std::chrono::system_clock::duration timeout;
+  std::chrono::system_clock::duration timeout{};
 
   /** Additional HTTP headers. */
   OtlpHeaders http_headers;
 
 #ifdef ENABLE_ASYNC_EXPORT
   /** Max number of concurrent requests. */
-  std::size_t max_concurrent_requests;
+  std::size_t max_concurrent_requests{};
 
   /** Max number of requests per connection. */
-  std::size_t max_requests_per_connection;
+  std::size_t max_requests_per_connection{};
 #endif
 
   /** True do disable SSL. */
-  bool ssl_insecure_skip_verify;
+  bool ssl_insecure_skip_verify{};
 
   /** CA CERT, path to a file. */
   std::string ssl_ca_cert_path;

--- a/exporters/otlp/include/opentelemetry/exporters/otlp/otlp_http_exporter_options.h
+++ b/exporters/otlp/include/opentelemetry/exporters/otlp/otlp_http_exporter_options.h
@@ -47,7 +47,7 @@ struct OPENTELEMETRY_EXPORT OtlpHttpExporterOptions
   std::string url;
 
   /** HTTP content type. */
-  HttpRequestContentType content_type;
+  HttpRequestContentType content_type{HttpRequestContentType::kBinary};
 
   /**
     Json byte mapping.
@@ -55,7 +55,7 @@ struct OPENTELEMETRY_EXPORT OtlpHttpExporterOptions
     Used only for HttpRequestContentType::kJson.
     Convert bytes to hex / base64.
   */
-  JsonBytesMappingKind json_bytes_mapping;
+  JsonBytesMappingKind json_bytes_mapping{JsonBytesMappingKind::kHexId};
 
   /**
     Use json names (true) or protobuf field names (false) to set the json key.
@@ -73,10 +73,10 @@ struct OPENTELEMETRY_EXPORT OtlpHttpExporterOptions
 
 #ifdef ENABLE_ASYNC_EXPORT
   /** Max number of concurrent requests. */
-  std::size_t max_concurrent_requests{};
+  std::size_t max_concurrent_requests{64};
 
   /** Max number of requests per connection. */
-  std::size_t max_requests_per_connection{};
+  std::size_t max_requests_per_connection{8};
 #endif
 
   /** True do disable SSL. */

--- a/exporters/otlp/include/opentelemetry/exporters/otlp/otlp_http_log_record_exporter_options.h
+++ b/exporters/otlp/include/opentelemetry/exporters/otlp/otlp_http_log_record_exporter_options.h
@@ -46,7 +46,7 @@ struct OPENTELEMETRY_EXPORT OtlpHttpLogRecordExporterOptions
   std::string url;
 
   /** HTTP content type. */
-  HttpRequestContentType content_type;
+  HttpRequestContentType content_type{HttpRequestContentType::kBinary};
 
   /**
     Json byte mapping.
@@ -54,7 +54,7 @@ struct OPENTELEMETRY_EXPORT OtlpHttpLogRecordExporterOptions
     Used only for HttpRequestContentType::kJson.
     Convert bytes to hex / base64.
   */
-  JsonBytesMappingKind json_bytes_mapping;
+  JsonBytesMappingKind json_bytes_mapping{JsonBytesMappingKind::kHexId};
 
   /**
     Use json names (true) or protobuf field names (false) to set the json key.
@@ -72,10 +72,10 @@ struct OPENTELEMETRY_EXPORT OtlpHttpLogRecordExporterOptions
 
 #ifdef ENABLE_ASYNC_EXPORT
   /** Max number of concurrent requests. */
-  std::size_t max_concurrent_requests{};
+  std::size_t max_concurrent_requests{64};
 
   /** Max number of requests per connection. */
-  std::size_t max_requests_per_connection{};
+  std::size_t max_requests_per_connection{8};
 #endif
 
   /** True do disable SSL. */

--- a/exporters/otlp/include/opentelemetry/exporters/otlp/otlp_http_log_record_exporter_options.h
+++ b/exporters/otlp/include/opentelemetry/exporters/otlp/otlp_http_log_record_exporter_options.h
@@ -59,27 +59,27 @@ struct OPENTELEMETRY_EXPORT OtlpHttpLogRecordExporterOptions
   /**
     Use json names (true) or protobuf field names (false) to set the json key.
   */
-  bool use_json_name;
+  bool use_json_name{false};
 
   /** Print debug messages. */
-  bool console_debug;
+  bool console_debug{false};
 
   /** Export timeout. */
-  std::chrono::system_clock::duration timeout;
+  std::chrono::system_clock::duration timeout{};
 
   /** Additional HTTP headers. */
   OtlpHeaders http_headers;
 
 #ifdef ENABLE_ASYNC_EXPORT
   /** Max number of concurrent requests. */
-  std::size_t max_concurrent_requests;
+  std::size_t max_concurrent_requests{};
 
   /** Max number of requests per connection. */
-  std::size_t max_requests_per_connection;
+  std::size_t max_requests_per_connection{};
 #endif
 
   /** True do disable SSL. */
-  bool ssl_insecure_skip_verify;
+  bool ssl_insecure_skip_verify{};
 
   /** CA CERT, path to a file. */
   std::string ssl_ca_cert_path;

--- a/exporters/otlp/include/opentelemetry/exporters/otlp/otlp_http_metric_exporter_options.h
+++ b/exporters/otlp/include/opentelemetry/exporters/otlp/otlp_http_metric_exporter_options.h
@@ -60,29 +60,29 @@ struct OPENTELEMETRY_EXPORT OtlpHttpMetricExporterOptions
   /**
     Use json names (true) or protobuf field names (false) to set the json key.
   */
-  bool use_json_name;
+  bool use_json_name{false};
 
   /** Print debug messages. */
-  bool console_debug;
+  bool console_debug{false};
 
   /** Export timeout. */
-  std::chrono::system_clock::duration timeout;
+  std::chrono::system_clock::duration timeout{};
 
   /** Additional HTTP headers. */
   OtlpHeaders http_headers;
 
-  PreferredAggregationTemporality aggregation_temporality;
+  PreferredAggregationTemporality aggregation_temporality{};
 
 #ifdef ENABLE_ASYNC_EXPORT
   /** Max number of concurrent requests. */
-  std::size_t max_concurrent_requests;
+  std::size_t max_concurrent_requests{};
 
   /** Max number of requests per connection. */
-  std::size_t max_requests_per_connection;
+  std::size_t max_requests_per_connection{};
 #endif
 
   /** True do disable SSL. */
-  bool ssl_insecure_skip_verify;
+  bool ssl_insecure_skip_verify{};
 
   /** CA CERT, path to a file. */
   std::string ssl_ca_cert_path;

--- a/exporters/otlp/include/opentelemetry/exporters/otlp/otlp_http_metric_exporter_options.h
+++ b/exporters/otlp/include/opentelemetry/exporters/otlp/otlp_http_metric_exporter_options.h
@@ -47,7 +47,7 @@ struct OPENTELEMETRY_EXPORT OtlpHttpMetricExporterOptions
   std::string url;
 
   /** HTTP content type. */
-  HttpRequestContentType content_type;
+  HttpRequestContentType content_type{HttpRequestContentType::kBinary};
 
   /**
     Json byte mapping.
@@ -55,7 +55,7 @@ struct OPENTELEMETRY_EXPORT OtlpHttpMetricExporterOptions
     Used only for HttpRequestContentType::kJson.
     Convert bytes to hex / base64.
   */
-  JsonBytesMappingKind json_bytes_mapping;
+  JsonBytesMappingKind json_bytes_mapping{JsonBytesMappingKind::kHexId};
 
   /**
     Use json names (true) or protobuf field names (false) to set the json key.
@@ -71,14 +71,15 @@ struct OPENTELEMETRY_EXPORT OtlpHttpMetricExporterOptions
   /** Additional HTTP headers. */
   OtlpHeaders http_headers;
 
-  PreferredAggregationTemporality aggregation_temporality{};
+  PreferredAggregationTemporality aggregation_temporality{
+      PreferredAggregationTemporality::kCumulative};
 
 #ifdef ENABLE_ASYNC_EXPORT
   /** Max number of concurrent requests. */
-  std::size_t max_concurrent_requests{};
+  std::size_t max_concurrent_requests{64};
 
   /** Max number of requests per connection. */
-  std::size_t max_requests_per_connection{};
+  std::size_t max_requests_per_connection{8};
 #endif
 
   /** True do disable SSL. */

--- a/exporters/otlp/src/otlp_file_client.cc
+++ b/exporters/otlp/src/otlp_file_client.cc
@@ -1569,16 +1569,16 @@ private:
 
   struct FileStats
   {
-    std::atomic<bool> is_shutdown;
-    std::size_t rotate_index;
-    std::size_t written_size;
-    std::size_t left_flush_record_count;
+    std::atomic<bool> is_shutdown{false};
+    std::size_t rotate_index{0};
+    std::size_t written_size{0};
+    std::size_t left_flush_record_count{0};
     std::shared_ptr<std::FILE> current_file;
     std::mutex file_lock;
-    std::time_t last_checkpoint;
+    std::time_t last_checkpoint{0};
     std::string file_path;
-    std::atomic<std::size_t> record_count;
-    std::atomic<std::size_t> flushed_record_count;
+    std::atomic<std::size_t> record_count{0};
+    std::atomic<std::size_t> flushed_record_count{0};
 
     std::unique_ptr<std::thread> background_flush_thread;
     std::mutex background_thread_lock;

--- a/exporters/otlp/src/otlp_grpc_metric_exporter_options.cc
+++ b/exporters/otlp/src/otlp_grpc_metric_exporter_options.cc
@@ -16,7 +16,6 @@ namespace otlp
 {
 
 OtlpGrpcMetricExporterOptions::OtlpGrpcMetricExporterOptions()
-    : aggregation_temporality(PreferredAggregationTemporality::kCumulative)
 {
   endpoint                    = GetOtlpDefaultGrpcMetricsEndpoint();
   use_ssl_credentials         = !GetOtlpDefaultGrpcMetricsIsInsecure(); /* negation intended. */
@@ -48,7 +47,6 @@ OtlpGrpcMetricExporterOptions::OtlpGrpcMetricExporterOptions()
 }
 
 OtlpGrpcMetricExporterOptions::OtlpGrpcMetricExporterOptions(void *)
-    : aggregation_temporality(PreferredAggregationTemporality::kCumulative)
 {
   use_ssl_credentials = true;
   max_threads         = 0;

--- a/exporters/otlp/src/otlp_grpc_metric_exporter_options.cc
+++ b/exporters/otlp/src/otlp_grpc_metric_exporter_options.cc
@@ -6,7 +6,6 @@
 
 #include "opentelemetry/exporters/otlp/otlp_environment.h"
 #include "opentelemetry/exporters/otlp/otlp_grpc_metric_exporter_options.h"
-#include "opentelemetry/exporters/otlp/otlp_preferred_temporality.h"
 #include "opentelemetry/version.h"
 
 OPENTELEMETRY_BEGIN_NAMESPACE

--- a/exporters/otlp/src/otlp_http_exporter_options.cc
+++ b/exporters/otlp/src/otlp_http_exporter_options.cc
@@ -16,15 +16,12 @@ OtlpHttpExporterOptions::OtlpHttpExporterOptions()
     : url(GetOtlpDefaultHttpTracesEndpoint()),
       content_type(GetOtlpHttpProtocolFromString(GetOtlpDefaultHttpTracesProtocol())),
       json_bytes_mapping(JsonBytesMappingKind::kHexId),
-      use_json_name(false),
-      console_debug(false),
       timeout(GetOtlpDefaultTracesTimeout()),
       http_headers(GetOtlpDefaultTracesHeaders()),
 #ifdef ENABLE_ASYNC_EXPORT
       max_concurrent_requests{64},
       max_requests_per_connection{8},
 #endif
-      ssl_insecure_skip_verify(false),
       ssl_ca_cert_path(GetOtlpDefaultTracesSslCertificatePath()),
       ssl_ca_cert_string(GetOtlpDefaultTracesSslCertificateString()),
       ssl_client_key_path(GetOtlpDefaultTracesSslClientKeyPath()),
@@ -45,14 +42,12 @@ OtlpHttpExporterOptions::OtlpHttpExporterOptions()
 OtlpHttpExporterOptions::OtlpHttpExporterOptions(void *)
     : url(),
       content_type(HttpRequestContentType::kBinary),
-      json_bytes_mapping(JsonBytesMappingKind::kHexId),
-      use_json_name(false),
-      console_debug(false),
+      json_bytes_mapping(JsonBytesMappingKind::kHexId)
 #ifdef ENABLE_ASYNC_EXPORT
+      ,
       max_concurrent_requests{64},
-      max_requests_per_connection{8},
+      max_requests_per_connection{8}
 #endif
-      ssl_insecure_skip_verify(false)
 {}
 
 OtlpHttpExporterOptions::~OtlpHttpExporterOptions() {}

--- a/exporters/otlp/src/otlp_http_exporter_options.cc
+++ b/exporters/otlp/src/otlp_http_exporter_options.cc
@@ -15,13 +15,8 @@ namespace otlp
 OtlpHttpExporterOptions::OtlpHttpExporterOptions()
     : url(GetOtlpDefaultHttpTracesEndpoint()),
       content_type(GetOtlpHttpProtocolFromString(GetOtlpDefaultHttpTracesProtocol())),
-      json_bytes_mapping(JsonBytesMappingKind::kHexId),
       timeout(GetOtlpDefaultTracesTimeout()),
       http_headers(GetOtlpDefaultTracesHeaders()),
-#ifdef ENABLE_ASYNC_EXPORT
-      max_concurrent_requests{64},
-      max_requests_per_connection{8},
-#endif
       ssl_ca_cert_path(GetOtlpDefaultTracesSslCertificatePath()),
       ssl_ca_cert_string(GetOtlpDefaultTracesSslCertificateString()),
       ssl_client_key_path(GetOtlpDefaultTracesSslClientKeyPath()),
@@ -39,16 +34,7 @@ OtlpHttpExporterOptions::OtlpHttpExporterOptions()
       retry_policy_backoff_multiplier(GetOtlpDefaultTracesRetryBackoffMultiplier())
 {}
 
-OtlpHttpExporterOptions::OtlpHttpExporterOptions(void *)
-    : url(),
-      content_type(HttpRequestContentType::kBinary),
-      json_bytes_mapping(JsonBytesMappingKind::kHexId)
-#ifdef ENABLE_ASYNC_EXPORT
-      ,
-      max_concurrent_requests{64},
-      max_requests_per_connection{8}
-#endif
-{}
+OtlpHttpExporterOptions::OtlpHttpExporterOptions(void *) {}
 
 OtlpHttpExporterOptions::~OtlpHttpExporterOptions() {}
 

--- a/exporters/otlp/src/otlp_http_log_record_exporter_options.cc
+++ b/exporters/otlp/src/otlp_http_log_record_exporter_options.cc
@@ -16,15 +16,12 @@ OtlpHttpLogRecordExporterOptions::OtlpHttpLogRecordExporterOptions()
     : url(GetOtlpDefaultHttpLogsEndpoint()),
       content_type(GetOtlpHttpProtocolFromString(GetOtlpDefaultHttpLogsProtocol())),
       json_bytes_mapping(JsonBytesMappingKind::kHexId),
-      use_json_name(false),
-      console_debug(false),
       timeout(GetOtlpDefaultLogsTimeout()),
       http_headers(GetOtlpDefaultLogsHeaders()),
 #ifdef ENABLE_ASYNC_EXPORT
       max_concurrent_requests{64},
       max_requests_per_connection{8},
 #endif
-      ssl_insecure_skip_verify(false),
       ssl_ca_cert_path(GetOtlpDefaultLogsSslCertificatePath()),
       ssl_ca_cert_string(GetOtlpDefaultLogsSslCertificateString()),
       ssl_client_key_path(GetOtlpDefaultLogsSslClientKeyPath()),
@@ -45,14 +42,12 @@ OtlpHttpLogRecordExporterOptions::OtlpHttpLogRecordExporterOptions()
 OtlpHttpLogRecordExporterOptions::OtlpHttpLogRecordExporterOptions(void *)
     : url(),
       content_type(exporter::otlp::HttpRequestContentType::kBinary),
-      json_bytes_mapping(JsonBytesMappingKind::kHexId),
-      use_json_name(false),
-      console_debug(false),
+      json_bytes_mapping(JsonBytesMappingKind::kHexId)
 #ifdef ENABLE_ASYNC_EXPORT
+      ,
       max_concurrent_requests{64},
-      max_requests_per_connection{8},
+      max_requests_per_connection{8}
 #endif
-      ssl_insecure_skip_verify(false)
 {}
 
 OtlpHttpLogRecordExporterOptions::~OtlpHttpLogRecordExporterOptions() {}

--- a/exporters/otlp/src/otlp_http_log_record_exporter_options.cc
+++ b/exporters/otlp/src/otlp_http_log_record_exporter_options.cc
@@ -15,13 +15,8 @@ namespace otlp
 OtlpHttpLogRecordExporterOptions::OtlpHttpLogRecordExporterOptions()
     : url(GetOtlpDefaultHttpLogsEndpoint()),
       content_type(GetOtlpHttpProtocolFromString(GetOtlpDefaultHttpLogsProtocol())),
-      json_bytes_mapping(JsonBytesMappingKind::kHexId),
       timeout(GetOtlpDefaultLogsTimeout()),
       http_headers(GetOtlpDefaultLogsHeaders()),
-#ifdef ENABLE_ASYNC_EXPORT
-      max_concurrent_requests{64},
-      max_requests_per_connection{8},
-#endif
       ssl_ca_cert_path(GetOtlpDefaultLogsSslCertificatePath()),
       ssl_ca_cert_string(GetOtlpDefaultLogsSslCertificateString()),
       ssl_client_key_path(GetOtlpDefaultLogsSslClientKeyPath()),
@@ -39,16 +34,7 @@ OtlpHttpLogRecordExporterOptions::OtlpHttpLogRecordExporterOptions()
       retry_policy_backoff_multiplier(GetOtlpDefaultLogsRetryBackoffMultiplier())
 {}
 
-OtlpHttpLogRecordExporterOptions::OtlpHttpLogRecordExporterOptions(void *)
-    : url(),
-      content_type(exporter::otlp::HttpRequestContentType::kBinary),
-      json_bytes_mapping(JsonBytesMappingKind::kHexId)
-#ifdef ENABLE_ASYNC_EXPORT
-      ,
-      max_concurrent_requests{64},
-      max_requests_per_connection{8}
-#endif
-{}
+OtlpHttpLogRecordExporterOptions::OtlpHttpLogRecordExporterOptions(void *) {}
 
 OtlpHttpLogRecordExporterOptions::~OtlpHttpLogRecordExporterOptions() {}
 

--- a/exporters/otlp/src/otlp_http_metric_exporter_options.cc
+++ b/exporters/otlp/src/otlp_http_metric_exporter_options.cc
@@ -17,8 +17,6 @@ OtlpHttpMetricExporterOptions::OtlpHttpMetricExporterOptions()
     : url(GetOtlpDefaultMetricsEndpoint()),
       content_type(GetOtlpHttpProtocolFromString(GetOtlpDefaultHttpMetricsProtocol())),
       json_bytes_mapping(JsonBytesMappingKind::kHexId),
-      use_json_name(false),
-      console_debug(false),
       timeout(GetOtlpDefaultMetricsTimeout()),
       http_headers(GetOtlpDefaultMetricsHeaders()),
       aggregation_temporality(PreferredAggregationTemporality::kCumulative),
@@ -26,7 +24,6 @@ OtlpHttpMetricExporterOptions::OtlpHttpMetricExporterOptions()
       max_concurrent_requests{64},
       max_requests_per_connection{8},
 #endif
-      ssl_insecure_skip_verify(false),
       ssl_ca_cert_path(GetOtlpDefaultMetricsSslCertificatePath()),
       ssl_ca_cert_string(GetOtlpDefaultMetricsSslCertificateString()),
       ssl_client_key_path(GetOtlpDefaultMetricsSslClientKeyPath()),
@@ -48,14 +45,12 @@ OtlpHttpMetricExporterOptions::OtlpHttpMetricExporterOptions(void *)
     : url(),
       content_type(exporter::otlp::HttpRequestContentType::kBinary),
       json_bytes_mapping(JsonBytesMappingKind::kHexId),
-      use_json_name(false),
-      console_debug(false),
-      aggregation_temporality(PreferredAggregationTemporality::kCumulative),
+      aggregation_temporality(PreferredAggregationTemporality::kCumulative)
 #ifdef ENABLE_ASYNC_EXPORT
+      ,
       max_concurrent_requests{64},
-      max_requests_per_connection{8},
+      max_requests_per_connection{8}
 #endif
-      ssl_insecure_skip_verify(false)
 {}
 
 OtlpHttpMetricExporterOptions::~OtlpHttpMetricExporterOptions() {}

--- a/exporters/otlp/src/otlp_http_metric_exporter_options.cc
+++ b/exporters/otlp/src/otlp_http_metric_exporter_options.cc
@@ -4,7 +4,6 @@
 #include "opentelemetry/exporters/otlp/otlp_http_metric_exporter_options.h"
 #include "opentelemetry/exporters/otlp/otlp_environment.h"
 #include "opentelemetry/exporters/otlp/otlp_http.h"
-#include "opentelemetry/exporters/otlp/otlp_preferred_temporality.h"
 #include "opentelemetry/version.h"
 
 OPENTELEMETRY_BEGIN_NAMESPACE

--- a/exporters/otlp/src/otlp_http_metric_exporter_options.cc
+++ b/exporters/otlp/src/otlp_http_metric_exporter_options.cc
@@ -16,14 +16,8 @@ namespace otlp
 OtlpHttpMetricExporterOptions::OtlpHttpMetricExporterOptions()
     : url(GetOtlpDefaultMetricsEndpoint()),
       content_type(GetOtlpHttpProtocolFromString(GetOtlpDefaultHttpMetricsProtocol())),
-      json_bytes_mapping(JsonBytesMappingKind::kHexId),
       timeout(GetOtlpDefaultMetricsTimeout()),
       http_headers(GetOtlpDefaultMetricsHeaders()),
-      aggregation_temporality(PreferredAggregationTemporality::kCumulative),
-#ifdef ENABLE_ASYNC_EXPORT
-      max_concurrent_requests{64},
-      max_requests_per_connection{8},
-#endif
       ssl_ca_cert_path(GetOtlpDefaultMetricsSslCertificatePath()),
       ssl_ca_cert_string(GetOtlpDefaultMetricsSslCertificateString()),
       ssl_client_key_path(GetOtlpDefaultMetricsSslClientKeyPath()),
@@ -41,17 +35,7 @@ OtlpHttpMetricExporterOptions::OtlpHttpMetricExporterOptions()
       retry_policy_backoff_multiplier(GetOtlpDefaultMetricsRetryBackoffMultiplier())
 {}
 
-OtlpHttpMetricExporterOptions::OtlpHttpMetricExporterOptions(void *)
-    : url(),
-      content_type(exporter::otlp::HttpRequestContentType::kBinary),
-      json_bytes_mapping(JsonBytesMappingKind::kHexId),
-      aggregation_temporality(PreferredAggregationTemporality::kCumulative)
-#ifdef ENABLE_ASYNC_EXPORT
-      ,
-      max_concurrent_requests{64},
-      max_requests_per_connection{8}
-#endif
-{}
+OtlpHttpMetricExporterOptions::OtlpHttpMetricExporterOptions(void *) {}
 
 OtlpHttpMetricExporterOptions::~OtlpHttpMetricExporterOptions() {}
 

--- a/ext/include/opentelemetry/ext/http/client/curl/http_operation_curl.h
+++ b/ext/include/opentelemetry/ext/http/client/curl/http_operation_curl.h
@@ -323,7 +323,7 @@ private:
   const bool reuse_connection_{false};    // Reuse connection
   const std::chrono::milliseconds http_conn_timeout_;  // Timeout for connect.  Default: 5000ms
 
-  char curl_error_message_[CURL_ERROR_SIZE];
+  char curl_error_message_[CURL_ERROR_SIZE]{};
   HttpCurlEasyResource curl_resource_;
   CURLcode last_curl_result_{CURLE_OK};  // Curl result OR HTTP status code if successful
 
@@ -361,7 +361,7 @@ private:
 
   struct AsyncData
   {
-    Session *session;  // Owner Session
+    Session *session{nullptr};  // Owner Session
 
     std::thread::id callback_thread;
     std::function<void(HttpOperation &)> callback;

--- a/ext/include/opentelemetry/ext/http/server/http_server.h
+++ b/ext/include/opentelemetry/ext/http/server/http_server.h
@@ -42,7 +42,7 @@ struct HttpRequest
 
 struct HttpResponse
 {
-  int code;
+  int code{0};
   std::string message;
   std::map<std::string, std::string> headers;
   std::string body;
@@ -108,9 +108,9 @@ protected:
       SendingHeaders,
       SendingBody,
       Closing
-    } state;
-    size_t contentLength;
-    bool keepalive;
+    } state{Idle};
+    size_t contentLength{0};
+    bool keepalive{false};
     HttpRequest request;
     HttpResponse response;
   };
@@ -783,7 +783,7 @@ protected:
 
   static std::string formatTimestamp(time_t time)
   {
-    tm tm;
+    tm tm{};
 #ifdef _WIN32
     gmtime_s(&tm, &time);
 #else

--- a/ext/include/opentelemetry/ext/http/server/socket_tools.h
+++ b/ext/include/opentelemetry/ext/http/server/socket_tools.h
@@ -165,13 +165,13 @@ struct SocketAddr
 {
   static u_long const Loopback = 0x7F000001;
 
-  sockaddr m_data;
+  sockaddr m_data{};
 
   /// <summary>
   /// SocketAddr constructor
   /// </summary>
   /// <returns>SocketAddr</returns>
-  SocketAddr() { memset(&m_data, 0, sizeof(m_data)); }
+  SocketAddr() {}
 
   SocketAddr(u_long addr, int port)
   {

--- a/ext/src/http/client/curl/http_operation_curl.cc
+++ b/ext/src/http/client/curl/http_operation_curl.cc
@@ -1255,7 +1255,7 @@ CURLcode HttpOperation::Setup()
       return rc;
     }
 
-    rc = SetCurlStrOption(CURLOPT_POSTFIELDS, NULL);
+    rc = SetCurlStrOption(CURLOPT_POSTFIELDS, nullptr);
     if (rc != CURLE_OK)
     {
       return rc;

--- a/ext/src/http/client/curl/http_operation_curl.cc
+++ b/ext/src/http/client/curl/http_operation_curl.cc
@@ -856,7 +856,8 @@ CURLcode HttpOperation::Setup()
       const char *data = ssl_options_.ssl_ca_cert_string.c_str();
       size_t data_len  = ssl_options_.ssl_ca_cert_string.length();
 
-      struct curl_blob stblob;
+      struct curl_blob stblob
+      {};
       stblob.data  = const_cast<char *>(data);
       stblob.len   = data_len;
       stblob.flags = CURL_BLOB_COPY;
@@ -897,7 +898,8 @@ CURLcode HttpOperation::Setup()
       const char *data = ssl_options_.ssl_client_key_string.c_str();
       size_t data_len  = ssl_options_.ssl_client_key_string.length();
 
-      struct curl_blob stblob;
+      struct curl_blob stblob
+      {};
       stblob.data  = const_cast<char *>(data);
       stblob.len   = data_len;
       stblob.flags = CURL_BLOB_COPY;
@@ -944,7 +946,8 @@ CURLcode HttpOperation::Setup()
       const char *data = ssl_options_.ssl_client_cert_string.c_str();
       size_t data_len  = ssl_options_.ssl_client_cert_string.length();
 
-      struct curl_blob stblob;
+      struct curl_blob stblob
+      {};
       stblob.data  = const_cast<char *>(data);
       stblob.len   = data_len;
       stblob.flags = CURL_BLOB_COPY;

--- a/functional/otlp/func_grpc_main.cc
+++ b/functional/otlp/func_grpc_main.cc
@@ -320,7 +320,7 @@ typedef int (*test_func_t)();
 struct test_case
 {
   nostd::string_view m_name;
-  test_func_t m_func;
+  test_func_t m_func{nullptr};
 };
 
 }  // namespace

--- a/functional/otlp/func_http_main.cc
+++ b/functional/otlp/func_http_main.cc
@@ -337,7 +337,7 @@ typedef int (*test_func_t)();
 struct test_case
 {
   nostd::string_view m_name;
-  test_func_t m_func;
+  test_func_t m_func{nullptr};
 };
 
 }  // namespace

--- a/sdk/include/opentelemetry/sdk/metrics/data/metric_data.h
+++ b/sdk/include/opentelemetry/sdk/metrics/data/metric_data.h
@@ -34,7 +34,7 @@ class MetricData
 {
 public:
   InstrumentDescriptor instrument_descriptor;
-  AggregationTemporality aggregation_temporality;
+  AggregationTemporality aggregation_temporality{AggregationTemporality::kUnspecified};
   opentelemetry::common::SystemTimestamp start_ts;
   opentelemetry::common::SystemTimestamp end_ts;
   std::vector<PointDataAttributes> point_data_attr_;

--- a/sdk/include/opentelemetry/sdk/metrics/exemplar/fixed_size_exemplar_reservoir.h
+++ b/sdk/include/opentelemetry/sdk/metrics/exemplar/fixed_size_exemplar_reservoir.h
@@ -98,7 +98,7 @@ private:
   explicit FixedSizeExemplarReservoir() = default;
   std::vector<ReservoirCell> storage_;
   std::shared_ptr<ReservoirCellSelector> reservoir_cell_selector_;
-  MapAndResetCellType map_and_reset_cell_;
+  MapAndResetCellType map_and_reset_cell_{nullptr};
 };
 
 }  // namespace metrics

--- a/sdk/include/opentelemetry/sdk/metrics/instruments.h
+++ b/sdk/include/opentelemetry/sdk/metrics/instruments.h
@@ -64,8 +64,8 @@ struct InstrumentDescriptor
   std::string name_;
   std::string description_;
   std::string unit_;
-  InstrumentType type_;
-  InstrumentValueType value_type_;
+  InstrumentType type_{InstrumentType::kCounter};
+  InstrumentValueType value_type_{InstrumentValueType::kInt};
 };
 
 struct InstrumentDescriptorUtil

--- a/sdk/include/opentelemetry/sdk/trace/sampler.h
+++ b/sdk/include/opentelemetry/sdk/trace/sampler.h
@@ -52,7 +52,7 @@ enum class Decision : std::uint8_t
  */
 struct SamplingResult
 {
-  Decision decision;
+  Decision decision{Decision::DROP};
   // A set of span Attributes that will also be added to the Span. Can be nullptr.
   std::unique_ptr<const std::map<std::string, opentelemetry::common::AttributeValue>> attributes;
   //  The tracestate used by the span.

--- a/sdk/src/trace/samplers/ot_trace_state.cc
+++ b/sdk/src/trace/samplers/ot_trace_state.cc
@@ -139,7 +139,7 @@ OtelTraceState OtelTraceState::Parse(const std::string &ot_value) noexcept
       std::size_t value_len   = end - value_start;
       if (ot_value.compare(pos, colon - pos, "th") == 0)
       {
-        uint64_t threshold_value;
+        uint64_t threshold_value{0};
         if (value_len <= 14 && ParseHex(ot_value, value_start, value_len, threshold_value))
         {
           state.has_threshold = true;
@@ -148,7 +148,7 @@ OtelTraceState OtelTraceState::Parse(const std::string &ot_value) noexcept
       }
       else if (ot_value.compare(pos, colon - pos, "rv") == 0)
       {
-        uint64_t random_value;
+        uint64_t random_value{0};
         if (value_len == 14 && ParseHex(ot_value, value_start, value_len, random_value))
         {
           state.has_random_value = true;

--- a/sdk/test/configuration/yaml_resource_test.cc
+++ b/sdk/test/configuration/yaml_resource_test.cc
@@ -30,7 +30,7 @@ static std::unique_ptr<opentelemetry::sdk::configuration::Configuration> DoParse
 
 namespace
 {
-enum class DetectorType
+enum class DetectorType : std::uint8_t
 {
   kNone,
   kContainer,

--- a/sdk/test/configuration/yaml_resource_test.cc
+++ b/sdk/test/configuration/yaml_resource_test.cc
@@ -3,6 +3,7 @@
 
 #include <gtest/gtest.h>
 #include <cstddef>
+#include <cstdint>
 #include <map>
 #include <memory>
 #include <string>

--- a/sdk/test/logs/logger_sdk_test.cc
+++ b/sdk/test/logs/logger_sdk_test.cc
@@ -230,7 +230,7 @@ public:
 private:
   opentelemetry::logs::Severity severity_ = opentelemetry::logs::Severity::kInvalid;
   std::string body_;
-  int64_t event_id_;
+  int64_t event_id_{0};
   std::string log_record_event_name_;
   opentelemetry::trace::TraceId trace_id_;
   opentelemetry::trace::SpanId span_id_;

--- a/sdk/test/metrics/base2_exponential_histogram_indexer_benchmark.cc
+++ b/sdk/test/metrics/base2_exponential_histogram_indexer_benchmark.cc
@@ -14,7 +14,7 @@ namespace
 
 void BM_NewIndexer(benchmark::State &state)
 {
-  std::array<int, 1000> batch;
+  std::array<int, 1000> batch{};
   std::default_random_engine generator;
   std::uniform_int_distribution<int> distribution(1, 32);
 
@@ -38,7 +38,7 @@ BENCHMARK(BM_NewIndexer);
 
 void BM_ComputeIndex(benchmark::State &state)
 {
-  std::array<double, 1000> batch;
+  std::array<double, 1000> batch{};
   std::default_random_engine generator;
   std::uniform_real_distribution<double> distribution(0, 1000);
   Base2ExponentialHistogramIndexer indexer(static_cast<int32_t>(state.range(0)));

--- a/sdk/test/metrics/multi_metric_storage_test.cc
+++ b/sdk/test/metrics/multi_metric_storage_test.cc
@@ -46,8 +46,8 @@ public:
     num_calls_double++;
   }
 
-  size_t num_calls_long;
-  size_t num_calls_double;
+  size_t num_calls_long{0};
+  size_t num_calls_double{0};
 };
 
 TEST(MultiMetricStorageTest, BasicTests)

--- a/sdk/test/trace/composable_sampler_test.cc
+++ b/sdk/test/trace/composable_sampler_test.cc
@@ -172,7 +172,7 @@ public:
       return attrs;
     };
     intent.trace_state_provider =
-        [](opentelemetry::nostd::shared_ptr<trace_api::TraceState> trace_state) {
+        [](const opentelemetry::nostd::shared_ptr<trace_api::TraceState> &trace_state) {
           return trace_state->Set("p", "1");
         };
     return intent;


### PR DESCRIPTION
Contributes to #2053

## Changes
- fix missing initialization clang-tidy warnings
- fix performance-unnecessary-value-param warning
- fix performance-enum-size warning
- fix modernize-use-nullptr warning
- fix modernize-use-bool-literals warnings

Please provide a brief description of the changes here.

For significant contributions please make sure you have completed the following items:

* [ ] `CHANGELOG.md` updated for non-trivial changes
* [ ] Unit tests have been added
* [ ] Changes in public API reviewed