### PR TITLE
[CODE HEALTH] Move remaining API test helpers into anonymous namespaces

### DIFF
--- a/.github/workflows/clang-tidy.yaml
+++ b/.github/workflows/clang-tidy.yaml
@@ -17,9 +17,9 @@ jobs:
       matrix:
         include:
           - cmake_options: all-options-abiv1-preview
-            warning_limit: 142
+            warning_limit: 136
           - cmake_options: all-options-abiv2-preview
-            warning_limit: 152
+            warning_limit: 147
     env:
       CC: /usr/bin/clang-22
       CXX: /usr/bin/clang++-22

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,9 @@ Increment the:
   namespaces
   [#4303](https://github.com/open-telemetry/opentelemetry-cpp/pull/4303)
 
+* [CODE HEALTH] Move remaining API test helpers into anonymous namespaces
+  [#4301](https://github.com/open-telemetry/opentelemetry-cpp/pull/4301)
+
 * [CODE HEALTH] Move metrics storage test fixtures into anonymous namespace
   [#4286](https://github.com/open-telemetry/opentelemetry-cpp/pull/4286)
 

--- a/api/test/logs/logger_test.cc
+++ b/api/test/logs/logger_test.cc
@@ -260,6 +260,9 @@ TEST(Logger, EventLogMethodOverloads)
 
 #endif
 
+namespace
+{
+
 // Define a basic Logger class
 class TestLogger : public Logger
 {
@@ -281,9 +284,6 @@ public:
     auto log_record_ptr = std::move(log_record);
   }
 };
-
-namespace
-{
 
 class EnablementAwareTestLogRecord : public opentelemetry::logs::LogRecord
 {
@@ -454,8 +454,6 @@ protected:
 private:
   bool enabled_impl_result_;
 };
-
-}  // namespace
 
 // Define a basic LoggerProvider class that returns an instance of the logger class defined above
 class TestProvider : public LoggerProvider
@@ -678,3 +676,5 @@ TEST(Logger, EmitLogRecordWithTracePartsInArgsRoutesSpanContextVariantToEnabled)
   EXPECT_EQ(logger.last_span_context_.trace_flags(), trace_flags);
 }
 #endif  // OPENTELEMETRY_ABI_VERSION_NO >= 2
+
+}  // namespace

--- a/api/test/logs/provider_test.cc
+++ b/api/test/logs/provider_test.cc
@@ -28,6 +28,9 @@ using opentelemetry::logs::Provider;
 using opentelemetry::nostd::shared_ptr;
 namespace nostd = opentelemetry::nostd;
 
+namespace
+{
+
 class TestProvider : public LoggerProvider
 {
 public:
@@ -167,3 +170,5 @@ TEST(NoopEventLoggerProvider, CreateNoopEventLogger)
 #  endif
 
 #endif
+
+}  // namespace

--- a/api/test/trace/propagation/detail/string_test.cc
+++ b/api/test/trace/propagation/detail/string_test.cc
@@ -43,7 +43,6 @@ const SplitStringTestData split_string_test_cases[] = {
     {"foo ,bar, baz ", ',', 4, 3},
     {"00-0af7651916cd43dd8448eb211c80319c-00f067aa0ba902b7-01", '-', 4, 4},
 };
-}  // namespace
 
 // Test fixture
 class SplitStringTestFixture : public ::testing::TestWithParam<SplitStringTestData>
@@ -63,3 +62,5 @@ TEST_P(SplitStringTestFixture, SplitsAsExpected)
 INSTANTIATE_TEST_SUITE_P(SplitStringTestCases,
                          SplitStringTestFixture,
                          ::testing::ValuesIn(split_string_test_cases));
+
+}  // namespace

--- a/api/test/trace/provider_test.cc
+++ b/api/test/trace/provider_test.cc
@@ -15,6 +15,9 @@ using opentelemetry::trace::TracerProvider;
 
 namespace nostd = opentelemetry::nostd;
 
+namespace
+{
+
 class TestProvider : public TracerProvider
 {
 public:
@@ -49,3 +52,5 @@ TEST(Provider, SetTracerProvider)
   Provider::SetTracerProvider(tf);
   ASSERT_EQ(tf, Provider::GetTracerProvider());
 }
+
+}  // namespace


### PR DESCRIPTION
Part of #4196

Six `misc-use-internal-linkage` sites in the API tests, continuing from #4217 and #4286. This is the first of three batches; the other two cover the SDK tests.

| file | classes |
|---|---|
| `api/test/logs/logger_test.cc` | `TestLogger`, `TestProvider` |
| `api/test/logs/provider_test.cc` | `TestProvider`, `TestEventLoggerProvider` |
| `api/test/trace/propagation/detail/string_test.cc` | `SplitStringTestFixture` |
| `api/test/trace/provider_test.cc` | `TestProvider` |

## Shape of the change

`logger_test.cc` and `string_test.cc` already had an anonymous namespace that stopped just short of the flagged classes, so those namespaces are extended rather than joined by a second one. In `logger_test.cc` that means moving the opening up past `TestLogger` and the closing down to the end of the file, since `TestProvider` sat below it.

The two `provider_test.cc` files get a namespace around the test body. In the logs one that places the deprecated-declaration pragma push and pop pair inside the namespace, which is fine because both ends stay on the same side of the boundary. Both ABI settings compile, which exercises that.

Worth flagging: `api/test/logs` contains two different classes both named `TestProvider`, one in `logger_test.cc` and one in `provider_test.cc`. They currently build into separate test executables (a distinct Bazel `cc_test` and a distinct CMake target each), so there is no present link-time conflict; being in the same Bazel package does not put them in the same binary. Giving them internal linkage nevertheless prevents an ODR hazard if these sources are ever combined into one test binary.

## Warning limit

151 to 145 on abiv1, and 161 to 156 on abiv2. The abiv2 delta is five rather than six because `TestEventLoggerProvider` sits behind deprecated-API pragmas and is only reported on abiv1. That single site is also the entire difference between the 25 and 24 totals I posted on #4196. If the artifact disagrees with those numbers I will correct them from it.

## Verification

- All six classes are inside an anonymous namespace after the change, checked by walking the namespace depth rather than by eye, and every file has balanced open and close.
- All four files compile with `-DOPENTELEMETRY_ABI_VERSION_NO=1` and `=2`.
- clang-format 18 clean.
- No `TEST`, `TEST_F`, or `TEST_P` suite name that would map to different fixture types is shared across translation units in any combined test target. `string_test.cc` uses `TEST_P`/`INSTANTIATE_TEST_SUITE_P`, and its fixture and parameter type are both in the anonymous namespace now; neither `api/test/logs` nor `api/test/trace` has a combined test target. So this should not repeat the `all_tests` redefinition that #4217 ran into, which was the main thing I wanted to rule out before sending this.

One honest gap: I could not re-run the check itself locally. `misc-use-internal-linkage` only reports classes from llvm-22 onward, which is what CI uses; clang-tidy 18, 20 and 21 report functions and variables only, so a local run returns zero both before and after the change and proves nothing. I checked that rather than assuming it. The site list therefore comes from the CI log artifact for main at `de8fa515`, and CI is the authority on the resulting count.

