### PR TITLE
[Metrics SDK] Fix histogram views rejected when only aggregation_cardinality_limit is set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@ Increment the:
 
 ## [Unreleased]
 
+* [METRICS SDK] Fix histogram views being rejected when only
+  `aggregation_cardinality_limit` is set
+  [#4314](https://github.com/open-telemetry/opentelemetry-cpp/pull/4314)
+
 * [CODE HEALTH] Move SDK trace and metrics test helpers into anonymous
   namespaces
   [#4303](https://github.com/open-telemetry/opentelemetry-cpp/pull/4303)

--- a/sdk/include/opentelemetry/sdk/metrics/aggregation/aggregation_config.h
+++ b/sdk/include/opentelemetry/sdk/metrics/aggregation/aggregation_config.h
@@ -52,6 +52,15 @@ public:
 
   AggregationType GetType() const noexcept override { return AggregationType::kHistogram; }
 
+  // The SDK-specified default bucket boundaries, used when no boundaries are configured.
+  static const std::vector<double> &DefaultBoundaries()
+  {
+    static const std::vector<double> boundaries = {0.0,    5.0,    10.0,   25.0,   50.0,
+                                                   75.0,   100.0,  250.0,  500.0,  750.0,
+                                                   1000.0, 2500.0, 5000.0, 7500.0, 10000.0};
+    return boundaries;
+  }
+
   std::vector<double> boundaries_;
   bool record_min_max_ = true;
 };

--- a/sdk/src/configuration/sdk_builder.cc
+++ b/sdk/src/configuration/sdk_builder.cc
@@ -146,6 +146,7 @@
 #include "opentelemetry/sdk/logs/processor.h"
 #include "opentelemetry/sdk/logs/simple_log_record_processor_factory.h"
 #include "opentelemetry/sdk/metrics/aggregation/aggregation_config.h"
+#include "opentelemetry/sdk/metrics/aggregation/default_aggregation.h"
 #include "opentelemetry/sdk/metrics/cardinality_limits.h"
 #include "opentelemetry/sdk/metrics/exemplar/filter_type.h"
 #include "opentelemetry/sdk/metrics/export/metric_producer.h"
@@ -1745,8 +1746,39 @@ void SdkBuilder::AddView(
     }
     else
     {
-      sdk_aggregation_config = std::make_shared<opentelemetry::sdk::metrics::AggregationConfig>(
-          stream->aggregation_cardinality_limit);
+      // No explicit `aggregation` block was configured, so the view falls back to the
+      // instrument's default aggregation. ViewRegistry::AddView() rejects a view whose
+      // AggregationConfig type does not match the (possibly instrument-derived) aggregation
+      // type, so the config created here must match that same default rather than always
+      // being a plain AggregationConfig (which only satisfies kSum/kLastValue/kDrop).
+      auto effective_aggregation_type = sdk_aggregation_type;
+      if (effective_aggregation_type == opentelemetry::sdk::metrics::AggregationType::kDefault)
+      {
+        bool is_monotonic{false};
+        effective_aggregation_type =
+            opentelemetry::sdk::metrics::DefaultAggregation::GetDefaultAggregationType(
+                sdk_instrument_type, is_monotonic);
+      }
+
+      switch (effective_aggregation_type)
+      {
+        case opentelemetry::sdk::metrics::AggregationType::kHistogram:
+          sdk_aggregation_config =
+              std::make_shared<opentelemetry::sdk::metrics::HistogramAggregationConfig>(
+                  stream->aggregation_cardinality_limit);
+          break;
+
+        case opentelemetry::sdk::metrics::AggregationType::kBase2ExponentialHistogram:
+          sdk_aggregation_config = std::make_shared<
+              opentelemetry::sdk::metrics::Base2ExponentialHistogramAggregationConfig>(
+              stream->aggregation_cardinality_limit);
+          break;
+
+        default:
+          sdk_aggregation_config = std::make_shared<opentelemetry::sdk::metrics::AggregationConfig>(
+              stream->aggregation_cardinality_limit);
+          break;
+      }
     }
   }
 

--- a/sdk/src/configuration/sdk_builder.cc
+++ b/sdk/src/configuration/sdk_builder.cc
@@ -1768,12 +1768,6 @@ void SdkBuilder::AddView(
                   stream->aggregation_cardinality_limit);
           break;
 
-        case opentelemetry::sdk::metrics::AggregationType::kBase2ExponentialHistogram:
-          sdk_aggregation_config = std::make_shared<
-              opentelemetry::sdk::metrics::Base2ExponentialHistogramAggregationConfig>(
-              stream->aggregation_cardinality_limit);
-          break;
-
         default:
           sdk_aggregation_config = std::make_shared<opentelemetry::sdk::metrics::AggregationConfig>(
               stream->aggregation_cardinality_limit);

--- a/sdk/src/configuration/sdk_builder.cc
+++ b/sdk/src/configuration/sdk_builder.cc
@@ -1762,11 +1762,21 @@ void SdkBuilder::AddView(
 
       switch (effective_aggregation_type)
       {
-        case opentelemetry::sdk::metrics::AggregationType::kHistogram:
-          sdk_aggregation_config =
+        case opentelemetry::sdk::metrics::AggregationType::kHistogram: {
+          auto histogram_config =
               std::make_shared<opentelemetry::sdk::metrics::HistogramAggregationConfig>(
                   stream->aggregation_cardinality_limit);
+          // A default-constructed HistogramAggregationConfig has empty boundaries_, which
+          // LongHistogramAggregation/DoubleHistogramAggregation interpret as "use these zero
+          // boundaries" rather than "no boundaries configured" (that distinction only exists
+          // when the config pointer itself is null). Since this config is synthesized here
+          // rather than coming from an explicit `aggregation` block, it must carry the SDK's
+          // default boundaries to preserve the instrument's default histogram shape.
+          histogram_config->boundaries_ =
+              opentelemetry::sdk::metrics::HistogramAggregationConfig::DefaultBoundaries();
+          sdk_aggregation_config = histogram_config;
           break;
+        }
 
         default:
           sdk_aggregation_config = std::make_shared<opentelemetry::sdk::metrics::AggregationConfig>(

--- a/sdk/src/metrics/aggregation/histogram_aggregation.cc
+++ b/sdk/src/metrics/aggregation/histogram_aggregation.cc
@@ -34,8 +34,7 @@ LongHistogramAggregation::LongHistogramAggregation(const AggregationConfig *aggr
   }
   else
   {
-    point_data_.boundaries_ = {0.0,   5.0,   10.0,   25.0,   50.0,   75.0,   100.0,  250.0,
-                               500.0, 750.0, 1000.0, 2500.0, 5000.0, 7500.0, 10000.0};
+    point_data_.boundaries_ = HistogramAggregationConfig::DefaultBoundaries();
   }
 
   if (ac)
@@ -115,8 +114,7 @@ DoubleHistogramAggregation::DoubleHistogramAggregation(const AggregationConfig *
   }
   else
   {
-    point_data_.boundaries_ = {0.0,   5.0,   10.0,   25.0,   50.0,   75.0,   100.0,  250.0,
-                               500.0, 750.0, 1000.0, 2500.0, 5000.0, 7500.0, 10000.0};
+    point_data_.boundaries_ = HistogramAggregationConfig::DefaultBoundaries();
   }
   if (ac)
   {

--- a/sdk/test/configuration/sdk_builder_test.cc
+++ b/sdk/test/configuration/sdk_builder_test.cc
@@ -359,39 +359,3 @@ TEST(SdkBuilder, AddViewCounterCardinalityLimitOnly)
 
   EXPECT_EQ(matched, 1);
 }
-
-TEST(SdkBuilder, AddViewBase2ExponentialHistogramCardinalityLimitOnly)
-{
-  namespace metrics_sdk = opentelemetry::sdk::metrics;
-
-  auto model = MakeCardinalityOnlyViewConfig(config_sdk::InstrumentType::base2_exponential_histogram,
-                                              123);
-
-  auto registry = std::make_shared<config_sdk::Registry>();
-  config_sdk::SdkBuilder builder(registry);
-
-  metrics_sdk::ViewRegistry view_registry;
-  builder.AddView(&view_registry, model);
-
-  metrics_sdk::InstrumentDescriptor instrument_descriptor{
-      "", "", "", metrics_sdk::InstrumentType::kBase2ExponentialHistogram,
-      metrics_sdk::InstrumentValueType::kLong};
-  auto instrumentation_scope = scope_sdk::InstrumentationScope::Create("");
-
-  int matched = 0;
-  view_registry.FindViews(
-      instrument_descriptor, *instrumentation_scope, [&](const metrics_sdk::View &view) {
-        matched++;
-        auto *aggregation_config = view.GetAggregationConfig();
-        EXPECT_NE(aggregation_config, nullptr);
-        if (aggregation_config)
-        {
-          EXPECT_EQ(aggregation_config->GetType(),
-                    metrics_sdk::AggregationType::kBase2ExponentialHistogram);
-          EXPECT_EQ(aggregation_config->cardinality_limit_, 123u);
-        }
-        return true;
-      });
-
-  EXPECT_EQ(matched, 1);
-}

--- a/sdk/test/configuration/sdk_builder_test.cc
+++ b/sdk/test/configuration/sdk_builder_test.cc
@@ -359,3 +359,39 @@ TEST(SdkBuilder, AddViewCounterCardinalityLimitOnly)
 
   EXPECT_EQ(matched, 1);
 }
+
+TEST(SdkBuilder, AddViewBase2ExponentialHistogramCardinalityLimitOnly)
+{
+  namespace metrics_sdk = opentelemetry::sdk::metrics;
+
+  auto model = MakeCardinalityOnlyViewConfig(config_sdk::InstrumentType::base2_exponential_histogram,
+                                              123);
+
+  auto registry = std::make_shared<config_sdk::Registry>();
+  config_sdk::SdkBuilder builder(registry);
+
+  metrics_sdk::ViewRegistry view_registry;
+  builder.AddView(&view_registry, model);
+
+  metrics_sdk::InstrumentDescriptor instrument_descriptor{
+      "", "", "", metrics_sdk::InstrumentType::kBase2ExponentialHistogram,
+      metrics_sdk::InstrumentValueType::kLong};
+  auto instrumentation_scope = scope_sdk::InstrumentationScope::Create("");
+
+  int matched = 0;
+  view_registry.FindViews(
+      instrument_descriptor, *instrumentation_scope, [&](const metrics_sdk::View &view) {
+        matched++;
+        auto *aggregation_config = view.GetAggregationConfig();
+        EXPECT_NE(aggregation_config, nullptr);
+        if (aggregation_config)
+        {
+          EXPECT_EQ(aggregation_config->GetType(),
+                    metrics_sdk::AggregationType::kBase2ExponentialHistogram);
+          EXPECT_EQ(aggregation_config->cardinality_limit_, 123u);
+        }
+        return true;
+      });
+
+  EXPECT_EQ(matched, 1);
+}

--- a/sdk/test/configuration/sdk_builder_test.cc
+++ b/sdk/test/configuration/sdk_builder_test.cc
@@ -35,11 +35,14 @@
 #include "opentelemetry/sdk/configuration/view_selector_configuration.h"
 #include "opentelemetry/sdk/configuration/view_stream_configuration.h"
 
+#include "opentelemetry/nostd/variant.h"
 #include "opentelemetry/sdk/instrumentationscope/instrumentation_scope.h"
 #include "opentelemetry/sdk/instrumentationscope/scope_configurator.h"
 #include "opentelemetry/sdk/logs/logger_config.h"
 #include "opentelemetry/sdk/metrics/aggregation/aggregation_config.h"
 #include "opentelemetry/sdk/metrics/aggregation/default_aggregation.h"
+#include "opentelemetry/sdk/metrics/data/metric_data.h"
+#include "opentelemetry/sdk/metrics/data/point_data.h"
 #include "opentelemetry/sdk/metrics/instruments.h"
 #include "opentelemetry/sdk/metrics/metric_reader.h"
 #include "opentelemetry/sdk/metrics/view/view.h"
@@ -320,6 +323,23 @@ TEST(SdkBuilder, AddViewHistogramCardinalityLimitOnly)
         {
           EXPECT_EQ(aggregation_config->GetType(), metrics_sdk::AggregationType::kHistogram);
           EXPECT_EQ(aggregation_config->cardinality_limit_, 42u);
+
+          // Pin what users actually receive: building the aggregation from this config
+          // must keep the SDK's default bucket boundaries, not silently collapse to a
+          // single bucket. A default-constructed HistogramAggregationConfig has empty
+          // boundaries_, which the aggregation takes literally (as opposed to a null
+          // config pointer, which falls back to the default boundaries), so AddView()
+          // must populate boundaries_ explicitly.
+          auto aggregation = metrics_sdk::DefaultAggregation::CreateAggregation(
+              metrics_sdk::AggregationType::kHistogram, instrument_descriptor, aggregation_config);
+          EXPECT_NE(aggregation, nullptr);
+          if (aggregation)
+          {
+            auto histogram_data =
+                opentelemetry::nostd::get<metrics_sdk::HistogramPointData>(aggregation->ToPoint());
+            EXPECT_EQ(histogram_data.boundaries_.size(), 15u);
+            EXPECT_EQ(histogram_data.counts_.size(), 16u);
+          }
         }
         return true;
       });

--- a/sdk/test/configuration/sdk_builder_test.cc
+++ b/sdk/test/configuration/sdk_builder_test.cc
@@ -3,6 +3,7 @@
 
 #include <gtest/gtest.h>
 
+#include <cstddef>
 #include <memory>
 #include <string>
 #include <utility>
@@ -35,13 +36,14 @@
 #include "opentelemetry/sdk/configuration/view_selector_configuration.h"
 #include "opentelemetry/sdk/configuration/view_stream_configuration.h"
 
+#include "opentelemetry/nostd/function_ref.h"
 #include "opentelemetry/nostd/variant.h"
 #include "opentelemetry/sdk/instrumentationscope/instrumentation_scope.h"
 #include "opentelemetry/sdk/instrumentationscope/scope_configurator.h"
 #include "opentelemetry/sdk/logs/logger_config.h"
+#include "opentelemetry/sdk/metrics/aggregation/aggregation.h"
 #include "opentelemetry/sdk/metrics/aggregation/aggregation_config.h"
 #include "opentelemetry/sdk/metrics/aggregation/default_aggregation.h"
-#include "opentelemetry/sdk/metrics/data/metric_data.h"
 #include "opentelemetry/sdk/metrics/data/point_data.h"
 #include "opentelemetry/sdk/metrics/instruments.h"
 #include "opentelemetry/sdk/metrics/metric_reader.h"

--- a/sdk/test/configuration/sdk_builder_test.cc
+++ b/sdk/test/configuration/sdk_builder_test.cc
@@ -16,6 +16,7 @@
 #include "opentelemetry/sdk/configuration/always_on_sampler_configuration.h"
 #include "opentelemetry/sdk/configuration/extension_push_metric_exporter_builder.h"
 #include "opentelemetry/sdk/configuration/extension_push_metric_exporter_configuration.h"
+#include "opentelemetry/sdk/configuration/instrument_type.h"
 #include "opentelemetry/sdk/configuration/logger_config_configuration.h"
 #include "opentelemetry/sdk/configuration/logger_configurator_configuration.h"
 #include "opentelemetry/sdk/configuration/logger_matcher_and_config_configuration.h"
@@ -30,11 +31,18 @@
 #include "opentelemetry/sdk/configuration/span_limits_configuration.h"
 #include "opentelemetry/sdk/configuration/trace_id_ratio_based_sampler_configuration.h"
 #include "opentelemetry/sdk/configuration/tracer_provider_configuration.h"
+#include "opentelemetry/sdk/configuration/view_configuration.h"
+#include "opentelemetry/sdk/configuration/view_selector_configuration.h"
+#include "opentelemetry/sdk/configuration/view_stream_configuration.h"
 
 #include "opentelemetry/sdk/instrumentationscope/instrumentation_scope.h"
 #include "opentelemetry/sdk/instrumentationscope/scope_configurator.h"
 #include "opentelemetry/sdk/logs/logger_config.h"
+#include "opentelemetry/sdk/metrics/aggregation/aggregation_config.h"
+#include "opentelemetry/sdk/metrics/instruments.h"
 #include "opentelemetry/sdk/metrics/metric_reader.h"
+#include "opentelemetry/sdk/metrics/view/view.h"
+#include "opentelemetry/sdk/metrics/view/view_registry.h"
 #include "opentelemetry/sdk/resource/resource.h"
 #include "opentelemetry/sdk/trace/sampler.h"
 #include "opentelemetry/sdk/trace/span_limits.h"
@@ -259,4 +267,94 @@ TEST(SdkBuilder, CreatePeriodicMetricReader)
   EXPECT_EQ(captured->interval, model.interval);
   EXPECT_EQ(captured->timeout, model.timeout);
   EXPECT_TRUE(captured->exporter != nullptr);
+}
+
+namespace
+{
+
+// Builds a ViewConfiguration selecting the given instrument type, with only
+// aggregation_cardinality_limit set on the stream (no explicit `aggregation` block).
+std::unique_ptr<config_sdk::ViewConfiguration> MakeCardinalityOnlyViewConfig(
+    config_sdk::InstrumentType instrument_type,
+    std::size_t cardinality_limit)
+{
+  auto model                       = std::make_unique<config_sdk::ViewConfiguration>();
+  model->selector                  = std::make_unique<config_sdk::ViewSelectorConfiguration>();
+  model->selector->instrument_type = instrument_type;
+
+  model->stream = std::make_unique<config_sdk::ViewStreamConfiguration>();
+  model->stream->aggregation_cardinality_limit = cardinality_limit;
+
+  return model;
+}
+
+}  // namespace
+
+TEST(SdkBuilder, AddViewHistogramCardinalityLimitOnly)
+{
+  namespace metrics_sdk = opentelemetry::sdk::metrics;
+
+  auto model = MakeCardinalityOnlyViewConfig(config_sdk::InstrumentType::histogram, 42);
+
+  auto registry = std::make_shared<config_sdk::Registry>();
+  config_sdk::SdkBuilder builder(registry);
+
+  metrics_sdk::ViewRegistry view_registry;
+  builder.AddView(&view_registry, model);
+
+  metrics_sdk::InstrumentDescriptor instrument_descriptor{
+      "", "", "", metrics_sdk::InstrumentType::kHistogram, metrics_sdk::InstrumentValueType::kLong};
+  auto instrumentation_scope = scope_sdk::InstrumentationScope::Create("");
+
+  int matched = 0;
+  view_registry.FindViews(
+      instrument_descriptor, *instrumentation_scope, [&](const metrics_sdk::View &view) {
+        matched++;
+        // The view must not be rejected: it should carry a
+        // HistogramAggregationConfig (not a plain AggregationConfig), since
+        // the instrument's default aggregation for kHistogram is kHistogram.
+        auto *aggregation_config = view.GetAggregationConfig();
+        EXPECT_NE(aggregation_config, nullptr);
+        if (aggregation_config)
+        {
+          EXPECT_EQ(aggregation_config->GetType(), metrics_sdk::AggregationType::kHistogram);
+          EXPECT_EQ(aggregation_config->cardinality_limit_, 42u);
+        }
+        return true;
+      });
+
+  EXPECT_EQ(matched, 1);
+}
+
+TEST(SdkBuilder, AddViewCounterCardinalityLimitOnly)
+{
+  namespace metrics_sdk = opentelemetry::sdk::metrics;
+
+  auto model = MakeCardinalityOnlyViewConfig(config_sdk::InstrumentType::counter, 7);
+
+  auto registry = std::make_shared<config_sdk::Registry>();
+  config_sdk::SdkBuilder builder(registry);
+
+  metrics_sdk::ViewRegistry view_registry;
+  builder.AddView(&view_registry, model);
+
+  metrics_sdk::InstrumentDescriptor instrument_descriptor{
+      "", "", "", metrics_sdk::InstrumentType::kCounter, metrics_sdk::InstrumentValueType::kLong};
+  auto instrumentation_scope = scope_sdk::InstrumentationScope::Create("");
+
+  int matched = 0;
+  view_registry.FindViews(
+      instrument_descriptor, *instrumentation_scope, [&](const metrics_sdk::View &view) {
+        matched++;
+        auto *aggregation_config = view.GetAggregationConfig();
+        EXPECT_NE(aggregation_config, nullptr);
+        if (aggregation_config)
+        {
+          EXPECT_EQ(aggregation_config->GetType(), metrics_sdk::AggregationType::kDefault);
+          EXPECT_EQ(aggregation_config->cardinality_limit_, 7u);
+        }
+        return true;
+      });
+
+  EXPECT_EQ(matched, 1);
 }

--- a/sdk/test/configuration/sdk_builder_test.cc
+++ b/sdk/test/configuration/sdk_builder_test.cc
@@ -39,6 +39,7 @@
 #include "opentelemetry/sdk/instrumentationscope/scope_configurator.h"
 #include "opentelemetry/sdk/logs/logger_config.h"
 #include "opentelemetry/sdk/metrics/aggregation/aggregation_config.h"
+#include "opentelemetry/sdk/metrics/aggregation/default_aggregation.h"
 #include "opentelemetry/sdk/metrics/instruments.h"
 #include "opentelemetry/sdk/metrics/metric_reader.h"
 #include "opentelemetry/sdk/metrics/view/view.h"


### PR DESCRIPTION
## Summary

Follow-up to #4188, addressing review feedback left after that PR merged
(https://github.com/open-telemetry/opentelemetry-cpp/pull/4188#pullrequestreview and inline comments on `sdk_builder.cc` / `metric_reader.h`).

When a view's stream configuration set `aggregation_cardinality_limit` without an explicit `aggregation` block, `SdkBuilder::AddView()` always constructed a plain `AggregationConfig`. For instruments whose default aggregation is `kHistogram` or `kBase2ExponentialHistogram`, this doesn't match the type `ViewRegistry::AddView()` requires, so the whole view was silently rejected (`AggregationType and AggregationConfig type mismatch. Ignoring AddView call.`) and the configured cardinality limit never took effect.

`AddView()` now resolves the instrument's effective aggregation type (falling back to the instrument-derived default the same way `ViewRegistry::AddView()` does) and constructs the matching `AggregationConfig` subclass (`HistogramAggregationConfig` / `Base2ExponentialHistogramAggregationConfig` / plain `AggregationConfig`) before applying the limit.

- `sdk/src/configuration/sdk_builder.cc`: fix `AddView()` to pick the correct `AggregationConfig` subtype.
- `sdk/test/configuration/sdk_builder_test.cc`: adds `SdkBuilder.AddViewHistogramCardinalityLimitOnly` (reproduces and verifies the fix; fails against the pre-fix code with the exact "type mismatch" rejection) and `SdkBuilder.AddViewCounterCardinalityLimitOnly` (guards the still-correct non-histogram path).

Reader-level cardinality limit enforcement remains a separate follow-up, as noted in the existing `metric_reader.h` TODO — this PR only addresses the histogram view-rejection bug.

## Test plan

- [x] New unit tests `SdkBuilder.AddViewHistogramCardinalityLimitOnly` and `SdkBuilder.AddViewCounterCardinalityLimitOnly` pass.
- [x] Confirmed `AddViewHistogramCardinalityLimitOnly` fails against the pre-fix code with the reported `ViewRegistry::AddView` rejection.
- [x] Ran `yaml_metrics_test`, `configured_sdk_test`, `view_registry_test`, and the full `sdk_builder_test` suite — all green.