### PR TITLE
[CODE HEALTH] Move metrics storage test fixtures into anonymous namespace

### DIFF
--- a/.github/workflows/clang-tidy.yaml
+++ b/.github/workflows/clang-tidy.yaml
@@ -17,9 +17,9 @@ jobs:
       matrix:
         include:
           - cmake_options: all-options-abiv1-preview
-            warning_limit: 163
+            warning_limit: 156
           - cmake_options: all-options-abiv2-preview
-            warning_limit: 173
+            warning_limit: 166
     env:
       CC: /usr/bin/clang-22
       CXX: /usr/bin/clang++-22

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,9 @@ Increment the:
 
 ## [Unreleased]
 
+* [CODE HEALTH] Move metrics storage test fixtures into anonymous namespace
+  [#4286](https://github.com/open-telemetry/opentelemetry-cpp/pull/4286)
+
 * [CODE HEALTH] Fix more clang tidy warnings (member initialization)
   [#4270](https://github.com/open-telemetry/opentelemetry-cpp/pull/4270)
 

--- a/sdk/test/metrics/async_metric_storage_test.cc
+++ b/sdk/test/metrics/async_metric_storage_test.cc
@@ -37,7 +37,11 @@ using namespace opentelemetry::sdk::instrumentationscope;
 using namespace opentelemetry::sdk::resource;
 using namespace opentelemetry::common;
 
-class WritableMetricStorageTestFixture : public ::testing::TestWithParam<AggregationTemporality>
+namespace
+{
+
+class AsyncWritableMetricStorageTestFixture
+    : public ::testing::TestWithParam<AggregationTemporality>
 {};
 
 class WritableMetricStorageTestUpDownFixture
@@ -48,7 +52,7 @@ class WritableMetricStorageTestObservableGaugeFixture
     : public ::testing::TestWithParam<AggregationTemporality>
 {};
 
-TEST_P(WritableMetricStorageTestFixture, TestAggregation)
+TEST_P(AsyncWritableMetricStorageTestFixture, TestAggregation)
 {
   AggregationTemporality temporality = GetParam();
 
@@ -138,7 +142,7 @@ TEST_P(WritableMetricStorageTestFixture, TestAggregation)
 }
 
 INSTANTIATE_TEST_SUITE_P(WritableMetricStorageTestLong,
-                         WritableMetricStorageTestFixture,
+                         AsyncWritableMetricStorageTestFixture,
                          ::testing::Values(AggregationTemporality::kCumulative,
                                            AggregationTemporality::kDelta));
 
@@ -317,3 +321,5 @@ INSTANTIATE_TEST_SUITE_P(WritableMetricStorageTestObservableGaugeFixtureLong,
                          WritableMetricStorageTestObservableGaugeFixture,
                          ::testing::Values(AggregationTemporality::kCumulative,
                                            AggregationTemporality::kDelta));
+
+}  // namespace

--- a/sdk/test/metrics/sync_metric_storage_counter_test.cc
+++ b/sdk/test/metrics/sync_metric_storage_counter_test.cc
@@ -34,10 +34,14 @@
 using namespace opentelemetry::sdk::metrics;
 using namespace opentelemetry::common;
 
-class WritableMetricStorageTestFixture : public ::testing::TestWithParam<AggregationTemporality>
+namespace
+{
+
+class CounterWritableMetricStorageTestFixture
+    : public ::testing::TestWithParam<AggregationTemporality>
 {};
 
-TEST_P(WritableMetricStorageTestFixture, LongCounterSumAggregation)
+TEST_P(CounterWritableMetricStorageTestFixture, LongCounterSumAggregation)
 {
   AggregationTemporality temporality  = GetParam();
   auto sdk_start_ts                   = std::chrono::system_clock::now();
@@ -173,11 +177,11 @@ TEST_P(WritableMetricStorageTestFixture, LongCounterSumAggregation)
 }
 
 INSTANTIATE_TEST_SUITE_P(WritableMetricStorageTestLong,
-                         WritableMetricStorageTestFixture,
+                         CounterWritableMetricStorageTestFixture,
                          ::testing::Values(AggregationTemporality::kCumulative,
                                            AggregationTemporality::kDelta));
 
-TEST_P(WritableMetricStorageTestFixture, DoubleCounterSumAggregation)
+TEST_P(CounterWritableMetricStorageTestFixture, DoubleCounterSumAggregation)
 {
   AggregationTemporality temporality = GetParam();
   auto sdk_start_ts                  = std::chrono::system_clock::now();
@@ -496,6 +500,8 @@ TEST(SyncMetricStorageTest, DeltaCounterMultiCollectorFirstIntervalUsesInstrumen
   EXPECT_EQ(metric_data.end_ts, collection_ts);
 }
 INSTANTIATE_TEST_SUITE_P(WritableMetricStorageTestDouble,
-                         WritableMetricStorageTestFixture,
+                         CounterWritableMetricStorageTestFixture,
                          ::testing::Values(AggregationTemporality::kCumulative,
                                            AggregationTemporality::kDelta));
+
+}  // namespace

--- a/sdk/test/metrics/sync_metric_storage_gauge_test.cc
+++ b/sdk/test/metrics/sync_metric_storage_gauge_test.cc
@@ -36,14 +36,18 @@
 using namespace opentelemetry::sdk::metrics;
 using namespace opentelemetry::common;
 
-class WritableMetricStorageTestFixture : public ::testing::TestWithParam<AggregationTemporality>
+namespace
+{
+
+class GaugeWritableMetricStorageTestFixture
+    : public ::testing::TestWithParam<AggregationTemporality>
 {};
 
 class WritableMetricStorageDeltaMultiReaderTestFixture
     : public ::testing::TestWithParam<AggregationTemporality>
 {};
 
-TEST_P(WritableMetricStorageTestFixture, LongGaugeLastValueAggregation)
+TEST_P(GaugeWritableMetricStorageTestFixture, LongGaugeLastValueAggregation)
 {
 #if OPENTELEMETRY_ABI_VERSION_NO >= 2
   AggregationTemporality temporality = GetParam();
@@ -124,10 +128,10 @@ TEST_P(WritableMetricStorageTestFixture, LongGaugeLastValueAggregation)
 }
 
 INSTANTIATE_TEST_SUITE_P(WritableMetricStorageTestLong,
-                         WritableMetricStorageTestFixture,
+                         GaugeWritableMetricStorageTestFixture,
                          ::testing::Values(AggregationTemporality::kCumulative));
 
-TEST_P(WritableMetricStorageTestFixture, DoubleGaugeLastValueAggregation)
+TEST_P(GaugeWritableMetricStorageTestFixture, DoubleGaugeLastValueAggregation)
 {
 #if OPENTELEMETRY_ABI_VERSION_NO >= 2
   AggregationTemporality temporality = GetParam();
@@ -208,7 +212,7 @@ TEST_P(WritableMetricStorageTestFixture, DoubleGaugeLastValueAggregation)
 }
 
 INSTANTIATE_TEST_SUITE_P(WritableMetricStorageTestDouble,
-                         WritableMetricStorageTestFixture,
+                         GaugeWritableMetricStorageTestFixture,
                          ::testing::Values(AggregationTemporality::kCumulative));
 
 TEST_P(WritableMetricStorageDeltaMultiReaderTestFixture,
@@ -579,3 +583,5 @@ TEST_P(WritableMetricStorageDeltaMultiReaderTestFixture,
 INSTANTIATE_TEST_SUITE_P(WritableMetricStorageTestDoubleDeltaMultiReader,
                          WritableMetricStorageDeltaMultiReaderTestFixture,
                          ::testing::Values(AggregationTemporality::kDelta));
+
+}  // namespace

--- a/sdk/test/metrics/sync_metric_storage_up_down_counter_test.cc
+++ b/sdk/test/metrics/sync_metric_storage_up_down_counter_test.cc
@@ -33,10 +33,14 @@
 using namespace opentelemetry::sdk::metrics;
 using namespace opentelemetry::common;
 
-class WritableMetricStorageTestFixture : public ::testing::TestWithParam<AggregationTemporality>
+namespace
+{
+
+class UpDownCounterWritableMetricStorageTestFixture
+    : public ::testing::TestWithParam<AggregationTemporality>
 {};
 
-TEST_P(WritableMetricStorageTestFixture, LongUpDownCounterSumAggregation)
+TEST_P(UpDownCounterWritableMetricStorageTestFixture, LongUpDownCounterSumAggregation)
 {
   AggregationTemporality temporality         = GetParam();
   auto sdk_start_ts                          = std::chrono::system_clock::now();
@@ -182,11 +186,11 @@ TEST_P(WritableMetricStorageTestFixture, LongUpDownCounterSumAggregation)
 }
 
 INSTANTIATE_TEST_SUITE_P(WritableMetricStorageTestLong,
-                         WritableMetricStorageTestFixture,
+                         UpDownCounterWritableMetricStorageTestFixture,
                          ::testing::Values(AggregationTemporality::kCumulative,
                                            AggregationTemporality::kDelta));
 
-TEST_P(WritableMetricStorageTestFixture, DoubleUpDownCounterSumAggregation)
+TEST_P(UpDownCounterWritableMetricStorageTestFixture, DoubleUpDownCounterSumAggregation)
 {
   AggregationTemporality temporality        = GetParam();
   auto sdk_start_ts                         = std::chrono::system_clock::now();
@@ -335,6 +339,8 @@ TEST_P(WritableMetricStorageTestFixture, DoubleUpDownCounterSumAggregation)
   EXPECT_EQ(count_attributes, 2);  // GET and PUT
 }
 INSTANTIATE_TEST_SUITE_P(WritableMetricStorageTestDouble,
-                         WritableMetricStorageTestFixture,
+                         UpDownCounterWritableMetricStorageTestFixture,
                          ::testing::Values(AggregationTemporality::kCumulative,
                                            AggregationTemporality::kDelta));
+
+}  // namespace


### PR DESCRIPTION
## Changes

Part of #4196. Moves the `WritableMetricStorage*` test fixtures in the four sync/async metric storage test files into an anonymous namespace to enforce internal linkage (`misc-use-internal-linkage`), resolving 7 warnings and lowering `warning_limit` to 156/166.

### The gtest suite-name collision

These four files (`async_metric_storage_test.cc`, `sync_metric_storage_{counter,gauge,up_down_counter}_test.cc`) each define an identical `WritableMetricStorageTestFixture`, and all link into a single `//sdk/test/metrics:all_tests` binary. Wrapping them in per-translation-unit anonymous namespaces as-is would make gtest see one suite name backing four different types and abort at startup ("Attempted redefinition of test suite") — this is exactly what #4217 hit, which is why these files were deferred there.

So each shared fixture is first renamed with a file-specific prefix (`Async`/`Counter`/`Gauge`/`UpDownCounter`) so the suites stay distinct, as gtest's own diagnostic suggests. The file-local fixtures (`WritableMetricStorageTestUpDownFixture`, `WritableMetricStorageTestObservableGaugeFixture`, `WritableMetricStorageDeltaMultiReaderTestFixture`) already have unique names and are wrapped unchanged.

An alternative would be to hoist the shared fixture into `sdk/test/metrics/common.h` to de-duplicate it; happy to take that direction instead if preferred.

### Verification

- clang-format clean.
- No fixture name is shared across any `sdk/test/metrics/*.cc`, so the combined `all_tests` binary has no suite-name collision (verified by grep).
- `warning_limit` lowered 163/173 to 156/166 (7 resolved). This touches the same `warning_limit` line as #4280; whichever merges first, I will rebase the other.
