### PR TITLE
[CODE HEALTH] Fix remaining misc-override-with-different-visibility warnings

### DIFF
--- a/.github/workflows/clang-tidy.yaml
+++ b/.github/workflows/clang-tidy.yaml
@@ -17,9 +17,9 @@ jobs:
       matrix:
         include:
           - cmake_options: all-options-abiv1-preview
-            warning_limit: 163
+            warning_limit: 158
           - cmake_options: all-options-abiv2-preview
-            warning_limit: 173
+            warning_limit: 168
     env:
       CC: /usr/bin/clang-22
       CXX: /usr/bin/clang++-22

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,9 @@ Increment the:
 
 ## [Unreleased]
 
+* [CODE HEALTH] Fix remaining misc-override-with-different-visibility warnings
+  [#4280](https://github.com/open-telemetry/opentelemetry-cpp/pull/4280)
+
 * [CODE HEALTH] Fix more clang tidy warnings (member initialization)
   [#4270](https://github.com/open-telemetry/opentelemetry-cpp/pull/4270)
 

--- a/ext/include/opentelemetry/ext/http/server/http_server.h
+++ b/ext/include/opentelemetry/ext/http/server/http_server.h
@@ -244,7 +244,7 @@ public:
 
   void stop() { m_reactor.stop(); }
 
-protected:
+private:
   void onSocketAcceptable(SocketTools::Socket socket) override
   {
     LOG_TRACE("HttpServer: accepting socket fd=0x%llx", socket.m_sock);
@@ -331,6 +331,7 @@ protected:
     handleConnectionClosed(conn);
   }
 
+protected:
   bool sendMore(Connection &conn)
   {
     if (conn.sendBuffer.empty())
@@ -356,7 +357,6 @@ protected:
     return false;
   }
 
-protected:
   void handleConnectionClosed(Connection &conn)
   {
     LOG_TRACE("HttpServer: [%s] closed", conn.request.client.c_str());

--- a/ext/include/opentelemetry/ext/http/server/socket_tools.h
+++ b/ext/include/opentelemetry/ext/http/server/socket_tools.h
@@ -717,6 +717,7 @@ public:
     m_sockets.clear();
   }
 
+protected:
   /// <summary>
   /// Thread Loop for async events processing
   /// </summary>


### PR DESCRIPTION
## Changes

Completes #4195 by resolving the 5 `misc-override-with-different-visibility` warnings that #4215 deferred, all in the `ext/http` embedded server. Each override had wider visibility than its inheritance-adjusted base:

- `HttpServer` privately inherits `SocketCallback`, so its `onSocketAcceptable`, `onSocketReadable`, `onSocketWritable` and `onSocketClosed` overrides are aligned from `protected` to `private`.
- `Reactor` inherits `Thread` as `protected`, so its `onThread` override is aligned from `public` to `protected`.

### Scope and compatibility

These overrides are dispatched only through their base interfaces (`SocketCallback&` and `Thread::onThread`), so no dynamic-dispatch call path changes. The change does narrow the source-level surface a derived class could reach (for example, calling the base implementation from a subclass) in these installed headers.

I chose this direction because the private inheritance of `SocketCallback` looks deliberate (the callbacks are HttpServer's internal reactor plumbing) and HttpServer is extended through its public request-handler API (e.g. `operator[]`, `setServerName`) rather than by overriding the reactor callbacks; `FileHttpServer` is such a subclass and does not touch them. If maintainers would rather preserve that extension surface, two alternatives are: switch `HttpServer` to `protected` inheritance of `SocketCallback` (keeps the callbacks protected but widens the base-conversion surface), or `NOLINT` the four overrides. I am happy to take whichever direction you prefer.

The unrelated `sendMore()` helper keeps its `protected` visibility (an earlier revision narrowed it along with the section; that has been reverted).

### Verification

- A syntax-only build (clang-18, C++14) of `file_http_server.h`, which pulls in `http_server.h` and `socket_tools.h`, the `FileHttpServer` subclass, and an `HttpServer` instantiation, compiles cleanly.
- clang-format and markdownlint 0.46.0 clean.
- `warning_limit` lowered from 163/173 to 158/168. I will confirm from the clang-tidy report artifacts that `misc-override-with-different-visibility` reaches 0 and the totals match before treating this as ready.
