### PR TITLE
[BUG] Make file_http_server.h compile on Windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,9 @@ Increment the:
   namespaces
   [#4303](https://github.com/open-telemetry/opentelemetry-cpp/pull/4303)
 
+* [BUG] Make file_http_server.h compile on Windows
+  [#4300](https://github.com/open-telemetry/opentelemetry-cpp/pull/4300)
+
 * [CODE HEALTH] Move metrics storage test fixtures into anonymous namespace
   [#4286](https://github.com/open-telemetry/opentelemetry-cpp/pull/4286)
 

--- a/ext/include/opentelemetry/ext/http/server/file_http_server.h
+++ b/ext/include/opentelemetry/ext/http/server/file_http_server.h
@@ -85,7 +85,7 @@ private:
    */
   std::string GetMimeContentType(const std::string &filename)
   {
-    std::string file_ext = filename.substr(filename.find_last_of(".") + 1);
+    std::string file_ext = filename.substr(filename.find_last_of('.') + 1);
     auto file_type       = mime_types_.find(file_ext);
     return (file_type != mime_types_.end()) ? file_type->second : HTTP_SERVER_NS::CONTENT_TYPE_TEXT;
   };
@@ -104,7 +104,7 @@ private:
     }
     // If filename appears to be a directory, serve the hypothetical index.html
     // file there
-    if (name.find(".") == std::string::npos)
+    if (name.find('.') == std::string::npos)
       name += "/index.html";
 
     return name;

--- a/ext/include/opentelemetry/ext/http/server/file_http_server.h
+++ b/ext/include/opentelemetry/ext/http/server/file_http_server.h
@@ -6,6 +6,7 @@
 #include <algorithm>
 #include <fstream>
 #include <iostream>
+#include <sstream>
 #include <string>
 #include <unordered_map>
 #include <vector>

--- a/ext/include/opentelemetry/ext/http/server/file_http_server.h
+++ b/ext/include/opentelemetry/ext/http/server/file_http_server.h
@@ -3,6 +3,7 @@
 
 #pragma once
 
+#include <algorithm>
 #include <fstream>
 #include <iostream>
 #include <string>
@@ -52,10 +53,15 @@ private:
   bool FileGetSuccess(const std::string &filename, std::vector<char> &result)
   {
 #ifdef _WIN32
-    std::replace(filename.begin(), filename.end(), '/', '\\');
+    // std::replace writes through its iterators, so it needs a modifiable string rather than
+    // the const parameter.
+    std::string path = filename;
+    std::replace(path.begin(), path.end(), '/', '\\');
+#else
+    const std::string &path = filename;
 #endif
     std::streampos size;
-    std::ifstream file(filename, std::ios::in | std::ios::binary | std::ios::ate);
+    std::ifstream file(path, std::ios::in | std::ios::binary | std::ios::ate);
     if (file.is_open())
     {
       size = file.tellg();

--- a/ext/include/opentelemetry/ext/http/server/file_http_server.h
+++ b/ext/include/opentelemetry/ext/http/server/file_http_server.h
@@ -3,13 +3,14 @@
 
 #pragma once
 
-#include <algorithm>
 #include <fstream>
-#include <iostream>
 #include <sstream>
 #include <string>
 #include <unordered_map>
 #include <vector>
+#ifdef _WIN32
+#  include <algorithm>  // std::replace, used only in the _WIN32 path below
+#endif
 
 #include "opentelemetry/ext/http/server/http_server.h"
 
@@ -30,7 +31,7 @@ protected:
     os << host << ":" << port;
     setServerName(os.str());
     addListeningPort(port);
-  };
+  }
 
   /**
    * Set the HTTP server to serve static files from the root of host:port.
@@ -76,7 +77,7 @@ private:
       return true;
     }
     return false;
-  };
+  }
 
   /**
    * Returns the extension of a file
@@ -88,7 +89,7 @@ private:
     std::string file_ext = filename.substr(filename.find_last_of('.') + 1);
     auto file_type       = mime_types_.find(file_ext);
     return (file_type != mime_types_.end()) ? file_type->second : HTTP_SERVER_NS::CONTENT_TYPE_TEXT;
-  };
+  }
 
   /**
    * Returns the standardized name of a file by removing backslashes, and

--- a/ext/test/http/BUILD
+++ b/ext/test/http/BUILD
@@ -1,7 +1,20 @@
 # Copyright The OpenTelemetry Authors
 # SPDX-License-Identifier: Apache-2.0
 
+load("@rules_cc//cc:cc_library.bzl", "cc_library")
 load("@rules_cc//cc:cc_test.bzl", "cc_test")
+
+# file_http_server.h is an installed header no other target includes, so it was never compiled.
+# This library compiles it (the POSIX branch here, the Windows branch on the Windows runners) so
+# a build regression in it is caught.
+cc_library(
+    name = "file_http_server_header_compile",
+    srcs = ["file_http_server_header_compile.cc"],
+    tags = ["test"],
+    deps = [
+        "//ext:headers",
+    ],
+)
 
 cc_test(
     name = "curl_http_test",

--- a/ext/test/http/CMakeLists.txt
+++ b/ext/test/http/CMakeLists.txt
@@ -22,3 +22,9 @@ gtest_add_tests(
   TARGET ${URL_PARSER_FILENAME}
   TEST_PREFIX ext.http.urlparser.
   TEST_LIST ${URL_PARSER_FILENAME})
+
+# file_http_server.h is an installed header that no other target includes, so it was never
+# compiled. This object library compiles it (the POSIX branch here, the Windows branch on the
+# Windows runners) so a build regression in it is caught. It is not run.
+add_library(file_http_server_header_compile OBJECT file_http_server_header_compile.cc)
+target_link_libraries(file_http_server_header_compile PRIVATE opentelemetry_ext)

--- a/ext/test/http/CMakeLists.txt
+++ b/ext/test/http/CMakeLists.txt
@@ -23,8 +23,10 @@ gtest_add_tests(
   TEST_PREFIX ext.http.urlparser.
   TEST_LIST ${URL_PARSER_FILENAME})
 
-# file_http_server.h is an installed header that no other target includes, so it was never
-# compiled. This object library compiles it (the POSIX branch here, the Windows branch on the
-# Windows runners) so a build regression in it is caught. It is not run.
-add_library(file_http_server_header_compile OBJECT file_http_server_header_compile.cc)
+# file_http_server.h is an installed header that no other target includes, so it
+# was never compiled. This object library compiles it (the POSIX branch here,
+# the Windows branch on the Windows runners) so a build regression in it is
+# caught. It is not run.
+add_library(file_http_server_header_compile OBJECT
+            file_http_server_header_compile.cc)
 target_link_libraries(file_http_server_header_compile PRIVATE opentelemetry_ext)

--- a/ext/test/http/file_http_server_header_compile.cc
+++ b/ext/test/http/file_http_server_header_compile.cc
@@ -6,4 +6,4 @@
 // _WIN32 branch did exactly that). This translation unit exists only to compile the header, so
 // CI builds the POSIX branch here and the Windows branch on the Windows runners. It has no
 // main() and is never run.
-#include "opentelemetry/ext/http/server/file_http_server.h"
+#include "opentelemetry/ext/http/server/file_http_server.h"  // IWYU pragma: keep

--- a/ext/test/http/file_http_server_header_compile.cc
+++ b/ext/test/http/file_http_server_header_compile.cc
@@ -1,0 +1,9 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+// file_http_server.h is an installed public header that no other translation unit in the
+// repository includes, so nothing compiled it and a build error could sit there unnoticed (the
+// _WIN32 branch did exactly that). This translation unit exists only to compile the header, so
+// CI builds the POSIX branch here and the Windows branch on the Windows runners. It has no
+// main() and is never run.
+#include "opentelemetry/ext/http/server/file_http_server.h"


### PR DESCRIPTION
Fixes #4299
Refs #4287

## The problem

`FileHttpServer::FileGetSuccess()` called `std::replace(filename.begin(), filename.end(), ...)` on a `const std::string &`, which yields const iterators, so the `_WIN32` branch could not compile. clang 18 and gcc 12 both reject it; it is plain C++, not an MSVC quirk. It survived because no translation unit in the repository includes this installed header, so CI never compiled it on any platform.

## The fix

The separator substitution runs on a local copy on Windows; the `#else` branch binds a reference so other platforms do not pay for a copy. `<sstream>` is now included directly for `std::ostringstream`, and `<algorithm>` (for the Windows-only `std::replace`) is included under `_WIN32`; both were previously resolving only because `socket_tools.h` happens to include them.

## Regression protection (added in review)

The header still had no test compiling it, so the fix could regress unnoticed. A compile-only target (`file_http_server_header_compile`, a CMake OBJECT library and a Bazel `cc_library`) now includes the header as its only translation unit. CI compiles the POSIX branch on Linux and macOS and the `_WIN32` branch on the Windows runners, so a compile-time break in the active platform branch of this header now fails the build. It is compiled, not run. It does not prove direct-include hygiene, since a symbol can still resolve through a transitive header; that is checked separately by the repository's IWYU workflow. The probe uses no symbol from the header on purpose, so its include is marked `// IWYU pragma: keep`.

Compiling the header for the first time under the maintainer configuration also surfaced pre-existing issues in it that no build had seen before: three extra semicolons after in-class function bodies (errors under `-Wextra-semi -Werror`) and two single-character string-literal searches, `find(".")` and `find_last_of(".")`, that `clang-tidy performance-faster-string-find` flags. Both are fixed here so the header clears the same gates as the rest of the tree rather than raising a limit.

## Not in this PR

The header has neighbouring robustness gaps (unchecked `tellg()`, ignored `read()` result, non-ASCII filenames, URI query handling) and a path-confinement concern already being handled privately. They are recorded in #4287 rather than folded into this scoped build fix.

## Verification

- The compile-only target builds under `-Wall -Wextra -Werror -Wextra-semi` on clang for C++14, 17 and 20, and on the repository's Windows runners for the `_WIN32` branch.
- clang-format 18 clean; the CHANGELOG entry is within the markdown line-length limit.
- Rebased onto current `main`, keeping both the #4300 and #4303 CHANGELOG entries; GitHub reports the branch mergeable.
