### PR TITLE
[BUILD] Create the configuration_core library for programmatic config

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -242,6 +242,8 @@ build configuration.
 |                            | opentelemetry-cpp::trace                                                                         |
 |                            | opentelemetry-cpp::metrics                                                                       |
 |                            | opentelemetry-cpp::logs                                                                          |
+|                            | opentelemetry-cpp::configuration_core  (EXPERIMENTAL: Programmatic configuration)                |
+| **configuration**          | opentelemetry-cpp::configuration       (EXPERIMENTAL: YAML configuration)                        |
 | **ext_common**             | opentelemetry-cpp::ext                                                                           |
 | **ext_http_curl**          | opentelemetry-cpp::http_client_curl                                                              |
 | **ext_dll**                | opentelemetry-cpp::opentelemetry_cpp                                                             |

--- a/install/test/cmake/component_tests/sdk/CMakeLists.txt
+++ b/install/test/cmake/component_tests/sdk/CMakeLists.txt
@@ -24,6 +24,7 @@ target_link_libraries(
           opentelemetry-cpp::trace
           opentelemetry-cpp::metrics
           opentelemetry-cpp::logs
+          opentelemetry-cpp::configuration_core
           GTest::gtest
           GTest::gtest_main)
 

--- a/install/test/cmake/fetch_content_test/CMakeLists.txt
+++ b/install/test/cmake/fetch_content_test/CMakeLists.txt
@@ -56,7 +56,10 @@ add_executable(
   fetch_content_src_test
   ${OPENTELEMETRY_CPP_SRC_DIR}/install/test/src/test_api.cc
   ${OPENTELEMETRY_CPP_SRC_DIR}/install/test/src/test_sdk.cc
+  ${OPENTELEMETRY_CPP_SRC_DIR}/install/test/src/test_configuration.cc
+  ${OPENTELEMETRY_CPP_SRC_DIR}/install/test/src/test_resource_detectors.cc
   ${OPENTELEMETRY_CPP_SRC_DIR}/install/test/src/test_ext_common.cc
+  ${OPENTELEMETRY_CPP_SRC_DIR}/install/test/src/test_ext_http.cc
   ${OPENTELEMETRY_CPP_SRC_DIR}/install/test/src/test_ext_http_curl.cc
   ${OPENTELEMETRY_CPP_SRC_DIR}/install/test/src/test_exporters_ostream.cc
   ${OPENTELEMETRY_CPP_SRC_DIR}/install/test/src/test_exporters_in_memory.cc
@@ -75,22 +78,39 @@ target_link_libraries(
           opentelemetry-cpp::metrics
           opentelemetry-cpp::trace
           opentelemetry-cpp::logs
+          opentelemetry-cpp::configuration_core
+          opentelemetry-cpp::configuration
+          opentelemetry-cpp::resource_detectors
+          opentelemetry-cpp::http_client
           opentelemetry-cpp::http_client_curl
           opentelemetry-cpp::in_memory_span_exporter
           opentelemetry-cpp::in_memory_metric_exporter
           opentelemetry-cpp::ostream_log_record_exporter
+          opentelemetry-cpp::ostream_log_record_exporter_builder
           opentelemetry-cpp::ostream_metrics_exporter
+          opentelemetry-cpp::ostream_metrics_exporter_builder
           opentelemetry-cpp::ostream_span_exporter
+          opentelemetry-cpp::ostream_span_exporter_builder
           opentelemetry-cpp::otlp_file_exporter
+          opentelemetry-cpp::otlp_file_exporter_builder
           opentelemetry-cpp::otlp_file_log_record_exporter
+          opentelemetry-cpp::otlp_file_log_record_exporter_builder
           opentelemetry-cpp::otlp_file_metric_exporter
+          opentelemetry-cpp::otlp_file_metric_exporter_builder
           opentelemetry-cpp::otlp_grpc_exporter
+          opentelemetry-cpp::otlp_grpc_exporter_builder
           opentelemetry-cpp::otlp_grpc_log_record_exporter
+          opentelemetry-cpp::otlp_grpc_log_record_exporter_builder
           opentelemetry-cpp::otlp_grpc_metrics_exporter
+          opentelemetry-cpp::otlp_grpc_metric_exporter_builder
           opentelemetry-cpp::otlp_http_exporter
+          opentelemetry-cpp::otlp_http_exporter_builder
           opentelemetry-cpp::otlp_http_log_record_exporter
+          opentelemetry-cpp::otlp_http_log_record_exporter_builder
           opentelemetry-cpp::otlp_http_metric_exporter
+          opentelemetry-cpp::otlp_http_metric_exporter_builder
           opentelemetry-cpp::prometheus_exporter
+          opentelemetry-cpp::prometheus_exporter_builder
           opentelemetry-cpp::zipkin_trace_exporter
           opentelemetry-cpp::elasticsearch_log_record_exporter
           GTest::gtest

--- a/install/test/src/test_sdk.cc
+++ b/install/test/src/test_sdk.cc
@@ -3,6 +3,9 @@
 
 #include <gtest/gtest.h>
 
+#include <opentelemetry/context/propagation/global_propagator.h>
+#include <opentelemetry/context/propagation/noop_propagator.h>
+#include <opentelemetry/context/propagation/text_map_propagator.h>
 #include <opentelemetry/logs/provider.h>
 #include <opentelemetry/metrics/provider.h>
 #include <opentelemetry/trace/provider.h>
@@ -32,7 +35,27 @@
 #include <opentelemetry/sdk/metrics/meter_provider_factory.h>
 #include <opentelemetry/sdk/metrics/provider.h>
 
+#include <opentelemetry/sdk/configuration/configuration.h>
+#include <opentelemetry/sdk/configuration/configured_sdk.h>
+#include <opentelemetry/sdk/configuration/console_log_record_exporter_builder.h>
+#include <opentelemetry/sdk/configuration/console_log_record_exporter_configuration.h>
+#include <opentelemetry/sdk/configuration/console_push_metric_exporter_builder.h>
+#include <opentelemetry/sdk/configuration/console_push_metric_exporter_configuration.h>
+#include <opentelemetry/sdk/configuration/console_span_exporter_builder.h>
+#include <opentelemetry/sdk/configuration/console_span_exporter_configuration.h>
+#include <opentelemetry/sdk/configuration/logger_provider_configuration.h>
+#include <opentelemetry/sdk/configuration/meter_provider_configuration.h>
+#include <opentelemetry/sdk/configuration/periodic_metric_reader_configuration.h>
+#include <opentelemetry/sdk/configuration/propagator_configuration.h>
+#include <opentelemetry/sdk/configuration/registry.h>
+#include <opentelemetry/sdk/configuration/simple_log_record_processor_configuration.h>
+#include <opentelemetry/sdk/configuration/simple_span_processor_configuration.h>
+#include <opentelemetry/sdk/configuration/text_map_propagator_builder.h>
+#include <opentelemetry/sdk/configuration/tracer_provider_configuration.h>
+
 namespace nostd        = opentelemetry::nostd;
+namespace propagation  = opentelemetry::context::propagation;
+namespace config_sdk   = opentelemetry::sdk::configuration;
 namespace version_sdk  = opentelemetry::sdk::version;
 namespace common       = opentelemetry::common;
 namespace common_sdk   = opentelemetry::sdk::common;
@@ -45,6 +68,8 @@ namespace logs         = opentelemetry::logs;
 namespace trace_sdk    = opentelemetry::sdk::trace;
 namespace trace        = opentelemetry::trace;
 
+namespace
+{
 class NoopLogRecordable : public logs_sdk::Recordable
 {
 public:
@@ -171,7 +196,31 @@ public:
   }
 };
 
-TEST(SdkInstallTest, SdkVersionCheck)
+class SdkInstallTest : public ::testing::Test
+{
+protected:
+  void SetUp() override
+  {
+    propagation::GlobalTextMapPropagator::SetGlobalPropagator(
+        {std::make_shared<propagation::NoOpPropagator>()});
+    trace::Provider::SetTracerProvider({std::make_shared<trace::NoopTracerProvider>()});
+    logs::Provider::SetLoggerProvider({std::make_shared<logs::NoopLoggerProvider>()});
+    metrics::Provider::SetMeterProvider({std::make_shared<metrics::NoopMeterProvider>()});
+  }
+
+  void TearDown() override
+  {
+    propagation::GlobalTextMapPropagator::SetGlobalPropagator(
+        {std::make_shared<propagation::NoOpPropagator>()});
+    trace::Provider::SetTracerProvider({std::make_shared<trace::NoopTracerProvider>()});
+    logs::Provider::SetLoggerProvider({std::make_shared<logs::NoopLoggerProvider>()});
+    metrics::Provider::SetMeterProvider({std::make_shared<metrics::NoopMeterProvider>()});
+  }
+};
+
+}  // namespace
+
+TEST_F(SdkInstallTest, SdkVersionCheck)
 {
   EXPECT_NE(OPENTELEMETRY_SDK_VERSION, "not a version");
   EXPECT_GE(version_sdk::major_version, 0);
@@ -181,7 +230,7 @@ TEST(SdkInstallTest, SdkVersionCheck)
   EXPECT_NE(version_sdk::short_version, "");
 }
 
-TEST(SdkInstallTest, ResourceDetectorCheck)
+TEST_F(SdkInstallTest, ResourceDetectorCheck)
 {
   auto resource = resource_sdk::Resource::GetDefault();
   resource_sdk::OTELResourceDetector detector;
@@ -190,7 +239,7 @@ TEST(SdkInstallTest, ResourceDetectorCheck)
   EXPECT_NE(attributes.size(), 0);
 }
 
-TEST(SdkInstallTest, LoggerProviderCheck)
+TEST_F(SdkInstallTest, LoggerProviderCheck)
 {
   {
     auto exporter     = nostd::unique_ptr<logs_sdk::LogRecordExporter>(new NoopLogRecordExporter());
@@ -211,7 +260,7 @@ TEST(SdkInstallTest, LoggerProviderCheck)
   sdk_provider->ForceFlush();
 }
 
-TEST(SdkInstallTest, TracerProviderCheck)
+TEST_F(SdkInstallTest, TracerProviderCheck)
 {
   {
     auto exporter     = nostd::unique_ptr<trace_sdk::SpanExporter>(new NoopSpanExporter());
@@ -234,7 +283,7 @@ TEST(SdkInstallTest, TracerProviderCheck)
   sdk_provider->ForceFlush();
 }
 
-TEST(SdkInstallTest, MeterProviderCheck)
+TEST_F(SdkInstallTest, MeterProviderCheck)
 {
   {
     auto exporter =
@@ -259,4 +308,130 @@ TEST(SdkInstallTest, MeterProviderCheck)
   }
   auto sdk_provider = static_cast<metrics_sdk::MeterProvider *>(provider.get());
   sdk_provider->ForceFlush();
+}
+
+TEST_F(SdkInstallTest, ConfigurationCoreCheck)
+{
+  class NoopConsoleSpanBuilder : public config_sdk::ConsoleSpanExporterBuilder
+  {
+  public:
+    std::unique_ptr<trace_sdk::SpanExporter> Build(
+        const config_sdk::ConsoleSpanExporterConfiguration *) const override
+    {
+      return std::make_unique<NoopSpanExporter>();
+    }
+  };
+
+  class NoopConsoleLogRecordBuilder : public config_sdk::ConsoleLogRecordExporterBuilder
+  {
+  public:
+    std::unique_ptr<logs_sdk::LogRecordExporter> Build(
+        const config_sdk::ConsoleLogRecordExporterConfiguration *) const override
+    {
+      return std::make_unique<NoopLogRecordExporter>();
+    }
+  };
+
+  class NoopConsolePushMetricBuilder : public config_sdk::ConsolePushMetricExporterBuilder
+  {
+  public:
+    std::unique_ptr<metrics_sdk::PushMetricExporter> Build(
+        const config_sdk::ConsolePushMetricExporterConfiguration *) const override
+    {
+      return std::make_unique<NoopPushMetricExporter>();
+    }
+  };
+
+  class NoopTextMapPropagatorBuilder : public config_sdk::TextMapPropagatorBuilder
+  {
+  public:
+    std::unique_ptr<opentelemetry::context::propagation::TextMapPropagator> Build() const override
+    {
+      return std::make_unique<opentelemetry::context::propagation::NoOpPropagator>();
+    }
+  };
+
+  // Programmatic SDK Configuration
+  std::unique_ptr<config_sdk::ConfiguredSdk> sdk;
+  {
+    const std::string propagator_name{"noop"};
+
+    auto registry = std::make_shared<config_sdk::Registry>();
+    registry->SetConsoleSpanBuilder(std::make_unique<NoopConsoleSpanBuilder>());
+    registry->SetConsoleLogRecordBuilder(std::make_unique<NoopConsoleLogRecordBuilder>());
+    registry->SetConsolePushMetricExporterBuilder(std::make_unique<NoopConsolePushMetricBuilder>());
+    registry->SetTextMapPropagatorBuilder(propagator_name,
+                                          std::make_unique<NoopTextMapPropagatorBuilder>());
+
+    auto model = std::make_unique<config_sdk::Configuration>();
+
+    // Tracer provider: simple processor + console exporter
+    auto span_exporter       = std::make_unique<config_sdk::ConsoleSpanExporterConfiguration>();
+    auto span_processor      = std::make_unique<config_sdk::SimpleSpanProcessorConfiguration>();
+    span_processor->exporter = std::move(span_exporter);
+    auto tracer_config       = std::make_unique<config_sdk::TracerProviderConfiguration>();
+    tracer_config->processors.push_back(std::move(span_processor));
+
+    // Logger provider: simple processor + console exporter
+    auto log_exporter       = std::make_unique<config_sdk::ConsoleLogRecordExporterConfiguration>();
+    auto log_processor      = std::make_unique<config_sdk::SimpleLogRecordProcessorConfiguration>();
+    log_processor->exporter = std::move(log_exporter);
+    auto logger_config      = std::make_unique<config_sdk::LoggerProviderConfiguration>();
+    logger_config->processors.push_back(std::move(log_processor));
+
+    // Meter provider: periodic reader + console push exporter
+    auto metric_exporter = std::make_unique<config_sdk::ConsolePushMetricExporterConfiguration>();
+    auto metric_reader   = std::make_unique<config_sdk::PeriodicMetricReaderConfiguration>();
+    metric_reader->exporter = std::move(metric_exporter);
+    auto meter_config       = std::make_unique<config_sdk::MeterProviderConfiguration>();
+    meter_config->readers.push_back(std::move(metric_reader));
+
+    // Propagator: noop
+    auto propagator_config = std::make_unique<config_sdk::PropagatorConfiguration>();
+    propagator_config->composite.push_back(propagator_name);
+
+    // Assemble the full configuration model
+    model->tracer_provider = std::move(tracer_config);
+    model->logger_provider = std::move(logger_config);
+    model->meter_provider  = std::move(meter_config);
+    model->propagator      = std::move(propagator_config);
+
+    ASSERT_NO_THROW(sdk = config_sdk::ConfiguredSdk::Create(registry, model));
+    ASSERT_NE(sdk, nullptr);
+    ASSERT_NE(sdk->tracer_provider, nullptr);
+    ASSERT_NE(sdk->logger_provider, nullptr);
+    ASSERT_NE(sdk->meter_provider, nullptr);
+    ASSERT_NE(sdk->propagator, nullptr);
+  }
+
+  // Set the global providers
+  sdk->Install();
+
+  auto propagator = propagation::GlobalTextMapPropagator::GetGlobalPropagator();
+  ASSERT_NE(propagator, nullptr);
+
+  auto tracer_provider = trace::Provider::GetTracerProvider();
+  ASSERT_NE(tracer_provider, nullptr);
+
+  auto logger_provider = logs::Provider::GetLoggerProvider();
+  ASSERT_NE(logger_provider, nullptr);
+
+  auto meter_provider = metrics::Provider::GetMeterProvider();
+  ASSERT_NE(meter_provider, nullptr);
+
+  auto tracer  = tracer_provider->GetTracer("config-core-test");
+  auto logger  = logger_provider->GetLogger("config-core-test");
+  auto meter   = meter_provider->GetMeter("config-core-test");
+  auto counter = meter->CreateUInt64Counter("test-counter");
+
+  {
+    auto span = tracer->StartSpan("test-span");
+    opentelemetry::trace::Scope scope(span);
+    logger->Info("test-message");
+    counter->Add(1);
+    span->End();
+  }
+
+  // Destroy the global providers
+  sdk->UnInstall();
 }

--- a/sdk/CMakeLists.txt
+++ b/sdk/CMakeLists.txt
@@ -25,6 +25,7 @@ otel_add_component(
   opentelemetry_logs
   opentelemetry_trace
   opentelemetry_metrics
+  opentelemetry_configuration_core
   FILES_DIRECTORY
   "include/opentelemetry/"
   FILES_DESTINATION
@@ -33,7 +34,16 @@ otel_add_component(
   PATTERN
   "*.h"
   PATTERN
-  "sdk/configuration/*.h"
+  "sdk/configuration/configuration_parser.h"
+  EXCLUDE
+  PATTERN
+  "sdk/configuration/yaml_configuration_parser.h"
+  EXCLUDE
+  PATTERN
+  "sdk/configuration/ryml_document.h"
+  EXCLUDE
+  PATTERN
+  "sdk/configuration/ryml_document_node.h"
   EXCLUDE)
 
 if(WITH_CONFIGURATION)
@@ -48,7 +58,13 @@ if(WITH_CONFIGURATION)
     "include/opentelemetry"
     FILES_MATCHING
     PATTERN
-    "sdk/configuration/*.h")
+    "sdk/configuration/configuration_parser.h"
+    PATTERN
+    "sdk/configuration/yaml_configuration_parser.h"
+    PATTERN
+    "sdk/configuration/ryml_document.h"
+    PATTERN
+    "sdk/configuration/ryml_document_node.h")
 endif()
 
 if(BUILD_TESTING)

--- a/sdk/src/CMakeLists.txt
+++ b/sdk/src/CMakeLists.txt
@@ -7,7 +7,4 @@ add_subdirectory(metrics)
 add_subdirectory(logs)
 add_subdirectory(version)
 add_subdirectory(resource)
-
-if(WITH_CONFIGURATION)
-  add_subdirectory(configuration)
-endif()
+add_subdirectory(configuration)

--- a/sdk/src/configuration/BUILD
+++ b/sdk/src/configuration/BUILD
@@ -6,13 +6,39 @@ load("@rules_cc//cc:cc_library.bzl", "cc_library")
 package(default_visibility = ["//visibility:public"])
 
 cc_library(
-    name = "configuration",
-    srcs = glob(["**/*.cc"]),
+    name = "configuration_core",
+    srcs = [
+        "composable_always_off_sampler_configuration.cc",
+        "composable_always_on_sampler_configuration.cc",
+        "composable_parent_threshold_sampler_configuration.cc",
+        "composable_probability_sampler_configuration.cc",
+        "composable_rule_based_sampler_configuration.cc",
+        "configured_sdk.cc",
+        "document_node.cc",
+        "registry.cc",
+        "sdk_builder.cc",
+    ],
     include_prefix = "src/configuration",
     deps = [
         "//api",
         "//sdk:headers",
         "//sdk/src/common:wildcard_match",
+    ],
+)
+
+cc_library(
+    name = "configuration",
+    srcs = [
+        "configuration_parser.cc",
+        "ryml_document.cc",
+        "ryml_document_node.cc",
+        "yaml_configuration_parser.cc",
+    ],
+    include_prefix = "src/configuration",
+    deps = [
+        ":configuration_core",
+        "//api",
+        "//sdk:headers",
         "@rapidyaml",
     ],
 )

--- a/sdk/src/configuration/CMakeLists.txt
+++ b/sdk/src/configuration/CMakeLists.txt
@@ -2,12 +2,8 @@
 # SPDX-License-Identifier: Apache-2.0
 
 add_library(
-  opentelemetry_configuration
-  configuration_parser.cc
+  opentelemetry_configuration_core
   document_node.cc
-  yaml_configuration_parser.cc
-  ryml_document.cc
-  ryml_document_node.cc
   configured_sdk.cc
   sdk_builder.cc
   registry.cc
@@ -17,24 +13,46 @@ add_library(
   composable_parent_threshold_sampler_configuration.cc
   composable_rule_based_sampler_configuration.cc)
 
-set_target_properties(opentelemetry_configuration PROPERTIES EXPORT_NAME
-                                                             configuration)
-set_target_version(opentelemetry_configuration)
+set_target_properties(opentelemetry_configuration_core
+                      PROPERTIES EXPORT_NAME configuration_core)
 
 target_include_directories(
-  opentelemetry_configuration
+  opentelemetry_configuration_core
   PUBLIC "$<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/sdk/include>"
          "$<INSTALL_INTERFACE:include>")
 
 target_link_libraries(
-  opentelemetry_configuration
+  opentelemetry_configuration_core
   PUBLIC opentelemetry_api opentelemetry_common opentelemetry_trace
          opentelemetry_metrics opentelemetry_logs
-  PRIVATE ryml::ryml)
+  PRIVATE)
 
-if(OPENTELEMETRY_INSTALL)
-  opentelemetry_add_pkgconfig(
-    configuration "OpenTelemetry SDK - Configuration"
-    "Components for exporting traces in the OpenTelemetry SDK."
-    "opentelemetry_configuration")
-endif()
+if(WITH_CONFIGURATION)
+
+  add_library(
+    opentelemetry_configuration
+    configuration_parser.cc yaml_configuration_parser.cc ryml_document.cc
+    ryml_document_node.cc)
+
+  set_target_properties(opentelemetry_configuration PROPERTIES EXPORT_NAME
+                                                               configuration)
+  set_target_version(opentelemetry_configuration)
+
+  target_include_directories(
+    opentelemetry_configuration
+    PUBLIC "$<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/sdk/include>"
+           "$<INSTALL_INTERFACE:include>")
+
+  target_link_libraries(
+    opentelemetry_configuration
+    PUBLIC opentelemetry_configuration_core
+    PRIVATE ryml::ryml)
+
+  if(OPENTELEMETRY_INSTALL)
+    opentelemetry_add_pkgconfig(
+      configuration "OpenTelemetry SDK - Configuration"
+      "Components for exporting traces in the OpenTelemetry SDK."
+      "opentelemetry_configuration")
+  endif()
+
+endif(WITH_CONFIGURATION)

--- a/sdk/src/configuration/registry.cc
+++ b/sdk/src/configuration/registry.cc
@@ -8,6 +8,7 @@
 #include <utility>
 
 #include "opentelemetry/baggage/propagation/baggage_propagator.h"
+#include "opentelemetry/context/propagation/text_map_propagator.h"
 #include "opentelemetry/sdk/configuration/extension_log_record_exporter_builder.h"
 #include "opentelemetry/sdk/configuration/extension_log_record_processor_builder.h"
 #include "opentelemetry/sdk/configuration/extension_pull_metric_exporter_builder.h"

--- a/sdk/src/configuration/sdk_builder.cc
+++ b/sdk/src/configuration/sdk_builder.cc
@@ -147,7 +147,6 @@
 #include "opentelemetry/sdk/logs/simple_log_record_processor_factory.h"
 #include "opentelemetry/sdk/metrics/aggregation/aggregation_config.h"
 #include "opentelemetry/sdk/metrics/cardinality_limits.h"
-#include "opentelemetry/sdk/metrics/exemplar/filter_type.h"
 #include "opentelemetry/sdk/metrics/export/metric_producer.h"
 #include "opentelemetry/sdk/metrics/instruments.h"
 #include "opentelemetry/sdk/metrics/meter_config.h"
@@ -182,6 +181,10 @@
 #include "opentelemetry/sdk/trace/tracer_provider_factory.h"
 #include "opentelemetry/version.h"
 #include "src/common/wildcard_match.h"
+
+#ifdef ENABLE_METRICS_EXEMPLAR_PREVIEW
+#  include "opentelemetry/sdk/metrics/exemplar/filter_type.h"
+#endif
 
 OPENTELEMETRY_BEGIN_NAMESPACE
 namespace sdk

--- a/sdk/test/CMakeLists.txt
+++ b/sdk/test/CMakeLists.txt
@@ -7,7 +7,4 @@ add_subdirectory(metrics)
 add_subdirectory(logs)
 add_subdirectory(resource)
 add_subdirectory(instrumentationscope)
-
-if(WITH_CONFIGURATION)
-  add_subdirectory(configuration)
-endif()
+add_subdirectory(configuration)

--- a/sdk/test/configuration/BUILD
+++ b/sdk/test/configuration/BUILD
@@ -15,7 +15,7 @@ cc_test(
     ],
     deps = [
         "//sdk:headers",
-        "//sdk/src/configuration",
+        "//sdk/src/configuration:configuration_core",
         "//sdk/src/logs",
         "//sdk/src/metrics",
         "//sdk/src/resource",
@@ -36,7 +36,7 @@ cc_test(
     ],
     deps = [
         "//sdk:headers",
-        "//sdk/src/configuration",
+        "//sdk/src/configuration:configuration_core",
         "//sdk/src/logs",
         "//sdk/src/metrics",
         "//sdk/src/resource",
@@ -57,7 +57,7 @@ cc_test(
     ],
     deps = [
         "//sdk:headers",
-        "//sdk/src/configuration",
+        "//sdk/src/configuration:configuration_core",
         "//sdk/src/logs",
         "//sdk/src/metrics",
         "//sdk/src/resource",

--- a/sdk/test/configuration/CMakeLists.txt
+++ b/sdk/test/configuration/CMakeLists.txt
@@ -6,28 +6,30 @@ foreach(testname sdk_builder_test configured_sdk_test
   add_executable(${testname} "${testname}.cc")
   target_link_libraries(
     ${testname} PRIVATE ${GTEST_BOTH_LIBRARIES} ${CMAKE_THREAD_LIBS_INIT}
-                        opentelemetry_configuration)
+                        opentelemetry_configuration_core)
   gtest_add_tests(
     TARGET ${testname}
     TEST_PREFIX config.
     TEST_LIST ${testname})
 endforeach()
 
-foreach(
-  testname
-  yaml_logs_test
-  yaml_metrics_test
-  yaml_propagator_test
-  yaml_resource_test
-  yaml_test
-  yaml_trace_test
-  yaml_distribution_test)
-  add_executable(${testname} "${testname}.cc")
-  target_link_libraries(
-    ${testname} PRIVATE ${GTEST_BOTH_LIBRARIES} ${CMAKE_THREAD_LIBS_INIT}
-                        opentelemetry_configuration)
-  gtest_add_tests(
-    TARGET ${testname}
-    TEST_PREFIX yaml.
-    TEST_LIST ${testname})
-endforeach()
+if(WITH_CONFIGURATION)
+  foreach(
+    testname
+    yaml_logs_test
+    yaml_metrics_test
+    yaml_propagator_test
+    yaml_resource_test
+    yaml_test
+    yaml_trace_test
+    yaml_distribution_test)
+    add_executable(${testname} "${testname}.cc")
+    target_link_libraries(
+      ${testname} PRIVATE ${GTEST_BOTH_LIBRARIES} ${CMAKE_THREAD_LIBS_INIT}
+                          opentelemetry_configuration)
+    gtest_add_tests(
+      TARGET ${testname}
+      TEST_PREFIX yaml.
+      TEST_LIST ${testname})
+  endforeach()
+endif()


### PR DESCRIPTION
Contributes to #4134 and follow up from #https://github.com/open-telemetry/opentelemetry-cpp/pull/3655#pullrequestreview-3277362332

This PR creates a new library (`configuration_core`) to contain the SDK configuration components that do not require external dependencies. This library is built unconditionally with the SDK and available in the `sdk` CMake component. The YAML configuration component (and ryml dependency) remain with the `configuration` library and publicly link to the `configuration_core` library. 

## Changes
- Creates the `opentelemetry-cpp::configuration_core` CMake target for all configuration components that don't require external dependencies
   - The  `opentelemetry-cpp::configuration` CMake target now just includes the  ryml dependent components (ryml document, yaml parser). 
- Creates the configuration_core library for Bazel builds
- Updates the INSTALL guide to cover these two targets

For significant contributions please make sure you have completed the following items:

* [ ] `CHANGELOG.md` updated for non-trivial changes
* [ ] Unit tests have been added
* [ ] Changes in public API reviewed