### PR TITLE
[CI] test examples in bazel builds

### DIFF
--- a/examples/batch/BUILD
+++ b/examples/batch/BUILD
@@ -1,15 +1,19 @@
 # Copyright The OpenTelemetry Authors
 # SPDX-License-Identifier: Apache-2.0
 
-load("@rules_cc//cc:cc_binary.bzl", "cc_binary")
+load("@rules_cc//cc:cc_test.bzl", "cc_test")
 
-cc_binary(
+cc_test(
     name = "example_simple",
+    size = "medium",
     srcs = [
         "main.cc",
     ],
     linkopts = ["-lpthread"],
-    tags = ["ostream"],
+    tags = [
+        "ostream",
+        "tested_example",
+    ],
     deps = [
         "//api",
         "//exporters/ostream:ostream_span_exporter",

--- a/examples/configuration/BUILD
+++ b/examples/configuration/BUILD
@@ -1,10 +1,11 @@
 # Copyright The OpenTelemetry Authors
 # SPDX-License-Identifier: Apache-2.0
 
-load("@rules_cc//cc:cc_binary.bzl", "cc_binary")
+load("@rules_cc//cc:cc_test.bzl", "cc_test")
 
-cc_binary(
+cc_test(
     name = "example_yaml",
+    size = "medium",
     srcs = glob(["*.cc"]) + glob(["*.h"]),
     defines = [
         "OTEL_HAVE_OTLP_HTTP",

--- a/examples/custom_http_client/BUILD
+++ b/examples/custom_http_client/BUILD
@@ -1,0 +1,39 @@
+# Copyright The OpenTelemetry Authors
+# SPDX-License-Identifier: Apache-2.0
+
+load("@rules_cc//cc:cc_library.bzl", "cc_library")
+load("@rules_cc//cc:cc_test.bzl", "cc_test")
+
+cc_library(
+    name = "custom_http_client_stub",
+    srcs = [
+        "custom_http_client.cc",
+    ],
+    hdrs = [
+        "custom_http_client.h",
+    ],
+    deps = [
+        "//api",
+        "//ext:headers",
+        "//sdk:headers",
+    ],
+)
+
+cc_test(
+    name = "example_custom_http_client",
+    srcs = [
+        "main.cc",
+    ],
+    tags = [
+        "otlp",
+        "otlp_http",
+        "tested_example",
+    ],
+    deps = [
+        ":custom_http_client_stub",
+        "//api",
+        "//exporters/otlp:otlp_http_exporter",
+        "//sdk/src/metrics",
+        "//sdk/src/trace",
+    ],
+)

--- a/examples/environment_carrier/BUILD
+++ b/examples/environment_carrier/BUILD
@@ -4,7 +4,7 @@
 load("@rules_cc//cc:cc_test.bzl", "cc_test")
 
 cc_test(
-    name = "example_explicit_parent",
+    name = "example_environment_carrier",
     srcs = [
         "main.cc",
     ],
@@ -12,6 +12,10 @@ cc_test(
         "ostream",
         "tested_example",
     ],
+    target_compatible_with = select({
+        "//bazel:windows": ["@platforms//:incompatible"],
+        "//conditions:default": [],
+    }),
     deps = [
         "//api",
         "//exporters/ostream:ostream_span_exporter",

--- a/examples/logger_configurator/BUILD
+++ b/examples/logger_configurator/BUILD
@@ -4,7 +4,7 @@
 load("@rules_cc//cc:cc_test.bzl", "cc_test")
 
 cc_test(
-    name = "example_explicit_parent",
+    name = "example_logger_configurator",
     srcs = [
         "main.cc",
     ],
@@ -14,7 +14,7 @@ cc_test(
     ],
     deps = [
         "//api",
-        "//exporters/ostream:ostream_span_exporter",
-        "//sdk/src/trace",
+        "//exporters/ostream:ostream_log_record_exporter",
+        "//sdk/src/logs",
     ],
 )

--- a/examples/logs_simple/BUILD
+++ b/examples/logs_simple/BUILD
@@ -1,9 +1,9 @@
 # Copyright The OpenTelemetry Authors
 # SPDX-License-Identifier: Apache-2.0
 
-load("@rules_cc//cc:cc_binary.bzl", "cc_binary")
+load("@rules_cc//cc:cc_test.bzl", "cc_test")
 
-cc_binary(
+cc_test(
     name = "example_logs_simple",
     srcs = [
         "main.cc",
@@ -11,6 +11,7 @@ cc_binary(
     tags = [
         "examples",
         "ostream",
+        "tested_example",
     ],
     deps = [
         "//api",

--- a/examples/metrics_simple/BUILD
+++ b/examples/metrics_simple/BUILD
@@ -1,15 +1,19 @@
 # Copyright The OpenTelemetry Authors
 # SPDX-License-Identifier: Apache-2.0
 
-load("@rules_cc//cc:cc_binary.bzl", "cc_binary")
+load("@rules_cc//cc:cc_test.bzl", "cc_test")
 
-cc_binary(
+cc_test(
     name = "metrics_ostream_example",
+    size = "medium",
     srcs = [
         "metrics_ostream.cc",
     ],
     linkopts = ["-pthread"],
-    tags = ["ostream"],
+    tags = [
+        "ostream",
+        "tested_example",
+    ],
     deps = [
         "//api",
         "//examples/common/metrics_foo_library:common_metrics_foo_library",

--- a/examples/multi_processor/BUILD
+++ b/examples/multi_processor/BUILD
@@ -1,9 +1,9 @@
 # Copyright The OpenTelemetry Authors
 # SPDX-License-Identifier: Apache-2.0
 
-load("@rules_cc//cc:cc_binary.bzl", "cc_binary")
+load("@rules_cc//cc:cc_test.bzl", "cc_test")
 
-cc_binary(
+cc_test(
     name = "example_multi_processor",
     srcs = [
         "main.cc",
@@ -11,6 +11,7 @@ cc_binary(
     tags = [
         "memory",
         "ostream",
+        "tested_example",
     ],
     deps = [
         "//api",

--- a/examples/multithreaded/BUILD
+++ b/examples/multithreaded/BUILD
@@ -1,14 +1,17 @@
 # Copyright The OpenTelemetry Authors
 # SPDX-License-Identifier: Apache-2.0
 
-load("@rules_cc//cc:cc_binary.bzl", "cc_binary")
+load("@rules_cc//cc:cc_test.bzl", "cc_test")
 
-cc_binary(
+cc_test(
     name = "example_multithreaded",
     srcs = [
         "main.cc",
     ],
-    tags = ["ostream"],
+    tags = [
+        "ostream",
+        "tested_example",
+    ],
     deps = [
         "//api",
         "//exporters/ostream:ostream_span_exporter",

--- a/examples/simple/BUILD
+++ b/examples/simple/BUILD
@@ -1,9 +1,9 @@
 # Copyright The OpenTelemetry Authors
 # SPDX-License-Identifier: Apache-2.0
 
-load("@rules_cc//cc:cc_binary.bzl", "cc_binary")
+load("@rules_cc//cc:cc_test.bzl", "cc_test")
 
-cc_binary(
+cc_test(
     name = "example_simple",
     srcs = [
         "main.cc",
@@ -11,6 +11,7 @@ cc_binary(
     tags = [
         "examples",
         "ostream",
+        "tested_example",
     ],
     deps = [
         "//api",

--- a/examples/tracer_configurator/BUILD
+++ b/examples/tracer_configurator/BUILD
@@ -4,7 +4,7 @@
 load("@rules_cc//cc:cc_test.bzl", "cc_test")
 
 cc_test(
-    name = "example_explicit_parent",
+    name = "example_tracer_configurator",
     srcs = [
         "main.cc",
     ],


### PR DESCRIPTION
Contributes to #454

Many simple examples are built and run with CMake CI jobs, but the Bazel builds do not. 

This PR adds missing BUILD files to examples and builds all the simple examples with `cc_test` in Bazel to match CMake. This is also helpful since the sanitizer jobs are run with Bazel builds.  The examples can still be run with `bazel run` as before. 

The following examples run as Bazel tests: 

```
//examples/batch:example_simple                                          PASSED in 8.2s
//examples/configuration:example_yaml                                    PASSED in 28.8s
//examples/custom_http_client:example_custom_http_client                 PASSED in 0.3s
//examples/environment_carrier:example_environment_carrier               PASSED in 0.1s
//examples/explicit_parent:example_explicit_parent                       PASSED in 0.0s
//examples/logger_configurator:example_logger_configurator               PASSED in 0.1s
//examples/logs_simple:example_logs_simple                               PASSED in 0.1s
//examples/metrics_simple:metrics_ostream_example                        PASSED in 10.1s
//examples/multi_processor:example_multi_processor                       PASSED in 0.0s
//examples/multithreaded:example_multithreaded                           PASSED in 0.0s
//examples/simple:example_simple                                         PASSED in 0.1s
//examples/tracer_configurator:example_tracer_configurator               PASSED in 0.1s
```

## Changes

- Add missing Bazel build files for examples:
    -  custom_http_client
    - tracer_configurator
    - logger_configurator 
    - environment_carrier
 - Use `cc_test` instead of `cc_binary` for all examples that can be simply run in CI

For significant contributions please make sure you have completed the following items:

* [ ] `CHANGELOG.md` updated for non-trivial changes
* [ ] Unit tests have been added
* [ ] Changes in public API reviewed