### PR TITLE
[SDK] Convert `SpinLockMutex` to `std::mutex` part 1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,11 @@ Increment the:
 * [BUILD] Run the ext_http component install test on Windows
   [#4326](https://github.com/open-telemetry/opentelemetry-cpp/pull/4326)
 
+* [SDK] Convert SpinLockMutex to std::mutex part 1
+  Replace SpinLockMutex with std::mutex in SimpleProcessor,
+  SimpleLogRecordProcessor, MeterContext and Meter.
+  [#4323](https://github.com/open-telemetry/opentelemetry-cpp/pull/4323)
+
 * [CONFIGURATION] Decouple config registry and builder headers
   [#4335](https://github.com/open-telemetry/opentelemetry-cpp/pull/4335)
 

--- a/sdk/include/opentelemetry/sdk/logs/simple_log_record_processor.h
+++ b/sdk/include/opentelemetry/sdk/logs/simple_log_record_processor.h
@@ -6,8 +6,7 @@
 #include <atomic>
 #include <chrono>
 #include <memory>
-
-#include "opentelemetry/common/spin_lock_mutex.h"
+#include <mutex>
 #include "opentelemetry/sdk/logs/exporter.h"
 #include "opentelemetry/sdk/logs/processor.h"
 #include "opentelemetry/sdk/logs/recordable.h"
@@ -24,7 +23,7 @@ namespace logs
  * LogRecordExporter.
  *
  * All calls to the configured LogRecordExporter are synchronized using a
- * spin-lock on an atomic_flag.
+ * mutex.
  */
 class SimpleLogRecordProcessor : public LogRecordProcessor
 {
@@ -62,7 +61,7 @@ private:
   // The configured exporter
   std::unique_ptr<LogRecordExporter> exporter_;
   // The lock used to ensure the exporter is not called concurrently
-  opentelemetry::common::SpinLockMutex lock_;
+  std::mutex lock_;
   // The atomic boolean to ensure the ShutDown() function is only called once
   std::atomic<bool> is_shutdown_{false};
 };

--- a/sdk/include/opentelemetry/sdk/metrics/meter.h
+++ b/sdk/include/opentelemetry/sdk/metrics/meter.h
@@ -5,6 +5,7 @@
 
 #include <chrono>
 #include <memory>
+#include <mutex>
 #include <string>
 #include <unordered_map>
 #include <vector>
@@ -156,7 +157,7 @@ private:
       InstrumentDescriptor &instrument_descriptor);
   std::unique_ptr<AsyncWritableMetricStorage> RegisterAsyncMetricStorage(
       InstrumentDescriptor &instrument_descriptor);
-  opentelemetry::common::SpinLockMutex storage_lock_;
+  std::mutex storage_lock_;
 
   static opentelemetry::metrics::NoopMeter kNoopMeter;
 

--- a/sdk/include/opentelemetry/sdk/metrics/meter_context.h
+++ b/sdk/include/opentelemetry/sdk/metrics/meter_context.h
@@ -6,9 +6,8 @@
 #include <atomic>
 #include <chrono>
 #include <memory>
+#include <mutex>
 #include <vector>
-
-#include "opentelemetry/common/spin_lock_mutex.h"
 #include "opentelemetry/common/timestamp.h"
 #include "opentelemetry/nostd/function_ref.h"
 #include "opentelemetry/nostd/span.h"
@@ -194,8 +193,8 @@ private:
 #else
   std::atomic_flag shutdown_latch_ = ATOMIC_FLAG_INIT;
 #endif
-  opentelemetry::common::SpinLockMutex forceflush_lock_;
-  opentelemetry::common::SpinLockMutex meter_lock_;
+  std::mutex forceflush_lock_;
+  std::mutex meter_lock_;
 };
 
 }  // namespace metrics

--- a/sdk/include/opentelemetry/sdk/trace/simple_processor.h
+++ b/sdk/include/opentelemetry/sdk/trace/simple_processor.h
@@ -9,7 +9,6 @@
 #include <mutex>
 #include <utility>
 
-#include "opentelemetry/common/spin_lock_mutex.h"
 #include "opentelemetry/nostd/span.h"
 #include "opentelemetry/sdk/common/exporter_utils.h"
 #include "opentelemetry/sdk/trace/exporter.h"
@@ -30,7 +29,7 @@ namespace trace
  * OnEnd and ForceFlush are no-ops.
  *
  * All calls to the configured SpanExporter are synchronized using a
- * spin-lock on an atomic_flag.
+ * mutex.
  */
 class SimpleSpanProcessor : public SpanProcessor
 {
@@ -61,7 +60,7 @@ public:
   {
     std::unique_ptr<Recordable> local = std::move(span);
     nostd::span<std::unique_ptr<Recordable>> batch(&local, 1);
-    const std::lock_guard<opentelemetry::common::SpinLockMutex> locked(lock_);
+    const std::lock_guard<std::mutex> locked(lock_);
     if (exporter_->Export(batch) == sdk::common::ExportResult::kFailure)
     {
       /* Once it is defined how the SDK does logging, an error should be
@@ -102,7 +101,7 @@ protected:
 
 private:
   std::unique_ptr<SpanExporter> exporter_;
-  opentelemetry::common::SpinLockMutex lock_;
+  std::mutex lock_;
 #if defined(__cpp_lib_atomic_value_initialization) && \
     __cpp_lib_atomic_value_initialization >= 201911L
   std::atomic_flag shutdown_latch_{};

--- a/sdk/src/logs/simple_log_record_processor.cc
+++ b/sdk/src/logs/simple_log_record_processor.cc
@@ -7,7 +7,6 @@
 #include <mutex>
 #include <utility>
 
-#include "opentelemetry/common/spin_lock_mutex.h"
 #include "opentelemetry/nostd/span.h"
 #include "opentelemetry/sdk/common/exporter_utils.h"
 #include "opentelemetry/sdk/logs/exporter.h"
@@ -44,7 +43,7 @@ void SimpleLogRecordProcessor::OnEmit(std::unique_ptr<Recordable> &&record) noex
   auto log_record = std::move(record);
   nostd::span<std::unique_ptr<Recordable>> batch(&log_record, 1);
   // Get lock to ensure Export() is never called concurrently
-  const std::lock_guard<opentelemetry::common::SpinLockMutex> locked(lock_);
+  const std::lock_guard<std::mutex> locked(lock_);
 
   if (exporter_->Export(batch) != sdk::common::ExportResult::kSuccess)
   {

--- a/sdk/src/metrics/meter.cc
+++ b/sdk/src/metrics/meter.cc
@@ -10,7 +10,6 @@
 #include <utility>
 #include <vector>
 
-#include "opentelemetry/common/spin_lock_mutex.h"
 #include "opentelemetry/common/timestamp.h"
 #include "opentelemetry/metrics/noop.h"
 #include "opentelemetry/metrics/sync_instruments.h"
@@ -495,7 +494,7 @@ const sdk::instrumentationscope::InstrumentationScope *Meter::GetInstrumentation
 std::unique_ptr<SyncWritableMetricStorage> Meter::RegisterSyncMetricStorage(
     InstrumentDescriptor &instrument_descriptor)
 {
-  std::lock_guard<opentelemetry::common::SpinLockMutex> guard(storage_lock_);
+  std::lock_guard<std::mutex> guard(storage_lock_);
   auto ctx = meter_context_.lock();
   if (!ctx)
   {
@@ -569,7 +568,7 @@ std::unique_ptr<SyncWritableMetricStorage> Meter::RegisterSyncMetricStorage(
 std::unique_ptr<AsyncWritableMetricStorage> Meter::RegisterAsyncMetricStorage(
     InstrumentDescriptor &instrument_descriptor)
 {
-  std::lock_guard<opentelemetry::common::SpinLockMutex> guard(storage_lock_);
+  std::lock_guard<std::mutex> guard(storage_lock_);
   auto ctx = meter_context_.lock();
   if (!ctx)
   {
@@ -655,7 +654,7 @@ std::vector<MetricData> Meter::Collect(CollectorHandle *collector,
                             << "The metric context is invalid");
     return std::vector<MetricData>{};
   }
-  std::lock_guard<opentelemetry::common::SpinLockMutex> guard(storage_lock_);
+  std::lock_guard<std::mutex> guard(storage_lock_);
   for (auto &metric_storage : storage_registry_)
   {
     metric_storage.second->Collect(collector, ctx->GetCollectors(), ctx->GetSDKStartTime(),

--- a/sdk/src/metrics/meter_context.cc
+++ b/sdk/src/metrics/meter_context.cc
@@ -9,7 +9,6 @@
 #include <utility>
 #include <vector>
 
-#include "opentelemetry/common/spin_lock_mutex.h"
 #include "opentelemetry/common/timestamp.h"
 #include "opentelemetry/nostd/function_ref.h"
 #include "opentelemetry/nostd/span.h"
@@ -69,7 +68,7 @@ const instrumentationscope::ScopeConfigurator<MeterConfig> &MeterContext::GetMet
 bool MeterContext::ForEachMeter(
     nostd::function_ref<bool(std::shared_ptr<Meter> &meter)> callback) noexcept
 {
-  std::lock_guard<opentelemetry::common::SpinLockMutex> guard(meter_lock_);
+  std::lock_guard<std::mutex> guard(meter_lock_);
   for (auto &meter : meters_)
   {
     if (!callback(meter))
@@ -127,7 +126,7 @@ ExemplarFilterType MeterContext::GetExemplarFilter() const noexcept
 
 void MeterContext::AddMeter(const std::shared_ptr<Meter> &meter)
 {
-  std::lock_guard<opentelemetry::common::SpinLockMutex> guard(meter_lock_);
+  std::lock_guard<std::mutex> guard(meter_lock_);
   meters_.push_back(meter);
 }
 
@@ -135,7 +134,7 @@ void MeterContext::RemoveMeter(nostd::string_view name,
                                nostd::string_view version,
                                nostd::string_view schema_url)
 {
-  std::lock_guard<opentelemetry::common::SpinLockMutex> guard(meter_lock_);
+  std::lock_guard<std::mutex> guard(meter_lock_);
 
   std::vector<std::shared_ptr<Meter>> filtered_meters;
 
@@ -184,7 +183,7 @@ bool MeterContext::ForceFlush(std::chrono::microseconds timeout) noexcept
 {
   bool result = true;
   // Simultaneous flush not allowed.
-  const std::lock_guard<opentelemetry::common::SpinLockMutex> locked(forceflush_lock_);
+  const std::lock_guard<std::mutex> locked(forceflush_lock_);
 
   auto time_remaining = (std::chrono::steady_clock::duration::max)();
   if (std::chrono::duration_cast<std::chrono::microseconds>(time_remaining) > timeout)


### PR DESCRIPTION
Contributes to #4317

Spinlocks are not a fit for the use cases in classes covered by this PR. See #4317 for rationale.  

## Changes

Converts `SpinLockMutex` to `std::mutex` in: 
- SimpleProcessor
- SimpleLogRecordProcessor
- MeterContext
- Meter

Please provide a brief description of the changes here.

For significant contributions please make sure you have completed the following items:

* [x] `CHANGELOG.md` updated for non-trivial changes
* [ ] Unit tests have been added
* [ ] Changes in public API reviewed