### PR TITLE
[CONFIGURATION] Add periodic metric reader builder support to registry

### DIFF
--- a/sdk/include/opentelemetry/sdk/configuration/periodic_metric_reader_builder.h
+++ b/sdk/include/opentelemetry/sdk/configuration/periodic_metric_reader_builder.h
@@ -1,0 +1,36 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <memory>
+
+#include "opentelemetry/sdk/configuration/periodic_metric_reader_configuration.h"
+#include "opentelemetry/sdk/metrics/metric_reader.h"
+#include "opentelemetry/sdk/metrics/push_metric_exporter.h"
+#include "opentelemetry/version.h"
+
+OPENTELEMETRY_BEGIN_NAMESPACE
+namespace sdk
+{
+namespace configuration
+{
+
+class PeriodicMetricReaderBuilder
+{
+public:
+  PeriodicMetricReaderBuilder()                                                    = default;
+  PeriodicMetricReaderBuilder(PeriodicMetricReaderBuilder &&)                      = default;
+  PeriodicMetricReaderBuilder(const PeriodicMetricReaderBuilder &)                 = default;
+  PeriodicMetricReaderBuilder &operator=(PeriodicMetricReaderBuilder &&)           = default;
+  PeriodicMetricReaderBuilder &operator=(const PeriodicMetricReaderBuilder &other) = default;
+  virtual ~PeriodicMetricReaderBuilder()                                           = default;
+
+  virtual std::unique_ptr<opentelemetry::sdk::metrics::MetricReader> Build(
+      const opentelemetry::sdk::configuration::PeriodicMetricReaderConfiguration *model,
+      std::unique_ptr<opentelemetry::sdk::metrics::PushMetricExporter> &&exporter) const = 0;
+};
+
+}  // namespace configuration
+}  // namespace sdk
+OPENTELEMETRY_END_NAMESPACE

--- a/sdk/include/opentelemetry/sdk/configuration/registry.h
+++ b/sdk/include/opentelemetry/sdk/configuration/registry.h
@@ -25,6 +25,7 @@
 #include "opentelemetry/sdk/configuration/otlp_http_log_record_exporter_builder.h"
 #include "opentelemetry/sdk/configuration/otlp_http_push_metric_exporter_builder.h"
 #include "opentelemetry/sdk/configuration/otlp_http_span_exporter_builder.h"
+#include "opentelemetry/sdk/configuration/periodic_metric_reader_builder.h"
 #include "opentelemetry/sdk/configuration/prometheus_pull_metric_exporter_builder.h"
 #include "opentelemetry/sdk/configuration/text_map_propagator_builder.h"
 #include "opentelemetry/version.h"
@@ -143,6 +144,16 @@ public:
     prometheus_metric_builder_ = std::move(builder);
   }
 
+  const PeriodicMetricReaderBuilder *GetPeriodicMetricReaderBuilder() const
+  {
+    return periodic_metric_reader_builder_.get();
+  }
+
+  void SetPeriodicMetricReaderBuilder(std::unique_ptr<PeriodicMetricReaderBuilder> &&builder)
+  {
+    periodic_metric_reader_builder_ = std::move(builder);
+  }
+
   const OtlpHttpLogRecordExporterBuilder *GetOtlpHttpLogRecordBuilder() const
   {
     return otlp_http_log_record_builder_.get();
@@ -246,6 +257,7 @@ private:
   std::unique_ptr<OtlpFilePushMetricExporterBuilder> otlp_file_push_metric_builder_;
   std::unique_ptr<ConsolePushMetricExporterBuilder> console_metric_builder_;
   std::unique_ptr<PrometheusPullMetricExporterBuilder> prometheus_metric_builder_;
+  std::unique_ptr<PeriodicMetricReaderBuilder> periodic_metric_reader_builder_;
 
   std::unique_ptr<OtlpHttpLogRecordExporterBuilder> otlp_http_log_record_builder_;
   std::unique_ptr<OtlpGrpcLogRecordExporterBuilder> otlp_grpc_log_record_builder_;

--- a/sdk/src/configuration/registry.cc
+++ b/sdk/src/configuration/registry.cc
@@ -1,6 +1,7 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
+#include <chrono>
 #include <map>
 #include <memory>
 #include <string>
@@ -14,8 +15,14 @@
 #include "opentelemetry/sdk/configuration/extension_sampler_builder.h"
 #include "opentelemetry/sdk/configuration/extension_span_exporter_builder.h"
 #include "opentelemetry/sdk/configuration/extension_span_processor_builder.h"
+#include "opentelemetry/sdk/configuration/periodic_metric_reader_builder.h"
+#include "opentelemetry/sdk/configuration/periodic_metric_reader_configuration.h"
 #include "opentelemetry/sdk/configuration/registry.h"
 #include "opentelemetry/sdk/configuration/text_map_propagator_builder.h"
+#include "opentelemetry/sdk/metrics/export/periodic_exporting_metric_reader_factory.h"
+#include "opentelemetry/sdk/metrics/export/periodic_exporting_metric_reader_options.h"
+#include "opentelemetry/sdk/metrics/metric_reader.h"
+#include "opentelemetry/sdk/metrics/push_metric_exporter.h"
 #include "opentelemetry/trace/propagation/b3_propagator.h"
 #include "opentelemetry/trace/propagation/http_trace_context.h"
 #include "opentelemetry/trace/propagation/jaeger.h"
@@ -80,6 +87,23 @@ public:
   }
 };
 
+class DefaultPeriodicMetricReaderBuilder : public PeriodicMetricReaderBuilder
+{
+public:
+  std::unique_ptr<opentelemetry::sdk::metrics::MetricReader> Build(
+      const opentelemetry::sdk::configuration::PeriodicMetricReaderConfiguration *model,
+      std::unique_ptr<opentelemetry::sdk::metrics::PushMetricExporter> &&exporter) const override
+  {
+    opentelemetry::sdk::metrics::PeriodicExportingMetricReaderOptions options;
+
+    options.export_interval_millis = std::chrono::milliseconds(model->interval);
+    options.export_timeout_millis  = std::chrono::milliseconds(model->timeout);
+
+    return opentelemetry::sdk::metrics::PeriodicExportingMetricReaderFactory::Create(
+        std::move(exporter), options);
+  }
+};
+
 }  // namespace
 
 Registry::Registry()
@@ -89,6 +113,8 @@ Registry::Registry()
   SetTextMapPropagatorBuilder("b3", std::make_unique<B3Builder>());
   SetTextMapPropagatorBuilder("b3multi", std::make_unique<B3MultiBuilder>());
   SetTextMapPropagatorBuilder("jaeger", std::make_unique<JaegerBuilder>());
+
+  SetPeriodicMetricReaderBuilder(std::make_unique<DefaultPeriodicMetricReaderBuilder>());
 }
 
 const TextMapPropagatorBuilder *Registry::GetTextMapPropagatorBuilder(const std::string &name) const

--- a/sdk/src/configuration/sdk_builder.cc
+++ b/sdk/src/configuration/sdk_builder.cc
@@ -98,6 +98,7 @@
 #include "opentelemetry/sdk/configuration/otlp_http_span_exporter_builder.h"
 #include "opentelemetry/sdk/configuration/otlp_http_span_exporter_configuration.h"
 #include "opentelemetry/sdk/configuration/parent_based_sampler_configuration.h"
+#include "opentelemetry/sdk/configuration/periodic_metric_reader_builder.h"
 #include "opentelemetry/sdk/configuration/periodic_metric_reader_configuration.h"
 #include "opentelemetry/sdk/configuration/prometheus_pull_metric_exporter_builder.h"
 #include "opentelemetry/sdk/configuration/prometheus_pull_metric_exporter_configuration.h"
@@ -145,8 +146,6 @@
 #include "opentelemetry/sdk/logs/simple_log_record_processor_factory.h"
 #include "opentelemetry/sdk/metrics/aggregation/aggregation_config.h"
 #include "opentelemetry/sdk/metrics/export/metric_producer.h"
-#include "opentelemetry/sdk/metrics/export/periodic_exporting_metric_reader_factory.h"
-#include "opentelemetry/sdk/metrics/export/periodic_exporting_metric_reader_options.h"
 #include "opentelemetry/sdk/metrics/instruments.h"
 #include "opentelemetry/sdk/metrics/meter_config.h"
 #include "opentelemetry/sdk/metrics/meter_context.h"
@@ -1555,11 +1554,6 @@ std::unique_ptr<opentelemetry::sdk::metrics::MetricReader> SdkBuilder::CreatePer
 {
   std::unique_ptr<opentelemetry::sdk::metrics::MetricReader> sdk;
 
-  opentelemetry::sdk::metrics::PeriodicExportingMetricReaderOptions options;
-
-  options.export_interval_millis = std::chrono::milliseconds(model->interval);
-  options.export_timeout_millis  = std::chrono::milliseconds(model->timeout);
-
   auto exporter_sdk = CreatePushMetricExporter(model->exporter);
 
   if (model->producers.size() > 0)
@@ -1572,10 +1566,17 @@ std::unique_ptr<opentelemetry::sdk::metrics::MetricReader> SdkBuilder::CreatePer
     OTEL_INTERNAL_LOG_WARN("cardinality limits not supported, ignoring");
   }
 
-  sdk = opentelemetry::sdk::metrics::PeriodicExportingMetricReaderFactory::Create(
-      std::move(exporter_sdk), options);
+  const PeriodicMetricReaderBuilder *builder = registry_->GetPeriodicMetricReaderBuilder();
 
-  return sdk;
+  if (builder != nullptr)
+  {
+    OTEL_INTERNAL_LOG_DEBUG("CreatePeriodicMetricReader() using registered builder");
+    sdk = builder->Build(model, std::move(exporter_sdk));
+    return sdk;
+  }
+
+  static const std::string die("No builder for PeriodicMetricReader");
+  throw UnsupportedException(die);
 }
 
 std::unique_ptr<opentelemetry::sdk::metrics::MetricReader> SdkBuilder::CreatePullMetricReader(

--- a/sdk/test/configuration/BUILD
+++ b/sdk/test/configuration/BUILD
@@ -6,6 +6,7 @@ load("@rules_cc//cc:cc_test.bzl", "cc_test")
 cc_test(
     name = "sdk_builder_test",
     srcs = [
+        "config_test_common.h",
         "sdk_builder_test.cc",
     ],
     tags = [
@@ -26,6 +27,7 @@ cc_test(
 cc_test(
     name = "configured_sdk_test",
     srcs = [
+        "config_test_common.h",
         "configured_sdk_test.cc",
     ],
     tags = [
@@ -46,6 +48,7 @@ cc_test(
 cc_test(
     name = "programmatic_configuration_test",
     srcs = [
+        "config_test_common.h",
         "programmatic_configuration_test.cc",
     ],
     tags = [

--- a/sdk/test/configuration/config_test_common.h
+++ b/sdk/test/configuration/config_test_common.h
@@ -332,7 +332,7 @@ private:
 };
 
 // ---------------------------------------------------------------------------
-// Synchronous metric reader: collects and exports on ForceFlush/Shutdown in
+// Synchronous metric reader: collects and exports on ForceFlush in
 // the calling thread.
 class SyncMetricReader : public opentelemetry::sdk::metrics::MetricReader
 {
@@ -351,23 +351,22 @@ public:
 private:
   bool CollectAndExport() noexcept
   {
-    bool result = true;
-    Collect([this, &result](opentelemetry::sdk::metrics::ResourceMetrics &metric_data) {
-      result =
-          (exporter_->Export(metric_data) == opentelemetry::sdk::common::ExportResult::kSuccess);
-      return true;
+    const bool success = Collect([this](opentelemetry::sdk::metrics::ResourceMetrics &metric_data) {
+      return (exporter_->Export(metric_data) == opentelemetry::sdk::common::ExportResult::kSuccess);
     });
-    return result;
+    return success;
   }
 
   bool OnForceFlush(std::chrono::microseconds timeout) noexcept override
   {
-    return CollectAndExport() && exporter_->ForceFlush(timeout);
+    const bool collect_result = CollectAndExport();
+    const bool flush_result   = exporter_->ForceFlush(timeout);
+    return collect_result && flush_result;
   }
 
   bool OnShutDown(std::chrono::microseconds timeout) noexcept override
   {
-    return CollectAndExport() && exporter_->Shutdown(timeout);
+    return exporter_->Shutdown(timeout);
   }
 
   std::unique_ptr<opentelemetry::sdk::metrics::PushMetricExporter> exporter_;

--- a/sdk/test/configuration/config_test_common.h
+++ b/sdk/test/configuration/config_test_common.h
@@ -1,0 +1,443 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+// Shared test helpers for the SDK configuration test suite.
+//
+// Provides:
+//   - Buffer type aliases  (SpanBuffer, LogRecordBuffer, MetricBuffer)
+//   - Noop exporters and their extension builders  (install/uninstall tests)
+//   - NoopMetricReader / NoopPeriodicMetricReaderBuilder  (no export thread)
+//   - SyncMetricReader / SyncPeriodicMetricReaderBuilder  (deterministic flush)
+//   - Recording exporters and their extension builders  (integration tests)
+//   - CapturedPeriodicReaderArgs / CapturingPeriodicMetricReaderBuilder
+//       (unit tests that verify builder is called with the right config)
+
+#include <chrono>
+#include <cstddef>
+#include <memory>
+#include <vector>
+
+#include "opentelemetry/context/propagation/text_map_propagator.h"
+#include "opentelemetry/nostd/span.h"
+#include "opentelemetry/sdk/common/exporter_utils.h"
+#include "opentelemetry/sdk/configuration/extension_log_record_exporter_builder.h"
+#include "opentelemetry/sdk/configuration/extension_log_record_exporter_configuration.h"
+#include "opentelemetry/sdk/configuration/extension_push_metric_exporter_builder.h"
+#include "opentelemetry/sdk/configuration/extension_push_metric_exporter_configuration.h"
+#include "opentelemetry/sdk/configuration/extension_span_exporter_builder.h"
+#include "opentelemetry/sdk/configuration/extension_span_exporter_configuration.h"
+#include "opentelemetry/sdk/configuration/periodic_metric_reader_builder.h"
+#include "opentelemetry/sdk/configuration/periodic_metric_reader_configuration.h"
+#include "opentelemetry/sdk/logs/exporter.h"
+#include "opentelemetry/sdk/logs/read_write_log_record.h"
+#include "opentelemetry/sdk/metrics/data/metric_data.h"
+#include "opentelemetry/sdk/metrics/export/metric_producer.h"
+#include "opentelemetry/sdk/metrics/instruments.h"
+#include "opentelemetry/sdk/metrics/metric_reader.h"
+#include "opentelemetry/sdk/metrics/push_metric_exporter.h"
+#include "opentelemetry/sdk/trace/exporter.h"
+#include "opentelemetry/sdk/trace/span_data.h"
+
+namespace config_test
+{
+
+// ---------------------------------------------------------------------------
+// Export buffer type aliases
+
+using SpanBuffer      = std::vector<std::unique_ptr<opentelemetry::sdk::trace::SpanData>>;
+using LogRecordBuffer = std::vector<std::unique_ptr<opentelemetry::sdk::logs::ReadWriteLogRecord>>;
+using MetricBuffer    = std::vector<opentelemetry::sdk::metrics::MetricData>;
+
+// ---------------------------------------------------------------------------
+// No-op exporters: accept data silently.
+
+class NoopSpanExporter : public opentelemetry::sdk::trace::SpanExporter
+{
+public:
+  std::unique_ptr<opentelemetry::sdk::trace::Recordable> MakeRecordable() noexcept override
+  {
+    return std::make_unique<opentelemetry::sdk::trace::SpanData>();
+  }
+  opentelemetry::sdk::common::ExportResult Export(
+      const opentelemetry::nostd::span<std::unique_ptr<opentelemetry::sdk::trace::Recordable>>
+          &) noexcept override
+  {
+    return opentelemetry::sdk::common::ExportResult::kSuccess;
+  }
+  bool ForceFlush(std::chrono::microseconds) noexcept override { return true; }
+  bool Shutdown(std::chrono::microseconds) noexcept override { return true; }
+};
+
+class NoopLogRecordExporter : public opentelemetry::sdk::logs::LogRecordExporter
+{
+public:
+  std::unique_ptr<opentelemetry::sdk::logs::Recordable> MakeRecordable() noexcept override
+  {
+    return std::make_unique<opentelemetry::sdk::logs::ReadWriteLogRecord>();
+  }
+  opentelemetry::sdk::common::ExportResult Export(
+      const opentelemetry::nostd::span<std::unique_ptr<opentelemetry::sdk::logs::Recordable>>
+          &) noexcept override
+  {
+    return opentelemetry::sdk::common::ExportResult::kSuccess;
+  }
+  bool ForceFlush(std::chrono::microseconds) noexcept override { return true; }
+  bool Shutdown(std::chrono::microseconds) noexcept override { return true; }
+};
+
+class NoopPushMetricExporter : public opentelemetry::sdk::metrics::PushMetricExporter
+{
+public:
+  opentelemetry::sdk::common::ExportResult Export(
+      const opentelemetry::sdk::metrics::ResourceMetrics &) noexcept override
+  {
+    return opentelemetry::sdk::common::ExportResult::kSuccess;
+  }
+  opentelemetry::sdk::metrics::AggregationTemporality GetAggregationTemporality(
+      opentelemetry::sdk::metrics::InstrumentType) const noexcept override
+  {
+    return opentelemetry::sdk::metrics::AggregationTemporality::kCumulative;
+  }
+  bool ForceFlush(std::chrono::microseconds) noexcept override { return true; }
+  bool Shutdown(std::chrono::microseconds) noexcept override { return true; }
+};
+
+// ---------------------------------------------------------------------------
+// No-op extension builders
+
+class NoopSpanExporterBuilder
+    : public opentelemetry::sdk::configuration::ExtensionSpanExporterBuilder
+{
+public:
+  std::unique_ptr<opentelemetry::sdk::trace::SpanExporter> Build(
+      const opentelemetry::sdk::configuration::ExtensionSpanExporterConfiguration *) const override
+  {
+    return std::make_unique<NoopSpanExporter>();
+  }
+};
+
+class NoopLogRecordExporterBuilder
+    : public opentelemetry::sdk::configuration::ExtensionLogRecordExporterBuilder
+{
+public:
+  std::unique_ptr<opentelemetry::sdk::logs::LogRecordExporter> Build(
+      const opentelemetry::sdk::configuration::ExtensionLogRecordExporterConfiguration *)
+      const override
+  {
+    return std::make_unique<NoopLogRecordExporter>();
+  }
+};
+
+class NoopPushMetricExporterBuilder
+    : public opentelemetry::sdk::configuration::ExtensionPushMetricExporterBuilder
+{
+public:
+  std::unique_ptr<opentelemetry::sdk::metrics::PushMetricExporter> Build(
+      const opentelemetry::sdk::configuration::ExtensionPushMetricExporterConfiguration *)
+      const override
+  {
+    return std::make_unique<NoopPushMetricExporter>();
+  }
+};
+
+// ---------------------------------------------------------------------------
+// No-op metric reader: no export thread, for install/uninstall tests.
+
+class NoopMetricReader : public opentelemetry::sdk::metrics::MetricReader
+{
+public:
+  opentelemetry::sdk::metrics::AggregationTemporality GetAggregationTemporality(
+      opentelemetry::sdk::metrics::InstrumentType) const noexcept override
+  {
+    return opentelemetry::sdk::metrics::AggregationTemporality::kCumulative;
+  }
+
+private:
+  bool OnForceFlush(std::chrono::microseconds) noexcept override { return true; }
+  bool OnShutDown(std::chrono::microseconds) noexcept override { return true; }
+};
+
+class NoopPeriodicMetricReaderBuilder
+    : public opentelemetry::sdk::configuration::PeriodicMetricReaderBuilder
+{
+public:
+  std::unique_ptr<opentelemetry::sdk::metrics::MetricReader> Build(
+      const opentelemetry::sdk::configuration::PeriodicMetricReaderConfiguration *,
+      std::unique_ptr<opentelemetry::sdk::metrics::PushMetricExporter> &&) const override
+  {
+    return std::make_unique<NoopMetricReader>();
+  }
+};
+
+// ---------------------------------------------------------------------------
+// Synchronous metric reader: collects and exports on ForceFlush/Shutdown in
+// the calling thread. Avoids the threaded PeriodicExportingMetricReader so
+// integration tests are deterministic and cannot block indefinitely.
+
+class SyncMetricReader : public opentelemetry::sdk::metrics::MetricReader
+{
+public:
+  explicit SyncMetricReader(
+      std::unique_ptr<opentelemetry::sdk::metrics::PushMetricExporter> exporter)
+      : exporter_(std::move(exporter))
+  {}
+
+  opentelemetry::sdk::metrics::AggregationTemporality GetAggregationTemporality(
+      opentelemetry::sdk::metrics::InstrumentType instrument_type) const noexcept override
+  {
+    return exporter_->GetAggregationTemporality(instrument_type);
+  }
+
+private:
+  bool CollectAndExport() noexcept
+  {
+    bool result = true;
+    Collect([this, &result](opentelemetry::sdk::metrics::ResourceMetrics &metric_data) {
+      result =
+          (exporter_->Export(metric_data) == opentelemetry::sdk::common::ExportResult::kSuccess);
+      return true;
+    });
+    return result;
+  }
+
+  bool OnForceFlush(std::chrono::microseconds timeout) noexcept override
+  {
+    return CollectAndExport() && exporter_->ForceFlush(timeout);
+  }
+
+  bool OnShutDown(std::chrono::microseconds timeout) noexcept override
+  {
+    return CollectAndExport() && exporter_->Shutdown(timeout);
+  }
+
+  std::unique_ptr<opentelemetry::sdk::metrics::PushMetricExporter> exporter_;
+};
+
+class SyncPeriodicMetricReaderBuilder
+    : public opentelemetry::sdk::configuration::PeriodicMetricReaderBuilder
+{
+public:
+  std::unique_ptr<opentelemetry::sdk::metrics::MetricReader> Build(
+      const opentelemetry::sdk::configuration::PeriodicMetricReaderConfiguration *,
+      std::unique_ptr<opentelemetry::sdk::metrics::PushMetricExporter> &&exporter) const override
+  {
+    return std::make_unique<SyncMetricReader>(std::move(exporter));
+  }
+};
+
+// ---------------------------------------------------------------------------
+// Recording exporters: capture exported data into shared buffers for
+// inspection in integration tests.
+
+class RecordingSpanExporter : public opentelemetry::sdk::trace::SpanExporter
+{
+public:
+  explicit RecordingSpanExporter(std::shared_ptr<SpanBuffer> buffer) : buffer_(std::move(buffer)) {}
+
+  std::unique_ptr<opentelemetry::sdk::trace::Recordable> MakeRecordable() noexcept override
+  {
+    return std::make_unique<opentelemetry::sdk::trace::SpanData>();
+  }
+
+  opentelemetry::sdk::common::ExportResult Export(
+      const opentelemetry::nostd::span<std::unique_ptr<opentelemetry::sdk::trace::Recordable>>
+          &spans) noexcept override
+  {
+    for (auto &span : spans)
+    {
+      buffer_->emplace_back(static_cast<opentelemetry::sdk::trace::SpanData *>(span.release()));
+    }
+    return opentelemetry::sdk::common::ExportResult::kSuccess;
+  }
+
+  bool ForceFlush(std::chrono::microseconds) noexcept override { return true; }
+  bool Shutdown(std::chrono::microseconds) noexcept override { return true; }
+
+private:
+  std::shared_ptr<SpanBuffer> buffer_;
+};
+
+class RecordingLogRecordExporter : public opentelemetry::sdk::logs::LogRecordExporter
+{
+public:
+  explicit RecordingLogRecordExporter(std::shared_ptr<LogRecordBuffer> buffer)
+      : buffer_(std::move(buffer))
+  {}
+
+  std::unique_ptr<opentelemetry::sdk::logs::Recordable> MakeRecordable() noexcept override
+  {
+    return std::make_unique<opentelemetry::sdk::logs::ReadWriteLogRecord>();
+  }
+
+  opentelemetry::sdk::common::ExportResult Export(
+      const opentelemetry::nostd::span<std::unique_ptr<opentelemetry::sdk::logs::Recordable>>
+          &records) noexcept override
+  {
+    for (auto &rec : records)
+    {
+      buffer_->emplace_back(
+          static_cast<opentelemetry::sdk::logs::ReadWriteLogRecord *>(rec.release()));
+    }
+    return opentelemetry::sdk::common::ExportResult::kSuccess;
+  }
+
+  bool RecordableEnforcesLogRecordLimits() const noexcept override { return true; }
+  bool ForceFlush(std::chrono::microseconds) noexcept override { return true; }
+  bool Shutdown(std::chrono::microseconds) noexcept override { return true; }
+
+private:
+  std::shared_ptr<LogRecordBuffer> buffer_;
+};
+
+class RecordingPushMetricExporter : public opentelemetry::sdk::metrics::PushMetricExporter
+{
+public:
+  explicit RecordingPushMetricExporter(std::shared_ptr<MetricBuffer> buffer)
+      : buffer_(std::move(buffer))
+  {}
+
+  opentelemetry::sdk::common::ExportResult Export(
+      const opentelemetry::sdk::metrics::ResourceMetrics &resource_metrics) noexcept override
+  {
+    for (const auto &scope : resource_metrics.scope_metric_data_)
+    {
+      for (const auto &metric : scope.metric_data_)
+      {
+        buffer_->emplace_back(metric);
+      }
+    }
+    return opentelemetry::sdk::common::ExportResult::kSuccess;
+  }
+
+  opentelemetry::sdk::metrics::AggregationTemporality GetAggregationTemporality(
+      opentelemetry::sdk::metrics::InstrumentType) const noexcept override
+  {
+    return opentelemetry::sdk::metrics::AggregationTemporality::kCumulative;
+  }
+
+  bool ForceFlush(std::chrono::microseconds) noexcept override { return true; }
+  bool Shutdown(std::chrono::microseconds) noexcept override { return true; }
+
+private:
+  std::shared_ptr<MetricBuffer> buffer_;
+};
+
+// ---------------------------------------------------------------------------
+// Recording extension builders
+
+class RecordingSpanExporterBuilder
+    : public opentelemetry::sdk::configuration::ExtensionSpanExporterBuilder
+{
+public:
+  explicit RecordingSpanExporterBuilder(std::shared_ptr<SpanBuffer> buffer)
+      : buffer_(std::move(buffer))
+  {}
+  std::unique_ptr<opentelemetry::sdk::trace::SpanExporter> Build(
+      const opentelemetry::sdk::configuration::ExtensionSpanExporterConfiguration *) const override
+  {
+    return std::make_unique<RecordingSpanExporter>(buffer_);
+  }
+
+private:
+  std::shared_ptr<SpanBuffer> buffer_;
+};
+
+class RecordingLogRecordExporterBuilder
+    : public opentelemetry::sdk::configuration::ExtensionLogRecordExporterBuilder
+{
+public:
+  explicit RecordingLogRecordExporterBuilder(std::shared_ptr<LogRecordBuffer> buffer)
+      : buffer_(std::move(buffer))
+  {}
+  std::unique_ptr<opentelemetry::sdk::logs::LogRecordExporter> Build(
+      const opentelemetry::sdk::configuration::ExtensionLogRecordExporterConfiguration *)
+      const override
+  {
+    return std::make_unique<RecordingLogRecordExporter>(buffer_);
+  }
+
+private:
+  std::shared_ptr<LogRecordBuffer> buffer_;
+};
+
+class RecordingPushMetricExporterBuilder
+    : public opentelemetry::sdk::configuration::ExtensionPushMetricExporterBuilder
+{
+public:
+  explicit RecordingPushMetricExporterBuilder(std::shared_ptr<MetricBuffer> buffer)
+      : buffer_(std::move(buffer))
+  {}
+  std::unique_ptr<opentelemetry::sdk::metrics::PushMetricExporter> Build(
+      const opentelemetry::sdk::configuration::ExtensionPushMetricExporterConfiguration *)
+      const override
+  {
+    return std::make_unique<RecordingPushMetricExporter>(buffer_);
+  }
+
+private:
+  std::shared_ptr<MetricBuffer> buffer_;
+};
+
+// ---------------------------------------------------------------------------
+// Capturing periodic metric reader builder: records the configuration
+// arguments passed to Build() so unit tests can verify them.
+
+struct CapturedPeriodicReaderArgs
+{
+  std::size_t interval{0};
+  std::size_t timeout{0};
+  bool exporter_provided{false};
+  bool called{false};
+};
+
+class CapturingPeriodicMetricReaderBuilder
+    : public opentelemetry::sdk::configuration::PeriodicMetricReaderBuilder
+{
+public:
+  explicit CapturingPeriodicMetricReaderBuilder(
+      std::shared_ptr<CapturedPeriodicReaderArgs> captured)
+      : captured_(std::move(captured))
+  {}
+
+  std::unique_ptr<opentelemetry::sdk::metrics::MetricReader> Build(
+      const opentelemetry::sdk::configuration::PeriodicMetricReaderConfiguration *model,
+      std::unique_ptr<opentelemetry::sdk::metrics::PushMetricExporter> &&exporter) const override
+  {
+    captured_->called            = true;
+    captured_->interval          = model->interval;
+    captured_->timeout           = model->timeout;
+    captured_->exporter_provided = (exporter != nullptr);
+    return std::make_unique<NoopMetricReader>();
+  }
+
+private:
+  std::shared_ptr<CapturedPeriodicReaderArgs> captured_;
+};
+
+// ---------------------------------------------------------------------------
+// TextMapCarrier for propagator tests.
+
+class MapCarrier : public opentelemetry::context::propagation::TextMapCarrier
+{
+public:
+  opentelemetry::nostd::string_view Get(
+      opentelemetry::nostd::string_view key) const noexcept override
+  {
+    auto it = map_.find(std::string(key));
+    return it != map_.end() ? opentelemetry::nostd::string_view(it->second) : "";
+  }
+  void Set(opentelemetry::nostd::string_view key,
+           opentelemetry::nostd::string_view value) noexcept override
+  {
+    map_[std::string(key)] = std::string(value);
+  }
+
+  const std::map<std::string, std::string> &map() const { return map_; }
+
+private:
+  std::map<std::string, std::string> map_;
+};
+
+}  // namespace config_test

--- a/sdk/test/configuration/config_test_common.h
+++ b/sdk/test/configuration/config_test_common.h
@@ -165,8 +165,9 @@ class NoopPeriodicMetricReaderBuilder
 public:
   std::unique_ptr<opentelemetry::sdk::metrics::MetricReader> Build(
       const opentelemetry::sdk::configuration::PeriodicMetricReaderConfiguration *,
-      std::unique_ptr<opentelemetry::sdk::metrics::PushMetricExporter> &&) const override
+      std::unique_ptr<opentelemetry::sdk::metrics::PushMetricExporter> &&exporter) const override
   {
+    auto unused = std::move(exporter);
     return std::make_unique<NoopMetricReader>();
   }
 };
@@ -405,10 +406,11 @@ public:
       const opentelemetry::sdk::configuration::PeriodicMetricReaderConfiguration *model,
       std::unique_ptr<opentelemetry::sdk::metrics::PushMetricExporter> &&exporter) const override
   {
+    auto owned_exporter          = std::move(exporter);
     captured_->called            = true;
     captured_->interval          = model->interval;
     captured_->timeout           = model->timeout;
-    captured_->exporter_provided = (exporter != nullptr);
+    captured_->exporter_provided = (owned_exporter != nullptr);
     return std::make_unique<NoopMetricReader>();
   }
 

--- a/sdk/test/configuration/config_test_common.h
+++ b/sdk/test/configuration/config_test_common.h
@@ -1,18 +1,24 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-#pragma once
-
-// Shared test helpers for the SDK configuration test suite.
+// Shared test helpers for the SDK configuration tests
 //
 // Provides:
-//   - Buffer type aliases  (SpanBuffer, LogRecordBuffer, MetricBuffer)
-//   - Noop exporters and their extension builders  (install/uninstall tests)
-//   - NoopMetricReader / NoopPeriodicMetricReaderBuilder  (no export thread)
-//   - SyncMetricReader / SyncPeriodicMetricReaderBuilder  (deterministic flush)
-//   - Recording exporters and their extension builders  (integration tests)
+//  Noop Exporters and Builders:
+//   - NoopSpanExporter / NoopSpanExporterBuilder
+//   - NoopLogRecordExporter / NoopLogRecordExporterBuilder
+//   - NoopPushMetricExporter / NoopPeriodicMetricReaderBuilder
+//
+//  Recording Exporters and Builders: (data collection with no threading)
+//   - RecordingLogRecordExporter / RecordingLogRecordExporterBuilder
+//   - RecordingSpanExporter / RecordingSpanExporterBuilder
+//   - SyncMetricReader / SyncPeriodicMetricReaderBuilder
 //   - CapturedPeriodicReaderArgs / CapturingPeriodicMetricReaderBuilder
-//       (unit tests that verify builder is called with the right config)
+//
+//  Propagator:
+//   - MapCarrier
+
+#pragma once
 
 #include <chrono>
 #include <cstddef>
@@ -51,7 +57,7 @@ using LogRecordBuffer = std::vector<std::unique_ptr<opentelemetry::sdk::logs::Re
 using MetricBuffer    = std::vector<opentelemetry::sdk::metrics::MetricData>;
 
 // ---------------------------------------------------------------------------
-// No-op exporters: accept data silently.
+// No-op exporters
 
 class NoopSpanExporter : public opentelemetry::sdk::trace::SpanExporter
 {
@@ -143,7 +149,7 @@ public:
 };
 
 // ---------------------------------------------------------------------------
-// No-op metric reader: no export thread, for install/uninstall tests.
+// No-op metric reader
 
 class NoopMetricReader : public opentelemetry::sdk::metrics::MetricReader
 {
@@ -169,62 +175,6 @@ public:
   {
     auto unused = std::move(exporter);
     return std::make_unique<NoopMetricReader>();
-  }
-};
-
-// ---------------------------------------------------------------------------
-// Synchronous metric reader: collects and exports on ForceFlush/Shutdown in
-// the calling thread. Avoids the threaded PeriodicExportingMetricReader so
-// integration tests are deterministic and cannot block indefinitely.
-
-class SyncMetricReader : public opentelemetry::sdk::metrics::MetricReader
-{
-public:
-  explicit SyncMetricReader(
-      std::unique_ptr<opentelemetry::sdk::metrics::PushMetricExporter> exporter)
-      : exporter_(std::move(exporter))
-  {}
-
-  opentelemetry::sdk::metrics::AggregationTemporality GetAggregationTemporality(
-      opentelemetry::sdk::metrics::InstrumentType instrument_type) const noexcept override
-  {
-    return exporter_->GetAggregationTemporality(instrument_type);
-  }
-
-private:
-  bool CollectAndExport() noexcept
-  {
-    bool result = true;
-    Collect([this, &result](opentelemetry::sdk::metrics::ResourceMetrics &metric_data) {
-      result =
-          (exporter_->Export(metric_data) == opentelemetry::sdk::common::ExportResult::kSuccess);
-      return true;
-    });
-    return result;
-  }
-
-  bool OnForceFlush(std::chrono::microseconds timeout) noexcept override
-  {
-    return CollectAndExport() && exporter_->ForceFlush(timeout);
-  }
-
-  bool OnShutDown(std::chrono::microseconds timeout) noexcept override
-  {
-    return CollectAndExport() && exporter_->Shutdown(timeout);
-  }
-
-  std::unique_ptr<opentelemetry::sdk::metrics::PushMetricExporter> exporter_;
-};
-
-class SyncPeriodicMetricReaderBuilder
-    : public opentelemetry::sdk::configuration::PeriodicMetricReaderBuilder
-{
-public:
-  std::unique_ptr<opentelemetry::sdk::metrics::MetricReader> Build(
-      const opentelemetry::sdk::configuration::PeriodicMetricReaderConfiguration *,
-      std::unique_ptr<opentelemetry::sdk::metrics::PushMetricExporter> &&exporter) const override
-  {
-    return std::make_unique<SyncMetricReader>(std::move(exporter));
   }
 };
 
@@ -382,14 +332,69 @@ private:
 };
 
 // ---------------------------------------------------------------------------
-// Capturing periodic metric reader builder: records the configuration
-// arguments passed to Build() so unit tests can verify them.
+// Synchronous metric reader: collects and exports on ForceFlush/Shutdown in
+// the calling thread.
+class SyncMetricReader : public opentelemetry::sdk::metrics::MetricReader
+{
+public:
+  explicit SyncMetricReader(
+      std::unique_ptr<opentelemetry::sdk::metrics::PushMetricExporter> exporter)
+      : exporter_(std::move(exporter))
+  {}
+
+  opentelemetry::sdk::metrics::AggregationTemporality GetAggregationTemporality(
+      opentelemetry::sdk::metrics::InstrumentType instrument_type) const noexcept override
+  {
+    return exporter_->GetAggregationTemporality(instrument_type);
+  }
+
+private:
+  bool CollectAndExport() noexcept
+  {
+    bool result = true;
+    Collect([this, &result](opentelemetry::sdk::metrics::ResourceMetrics &metric_data) {
+      result =
+          (exporter_->Export(metric_data) == opentelemetry::sdk::common::ExportResult::kSuccess);
+      return true;
+    });
+    return result;
+  }
+
+  bool OnForceFlush(std::chrono::microseconds timeout) noexcept override
+  {
+    return CollectAndExport() && exporter_->ForceFlush(timeout);
+  }
+
+  bool OnShutDown(std::chrono::microseconds timeout) noexcept override
+  {
+    return CollectAndExport() && exporter_->Shutdown(timeout);
+  }
+
+  std::unique_ptr<opentelemetry::sdk::metrics::PushMetricExporter> exporter_;
+};
+
+class SyncPeriodicMetricReaderBuilder
+    : public opentelemetry::sdk::configuration::PeriodicMetricReaderBuilder
+{
+public:
+  std::unique_ptr<opentelemetry::sdk::metrics::MetricReader> Build(
+      const opentelemetry::sdk::configuration::PeriodicMetricReaderConfiguration *,
+      std::unique_ptr<opentelemetry::sdk::metrics::PushMetricExporter> &&exporter) const override
+  {
+    return std::make_unique<SyncMetricReader>(std::move(exporter));
+  }
+};
+
+// ---------------------------------------------------------------------------
+// Capturing periodic metric reader builder. Records the configuration
+// arguments passed to Build()
 
 struct CapturedPeriodicReaderArgs
 {
   std::size_t interval{0};
   std::size_t timeout{0};
-  bool exporter_provided{false};
+  std::unique_ptr<opentelemetry::sdk::metrics::PushMetricExporter> exporter;
+  // TODO: add cardinality limits and producers when we support them in the builder
   bool called{false};
 };
 
@@ -406,11 +411,10 @@ public:
       const opentelemetry::sdk::configuration::PeriodicMetricReaderConfiguration *model,
       std::unique_ptr<opentelemetry::sdk::metrics::PushMetricExporter> &&exporter) const override
   {
-    auto owned_exporter          = std::move(exporter);
-    captured_->called            = true;
-    captured_->interval          = model->interval;
-    captured_->timeout           = model->timeout;
-    captured_->exporter_provided = (owned_exporter != nullptr);
+    captured_->called   = true;
+    captured_->interval = model->interval;
+    captured_->timeout  = model->timeout;
+    captured_->exporter = std::move(exporter);
     return std::make_unique<NoopMetricReader>();
   }
 

--- a/sdk/test/configuration/configured_sdk_test.cc
+++ b/sdk/test/configuration/configured_sdk_test.cc
@@ -33,6 +33,7 @@
 #include "opentelemetry/sdk/configuration/logger_provider_configuration.h"
 #include "opentelemetry/sdk/configuration/meter_provider_configuration.h"
 #include "opentelemetry/sdk/configuration/metric_reader_configuration.h"
+#include "opentelemetry/sdk/configuration/periodic_metric_reader_builder.h"
 #include "opentelemetry/sdk/configuration/periodic_metric_reader_configuration.h"
 #include "opentelemetry/sdk/configuration/propagator_configuration.h"
 #include "opentelemetry/sdk/configuration/push_metric_exporter_configuration.h"
@@ -47,9 +48,12 @@
 #include "opentelemetry/sdk/logs/exporter.h"
 #include "opentelemetry/sdk/logs/read_write_log_record.h"
 #include "opentelemetry/sdk/metrics/instruments.h"
+#include "opentelemetry/sdk/metrics/metric_reader.h"
 #include "opentelemetry/sdk/metrics/push_metric_exporter.h"
 #include "opentelemetry/sdk/trace/exporter.h"
 #include "opentelemetry/sdk/trace/span_data.h"
+
+#include "config_test_common.h"
 
 namespace nostd       = opentelemetry::nostd;
 namespace trace       = opentelemetry::trace;
@@ -66,92 +70,8 @@ namespace internal_log = opentelemetry::sdk::common::internal_log;
 
 namespace
 {
-//------------------------------------------------------------------------------
-// Noop Exporters
 
-class NoopSpanExporter : public trace_sdk::SpanExporter
-{
-public:
-  NoopSpanExporter() = default;
-  std::unique_ptr<trace_sdk::Recordable> MakeRecordable() noexcept override
-  {
-    return std::make_unique<trace_sdk::SpanData>();
-  }
-  common_sdk::ExportResult Export(
-      const nostd::span<std::unique_ptr<trace_sdk::Recordable>> &) noexcept override
-  {
-    return common_sdk::ExportResult::kSuccess;
-  }
-  bool ForceFlush(std::chrono::microseconds) noexcept override { return true; }
-  bool Shutdown(std::chrono::microseconds) noexcept override { return true; }
-};
-
-class NoopLogRecordExporter : public logs_sdk::LogRecordExporter
-{
-public:
-  NoopLogRecordExporter() = default;
-  std::unique_ptr<logs_sdk::Recordable> MakeRecordable() noexcept override
-  {
-    return std::make_unique<logs_sdk::ReadWriteLogRecord>();
-  }
-  common_sdk::ExportResult Export(
-      const nostd::span<std::unique_ptr<logs_sdk::Recordable>> &) noexcept override
-  {
-    return common_sdk::ExportResult::kSuccess;
-  }
-  bool ForceFlush(std::chrono::microseconds) noexcept override { return true; }
-  bool Shutdown(std::chrono::microseconds) noexcept override { return true; }
-};
-
-class NoopPushMetricExporter : public metrics_sdk::PushMetricExporter
-{
-public:
-  NoopPushMetricExporter() = default;
-  common_sdk::ExportResult Export(const metrics_sdk::ResourceMetrics &) noexcept override
-  {
-    return common_sdk::ExportResult::kSuccess;
-  }
-  metrics_sdk::AggregationTemporality GetAggregationTemporality(
-      metrics_sdk::InstrumentType) const noexcept override
-  {
-    return metrics_sdk::AggregationTemporality::kCumulative;
-  }
-  bool ForceFlush(std::chrono::microseconds) noexcept override { return true; }
-  bool Shutdown(std::chrono::microseconds) noexcept override { return true; }
-};
-
-//------------------------------------------------------------------------------
-// Configuration Builders
-
-class NoopSpanExporterBuilder : public config_sdk::ExtensionSpanExporterBuilder
-{
-public:
-  std::unique_ptr<trace_sdk::SpanExporter> Build(
-      const config_sdk::ExtensionSpanExporterConfiguration *) const override
-  {
-    return std::make_unique<NoopSpanExporter>();
-  }
-};
-
-class NoopLogRecordExporterBuilder : public config_sdk::ExtensionLogRecordExporterBuilder
-{
-public:
-  std::unique_ptr<logs_sdk::LogRecordExporter> Build(
-      const config_sdk::ExtensionLogRecordExporterConfiguration *) const override
-  {
-    return std::make_unique<NoopLogRecordExporter>();
-  }
-};
-
-class NoopPushMetricExporterBuilder : public config_sdk::ExtensionPushMetricExporterBuilder
-{
-public:
-  std::unique_ptr<metrics_sdk::PushMetricExporter> Build(
-      const config_sdk::ExtensionPushMetricExporterConfiguration *) const override
-  {
-    return std::make_unique<NoopPushMetricExporter>();
-  }
-};
+using namespace config_test;  // NOLINT(google-build-using-namespace)
 
 //------------------------------------------------------------------------------
 // ConfiguredSdkTest fixture
@@ -216,6 +136,7 @@ protected:
         "noop", std::make_unique<NoopLogRecordExporterBuilder>());
     registry_->SetExtensionPushMetricExporterBuilder(
         "noop", std::make_unique<NoopPushMetricExporterBuilder>());
+    registry_->SetPeriodicMetricReaderBuilder(std::make_unique<NoopPeriodicMetricReaderBuilder>());
   }
 
   static std::unique_ptr<config_sdk::TracerProviderConfiguration> MakeTracerProviderConfig()

--- a/sdk/test/configuration/configured_sdk_test.cc
+++ b/sdk/test/configuration/configured_sdk_test.cc
@@ -43,9 +43,6 @@
 #include "opentelemetry/sdk/configuration/span_exporter_configuration.h"
 #include "opentelemetry/sdk/configuration/span_processor_configuration.h"
 #include "opentelemetry/sdk/configuration/tracer_provider_configuration.h"
-#include "opentelemetry/sdk/logs/recordable.h"
-#include "opentelemetry/sdk/metrics/state/filtered_ordered_attribute_map.h"
-#include "opentelemetry/sdk/trace/span_limits.h"
 
 #include "config_test_common.h"
 
@@ -58,8 +55,6 @@ namespace internal_log = opentelemetry::sdk::common::internal_log;
 
 namespace
 {
-
-using namespace config_test;  // NOLINT(google-build-using-namespace)
 
 //------------------------------------------------------------------------------
 // ConfiguredSdkTest fixture
@@ -119,12 +114,14 @@ protected:
   void MakeRegistry()
   {
     registry_ = std::make_shared<config_sdk::Registry>();
-    registry_->SetExtensionSpanExporterBuilder("noop", std::make_unique<NoopSpanExporterBuilder>());
+    registry_->SetExtensionSpanExporterBuilder(
+        "noop", std::make_unique<config_test::NoopSpanExporterBuilder>());
     registry_->SetExtensionLogRecordExporterBuilder(
-        "noop", std::make_unique<NoopLogRecordExporterBuilder>());
+        "noop", std::make_unique<config_test::NoopLogRecordExporterBuilder>());
     registry_->SetExtensionPushMetricExporterBuilder(
-        "noop", std::make_unique<NoopPushMetricExporterBuilder>());
-    registry_->SetPeriodicMetricReaderBuilder(std::make_unique<NoopPeriodicMetricReaderBuilder>());
+        "noop", std::make_unique<config_test::NoopPushMetricExporterBuilder>());
+    registry_->SetPeriodicMetricReaderBuilder(
+        std::make_unique<config_test::NoopPeriodicMetricReaderBuilder>());
   }
 
   static std::unique_ptr<config_sdk::TracerProviderConfiguration> MakeTracerProviderConfig()

--- a/sdk/test/configuration/configured_sdk_test.cc
+++ b/sdk/test/configuration/configured_sdk_test.cc
@@ -3,7 +3,6 @@
 
 #include <gtest/gtest.h>
 
-#include <chrono>
 #include <string>
 #include <utility>
 #include <vector>
@@ -18,7 +17,6 @@
 #include "opentelemetry/trace/noop.h"
 #include "opentelemetry/trace/provider.h"
 
-#include "opentelemetry/sdk/common/exporter_utils.h"
 #include "opentelemetry/sdk/common/global_log_handler.h"
 #include "opentelemetry/sdk/configuration/configuration.h"
 #include "opentelemetry/sdk/configuration/configured_sdk.h"
@@ -45,13 +43,9 @@
 #include "opentelemetry/sdk/configuration/span_exporter_configuration.h"
 #include "opentelemetry/sdk/configuration/span_processor_configuration.h"
 #include "opentelemetry/sdk/configuration/tracer_provider_configuration.h"
-#include "opentelemetry/sdk/logs/exporter.h"
-#include "opentelemetry/sdk/logs/read_write_log_record.h"
-#include "opentelemetry/sdk/metrics/instruments.h"
-#include "opentelemetry/sdk/metrics/metric_reader.h"
-#include "opentelemetry/sdk/metrics/push_metric_exporter.h"
-#include "opentelemetry/sdk/trace/exporter.h"
-#include "opentelemetry/sdk/trace/span_data.h"
+#include "opentelemetry/sdk/logs/recordable.h"
+#include "opentelemetry/sdk/metrics/state/filtered_ordered_attribute_map.h"
+#include "opentelemetry/sdk/trace/span_limits.h"
 
 #include "config_test_common.h"
 

--- a/sdk/test/configuration/configured_sdk_test.cc
+++ b/sdk/test/configuration/configured_sdk_test.cc
@@ -49,16 +49,10 @@
 
 #include "config_test_common.h"
 
-namespace nostd       = opentelemetry::nostd;
-namespace trace       = opentelemetry::trace;
-namespace logs        = opentelemetry::logs;
-namespace metrics     = opentelemetry::metrics;
-namespace propagation = opentelemetry::context::propagation;
-
-namespace common_sdk   = opentelemetry::sdk::common;
-namespace logs_sdk     = opentelemetry::sdk::logs;
-namespace metrics_sdk  = opentelemetry::sdk::metrics;
-namespace trace_sdk    = opentelemetry::sdk::trace;
+namespace trace        = opentelemetry::trace;
+namespace logs         = opentelemetry::logs;
+namespace metrics      = opentelemetry::metrics;
+namespace propagation  = opentelemetry::context::propagation;
 namespace config_sdk   = opentelemetry::sdk::configuration;
 namespace internal_log = opentelemetry::sdk::common::internal_log;
 

--- a/sdk/test/configuration/programmatic_configuration_test.cc
+++ b/sdk/test/configuration/programmatic_configuration_test.cc
@@ -40,6 +40,7 @@
 #include "opentelemetry/trace/tracer.h"
 #include "opentelemetry/trace/tracer_provider.h"
 
+#include "opentelemetry/sdk/common/exporter_utils.h"
 #include "opentelemetry/sdk/configuration/aggregation_configuration.h"
 #include "opentelemetry/sdk/configuration/always_off_sampler_configuration.h"
 #include "opentelemetry/sdk/configuration/base2_exponential_bucket_histogram_aggregation_configuration.h"
@@ -87,20 +88,13 @@
 #include "opentelemetry/sdk/configuration/view_configuration.h"
 #include "opentelemetry/sdk/configuration/view_selector_configuration.h"
 #include "opentelemetry/sdk/configuration/view_stream_configuration.h"
-
-#include "opentelemetry/sdk/common/exporter_utils.h"
-#include "opentelemetry/sdk/logs/exporter.h"
 #include "opentelemetry/sdk/logs/logger_provider.h"
 #include "opentelemetry/sdk/logs/read_write_log_record.h"
 #include "opentelemetry/sdk/metrics/data/metric_data.h"
 #include "opentelemetry/sdk/metrics/data/point_data.h"
-#include "opentelemetry/sdk/metrics/export/metric_producer.h"
 #include "opentelemetry/sdk/metrics/instruments.h"
 #include "opentelemetry/sdk/metrics/meter_provider.h"
-#include "opentelemetry/sdk/metrics/metric_reader.h"
-#include "opentelemetry/sdk/metrics/push_metric_exporter.h"
 #include "opentelemetry/sdk/resource/resource.h"
-#include "opentelemetry/sdk/trace/exporter.h"
 #include "opentelemetry/sdk/trace/span_data.h"
 #include "opentelemetry/sdk/trace/tracer_provider.h"
 

--- a/sdk/test/configuration/programmatic_configuration_test.cc
+++ b/sdk/test/configuration/programmatic_configuration_test.cc
@@ -113,6 +113,8 @@ namespace config_sdk  = opentelemetry::sdk::configuration;
 namespace
 {
 
+constexpr std::chrono::milliseconds kProcessTimeout{1000};
+
 //---------------------------------------------------------------------------
 // ProgrammaticConfigTest fixture: This supports integration testing of the configured SDK.
 // It registers the recording exporters and maintains buffers for inspection of exported signal
@@ -190,10 +192,7 @@ protected:
     exporter->name   = "recording";
     auto reader      = std::make_unique<config_sdk::PeriodicMetricReaderConfiguration>();
     reader->exporter = std::move(exporter);
-    reader->interval = 3'600'000;  // milliseconds. Set to a large value and rely on ForceFlush to
-                                   // trigger collection.
-    reader->timeout = 60'000;      // milliseconds
-    auto config     = std::make_unique<config_sdk::MeterProviderConfiguration>();
+    auto config      = std::make_unique<config_sdk::MeterProviderConfiguration>();
     config->readers.emplace_back(std::move(reader));
     return config;
   }
@@ -286,10 +285,10 @@ TEST_F(ProgrammaticConfigTest, LoggerProviderWithDefaults)
       logs::Severity::kInfo, nostd::string_view("test-message"),
       common::MakeAttributes({{"key1", "value1"}, {"key2", "value2"}, {"key3", "value3"}}));
 
-  ASSERT_TRUE(sdk_->logger_provider->ForceFlush(std::chrono::milliseconds(5000)));
-  ASSERT_TRUE(sdk_->logger_provider->Shutdown(std::chrono::milliseconds(5000)));
+  ASSERT_TRUE(sdk_->logger_provider->ForceFlush(std::chrono::milliseconds(kProcessTimeout)));
+  ASSERT_TRUE(sdk_->logger_provider->Shutdown(std::chrono::milliseconds(kProcessTimeout)));
 
-  EXPECT_GE(log_buffer_->size(), 1);
+  EXPECT_EQ(log_buffer_->size(), 1);
 }
 
 TEST_F(ProgrammaticConfigTest, LoggerProviderWithLogRecordLimits)
@@ -313,10 +312,10 @@ TEST_F(ProgrammaticConfigTest, LoggerProviderWithLogRecordLimits)
       logs::Severity::kInfo, nostd::string_view("test-message"),
       common::MakeAttributes({{"key1", "value1"}, {"key2", "value2"}, {"key3", "value3"}}));
 
-  ASSERT_TRUE(sdk_->logger_provider->ForceFlush(std::chrono::milliseconds(5000)));
-  ASSERT_TRUE(sdk_->logger_provider->Shutdown(std::chrono::milliseconds(5000)));
+  ASSERT_TRUE(sdk_->logger_provider->ForceFlush(std::chrono::milliseconds(kProcessTimeout)));
+  ASSERT_TRUE(sdk_->logger_provider->Shutdown(std::chrono::milliseconds(kProcessTimeout)));
 
-  EXPECT_GE(log_buffer_->size(), 1);
+  EXPECT_EQ(log_buffer_->size(), 1);
   auto *record = log_buffer_->front().get();
   EXPECT_EQ(nostd::get<std::string>(record->GetBody()), "test-message");
   const auto &attributes = record->GetAttributes();
@@ -362,10 +361,10 @@ TEST_F(ProgrammaticConfigTest, LoggerProviderWithLoggerConfigurator)
   EXPECT_FALSE(error_logger->Enabled(logs::Severity::kInfo));
   EXPECT_TRUE(error_logger->Enabled(logs::Severity::kError));
 
-  ASSERT_TRUE(sdk_->logger_provider->ForceFlush(std::chrono::milliseconds(5000)));
-  ASSERT_TRUE(sdk_->logger_provider->Shutdown(std::chrono::milliseconds(5000)));
+  ASSERT_TRUE(sdk_->logger_provider->ForceFlush(std::chrono::milliseconds(kProcessTimeout)));
+  ASSERT_TRUE(sdk_->logger_provider->Shutdown(std::chrono::milliseconds(kProcessTimeout)));
 
-  EXPECT_GE(log_buffer_->size(), 2);
+  EXPECT_EQ(log_buffer_->size(), 2);
 }
 
 // TODO: Re-enable this test once a mock BatchSpanProcessor can be configured.
@@ -387,8 +386,8 @@ TEST_F(ProgrammaticConfigTest, DISABLED_LoggerProviderWithBatchProcessorDefaults
   ASSERT_NE(sdk_->logger_provider, nullptr);
 
   logs::Provider::GetLoggerProvider()->GetLogger("test")->Info("test-message");
-  ASSERT_TRUE(sdk_->logger_provider->ForceFlush(std::chrono::milliseconds(5000)));
-  ASSERT_TRUE(sdk_->logger_provider->Shutdown(std::chrono::milliseconds(5000)));
+  ASSERT_TRUE(sdk_->logger_provider->ForceFlush(std::chrono::milliseconds(kProcessTimeout)));
+  ASSERT_TRUE(sdk_->logger_provider->Shutdown(std::chrono::milliseconds(kProcessTimeout)));
 
   EXPECT_GE(log_buffer_->size(), 1);
 }
@@ -400,10 +399,10 @@ TEST_F(ProgrammaticConfigTest, DISABLED_LoggerProviderWithBatchProcessorConfigur
   exporter->name      = "recording";
   auto processor      = std::make_unique<config_sdk::BatchLogRecordProcessorConfiguration>();
   processor->exporter = std::move(exporter);
-  processor->schedule_delay        = 60000;
+  processor->schedule_delay        = 1000;
   processor->max_queue_size        = 100;
   processor->max_export_batch_size = 50;
-  processor->export_timeout        = 5000;
+  processor->export_timeout        = 1000;
   auto logger_provider_config      = std::make_unique<config_sdk::LoggerProviderConfiguration>();
   logger_provider_config->processors.emplace_back(std::move(processor));
 
@@ -414,8 +413,8 @@ TEST_F(ProgrammaticConfigTest, DISABLED_LoggerProviderWithBatchProcessorConfigur
   ASSERT_NE(sdk_->logger_provider, nullptr);
 
   logs::Provider::GetLoggerProvider()->GetLogger("test")->Info("test-message");
-  ASSERT_TRUE(sdk_->logger_provider->ForceFlush(std::chrono::milliseconds(5000)));
-  ASSERT_TRUE(sdk_->logger_provider->Shutdown(std::chrono::milliseconds(5000)));
+  ASSERT_TRUE(sdk_->logger_provider->ForceFlush(std::chrono::milliseconds(kProcessTimeout)));
+  ASSERT_TRUE(sdk_->logger_provider->Shutdown(std::chrono::milliseconds(kProcessTimeout)));
 
   EXPECT_GE(log_buffer_->size(), 1);
 }
@@ -436,10 +435,10 @@ TEST_F(ProgrammaticConfigTest, MeterProviderWithDefaults)
       ->CreateUInt64Counter("test-counter")
       ->Add(1);
 
-  ASSERT_TRUE(sdk_->meter_provider->ForceFlush(std::chrono::milliseconds(5000)));
-  ASSERT_TRUE(sdk_->meter_provider->Shutdown(std::chrono::milliseconds(5000)));
+  ASSERT_TRUE(sdk_->meter_provider->ForceFlush(std::chrono::milliseconds(kProcessTimeout)));
+  ASSERT_TRUE(sdk_->meter_provider->Shutdown(std::chrono::milliseconds(kProcessTimeout)));
 
-  EXPECT_GE(metric_buffer_->size(), 1);
+  EXPECT_EQ(metric_buffer_->size(), 1);
 }
 
 TEST_F(ProgrammaticConfigTest, MeterProviderWithMeterConfigurator)
@@ -465,10 +464,10 @@ TEST_F(ProgrammaticConfigTest, MeterProviderWithMeterConfigurator)
   auto disabled_meter = metrics::Provider::GetMeterProvider()->GetMeter(disabled_meter_config.name);
   disabled_meter->CreateUInt64Counter("disabled-test-counter")->Add(1);
 
-  ASSERT_TRUE(sdk_->meter_provider->ForceFlush(std::chrono::milliseconds(5000)));
-  ASSERT_TRUE(sdk_->meter_provider->Shutdown(std::chrono::milliseconds(5000)));
+  ASSERT_TRUE(sdk_->meter_provider->ForceFlush(std::chrono::milliseconds(kProcessTimeout)));
+  ASSERT_TRUE(sdk_->meter_provider->Shutdown(std::chrono::milliseconds(kProcessTimeout)));
 
-  EXPECT_GE(metric_buffer_->size(), 1);
+  EXPECT_EQ(metric_buffer_->size(), 1);
   for (const auto &metric : *metric_buffer_)
   {
     EXPECT_NE(metric.instrument_descriptor.name_, "disabled-test-counter");
@@ -541,11 +540,11 @@ TEST_F(ProgrammaticConfigTest, MeterProviderWithViews)
   meter->CreateDoubleHistogram("exponential-histogram")->Record(42.0, context);
   meter->CreateDoubleHistogram("explicit-histogram")->Record(42.0, context);
   meter->CreateUInt64Counter("default-counter")->Add(1, context);
-  ASSERT_TRUE(sdk_->meter_provider->ForceFlush(std::chrono::milliseconds(5000)));
-  ASSERT_TRUE(sdk_->meter_provider->Shutdown(std::chrono::milliseconds(5000)));
+  ASSERT_TRUE(sdk_->meter_provider->ForceFlush(std::chrono::milliseconds(kProcessTimeout)));
+  ASSERT_TRUE(sdk_->meter_provider->Shutdown(std::chrono::milliseconds(kProcessTimeout)));
 
   // check that instances of the three data points were collected and are of the right type.
-  EXPECT_GE(metric_buffer_->size(), 3);
+  EXPECT_EQ(metric_buffer_->size(), 3);
   bool found_base2_histogram    = false;
   bool found_explicit_histogram = false;
   bool found_default_counter    = false;
@@ -590,8 +589,8 @@ TEST_F(ProgrammaticConfigTest, TracerProviderWithDefaults)
   auto default_tracer = trace::Provider::GetTracerProvider()->GetTracer("default-tracer");
   default_tracer->StartSpan("test-span")->End();
 
-  ASSERT_TRUE(sdk_->tracer_provider->ForceFlush(std::chrono::milliseconds(5000)));
-  ASSERT_TRUE(sdk_->tracer_provider->Shutdown(std::chrono::milliseconds(5000)));
+  ASSERT_TRUE(sdk_->tracer_provider->ForceFlush(std::chrono::milliseconds(kProcessTimeout)));
+  ASSERT_TRUE(sdk_->tracer_provider->Shutdown(std::chrono::milliseconds(kProcessTimeout)));
 
   EXPECT_EQ(span_buffer_->size(), 1);
 }
@@ -619,7 +618,7 @@ TEST_F(ProgrammaticConfigTest, TracerProviderWithTracerConfigurator)
   auto disabled_tracer = trace::Provider::GetTracerProvider()->GetTracer("disabled-tracer");
   disabled_tracer->StartSpan("disabled-test-span")->End();
 
-  ASSERT_TRUE(sdk_->tracer_provider->ForceFlush(std::chrono::milliseconds(5000)));
+  ASSERT_TRUE(sdk_->tracer_provider->ForceFlush(std::chrono::milliseconds(kProcessTimeout)));
 
   ASSERT_EQ(span_buffer_->size(), 1);
   EXPECT_NE(span_buffer_->at(0)->GetName(), "disabled-test-span");
@@ -636,8 +635,8 @@ TEST_F(ProgrammaticConfigTest, TracerProviderWithSampler)
   ASSERT_NE(sdk_->tracer_provider, nullptr);
 
   trace::Provider::GetTracerProvider()->GetTracer("test")->StartSpan("test-span")->End();
-  ASSERT_TRUE(sdk_->tracer_provider->ForceFlush(std::chrono::milliseconds(5000)));
-  ASSERT_TRUE(sdk_->tracer_provider->Shutdown(std::chrono::milliseconds(5000)));
+  ASSERT_TRUE(sdk_->tracer_provider->ForceFlush(std::chrono::milliseconds(kProcessTimeout)));
+  ASSERT_TRUE(sdk_->tracer_provider->Shutdown(std::chrono::milliseconds(kProcessTimeout)));
 
   EXPECT_EQ(span_buffer_->size(), 0);
 }
@@ -654,8 +653,8 @@ TEST_F(ProgrammaticConfigTest, TracerProviderWithParentBasedSamplerNullRoot)
   ASSERT_NE(sdk_->tracer_provider, nullptr);
 
   trace::Provider::GetTracerProvider()->GetTracer("test")->StartSpan("test-span")->End();
-  ASSERT_TRUE(sdk_->tracer_provider->ForceFlush(std::chrono::milliseconds(5000)));
-  ASSERT_TRUE(sdk_->tracer_provider->Shutdown(std::chrono::milliseconds(5000)));
+  ASSERT_TRUE(sdk_->tracer_provider->ForceFlush(std::chrono::milliseconds(kProcessTimeout)));
+  ASSERT_TRUE(sdk_->tracer_provider->Shutdown(std::chrono::milliseconds(kProcessTimeout)));
 
   EXPECT_EQ(span_buffer_->size(), 1);
 }
@@ -676,8 +675,8 @@ TEST_F(ProgrammaticConfigTest, DISABLED_TracerProviderWithBatchProcessor)
   CreateAndInstallSdk(model);
 
   trace::Provider::GetTracerProvider()->GetTracer("test")->StartSpan("test-span")->End();
-  ASSERT_TRUE(sdk_->tracer_provider->ForceFlush(std::chrono::milliseconds(5000)));
-  ASSERT_TRUE(sdk_->tracer_provider->Shutdown(std::chrono::milliseconds(5000)));
+  ASSERT_TRUE(sdk_->tracer_provider->ForceFlush(std::chrono::milliseconds(kProcessTimeout)));
+  ASSERT_TRUE(sdk_->tracer_provider->Shutdown(std::chrono::milliseconds(kProcessTimeout)));
 
   EXPECT_GE(span_buffer_->size(), 1);
 }
@@ -691,7 +690,7 @@ TEST_F(ProgrammaticConfigTest, DISABLED_TracerProviderWithBatchProcessorConfigur
   processor->schedule_delay = 60000;
   processor->max_queue_size = 100;
   processor->max_export_batch_size = 50;
-  processor->export_timeout        = 5000;
+  processor->export_timeout        = 1000;
   processor->exporter              = std::move(exporter);
   auto tracer_provider_config      = std::make_unique<config_sdk::TracerProviderConfiguration>();
   tracer_provider_config->processors.emplace_back(std::move(processor));
@@ -702,8 +701,8 @@ TEST_F(ProgrammaticConfigTest, DISABLED_TracerProviderWithBatchProcessorConfigur
   CreateAndInstallSdk(model);
 
   trace::Provider::GetTracerProvider()->GetTracer("test")->StartSpan("test-span")->End();
-  ASSERT_TRUE(sdk_->tracer_provider->ForceFlush(std::chrono::milliseconds(5000)));
-  ASSERT_TRUE(sdk_->tracer_provider->Shutdown(std::chrono::milliseconds(5000)));
+  ASSERT_TRUE(sdk_->tracer_provider->ForceFlush(std::chrono::milliseconds(kProcessTimeout)));
+  ASSERT_TRUE(sdk_->tracer_provider->Shutdown(std::chrono::milliseconds(kProcessTimeout)));
 
   EXPECT_GE(span_buffer_->size(), 1);
 }

--- a/sdk/test/configuration/programmatic_configuration_test.cc
+++ b/sdk/test/configuration/programmatic_configuration_test.cc
@@ -368,7 +368,10 @@ TEST_F(ProgrammaticConfigTest, LoggerProviderWithLoggerConfigurator)
   EXPECT_GE(log_buffer_->size(), 2);
 }
 
-TEST_F(ProgrammaticConfigTest, LoggerProviderWithBatchProcessorDefaults)
+// TODO: Re-enable this test once a mock BatchSpanProcessor can be configured.
+// All tests that use a BatchProcessor may timeout due to the a race between the background thread
+// and the ForceFlush call.
+TEST_F(ProgrammaticConfigTest, DISABLED_LoggerProviderWithBatchProcessorDefaults)
 {
   auto exporter       = std::make_unique<config_sdk::ExtensionLogRecordExporterConfiguration>();
   exporter->name      = "recording";
@@ -390,7 +393,8 @@ TEST_F(ProgrammaticConfigTest, LoggerProviderWithBatchProcessorDefaults)
   EXPECT_GE(log_buffer_->size(), 1);
 }
 
-TEST_F(ProgrammaticConfigTest, LoggerProviderWithBatchProcessorConfigured)
+// TODO: Re-enable this test once a mock BatchProcessor can be configured.
+TEST_F(ProgrammaticConfigTest, DISABLED_LoggerProviderWithBatchProcessorConfigured)
 {
   auto exporter       = std::make_unique<config_sdk::ExtensionLogRecordExporterConfiguration>();
   exporter->name      = "recording";
@@ -656,9 +660,8 @@ TEST_F(ProgrammaticConfigTest, TracerProviderWithParentBasedSamplerNullRoot)
   EXPECT_EQ(span_buffer_->size(), 1);
 }
 
-// TODO: Re-enable this test once the BatchSpanProcessorConfiguration is initialized with spec
-// defaults.
-TEST_F(ProgrammaticConfigTest, TracerProviderWithBatchProcessor)
+// TODO: Re-enable this test once a mock BatchSpanProcessor can be configured.
+TEST_F(ProgrammaticConfigTest, DISABLED_TracerProviderWithBatchProcessor)
 {
   auto exporter               = std::make_unique<config_sdk::ExtensionSpanExporterConfiguration>();
   exporter->name              = "recording";
@@ -679,7 +682,8 @@ TEST_F(ProgrammaticConfigTest, TracerProviderWithBatchProcessor)
   EXPECT_GE(span_buffer_->size(), 1);
 }
 
-TEST_F(ProgrammaticConfigTest, TracerProviderWithBatchProcessorConfigured)
+// TODO: Re-enable this test once a mock BatchSpanProcessor can be configured.
+TEST_F(ProgrammaticConfigTest, DISABLED_TracerProviderWithBatchProcessorConfigured)
 {
   auto exporter             = std::make_unique<config_sdk::ExtensionSpanExporterConfiguration>();
   exporter->name            = "recording";

--- a/sdk/test/configuration/programmatic_configuration_test.cc
+++ b/sdk/test/configuration/programmatic_configuration_test.cc
@@ -100,18 +100,15 @@
 
 #include "config_test_common.h"
 
+namespace common      = opentelemetry::common;
 namespace nostd       = opentelemetry::nostd;
+namespace metrics     = opentelemetry::metrics;
 namespace trace       = opentelemetry::trace;
 namespace logs        = opentelemetry::logs;
-namespace metrics     = opentelemetry::metrics;
-namespace common      = opentelemetry::common;
 namespace baggage     = opentelemetry::baggage;
 namespace propagation = opentelemetry::context::propagation;
 namespace context     = opentelemetry::context;
-namespace common_sdk  = opentelemetry::sdk::common;
-namespace logs_sdk    = opentelemetry::sdk::logs;
 namespace metrics_sdk = opentelemetry::sdk::metrics;
-namespace trace_sdk   = opentelemetry::sdk::trace;
 namespace config_sdk  = opentelemetry::sdk::configuration;
 
 namespace

--- a/sdk/test/configuration/programmatic_configuration_test.cc
+++ b/sdk/test/configuration/programmatic_configuration_test.cc
@@ -68,6 +68,7 @@
 #include "opentelemetry/sdk/configuration/meter_provider_configuration.h"
 #include "opentelemetry/sdk/configuration/metric_reader_configuration.h"
 #include "opentelemetry/sdk/configuration/parent_based_sampler_configuration.h"
+#include "opentelemetry/sdk/configuration/periodic_metric_reader_builder.h"
 #include "opentelemetry/sdk/configuration/periodic_metric_reader_configuration.h"
 #include "opentelemetry/sdk/configuration/propagator_configuration.h"
 #include "opentelemetry/sdk/configuration/push_metric_exporter_configuration.h"
@@ -96,11 +97,14 @@
 #include "opentelemetry/sdk/metrics/export/metric_producer.h"
 #include "opentelemetry/sdk/metrics/instruments.h"
 #include "opentelemetry/sdk/metrics/meter_provider.h"
+#include "opentelemetry/sdk/metrics/metric_reader.h"
 #include "opentelemetry/sdk/metrics/push_metric_exporter.h"
 #include "opentelemetry/sdk/resource/resource.h"
 #include "opentelemetry/sdk/trace/exporter.h"
 #include "opentelemetry/sdk/trace/span_data.h"
 #include "opentelemetry/sdk/trace/tracer_provider.h"
+
+#include "config_test_common.h"
 
 namespace nostd       = opentelemetry::nostd;
 namespace trace       = opentelemetry::trace;
@@ -118,181 +122,8 @@ namespace config_sdk  = opentelemetry::sdk::configuration;
 
 namespace
 {
-// ---------------------------------------------------------------------------
-// Shared export buffers
 
-using LogRecordBuffer = std::vector<std::unique_ptr<logs_sdk::ReadWriteLogRecord>>;
-using SpanBuffer      = std::vector<std::unique_ptr<trace_sdk::SpanData>>;
-using MetricBuffer    = std::vector<metrics_sdk::MetricData>;
-
-// ---------------------------------------------------------------------------
-// Recording exporters to support integration testing of the configured SDK.
-// These exporters record the data they receive into a buffer for later inspection.
-
-class RecordingSpanExporter : public trace_sdk::SpanExporter
-{
-public:
-  explicit RecordingSpanExporter(std::shared_ptr<SpanBuffer> buffer) : buffer_(std::move(buffer)) {}
-
-  std::unique_ptr<trace_sdk::Recordable> MakeRecordable() noexcept override
-  {
-    return std::make_unique<trace_sdk::SpanData>();
-  }
-
-  common_sdk::ExportResult Export(
-      const nostd::span<std::unique_ptr<trace_sdk::Recordable>> &spans) noexcept override
-  {
-    for (auto &span : spans)
-    {
-      buffer_->emplace_back(static_cast<trace_sdk::SpanData *>(span.release()));
-    }
-    return common_sdk::ExportResult::kSuccess;
-  }
-
-  bool ForceFlush(std::chrono::microseconds) noexcept override { return true; }
-  bool Shutdown(std::chrono::microseconds) noexcept override { return true; }
-
-private:
-  std::shared_ptr<SpanBuffer> buffer_;
-};
-
-class RecordingLogRecordExporter : public logs_sdk::LogRecordExporter
-{
-public:
-  explicit RecordingLogRecordExporter(std::shared_ptr<LogRecordBuffer> buffer)
-      : buffer_(std::move(buffer))
-  {}
-
-  std::unique_ptr<logs_sdk::Recordable> MakeRecordable() noexcept override
-  {
-    return std::make_unique<logs_sdk::ReadWriteLogRecord>();
-  }
-
-  common_sdk::ExportResult Export(
-      const nostd::span<std::unique_ptr<logs_sdk::Recordable>> &records) noexcept override
-  {
-    for (auto &rec : records)
-    {
-      buffer_->emplace_back(static_cast<logs_sdk::ReadWriteLogRecord *>(rec.release()));
-    }
-    return common_sdk::ExportResult::kSuccess;
-  }
-
-  bool RecordableEnforcesLogRecordLimits() const noexcept override { return true; }
-
-  bool ForceFlush(std::chrono::microseconds) noexcept override { return true; }
-  bool Shutdown(std::chrono::microseconds) noexcept override { return true; }
-
-private:
-  std::shared_ptr<LogRecordBuffer> buffer_;
-};
-
-class RecordingPushMetricExporter : public metrics_sdk::PushMetricExporter
-{
-public:
-  explicit RecordingPushMetricExporter(std::shared_ptr<MetricBuffer> buffer)
-      : buffer_(std::move(buffer))
-  {}
-
-  common_sdk::ExportResult Export(
-      const metrics_sdk::ResourceMetrics &resource_metrics) noexcept override
-  {
-    for (const auto &scope : resource_metrics.scope_metric_data_)
-    {
-      for (const auto &metric : scope.metric_data_)
-      {
-        buffer_->emplace_back(metric);
-      }
-    }
-    return common_sdk::ExportResult::kSuccess;
-  }
-
-  metrics_sdk::AggregationTemporality GetAggregationTemporality(
-      metrics_sdk::InstrumentType) const noexcept override
-  {
-    return metrics_sdk::AggregationTemporality::kCumulative;
-  }
-
-  bool ForceFlush(std::chrono::microseconds) noexcept override { return true; }
-  bool Shutdown(std::chrono::microseconds) noexcept override { return true; }
-
-private:
-  std::shared_ptr<MetricBuffer> buffer_;
-};
-
-// ---------------------------------------------------------------------------
-// Configuration Builders for recording exporters
-
-class RecordingSpanExporterBuilder : public config_sdk::ExtensionSpanExporterBuilder
-{
-public:
-  explicit RecordingSpanExporterBuilder(std::shared_ptr<SpanBuffer> buffer)
-      : buffer_(std::move(buffer))
-  {}
-  std::unique_ptr<trace_sdk::SpanExporter> Build(
-      const config_sdk::ExtensionSpanExporterConfiguration *) const override
-  {
-    return std::make_unique<RecordingSpanExporter>(buffer_);
-  }
-
-private:
-  std::shared_ptr<SpanBuffer> buffer_;
-};
-
-class RecordingLogRecordExporterBuilder : public config_sdk::ExtensionLogRecordExporterBuilder
-{
-public:
-  explicit RecordingLogRecordExporterBuilder(std::shared_ptr<LogRecordBuffer> buffer)
-      : buffer_(std::move(buffer))
-  {}
-  std::unique_ptr<logs_sdk::LogRecordExporter> Build(
-      const config_sdk::ExtensionLogRecordExporterConfiguration *) const override
-  {
-    return std::make_unique<RecordingLogRecordExporter>(buffer_);
-  }
-
-private:
-  std::shared_ptr<LogRecordBuffer> buffer_;
-};
-
-class RecordingPushMetricExporterBuilder : public config_sdk::ExtensionPushMetricExporterBuilder
-{
-public:
-  explicit RecordingPushMetricExporterBuilder(std::shared_ptr<MetricBuffer> buffer)
-      : buffer_(std::move(buffer))
-  {}
-  std::unique_ptr<metrics_sdk::PushMetricExporter> Build(
-      const config_sdk::ExtensionPushMetricExporterConfiguration *) const override
-  {
-    auto exporter = std::make_unique<RecordingPushMetricExporter>(buffer_);
-    return exporter;
-  }
-
-private:
-  std::shared_ptr<MetricBuffer> buffer_;
-};
-
-// ---------------------------------------------------------------------------
-// TextMapCarrier for propagator tests.
-
-class MapCarrier : public propagation::TextMapCarrier
-{
-public:
-  nostd::string_view Get(nostd::string_view key) const noexcept override
-  {
-    auto it = map_.find(std::string(key));
-    return it != map_.end() ? nostd::string_view(it->second) : "";
-  }
-  void Set(nostd::string_view key, nostd::string_view value) noexcept override
-  {
-    map_[std::string(key)] = std::string(value);
-  }
-
-  const std::map<std::string, std::string> &map() const { return map_; }
-
-private:
-  std::map<std::string, std::string> map_;
-};
+using namespace config_test;  // NOLINT(google-build-using-namespace)
 
 //---------------------------------------------------------------------------
 // ProgrammaticConfigTest fixture: This supports integration testing of the configured SDK.
@@ -338,6 +169,7 @@ protected:
         "recording", std::make_unique<RecordingLogRecordExporterBuilder>(log_buffer_));
     registry_->SetExtensionPushMetricExporterBuilder(
         "recording", std::make_unique<RecordingPushMetricExporterBuilder>(metric_buffer_));
+    registry_->SetPeriodicMetricReaderBuilder(std::make_unique<SyncPeriodicMetricReaderBuilder>());
   }
 
   static std::unique_ptr<config_sdk::TracerProviderConfiguration> MakeTracerProviderConfig()
@@ -469,8 +301,7 @@ TEST_F(ProgrammaticConfigTest, LoggerProviderWithDefaults)
 
 TEST_F(ProgrammaticConfigTest, LoggerProviderWithLogRecordLimits)
 {
-  config_sdk::LogRecordLimitsConfiguration limits{
-      0, 0};  // TODO: Remove the default initialization once the limit members are initialized.
+  config_sdk::LogRecordLimitsConfiguration limits;
   limits.attribute_count_limit        = 2;
   limits.attribute_value_length_limit = 5;
 
@@ -595,10 +426,7 @@ TEST_F(ProgrammaticConfigTest, LoggerProviderWithBatchProcessorConfigured)
 //--------------------------------------------------------------------------
 // MeterProvider tests
 
-// TODO: These test cases may timeout due to threading in the PeriodicExportingMetricReader
-// that cause ForceFlush or Shutdown to block indefinitely. Disabling for now until we can fix the
-// underlying issue.
-TEST_F(ProgrammaticConfigTest, DISABLED_MeterProviderWithDefaults)
+TEST_F(ProgrammaticConfigTest, MeterProviderWithDefaults)
 {
   auto model            = std::make_unique<config_sdk::Configuration>();
   model->meter_provider = MakeMeterProviderConfig();
@@ -617,7 +445,7 @@ TEST_F(ProgrammaticConfigTest, DISABLED_MeterProviderWithDefaults)
   EXPECT_GE(metric_buffer_->size(), 1);
 }
 
-TEST_F(ProgrammaticConfigTest, DISABLED_MeterProviderWithMeterConfigurator)
+TEST_F(ProgrammaticConfigTest, MeterProviderWithMeterConfigurator)
 {
   auto disabled_meter_config           = config_sdk::MeterMatcherAndConfigConfiguration();
   disabled_meter_config.name           = "disabled-meter";
@@ -650,7 +478,7 @@ TEST_F(ProgrammaticConfigTest, DISABLED_MeterProviderWithMeterConfigurator)
   }
 }
 
-TEST_F(ProgrammaticConfigTest, DISABLED_MeterProviderWithViews)
+TEST_F(ProgrammaticConfigTest, MeterProviderWithViews)
 {
   // View 1: Base2 exponential aggregation
   const std::size_t max_scale   = 10;

--- a/sdk/test/configuration/programmatic_configuration_test.cc
+++ b/sdk/test/configuration/programmatic_configuration_test.cc
@@ -40,7 +40,6 @@
 #include "opentelemetry/trace/tracer.h"
 #include "opentelemetry/trace/tracer_provider.h"
 
-#include "opentelemetry/sdk/common/exporter_utils.h"
 #include "opentelemetry/sdk/configuration/aggregation_configuration.h"
 #include "opentelemetry/sdk/configuration/always_off_sampler_configuration.h"
 #include "opentelemetry/sdk/configuration/base2_exponential_bucket_histogram_aggregation_configuration.h"
@@ -114,8 +113,6 @@ namespace config_sdk  = opentelemetry::sdk::configuration;
 namespace
 {
 
-using namespace config_test;  // NOLINT(google-build-using-namespace)
-
 //---------------------------------------------------------------------------
 // ProgrammaticConfigTest fixture: This supports integration testing of the configured SDK.
 // It registers the recording exporters and maintains buffers for inspection of exported signal
@@ -155,12 +152,14 @@ protected:
   {
     registry_ = std::make_shared<config_sdk::Registry>();
     registry_->SetExtensionSpanExporterBuilder(
-        "recording", std::make_unique<RecordingSpanExporterBuilder>(span_buffer_));
+        "recording", std::make_unique<config_test::RecordingSpanExporterBuilder>(span_buffer_));
     registry_->SetExtensionLogRecordExporterBuilder(
-        "recording", std::make_unique<RecordingLogRecordExporterBuilder>(log_buffer_));
+        "recording", std::make_unique<config_test::RecordingLogRecordExporterBuilder>(log_buffer_));
     registry_->SetExtensionPushMetricExporterBuilder(
-        "recording", std::make_unique<RecordingPushMetricExporterBuilder>(metric_buffer_));
-    registry_->SetPeriodicMetricReaderBuilder(std::make_unique<SyncPeriodicMetricReaderBuilder>());
+        "recording",
+        std::make_unique<config_test::RecordingPushMetricExporterBuilder>(metric_buffer_));
+    registry_->SetPeriodicMetricReaderBuilder(
+        std::make_unique<config_test::SyncPeriodicMetricReaderBuilder>());
   }
 
   static std::unique_ptr<config_sdk::TracerProviderConfiguration> MakeTracerProviderConfig()
@@ -199,9 +198,12 @@ protected:
     return config;
   }
 
-  std::shared_ptr<SpanBuffer> span_buffer_{std::make_shared<SpanBuffer>()};
-  std::shared_ptr<LogRecordBuffer> log_buffer_{std::make_shared<LogRecordBuffer>()};
-  std::shared_ptr<MetricBuffer> metric_buffer_{std::make_shared<MetricBuffer>()};
+  std::shared_ptr<config_test::SpanBuffer> span_buffer_{
+      std::make_shared<config_test::SpanBuffer>()};
+  std::shared_ptr<config_test::LogRecordBuffer> log_buffer_{
+      std::make_shared<config_test::LogRecordBuffer>()};
+  std::shared_ptr<config_test::MetricBuffer> metric_buffer_{
+      std::make_shared<config_test::MetricBuffer>()};
 
   std::shared_ptr<config_sdk::Registry> registry_;
   std::unique_ptr<config_sdk::ConfiguredSdk> sdk_;
@@ -719,7 +721,7 @@ void CheckPropagators()
   auto baggage = baggage::Baggage::GetDefault()->Set("key", "value");
   auto ctx     = baggage::SetBaggage(ctx1, baggage);
 
-  MapCarrier carrier;
+  config_test::MapCarrier carrier;
   propagation::GlobalTextMapPropagator::GetGlobalPropagator()->Inject(carrier, ctx);
 
   ASSERT_NE(carrier.map().find("traceparent"), carrier.map().end());  // tracecontext

--- a/sdk/test/configuration/sdk_builder_test.cc
+++ b/sdk/test/configuration/sdk_builder_test.cc
@@ -45,12 +45,10 @@ using opentelemetry::sdk::configuration::SdkBuilder;
 using opentelemetry::sdk::configuration::SpanLimitsConfiguration;
 using opentelemetry::sdk::configuration::TracerProviderConfiguration;
 
-namespace logs        = opentelemetry::logs;
-namespace logs_sdk    = opentelemetry::sdk::logs;
-namespace scope_sdk   = opentelemetry::sdk::instrumentationscope;
-namespace config_sdk  = opentelemetry::sdk::configuration;
-namespace common_sdk  = opentelemetry::sdk::common;
-namespace metrics_sdk = opentelemetry::sdk::metrics;
+namespace logs       = opentelemetry::logs;
+namespace logs_sdk   = opentelemetry::sdk::logs;
+namespace scope_sdk  = opentelemetry::sdk::instrumentationscope;
+namespace config_sdk = opentelemetry::sdk::configuration;
 
 namespace
 {

--- a/sdk/test/configuration/sdk_builder_test.cc
+++ b/sdk/test/configuration/sdk_builder_test.cc
@@ -3,18 +3,24 @@
 
 #include <gtest/gtest.h>
 
+#include <chrono>
 #include <memory>
 #include <string>
 #include <utility>
 #include <vector>
 #include "opentelemetry/logs/severity.h"
 #include "opentelemetry/nostd/string_view.h"
+#include "opentelemetry/sdk/common/exporter_utils.h"
 #include "opentelemetry/sdk/configuration/always_off_sampler_configuration.h"
 #include "opentelemetry/sdk/configuration/always_on_sampler_configuration.h"
+#include "opentelemetry/sdk/configuration/extension_push_metric_exporter_builder.h"
+#include "opentelemetry/sdk/configuration/extension_push_metric_exporter_configuration.h"
 #include "opentelemetry/sdk/configuration/logger_config_configuration.h"
 #include "opentelemetry/sdk/configuration/logger_configurator_configuration.h"
 #include "opentelemetry/sdk/configuration/logger_matcher_and_config_configuration.h"
 #include "opentelemetry/sdk/configuration/parent_based_sampler_configuration.h"
+#include "opentelemetry/sdk/configuration/periodic_metric_reader_builder.h"
+#include "opentelemetry/sdk/configuration/periodic_metric_reader_configuration.h"
 #include "opentelemetry/sdk/configuration/registry.h"
 #include "opentelemetry/sdk/configuration/sampler_configuration.h"
 #include "opentelemetry/sdk/configuration/sdk_builder.h"
@@ -25,7 +31,12 @@
 #include "opentelemetry/sdk/instrumentationscope/instrumentation_scope.h"
 #include "opentelemetry/sdk/instrumentationscope/scope_configurator.h"
 #include "opentelemetry/sdk/logs/logger_config.h"
+#include "opentelemetry/sdk/metrics/instruments.h"
+#include "opentelemetry/sdk/metrics/metric_reader.h"
+#include "opentelemetry/sdk/metrics/push_metric_exporter.h"
 #include "opentelemetry/sdk/resource/resource.h"
+
+#include "config_test_common.h"
 #include "opentelemetry/sdk/trace/sampler.h"
 #include "opentelemetry/sdk/trace/span_limits.h"
 #include "opentelemetry/sdk/trace/tracer_provider.h"
@@ -35,10 +46,19 @@ using opentelemetry::sdk::configuration::SdkBuilder;
 using opentelemetry::sdk::configuration::SpanLimitsConfiguration;
 using opentelemetry::sdk::configuration::TracerProviderConfiguration;
 
-namespace logs       = opentelemetry::logs;
-namespace logs_sdk   = opentelemetry::sdk::logs;
-namespace scope_sdk  = opentelemetry::sdk::instrumentationscope;
-namespace config_sdk = opentelemetry::sdk::configuration;
+namespace logs        = opentelemetry::logs;
+namespace logs_sdk    = opentelemetry::sdk::logs;
+namespace scope_sdk   = opentelemetry::sdk::instrumentationscope;
+namespace config_sdk  = opentelemetry::sdk::configuration;
+namespace common_sdk  = opentelemetry::sdk::common;
+namespace metrics_sdk = opentelemetry::sdk::metrics;
+
+namespace
+{
+
+using namespace config_test;  // NOLINT(google-build-using-namespace)
+
+}  // namespace
 
 //------------------------------------------------------------------------------
 // Tests for the SdkBuilder class methods that create SDK components from configuration models
@@ -221,4 +241,34 @@ TEST(SdkBuilder, CreateParentBasedSampler)
     EXPECT_EQ(std::string{sampler->GetDescription()},
               R"(ParentBased{TraceIdRatioBasedSampler{0.250000}})");
   }
+}
+
+TEST(SdkBuilder, CreatePeriodicMetricReader)
+{
+  auto exporter  = std::make_unique<config_sdk::ExtensionPushMetricExporterConfiguration>();
+  exporter->name = "noop";
+
+  config_sdk::PeriodicMetricReaderConfiguration model;
+  model.exporter = std::move(exporter);
+  model.interval = 12345;  // milliseconds
+  model.timeout  = 678;    // milliseconds
+
+  auto captured = std::make_shared<CapturedPeriodicReaderArgs>();
+
+  auto registry = std::make_shared<config_sdk::Registry>();
+  registry->SetExtensionPushMetricExporterBuilder(
+      "noop", std::make_unique<NoopPushMetricExporterBuilder>());
+  registry->SetPeriodicMetricReaderBuilder(
+      std::make_unique<CapturingPeriodicMetricReaderBuilder>(captured));
+
+  config_sdk::SdkBuilder builder(registry);
+  auto reader = builder.CreatePeriodicMetricReader(&model);
+  ASSERT_NE(reader, nullptr);
+
+  // The registered builder must receive the reader configuration matching the input model,
+  // along with the exporter built from the model exporter configuration.
+  EXPECT_TRUE(captured->called);
+  EXPECT_EQ(captured->interval, model.interval);
+  EXPECT_EQ(captured->timeout, model.timeout);
+  EXPECT_TRUE(captured->exporter_provided);
 }

--- a/sdk/test/configuration/sdk_builder_test.cc
+++ b/sdk/test/configuration/sdk_builder_test.cc
@@ -50,13 +50,6 @@ namespace logs_sdk   = opentelemetry::sdk::logs;
 namespace scope_sdk  = opentelemetry::sdk::instrumentationscope;
 namespace config_sdk = opentelemetry::sdk::configuration;
 
-namespace
-{
-
-using namespace config_test;  // NOLINT(google-build-using-namespace)
-
-}  // namespace
-
 //------------------------------------------------------------------------------
 // Tests for the SdkBuilder class methods that create SDK components from configuration models
 // These tests focus on the API of the SdkBuilder for creating SDK components that can be
@@ -247,25 +240,23 @@ TEST(SdkBuilder, CreatePeriodicMetricReader)
 
   config_sdk::PeriodicMetricReaderConfiguration model;
   model.exporter = std::move(exporter);
-  model.interval = 12345;  // milliseconds
-  model.timeout  = 678;    // milliseconds
+  model.interval = 12345;
+  model.timeout  = 678;
 
-  auto captured = std::make_shared<CapturedPeriodicReaderArgs>();
+  auto captured = std::make_shared<config_test::CapturedPeriodicReaderArgs>();
 
   auto registry = std::make_shared<config_sdk::Registry>();
   registry->SetExtensionPushMetricExporterBuilder(
-      "noop", std::make_unique<NoopPushMetricExporterBuilder>());
+      "noop", std::make_unique<config_test::NoopPushMetricExporterBuilder>());
   registry->SetPeriodicMetricReaderBuilder(
-      std::make_unique<CapturingPeriodicMetricReaderBuilder>(captured));
+      std::make_unique<config_test::CapturingPeriodicMetricReaderBuilder>(captured));
 
   config_sdk::SdkBuilder builder(registry);
   auto reader = builder.CreatePeriodicMetricReader(&model);
   ASSERT_NE(reader, nullptr);
 
-  // The registered builder must receive the reader configuration matching the input model,
-  // along with the exporter built from the model exporter configuration.
   EXPECT_TRUE(captured->called);
   EXPECT_EQ(captured->interval, model.interval);
   EXPECT_EQ(captured->timeout, model.timeout);
-  EXPECT_TRUE(captured->exporter_provided);
+  EXPECT_TRUE(captured->exporter != nullptr);
 }

--- a/sdk/test/configuration/sdk_builder_test.cc
+++ b/sdk/test/configuration/sdk_builder_test.cc
@@ -3,14 +3,15 @@
 
 #include <gtest/gtest.h>
 
-#include <chrono>
 #include <memory>
 #include <string>
 #include <utility>
 #include <vector>
+
+#include "config_test_common.h"
 #include "opentelemetry/logs/severity.h"
 #include "opentelemetry/nostd/string_view.h"
-#include "opentelemetry/sdk/common/exporter_utils.h"
+
 #include "opentelemetry/sdk/configuration/always_off_sampler_configuration.h"
 #include "opentelemetry/sdk/configuration/always_on_sampler_configuration.h"
 #include "opentelemetry/sdk/configuration/extension_push_metric_exporter_builder.h"
@@ -21,6 +22,7 @@
 #include "opentelemetry/sdk/configuration/parent_based_sampler_configuration.h"
 #include "opentelemetry/sdk/configuration/periodic_metric_reader_builder.h"
 #include "opentelemetry/sdk/configuration/periodic_metric_reader_configuration.h"
+#include "opentelemetry/sdk/configuration/push_metric_exporter_configuration.h"
 #include "opentelemetry/sdk/configuration/registry.h"
 #include "opentelemetry/sdk/configuration/sampler_configuration.h"
 #include "opentelemetry/sdk/configuration/sdk_builder.h"
@@ -28,15 +30,12 @@
 #include "opentelemetry/sdk/configuration/span_limits_configuration.h"
 #include "opentelemetry/sdk/configuration/trace_id_ratio_based_sampler_configuration.h"
 #include "opentelemetry/sdk/configuration/tracer_provider_configuration.h"
+
 #include "opentelemetry/sdk/instrumentationscope/instrumentation_scope.h"
 #include "opentelemetry/sdk/instrumentationscope/scope_configurator.h"
 #include "opentelemetry/sdk/logs/logger_config.h"
-#include "opentelemetry/sdk/metrics/instruments.h"
 #include "opentelemetry/sdk/metrics/metric_reader.h"
-#include "opentelemetry/sdk/metrics/push_metric_exporter.h"
 #include "opentelemetry/sdk/resource/resource.h"
-
-#include "config_test_common.h"
 #include "opentelemetry/sdk/trace/sampler.h"
 #include "opentelemetry/sdk/trace/span_limits.h"
 #include "opentelemetry/sdk/trace/tracer_provider.h"


### PR DESCRIPTION
Followup to https://github.com/open-telemetry/opentelemetry-cpp/pull/4243#discussion_r3602430452

The configuration tests instantiated the PeriodicMetricReader and call ForceFlush. This caused tests to timeout sporadically. This PR extends the config registry and SDK builder to support setting a builder for the periodic metric reader. A synchronous mock reader is then used in configuration tests to verify config components. 

## Changes

- Add Set/Get methods for the PeriodicMetricReader to the registry and use them in the sdk builder
- Move common config test components to a common header
- Update config tests to use a simple sync metric reader in the periodic reader's registry slot. 
- Add an SDK builder test for PeriodicMetricReaderConfiguration
- Disable config tests that use the batch processors - they'll be enabled in a followup PR. 

For significant contributions please make sure you have completed the following items:

* [ ] `CHANGELOG.md` updated for non-trivial changes
* [ ] Unit tests have been added
* [ ] Changes in public API reviewed