### PR TITLE
[BUG] Decide Elasticsearch bulk export success from HTTP status and the errors flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,6 +65,10 @@ Increment the:
 * [BUG] Wait on a completion state in the Elasticsearch exporter
   [#4298](https://github.com/open-telemetry/opentelemetry-cpp/pull/4298)
 
+* [BUG] Decide Elasticsearch bulk export success from the HTTP status, the
+  errors flag, and one acknowledgement per record
+  [#4297](https://github.com/open-telemetry/opentelemetry-cpp/pull/4297)
+
 * [BUG] Make SocketAddr string parsing safe and reject malformed addresses
   [#4292](https://github.com/open-telemetry/opentelemetry-cpp/pull/4292)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -210,6 +210,11 @@ Increment the:
 * [BUG] Wait on a completion state in the Elasticsearch exporter
   [#4298](https://github.com/open-telemetry/opentelemetry-cpp/pull/4298)
 
+* [BUG] Decide Elasticsearch bulk export success from the HTTP status, the
+  errors flag, and one acknowledgement per record that names its target index
+  and says the operation applied
+  [#4297](https://github.com/open-telemetry/opentelemetry-cpp/pull/4297)
+
 * [BUG] Make SocketAddr string parsing safe and reject malformed addresses
   [#4292](https://github.com/open-telemetry/opentelemetry-cpp/pull/4292)
 

--- a/exporters/elasticsearch/BUILD
+++ b/exporters/elasticsearch/BUILD
@@ -6,6 +6,24 @@ load("@rules_cc//cc:cc_test.bzl", "cc_test")
 
 package(default_visibility = ["//visibility:public"])
 
+# The bulk response parser is an implementation detail that the CMake package
+# also leaves out. hdrs is a target's public interface, so it is kept in its own
+# target that only this package can depend on, and reached through
+# implementation_deps so the exporter does not re-export it.
+cc_library(
+    name = "es_bulk_response",
+    hdrs = [
+        "include/opentelemetry/exporters/elasticsearch/detail/es_bulk_response.h",
+    ],
+    strip_include_prefix = "include",
+    tags = ["es"],
+    visibility = ["//exporters/elasticsearch:__pkg__"],
+    deps = [
+        "//api",
+        "@github_nlohmann_json//:json",
+    ],
+)
+
 cc_library(
     name = "es_log_record_exporter",
     srcs = [
@@ -16,6 +34,7 @@ cc_library(
         "include/opentelemetry/exporters/elasticsearch/es_log_record_exporter.h",
         "include/opentelemetry/exporters/elasticsearch/es_log_recordable.h",
     ],
+    implementation_deps = [":es_bulk_response"],
     linkopts = select({
         "//bazel:windows": [
             "-DEFAULTLIB:advapi32.lib",
@@ -43,6 +62,7 @@ cc_test(
         "test",
     ],
     deps = [
+        ":es_bulk_response",
         ":es_log_record_exporter",
         "@com_google_googletest//:gtest_main",
         "@curl",

--- a/exporters/elasticsearch/CMakeLists.txt
+++ b/exporters/elasticsearch/CMakeLists.txt
@@ -34,6 +34,12 @@ otel_add_component(
   "*.h"
   PATTERN
   "es_log_recordable.h"
+  EXCLUDE
+  PATTERN
+  "es_bulk_response.h"
+  EXCLUDE
+  PATTERN
+  "detail"
   EXCLUDE)
 
 if(OPENTELEMETRY_INSTALL)

--- a/exporters/elasticsearch/CMakeLists.txt
+++ b/exporters/elasticsearch/CMakeLists.txt
@@ -34,6 +34,12 @@ otel_add_component(
   "*.h"
   PATTERN
   "es_log_recordable.h"
+  EXCLUDE
+  PATTERN
+  "es_bulk_response.h"
+  EXCLUDE
+  PATTERN
+  "detail"
   EXCLUDE)
 
 if(OTELCPP_INSTALL)
@@ -55,4 +61,10 @@ if(OTELCPP_BUILD_TESTING)
     TARGET es_log_record_exporter_test
     TEST_PREFIX exporter.
     TEST_LIST es_log_record_exporter_test)
+
+  # The synchronous wiring cases wait on a completion, and a regression that
+  # stops delivering one hangs the job rather than reporting. A bound turns that
+  # back into a red test. Not the asynchronous ones: their fake calls back from
+  # inside SendRequest() and Export() returns without waiting.
+  set_tests_properties(${es_log_record_exporter_test} PROPERTIES TIMEOUT 120)
 endif() # OTELCPP_BUILD_TESTING

--- a/exporters/elasticsearch/include/opentelemetry/exporters/elasticsearch/detail/es_bulk_response.h
+++ b/exporters/elasticsearch/include/opentelemetry/exporters/elasticsearch/detail/es_bulk_response.h
@@ -49,7 +49,7 @@ inline bool IsAcknowledgedStatus(const nlohmann::json &status) noexcept
  * @param expected_items the number of index operations the request submitted
  * @param failure_reason a best-effort explanation when this returns false
  * @return true only when the status is 2xx, "errors" is false, and "items" holds exactly
- *         expected_items index results that each acknowledge a 2xx status
+ *         expected_items index results that each acknowledge a 2xx status and carry no error
  */
 inline bool IsBulkResponseSuccessful(int status_code,
                                      const std::string &body,
@@ -100,7 +100,11 @@ inline bool IsBulkResponseSuccessful(int status_code,
 
     // Each entry is keyed by the action it answers, and every record goes out as an index
     // operation. Read before "errors", which a body that is not this answer does not get to decide.
-    const nlohmann::json *rejected = nullptr;
+    // An operation that was not applied says so twice, through its status and through an "error"
+    // member. Both are read here so that neither reading depends on the "errors" flag, which a
+    // response that contradicts itself also controls.
+    const nlohmann::json *rejected   = nullptr;
+    const nlohmann::json *item_error = nullptr;
     for (const auto &item : *items)
     {
       if (!item.is_object() || item.size() != 1)
@@ -127,6 +131,12 @@ inline bool IsBulkResponseSuccessful(int status_code,
       {
         rejected = &(*status);
       }
+
+      const auto error = operation->find("error");
+      if (item_error == nullptr && error != operation->end())
+      {
+        item_error = &(*error);
+      }
     }
 
     if (!errors->get<bool>())
@@ -138,20 +148,20 @@ inline bool IsBulkResponseSuccessful(int status_code,
             "the response reports no errors but acknowledges operation status " + rejected->dump();
         return false;
       }
+      if (item_error != nullptr)
+      {
+        failure_reason =
+            "the response reports no errors but an item carries error " + item_error->dump();
+        return false;
+      }
       return true;
     }
 
-    // Name the first item error rather than only saying that something failed. Every entry is one
-    // index result by now, so its single member is the result to look in.
-    for (const auto &item : *items)
+    // Name the first item error rather than only saying that something failed.
+    if (item_error != nullptr)
     {
-      const auto &result = *item.begin();
-      const auto error   = result.find("error");
-      if (error != result.end())
-      {
-        failure_reason = "at least one item failed, first error: " + error->dump();
-        return false;
-      }
+      failure_reason = "at least one item failed, first error: " + item_error->dump();
+      return false;
     }
 
     failure_reason = "the response reports errors";

--- a/exporters/elasticsearch/include/opentelemetry/exporters/elasticsearch/detail/es_bulk_response.h
+++ b/exporters/elasticsearch/include/opentelemetry/exporters/elasticsearch/detail/es_bulk_response.h
@@ -1,0 +1,208 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <cstddef>
+#include <nlohmann/json.hpp>
+#include <string>
+
+#include "opentelemetry/version.h"
+
+OPENTELEMETRY_BEGIN_NAMESPACE
+namespace exporter
+{
+namespace logs
+{
+namespace detail
+{
+
+/**
+ * What the bulk request itself has to answer with. Elasticsearch answers a bulk request with 200,
+ * and the rest of the 2xx band does not say the batch was written. 202 is the one that matters:
+ * it says the request was accepted and the processing is not finished, and may never be. Reading
+ * that as success is not a conservative reading of a vague answer, it is the opposite of what the
+ * answer says, and a success here lets the caller drop the records it just handed over.
+ */
+inline bool IsSuccessfulBulkStatus(int status_code) noexcept
+{
+  return 200 == status_code;
+}
+
+/**
+ * Whether an acknowledged operation status is one that applied the operation. Elasticsearch
+ * answers 201 when it created the document and 200 when it replaced an existing one.
+ *
+ * Comparing the json value rather than extracting one keeps this noexcept without relying on the
+ * type check to make an extraction safe. The check still has to be here: without it a float 200.5
+ * would answer for 200.
+ */
+inline bool IsAcknowledgedStatus(const nlohmann::json &status) noexcept
+{
+  return status.is_number_integer() && (status == 200 || status == 201);
+}
+
+/**
+ * Decide whether an Elasticsearch bulk response reports the whole batch as written.
+ *
+ * Callers include noexcept response handlers, so nothing may escape. Anything that stops the body
+ * being inspected counts as a failed export.
+ *
+ * This reads the fields the bulk response documents to decide an outcome. It is not a check
+ * against a responder that is trying to be believed: a repeated key, for one, is folded before
+ * this sees the document, so a body carrying both "errors": true and "errors": false arrives as
+ * whichever one the parser kept, and nothing here can tell that the other was ever sent.
+ *
+ * @param status_code the response status, which the caller passes rather than this reading the
+ *        body alone: "errors" describes item outcomes and cannot override a transport error
+ * @param body the raw response body
+ * @param expected_items the number of index operations the request submitted
+ * @param failure_reason a best-effort explanation when this returns false
+ * @return true only when the status is 200, "errors" is false, and "items" holds exactly
+ *         expected_items index results that each name a target index, acknowledge a status the
+ *         operation applied under, and carry no error
+ */
+inline bool IsBulkResponseSuccessful(int status_code,
+                                     const std::string &body,
+                                     std::size_t expected_items,
+                                     std::string &failure_reason) noexcept
+{
+  failure_reason.clear();
+#if OPENTELEMETRY_HAVE_EXCEPTIONS
+  try
+  {
+#endif
+    // Inside the try: building a reason allocates.
+    // Not the band an operation status is held to. This one answers for the request, and an
+    // operation that applied answers 201 for a document it created, which the request itself
+    // never says.
+    if (!IsSuccessfulBulkStatus(status_code))
+    {
+      failure_reason = "unexpected HTTP status " + std::to_string(status_code);
+      return false;
+    }
+
+    const nlohmann::json parsed = nlohmann::json::parse(body, nullptr, false);
+    if (parsed.is_discarded() || !parsed.is_object())
+    {
+      failure_reason = "the response body is not a JSON object";
+      return false;
+    }
+
+    const auto errors = parsed.find("errors");
+    if (errors == parsed.end() || !errors->is_boolean())
+    {
+      failure_reason = "the response body has no boolean \"errors\" field";
+      return false;
+    }
+
+    // The request is an unfiltered /_bulk, so "items" is always there and holds one entry per
+    // operation. The next three checks decide whether this body answers the request that was sent.
+    const auto items = parsed.find("items");
+    if (items == parsed.end() || !items->is_array())
+    {
+      failure_reason = "the response body has no \"items\" array";
+      return false;
+    }
+
+    if (items->size() != expected_items)
+    {
+      failure_reason = "the response acknowledges " + std::to_string(items->size()) + " of " +
+                       std::to_string(expected_items) + " submitted operations";
+      return false;
+    }
+
+    // Each entry is keyed by the action it answers, and every record goes out as an index
+    // operation. Read before "errors", which a body that is not this answer does not get to decide.
+    // An operation that was not applied says so twice, through its status and through an "error"
+    // member. Both are read here so that neither reading depends on the "errors" flag, which a
+    // response that contradicts itself also controls.
+    const nlohmann::json *rejected   = nullptr;
+    const nlohmann::json *item_error = nullptr;
+    for (const auto &item : *items)
+    {
+      if (!item.is_object() || item.size() != 1)
+      {
+        failure_reason = "the response has an \"items\" entry that is not one operation result";
+        return false;
+      }
+
+      const auto operation = item.find("index");
+      if (operation == item.end() || !operation->is_object())
+      {
+        failure_reason = "the response does not acknowledge the submitted index operation";
+        return false;
+      }
+
+      // Elasticsearch names the index it wrote to in every index result, whether the operation
+      // applied or not. Presence and type only: the name it reports is the index the write
+      // resolved to, which an alias or a date math index makes different from the one that was
+      // submitted, so it is not something to compare against.
+      const auto target = operation->find("_index");
+      if (target == operation->end() || !target->is_string())
+      {
+        failure_reason = "the response acknowledges an index operation with no target index";
+        return false;
+      }
+
+      const auto status = operation->find("status");
+      if (status == operation->end() || !status->is_number_integer())
+      {
+        failure_reason = "the response acknowledges an index operation with no status";
+        return false;
+      }
+
+      if (rejected == nullptr && !IsAcknowledgedStatus(*status))
+      {
+        rejected = &(*status);
+      }
+
+      // A null holds no cause, and a serialiser that writes absent optionals as null is saying
+      // the operation applied, which is what the flag says too. Only a cause contradicts it.
+      const auto error = operation->find("error");
+      if (item_error == nullptr && error != operation->end() && !error->is_null())
+      {
+        item_error = &(*error);
+      }
+    }
+
+    if (!errors->get<bool>())
+    {
+      // A false flag claims every operation was applied; hold the items to that claim.
+      if (rejected != nullptr)
+      {
+        failure_reason =
+            "the response reports no errors but acknowledges operation status " + rejected->dump();
+        return false;
+      }
+      if (item_error != nullptr)
+      {
+        failure_reason =
+            "the response reports no errors but an item carries error " + item_error->dump();
+        return false;
+      }
+      return true;
+    }
+
+    // Name the first item error rather than only saying that something failed.
+    if (item_error != nullptr)
+    {
+      failure_reason = "at least one item failed, first error: " + item_error->dump();
+      return false;
+    }
+
+    failure_reason = "the response reports errors";
+    return false;
+#if OPENTELEMETRY_HAVE_EXCEPTIONS
+  }
+  catch (...)
+  {
+    return false;
+  }
+#endif
+}
+
+}  // namespace detail
+}  // namespace logs
+}  // namespace exporter
+OPENTELEMETRY_END_NAMESPACE

--- a/exporters/elasticsearch/include/opentelemetry/exporters/elasticsearch/detail/es_bulk_response.h
+++ b/exporters/elasticsearch/include/opentelemetry/exporters/elasticsearch/detail/es_bulk_response.h
@@ -1,0 +1,171 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <cstddef>
+#include <nlohmann/json.hpp>
+#include <string>
+
+#include "opentelemetry/version.h"
+
+OPENTELEMETRY_BEGIN_NAMESPACE
+namespace exporter
+{
+namespace logs
+{
+namespace detail
+{
+
+/**
+ * Whether an acknowledged operation status is one that applied the operation. Elasticsearch
+ * answers an index operation with 200 or 201, so 2xx is the whole band.
+ *
+ * Compared in the type the number was parsed as. Narrowing to int first is not safe here: the
+ * value comes from the server, is_number_integer() is true for unsigned as well, and 2^32 + 200
+ * narrows back into the band on a 32 bit int.
+ */
+inline bool IsAcknowledgedStatus(const nlohmann::json &status) noexcept
+{
+  if (status.is_number_unsigned())
+  {
+    const auto value = status.get<nlohmann::json::number_unsigned_t>();
+    return value >= 200U && value <= 299U;
+  }
+
+  const auto value = status.get<nlohmann::json::number_integer_t>();
+  return value >= 200 && value <= 299;
+}
+
+/**
+ * Decide whether an Elasticsearch bulk response reports the whole batch as written.
+ *
+ * Callers include noexcept response handlers, so nothing may escape. Anything that stops the body
+ * being inspected counts as a failed export.
+ *
+ * @param status_code the response status, which the caller passes rather than this reading the
+ *        body alone: "errors" describes item outcomes and cannot override a transport error
+ * @param body the raw response body
+ * @param expected_items the number of index operations the request submitted
+ * @param failure_reason a best-effort explanation when this returns false
+ * @return true only when the status is 2xx, "errors" is false, and "items" holds exactly
+ *         expected_items index results that each acknowledge a 2xx status
+ */
+inline bool IsBulkResponseSuccessful(int status_code,
+                                     const std::string &body,
+                                     std::size_t expected_items,
+                                     std::string &failure_reason) noexcept
+{
+  failure_reason.clear();
+#if OPENTELEMETRY_HAVE_EXCEPTIONS
+  try
+  {
+#endif
+    // Inside the try: building a reason allocates.
+    if (status_code < 200 || status_code > 299)
+    {
+      failure_reason = "unexpected HTTP status " + std::to_string(status_code);
+      return false;
+    }
+
+    const nlohmann::json parsed = nlohmann::json::parse(body, nullptr, false);
+    if (parsed.is_discarded() || !parsed.is_object())
+    {
+      failure_reason = "the response body is not a JSON object";
+      return false;
+    }
+
+    const auto errors = parsed.find("errors");
+    if (errors == parsed.end() || !errors->is_boolean())
+    {
+      failure_reason = "the response body has no boolean \"errors\" field";
+      return false;
+    }
+
+    // The request is an unfiltered /_bulk, so "items" is always there and holds one entry per
+    // operation. The next three checks decide whether this body answers the request that was sent.
+    const auto items = parsed.find("items");
+    if (items == parsed.end() || !items->is_array())
+    {
+      failure_reason = "the response body has no \"items\" array";
+      return false;
+    }
+
+    if (items->size() != expected_items)
+    {
+      failure_reason = "the response acknowledges " + std::to_string(items->size()) + " of " +
+                       std::to_string(expected_items) + " submitted operations";
+      return false;
+    }
+
+    // Each entry is keyed by the action it answers, and every record goes out as an index
+    // operation. Read before "errors", which a body that is not this answer does not get to decide.
+    const nlohmann::json *rejected = nullptr;
+    for (const auto &item : *items)
+    {
+      if (!item.is_object() || item.size() != 1)
+      {
+        failure_reason = "the response has an \"items\" entry that is not one operation result";
+        return false;
+      }
+
+      const auto operation = item.find("index");
+      if (operation == item.end() || !operation->is_object())
+      {
+        failure_reason = "the response does not acknowledge the submitted index operation";
+        return false;
+      }
+
+      const auto status = operation->find("status");
+      if (status == operation->end() || !status->is_number_integer())
+      {
+        failure_reason = "the response acknowledges an index operation with no status";
+        return false;
+      }
+
+      if (rejected == nullptr && !IsAcknowledgedStatus(*status))
+      {
+        rejected = &(*status);
+      }
+    }
+
+    if (!errors->get<bool>())
+    {
+      // A false flag claims every operation was applied; hold the items to that claim.
+      if (rejected != nullptr)
+      {
+        failure_reason =
+            "the response reports no errors but acknowledges operation status " + rejected->dump();
+        return false;
+      }
+      return true;
+    }
+
+    // Name the first item error rather than only saying that something failed. Every entry is one
+    // index result by now, so its single member is the result to look in.
+    for (const auto &item : *items)
+    {
+      const auto &result = *item.begin();
+      const auto error   = result.find("error");
+      if (error != result.end())
+      {
+        failure_reason = "at least one item failed, first error: " + error->dump();
+        return false;
+      }
+    }
+
+    failure_reason = "the response reports errors";
+    return false;
+#if OPENTELEMETRY_HAVE_EXCEPTIONS
+  }
+  catch (...)
+  {
+    return false;
+  }
+#endif
+}
+
+}  // namespace detail
+}  // namespace logs
+}  // namespace exporter
+OPENTELEMETRY_END_NAMESPACE

--- a/exporters/elasticsearch/include/opentelemetry/exporters/elasticsearch/detail/es_bulk_response.h
+++ b/exporters/elasticsearch/include/opentelemetry/exporters/elasticsearch/detail/es_bulk_response.h
@@ -132,8 +132,10 @@ inline bool IsBulkResponseSuccessful(int status_code,
         rejected = &(*status);
       }
 
+      // A null holds no cause, and a serialiser that writes absent optionals as null is saying
+      // the operation applied, which is what the flag says too. Only a cause contradicts it.
       const auto error = operation->find("error");
-      if (item_error == nullptr && error != operation->end())
+      if (item_error == nullptr && error != operation->end() && !error->is_null())
       {
         item_error = &(*error);
       }

--- a/exporters/elasticsearch/src/es_log_record_exporter.cc
+++ b/exporters/elasticsearch/src/es_log_record_exporter.cc
@@ -14,6 +14,7 @@
 #include <utility>
 #include <vector>
 
+#include "opentelemetry/exporters/elasticsearch/detail/es_bulk_response.h"
 #include "opentelemetry/exporters/elasticsearch/es_log_record_exporter.h"
 #include "opentelemetry/exporters/elasticsearch/es_log_recordable.h"
 #include "opentelemetry/ext/http/client/detail/default_factory.h"
@@ -75,35 +76,29 @@ public:
    */
   void OnResponse(http_client::Response &response) noexcept override
   {
-    std::string log_message;
-
     // Lock the private members so they can't be read while being modified
     {
       std::unique_lock<std::mutex> lk(mutex_);
 
-      // Store the body of the request
-      body_ = std::string(response.GetBody().begin(), response.GetBody().end());
-
-      if (!(response.GetStatusCode() >= 200 && response.GetStatusCode() <= 299))
-      {
-        log_message = BuildResponseLogMessage(response, body_);
-
-        OTEL_INTERNAL_LOG_ERROR("[ES Log Exporter] Export failed, " << log_message);
-      }
+      std::string body(response.GetBody().begin(), response.GetBody().end());
 
       if (console_debug_)
       {
-        if (log_message.empty())
-        {
-          log_message = BuildResponseLogMessage(response, body_);
-        }
-
         OTEL_INTERNAL_LOG_DEBUG("[ES Log Exporter] Got response from Elasticsearch, "
-                                << log_message);
+                                << BuildResponseLogMessage(response, body));
       }
 
-      // Record the outcome and notify any threads waiting on this result
-      recordCompletionLocked(CompletionState::Success);
+      // Kept with the outcome it decides, and only by the call that decides it. Export() folds the
+      // status into the ExportResult, since storing the body alone let a non-2xx response be
+      // reported as a success, and a status from one response beside a body from another is not
+      // something the server sent. Export() is the single place that logs the failure, so a
+      // non-2xx response is not logged a second time here with the full body.
+      if (completion_ == CompletionState::Pending)
+      {
+        status_code_ = response.GetStatusCode();
+        body_        = std::move(body);
+        recordCompletionLocked(CompletionState::Success);
+      }
     }
     cv_.notify_all();
   }
@@ -122,14 +117,21 @@ public:
     return completion_ == CompletionState::Success;
   }
 
-  /**
-   * Returns the body of the response
-   */
-  std::string GetResponseBody()
+  /// The status and body of the response the recorded outcome was decided from.
+  struct Response
   {
-    // Lock so that body_ can't be written to while returning it
+    int status_code = 0;
+    std::string body;
+  };
+
+  /**
+   * Returns the response the outcome was decided from. Both halves together, since reading them
+   * one lock at a time can pair a status with a body that arrived in a different response.
+   */
+  Response GetResponse()
+  {
     std::unique_lock<std::mutex> lk(mutex_);
-    return body_;
+    return Response{status_code_, body_};
   }
 
   // Callback method when an http event occurs
@@ -236,6 +238,9 @@ private:
   // A string to store the response body
   std::string body_ = "";
 
+  // The HTTP status code of the response
+  int status_code_ = 0;
+
   // Whether to print the results from the callback
   bool console_debug_ = false;
 };
@@ -253,9 +258,11 @@ public:
   AsyncResponseHandler(
       std::shared_ptr<ext::http::client::Session> session,
       std::function<bool(opentelemetry::sdk::common::ExportResult)> &&result_callback,
+      std::size_t submitted_operations,
       bool console_debug = false)
       : session_{std::move(session)},
         result_callback_{std::move(result_callback)},
+        submitted_operations_{submitted_operations},
         console_debug_{console_debug}
   {}
 
@@ -275,18 +282,20 @@ public:
   void OnResponse(http_client::Response &response) noexcept override
   {
 
-    // Store the body of the response
-    body_ = std::string(response.GetBody().begin(), response.GetBody().end());
+    // Local, since nothing outside this call reads it and a member would be written twice over by
+    // a client that delivers two responses for one request.
+    const std::string body(response.GetBody().begin(), response.GetBody().end());
     if (console_debug_)
     {
       OTEL_INTERNAL_LOG_DEBUG(
-          "[ES Log Exporter] Got response from Elasticsearch,  response body: " << body_);
+          "[ES Log Exporter] Got response from Elasticsearch,  response body: " << body);
     }
-    if (body_.find("\"failed\" : 0") == std::string::npos)
+    std::string failure_reason;
+    if (!detail::IsBulkResponseSuccessful(response.GetStatusCode(), body, submitted_operations_,
+                                          failure_reason))
     {
-      OTEL_INTERNAL_LOG_ERROR(
-          "[ES Log Exporter] Logs were not written to Elasticsearch correctly, response body: "
-          << body_);
+      OTEL_INTERNAL_LOG_ERROR("[ES Log Exporter] Logs were not written to Elasticsearch correctly, "
+                              << failure_reason << ", response body: " << body);
       result_callback_(sdk::common::ExportResult::kFailure);
     }
     else
@@ -344,8 +353,8 @@ private:
   // Callback to call to on receiving events
   std::function<bool(opentelemetry::sdk::common::ExportResult)> result_callback_;
 
-  // A string to store the response body
-  std::string body_ = "";
+  // How many operations this request submitted, which is how many the response has to answer
+  std::size_t submitted_operations_ = 0;
 
   // Whether to print the results from the callback
   bool console_debug_ = false;
@@ -406,7 +415,7 @@ sdk::common::ExportResult ElasticsearchLogRecordExporter::Export(
   auto request = session->CreateRequest();
 
   // Populate the request with headers and methods
-  request->SetUri(options_.index_ + "/_bulk?pretty");
+  request->SetUri(options_.index_ + "/_bulk");
   request->SetMethod(http_client::Method::Post);
   request->AddHeader("Content-Type", "application/json");
 
@@ -423,7 +432,7 @@ sdk::common::ExportResult ElasticsearchLogRecordExporter::Export(
   for (auto &record : records)
   {
     // Append {"index":{}} before JSON body, which tells Elasticsearch to write to index specified
-    // in URI
+    // in URI. detail/es_bulk_response.h requires each acknowledgement to name this same action.
     body += "{\"index\" : {}}\n";
 
     // Add the context of the Recordable
@@ -458,7 +467,7 @@ sdk::common::ExportResult ElasticsearchLogRecordExporter::Export(
         synchronization_data->force_flush_cv.notify_all();
         return true;
       },
-      options_.console_debug_);
+      span_count, options_.console_debug_);
   session->SendRequest(handler);
   return sdk::common::ExportResult::kSuccess;
 #else
@@ -485,12 +494,13 @@ sdk::common::ExportResult ElasticsearchLogRecordExporter::Export(
   }
 
   // Parse the response output to determine if Elasticsearch consumed it correctly
-  std::string responseBody = handler->GetResponseBody();
-  if (responseBody.find("\"failed\" : 0") == std::string::npos)
+  const auto response = handler->GetResponse();
+  std::string failure_reason;
+  if (!detail::IsBulkResponseSuccessful(response.status_code, response.body, records.size(),
+                                        failure_reason))
   {
-    OTEL_INTERNAL_LOG_ERROR(
-        "[ES Log Exporter] Logs were not written to Elasticsearch correctly, response body: "
-        << responseBody);
+    OTEL_INTERNAL_LOG_ERROR("[ES Log Exporter] Logs were not written to Elasticsearch correctly, "
+                            << failure_reason << ", response body: " << response.body);
     // TODO: Retry logic
     return sdk::common::ExportResult::kFailure;
   }

--- a/exporters/elasticsearch/src/es_log_record_exporter.cc
+++ b/exporters/elasticsearch/src/es_log_record_exporter.cc
@@ -14,6 +14,7 @@
 #include <utility>
 #include <vector>
 
+#include "opentelemetry/exporters/elasticsearch/detail/es_bulk_response.h"
 #include "opentelemetry/exporters/elasticsearch/es_log_record_exporter.h"
 #include "opentelemetry/exporters/elasticsearch/es_log_recordable.h"
 #include "opentelemetry/ext/http/client/detail/default_factory.h"
@@ -75,37 +76,42 @@ public:
    */
   void OnResponse(http_client::Response &response) noexcept override
   {
-    std::string log_message;
+    std::string described;
+    bool decided = false;
 
     // Lock the private members so they can't be read while being modified
     {
       std::unique_lock<std::mutex> lk(mutex_);
 
-      // Store the body of the request
-      body_ = std::string(response.GetBody().begin(), response.GetBody().end());
+      std::string body(response.GetBody().begin(), response.GetBody().end());
 
-      if (!(response.GetStatusCode() >= 200 && response.GetStatusCode() <= 299))
+      // Kept with the outcome it decides, and only by the call that decides it. Export() folds the
+      // status into the ExportResult, since storing the body alone let a non-2xx response be
+      // reported as a success, and a status from one response beside a body from another is not
+      // something the server sent. Export() is the single place that logs the failure, so a
+      // non-2xx response is not logged a second time here with the full body.
+      if (completion_ == CompletionState::Pending)
       {
-        log_message = BuildResponseLogMessage(response, body_);
-
-        OTEL_INTERNAL_LOG_ERROR("[ES Log Exporter] Export failed, " << log_message);
-      }
-
-      if (console_debug_)
-      {
-        if (log_message.empty())
+        if (console_debug_)
         {
-          log_message = BuildResponseLogMessage(response, body_);
+          described = BuildResponseLogMessage(response, body);
         }
-
-        OTEL_INTERNAL_LOG_DEBUG("[ES Log Exporter] Got response from Elasticsearch, "
-                                << log_message);
+        status_code_ = response.GetStatusCode();
+        body_        = std::move(body);
+        recordCompletionLocked(CompletionState::Success);
+        decided = true;
       }
-
-      // Record the outcome and notify any threads waiting on this result
-      recordCompletionLocked(CompletionState::Success);
     }
     cv_.notify_all();
+
+    // Outside the lock and only for the response that decided the outcome. The log handler is
+    // replaceable application code, so one that reaches back into this exporter would otherwise do
+    // it while this thread holds mutex_, and a line for a response whose status and body were
+    // discarded describes an answer the caller was never given.
+    if (decided && console_debug_)
+    {
+      OTEL_INTERNAL_LOG_DEBUG("[ES Log Exporter] Got response from Elasticsearch, " << described);
+    }
   }
 
   /**
@@ -122,14 +128,21 @@ public:
     return completion_ == CompletionState::Success;
   }
 
-  /**
-   * Returns the body of the response
-   */
-  std::string GetResponseBody()
+  /// The status and body of the response the recorded outcome was decided from.
+  struct Response
   {
-    // Lock so that body_ can't be written to while returning it
+    int status_code = 0;
+    std::string body;
+  };
+
+  /**
+   * Returns the response the outcome was decided from. Both halves together, since reading them
+   * one lock at a time can pair a status with a body that arrived in a different response.
+   */
+  Response GetResponse()
+  {
     std::unique_lock<std::mutex> lk(mutex_);
-    return body_;
+    return Response{status_code_, body_};
   }
 
   // Callback method when an http event occurs
@@ -236,6 +249,9 @@ private:
   // A string to store the response body
   std::string body_ = "";
 
+  // The HTTP status code of the response
+  int status_code_ = 0;
+
   // Whether to print the results from the callback
   bool console_debug_ = false;
 };
@@ -253,9 +269,11 @@ public:
   AsyncResponseHandler(
       std::shared_ptr<ext::http::client::Session> session,
       std::function<bool(opentelemetry::sdk::common::ExportResult)> &&result_callback,
+      std::size_t submitted_operations,
       bool console_debug = false)
       : session_{std::move(session)},
         result_callback_{std::move(result_callback)},
+        submitted_operations_{submitted_operations},
         console_debug_{console_debug}
   {}
 
@@ -275,18 +293,20 @@ public:
   void OnResponse(http_client::Response &response) noexcept override
   {
 
-    // Store the body of the response
-    body_ = std::string(response.GetBody().begin(), response.GetBody().end());
+    // Local, since nothing outside this call reads it and a member would be written twice over by
+    // a client that delivers two responses for one request.
+    const std::string body(response.GetBody().begin(), response.GetBody().end());
     if (console_debug_)
     {
       OTEL_INTERNAL_LOG_DEBUG(
-          "[ES Log Exporter] Got response from Elasticsearch,  response body: " << body_);
+          "[ES Log Exporter] Got response from Elasticsearch,  response body: " << body);
     }
-    if (body_.find("\"failed\" : 0") == std::string::npos)
+    std::string failure_reason;
+    if (!detail::IsBulkResponseSuccessful(response.GetStatusCode(), body, submitted_operations_,
+                                          failure_reason))
     {
-      OTEL_INTERNAL_LOG_ERROR(
-          "[ES Log Exporter] Logs were not written to Elasticsearch correctly, response body: "
-          << body_);
+      OTEL_INTERNAL_LOG_ERROR("[ES Log Exporter] Logs were not written to Elasticsearch correctly, "
+                              << failure_reason << ", response body: " << body);
       result_callback_(sdk::common::ExportResult::kFailure);
     }
     else
@@ -344,8 +364,8 @@ private:
   // Callback to call to on receiving events
   std::function<bool(opentelemetry::sdk::common::ExportResult)> result_callback_;
 
-  // A string to store the response body
-  std::string body_ = "";
+  // How many operations this request submitted, which is how many the response has to answer
+  std::size_t submitted_operations_ = 0;
 
   // Whether to print the results from the callback
   bool console_debug_ = false;
@@ -406,7 +426,7 @@ sdk::common::ExportResult ElasticsearchLogRecordExporter::Export(
   auto request = session->CreateRequest();
 
   // Populate the request with headers and methods
-  request->SetUri(options_.index_ + "/_bulk?pretty");
+  request->SetUri(options_.index_ + "/_bulk");
   request->SetMethod(http_client::Method::Post);
   request->AddHeader("Content-Type", "application/json");
 
@@ -423,7 +443,7 @@ sdk::common::ExportResult ElasticsearchLogRecordExporter::Export(
   for (auto &record : records)
   {
     // Append {"index":{}} before JSON body, which tells Elasticsearch to write to index specified
-    // in URI
+    // in URI. detail/es_bulk_response.h requires each acknowledgement to name this same action.
     body += "{\"index\" : {}}\n";
 
     // Add the context of the Recordable
@@ -464,7 +484,7 @@ sdk::common::ExportResult ElasticsearchLogRecordExporter::Export(
         synchronization_data->force_flush_cv.notify_all();
         return true;
       },
-      options_.console_debug_);
+      span_count, options_.console_debug_);
   session->SendRequest(handler);
   return sdk::common::ExportResult::kSuccess;
 #else
@@ -491,12 +511,13 @@ sdk::common::ExportResult ElasticsearchLogRecordExporter::Export(
   }
 
   // Parse the response output to determine if Elasticsearch consumed it correctly
-  std::string responseBody = handler->GetResponseBody();
-  if (responseBody.find("\"failed\" : 0") == std::string::npos)
+  const auto response = handler->GetResponse();
+  std::string failure_reason;
+  if (!detail::IsBulkResponseSuccessful(response.status_code, response.body, records.size(),
+                                        failure_reason))
   {
-    OTEL_INTERNAL_LOG_ERROR(
-        "[ES Log Exporter] Logs were not written to Elasticsearch correctly, response body: "
-        << responseBody);
+    OTEL_INTERNAL_LOG_ERROR("[ES Log Exporter] Logs were not written to Elasticsearch correctly, "
+                            << failure_reason << ", response body: " << response.body);
     // TODO: Retry logic
     return sdk::common::ExportResult::kFailure;
   }

--- a/exporters/elasticsearch/test/es_log_record_exporter_test.cc
+++ b/exporters/elasticsearch/test/es_log_record_exporter_test.cc
@@ -366,6 +366,33 @@ TEST(ElasticsearchBulkResponseTests, RejectsAnAcknowledgedFailureUnderErrorsFals
   EXPECT_FALSE(logs_exporter::detail::IsBulkResponseSuccessful(
       200, R"({"errors":false,"items":[{"index":{"status":300}}]})", 1, reason));
 }
+
+// An operation that did not apply says so through its status and through an "error" member. The
+// errors:true path already reads the second one, so reading it here as well is what stops the same
+// body from being accepted or rejected according to a flag the responder also controls.
+TEST(ElasticsearchBulkResponseTests, RejectsAnItemErrorUnderErrorsFalse)
+{
+  std::string reason;
+  EXPECT_FALSE(logs_exporter::detail::IsBulkResponseSuccessful(
+      200,
+      R"({"errors":false,"items":[{"index":{"_index":"logs","status":201,)"
+      R"("error":{"type":"mapper_parsing_exception","reason":"rejected"}}}]})",
+      1, reason));
+  EXPECT_NE(reason.find("mapper_parsing_exception"), std::string::npos)
+      << "the reason names what the server said: " << reason;
+
+  // A conforming server sends the flag and the member together, and that reads the same way.
+  EXPECT_FALSE(logs_exporter::detail::IsBulkResponseSuccessful(
+      200,
+      R"({"errors":true,"items":[{"index":{"_index":"logs","status":400,)"
+      R"("error":{"type":"mapper_parsing_exception"}}}]})",
+      1, reason));
+  EXPECT_NE(reason.find("mapper_parsing_exception"), std::string::npos) << reason;
+
+  // Only the member decides. An acknowledgement without one stays a success.
+  EXPECT_TRUE(logs_exporter::detail::IsBulkResponseSuccessful(
+      200, R"({"errors":false,"items":[{"index":{"_index":"logs","status":201}}]})", 1, reason));
+}
 // ---------------------------------------------------------------------------
 // The response travelling from the HTTP callback to the verdict.
 //

--- a/exporters/elasticsearch/test/es_log_record_exporter_test.cc
+++ b/exporters/elasticsearch/test/es_log_record_exporter_test.cc
@@ -3,12 +3,17 @@
 
 #include "opentelemetry/exporters/elasticsearch/es_log_record_exporter.h"
 #include "opentelemetry/common/timestamp.h"
+#include "opentelemetry/exporters/elasticsearch/detail/es_bulk_response.h"
 #include "opentelemetry/exporters/elasticsearch/es_log_recordable.h"
+#include "opentelemetry/ext/http/client/http_client.h"
 #include "opentelemetry/logs/severity.h"
+#include "opentelemetry/nostd/function_ref.h"
+#include "opentelemetry/nostd/shared_ptr.h"
 #include "opentelemetry/nostd/span.h"
 #include "opentelemetry/nostd/string_view.h"
 #include "opentelemetry/nostd/utility.h"
 #include "opentelemetry/sdk/common/exporter_utils.h"
+#include "opentelemetry/sdk/common/global_log_handler.h"
 #include "opentelemetry/sdk/instrumentationscope/instrumentation_scope.h"
 #include "opentelemetry/sdk/logs/exporter.h"
 #include "opentelemetry/sdk/logs/recordable.h"
@@ -19,8 +24,10 @@
 #include <chrono>
 #include <cstddef>
 #include <cstdint>
+#include <functional>
 #include <string>
 #include <utility>
+#include <vector>
 #include "nlohmann/json.hpp"
 
 namespace sdklogs       = opentelemetry::sdk::logs;
@@ -141,4 +148,498 @@ TEST(ElasticsearchLogRecordableTests, BasicTests)
   const auto actual = recordable.GetJSON();
 
   EXPECT_EQ(actual, expected);
+}
+
+// The batch outcome is the top level "errors" field. Two success bodies that differ only in
+// whitespace, so a check that depends on formatting cannot answer the same for both.
+namespace
+{
+constexpr const char *kPrettySuccess =
+    R"({"took":30,"errors":false,"items":[{"index":{"_index":"logs","_id":"1",)"
+    R"("_shards":{"total":2,"successful":1,"failed" : 0},"status":201}}]})";
+constexpr const char *kCompactSuccess =
+    R"({"took":30,"errors":false,"items":[{"index":{"_index":"logs","_id":"1",)"
+    R"("_shards":{"total":2,"successful":1,"failed":0},"status":201}}]})";
+constexpr const char *kOneItemRejected =
+    R"({"took":30,"errors":true,"items":[{"index":{"_index":"logs","_id":"1",)"
+    R"("_shards":{"failed" : 0},"status":201}},{"index":{"_index":"logs","_id":"2",)"
+    R"("status":400,"error":{"type":"mapper_parsing_exception","reason":"bad field"}}}]})";
+}  // namespace
+
+TEST(ElasticsearchBulkResponseTests, ReportsSuccessWhenErrorsIsFalse)
+{
+  std::string reason;
+  EXPECT_TRUE(logs_exporter::detail::IsBulkResponseSuccessful(200, kPrettySuccess, 1, reason));
+  EXPECT_TRUE(logs_exporter::detail::IsBulkResponseSuccessful(200, kCompactSuccess, 1, reason));
+}
+
+// A successful check must not leave a stale failure reason from a previous call behind.
+TEST(ElasticsearchBulkResponseTests, ClearsFailureReasonOnSuccess)
+{
+  std::string reason = "stale";
+  EXPECT_TRUE(logs_exporter::detail::IsBulkResponseSuccessful(200, kCompactSuccess, 1, reason));
+  EXPECT_TRUE(reason.empty());
+}
+
+TEST(ElasticsearchBulkResponseTests, ReportsFailureWhenAnyItemWasRejected)
+{
+  std::string reason;
+  EXPECT_FALSE(logs_exporter::detail::IsBulkResponseSuccessful(200, kOneItemRejected, 2, reason));
+  EXPECT_NE(reason.find("mapper_parsing_exception"), std::string::npos);
+}
+
+TEST(ElasticsearchBulkResponseTests, ReportsFailureOnUnusableBody)
+{
+  std::string reason;
+  EXPECT_FALSE(logs_exporter::detail::IsBulkResponseSuccessful(200, "not json at all", 1, reason));
+  EXPECT_FALSE(reason.empty());
+
+  EXPECT_FALSE(logs_exporter::detail::IsBulkResponseSuccessful(200, "", 1, reason));
+  EXPECT_FALSE(reason.empty());
+
+  // An array rather than the expected object.
+  EXPECT_FALSE(logs_exporter::detail::IsBulkResponseSuccessful(200, "[1,2,3]", 1, reason));
+  EXPECT_FALSE(reason.empty());
+}
+
+TEST(ElasticsearchBulkResponseTests, ReportsFailureWhenErrorsFieldIsMissingOrNotBoolean)
+{
+  std::string reason;
+  EXPECT_FALSE(
+      logs_exporter::detail::IsBulkResponseSuccessful(200, R"({"took":30,"items":[]})", 1, reason));
+  EXPECT_FALSE(logs_exporter::detail::IsBulkResponseSuccessful(
+      200, R"({"errors":"false","items":[]})", 0, reason));
+}
+
+// A non-2xx status is a failure even when the body reports errors:false. This is the invariant
+// the substring check and the body-only check both missed, on both the sync and async paths.
+TEST(ElasticsearchBulkResponseTests, ReportsFailureOnNon2xxStatus)
+{
+  std::string reason;
+  const char *ok_body = R"({"errors":false,"items":[]})";
+  EXPECT_FALSE(logs_exporter::detail::IsBulkResponseSuccessful(500, ok_body, 0, reason));
+  EXPECT_FALSE(logs_exporter::detail::IsBulkResponseSuccessful(429, ok_body, 0, reason));
+  EXPECT_FALSE(logs_exporter::detail::IsBulkResponseSuccessful(400, ok_body, 0, reason));
+  EXPECT_TRUE(logs_exporter::detail::IsBulkResponseSuccessful(200, ok_body, 0, reason));
+}
+
+// errors:true with no extractable item error still fails, with the generic reason.
+TEST(ElasticsearchBulkResponseTests, ReportsFailureWhenErrorsTrueWithoutItemError)
+{
+  std::string reason;
+  EXPECT_FALSE(logs_exporter::detail::IsBulkResponseSuccessful(200, R"({"errors":true,"items":[]})",
+                                                               0, reason));
+  EXPECT_FALSE(logs_exporter::detail::IsBulkResponseSuccessful(
+      200, R"({"errors":true,"items":[null]})", 1, reason));
+  EXPECT_FALSE(logs_exporter::detail::IsBulkResponseSuccessful(
+      200, R"({"errors":true,"items":[{"index":42}]})", 1, reason));
+}
+
+// The 2xx range is the success band; the codes just outside it are failures. This pins the boundary
+// so a later change to the status check cannot silently widen or narrow it.
+TEST(ElasticsearchBulkResponseTests, TreatsThe2xxRangeAsTheSuccessBand)
+{
+  std::string reason;
+  const char *ok_body = R"({"errors":false,"items":[]})";
+  EXPECT_FALSE(logs_exporter::detail::IsBulkResponseSuccessful(199, ok_body, 0, reason));
+  EXPECT_TRUE(logs_exporter::detail::IsBulkResponseSuccessful(200, ok_body, 0, reason));
+  EXPECT_TRUE(logs_exporter::detail::IsBulkResponseSuccessful(299, ok_body, 0, reason));
+  EXPECT_FALSE(logs_exporter::detail::IsBulkResponseSuccessful(300, ok_body, 0, reason));
+}
+
+// The exporter posts an unfiltered /_bulk, so Elasticsearch answers every submitted operation in
+// "items". A body that does not is not an answer to that request, and treating it as success would
+// hand the caller a write acknowledgement nobody made.
+TEST(ElasticsearchBulkResponseTests, RequiresAnAcknowledgementForEverySubmittedOperation)
+{
+  std::string reason;
+  constexpr const char *kNoItems   = R"({"errors":false})";
+  constexpr const char *kNullItems = R"({"errors":false,"items":null})";
+  constexpr const char *kOneItemBody =
+      R"({"errors":false,"items":[{"index":{"_shards":{"failed":0},"status":201}}]})";
+  constexpr const char *kTwoItemBody =
+      R"({"errors":false,"items":[{"index":{"status":201}},{"index":{"status":201}}]})";
+
+  EXPECT_FALSE(logs_exporter::detail::IsBulkResponseSuccessful(200, kNoItems, 1, reason));
+  EXPECT_FALSE(logs_exporter::detail::IsBulkResponseSuccessful(200, kNullItems, 1, reason));
+  EXPECT_FALSE(logs_exporter::detail::IsBulkResponseSuccessful(200, kOneItemBody, 2, reason))
+      << "too few acknowledgements";
+  EXPECT_FALSE(logs_exporter::detail::IsBulkResponseSuccessful(200, kTwoItemBody, 1, reason))
+      << "more acknowledgements than operations";
+  EXPECT_TRUE(logs_exporter::detail::IsBulkResponseSuccessful(200, kOneItemBody, 1, reason));
+  EXPECT_TRUE(logs_exporter::detail::IsBulkResponseSuccessful(200, kTwoItemBody, 2, reason));
+}
+
+// The right count of the wrong entries is still the wrong answer, and the verdict cannot depend on
+// "errors", which the same responder controls.
+TEST(ElasticsearchBulkResponseTests, RejectsItemsEntriesThatDoNotAcknowledgeAnIndexOperation)
+{
+  std::string reason;
+  const auto rejected = [&reason](const char *body, std::size_t expected) {
+    return !logs_exporter::detail::IsBulkResponseSuccessful(200, body, expected, reason);
+  };
+
+  EXPECT_TRUE(rejected(R"({"errors":false,"items":[null,null]})", 2));
+  EXPECT_FALSE(reason.empty());
+  EXPECT_TRUE(rejected(R"({"errors":false,"items":[1,2]})", 2));
+  EXPECT_TRUE(rejected(R"({"errors":false,"items":[[]]})", 1));
+  EXPECT_TRUE(rejected(R"({"errors":false,"items":[{}]})", 1)) << "no operation at all";
+  EXPECT_TRUE(rejected(R"({"errors":false,"items":[{"unknown":{"status":201}}]})", 1))
+      << "an operation the exporter never submitted";
+  EXPECT_TRUE(rejected(R"({"errors":false,"items":[{"index":42}]})", 1))
+      << "the index key holds no result object";
+  EXPECT_TRUE(rejected(R"({"errors":false,"items":[{"index":{},"delete":{}}]})", 1))
+      << "one entry cannot answer two operations";
+  EXPECT_TRUE(rejected(R"({"errors":false,"items":[{"index":{"status":201},"delete":{}}]})", 1))
+      << "a valid acknowledgement does not license a second member";
+  EXPECT_TRUE(rejected(R"({"errors":false,"items":[{"index":{"_index":"logs"}}]})", 1))
+      << "an index result carrying no status";
+  EXPECT_TRUE(rejected(R"({"errors":true,"items":[null,null]})", 2))
+      << "the same shape has to fail whichever way errors reads";
+
+  // The shape a real acknowledgement has.
+  EXPECT_FALSE(rejected(R"({"errors":false,"items":[{"index":{"status":201}}]})", 1));
+
+  // Three shapes, three reasons: they are different things to go and look at.
+  const auto reason_for = [&reason](const char *body) {
+    logs_exporter::detail::IsBulkResponseSuccessful(200, body, 1, reason);
+    return reason;
+  };
+  const std::string padded  = reason_for(R"({"errors":false,"items":[{"index":{},"delete":{}}]})");
+  const std::string other   = reason_for(R"({"errors":false,"items":[{"unknown":{"status":1}}]})");
+  const std::string no_stat = reason_for(R"({"errors":false,"items":[{"index":{"_index":"l"}}]})");
+  EXPECT_NE(padded, other) << padded;
+  EXPECT_NE(other, no_stat) << other;
+  EXPECT_NE(padded, no_stat) << no_stat;
+}
+
+// The status says whether the operation applied, so the band has to hold for the number the server
+// sent rather than for what it becomes on the way into an int.
+TEST(ElasticsearchBulkResponseTests, RejectsAcknowledgementsOutsideTheSuccessBand)
+{
+  std::string reason;
+  const auto applied = [&reason](const char *status) {
+    const std::string body =
+        std::string(R"({"errors":false,"items":[{"index":{"status":)") + status + R"(}}]})";
+    return logs_exporter::detail::IsBulkResponseSuccessful(200, body, 1, reason);
+  };
+
+  EXPECT_TRUE(applied("200"));
+  EXPECT_TRUE(applied("201"));
+  EXPECT_TRUE(applied("299"));
+
+  EXPECT_FALSE(applied("0")) << "zero is a status, not the absence of one";
+  EXPECT_FALSE(reason.empty());
+  EXPECT_FALSE(applied("-0"));
+  EXPECT_FALSE(applied("-1"));
+  EXPECT_FALSE(applied("199"));
+  EXPECT_FALSE(applied("300"));
+  EXPECT_FALSE(applied("4294967496")) << "2^32 + 200, which lands on 200 in a 32 bit int";
+  EXPECT_FALSE(applied("18446744073709551615")) << "no signed type holds it";
+  EXPECT_FALSE(applied("200.5")) << "not an integer";
+  EXPECT_FALSE(applied(R"("200")")) << "a string is not a status";
+  EXPECT_FALSE(applied("null"));
+
+  // The value reaches the log as it arrived, so a reader sees what the server said.
+  applied("4294967496");
+  EXPECT_NE(reason.find("4294967496"), std::string::npos) << reason;
+}
+
+// A false flag claims every operation was applied. No conforming server sends it alongside a
+// rejection, so holding the items to the claim rejects nothing the flag alone would have taken.
+TEST(ElasticsearchBulkResponseTests, RejectsAnAcknowledgedFailureUnderErrorsFalse)
+{
+  std::string reason;
+  EXPECT_FALSE(logs_exporter::detail::IsBulkResponseSuccessful(
+      200, R"({"errors":false,"items":[{"index":{"status":400}}]})", 1, reason));
+  EXPECT_NE(reason.find("400"), std::string::npos) << "the reason names the status: " << reason;
+
+  EXPECT_FALSE(logs_exporter::detail::IsBulkResponseSuccessful(
+      200, R"({"errors":false,"items":[{"index":{"status":201}},{"index":{"status":429}}]})", 2,
+      reason))
+      << "one rejected operation among several is still a rejection";
+
+  // The whole 2xx band is a success, the same band the response's own HTTP status uses.
+  EXPECT_TRUE(logs_exporter::detail::IsBulkResponseSuccessful(
+      200, R"({"errors":false,"items":[{"index":{"status":200}},{"index":{"status":299}}]})", 2,
+      reason));
+  EXPECT_FALSE(logs_exporter::detail::IsBulkResponseSuccessful(
+      200, R"({"errors":false,"items":[{"index":{"status":300}}]})", 1, reason));
+}
+// ---------------------------------------------------------------------------
+// The response travelling from the HTTP callback to the verdict.
+//
+// The cases above call IsBulkResponseSuccessful() directly, so they cannot show
+// that the status and the body actually reach it. A fake HTTP client drives the
+// callbacks from inside SendRequest(), which runs before Export() reaches the
+// wait, and the assertions are on the ExportResult.
+//
+// This fixture is the same one #4331 adds to this file. Whichever lands first,
+// the other drops the duplicate when it rebases.
+// ---------------------------------------------------------------------------
+namespace
+{
+namespace http_client = opentelemetry::ext::http::client;
+
+class FakeResponse : public http_client::Response
+{
+public:
+  FakeResponse(http_client::StatusCode status, const std::string &body)
+      : status_(status), body_(body.begin(), body.end())
+  {}
+  const http_client::Body &GetBody() const noexcept override { return body_; }
+  bool ForEachHeader(
+      nostd::function_ref<bool(nostd::string_view, nostd::string_view)>) const noexcept override
+  {
+    return true;
+  }
+  bool ForEachHeader(
+      const nostd::string_view &,
+      nostd::function_ref<bool(nostd::string_view, nostd::string_view)>) const noexcept override
+  {
+    return true;
+  }
+  http_client::StatusCode GetStatusCode() const noexcept override { return status_; }
+
+private:
+  http_client::StatusCode status_;
+  http_client::Body body_;
+};
+
+class FakeRequest : public http_client::Request
+{
+public:
+  void SetMethod(http_client::Method) noexcept override {}
+  void SetUri(nostd::string_view) noexcept override {}
+  void SetSslOptions(const http_client::HttpSslOptions &) noexcept override {}
+  void SetBody(http_client::Body &) noexcept override {}
+  void AddHeader(nostd::string_view, nostd::string_view) noexcept override {}
+  void ReplaceHeader(nostd::string_view, nostd::string_view) noexcept override {}
+  void SetTimeoutMs(std::chrono::milliseconds) noexcept override {}
+  void SetCompression(const http_client::Compression &) noexcept override {}
+  void EnableLogging(bool) noexcept override {}
+  void SetRetryPolicy(const http_client::RetryPolicy &) noexcept override {}
+};
+
+using EventScript = std::function<void(http_client::EventHandler &)>;
+
+class FakeSession : public http_client::Session
+{
+public:
+  explicit FakeSession(EventScript script) : script_(std::move(script)) {}
+  std::shared_ptr<http_client::Request> CreateRequest() noexcept override
+  {
+    return std::make_shared<FakeRequest>();
+  }
+  void SendRequest(std::shared_ptr<http_client::EventHandler> handler) noexcept override
+  {
+    script_(*handler);
+  }
+  bool IsSessionActive() noexcept override { return false; }
+  bool CancelSession() noexcept override { return true; }
+  bool FinishSession() noexcept override { return true; }
+
+private:
+  EventScript script_;
+};
+
+class FakeHttpClient : public http_client::HttpClient
+{
+public:
+  explicit FakeHttpClient(EventScript script) : script_(std::move(script)) {}
+  std::shared_ptr<http_client::Session> CreateSession(nostd::string_view) noexcept override
+  {
+    return std::make_shared<FakeSession>(script_);
+  }
+  bool CancelAllSessions() noexcept override { return true; }
+  bool FinishAllSessions() noexcept override { return true; }
+  void SetMaxSessionsPerConnection(std::size_t) noexcept override {}
+
+private:
+  EventScript script_;
+};
+
+// The response has to answer one operation per record, so a case using a body with N items has to
+// export N records or it would be rejected on the count before reaching what it means to test.
+opentelemetry::sdk::common::ExportResult ExportWith(EventScript script, std::size_t records = 1)
+{
+  auto client = std::make_shared<FakeHttpClient>(std::move(script));
+  logs_exporter::ElasticsearchExporterOptions options;
+  logs_exporter::ElasticsearchLogRecordExporter exporter(options, client);
+
+  std::vector<std::unique_ptr<sdklogs::Recordable>> batch;
+  batch.reserve(records);
+  for (std::size_t i = 0; i < records; ++i)
+  {
+    batch.push_back(exporter.MakeRecordable());
+  }
+  return exporter.Export(
+      nostd::span<std::unique_ptr<sdklogs::Recordable>>(batch.data(), batch.size()));
+}
+}  // namespace
+
+// The synchronous wait exists only when the exporter is built without async export, so these cases
+// skip rather than compile out: gtest_add_tests reads the source, and a case that disappeared from
+// the binary would still be registered with CTest. The skip goes in SetUp rather than at the top of
+// each body, because GTEST_SKIP returns and leaves the rest of the body unreachable, which MSVC
+// reports as C4702 and the maintainer mode jobs turn into an error.
+namespace
+{
+class ElasticsearchLogsExporterWiringTests : public ::testing::Test
+{
+protected:
+  void SetUp() override
+  {
+#ifdef ENABLE_ASYNC_EXPORT
+    GTEST_SKIP() << "Export() returns without waiting when async export is enabled";
+#endif
+  }
+};
+}  // namespace
+
+// A body the parser accepts, through the whole path rather than through the helper alone.
+TEST_F(ElasticsearchLogsExporterWiringTests, AcceptedBulkResponseIsASuccessfulExport)
+{
+  const auto result = ExportWith([](http_client::EventHandler &handler) {
+    FakeResponse response(200, kPrettySuccess);
+    handler.OnResponse(response);
+  });
+  EXPECT_EQ(result, opentelemetry::sdk::common::ExportResult::kSuccess);
+}
+
+// The first response decides the outcome, so it has to be the one the verdict is read from. A
+// client that answers twice would otherwise leave the decision with the first and the evidence
+// for it with the second.
+TEST_F(ElasticsearchLogsExporterWiringTests, ASecondResponseDoesNotReplaceTheOneThatDecided)
+{
+  const auto result = ExportWith([](http_client::EventHandler &handler) {
+    FakeResponse rejected(500, kPrettySuccess);
+    handler.OnResponse(rejected);
+    FakeResponse accepted(200, kPrettySuccess);
+    handler.OnResponse(accepted);
+  });
+  EXPECT_EQ(result, opentelemetry::sdk::common::ExportResult::kFailure)
+      << "the 500 that decided the outcome was read back as the 200 that followed it";
+}
+
+// The case #4295 reports: a 200 whose rejected item still leaves a shard counter reading
+// "failed" : 0, so the body looks successful to anything that reads it as text.
+TEST_F(ElasticsearchLogsExporterWiringTests, RejectedItemIsAFailedExport)
+{
+  // Two records, because kOneItemRejected answers two operations. Exporting one would be rejected
+  // on the acknowledgement count and the case would stop testing what it is named for.
+  const auto result = ExportWith(
+      [](http_client::EventHandler &handler) {
+        FakeResponse response(200, kOneItemRejected);
+        handler.OnResponse(response);
+      },
+      2);
+  EXPECT_EQ(result, opentelemetry::sdk::common::ExportResult::kFailure);
+}
+
+// The status has to reach the parser, not just the body. A handler that stored a fixed status,
+// or an Export() that never asked for it, would still pass every case above.
+TEST_F(ElasticsearchLogsExporterWiringTests, ServerErrorIsAFailedExportEvenWithAnAcceptedBody)
+{
+  const auto result = ExportWith([](http_client::EventHandler &handler) {
+    FakeResponse response(500, kPrettySuccess);
+    handler.OnResponse(response);
+  });
+  EXPECT_EQ(result, opentelemetry::sdk::common::ExportResult::kFailure);
+}
+
+// ---------------------------------------------------------------------------
+// Asynchronous path.
+//
+// Export() hands the body to AsyncResponseHandler and returns before any
+// response arrives, so the parsed result decides nothing the caller can see.
+// It decides which internal log line is written, which is what these cases
+// read. The fake delivers the response from inside SendRequest(), so the line
+// is already written by the time Export() returns.
+// ---------------------------------------------------------------------------
+namespace
+{
+struct CapturingLogHandler : public opentelemetry::sdk::common::internal_log::LogHandler
+{
+  void Handle(opentelemetry::sdk::common::internal_log::LogLevel level,
+              const char * /* file */,
+              int /* line */,
+              const char *msg,
+              const opentelemetry::sdk::common::AttributeMap & /* attributes */) noexcept override
+  {
+    messages.emplace_back(level, std::string{msg});
+  }
+
+  std::vector<std::pair<opentelemetry::sdk::common::internal_log::LogLevel, std::string>> messages;
+};
+
+class ElasticsearchLogsExporterAsyncTests : public ::testing::Test
+{
+protected:
+  void SetUp() override
+  {
+#ifndef ENABLE_ASYNC_EXPORT
+    GTEST_SKIP() << "Export() takes the synchronous path when async export is disabled";
+#endif
+    handler_ = nostd::shared_ptr<opentelemetry::sdk::common::internal_log::LogHandler>(
+        new CapturingLogHandler());
+    opentelemetry::sdk::common::internal_log::GlobalLogHandler::SetLogHandler(handler_);
+  }
+
+  void TearDown() override
+  {
+    opentelemetry::sdk::common::internal_log::GlobalLogHandler::SetLogHandler(
+        nostd::shared_ptr<opentelemetry::sdk::common::internal_log::LogHandler>(
+            new opentelemetry::sdk::common::internal_log::DefaultLogHandler()));
+  }
+
+  bool LoggedAnExportFailure() const
+  {
+    const auto &messages = static_cast<CapturingLogHandler *>(handler_.get())->messages;
+    for (const auto &message : messages)
+    {
+      if (message.second.find("Logs were not written to Elasticsearch correctly") !=
+          std::string::npos)
+      {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  nostd::shared_ptr<opentelemetry::sdk::common::internal_log::LogHandler> handler_;
+};
+}  // namespace
+
+TEST_F(ElasticsearchLogsExporterAsyncTests, AnAcceptedResponseIsNotReportedAsAFailure)
+{
+  EXPECT_EQ(ExportWith([](http_client::EventHandler &handler) {
+              FakeResponse response(200, kPrettySuccess);
+              handler.OnResponse(response);
+            }),
+            opentelemetry::sdk::common::ExportResult::kSuccess);
+
+#if OTEL_INTERNAL_LOG_LEVEL >= OTEL_INTERNAL_LOG_LEVEL_ERROR
+  EXPECT_FALSE(LoggedAnExportFailure());
+#endif
+}
+
+// The count reaches the parser on this path through the handler rather than through Export(), so
+// a handler that dropped it would still satisfy every synchronous case.
+TEST_F(ElasticsearchLogsExporterAsyncTests, ARejectedResponseIsReportedAsAFailure)
+{
+  // Export() reports success on this path whatever the response says, which is why the outcome has
+  // to be read from the log below. Asserting it here also keeps this case from having no assertion
+  // at all where the internal log level excludes the one that follows.
+  EXPECT_EQ(ExportWith(
+                [](http_client::EventHandler &handler) {
+                  FakeResponse response(200, kOneItemRejected);
+                  handler.OnResponse(response);
+                },
+                2),
+            opentelemetry::sdk::common::ExportResult::kSuccess);
+
+#if OTEL_INTERNAL_LOG_LEVEL >= OTEL_INTERNAL_LOG_LEVEL_ERROR
+  EXPECT_TRUE(LoggedAnExportFailure());
+#endif
 }

--- a/exporters/elasticsearch/test/es_log_record_exporter_test.cc
+++ b/exporters/elasticsearch/test/es_log_record_exporter_test.cc
@@ -389,9 +389,13 @@ TEST(ElasticsearchBulkResponseTests, RejectsAnItemErrorUnderErrorsFalse)
       1, reason));
   EXPECT_NE(reason.find("mapper_parsing_exception"), std::string::npos) << reason;
 
-  // Only the member decides. An acknowledgement without one stays a success.
+  // Only a cause decides. An acknowledgement without the member stays a success, and so does one
+  // whose member is null, which is what a serialiser writing absent optionals produces.
   EXPECT_TRUE(logs_exporter::detail::IsBulkResponseSuccessful(
       200, R"({"errors":false,"items":[{"index":{"_index":"logs","status":201}}]})", 1, reason));
+  EXPECT_TRUE(logs_exporter::detail::IsBulkResponseSuccessful(
+      200, R"({"errors":false,"items":[{"index":{"_index":"logs","status":201,"error":null}}]})", 1,
+      reason));
 }
 // ---------------------------------------------------------------------------
 // The response travelling from the HTTP callback to the verdict.

--- a/exporters/elasticsearch/test/es_log_record_exporter_test.cc
+++ b/exporters/elasticsearch/test/es_log_record_exporter_test.cc
@@ -34,17 +34,19 @@ namespace
 {
 namespace http_client = opentelemetry::ext::http::client;
 
-// A response shaped like a successful Elasticsearch bulk reply: the exporter looks for
-// `"failed" : 0` in the body (see ElasticsearchLogRecordExporter::Export) in addition to the
-// status code before reporting success.
+// What the exporter accepts: a 2xx status, "errors" false, and one item result per record the
+// request submitted. A case that is not testing the response itself takes the default.
+constexpr const char *kOneAcceptedRecord =
+    R"({"took":30,"errors":false,"items":[{"index":{"_index":"logs","_id":"1",)"
+    R"("_shards":{"total":2,"successful":1,"failed":0},"status":201}}]})";
+
 class FakeResponse final : public http_client::Response
 {
 public:
-  FakeResponse()
-  {
-    static const std::string kSuccessBody = R"({"errors": false, "failed" : 0})";
-    body_.assign(kSuccessBody.begin(), kSuccessBody.end());
-  }
+  explicit FakeResponse(http_client::StatusCode status = 200,
+                        const std::string &body        = kOneAcceptedRecord)
+      : status_(status), body_(body.begin(), body.end())
+  {}
 
   const http_client::Body &GetBody() const noexcept override { return body_; }
 
@@ -63,9 +65,10 @@ public:
     return true;
   }
 
-  http_client::StatusCode GetStatusCode() const noexcept override { return 200; }
+  http_client::StatusCode GetStatusCode() const noexcept override { return status_; }
 
 private:
+  http_client::StatusCode status_;
   http_client::Body body_;
 };
 
@@ -90,11 +93,24 @@ public:
   void SetRetryPolicy(const http_client::RetryPolicy &) noexcept override {}
 };
 
-// A session whose SendRequest() answers synchronously with a successful FakeResponse, so the
-// exporter's own wait for a response returns immediately without needing a real connection.
+// What the client does with a request, called from inside SendRequest() so the exporter's own
+// wait returns without needing a connection. The default answers once, successfully, which is
+// what a case wants when the response is not the thing under test.
+using EventScript = std::function<void(http_client::EventHandler &)>;
+
+EventScript AnswerSuccessfully()
+{
+  return [](http_client::EventHandler &handler) {
+    FakeResponse response;
+    handler.OnResponse(response);
+  };
+}
+
 class FakeSession final : public http_client::Session
 {
 public:
+  explicit FakeSession(EventScript script = AnswerSuccessfully()) : script_(std::move(script)) {}
+
   std::shared_ptr<http_client::Request> CreateRequest() noexcept override
   {
     return std::make_shared<FakeRequest>();
@@ -102,27 +118,34 @@ public:
 
   void SendRequest(std::shared_ptr<http_client::EventHandler> handler) noexcept override
   {
-    FakeResponse response;
-    handler->OnResponse(response);
+    script_(*handler);
   }
 
   bool IsSessionActive() noexcept override { return true; }
   bool CancelSession() noexcept override { return true; }
   bool FinishSession() noexcept override { return true; }
+
+private:
+  EventScript script_;
 };
 
 class FakeHttpClient final : public http_client::HttpClient
 {
 public:
+  explicit FakeHttpClient(EventScript script = AnswerSuccessfully()) : script_(std::move(script)) {}
+
   std::shared_ptr<http_client::Session> CreateSession(
       opentelemetry::nostd::string_view) noexcept override
   {
-    return std::make_shared<FakeSession>();
+    return std::make_shared<FakeSession>(script_);
   }
 
   bool CancelAllSessions() noexcept override { return true; }
   bool FinishAllSessions() noexcept override { return true; }
   void SetMaxSessionsPerConnection(std::size_t) noexcept override {}
+
+private:
+  EventScript script_;
 };
 
 }  // namespace
@@ -554,86 +577,6 @@ TEST(ElasticsearchBulkResponseTests, RejectsAnItemErrorUnderErrorsFalse)
 // ---------------------------------------------------------------------------
 namespace
 {
-namespace http_client = opentelemetry::ext::http::client;
-
-class FakeResponse : public http_client::Response
-{
-public:
-  FakeResponse(http_client::StatusCode status, const std::string &body)
-      : status_(status), body_(body.begin(), body.end())
-  {}
-  const http_client::Body &GetBody() const noexcept override { return body_; }
-  bool ForEachHeader(
-      nostd::function_ref<bool(nostd::string_view, nostd::string_view)>) const noexcept override
-  {
-    return true;
-  }
-  bool ForEachHeader(
-      const nostd::string_view &,
-      nostd::function_ref<bool(nostd::string_view, nostd::string_view)>) const noexcept override
-  {
-    return true;
-  }
-  http_client::StatusCode GetStatusCode() const noexcept override { return status_; }
-
-private:
-  http_client::StatusCode status_;
-  http_client::Body body_;
-};
-
-class FakeRequest : public http_client::Request
-{
-public:
-  void SetMethod(http_client::Method) noexcept override {}
-  void SetUri(nostd::string_view) noexcept override {}
-  void SetSslOptions(const http_client::HttpSslOptions &) noexcept override {}
-  void SetBody(http_client::Body &) noexcept override {}
-  void AddHeader(nostd::string_view, nostd::string_view) noexcept override {}
-  void ReplaceHeader(nostd::string_view, nostd::string_view) noexcept override {}
-  void SetTimeoutMs(std::chrono::milliseconds) noexcept override {}
-  void SetCompression(const http_client::Compression &) noexcept override {}
-  void EnableLogging(bool) noexcept override {}
-  void SetRetryPolicy(const http_client::RetryPolicy &) noexcept override {}
-};
-
-using EventScript = std::function<void(http_client::EventHandler &)>;
-
-class FakeSession : public http_client::Session
-{
-public:
-  explicit FakeSession(EventScript script) : script_(std::move(script)) {}
-  std::shared_ptr<http_client::Request> CreateRequest() noexcept override
-  {
-    return std::make_shared<FakeRequest>();
-  }
-  void SendRequest(std::shared_ptr<http_client::EventHandler> handler) noexcept override
-  {
-    script_(*handler);
-  }
-  bool IsSessionActive() noexcept override { return false; }
-  bool CancelSession() noexcept override { return true; }
-  bool FinishSession() noexcept override { return true; }
-
-private:
-  EventScript script_;
-};
-
-class FakeHttpClient : public http_client::HttpClient
-{
-public:
-  explicit FakeHttpClient(EventScript script) : script_(std::move(script)) {}
-  std::shared_ptr<http_client::Session> CreateSession(nostd::string_view) noexcept override
-  {
-    return std::make_shared<FakeSession>(script_);
-  }
-  bool CancelAllSessions() noexcept override { return true; }
-  bool FinishAllSessions() noexcept override { return true; }
-  void SetMaxSessionsPerConnection(std::size_t) noexcept override {}
-
-private:
-  EventScript script_;
-};
-
 // The response has to answer one operation per record, so a case using a body with N items has to
 // export N records or it would be rejected on the count before reaching what it means to test.
 opentelemetry::sdk::common::ExportResult ExportWith(EventScript script,

--- a/exporters/elasticsearch/test/es_log_record_exporter_test.cc
+++ b/exporters/elasticsearch/test/es_log_record_exporter_test.cc
@@ -3,14 +3,17 @@
 
 #include "opentelemetry/exporters/elasticsearch/es_log_record_exporter.h"
 #include "opentelemetry/common/timestamp.h"
+#include "opentelemetry/exporters/elasticsearch/detail/es_bulk_response.h"
 #include "opentelemetry/exporters/elasticsearch/es_log_recordable.h"
 #include "opentelemetry/ext/http/client/http_client.h"
 #include "opentelemetry/logs/severity.h"
 #include "opentelemetry/nostd/function_ref.h"
+#include "opentelemetry/nostd/shared_ptr.h"
 #include "opentelemetry/nostd/span.h"
 #include "opentelemetry/nostd/string_view.h"
 #include "opentelemetry/nostd/utility.h"
 #include "opentelemetry/sdk/common/exporter_utils.h"
+#include "opentelemetry/sdk/common/global_log_handler.h"
 #include "opentelemetry/sdk/instrumentationscope/instrumentation_scope.h"
 #include "opentelemetry/sdk/logs/exporter.h"
 #include "opentelemetry/sdk/logs/recordable.h"
@@ -21,8 +24,10 @@
 #include <chrono>
 #include <cstddef>
 #include <cstdint>
+#include <functional>
 #include <string>
 #include <utility>
+#include <vector>
 #include "nlohmann/json.hpp"
 
 namespace
@@ -262,4 +267,702 @@ TEST(ElasticsearchLogRecordableTests, BasicTests)
   const auto actual = recordable.GetJSON();
 
   EXPECT_EQ(actual, expected);
+}
+
+// The batch outcome is the top level "errors" field. Two success bodies that differ only in
+// whitespace, so a check that depends on formatting cannot answer the same for both.
+namespace
+{
+constexpr const char *kPrettySuccess =
+    R"({"took":30,"errors":false,"items":[{"index":{"_index":"logs","_id":"1",)"
+    R"("_shards":{"total":2,"successful":1,"failed" : 0},"status":201}}]})";
+// Two operations acknowledged, so a batch of two has something to match. 201 for a new document
+// and 200 for an overwrite are both what Elasticsearch answers for an index operation.
+constexpr const char *kTwoItemCompactSuccess = R"({"took":30,"errors":false,"items":[)"
+                                               R"({"index":{"_index":"logs","status":201}},)"
+                                               R"({"index":{"_index":"logs","status":200}}]})";
+
+constexpr const char *kCompactSuccess =
+    R"({"took":30,"errors":false,"items":[{"index":{"_index":"logs","_id":"1",)"
+    R"("_shards":{"total":2,"successful":1,"failed":0},"status":201}}]})";
+constexpr const char *kOneItemRejected =
+    R"({"took":30,"errors":true,"items":[{"index":{"_index":"logs","_id":"1",)"
+    R"("_shards":{"failed" : 0},"status":201}},{"index":{"_index":"logs","_id":"2",)"
+    R"("status":400,"error":{"type":"mapper_parsing_exception","reason":"bad field"}}}]})";
+}  // namespace
+
+TEST(ElasticsearchBulkResponseTests, ReportsSuccessWhenErrorsIsFalse)
+{
+  std::string reason;
+  EXPECT_TRUE(logs_exporter::detail::IsBulkResponseSuccessful(200, kPrettySuccess, 1, reason));
+  EXPECT_TRUE(logs_exporter::detail::IsBulkResponseSuccessful(200, kCompactSuccess, 1, reason));
+}
+
+// A successful check must not leave a stale failure reason from a previous call behind.
+TEST(ElasticsearchBulkResponseTests, ClearsFailureReasonOnSuccess)
+{
+  std::string reason = "stale";
+  EXPECT_TRUE(logs_exporter::detail::IsBulkResponseSuccessful(200, kCompactSuccess, 1, reason));
+  EXPECT_TRUE(reason.empty());
+}
+
+TEST(ElasticsearchBulkResponseTests, ReportsFailureWhenAnyItemWasRejected)
+{
+  std::string reason;
+  EXPECT_FALSE(logs_exporter::detail::IsBulkResponseSuccessful(200, kOneItemRejected, 2, reason));
+  EXPECT_NE(reason.find("mapper_parsing_exception"), std::string::npos);
+}
+
+TEST(ElasticsearchBulkResponseTests, ReportsFailureOnUnusableBody)
+{
+  std::string reason;
+  EXPECT_FALSE(logs_exporter::detail::IsBulkResponseSuccessful(200, "not json at all", 1, reason));
+  EXPECT_FALSE(reason.empty());
+
+  EXPECT_FALSE(logs_exporter::detail::IsBulkResponseSuccessful(200, "", 1, reason));
+  EXPECT_FALSE(reason.empty());
+
+  // An array rather than the expected object.
+  EXPECT_FALSE(logs_exporter::detail::IsBulkResponseSuccessful(200, "[1,2,3]", 1, reason));
+  EXPECT_FALSE(reason.empty());
+}
+
+TEST(ElasticsearchBulkResponseTests, ReportsFailureWhenErrorsFieldIsMissingOrNotBoolean)
+{
+  std::string reason;
+  EXPECT_FALSE(
+      logs_exporter::detail::IsBulkResponseSuccessful(200, R"({"took":30,"items":[]})", 1, reason));
+  EXPECT_FALSE(logs_exporter::detail::IsBulkResponseSuccessful(
+      200, R"({"errors":"false","items":[]})", 0, reason));
+}
+
+// A non-2xx status is a failure even when the body reports errors:false. This is the invariant
+// the substring check and the body-only check both missed, on both the sync and async paths.
+TEST(ElasticsearchBulkResponseTests, ReportsFailureOnNon2xxStatus)
+{
+  std::string reason;
+  const char *ok_body = R"({"errors":false,"items":[]})";
+  EXPECT_FALSE(logs_exporter::detail::IsBulkResponseSuccessful(500, ok_body, 0, reason));
+  EXPECT_FALSE(logs_exporter::detail::IsBulkResponseSuccessful(429, ok_body, 0, reason));
+  EXPECT_FALSE(logs_exporter::detail::IsBulkResponseSuccessful(400, ok_body, 0, reason));
+  EXPECT_TRUE(logs_exporter::detail::IsBulkResponseSuccessful(200, ok_body, 0, reason));
+}
+
+// errors:true with no extractable item error still fails, with the generic reason.
+TEST(ElasticsearchBulkResponseTests, ReportsFailureWhenErrorsTrueWithoutItemError)
+{
+  std::string reason;
+  EXPECT_FALSE(logs_exporter::detail::IsBulkResponseSuccessful(200, R"({"errors":true,"items":[]})",
+                                                               0, reason));
+  EXPECT_FALSE(logs_exporter::detail::IsBulkResponseSuccessful(
+      200, R"({"errors":true,"items":[null]})", 1, reason));
+  EXPECT_FALSE(logs_exporter::detail::IsBulkResponseSuccessful(
+      200, R"({"errors":true,"items":[{"index":42}]})", 1, reason));
+}
+
+// 200 is what Elasticsearch answers a bulk request with, and it is the only status that says the
+// batch was written. 202 is the one worth naming: it says the request was accepted and the
+// processing is not finished, so reading it as success would let the caller drop records the
+// server has not promised to keep. This pins the boundary on both sides.
+TEST(ElasticsearchBulkResponseTests, AcceptsOnlyTheStatusThatSaysTheBatchWasWritten)
+{
+  std::string reason;
+  const char *ok_body = R"({"errors":false,"items":[]})";
+  EXPECT_FALSE(logs_exporter::detail::IsBulkResponseSuccessful(199, ok_body, 0, reason));
+  EXPECT_TRUE(logs_exporter::detail::IsBulkResponseSuccessful(200, ok_body, 0, reason));
+  EXPECT_FALSE(logs_exporter::detail::IsBulkResponseSuccessful(201, ok_body, 0, reason));
+  EXPECT_FALSE(logs_exporter::detail::IsBulkResponseSuccessful(202, ok_body, 0, reason))
+      << "202 says the processing is not finished, which is not a write acknowledgement";
+  EXPECT_FALSE(logs_exporter::detail::IsBulkResponseSuccessful(299, ok_body, 0, reason));
+  EXPECT_FALSE(logs_exporter::detail::IsBulkResponseSuccessful(300, ok_body, 0, reason));
+}
+
+// The exporter posts an unfiltered /_bulk, so Elasticsearch answers every submitted operation in
+// "items". A body that does not is not an answer to that request, and treating it as success would
+// hand the caller a write acknowledgement nobody made.
+TEST(ElasticsearchBulkResponseTests, RequiresAnAcknowledgementForEverySubmittedOperation)
+{
+  std::string reason;
+  constexpr const char *kNoItems   = R"({"errors":false})";
+  constexpr const char *kNullItems = R"({"errors":false,"items":null})";
+  constexpr const char *kOneItemBody =
+      R"({"errors":false,"items":[{"index":{"_index":"logs","_shards":{"failed":0},"status":201}}]})";
+  constexpr const char *kTwoItemBody =
+      R"({"errors":false,"items":[{"index":{"_index":"logs","status":201}},{"index":{"_index":"logs","status":201}}]})";
+
+  EXPECT_FALSE(logs_exporter::detail::IsBulkResponseSuccessful(200, kNoItems, 1, reason));
+  EXPECT_FALSE(logs_exporter::detail::IsBulkResponseSuccessful(200, kNullItems, 1, reason));
+  EXPECT_FALSE(logs_exporter::detail::IsBulkResponseSuccessful(200, kOneItemBody, 2, reason))
+      << "too few acknowledgements";
+  EXPECT_FALSE(logs_exporter::detail::IsBulkResponseSuccessful(200, kTwoItemBody, 1, reason))
+      << "more acknowledgements than operations";
+  EXPECT_TRUE(logs_exporter::detail::IsBulkResponseSuccessful(200, kOneItemBody, 1, reason));
+  EXPECT_TRUE(logs_exporter::detail::IsBulkResponseSuccessful(200, kTwoItemBody, 2, reason));
+}
+
+// The right count of the wrong entries is still the wrong answer, and the verdict cannot depend on
+// "errors", which the same responder controls.
+TEST(ElasticsearchBulkResponseTests, RejectsItemsEntriesThatDoNotAcknowledgeAnIndexOperation)
+{
+  std::string reason;
+  const auto rejected = [&reason](const char *body, std::size_t expected) {
+    return !logs_exporter::detail::IsBulkResponseSuccessful(200, body, expected, reason);
+  };
+
+  EXPECT_TRUE(rejected(R"({"errors":false,"items":[null,null]})", 2));
+  EXPECT_FALSE(reason.empty());
+  EXPECT_TRUE(rejected(R"({"errors":false,"items":[1,2]})", 2));
+  EXPECT_TRUE(rejected(R"({"errors":false,"items":[[]]})", 1));
+  EXPECT_TRUE(rejected(R"({"errors":false,"items":[{}]})", 1)) << "no operation at all";
+  EXPECT_TRUE(rejected(R"({"errors":false,"items":[{"unknown":{"status":201}}]})", 1))
+      << "an operation the exporter never submitted";
+  EXPECT_TRUE(rejected(R"({"errors":false,"items":[{"index":42}]})", 1))
+      << "the index key holds no result object";
+  EXPECT_TRUE(rejected(R"({"errors":false,"items":[{"index":{},"delete":{}}]})", 1))
+      << "one entry cannot answer two operations";
+  EXPECT_TRUE(rejected(
+      R"({"errors":false,"items":[{"index":{"_index":"logs","status":201},"delete":{}}]})", 1))
+      << "a valid acknowledgement does not license a second member";
+  EXPECT_TRUE(rejected(R"({"errors":false,"items":[{"index":{"_index":"logs"}}]})", 1))
+      << "an index result carrying no status";
+  EXPECT_TRUE(rejected(R"({"errors":false,"items":[{"index":{"status":201}}]})", 1))
+      << "an index result naming no target index";
+  EXPECT_TRUE(rejected(R"({"errors":false,"items":[{"index":{"_index":7,"status":201}}]})", 1))
+      << "a target index that is not a name";
+  EXPECT_TRUE(rejected(R"({"errors":false,"items":[{"index":{"_index":null,"status":201}}]})", 1))
+      << "a target index that is not there under another spelling";
+  EXPECT_TRUE(rejected(R"({"errors":true,"items":[null,null]})", 2))
+      << "the same shape has to fail whichever way errors reads";
+
+  // The shape a real acknowledgement has: one index result, naming the index it wrote to and
+  // carrying the status it wrote with.
+  EXPECT_FALSE(
+      rejected(R"({"errors":false,"items":[{"index":{"_index":"logs","status":201}}]})", 1));
+
+  // Three shapes, three reasons: they are different things to go and look at.
+  const auto reason_for = [&reason](const char *body) {
+    logs_exporter::detail::IsBulkResponseSuccessful(200, body, 1, reason);
+    return reason;
+  };
+  const std::string padded  = reason_for(R"({"errors":false,"items":[{"index":{},"delete":{}}]})");
+  const std::string other   = reason_for(R"({"errors":false,"items":[{"unknown":{"status":1}}]})");
+  const std::string no_stat = reason_for(R"({"errors":false,"items":[{"index":{"_index":"l"}}]})");
+  const std::string no_idx  = reason_for(R"({"errors":false,"items":[{"index":{"status":201}}]})");
+  EXPECT_NE(padded, other) << padded;
+  EXPECT_NE(other, no_stat) << other;
+  EXPECT_NE(padded, no_stat) << no_stat;
+  EXPECT_NE(no_stat, no_idx) << no_idx;
+}
+
+// The status says whether the operation applied, so the band has to hold for the number the server
+// sent rather than for what it becomes on the way into an int.
+TEST(ElasticsearchBulkResponseTests, RejectsAcknowledgementsOutsideTheSuccessBand)
+{
+  std::string reason;
+  const auto applied = [&reason](const char *status) {
+    const std::string body =
+        std::string(R"({"errors":false,"items":[{"index":{"_index":"logs","status":)") + status +
+        R"(}}]})";
+    return logs_exporter::detail::IsBulkResponseSuccessful(200, body, 1, reason);
+  };
+
+  EXPECT_FALSE(applied("199"));
+  EXPECT_TRUE(applied("200")) << "an index operation that replaced a document";
+  EXPECT_TRUE(applied("201")) << "an index operation that created one";
+  EXPECT_FALSE(applied("202")) << "accepted is not applied";
+  EXPECT_FALSE(applied("299"));
+  EXPECT_FALSE(applied("300"));
+
+  EXPECT_FALSE(applied("0")) << "zero is a status, not the absence of one";
+  EXPECT_FALSE(reason.empty());
+  EXPECT_FALSE(applied("-0"));
+  EXPECT_FALSE(applied("-1"));
+  EXPECT_FALSE(applied("199"));
+  EXPECT_FALSE(applied("300"));
+  EXPECT_FALSE(applied("4294967496")) << "2^32 + 200, which lands on 200 in a 32 bit int";
+  EXPECT_FALSE(applied("18446744073709551615")) << "no signed type holds it";
+  EXPECT_FALSE(applied("200.5")) << "not an integer";
+  EXPECT_FALSE(applied(R"("200")")) << "a string is not a status";
+  EXPECT_FALSE(applied("null"));
+
+  // The value reaches the log as it arrived, so a reader sees what the server said.
+  applied("4294967496");
+  EXPECT_NE(reason.find("4294967496"), std::string::npos) << reason;
+}
+
+// A false flag claims every operation was applied. No conforming server sends it alongside a
+// rejection, so holding the items to the claim rejects nothing the flag alone would have taken.
+TEST(ElasticsearchBulkResponseTests, RejectsAnAcknowledgedFailureUnderErrorsFalse)
+{
+  std::string reason;
+  EXPECT_FALSE(logs_exporter::detail::IsBulkResponseSuccessful(
+      200, R"({"errors":false,"items":[{"index":{"_index":"logs","status":400}}]})", 1, reason));
+  EXPECT_NE(reason.find("400"), std::string::npos) << "the reason names the status: " << reason;
+
+  EXPECT_FALSE(logs_exporter::detail::IsBulkResponseSuccessful(
+      200,
+      R"({"errors":false,"items":[{"index":{"_index":"logs","status":201}},{"index":{"_index":"logs","status":429}}]})",
+      2, reason))
+      << "one rejected operation among several is still a rejection";
+
+  // Both of the statuses an index operation answers with when it applied, in one response.
+  EXPECT_TRUE(logs_exporter::detail::IsBulkResponseSuccessful(
+      200,
+      R"({"errors":false,"items":[{"index":{"_index":"logs","status":200}},{"index":{"_index":"logs","status":201}}]})",
+      2, reason));
+  EXPECT_FALSE(logs_exporter::detail::IsBulkResponseSuccessful(
+      200, R"({"errors":false,"items":[{"index":{"_index":"logs","status":300}}]})", 1, reason));
+}
+
+// An operation that did not apply says so through its status and through an "error" member. The
+// errors:true path already reads the second one, so reading it here as well is what stops the same
+// body from being accepted or rejected according to a flag the responder also controls.
+TEST(ElasticsearchBulkResponseTests, RejectsAnItemErrorUnderErrorsFalse)
+{
+  std::string reason;
+  EXPECT_FALSE(logs_exporter::detail::IsBulkResponseSuccessful(
+      200,
+      R"({"errors":false,"items":[{"index":{"_index":"logs","status":201,)"
+      R"("error":{"type":"mapper_parsing_exception","reason":"rejected"}}}]})",
+      1, reason));
+  EXPECT_NE(reason.find("mapper_parsing_exception"), std::string::npos)
+      << "the reason names what the server said: " << reason;
+
+  // A conforming server sends the flag and the member together, and that reads the same way.
+  EXPECT_FALSE(logs_exporter::detail::IsBulkResponseSuccessful(
+      200,
+      R"({"errors":true,"items":[{"index":{"_index":"logs","status":400,)"
+      R"("error":{"type":"mapper_parsing_exception"}}}]})",
+      1, reason));
+  EXPECT_NE(reason.find("mapper_parsing_exception"), std::string::npos) << reason;
+
+  // Only a cause decides. An acknowledgement without the member stays a success, and so does one
+  // whose member is null, which is what a serialiser writing absent optionals produces.
+  EXPECT_TRUE(logs_exporter::detail::IsBulkResponseSuccessful(
+      200, R"({"errors":false,"items":[{"index":{"_index":"logs","status":201}}]})", 1, reason));
+  EXPECT_TRUE(logs_exporter::detail::IsBulkResponseSuccessful(
+      200, R"({"errors":false,"items":[{"index":{"_index":"logs","status":201,"error":null}}]})", 1,
+      reason));
+}
+// ---------------------------------------------------------------------------
+// The response travelling from the HTTP callback to the verdict.
+//
+// The cases above call IsBulkResponseSuccessful() directly, so they cannot show
+// that the status and the body actually reach it. A fake HTTP client drives the
+// callbacks from inside SendRequest(), which runs before Export() reaches the
+// wait, and the assertions are on the ExportResult.
+// ---------------------------------------------------------------------------
+namespace
+{
+namespace http_client = opentelemetry::ext::http::client;
+
+class FakeResponse : public http_client::Response
+{
+public:
+  FakeResponse(http_client::StatusCode status, const std::string &body)
+      : status_(status), body_(body.begin(), body.end())
+  {}
+  const http_client::Body &GetBody() const noexcept override { return body_; }
+  bool ForEachHeader(
+      nostd::function_ref<bool(nostd::string_view, nostd::string_view)>) const noexcept override
+  {
+    return true;
+  }
+  bool ForEachHeader(
+      const nostd::string_view &,
+      nostd::function_ref<bool(nostd::string_view, nostd::string_view)>) const noexcept override
+  {
+    return true;
+  }
+  http_client::StatusCode GetStatusCode() const noexcept override { return status_; }
+
+private:
+  http_client::StatusCode status_;
+  http_client::Body body_;
+};
+
+class FakeRequest : public http_client::Request
+{
+public:
+  void SetMethod(http_client::Method) noexcept override {}
+  void SetUri(nostd::string_view) noexcept override {}
+  void SetSslOptions(const http_client::HttpSslOptions &) noexcept override {}
+  void SetBody(http_client::Body &) noexcept override {}
+  void AddHeader(nostd::string_view, nostd::string_view) noexcept override {}
+  void ReplaceHeader(nostd::string_view, nostd::string_view) noexcept override {}
+  void SetTimeoutMs(std::chrono::milliseconds) noexcept override {}
+  void SetCompression(const http_client::Compression &) noexcept override {}
+  void EnableLogging(bool) noexcept override {}
+  void SetRetryPolicy(const http_client::RetryPolicy &) noexcept override {}
+};
+
+using EventScript = std::function<void(http_client::EventHandler &)>;
+
+class FakeSession : public http_client::Session
+{
+public:
+  explicit FakeSession(EventScript script) : script_(std::move(script)) {}
+  std::shared_ptr<http_client::Request> CreateRequest() noexcept override
+  {
+    return std::make_shared<FakeRequest>();
+  }
+  void SendRequest(std::shared_ptr<http_client::EventHandler> handler) noexcept override
+  {
+    script_(*handler);
+  }
+  bool IsSessionActive() noexcept override { return false; }
+  bool CancelSession() noexcept override { return true; }
+  bool FinishSession() noexcept override { return true; }
+
+private:
+  EventScript script_;
+};
+
+class FakeHttpClient : public http_client::HttpClient
+{
+public:
+  explicit FakeHttpClient(EventScript script) : script_(std::move(script)) {}
+  std::shared_ptr<http_client::Session> CreateSession(nostd::string_view) noexcept override
+  {
+    return std::make_shared<FakeSession>(script_);
+  }
+  bool CancelAllSessions() noexcept override { return true; }
+  bool FinishAllSessions() noexcept override { return true; }
+  void SetMaxSessionsPerConnection(std::size_t) noexcept override {}
+
+private:
+  EventScript script_;
+};
+
+// The response has to answer one operation per record, so a case using a body with N items has to
+// export N records or it would be rejected on the count before reaching what it means to test.
+opentelemetry::sdk::common::ExportResult ExportWith(EventScript script,
+                                                    std::size_t records = 1,
+                                                    bool console_debug  = false)
+{
+  auto client = std::make_shared<FakeHttpClient>(std::move(script));
+  logs_exporter::ElasticsearchExporterOptions options;
+  options.console_debug_ = console_debug;
+  logs_exporter::ElasticsearchLogRecordExporter exporter(options, client);
+
+  std::vector<std::unique_ptr<sdklogs::Recordable>> batch;
+  batch.reserve(records);
+  for (std::size_t i = 0; i < records; ++i)
+  {
+    batch.push_back(exporter.MakeRecordable());
+  }
+  return exporter.Export(
+      nostd::span<std::unique_ptr<sdklogs::Recordable>>(batch.data(), batch.size()));
+}
+}  // namespace
+
+// The synchronous wait exists only when the exporter is built without async export, so these cases
+// skip rather than compile out: gtest_add_tests reads the source, and a case that disappeared from
+// the binary would still be registered with CTest. The skip goes in SetUp rather than at the top of
+// each body, because GTEST_SKIP returns and leaves the rest of the body unreachable, which MSVC
+// reports as C4702 and the maintainer mode jobs turn into an error.
+namespace
+{
+class ElasticsearchLogsExporterWiringTests : public ::testing::Test
+{
+protected:
+  void SetUp() override
+  {
+#ifdef ENABLE_ASYNC_EXPORT
+    GTEST_SKIP() << "Export() returns without waiting when async export is enabled";
+#endif
+  }
+};
+}  // namespace
+
+// A body the parser accepts, through the whole path rather than through the helper alone.
+TEST_F(ElasticsearchLogsExporterWiringTests, AcceptedBulkResponseIsASuccessfulExport)
+{
+  const auto result = ExportWith([](http_client::EventHandler &handler) {
+    FakeResponse response(200, kPrettySuccess);
+    handler.OnResponse(response);
+  });
+  EXPECT_EQ(result, opentelemetry::sdk::common::ExportResult::kSuccess);
+}
+
+// The first response decides the outcome, so it has to be the one the verdict is read from. A
+// client that answers twice would otherwise leave the decision with the first and the evidence
+// for it with the second.
+TEST_F(ElasticsearchLogsExporterWiringTests, ASecondResponseDoesNotReplaceTheOneThatDecided)
+{
+  const auto result = ExportWith([](http_client::EventHandler &handler) {
+    FakeResponse rejected(500, kPrettySuccess);
+    handler.OnResponse(rejected);
+    FakeResponse accepted(200, kPrettySuccess);
+    handler.OnResponse(accepted);
+  });
+  EXPECT_EQ(result, opentelemetry::sdk::common::ExportResult::kFailure)
+      << "the 500 that decided the outcome was read back as the 200 that followed it";
+}
+
+// The case #4295 reports: a 200 whose rejected item still leaves a shard counter reading
+// "failed" : 0, so the body looks successful to anything that reads it as text.
+TEST_F(ElasticsearchLogsExporterWiringTests, RejectedItemIsAFailedExport)
+{
+  // Two records, because kOneItemRejected answers two operations. Exporting one would be rejected
+  // on the acknowledgement count and the case would stop testing what it is named for.
+  const auto result = ExportWith(
+      [](http_client::EventHandler &handler) {
+        FakeResponse response(200, kOneItemRejected);
+        handler.OnResponse(response);
+      },
+      2);
+  EXPECT_EQ(result, opentelemetry::sdk::common::ExportResult::kFailure);
+}
+
+// The status has to reach the parser, not just the body. A handler that stored a fixed status,
+// or an Export() that never asked for it, would still pass every case above.
+// The count has to travel. Every other successful case here sends one record, so an expected
+// count fixed at one would satisfy them all, and the only two item case is a rejection that fails
+// whatever the count is.
+TEST_F(ElasticsearchLogsExporterWiringTests, TwoAcceptedRecordsUseTheActualBatchSize)
+{
+  const auto result = ExportWith(
+      [](http_client::EventHandler &handler) {
+        FakeResponse response(200, kTwoItemCompactSuccess);
+        handler.OnResponse(response);
+      },
+      2);
+
+  EXPECT_EQ(result, opentelemetry::sdk::common::ExportResult::kSuccess);
+}
+
+TEST_F(ElasticsearchLogsExporterWiringTests, ServerErrorIsAFailedExportEvenWithAnAcceptedBody)
+{
+  const auto result = ExportWith([](http_client::EventHandler &handler) {
+    FakeResponse response(500, kPrettySuccess);
+    handler.OnResponse(response);
+  });
+  EXPECT_EQ(result, opentelemetry::sdk::common::ExportResult::kFailure);
+}
+
+// ---------------------------------------------------------------------------
+// Asynchronous path.
+//
+// Export() hands the body to AsyncResponseHandler and returns before any
+// response arrives, so the parsed result decides nothing the caller can see.
+// It decides which internal log line is written, which is what these cases
+// read. The fake delivers the response from inside SendRequest(), so the line
+// is already written by the time Export() returns.
+// ---------------------------------------------------------------------------
+namespace
+{
+struct CapturingLogHandler : public opentelemetry::sdk::common::internal_log::LogHandler
+{
+  void Handle(opentelemetry::sdk::common::internal_log::LogLevel level,
+              const char * /* file */,
+              int /* line */,
+              const char *msg,
+              const opentelemetry::sdk::common::AttributeMap & /* attributes */) noexcept override
+  {
+    messages.emplace_back(level, std::string{msg});
+  }
+
+  std::vector<std::pair<opentelemetry::sdk::common::internal_log::LogLevel, std::string>> messages;
+};
+
+class ElasticsearchLogsExporterAsyncTests : public ::testing::Test
+{
+protected:
+  void SetUp() override
+  {
+    // One skip point: GTEST_SKIP returns, and a second below it would leave the rest of this body
+    // unreachable, which MSVC reports as C4702 under maintainer mode.
+#if !defined(ENABLE_ASYNC_EXPORT)
+    GTEST_SKIP() << "Export() takes the synchronous path when async export is disabled";
+#elif OTEL_INTERNAL_LOG_LEVEL < OTEL_INTERNAL_LOG_LEVEL_ERROR
+    // These cases read the failure out of the log. Below error level it is not written at all, so
+    // a wrong result and a right one look the same and the cases would stop discriminating.
+    GTEST_SKIP() << "the failure these observe is compiled out below error level";
+#else
+    previous_handler_ = opentelemetry::sdk::common::internal_log::GlobalLogHandler::GetLogHandler();
+    handler_          = nostd::shared_ptr<opentelemetry::sdk::common::internal_log::LogHandler>(
+        new CapturingLogHandler());
+    opentelemetry::sdk::common::internal_log::GlobalLogHandler::SetLogHandler(handler_);
+
+    // The level as well as the handler. It is process wide and another case in this binary can
+    // lower it, and a failure filtered out at runtime looks exactly like one the parser never
+    // reported, so these cases would stop discriminating without saying so.
+    previous_level_ = opentelemetry::sdk::common::internal_log::GlobalLogHandler::GetLogLevel();
+    opentelemetry::sdk::common::internal_log::GlobalLogHandler::SetLogLevel(
+        opentelemetry::sdk::common::internal_log::LogLevel::Error);
+    restore_level_ = true;
+#endif
+  }
+
+  void TearDown() override
+  {
+    // Put back what was found, rather than a fresh default that would displace a handler another
+    // case in this binary had installed.
+    if (restore_level_)
+    {
+      opentelemetry::sdk::common::internal_log::GlobalLogHandler::SetLogLevel(previous_level_);
+    }
+    if (handler_)
+    {
+      opentelemetry::sdk::common::internal_log::GlobalLogHandler::SetLogHandler(previous_handler_);
+    }
+  }
+
+  bool LoggedAnExportFailure() const
+  {
+    const auto &messages = static_cast<CapturingLogHandler *>(handler_.get())->messages;
+    for (const auto &message : messages)
+    {
+      if (message.second.find("Logs were not written to Elasticsearch correctly") !=
+          std::string::npos)
+      {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  nostd::shared_ptr<opentelemetry::sdk::common::internal_log::LogHandler> handler_;
+  nostd::shared_ptr<opentelemetry::sdk::common::internal_log::LogHandler> previous_handler_;
+  opentelemetry::sdk::common::internal_log::LogLevel previous_level_ =
+      opentelemetry::sdk::common::internal_log::LogLevel::Warning;
+  bool restore_level_ = false;
+};
+
+class ElasticsearchLogsExporterDebugLoggingTests : public ::testing::Test
+{
+protected:
+  void SetUp() override
+  {
+    // One skip point: GTEST_SKIP returns, and a second below it would leave the rest of this body
+    // unreachable, which MSVC reports as C4702 under maintainer mode.
+#ifdef ENABLE_ASYNC_EXPORT
+    GTEST_SKIP() << "Export() returns without waiting when async export is enabled";
+#elif OTEL_INTERNAL_LOG_LEVEL < OTEL_INTERNAL_LOG_LEVEL_DEBUG
+    // The line these read is not filtered below debug level, it is not written, so a response
+    // that described itself and one that stayed quiet would look the same here.
+    GTEST_SKIP() << "the line these observe is compiled out below debug level";
+#else
+    previous_handler_ = opentelemetry::sdk::common::internal_log::GlobalLogHandler::GetLogHandler();
+    handler_          = nostd::shared_ptr<opentelemetry::sdk::common::internal_log::LogHandler>(
+        new CapturingLogHandler());
+    opentelemetry::sdk::common::internal_log::GlobalLogHandler::SetLogHandler(handler_);
+
+    // The compiled in level only decides whether the call exists. What it dispatches is filtered
+    // again at runtime, and the default there is Warning, so without this the handler is installed
+    // and never told anything.
+    previous_level_ = opentelemetry::sdk::common::internal_log::GlobalLogHandler::GetLogLevel();
+    opentelemetry::sdk::common::internal_log::GlobalLogHandler::SetLogLevel(
+        opentelemetry::sdk::common::internal_log::LogLevel::Debug);
+    restore_level_ = true;
+#endif
+  }
+
+  void TearDown() override
+  {
+    if (restore_level_)
+    {
+      opentelemetry::sdk::common::internal_log::GlobalLogHandler::SetLogLevel(previous_level_);
+    }
+    if (handler_)
+    {
+      opentelemetry::sdk::common::internal_log::GlobalLogHandler::SetLogHandler(previous_handler_);
+    }
+  }
+
+  std::size_t ResponsesDescribed() const
+  {
+    std::size_t described = 0;
+    for (const auto &message : static_cast<CapturingLogHandler *>(handler_.get())->messages)
+    {
+      if (message.second.find("Got response from Elasticsearch") != std::string::npos)
+      {
+        ++described;
+      }
+    }
+    return described;
+  }
+
+  nostd::shared_ptr<opentelemetry::sdk::common::internal_log::LogHandler> handler_;
+  nostd::shared_ptr<opentelemetry::sdk::common::internal_log::LogHandler> previous_handler_;
+  opentelemetry::sdk::common::internal_log::LogLevel previous_level_ =
+      opentelemetry::sdk::common::internal_log::LogLevel::Warning;
+  bool restore_level_ = false;
+};
+}  // namespace
+
+// Only the response the caller was given describes itself. A second one arriving for the same
+// request has its status and body dropped, so a line for it would describe an answer nobody was
+// handed, and the two lines together would disagree about what the export returned.
+TEST_F(ElasticsearchLogsExporterDebugLoggingTests, OnlyTheResponseThatDecidedTheOutcomeIsDescribed)
+{
+  const auto result = ExportWith(
+      [](http_client::EventHandler &handler) {
+        FakeResponse first(200, kCompactSuccess);
+        handler.OnResponse(first);
+        FakeResponse second(500, kCompactSuccess);
+        handler.OnResponse(second);
+      },
+      1, true);
+
+  EXPECT_EQ(result, opentelemetry::sdk::common::ExportResult::kSuccess);
+  EXPECT_EQ(ResponsesDescribed(), static_cast<std::size_t>(1))
+      << "the losing response described itself as well";
+}
+
+TEST_F(ElasticsearchLogsExporterAsyncTests, AnAcceptedResponseIsNotReportedAsAFailure)
+{
+  EXPECT_EQ(ExportWith([](http_client::EventHandler &handler) {
+              FakeResponse response(200, kPrettySuccess);
+              handler.OnResponse(response);
+            }),
+            opentelemetry::sdk::common::ExportResult::kSuccess);
+
+  EXPECT_FALSE(LoggedAnExportFailure());
+}
+
+// The count reaches the parser on this path through the handler rather than through Export(), so
+// a handler that dropped it would still satisfy every synchronous case.
+// The status has to travel on this path too. Every other case here answers 200, so a status fixed
+// at 200 would satisfy them all, and the original defect was this path ignoring the status.
+TEST_F(ElasticsearchLogsExporterAsyncTests, AServerErrorIsReportedEvenWithAnAcceptedBody)
+{
+  EXPECT_EQ(ExportWith([](http_client::EventHandler &handler) {
+              FakeResponse response(500, kCompactSuccess);
+              handler.OnResponse(response);
+            }),
+            opentelemetry::sdk::common::ExportResult::kSuccess);
+
+  EXPECT_TRUE(LoggedAnExportFailure()) << "a server error was not reported on the async path";
+}
+
+// And the count, for the same reason it is held on the synchronous path.
+TEST_F(ElasticsearchLogsExporterAsyncTests, TwoAcceptedRecordsAreNotReportedAsAFailure)
+{
+  EXPECT_EQ(ExportWith(
+                [](http_client::EventHandler &handler) {
+                  FakeResponse response(200, kTwoItemCompactSuccess);
+                  handler.OnResponse(response);
+                },
+                2),
+            opentelemetry::sdk::common::ExportResult::kSuccess);
+
+  EXPECT_FALSE(LoggedAnExportFailure()) << "two acknowledged records were reported as a failure";
+}
+
+TEST_F(ElasticsearchLogsExporterAsyncTests, ARejectedResponseIsReportedAsAFailure)
+{
+  // Export() reports success on this path whatever the response says, which is why the outcome has
+  // to be read from the log below. Asserting it here also keeps this case from having no assertion
+  // at all where the internal log level excludes the one that follows.
+  EXPECT_EQ(ExportWith(
+                [](http_client::EventHandler &handler) {
+                  FakeResponse response(200, kOneItemRejected);
+                  handler.OnResponse(response);
+                },
+                2),
+            opentelemetry::sdk::common::ExportResult::kSuccess);
+
+  EXPECT_TRUE(LoggedAnExportFailure());
 }


### PR DESCRIPTION
Fixes #4295

**Short summary for review: https://github.com/open-telemetry/opentelemetry-cpp/pull/4297#issuecomment-5249641807**


## The bug

Both export paths decided whether a bulk write succeeded with `body.find("\"failed\" : 0")`. `failed` is per-shard information for one item, not the batch outcome (which is the top-level `errors` flag), and the literal even baked in pretty-printing whitespace, so it was wrong in both directions: a batch with a rejected item read as success, and a compact successful response read as failure.

## The fix

A single `IsBulkResponseSuccessful(status_code, body, expected_items, reason)` that both paths call. A non-2xx status is a failure first. Then the body has to be a JSON object with a boolean `errors` flag and an `items` array holding one operation result per operation the request submitted, and `errors` has to be false. A malformed body counts as a failure, and the first item error is reported so the log says why.

The count is there because the exporter posts an unfiltered `/_bulk` with exactly one index operation per record, and Elasticsearch answers those with one entry in `items` per operation. Without it, `{"errors":false}` on its own was reported as a successful write of the whole batch. An exporter that claims success without a write acknowledgement gives the caller no reason to retry, which is the worse of the two directions to be wrong in, and a misconfigured proxy or a non-Elasticsearch endpoint answering with coincidentally shaped JSON both landed there.

Matching the count is not enough on its own. Elasticsearch answers each operation with an object keyed by the action name, so `{"errors":false,"items":[null,null]}` for a two record batch had the right length and was reported as a successful write of both records. That requirement already existed, but only on the `errors:true` path, where the walk that extracts the first item error skips anything that is not an object. The same body was therefore a failure with `errors:true` and a success with `errors:false`, so a responder that sends neither shape correctly picked the verdict with a flag it also controls. The requirement now runs before `errors` is read, and the skip inside the walk goes with it.

An acknowledgement is an entry with exactly one member, named `index`, holding a result object with a `status`. Elasticsearch keys each entry by the action it answers and the exporter writes every record with an index action, so that is what an answer to this request looks like, and [the bulk schema](https://github.com/elastic/elasticsearch-specification/blob/main/specification/_global/bulk/types.ts) makes `status` a required member of the result alongside `_index`. The parser holds each acknowledgement to a string `_index` and an integer `status`, and stops there. `_index` is checked for presence and type only, never compared: an alias resolves to the concrete index behind it, so the name a conforming server reports is not always the name the request was addressed to. Nothing beyond `_index`, `status` and a non-null `error` changes the verdict.

Nothing weaker ties the entry to the operation that was sent. Being an object was not the line it looked like: `{"errors":false,"items":[{},{}]}` matched the count and was an object per entry. Neither is carrying some action or other: `{"unknown":{"status":201}}` answers something this exporter never submitted, and `{"index":{"status":201},"delete":{}}` answers one operation with two. The count check is what makes those dangerous rather than untidy. A hundred records answered with a hundred filler entries reads as a successful write, the processor drops the batch, and the records are gone.

The status is then read against the flag rather than instead of it. A false `errors` asserts that every operation was applied, so `{"errors":false,"items":[{"index":{"status":400}}]}` is the response contradicting itself, and a response that contradicts itself is not evidence that anything was written. A conforming server never sends that combination, which is why this rejects nothing the flag alone would have accepted.

2xx is the whole success band on both layers, and that is a compatibility choice rather than a property of the endpoint. Elasticsearch documents the bulk response as HTTP 200, and an `index` operation as 201 for a new document or 200 for an overwrite, so 202, 206 and 299 are values a compliant server will not send. Accepting the band keeps the check working against proxies and Elasticsearch compatible servers that answer inside it, and it costs nothing here because every record is written with an `index` operation: there is no `create` returning 409 for a duplicate or `delete` returning 404 that could hide in the widened range. The boundaries are pinned at 199/200/299/300 by a case, so narrowing this to 200 and 200/201 later is a two line change with its edges already held. Say if you would rather have it narrow now.

The band is compared in the type the number was parsed as, not through an `int`. The value comes from the server, `is_number_integer()` holds for unsigned as well, and nlohmann does not range check `get<int>()`, so `2^32 + 200` narrows straight back into the band on a 32 bit `int` and reads as applied. Comparing directly also removes the need for a rejected-status sentinel: an earlier revision returned the first rejected status as an `int` and used `0` to mean "nothing was rejected", which cannot tell those apart, so `{"errors":false,"items":[{"index":{"status":0}}]}` was reported as a successful write. Both are covered by cases at 0, -0, -1, 199, 200, 201, 299, 300, `2^32 + 200` and `UINT64_MAX`, plus a non-integer and a string.

The status is what makes the response two things rather than one, so the synchronous handler now keeps both halves together. It publishes the status and the body only on the transition that records the outcome, and `Export` takes them in a single call. Reading them one lock at a time, with each response overwriting them unconditionally, let a client that delivers two responses for one request pair a status from one with a body from the other, and that pair is what the verdict is computed from. The asynchronous handler keeps its body in a local for the same reason, since nothing outside the call reads it.

An operation that did not apply says so twice, and both are read the same way whichever value the flag has. Elasticsearch documents `error` as present only on a failed operation, and the `errors:true` path already relied on that to name the first failure. Under `errors:false` it was ignored, so `{"index":{"status":201,"error":{"type":"mapper_parsing_exception"}}}` was accepted while the same body with `errors:true` was rejected. That is the same shape as the `items` entry problem above: one body, two verdicts, chosen by a flag the broken responder also controls. The status alone does not cover it, since the contradiction is between the status and the error rather than between the status and the flag. Both signals are now collected in the pass that already validates the items, which also removes the second walk the `errors:true` branch needed.

A null member is not a cause. `find` reports a key that is present holding `null`, and a serialiser that writes absent optionals that way is saying the operation applied, which is what the flag says too, so rejecting it would fail exports that are fine and catch nothing. Both shapes have a case.

The check stops there. It never asks what an operation's status means beyond the band, and it reads no other member of the result.

An earlier revision of this branch had the count check and dropped it, on the grounds that a `filter_path` response need not carry `items`. That reasoning does not apply here: this exporter never sends `filter_path`. If it ever does, the request side should say so rather than the parser accepting two incompatible response shapes.

The HTTP status matters and was the second-round finding: the synchronous path previously only logged a non-2xx status and still returned success, so `HTTP 500` with `{"errors":false}` was reported as `kSuccess`. The status is now part of the result on both paths; the async handler drops its duplicated check and the sync handler stores the status for `Export` to pass in.

## Structure

The helper lives in `include/opentelemetry/exporters/elasticsearch/detail/es_bulk_response.h` so tests can reach it, following the `detail/` pattern already used by `ext/http/client/detail/default_factory.h`. It is a `detail` header rather than an anonymous-namespace function in the `.cc` (an earlier revision put it there, which is why it could not be tested).

It is excluded from the installed package, both the header and the `detail` directory, since the file name pattern alone still leaves an empty directory behind in the package. The component's `*.h` glob would otherwise ship it, and it includes `<nlohmann/json.hpp>`, which would make nlohmann a public dependency of the installed Elasticsearch headers for the first time. `es_log_recordable.h` is the precedent one line above in the same call: it is the only other header here that includes nlohmann, and it is already excluded for the same reason. Verified by installing into a clean prefix and listing what lands under `include/opentelemetry/exporters/elasticsearch`, which is now just `es_log_record_exporter.h`.

Worth your call rather than mine: the only other `detail/` directory in the tree is `ext/http/client/detail`, and it is installed today, so `detail/` has meant "public but unstable" here rather than "private". #4327 stopped installing it when it merged on 4 August, so excluding this one follows the convention rather than standing against it. On the reading that held before that, the file would belong in `src/` instead, which would need no exclusion at all. I kept it where the tests can reach it and excluded it, and I am happy to move it if you would rather it were not reachable as a header at all.

On the Bazel side the header is not in the exporter target's `hdrs`. `hdrs` is a target's public interface, so listing it there would let a Bazel consumer include a header the CMake package deliberately does not install. It has its own target, visible only to this package, and the exporter reaches it through `implementation_deps` so it is not re-exported; the test depends on it directly.

Checked rather than assumed. A consumer that depends only on `:es_log_record_exporter`:

```
fatal error: opentelemetry/exporters/elasticsearch/detail/es_bulk_response.h: No such file or directory
```

and the same consumer with `:es_bulk_response` added builds. This is the repository's first `implementation_deps` and its first target level `visibility`, so say if you would rather the header simply stayed in `hdrs` and the two package surfaces differed, the way `//ext:headers` currently does.

One other thing in this diff that is not strictly part of the fix: the bulk URI drops `?pretty`. The old check depended on pretty printed whitespace, so asking the server for it no longer serves any purpose, but it does change the request and I would rather name it than have it found.

Guarded with `OPENTELEMETRY_HAVE_EXCEPTIONS` so the `try`/`catch` compiles under the `-fno-exceptions` Bazel config. `<nlohmann/json.hpp>` stays included by the `.cc` because it still calls `GetJSON().dump()` directly.

## Tests

The helper's cases are covered directly: pretty and compact success, a rejected item (reason names the underlying error), a non-2xx status with `{"errors":false}` (the sync false-success invariant), `errors:true` with no extractable item error, malformed and empty bodies, and a missing or non-boolean `errors` field. The accepted statuses are pinned on both sides and for both places they are read: 199, 200, 201, 202, 299 and 300 against the request, where only 200 passes, and the same set against an operation, where 200 and 201 pass. The acknowledgement count is pinned in both directions: no `items`, `items:null`, too few, too many, and the exact count. Entries that do not acknowledge an index operation are pinned separately: `null` entries, scalars, a nested array, `{}`, an action the exporter never submitted, `index` holding a scalar, two members in one entry, two members where one of them is valid, `index` with no status, and the same `null` shape with `errors:true`, which has to fail whichever way the flag reads. That case is mutation checked: removing the `index` lookup from the helper while leaving the member count and the status requirement turns it red, so it pins the operation identity rather than the JSON shape around it. A separate case covers the response contradicting itself: a 400 under `errors:false`, one rejection among several acknowledgements, and a response pairing the two statuses an applied operation answers with. The shared success and rejection fixtures now carry the `status` and `_index` a real bulk response has; they were abridged to what the old substring check looked at.

Now that #4298 has landed, a fake session that responds from inside `SendRequest()` no longer deadlocks the synchronous path, so three cases run through the exporter itself rather than through the helper:

- an accepted bulk response is a successful export,
- the rejected item from #4295, whose shard counter still reads `"failed" : 0`, is a failed export,
- a 500 carrying a body the parser would otherwise accept is a failed export.

The third is the one the helper tests cannot give you. A handler that stored a fixed status, or an `Export()` that never asked for one, passes every helper case.

Those three drive the synchronous path, and they skip in the configuration the coverage job builds. `code.coverage` configures `all-options-abiv2-preview`, which turns on `ENABLE_ASYNC_EXPORT`, so nothing there called `Export()` at all and six lines of this change went unexecuted: the handler's `submitted_operations_` member, the bulk URI, the handler construction, and the parse with its failure log.

Two more cases cover that path. `Export()` returns before a response arrives there, so the parsed result decides only which internal log line is written, and they read it through a captured log handler the way `batch_span_processor_test` does: an accepted response logs no export failure, a rejected one does. Measured with lcov on the coverage preset, the six lines go from zero hits to covered. Of the two, only the rejected one discriminates: putting the substring check back on the asynchronous path makes it fail, because `"failed" : 0` appears in a body that has a rejected item.

```
[  FAILED  ] ElasticsearchLogsExporterAsyncTests.ARejectedResponseIsReportedAsAFailure
```

The accepted one passes either way and is there as its control.

Both sets are fixtures that skip in `SetUp` rather than cases that compile out. `gtest_add_tests` registers from the source, so a case missing from the binary is still handed to CTest, and a gtest filter that matches nothing exits zero, which reports a pass without running. Putting the skip in `SetUp` rather than at the top of each body also keeps `GTEST_SKIP`, which returns, from leaving the rest of a body unreachable, which MSVC reports as C4702 and the maintainer mode jobs turn into an error.

The `catch (...)` guard in the helper stays uncovered. It is unreachable by input, since the parser rejects malformed bodies rather than throwing, and reaching it needs allocation fault injection, which has no precedent here.

The fake client is the same one #4331 adds to this file. Whichever lands first, the other drops the duplicate when it rebases.

## Three things a later reading turned up

**One success band, said once.** The response status was compared as a plain `int` against 200 and 299, and each operation status went through a separate predicate that compares in the type nlohmann parsed it as. Same band, two spellings, and only one of them safe against a number the server chooses. Both go through one pair of overloads now, documented in one place, and the response status reaches the signed one through a cast an `int` cannot lose anything to. The two overloads are not one signed parameter because an operation status arrives as JSON: `is_number_integer()` is true for unsigned as well, and 2^32 + 200 narrows back into the band on a 32 bit `int`.

Worth saying that the HTTP side was never at risk of that. `StatusCode` is a `uint16_t`, so reaching the `int` parameter widens rather than narrows. What changed is that one rule is now written once rather than twice.

**An acknowledgement has to name the index it wrote to.** Every Elasticsearch index result carries `_index`, on a failed operation as much as an applied one, so a result without one is not an answer to an index operation. This now requires it, and that is a tightening: a backend that answers a bulk request without `_index` in its index results was accepted before and is a failed export now.

Presence and type only, deliberately. The name reported is the index the write resolved to, and an alias or a date math index makes that different from the one submitted, so comparing it against `options_.index_` would fail an ordinary setup. That is also why the exporter's own index name is not passed down.

**The cases had no bound.** `gtest_add_tests` registered them with no timeout, and what these cases catch fails by hanging rather than by asserting, which stops the job instead of reporting. They carry a 120 second CTest timeout now: 27 registered entries, three of which the suite disables and CTest therefore skips, and all 24 enabled ones carry it, read back from `ctest --show-only=json-v1` rather than assumed from having written it.

Against the same header with the target index check taken out, the case that holds it fails on all three of its new shapes: no `_index` at all, an `_index` that is a number, and one that is null.

## Verification

- Twenty four cases, none failing in any configuration, and 100% of them passing through `ctest -R exporter.Elasticsearch`. `WITH_ELASTICSEARCH=ON` gives `[  PASSED  ] 20 tests.` with the four asynchronous cases skipped, and `WITH_ASYNC_EXPORT_PREVIEW=ON` gives `[  PASSED  ] 19 tests.` with the five synchronous wiring cases skipped instead. A build with error logging compiled out, `-DOTEL_INTERNAL_LOG_LEVEL=0`, gives `[  PASSED  ] 15 tests.` and skips the nine that read the outcome out of the log, because below error level an absent log cannot be told from one that was never written. Removing that skip makes two of them fail on correct code, 2 of 2. All build with no warnings under `OTELCPP_MAINTAINER_MODE=ON`.
- Reverting `Export()` to the old substring check and rebuilding fails exactly the two cases that should discriminate:

```
[  FAILED  ] ElasticsearchLogsExporterWiringTests.RejectedItemIsAFailedExport
[  FAILED  ] ElasticsearchLogsExporterWiringTests.ServerErrorIsAFailedExportEvenWithAnAcceptedBody
```

`AcceptedBulkResponseIsASuccessfulExport` still passes there, which is correct: the happy path works under either check, so it is not a discriminator.
- Success is decided from the compact `/_bulk` response; parsing no longer depends on pretty-printing.
- `./ci/do_ci.sh format` exits 0 with no diff (clang-format 18, cmake-format 0.6.13, buildifier 3.5.0). Worth running rather than `cmake-format --check`: the job reformats in place and diffs, and it wraps a comment narrower than `--check` accepts with the same config, so `--check` reported clean on a file the job then rewrote.
- The lines the coverage report still marks in `es_bulk_response.h` are the defensive
`catch (...)` that keeps anything from escaping the `noexcept` response handlers. No response body reaches it, since the parser rejects malformed and invalid-UTF-8 input before any throwing call, so exercising it would mean injecting an allocation failure through a global `operator new` override. That is program-wide machinery this repository does not use elsewhere, and it behaves differently in the shared-library configurations, so I left the guard uncovered rather than add it. I can add it if you would rather have the coverage.

- clang-tidy did add one warning, and the local measurement I first made did not find it. The job reported 134 against a limit of 133; downloading its report and diffing the per-file table against `main`'s named the single file responsible, `es_bulk_response.h`, with `bugprone-exception-escape` on `IsAcknowledgedStatus`. That function is `noexcept` and reached `get<T>()` through a type check, so the guard was what kept the promise rather than the code. It now compares the json value instead of extracting one, which holds the same answers with nothing left to throw: 200 and 201 in either integer type are accepted, 2^32 + 200 is not, and a float is still rejected by the type check, which the existing case at `4294967496` pins. Re-measured the way the job runs it, over the test target so the test file is compiled too, the header reports nothing and the only remaining warning in this component is the one `main` already has. The include-what-you-use jobs are green on all three presets.












