### PR TITLE
[DOC] Publish Doxygen documentation to GitHub Pages

### DIFF
--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -1,0 +1,80 @@
+name: Publish Doxygen Docs
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Install dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y cmake doxygen graphviz
+
+      - name: Configure documentation version
+        shell: bash
+        run: |
+          VERSION=$(grep -E '^[[:space:]]*set\(OPENTELEMETRY_VERSION_NUMBER' CMakeLists.txt | sed -E 's/.*"([^"]+)".*/\1/')
+          SUFFIX=$(grep -E '^[[:space:]]*set\(OPENTELEMETRY_VERSION_SUFFIX' CMakeLists.txt | sed -E 's/.*"([^"]+)".*/\1/')
+          FULL_VERSION="${VERSION}${SUFFIX}"
+
+          if [ -z "$VERSION" ]; then
+            echo "Failed to determine OpenTelemetry version."
+            exit 1
+          fi
+
+          echo "Documentation version: ${FULL_VERSION}"
+
+          sed -i \
+            "s/^PROJECT_BRIEF.*/PROJECT_BRIEF = \"Version ${FULL_VERSION}\"/" \
+            docs/public/Doxyfile
+
+      - name: Generate Doxygen documentation
+        working-directory: docs/public
+        run: doxygen Doxyfile
+
+      - name: Verify generated documentation
+        run: |
+          test -f docs/public/html/index.html
+
+      - name: Setup GitHub Pages
+        uses: actions/configure-pages@v5
+
+      - name: Upload GitHub Pages artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: docs/public/html
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+
+    permissions:
+      pages: write
+      id-token: write
+
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/docs/public/Doxyfile
+++ b/docs/public/Doxyfile
@@ -1106,7 +1106,7 @@ IGNORE_PREFIX          =
 # If the GENERATE_HTML tag is set to YES, doxygen will generate HTML output
 # The default value is: YES.
 
-GENERATE_HTML          = NO
+GENERATE_HTML          = YES
 
 # The HTML_OUTPUT tag is used to specify where the HTML docs will be put. If a
 # relative path is entered the value of OUTPUT_DIRECTORY will be put in front of


### PR DESCRIPTION
Fixes #3913
## Changes

- Enable Doxygen HTML generation (`GENERATE_HTML = YES`).
- Add a GitHub Actions workflow to build and deploy the generated Doxygen documentation to GitHub Pages.
- Automatically derive the documentation version from `CMakeLists.txt` and update `PROJECT_BRIEF` during the workflow.
- Upload the generated HTML as a GitHub Pages artifact and deploy it using GitHub Pages.

## Validation

- Verified local Doxygen HTML generation.
- Verified the generated HTML renders correctly in a browser.
- Verified the documentation version is updated automatically from `CMakeLists.txt`.
<img width="1866" height="849" alt="image" src="https://github.com/user-attachments/assets/279d1b7d-79e7-4385-98c9-6085250b15ed" />
