### PR TITLE
[BUILD] Add missing opentelemetry_proto dependency to otlp_recordable pkg-config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@ Increment the:
 
 ## [Unreleased]
 
+* [BUILD] Add missing opentelemetry_proto dependency to otlp_recordable
+  pkg-config
+  [#4316](https://github.com/open-telemetry/opentelemetry-cpp/pull/4316)
+
 * [CODE HEALTH] Move SDK trace and metrics test helpers into anonymous
   namespaces
   [#4303](https://github.com/open-telemetry/opentelemetry-cpp/pull/4303)

--- a/exporters/otlp/CMakeLists.txt
+++ b/exporters/otlp/CMakeLists.txt
@@ -69,7 +69,7 @@ if(OPENTELEMETRY_INSTALL)
     otlp_recordable
     "OpenTelemetry OTLP - Recordable"
     "OTLP recordable implementation for spans, metrics, and logs."
-    "opentelemetry_trace opentelemetry_metrics opentelemetry_logs opentelemetry_resources"
+    "opentelemetry_trace opentelemetry_metrics opentelemetry_logs opentelemetry_resources opentelemetry_proto"
   )
 
   opentelemetry_add_pkgconfig(


### PR DESCRIPTION
Fixes # (issue)

## Changes

`opentelemetry_otlp_recordable.pc` omits `opentelemetry_proto` from its
`Requires:` line, even though the CMake target declares it as a plain `PUBLIC`
dependency:

https://github.com/open-telemetry/opentelemetry-cpp/blob/main/exporters/otlp/CMakeLists.txt#L704-L706

```cmake
target_link_libraries(
  opentelemetry_otlp_recordable
  PUBLIC opentelemetry_trace opentelemetry_resources opentelemetry_proto)
```

For significant contributions please make sure you have completed the following items:

* [x] `CHANGELOG.md` updated for non-trivial changes
* [ ] Unit tests have been added
* [ ] Changes in public API reviewed