### PR TITLE
[CODE HEALTH] Move SDK trace and metrics test helpers into anonymous namespaces

### DIFF
--- a/.github/workflows/clang-tidy.yaml
+++ b/.github/workflows/clang-tidy.yaml
@@ -17,9 +17,9 @@ jobs:
       matrix:
         include:
           - cmake_options: all-options-abiv1-preview
-            warning_limit: 151
+            warning_limit: 142
           - cmake_options: all-options-abiv2-preview
-            warning_limit: 161
+            warning_limit: 152
     env:
       CC: /usr/bin/clang-22
       CXX: /usr/bin/clang++-22

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@ Increment the:
 
 ## [Unreleased]
 
+* [CODE HEALTH] Move SDK trace and metrics test helpers into anonymous
+  namespaces
+  [#4303](https://github.com/open-telemetry/opentelemetry-cpp/pull/4303)
+
 * [CODE HEALTH] Move metrics storage test fixtures into anonymous namespace
   [#4286](https://github.com/open-telemetry/opentelemetry-cpp/pull/4286)
 

--- a/sdk/test/metrics/exemplar/aligned_histogram_bucket_exemplar_reservoir_test.cc
+++ b/sdk/test/metrics/exemplar/aligned_histogram_bucket_exemplar_reservoir_test.cc
@@ -23,6 +23,9 @@ namespace sdk
 {
 namespace metrics
 {
+namespace
+{
+
 class AlignedHistogramBucketExemplarReservoirTestPeer : public ::testing::Test
 {
 public:
@@ -58,6 +61,8 @@ TEST_F(AlignedHistogramBucketExemplarReservoirTestPeer, OfferMeasurementWithNonE
   auto exemplar_data = histogram_exemplar_reservoir->CollectAndReset(MetricAttributes{});
   ASSERT_TRUE(!exemplar_data.empty());
 }
+
+}  // namespace
 
 }  // namespace metrics
 }  // namespace sdk

--- a/sdk/test/metrics/measurements_benchmark.cc
+++ b/sdk/test/metrics/measurements_benchmark.cc
@@ -35,6 +35,9 @@ using namespace opentelemetry::sdk::instrumentationscope;
 using namespace opentelemetry::sdk::metrics;
 using namespace opentelemetry::sdk::common;
 
+namespace
+{
+
 class MockMetricExporter : public MetricReader
 {
 public:
@@ -53,9 +56,6 @@ private:
 
   void OnInitialized() noexcept override {}
 };
-
-namespace
-{
 
 size_t GetBenchmarkThreads()
 {

--- a/sdk/test/trace/batch_span_processor_test.cc
+++ b/sdk/test/trace/batch_span_processor_test.cc
@@ -32,6 +32,9 @@ using opentelemetry::sdk::common::unsetenv;
 
 OPENTELEMETRY_BEGIN_NAMESPACE
 
+namespace
+{
+
 /**
  * Returns a mock span exporter meant exclusively for testing only
  */
@@ -498,5 +501,7 @@ TEST(BatchSpanProcessorOptionsEnvTest, TestDesignatedInitializers)
   EXPECT_EQ(partial_options.max_export_batch_size, static_cast<size_t>(50));
 }
 #endif
+
+}  // namespace
 
 OPENTELEMETRY_END_NAMESPACE

--- a/sdk/test/trace/tracer_provider_set_test.cc
+++ b/sdk/test/trace/tracer_provider_set_test.cc
@@ -24,6 +24,9 @@ namespace nostd     = opentelemetry::nostd;
 namespace trace_api = opentelemetry::trace;
 namespace trace_sdk = opentelemetry::sdk::trace;
 
+namespace
+{
+
 class TestProvider : public TracerProvider
 {
 public:
@@ -80,3 +83,5 @@ TEST(Provider, SetTracerProviderDisabled)
   unsetenv("OTEL_SDK_DISABLED");
 }
 #endif
+
+}  // namespace

--- a/sdk/test/trace/tracer_test.cc
+++ b/sdk/test/trace/tracer_test.cc
@@ -67,6 +67,9 @@ using opentelemetry::exporter::memory::InMemorySpanData;
 using opentelemetry::exporter::memory::InMemorySpanExporter;
 using opentelemetry::trace::SpanContext;
 
+namespace
+{
+
 /**
  * A mock sampler with ShouldSample returning:
  *  Decision::RECORD_AND_SAMPLE if trace_id is valid
@@ -171,8 +174,6 @@ public:
   uint8_t buf_trace[16] = {1, 2, 3, 4, 5, 6, 7, 8, 8, 7, 6, 5, 4, 3, 2, 1};
 };
 
-namespace
-{
 std::shared_ptr<opentelemetry::trace::Tracer> initTracer(std::unique_ptr<SpanExporter> &&exporter)
 {
   auto processor = std::unique_ptr<SpanProcessor>(new SimpleSpanProcessor(std::move(exporter)));


### PR DESCRIPTION
Part of #4196

This is the last of three batches after #4301 and #4302, and clears the SDK test sites in #4196.

| file | classes |
|---|---|
| `sdk/test/metrics/exemplar/aligned_histogram_bucket_exemplar_reservoir_test.cc` | `AlignedHistogramBucketExemplarReservoirTestPeer` |
| `sdk/test/metrics/measurements_benchmark.cc` | `MockMetricExporter` |
| `sdk/test/trace/batch_span_processor_test.cc` | `MockSpanExporter`, `BatchSpanProcessorTestPeer`, `MockLogHandler` |
| `sdk/test/trace/tracer_provider_set_test.cc` | `TestProvider` |
| `sdk/test/trace/tracer_test.cc` | `MockSampler`, `MockDecisionSampler`, `MockIdGenerator` |

## Shape of the change

`tracer_test.cc` and `measurements_benchmark.cc` already had an anonymous namespace that stopped just short of the flagged classes, so those are extended rather than joined by a second one.

`batch_span_processor_test.cc` is the one worth a second look. It already sits inside a named namespace opened by `OPENTELEMETRY_BEGIN_NAMESPACE`, so the anonymous namespace nests inside that and closes just before `OPENTELEMETRY_END_NAMESPACE`. It covers every class and every `TEST` in the file, including the `BatchSpanProcessorOptionsEnvTest` group at the end.

`tracer_provider_set_test.cc` closes its namespace after the trailing `#endif` of the `NO_GETENV` block, so the placement holds whether or not that block is compiled.

## Warning limit

151 to 142 and 161 to 152, nine on each preset since none are ABI gated.

Cut from main rather than stacked on #4301 and #4302. If any of the three merge before this, the limit needs recomputing down by the merged batch's count. Happy to rebase whenever; they were kept independent so they can be reviewed in any order.

## Verification

- All nine classes end up inside an anonymous namespace, checked by finding the nearest namespace open and close around each rather than by eye.
- Every file compiles under `-DOPENTELEMETRY_ABI_VERSION_NO=1` and `=2`.
- `BatchSpanProcessorTestPeer` and `AlignedHistogramBucketExemplarReservoirTestPeer` are the only `TEST_F` suite names in the batch, and each appears in exactly one file, so no `all_tests` redefinition. This was the specific risk from #4217 and the main thing I wanted to rule out.
- `measurements_benchmark.cc` is a benchmark target, so it needs to link rather than only compile; the change is a namespace wrap and does not touch linkage of any symbol the benchmark harness needs.
- clang-format 18 clean.

Same honest gap as the earlier two batches: `misc-use-internal-linkage` only reports classes from llvm-22 onward, so a local clang-tidy run returns zero regardless and proves nothing. The site list is from the CI log artifact for main, and CI is the authority on the count.
