### PR TITLE
fix(http): reject out-of-range listening ports

### DIFF
--- a/ext/include/opentelemetry/ext/http/server/http_server.h
+++ b/ext/include/opentelemetry/ext/http/server/http_server.h
@@ -199,7 +199,7 @@ public:
 
   void setServerName(std::string const &name) { m_serverHost = name; }
 
-  int addListeningPort(int port)
+  int addListeningPort(uint16_t port)
   {
 
 

--- a/ext/include/opentelemetry/ext/http/server/http_server.h
+++ b/ext/include/opentelemetry/ext/http/server/http_server.h
@@ -201,11 +201,18 @@ public:
 
   int addListeningPort(int port)
   {
+
+
+    SocketTools::SocketAddr addr(0, port);
+    if (addr.port() == -1)
+    {
+      return -1;
+    }
+
     SocketTools::Socket socket(AF_INET, SOCK_STREAM, IPPROTO_TCP);
     socket.setNonBlocking();
     socket.setReuseAddr();
 
-    SocketTools::SocketAddr addr(0, port);
     socket.bind(addr);
     socket.getsockname(addr);
 

--- a/ext/include/opentelemetry/ext/http/server/socket_tools.h
+++ b/ext/include/opentelemetry/ext/http/server/socket_tools.h
@@ -174,12 +174,8 @@ struct SocketAddr
   /// <returns>SocketAddr</returns>
   SocketAddr() {}
 
-  SocketAddr(u_long addr, int port)
+  SocketAddr(u_long addr, u_int16_t port)
   {
-    if (port < 0 || port > 65535)
-    {
-      return;
-    }
 
     sockaddr_in &inet4    = reinterpret_cast<sockaddr_in &>(m_data);
     inet4.sin_family      = AF_INET;

--- a/ext/include/opentelemetry/ext/http/server/socket_tools.h
+++ b/ext/include/opentelemetry/ext/http/server/socket_tools.h
@@ -176,6 +176,11 @@ struct SocketAddr
 
   SocketAddr(u_long addr, int port)
   {
+    if (port < 0 || port > 65535)
+    {
+      return;
+    }
+
     sockaddr_in &inet4    = reinterpret_cast<sockaddr_in &>(m_data);
     inet4.sin_family      = AF_INET;
     inet4.sin_port        = htons(static_cast<uint16_t>(port));

--- a/ext/test/http/curl_http_test.cc
+++ b/ext/test/http/curl_http_test.cc
@@ -238,6 +238,15 @@ class DISABLED_BasicCurlHttpTests : public BasicCurlHttpTests
 
 TEST_F(BasicCurlHttpTests, DoNothing) {}
 
+TEST(HttpServerTest, RejectsOutOfRangeListeningPorts)
+{
+  HTTP_SERVER_NS::HttpServer server;
+
+  EXPECT_EQ(server.addListeningPort(-1), -1);
+  EXPECT_EQ(server.addListeningPort(65536), -1);
+  EXPECT_EQ(server.addListeningPort(99999), -1);
+}
+
 TEST_F(BasicCurlHttpTests, HttpRequest)
 {
   curl::Request req;

--- a/ext/test/http/curl_http_test.cc
+++ b/ext/test/http/curl_http_test.cc
@@ -238,15 +238,6 @@ class DISABLED_BasicCurlHttpTests : public BasicCurlHttpTests
 
 TEST_F(BasicCurlHttpTests, DoNothing) {}
 
-TEST(HttpServerTest, RejectsOutOfRangeListeningPorts)
-{
-  HTTP_SERVER_NS::HttpServer server;
-
-  EXPECT_EQ(server.addListeningPort(-1), -1);
-  EXPECT_EQ(server.addListeningPort(65536), -1);
-  EXPECT_EQ(server.addListeningPort(99999), -1);
-}
-
 TEST_F(BasicCurlHttpTests, HttpRequest)
 {
   curl::Request req;

--- a/ext/test/http/socket_tools_test.cc
+++ b/ext/test/http/socket_tools_test.cc
@@ -71,6 +71,13 @@ TEST(SocketAddrTest, AcceptsLeadingZeroPort)
   EXPECT_EQ(addr.port(), 80);
 }
 
+TEST(SocketAddrTest, RejectsOutOfRangeIntegerPorts)
+{
+  ExpectInvalid(SocketTools::SocketAddr(0, -1));
+  ExpectInvalid(SocketTools::SocketAddr(0, 65536));
+  ExpectInvalid(SocketTools::SocketAddr(0, 99999));
+}
+
 TEST(SocketAddrTest, RejectsOutOfRangePort)
 {
   SocketTools::SocketAddr addr("127.0.0.1:99999");


### PR DESCRIPTION
Fixes #4305

## Changes

* Added range validation to `SocketAddr(u_long addr, int port)` so ports below `0` or above `65535` are rejected instead of wrapping during the `uint16_t` conversion.
* Updated `HttpServer::addListeningPort(int port)` to return `-1` for an invalid port before creating or binding a socket.
* Added a unit test covering invalid values including `-1`, `65536`, and `99999`.

Tested with:
```text
bazel test //ext/test/http:curl_http_test \
  --test_filter=HttpServerTest.RejectsOutOfRangeListeningPorts
```

* [ ] `CHANGELOG.md` updated for non-trivial changes
* [x] Unit tests have been added
* [ ] Changes in public API reviewed
