### PR TITLE
[CI] Run the ext_http component install test on Windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,9 @@ Increment the:
 
 ## [Unreleased]
 
+* [BUILD] Run the ext_http component install test on Windows
+  [#4326](https://github.com/open-telemetry/opentelemetry-cpp/pull/4326)
+
 * [BENCHMARK] Add multi-threaded base2 exponential histogram benchmarks
   [#4319](https://github.com/open-telemetry/opentelemetry-cpp/pull/4319)
 

--- a/ci/do_ci.ps1
+++ b/ci/do_ci.ps1
@@ -432,6 +432,7 @@ switch ($action) {
       "api",
       "sdk",
       "ext_common",
+      "ext_http",
       "ext_http_curl",
       "exporters_in_memory",
       "exporters_ostream",


### PR DESCRIPTION
Split out of #4315, which @dbarker asked to take separately.

The Windows `cmake.install.test` component list in `ci/do_ci.ps1` contains `ext_http_curl` but not `ext_http`, so `install/test/cmake/component_tests/ext_http` is never configured or built on Windows. The component is installed there, since `WITH_HTTP_CLIENT_CURL` is on whenever an HTTP exporter is enabled and that is what creates the `opentelemetry_http_client` target, so this was a gap in the list rather than a component that does not exist on the platform.

With this, `test_ext_http.cc` compiles against the installed package on Windows the way it already does on Linux and macOS.
