### PR TITLE
[BUILD] Fix build break on old protobuf

### DIFF
--- a/exporters/otlp/src/otlp_populate_attribute_utils.cc
+++ b/exporters/otlp/src/otlp_populate_attribute_utils.cc
@@ -28,7 +28,7 @@
 
 // clang-format off
 #include "opentelemetry/exporters/otlp/protobuf_include_prefix.h" // IWYU pragma: keep
-#include <google/protobuf/repeated_ptr_field.h>
+// IWYU pragma: no_include <google/protobuf/repeated_ptr_field.h>
 // IWYU pragma: no_include "net/proto2/public/repeated_field.h"
 #include "opentelemetry/proto/common/v1/common.pb.h"
 #include "opentelemetry/proto/resource/v1/resource.pb.h"

--- a/exporters/otlp/test/otlp_metrics_serialization_test.cc
+++ b/exporters/otlp/test/otlp_metrics_serialization_test.cc
@@ -27,7 +27,7 @@
 
 // clang-format off
 #include "opentelemetry/exporters/otlp/protobuf_include_prefix.h" // IWYU pragma: keep
-#include <google/protobuf/repeated_ptr_field.h>
+// IWYU pragma: no_include <google/protobuf/repeated_ptr_field.h>
 #include "opentelemetry/proto/collector/metrics/v1/metrics_service.pb.h"
 #include "opentelemetry/proto/common/v1/common.pb.h"
 #include "opentelemetry/proto/metrics/v1/metrics.pb.h"


### PR DESCRIPTION
## Issue

OTLP HTTP fails to build with old protobuf versions.

Header file `google/protobuf/repeated_ptr_field.h` may not always exist in protobuf.

## Changes

Adjust IWYU pragmas to ignore header `google/protobuf/repeated_ptr_field.h`.

For significant contributions please make sure you have completed the following items:

* [ ] `CHANGELOG.md` updated for non-trivial changes
* [ ] Unit tests have been added
* [ ] Changes in public API reviewed