### PR TITLE
[BUG] End the Elasticsearch exporter's wait on a read or write error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,8 @@ Increment the:
   [#4334](https://github.com/open-telemetry/opentelemetry-cpp/pull/4334)
 * [BUG] Stop reading past a `nostd::string_view` that is not NUL terminated
   [#4346](https://github.com/open-telemetry/opentelemetry-cpp/pull/4346)
+* [BUG] End the Elasticsearch exporter's wait on a read or write error
+  [#4331](https://github.com/open-telemetry/opentelemetry-cpp/pull/4331)
 
 * [OTLP/HTTP] Honor `Retry-After` response header when retrying exports,
   supporting both delay-seconds and HTTP-date formats per RFC 7231 §7.1.3.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -128,6 +128,8 @@ Increment the:
   deprecated C headers (`stdint.h`, `stddef.h`, `stdlib.h`, `string.h`,
   `stdio.h`, `ctype.h`, `limits.h`, `assert.h`) with their C++ equivalents
   ([#4349](https://github.com/open-telemetry/opentelemetry-cpp/pull/4349))
+* [BUG] End the Elasticsearch exporter's wait on a read or write error
+  [#4331](https://github.com/open-telemetry/opentelemetry-cpp/pull/4331)
 
 * [CONFIGURATION] Add SDK component builder interfaces to the registry
   [#4358](https://github.com/open-telemetry/opentelemetry-cpp/issues/4358)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -130,6 +130,9 @@ Increment the:
   ([#4349](https://github.com/open-telemetry/opentelemetry-cpp/pull/4349))
 * [BUG] End the Elasticsearch exporter's wait on a read or write error
   [#4331](https://github.com/open-telemetry/opentelemetry-cpp/pull/4331)
+* [BUG] Say why an Elasticsearch export failed when the session was destroyed
+  before a response arrived
+  [#4331](https://github.com/open-telemetry/opentelemetry-cpp/pull/4331)
 
 * [CONFIGURATION] Add SDK component builder interfaces to the registry
   [#4358](https://github.com/open-telemetry/opentelemetry-cpp/issues/4358)

--- a/exporters/elasticsearch/CMakeLists.txt
+++ b/exporters/elasticsearch/CMakeLists.txt
@@ -55,4 +55,8 @@ if(BUILD_TESTING)
     TARGET es_log_record_exporter_test
     TEST_PREFIX exporter.
     TEST_LIST es_log_record_exporter_test)
+
+  # These cases exist to catch a wait that never returns. Without a per test
+  # bound a regression stalls the job instead of failing it.
+  set_tests_properties(${es_log_record_exporter_test} PROPERTIES TIMEOUT 30)
 endif() # BUILD_TESTING

--- a/exporters/elasticsearch/CMakeLists.txt
+++ b/exporters/elasticsearch/CMakeLists.txt
@@ -55,4 +55,8 @@ if(OTELCPP_BUILD_TESTING)
     TARGET es_log_record_exporter_test
     TEST_PREFIX exporter.
     TEST_LIST es_log_record_exporter_test)
+
+  # These cases exist to catch a wait that never returns. Without a per test
+  # bound a regression stalls the job instead of failing it.
+  set_tests_properties(${es_log_record_exporter_test} PROPERTIES TIMEOUT 30)
 endif() # OTELCPP_BUILD_TESTING

--- a/exporters/elasticsearch/src/es_log_record_exporter.cc
+++ b/exporters/elasticsearch/src/es_log_record_exporter.cc
@@ -151,10 +151,18 @@ public:
         OTEL_INTERNAL_LOG_DEBUG("[ES Log Exporter] Session created");
         break;
       case http_client::SessionState::Destroyed:
-        OTEL_INTERNAL_LOG_DEBUG("[ES Log Exporter] Session destroyed");
         // Nothing else will arrive after this. If no outcome was recorded, the session ended
-        // without a response, so release the waiter rather than leaving it blocked forever.
-        recordCompletion(CompletionState::Failure);
+        // without a response, so release the waiter rather than leaving it blocked forever, and
+        // say why: this is the event that decided the export failed, and the default level does
+        // not show debug.
+        if (recordCompletion(CompletionState::Failure))
+        {
+          OTEL_INTERNAL_LOG_ERROR("[ES Log Exporter] Session destroyed before a response");
+        }
+        else
+        {
+          OTEL_INTERNAL_LOG_DEBUG("[ES Log Exporter] Session destroyed");
+        }
         break;
       case http_client::SessionState::Connecting:
         OTEL_INTERNAL_LOG_DEBUG("[ES Log Exporter] Connecting to peer");

--- a/exporters/elasticsearch/src/es_log_record_exporter.cc
+++ b/exporters/elasticsearch/src/es_log_record_exporter.cc
@@ -137,9 +137,8 @@ public:
   {
     // If any failure event occurs, release the condition variable to unblock main thread.
     //
-    // A failure is reported only by the event that decided the outcome. Recording is first writer
-    // wins, so any of these can arrive after a response has already succeeded, and an error line
-    // there would describe a failure the caller was never told about.
+    // Recording is first writer wins, and only the event that decided the outcome reports it: a
+    // line from a later event would describe a failure the caller was never told about.
     switch (state)
     {
       case http_client::SessionState::CreateFailed:

--- a/exporters/elasticsearch/src/es_log_record_exporter.cc
+++ b/exporters/elasticsearch/src/es_log_record_exporter.cc
@@ -230,8 +230,9 @@ private:
   /**
    * Record the outcome of the request, first writer wins, then release any waiter. Keeping the
    * first outcome means a session destroyed after a successful response does not overwrite it.
+   *
+   * @return whether this call is the one that decided the outcome
    */
-  /// Returns whether this call is the one that decided the outcome.
   bool recordCompletion(CompletionState state)
   {
     bool recorded = false;

--- a/exporters/elasticsearch/src/es_log_record_exporter.cc
+++ b/exporters/elasticsearch/src/es_log_record_exporter.cc
@@ -110,8 +110,8 @@ public:
 
   /**
    * A method the user calls to block their thread until the request has either produced a
-   * response or failed. The longest duration is the timeout of the request, set by
-   * SetTimeoutMs(), which arrives here as a TimedOut session event.
+   * response or failed. It has no deadline of its own and relies on the HTTP client reporting
+   * one of the terminal session states.
    */
   bool waitForResponse()
   {
@@ -135,12 +135,18 @@ public:
   // Callback method when an http event occurs
   void OnEvent(http_client::SessionState state, nostd::string_view /* reason */) noexcept override
   {
-    // If any failure event occurs, release the condition variable to unblock main thread
+    // If any failure event occurs, release the condition variable to unblock main thread.
+    //
+    // A failure is reported only by the event that decided the outcome. Recording is first writer
+    // wins, so any of these can arrive after a response has already succeeded, and an error line
+    // there would describe a failure the caller was never told about.
     switch (state)
     {
       case http_client::SessionState::CreateFailed:
-        OTEL_INTERNAL_LOG_ERROR("[ES Log Exporter] Failed to create session");
-        recordCompletion(CompletionState::Failure);
+        if (recordCompletion(CompletionState::Failure))
+        {
+          OTEL_INTERNAL_LOG_ERROR("[ES Log Exporter] Failed to create session");
+        }
         break;
       case http_client::SessionState::Created:
         OTEL_INTERNAL_LOG_DEBUG("[ES Log Exporter] Session created");
@@ -155,8 +161,10 @@ public:
         OTEL_INTERNAL_LOG_DEBUG("[ES Log Exporter] Connecting to peer");
         break;
       case http_client::SessionState::ConnectFailed:
-        OTEL_INTERNAL_LOG_ERROR("[ES Log Exporter] Failed to connect to peer");
-        recordCompletion(CompletionState::Failure);
+        if (recordCompletion(CompletionState::Failure))
+        {
+          OTEL_INTERNAL_LOG_ERROR("[ES Log Exporter] Failed to connect to peer");
+        }
         break;
       case http_client::SessionState::Connected:
         OTEL_INTERNAL_LOG_DEBUG("[ES Log Exporter] Connected to peer");
@@ -165,33 +173,49 @@ public:
         OTEL_INTERNAL_LOG_DEBUG("[ES Log Exporter] Sending request");
         break;
       case http_client::SessionState::SendFailed:
-        OTEL_INTERNAL_LOG_ERROR("[ES Log Exporter] Failed to send request");
-        recordCompletion(CompletionState::Failure);
+        if (recordCompletion(CompletionState::Failure))
+        {
+          OTEL_INTERNAL_LOG_ERROR("[ES Log Exporter] Failed to send request");
+        }
         break;
       case http_client::SessionState::Response:
         OTEL_INTERNAL_LOG_DEBUG("[ES Log Exporter] Received response");
         break;
       case http_client::SessionState::SSLHandshakeFailed:
-        OTEL_INTERNAL_LOG_ERROR("[ES Log Exporter] Failed SSL Handshake");
-        recordCompletion(CompletionState::Failure);
+        if (recordCompletion(CompletionState::Failure))
+        {
+          OTEL_INTERNAL_LOG_ERROR("[ES Log Exporter] Failed SSL Handshake");
+        }
         break;
       case http_client::SessionState::TimedOut:
-        OTEL_INTERNAL_LOG_ERROR("[ES Log Exporter] Request timed out");
-        recordCompletion(CompletionState::Failure);
+        if (recordCompletion(CompletionState::Failure))
+        {
+          OTEL_INTERNAL_LOG_ERROR("[ES Log Exporter] Request timed out");
+        }
         break;
       case http_client::SessionState::NetworkError:
-        OTEL_INTERNAL_LOG_ERROR("[ES Log Exporter] Network error");
-        recordCompletion(CompletionState::Failure);
+        if (recordCompletion(CompletionState::Failure))
+        {
+          OTEL_INTERNAL_LOG_ERROR("[ES Log Exporter] Network error");
+        }
         break;
       case http_client::SessionState::ReadError:
-        OTEL_INTERNAL_LOG_DEBUG("[ES Log Exporter] Read error");
+        if (recordCompletion(CompletionState::Failure))
+        {
+          OTEL_INTERNAL_LOG_ERROR("[ES Log Exporter] Read error");
+        }
         break;
       case http_client::SessionState::WriteError:
-        OTEL_INTERNAL_LOG_DEBUG("[ES Log Exporter] Write error");
+        if (recordCompletion(CompletionState::Failure))
+        {
+          OTEL_INTERNAL_LOG_ERROR("[ES Log Exporter] Write error");
+        }
         break;
       case http_client::SessionState::Cancelled:
-        OTEL_INTERNAL_LOG_ERROR("[ES Log Exporter] (manually) cancelled");
-        recordCompletion(CompletionState::Failure);
+        if (recordCompletion(CompletionState::Failure))
+        {
+          OTEL_INTERNAL_LOG_ERROR("[ES Log Exporter] (manually) cancelled");
+        }
         break;
     }
   }
@@ -208,22 +232,27 @@ private:
    * Record the outcome of the request, first writer wins, then release any waiter. Keeping the
    * first outcome means a session destroyed after a successful response does not overwrite it.
    */
-  void recordCompletion(CompletionState state)
+  /// Returns whether this call is the one that decided the outcome.
+  bool recordCompletion(CompletionState state)
   {
+    bool recorded = false;
     {
       std::unique_lock<std::mutex> lk(mutex_);
-      recordCompletionLocked(state);
+      recorded = recordCompletionLocked(state);
     }
     cv_.notify_all();
+    return recorded;
   }
 
   /// As recordCompletion(), for callers that already hold mutex_ and notify themselves.
-  void recordCompletionLocked(CompletionState state)
+  bool recordCompletionLocked(CompletionState state)
   {
-    if (completion_ == CompletionState::Pending)
+    if (completion_ != CompletionState::Pending)
     {
-      completion_ = state;
+      return false;
     }
+    completion_ = state;
+    return true;
   }
 
   // Define a condition variable and mutex

--- a/exporters/elasticsearch/test/es_log_record_exporter_test.cc
+++ b/exporters/elasticsearch/test/es_log_record_exporter_test.cc
@@ -4,11 +4,14 @@
 #include "opentelemetry/exporters/elasticsearch/es_log_record_exporter.h"
 #include "opentelemetry/common/timestamp.h"
 #include "opentelemetry/exporters/elasticsearch/es_log_recordable.h"
+#include "opentelemetry/ext/http/client/http_client.h"
 #include "opentelemetry/logs/severity.h"
+#include "opentelemetry/nostd/function_ref.h"
 #include "opentelemetry/nostd/span.h"
 #include "opentelemetry/nostd/string_view.h"
 #include "opentelemetry/nostd/utility.h"
 #include "opentelemetry/sdk/common/exporter_utils.h"
+#include "opentelemetry/sdk/common/global_log_handler.h"
 #include "opentelemetry/sdk/instrumentationscope/instrumentation_scope.h"
 #include "opentelemetry/sdk/logs/exporter.h"
 #include "opentelemetry/sdk/logs/recordable.h"
@@ -19,14 +22,19 @@
 #include <chrono>
 #include <cstddef>
 #include <cstdint>
+#include <functional>
+#include <initializer_list>
+#include <mutex>
 #include <string>
 #include <utility>
+#include <vector>
 #include "nlohmann/json.hpp"
 
 namespace sdklogs       = opentelemetry::sdk::logs;
 namespace logs_api      = opentelemetry::logs;
 namespace nostd         = opentelemetry::nostd;
 namespace logs_exporter = opentelemetry::exporter::logs;
+namespace internal_log  = opentelemetry::sdk::common::internal_log;
 
 TEST(ElasticsearchLogsExporterTests, CustomClientConstructionSucceeds)
 {
@@ -141,4 +149,306 @@ TEST(ElasticsearchLogRecordableTests, BasicTests)
   const auto actual = recordable.GetJSON();
 
   EXPECT_EQ(actual, expected);
+}
+
+// ---------------------------------------------------------------------------
+// Synchronous completion path.
+//
+// A fake HTTP client drives a scripted sequence of callbacks from inside
+// SendRequest(), which runs before the exporter reaches waitForResponse(). Every
+// case here therefore also covers a completion recorded before the wait starts,
+// the notification a bare cv_.wait() would have missed.
+// ---------------------------------------------------------------------------
+namespace
+{
+namespace http_client = opentelemetry::ext::http::client;
+
+// Accepted by the substring check, by a top level "errors": false parse, and by one
+// acknowledged operation result carrying a 2xx status, so these cases keep meaning the
+// same thing whichever success check is in place.
+constexpr const char *kAcceptedBody =
+    R"({"took":30,"errors":false,"items":[{"index":{"status":201,"_shards":{"failed" : 0}}}]})";
+
+class FakeResponse : public http_client::Response
+{
+public:
+  FakeResponse(http_client::StatusCode status, const std::string &body)
+      : status_(status), body_(body.begin(), body.end())
+  {}
+  const http_client::Body &GetBody() const noexcept override { return body_; }
+  bool ForEachHeader(
+      nostd::function_ref<bool(nostd::string_view, nostd::string_view)>) const noexcept override
+  {
+    return true;
+  }
+  bool ForEachHeader(
+      const nostd::string_view &,
+      nostd::function_ref<bool(nostd::string_view, nostd::string_view)>) const noexcept override
+  {
+    return true;
+  }
+  http_client::StatusCode GetStatusCode() const noexcept override { return status_; }
+
+private:
+  http_client::StatusCode status_;
+  http_client::Body body_;
+};
+
+class FakeRequest : public http_client::Request
+{
+public:
+  void SetMethod(http_client::Method) noexcept override {}
+  void SetUri(nostd::string_view) noexcept override {}
+  void SetSslOptions(const http_client::HttpSslOptions &) noexcept override {}
+  void SetBody(http_client::Body &) noexcept override {}
+  void AddHeader(nostd::string_view, nostd::string_view) noexcept override {}
+  void ReplaceHeader(nostd::string_view, nostd::string_view) noexcept override {}
+  void SetTimeoutMs(std::chrono::milliseconds) noexcept override {}
+  void SetCompression(const http_client::Compression &) noexcept override {}
+  void EnableLogging(bool) noexcept override {}
+  void SetRetryPolicy(const http_client::RetryPolicy &) noexcept override {}
+};
+
+using EventScript = std::function<void(http_client::EventHandler &)>;
+
+class FakeSession : public http_client::Session
+{
+public:
+  explicit FakeSession(EventScript script) : script_(std::move(script)) {}
+  std::shared_ptr<http_client::Request> CreateRequest() noexcept override
+  {
+    return std::make_shared<FakeRequest>();
+  }
+  void SendRequest(std::shared_ptr<http_client::EventHandler> handler) noexcept override
+  {
+    script_(*handler);
+  }
+  bool IsSessionActive() noexcept override { return false; }
+  bool CancelSession() noexcept override { return true; }
+  bool FinishSession() noexcept override { return true; }
+
+private:
+  EventScript script_;
+};
+
+class FakeHttpClient : public http_client::HttpClient
+{
+public:
+  explicit FakeHttpClient(EventScript script) : script_(std::move(script)) {}
+  std::shared_ptr<http_client::Session> CreateSession(nostd::string_view) noexcept override
+  {
+    return std::make_shared<FakeSession>(script_);
+  }
+  bool CancelAllSessions() noexcept override { return true; }
+  bool FinishAllSessions() noexcept override { return true; }
+  void SetMaxSessionsPerConnection(std::size_t) noexcept override {}
+
+private:
+  EventScript script_;
+};
+
+opentelemetry::sdk::common::ExportResult ExportWith(EventScript script)
+{
+  auto client = std::make_shared<FakeHttpClient>(std::move(script));
+  logs_exporter::ElasticsearchExporterOptions options;
+  logs_exporter::ElasticsearchLogRecordExporter exporter(options, client);
+  auto record = exporter.MakeRecordable();
+  return exporter.Export(nostd::span<std::unique_ptr<sdklogs::Recordable>>(&record, 1));
+}
+}  // namespace
+
+// The synchronous wait exists only when the exporter is built without async export, so these cases
+// skip rather than compile out: gtest_add_tests reads the source, and a case that disappeared from
+// the binary would still be registered with CTest. The skip goes in SetUp rather than at the top of
+// each body, because GTEST_SKIP returns and leaves the rest of the body unreachable, which MSVC
+// reports as C4702 and the maintainer mode jobs turn into an error.
+namespace
+{
+class ElasticsearchLogsExporterSyncTests : public ::testing::Test
+{
+protected:
+  void SetUp() override
+  {
+#ifdef ENABLE_ASYNC_EXPORT
+    GTEST_SKIP() << "Export() returns without waiting when async export is enabled";
+#endif
+  }
+};
+}  // namespace
+
+TEST_F(ElasticsearchLogsExporterSyncTests, ResponseRecordedBeforeTheWaitIsStillSeen)
+{
+  const auto result = ExportWith([](http_client::EventHandler &handler) {
+    FakeResponse response(200, kAcceptedBody);
+    handler.OnResponse(response);
+  });
+  EXPECT_EQ(result, opentelemetry::sdk::common::ExportResult::kSuccess);
+}
+
+namespace
+{
+class ErrorCapturingLogHandler : public internal_log::LogHandler
+{
+public:
+  void Handle(internal_log::LogLevel level,
+              const char * /* file */,
+              int /* line */,
+              const char *msg,
+              const opentelemetry::sdk::common::AttributeMap & /* attributes */) noexcept override
+  {
+    if (level != internal_log::LogLevel::Error || msg == nullptr)
+    {
+      return;
+    }
+    std::lock_guard<std::mutex> lock(mutex_);
+    errors_.emplace_back(msg);
+  }
+
+  std::vector<std::string> errors() const
+  {
+    std::lock_guard<std::mutex> lock(mutex_);
+    return errors_;
+  }
+
+private:
+  mutable std::mutex mutex_;
+  std::vector<std::string> errors_;
+};
+}  // namespace
+
+// Only the event that decided the outcome reports it. A terminal failure arriving after a response
+// has already succeeded would otherwise leave an export failure in the log that the caller was
+// never given, and the result alone cannot tell the two apart.
+TEST_F(ElasticsearchLogsExporterSyncTests, ALateTerminalFailureDoesNotClaimTheExportFailed)
+{
+  auto capturing      = nostd::shared_ptr<internal_log::LogHandler>(new ErrorCapturingLogHandler());
+  const auto previous = internal_log::GlobalLogHandler::GetLogHandler();
+  internal_log::GlobalLogHandler::SetLogHandler(capturing);
+
+  const auto result = ExportWith([](http_client::EventHandler &handler) {
+    FakeResponse response(200, kAcceptedBody);
+    handler.OnResponse(response);
+    handler.OnEvent(http_client::SessionState::ReadError, "");
+    handler.OnEvent(http_client::SessionState::WriteError, "");
+    handler.OnEvent(http_client::SessionState::TimedOut, "");
+  });
+
+  const auto errors = static_cast<ErrorCapturingLogHandler *>(capturing.get())->errors();
+  internal_log::GlobalLogHandler::SetLogHandler(previous);
+
+  EXPECT_EQ(result, opentelemetry::sdk::common::ExportResult::kSuccess);
+  for (const auto &line : errors)
+  {
+    EXPECT_EQ(line.find("[ES Log Exporter]"), std::string::npos)
+        << "an event that did not decide the outcome reported: " << line;
+  }
+}
+
+TEST_F(ElasticsearchLogsExporterSyncTests, ReadErrorEndsTheWait)
+{
+  const auto result = ExportWith([](http_client::EventHandler &handler) {
+    handler.OnEvent(http_client::SessionState::ReadError, "");
+  });
+  EXPECT_EQ(result, opentelemetry::sdk::common::ExportResult::kFailure);
+}
+
+// The whole contract in one place. Every state that ends a session has to leave a result behind,
+// otherwise a client that emits it last strands the wait. The seven states other than the two
+// this change adds have behaved this way since #4298 but had no test.
+//
+// A regression here surfaces as a CTest timeout rather than a failed assertion, because a state
+// that stops being terminal leaves Export() waiting with nothing left to wake it.
+TEST_F(ElasticsearchLogsExporterSyncTests, EveryTerminalStateEndsTheWaitInFailure)
+{
+  const http_client::SessionState terminal[] = {
+      http_client::SessionState::CreateFailed, http_client::SessionState::ConnectFailed,
+      http_client::SessionState::SendFailed,   http_client::SessionState::SSLHandshakeFailed,
+      http_client::SessionState::TimedOut,     http_client::SessionState::NetworkError,
+      http_client::SessionState::Cancelled,    http_client::SessionState::ReadError,
+      http_client::SessionState::WriteError,   http_client::SessionState::Destroyed};
+
+  for (const auto state : terminal)
+  {
+    SCOPED_TRACE(static_cast<int>(state));
+    const auto result =
+        ExportWith([state](http_client::EventHandler &handler) { handler.OnEvent(state, ""); });
+    EXPECT_EQ(result, opentelemetry::sdk::common::ExportResult::kFailure);
+  }
+}
+
+// The other side of the same contract: a state that only reports progress must not complete the
+// export on its own, or a response that arrives afterwards is never consulted.
+TEST_F(ElasticsearchLogsExporterSyncTests, ProgressStatesDoNotDecideTheResult)
+{
+  const auto result = ExportWith([](http_client::EventHandler &handler) {
+    handler.OnEvent(http_client::SessionState::Created, "");
+    handler.OnEvent(http_client::SessionState::Connecting, "");
+    handler.OnEvent(http_client::SessionState::Connected, "");
+    handler.OnEvent(http_client::SessionState::Sending, "");
+    handler.OnEvent(http_client::SessionState::Response, "");
+    FakeResponse response(200, kAcceptedBody);
+    handler.OnResponse(response);
+  });
+  EXPECT_EQ(result, opentelemetry::sdk::common::ExportResult::kSuccess);
+}
+
+TEST_F(ElasticsearchLogsExporterSyncTests, WriteErrorEndsTheWait)
+{
+  const auto result = ExportWith([](http_client::EventHandler &handler) {
+    handler.OnEvent(http_client::SessionState::WriteError, "");
+  });
+  EXPECT_EQ(result, opentelemetry::sdk::common::ExportResult::kFailure);
+}
+
+TEST_F(ElasticsearchLogsExporterSyncTests, SessionDestroyedWhilePendingEndsTheWait)
+{
+  const auto result = ExportWith([](http_client::EventHandler &handler) {
+    handler.OnEvent(http_client::SessionState::Destroyed, "");
+  });
+  EXPECT_EQ(result, opentelemetry::sdk::common::ExportResult::kFailure);
+}
+
+// The first outcome recorded is the one reported, so tearing the session down after a response has
+// arrived does not turn a successful export into a failure.
+TEST_F(ElasticsearchLogsExporterSyncTests, SessionDestroyedAfterAResponseKeepsTheSuccess)
+{
+  const auto result = ExportWith([](http_client::EventHandler &handler) {
+    FakeResponse response(200, kAcceptedBody);
+    handler.OnResponse(response);
+    handler.OnEvent(http_client::SessionState::Destroyed, "");
+  });
+  EXPECT_EQ(result, opentelemetry::sdk::common::ExportResult::kSuccess);
+}
+
+// Same rule for the two states this change makes terminal, and the reason their error line is
+// conditional: reaching one of them says nothing on its own about the result Export() reports.
+TEST_F(ElasticsearchLogsExporterSyncTests, IoErrorAfterAResponseKeepsTheSuccess)
+{
+  for (const auto state :
+       {http_client::SessionState::ReadError, http_client::SessionState::WriteError})
+  {
+    const auto result = ExportWith([state](http_client::EventHandler &handler) {
+      FakeResponse response(200, kAcceptedBody);
+      handler.OnResponse(response);
+      handler.OnEvent(state, "");
+    });
+    EXPECT_EQ(result, opentelemetry::sdk::common::ExportResult::kSuccess);
+  }
+}
+
+// The mirror image, and the case where the error line is the only diagnostic the caller gets:
+// the I/O error is recorded first, so a response arriving afterwards does not rescue the export.
+TEST_F(ElasticsearchLogsExporterSyncTests, IoErrorBeforeAResponseKeepsTheFailure)
+{
+  for (const auto state :
+       {http_client::SessionState::ReadError, http_client::SessionState::WriteError})
+  {
+    SCOPED_TRACE(static_cast<int>(state));
+    const auto result = ExportWith([state](http_client::EventHandler &handler) {
+      handler.OnEvent(state, "");
+      FakeResponse response(200, kAcceptedBody);
+      handler.OnResponse(response);
+    });
+    EXPECT_EQ(result, opentelemetry::sdk::common::ExportResult::kFailure);
+  }
 }

--- a/exporters/elasticsearch/test/es_log_record_exporter_test.cc
+++ b/exporters/elasticsearch/test/es_log_record_exporter_test.cc
@@ -284,7 +284,7 @@ namespace http_client = opentelemetry::ext::http::client;
 // acknowledged operation result carrying a 2xx status, so these cases keep meaning the
 // same thing whichever success check is in place.
 constexpr const char *kAcceptedBody =
-    R"({"took":30,"errors":false,"items":[{"index":{"status":201,"_shards":{"failed" : 0}}}]})";
+    R"({"took":30,"errors":false,"items":[{"index":{"_index":"logs","status":201,"_shards":{"failed" : 0}}}]})";
 
 class FakeResponse : public http_client::Response
 {
@@ -353,46 +353,46 @@ private:
 class DeferredSession : public http_client::Session
 {
 public:
-  DeferredSession(std::shared_ptr<http_client::EventHandler> *slot, std::promise<void> *arrived)
-      : slot_(slot), arrived_(arrived)
+  explicit DeferredSession(std::promise<std::shared_ptr<http_client::EventHandler>> *arrived)
+      : arrived_(arrived)
   {}
 
   std::shared_ptr<http_client::Request> CreateRequest() noexcept override
   {
     return std::make_shared<FakeRequest>();
   }
+  // The handler travels in the promise rather than beside it. A waiter that times out has not
+  // observed the promise becoming ready and so is not synchronized with this thread, which would
+  // make a handler read on that path a race with this write.
   void SendRequest(std::shared_ptr<http_client::EventHandler> handler) noexcept override
   {
-    *slot_ = std::move(handler);
-    arrived_->set_value();
+    arrived_->set_value(std::move(handler));
   }
   bool IsSessionActive() noexcept override { return true; }
   bool CancelSession() noexcept override { return true; }
   bool FinishSession() noexcept override { return true; }
 
 private:
-  std::shared_ptr<http_client::EventHandler> *slot_;
-  std::promise<void> *arrived_;
+  std::promise<std::shared_ptr<http_client::EventHandler>> *arrived_;
 };
 
 class DeferredHttpClient : public http_client::HttpClient
 {
 public:
-  DeferredHttpClient(std::shared_ptr<http_client::EventHandler> *slot, std::promise<void> *arrived)
-      : slot_(slot), arrived_(arrived)
+  explicit DeferredHttpClient(std::promise<std::shared_ptr<http_client::EventHandler>> *arrived)
+      : arrived_(arrived)
   {}
 
   std::shared_ptr<http_client::Session> CreateSession(nostd::string_view) noexcept override
   {
-    return std::make_shared<DeferredSession>(slot_, arrived_);
+    return std::make_shared<DeferredSession>(arrived_);
   }
   bool CancelAllSessions() noexcept override { return true; }
   bool FinishAllSessions() noexcept override { return true; }
   void SetMaxSessionsPerConnection(std::size_t) noexcept override {}
 
 private:
-  std::shared_ptr<http_client::EventHandler> *slot_;
-  std::promise<void> *arrived_;
+  std::promise<std::shared_ptr<http_client::EventHandler>> *arrived_;
 };
 
 class FakeHttpClient : public http_client::HttpClient
@@ -438,6 +438,25 @@ protected:
 #endif
   }
 };
+
+// For the cases that read the lines the exporter writes rather than only the result it returns.
+// Below error level OTEL_INTERNAL_LOG_ERROR expands to nothing, so the line is not filtered at
+// runtime, it does not exist: a case expecting the winner to report one would fail on correct
+// code, and one expecting silence from the loser would pass without testing anything.
+class ElasticsearchLogsExporterSyncLoggingTests : public ::testing::Test
+{
+protected:
+  void SetUp() override
+  {
+#ifdef ENABLE_ASYNC_EXPORT
+    GTEST_SKIP() << "Export() returns without waiting when async export is enabled";
+#elif OTEL_INTERNAL_LOG_LEVEL < OTEL_INTERNAL_LOG_LEVEL_ERROR
+    // One skip point, because GTEST_SKIP returns and a second one after it would leave the rest of
+    // this body unreachable, which MSVC reports as C4702 under maintainer mode.
+    GTEST_SKIP() << "the exporter's error lines are compiled out below error level";
+#endif
+  }
+};
 }  // namespace
 
 namespace
@@ -451,15 +470,18 @@ struct ParkedExport
   std::shared_ptr<DeferredHttpClient> client;
   std::shared_ptr<logs_exporter::ElasticsearchLogRecordExporter> exporter;
   std::shared_ptr<http_client::EventHandler> handler;
-  std::promise<void> arrived;
+  std::promise<std::shared_ptr<http_client::EventHandler>> arrived;
   std::promise<opentelemetry::sdk::common::ExportResult> done;
   std::future<opentelemetry::sdk::common::ExportResult> finished;
 };
 
+// Answers with nullptr rather than a half prepared handle when a precondition does not hold. Each
+// step below is something a case needs before it can mean anything, and carrying on past one of
+// them reads state the other thread is still writing.
 std::shared_ptr<ParkedExport> StartParkedExport()
 {
   auto parked    = std::make_shared<ParkedExport>();
-  parked->client = std::make_shared<DeferredHttpClient>(&parked->handler, &parked->arrived);
+  parked->client = std::make_shared<DeferredHttpClient>(&parked->arrived);
 
   logs_exporter::ElasticsearchExporterOptions options;
   parked->exporter =
@@ -474,23 +496,42 @@ std::shared_ptr<ParkedExport> StartParkedExport()
         parked->exporter->Export(nostd::span<std::unique_ptr<sdklogs::Recordable>>(&record, 1)));
   }).detach();
 
-  EXPECT_EQ(std::future_status::ready, reached.wait_for(std::chrono::seconds{5}))
-      << "the exporter never sent the request";
-  EXPECT_TRUE(parked->handler) << "the session was not given a handler";
-  EXPECT_EQ(std::future_status::timeout, finished.wait_for(std::chrono::milliseconds{100}))
-      << "the export returned without waiting for anything";
+  if (std::future_status::ready != reached.wait_for(std::chrono::seconds{5}))
+  {
+    ADD_FAILURE() << "the exporter never handed off the request handler";
+    return nullptr;
+  }
+
+  parked->handler = reached.get();
+  if (!parked->handler)
+  {
+    ADD_FAILURE() << "the session was handed a null handler";
+    return nullptr;
+  }
+
+  if (std::future_status::timeout != finished.wait_for(std::chrono::milliseconds{100}))
+  {
+    ADD_FAILURE() << "the export returned before any callback was delivered";
+    return nullptr;
+  }
 
   parked->finished = std::move(finished);
   return parked;
 }
 }  // namespace
 
-// A terminal error delivered once the waiter is parked has to end the wait, which is the half the
-// notification is responsible for. Without these, removing cv_.notify_all() keeps this file green.
-TEST_F(ElasticsearchLogsExporterSyncTests, AReadErrorAfterTheWaiterParksWakesTheExport)
+// A terminal error that arrives after the handler has been handed off, while the export is still
+// running, has to end the wait, which is the half the notification is responsible for. Without
+// these two, removing cv_.notify_all() keeps this file green.
+//
+// The handoff is what they hold, not the parking: the session publishes the handler before
+// SendRequest() returns, so the export need not have reached cv_.wait() when the callback is
+// delivered. Holding that would want a wait entry seam in production code, which is not worth the
+// API it would add.
+TEST_F(ElasticsearchLogsExporterSyncTests, AReadErrorAfterTheHandoffEndsTheExport)
 {
   auto parked = StartParkedExport();
-  ASSERT_TRUE(parked->handler);
+  ASSERT_NE(nullptr, parked);
 
   parked->handler->OnEvent(http_client::SessionState::ReadError, "");
 
@@ -501,10 +542,10 @@ TEST_F(ElasticsearchLogsExporterSyncTests, AReadErrorAfterTheWaiterParksWakesThe
 
 // The same for the success half, which also holds that the wait is a wait: a waitForResponse that
 // only read the current state would answer before this response arrives.
-TEST_F(ElasticsearchLogsExporterSyncTests, AResponseAfterTheWaiterParksWakesTheExport)
+TEST_F(ElasticsearchLogsExporterSyncTests, AResponseAfterTheHandoffEndsTheExport)
 {
   auto parked = StartParkedExport();
-  ASSERT_TRUE(parked->handler);
+  ASSERT_NE(nullptr, parked);
 
   FakeResponse response(200, kAcceptedBody);
   parked->handler->OnResponse(response);
@@ -514,7 +555,7 @@ TEST_F(ElasticsearchLogsExporterSyncTests, AResponseAfterTheWaiterParksWakesTheE
   EXPECT_EQ(opentelemetry::sdk::common::ExportResult::kSuccess, parked->finished.get());
 }
 
-TEST_F(ElasticsearchLogsExporterSyncTests, ResponseRecordedBeforeTheWaitIsStillSeen)
+TEST_F(ElasticsearchLogsExporterSyncLoggingTests, ResponseRecordedBeforeTheWaitIsStillSeen)
 {
   const auto result = ExportWith([](http_client::EventHandler &handler) {
     FakeResponse response(200, kAcceptedBody);
@@ -596,7 +637,7 @@ std::size_t CountExporterErrors(const std::vector<std::string> &lines)
 // The winning side of the same rule. Without this, a recordCompletion that still records the
 // outcome but always answers "you did not decide it" passes every other case here while the
 // exporter goes silent about every failure it reports to its caller.
-TEST_F(ElasticsearchLogsExporterSyncTests, AWinningTerminalErrorIsReportedExactlyOnce)
+TEST_F(ElasticsearchLogsExporterSyncLoggingTests, AWinningTerminalErrorIsReportedExactlyOnce)
 {
   for (const auto &terminal : kErrorTerminalStates)
   {
@@ -630,7 +671,7 @@ TEST_F(ElasticsearchLogsExporterSyncTests, AWinningTerminalErrorIsReportedExactl
 
 // The shared curl client has reported more than one terminal event for one request, see #4360,
 // so which of two failures is described matters rather than only how many arrive.
-TEST_F(ElasticsearchLogsExporterSyncTests, OnlyTheFirstTerminalFailureIsReported)
+TEST_F(ElasticsearchLogsExporterSyncLoggingTests, OnlyTheFirstTerminalFailureIsReported)
 {
   auto capturing      = nostd::shared_ptr<internal_log::LogHandler>(new ErrorCapturingLogHandler());
   const auto previous = internal_log::GlobalLogHandler::GetLogHandler();
@@ -664,7 +705,7 @@ TEST_F(ElasticsearchLogsExporterSyncTests, OnlyTheFirstTerminalFailureIsReported
 // covers a completion recorded before the waiter arrives but never two callbacks at once. This
 // releases a response and a read error together. Either may win, and the point is that the result
 // and the diagnostic never disagree about which one did.
-TEST_F(ElasticsearchLogsExporterSyncTests, AResponseRacingAReadErrorAgree)
+TEST_F(ElasticsearchLogsExporterSyncLoggingTests, AResponseRacingAReadErrorAgree)
 {
   for (int attempt = 0; attempt < 50; ++attempt)
   {
@@ -726,7 +767,7 @@ TEST_F(ElasticsearchLogsExporterSyncTests, AResponseRacingAReadErrorAgree)
 }
 
 // The losing side, over the same table rather than three of the nine.
-TEST_F(ElasticsearchLogsExporterSyncTests, NoTerminalErrorAfterAResponseIsReported)
+TEST_F(ElasticsearchLogsExporterSyncLoggingTests, NoTerminalErrorAfterAResponseIsReported)
 {
   for (const auto &terminal : kErrorTerminalStates)
   {
@@ -751,7 +792,7 @@ TEST_F(ElasticsearchLogsExporterSyncTests, NoTerminalErrorAfterAResponseIsReport
   }
 }
 
-TEST_F(ElasticsearchLogsExporterSyncTests, ALateTerminalFailureDoesNotClaimTheExportFailed)
+TEST_F(ElasticsearchLogsExporterSyncLoggingTests, ALateTerminalFailureDoesNotClaimTheExportFailed)
 {
   auto capturing      = nostd::shared_ptr<internal_log::LogHandler>(new ErrorCapturingLogHandler());
   const auto previous = internal_log::GlobalLogHandler::GetLogHandler();

--- a/exporters/elasticsearch/test/es_log_record_exporter_test.cc
+++ b/exporters/elasticsearch/test/es_log_record_exporter_test.cc
@@ -272,14 +272,9 @@ TEST(ElasticsearchLogRecordableTests, BasicTests)
   EXPECT_EQ(actual, expected);
 }
 
-// ---------------------------------------------------------------------------
-// Synchronous completion path.
-//
-// A fake HTTP client drives a scripted sequence of callbacks from inside
-// SendRequest(), which runs before the exporter reaches waitForResponse(). Every
-// case here therefore also covers a completion recorded before the wait starts,
-// the notification a bare cv_.wait() would have missed.
-// ---------------------------------------------------------------------------
+// Synchronous completion path. The fake client scripts its callbacks from inside SendRequest(),
+// which runs before the exporter reaches waitForResponse(), so every case here also covers a
+// completion recorded before the wait starts.
 namespace
 {
 namespace http_client = opentelemetry::ext::http::client;
@@ -437,9 +432,8 @@ private:
 };
 }  // namespace
 
-// Only the event that decided the outcome reports it. A terminal failure arriving after a response
-// has already succeeded would otherwise leave an export failure in the log that the caller was
-// never given, and the result alone cannot tell the two apart.
+// Only the event that decided the outcome reports it: a failure logged after a response succeeded
+// would describe an outcome the caller was never given.
 namespace
 {
 // The states that end the wait in failure and say so. Destroyed is terminal too, but it reports

--- a/exporters/elasticsearch/test/es_log_record_exporter_test.cc
+++ b/exporters/elasticsearch/test/es_log_record_exporter_test.cc
@@ -11,6 +11,7 @@
 #include "opentelemetry/nostd/string_view.h"
 #include "opentelemetry/nostd/utility.h"
 #include "opentelemetry/sdk/common/exporter_utils.h"
+#include "opentelemetry/sdk/common/global_log_handler.h"
 #include "opentelemetry/sdk/instrumentationscope/instrumentation_scope.h"
 #include "opentelemetry/sdk/logs/exporter.h"
 #include "opentelemetry/sdk/logs/recordable.h"
@@ -21,8 +22,12 @@
 #include <chrono>
 #include <cstddef>
 #include <cstdint>
+#include <functional>
+#include <initializer_list>
+#include <mutex>
 #include <string>
 #include <utility>
+#include <vector>
 #include "nlohmann/json.hpp"
 
 namespace
@@ -126,6 +131,7 @@ namespace sdklogs       = opentelemetry::sdk::logs;
 namespace logs_api      = opentelemetry::logs;
 namespace nostd         = opentelemetry::nostd;
 namespace logs_exporter = opentelemetry::exporter::logs;
+namespace internal_log  = opentelemetry::sdk::common::internal_log;
 
 // Regression test: a log record whose body carries bytes that are not valid UTF-8 used to
 // abort the process. ElasticSearchRecordable::WriteValue stores the value as given, and
@@ -262,4 +268,305 @@ TEST(ElasticsearchLogRecordableTests, BasicTests)
   const auto actual = recordable.GetJSON();
 
   EXPECT_EQ(actual, expected);
+}
+
+// ---------------------------------------------------------------------------
+// Synchronous completion path.
+//
+// A fake HTTP client drives a scripted sequence of callbacks from inside
+// SendRequest(), which runs before the exporter reaches waitForResponse(). Every
+// case here therefore also covers a completion recorded before the wait starts,
+// the notification a bare cv_.wait() would have missed.
+// ---------------------------------------------------------------------------
+namespace
+{
+namespace http_client = opentelemetry::ext::http::client;
+
+// Accepted by the substring check, by a top level "errors": false parse, and by one
+// acknowledged operation result carrying a 2xx status, so these cases keep meaning the
+// same thing whichever success check is in place.
+constexpr const char *kAcceptedBody =
+    R"({"took":30,"errors":false,"items":[{"index":{"status":201,"_shards":{"failed" : 0}}}]})";
+
+class FakeResponse : public http_client::Response
+{
+public:
+  FakeResponse(http_client::StatusCode status, const std::string &body)
+      : status_(status), body_(body.begin(), body.end())
+  {}
+  const http_client::Body &GetBody() const noexcept override { return body_; }
+  bool ForEachHeader(
+      nostd::function_ref<bool(nostd::string_view, nostd::string_view)>) const noexcept override
+  {
+    return true;
+  }
+  bool ForEachHeader(
+      const nostd::string_view &,
+      nostd::function_ref<bool(nostd::string_view, nostd::string_view)>) const noexcept override
+  {
+    return true;
+  }
+  http_client::StatusCode GetStatusCode() const noexcept override { return status_; }
+
+private:
+  http_client::StatusCode status_;
+  http_client::Body body_;
+};
+
+class FakeRequest : public http_client::Request
+{
+public:
+  void SetMethod(http_client::Method) noexcept override {}
+  void SetUri(nostd::string_view) noexcept override {}
+  void SetSslOptions(const http_client::HttpSslOptions &) noexcept override {}
+  void SetBody(http_client::Body &) noexcept override {}
+  void AddHeader(nostd::string_view, nostd::string_view) noexcept override {}
+  void ReplaceHeader(nostd::string_view, nostd::string_view) noexcept override {}
+  void SetTimeoutMs(std::chrono::milliseconds) noexcept override {}
+  void SetCompression(const http_client::Compression &) noexcept override {}
+  void EnableLogging(bool) noexcept override {}
+  void SetRetryPolicy(const http_client::RetryPolicy &) noexcept override {}
+};
+
+using EventScript = std::function<void(http_client::EventHandler &)>;
+
+class FakeSession : public http_client::Session
+{
+public:
+  explicit FakeSession(EventScript script) : script_(std::move(script)) {}
+  std::shared_ptr<http_client::Request> CreateRequest() noexcept override
+  {
+    return std::make_shared<FakeRequest>();
+  }
+  void SendRequest(std::shared_ptr<http_client::EventHandler> handler) noexcept override
+  {
+    script_(*handler);
+  }
+  bool IsSessionActive() noexcept override { return false; }
+  bool CancelSession() noexcept override { return true; }
+  bool FinishSession() noexcept override { return true; }
+
+private:
+  EventScript script_;
+};
+
+class FakeHttpClient : public http_client::HttpClient
+{
+public:
+  explicit FakeHttpClient(EventScript script) : script_(std::move(script)) {}
+  std::shared_ptr<http_client::Session> CreateSession(nostd::string_view) noexcept override
+  {
+    return std::make_shared<FakeSession>(script_);
+  }
+  bool CancelAllSessions() noexcept override { return true; }
+  bool FinishAllSessions() noexcept override { return true; }
+  void SetMaxSessionsPerConnection(std::size_t) noexcept override {}
+
+private:
+  EventScript script_;
+};
+
+opentelemetry::sdk::common::ExportResult ExportWith(EventScript script)
+{
+  auto client = std::make_shared<FakeHttpClient>(std::move(script));
+  logs_exporter::ElasticsearchExporterOptions options;
+  logs_exporter::ElasticsearchLogRecordExporter exporter(options, client);
+  auto record = exporter.MakeRecordable();
+  return exporter.Export(nostd::span<std::unique_ptr<sdklogs::Recordable>>(&record, 1));
+}
+}  // namespace
+
+// The synchronous wait exists only when the exporter is built without async export, so these cases
+// skip rather than compile out: gtest_add_tests reads the source, and a case that disappeared from
+// the binary would still be registered with CTest. The skip goes in SetUp rather than at the top of
+// each body, because GTEST_SKIP returns and leaves the rest of the body unreachable, which MSVC
+// reports as C4702 and the maintainer mode jobs turn into an error.
+namespace
+{
+class ElasticsearchLogsExporterSyncTests : public ::testing::Test
+{
+protected:
+  void SetUp() override
+  {
+#ifdef ENABLE_ASYNC_EXPORT
+    GTEST_SKIP() << "Export() returns without waiting when async export is enabled";
+#endif
+  }
+};
+}  // namespace
+
+TEST_F(ElasticsearchLogsExporterSyncTests, ResponseRecordedBeforeTheWaitIsStillSeen)
+{
+  const auto result = ExportWith([](http_client::EventHandler &handler) {
+    FakeResponse response(200, kAcceptedBody);
+    handler.OnResponse(response);
+  });
+  EXPECT_EQ(result, opentelemetry::sdk::common::ExportResult::kSuccess);
+}
+
+namespace
+{
+class ErrorCapturingLogHandler : public internal_log::LogHandler
+{
+public:
+  void Handle(internal_log::LogLevel level,
+              const char * /* file */,
+              int /* line */,
+              const char *msg,
+              const opentelemetry::sdk::common::AttributeMap & /* attributes */) noexcept override
+  {
+    if (level != internal_log::LogLevel::Error || msg == nullptr)
+    {
+      return;
+    }
+    std::lock_guard<std::mutex> lock(mutex_);
+    errors_.emplace_back(msg);
+  }
+
+  std::vector<std::string> errors() const
+  {
+    std::lock_guard<std::mutex> lock(mutex_);
+    return errors_;
+  }
+
+private:
+  mutable std::mutex mutex_;
+  std::vector<std::string> errors_;
+};
+}  // namespace
+
+// Only the event that decided the outcome reports it. A terminal failure arriving after a response
+// has already succeeded would otherwise leave an export failure in the log that the caller was
+// never given, and the result alone cannot tell the two apart.
+TEST_F(ElasticsearchLogsExporterSyncTests, ALateTerminalFailureDoesNotClaimTheExportFailed)
+{
+  auto capturing      = nostd::shared_ptr<internal_log::LogHandler>(new ErrorCapturingLogHandler());
+  const auto previous = internal_log::GlobalLogHandler::GetLogHandler();
+  internal_log::GlobalLogHandler::SetLogHandler(capturing);
+
+  const auto result = ExportWith([](http_client::EventHandler &handler) {
+    FakeResponse response(200, kAcceptedBody);
+    handler.OnResponse(response);
+    handler.OnEvent(http_client::SessionState::ReadError, "");
+    handler.OnEvent(http_client::SessionState::WriteError, "");
+    handler.OnEvent(http_client::SessionState::TimedOut, "");
+  });
+
+  const auto errors = static_cast<ErrorCapturingLogHandler *>(capturing.get())->errors();
+  internal_log::GlobalLogHandler::SetLogHandler(previous);
+
+  EXPECT_EQ(result, opentelemetry::sdk::common::ExportResult::kSuccess);
+  for (const auto &line : errors)
+  {
+    EXPECT_EQ(line.find("[ES Log Exporter]"), std::string::npos)
+        << "an event that did not decide the outcome reported: " << line;
+  }
+}
+
+TEST_F(ElasticsearchLogsExporterSyncTests, ReadErrorEndsTheWait)
+{
+  const auto result = ExportWith([](http_client::EventHandler &handler) {
+    handler.OnEvent(http_client::SessionState::ReadError, "");
+  });
+  EXPECT_EQ(result, opentelemetry::sdk::common::ExportResult::kFailure);
+}
+
+// The whole contract in one place. Every state that ends a session has to leave a result behind,
+// otherwise a client that emits it last strands the wait.
+//
+// A regression here surfaces as a CTest timeout rather than a failed assertion, because a state
+// that stops being terminal leaves Export() waiting with nothing left to wake it.
+TEST_F(ElasticsearchLogsExporterSyncTests, EveryTerminalStateEndsTheWaitInFailure)
+{
+  const http_client::SessionState terminal[] = {
+      http_client::SessionState::CreateFailed, http_client::SessionState::ConnectFailed,
+      http_client::SessionState::SendFailed,   http_client::SessionState::SSLHandshakeFailed,
+      http_client::SessionState::TimedOut,     http_client::SessionState::NetworkError,
+      http_client::SessionState::Cancelled,    http_client::SessionState::ReadError,
+      http_client::SessionState::WriteError,   http_client::SessionState::Destroyed};
+
+  for (const auto state : terminal)
+  {
+    SCOPED_TRACE(static_cast<int>(state));
+    const auto result =
+        ExportWith([state](http_client::EventHandler &handler) { handler.OnEvent(state, ""); });
+    EXPECT_EQ(result, opentelemetry::sdk::common::ExportResult::kFailure);
+  }
+}
+
+// The other side of the same contract: a state that only reports progress must not complete the
+// export on its own, or a response that arrives afterwards is never consulted.
+TEST_F(ElasticsearchLogsExporterSyncTests, ProgressStatesDoNotDecideTheResult)
+{
+  const auto result = ExportWith([](http_client::EventHandler &handler) {
+    handler.OnEvent(http_client::SessionState::Created, "");
+    handler.OnEvent(http_client::SessionState::Connecting, "");
+    handler.OnEvent(http_client::SessionState::Connected, "");
+    handler.OnEvent(http_client::SessionState::Sending, "");
+    handler.OnEvent(http_client::SessionState::Response, "");
+    FakeResponse response(200, kAcceptedBody);
+    handler.OnResponse(response);
+  });
+  EXPECT_EQ(result, opentelemetry::sdk::common::ExportResult::kSuccess);
+}
+
+TEST_F(ElasticsearchLogsExporterSyncTests, WriteErrorEndsTheWait)
+{
+  const auto result = ExportWith([](http_client::EventHandler &handler) {
+    handler.OnEvent(http_client::SessionState::WriteError, "");
+  });
+  EXPECT_EQ(result, opentelemetry::sdk::common::ExportResult::kFailure);
+}
+
+TEST_F(ElasticsearchLogsExporterSyncTests, SessionDestroyedWhilePendingEndsTheWait)
+{
+  const auto result = ExportWith([](http_client::EventHandler &handler) {
+    handler.OnEvent(http_client::SessionState::Destroyed, "");
+  });
+  EXPECT_EQ(result, opentelemetry::sdk::common::ExportResult::kFailure);
+}
+
+// The first outcome recorded is the one reported, so tearing the session down after a response has
+// arrived does not turn a successful export into a failure.
+TEST_F(ElasticsearchLogsExporterSyncTests, SessionDestroyedAfterAResponseKeepsTheSuccess)
+{
+  const auto result = ExportWith([](http_client::EventHandler &handler) {
+    FakeResponse response(200, kAcceptedBody);
+    handler.OnResponse(response);
+    handler.OnEvent(http_client::SessionState::Destroyed, "");
+  });
+  EXPECT_EQ(result, opentelemetry::sdk::common::ExportResult::kSuccess);
+}
+
+// Same rule for ReadError and WriteError, and the reason their error line is conditional:
+// reaching one of them says nothing on its own about the result Export() reports.
+TEST_F(ElasticsearchLogsExporterSyncTests, IoErrorAfterAResponseKeepsTheSuccess)
+{
+  for (const auto state :
+       {http_client::SessionState::ReadError, http_client::SessionState::WriteError})
+  {
+    const auto result = ExportWith([state](http_client::EventHandler &handler) {
+      FakeResponse response(200, kAcceptedBody);
+      handler.OnResponse(response);
+      handler.OnEvent(state, "");
+    });
+    EXPECT_EQ(result, opentelemetry::sdk::common::ExportResult::kSuccess);
+  }
+}
+
+// The mirror image, and the case where the error line is the only diagnostic the caller gets:
+// the I/O error is recorded first, so a response arriving afterwards does not rescue the export.
+TEST_F(ElasticsearchLogsExporterSyncTests, IoErrorBeforeAResponseKeepsTheFailure)
+{
+  for (const auto state :
+       {http_client::SessionState::ReadError, http_client::SessionState::WriteError})
+  {
+    SCOPED_TRACE(static_cast<int>(state));
+    const auto result = ExportWith([state](http_client::EventHandler &handler) {
+      handler.OnEvent(state, "");
+      FakeResponse response(200, kAcceptedBody);
+      handler.OnResponse(response);
+    });
+    EXPECT_EQ(result, opentelemetry::sdk::common::ExportResult::kFailure);
+  }
 }

--- a/exporters/elasticsearch/test/es_log_record_exporter_test.cc
+++ b/exporters/elasticsearch/test/es_log_record_exporter_test.cc
@@ -438,6 +438,133 @@ private:
 // Only the event that decided the outcome reports it. A terminal failure arriving after a response
 // has already succeeded would otherwise leave an export failure in the log that the caller was
 // never given, and the result alone cannot tell the two apart.
+// The states that end the wait in failure and say so. Destroyed is terminal too, but it reports
+// the end of the session rather than an error, so it is not in this table.
+struct ErrorTerminalState
+{
+  http_client::SessionState state;
+  const char *message;
+};
+
+const ErrorTerminalState kErrorTerminalStates[] = {
+    {http_client::SessionState::CreateFailed, "Failed to create session"},
+    {http_client::SessionState::ConnectFailed, "Failed to connect to peer"},
+    {http_client::SessionState::SendFailed, "Failed to send request"},
+    {http_client::SessionState::SSLHandshakeFailed, "Failed SSL Handshake"},
+    {http_client::SessionState::TimedOut, "Request timed out"},
+    {http_client::SessionState::NetworkError, "Network error"},
+    {http_client::SessionState::ReadError, "Read error"},
+    {http_client::SessionState::WriteError, "Write error"},
+    {http_client::SessionState::Cancelled, "(manually) cancelled"},
+};
+
+// Counts the exporter's own error lines, and returns the ones that carry a given message.
+std::size_t CountExporterErrors(const std::vector<std::string> &lines)
+{
+  std::size_t count = 0;
+  for (const auto &line : lines)
+  {
+    if (line.find("[ES Log Exporter]") != std::string::npos)
+    {
+      ++count;
+    }
+  }
+  return count;
+}
+
+// The winning side of the same rule. Without this, a recordCompletion that still records the
+// outcome but always answers "you did not decide it" passes every other case here while the
+// exporter goes silent about every failure it reports to its caller.
+TEST_F(ElasticsearchLogsExporterSyncTests, AWinningTerminalErrorIsReportedExactlyOnce)
+{
+  for (const auto &terminal : kErrorTerminalStates)
+  {
+    auto capturing = nostd::shared_ptr<internal_log::LogHandler>(new ErrorCapturingLogHandler());
+    const auto previous = internal_log::GlobalLogHandler::GetLogHandler();
+    internal_log::GlobalLogHandler::SetLogHandler(capturing);
+
+    const auto state = terminal.state;
+    const auto result =
+        ExportWith([state](http_client::EventHandler &handler) { handler.OnEvent(state, ""); });
+
+    const auto errors = static_cast<ErrorCapturingLogHandler *>(capturing.get())->errors();
+    internal_log::GlobalLogHandler::SetLogHandler(previous);
+
+    EXPECT_EQ(result, opentelemetry::sdk::common::ExportResult::kFailure)
+        << "state " << static_cast<int>(state) << " did not fail the export";
+    EXPECT_EQ(CountExporterErrors(errors), static_cast<std::size_t>(1))
+        << "state " << static_cast<int>(state) << " reported " << CountExporterErrors(errors)
+        << " times rather than once";
+    bool found = false;
+    for (const auto &line : errors)
+    {
+      if (line.find(terminal.message) != std::string::npos)
+      {
+        found = true;
+      }
+    }
+    EXPECT_TRUE(found) << "no line carried " << terminal.message;
+  }
+}
+
+// The shared curl client has reported more than one terminal event for one request, see #4360,
+// so which of two failures is described matters rather than only how many arrive.
+TEST_F(ElasticsearchLogsExporterSyncTests, OnlyTheFirstTerminalFailureIsReported)
+{
+  auto capturing      = nostd::shared_ptr<internal_log::LogHandler>(new ErrorCapturingLogHandler());
+  const auto previous = internal_log::GlobalLogHandler::GetLogHandler();
+  internal_log::GlobalLogHandler::SetLogHandler(capturing);
+
+  const auto result = ExportWith([](http_client::EventHandler &handler) {
+    handler.OnEvent(http_client::SessionState::ConnectFailed, "");
+    handler.OnEvent(http_client::SessionState::CreateFailed, "");
+    handler.OnEvent(http_client::SessionState::TimedOut, "");
+  });
+
+  const auto errors = static_cast<ErrorCapturingLogHandler *>(capturing.get())->errors();
+  internal_log::GlobalLogHandler::SetLogHandler(previous);
+
+  EXPECT_EQ(result, opentelemetry::sdk::common::ExportResult::kFailure);
+  EXPECT_EQ(CountExporterErrors(errors), static_cast<std::size_t>(1));
+  bool found_first = false;
+  for (const auto &line : errors)
+  {
+    if (line.find("Failed to connect to peer") != std::string::npos)
+    {
+      found_first = true;
+    }
+    EXPECT_EQ(line.find("Failed to create session"), std::string::npos)
+        << "a later failure described the outcome: " << line;
+  }
+  EXPECT_TRUE(found_first) << "the failure that decided the outcome was not the one reported";
+}
+
+// The losing side, over the same table rather than three of the nine.
+TEST_F(ElasticsearchLogsExporterSyncTests, NoTerminalErrorAfterAResponseIsReported)
+{
+  for (const auto &terminal : kErrorTerminalStates)
+  {
+    auto capturing = nostd::shared_ptr<internal_log::LogHandler>(new ErrorCapturingLogHandler());
+    const auto previous = internal_log::GlobalLogHandler::GetLogHandler();
+    internal_log::GlobalLogHandler::SetLogHandler(capturing);
+
+    const auto state  = terminal.state;
+    const auto result = ExportWith([state](http_client::EventHandler &handler) {
+      FakeResponse response(200, kAcceptedBody);
+      handler.OnResponse(response);
+      handler.OnEvent(state, "");
+    });
+
+    const auto errors = static_cast<ErrorCapturingLogHandler *>(capturing.get())->errors();
+    internal_log::GlobalLogHandler::SetLogHandler(previous);
+
+    EXPECT_EQ(result, opentelemetry::sdk::common::ExportResult::kSuccess)
+        << "state " << static_cast<int>(state) << " took the outcome from the response";
+    EXPECT_EQ(CountExporterErrors(errors), static_cast<std::size_t>(0))
+        << "state " << static_cast<int>(state) << " reported a failure the caller never saw";
+  }
+}
+
 TEST_F(ElasticsearchLogsExporterSyncTests, ALateTerminalFailureDoesNotClaimTheExportFailed)
 {
   auto capturing      = nostd::shared_ptr<internal_log::LogHandler>(new ErrorCapturingLogHandler());

--- a/exporters/elasticsearch/test/es_log_record_exporter_test.cc
+++ b/exporters/elasticsearch/test/es_log_record_exporter_test.cc
@@ -617,6 +617,7 @@ const ErrorTerminalState kErrorTerminalStates[] = {
     {http_client::SessionState::ReadError, "Read error"},
     {http_client::SessionState::WriteError, "Write error"},
     {http_client::SessionState::Cancelled, "(manually) cancelled"},
+    {http_client::SessionState::Destroyed, "Session destroyed before a response"},
 };
 
 // Counts the exporter's own error lines.

--- a/exporters/elasticsearch/test/es_log_record_exporter_test.cc
+++ b/exporters/elasticsearch/test/es_log_record_exporter_test.cc
@@ -24,6 +24,7 @@
 #include <cstddef>
 #include <cstdint>
 #include <functional>
+#include <future>
 #include <initializer_list>
 #include <mutex>
 #include <string>
@@ -347,6 +348,53 @@ private:
   EventScript script_;
 };
 
+// Keeps the handler and returns, so the export reaches its wait with nothing recorded and only a
+// notification can end it.
+class DeferredSession : public http_client::Session
+{
+public:
+  DeferredSession(std::shared_ptr<http_client::EventHandler> *slot, std::promise<void> *arrived)
+      : slot_(slot), arrived_(arrived)
+  {}
+
+  std::shared_ptr<http_client::Request> CreateRequest() noexcept override
+  {
+    return std::make_shared<FakeRequest>();
+  }
+  void SendRequest(std::shared_ptr<http_client::EventHandler> handler) noexcept override
+  {
+    *slot_ = std::move(handler);
+    arrived_->set_value();
+  }
+  bool IsSessionActive() noexcept override { return true; }
+  bool CancelSession() noexcept override { return true; }
+  bool FinishSession() noexcept override { return true; }
+
+private:
+  std::shared_ptr<http_client::EventHandler> *slot_;
+  std::promise<void> *arrived_;
+};
+
+class DeferredHttpClient : public http_client::HttpClient
+{
+public:
+  DeferredHttpClient(std::shared_ptr<http_client::EventHandler> *slot, std::promise<void> *arrived)
+      : slot_(slot), arrived_(arrived)
+  {}
+
+  std::shared_ptr<http_client::Session> CreateSession(nostd::string_view) noexcept override
+  {
+    return std::make_shared<DeferredSession>(slot_, arrived_);
+  }
+  bool CancelAllSessions() noexcept override { return true; }
+  bool FinishAllSessions() noexcept override { return true; }
+  void SetMaxSessionsPerConnection(std::size_t) noexcept override {}
+
+private:
+  std::shared_ptr<http_client::EventHandler> *slot_;
+  std::promise<void> *arrived_;
+};
+
 class FakeHttpClient : public http_client::HttpClient
 {
 public:
@@ -391,6 +439,80 @@ protected:
   }
 };
 }  // namespace
+
+namespace
+{
+// Runs one export on another thread against a session that keeps its handler, and hands back the
+// handler once the exporter has reached it. Everything is held by shared_ptr and the thread is
+// detached, because waitForResponse has no deadline: if a wake-up stops working the export never
+// returns, and joining it would hang the binary rather than fail the case.
+struct ParkedExport
+{
+  std::shared_ptr<DeferredHttpClient> client;
+  std::shared_ptr<logs_exporter::ElasticsearchLogRecordExporter> exporter;
+  std::shared_ptr<http_client::EventHandler> handler;
+  std::promise<void> arrived;
+  std::promise<opentelemetry::sdk::common::ExportResult> done;
+  std::future<opentelemetry::sdk::common::ExportResult> finished;
+};
+
+std::shared_ptr<ParkedExport> StartParkedExport()
+{
+  auto parked    = std::make_shared<ParkedExport>();
+  parked->client = std::make_shared<DeferredHttpClient>(&parked->handler, &parked->arrived);
+
+  logs_exporter::ElasticsearchExporterOptions options;
+  parked->exporter =
+      std::make_shared<logs_exporter::ElasticsearchLogRecordExporter>(options, parked->client);
+
+  auto reached  = parked->arrived.get_future();
+  auto finished = parked->done.get_future();
+
+  std::thread([parked] {
+    auto record = parked->exporter->MakeRecordable();
+    parked->done.set_value(
+        parked->exporter->Export(nostd::span<std::unique_ptr<sdklogs::Recordable>>(&record, 1)));
+  }).detach();
+
+  EXPECT_EQ(std::future_status::ready, reached.wait_for(std::chrono::seconds{5}))
+      << "the exporter never sent the request";
+  EXPECT_TRUE(parked->handler) << "the session was not given a handler";
+  EXPECT_EQ(std::future_status::timeout, finished.wait_for(std::chrono::milliseconds{100}))
+      << "the export returned without waiting for anything";
+
+  parked->finished = std::move(finished);
+  return parked;
+}
+}  // namespace
+
+// A terminal error delivered once the waiter is parked has to end the wait, which is the half the
+// notification is responsible for. Without these, removing cv_.notify_all() keeps this file green.
+TEST_F(ElasticsearchLogsExporterSyncTests, AReadErrorAfterTheWaiterParksWakesTheExport)
+{
+  auto parked = StartParkedExport();
+  ASSERT_TRUE(parked->handler);
+
+  parked->handler->OnEvent(http_client::SessionState::ReadError, "");
+
+  ASSERT_EQ(std::future_status::ready, parked->finished.wait_for(std::chrono::seconds{10}))
+      << "the read error never woke the export";
+  EXPECT_EQ(opentelemetry::sdk::common::ExportResult::kFailure, parked->finished.get());
+}
+
+// The same for the success half, which also holds that the wait is a wait: a waitForResponse that
+// only read the current state would answer before this response arrives.
+TEST_F(ElasticsearchLogsExporterSyncTests, AResponseAfterTheWaiterParksWakesTheExport)
+{
+  auto parked = StartParkedExport();
+  ASSERT_TRUE(parked->handler);
+
+  FakeResponse response(200, kAcceptedBody);
+  parked->handler->OnResponse(response);
+
+  ASSERT_EQ(std::future_status::ready, parked->finished.wait_for(std::chrono::seconds{10}))
+      << "the response never woke the export";
+  EXPECT_EQ(opentelemetry::sdk::common::ExportResult::kSuccess, parked->finished.get());
+}
 
 TEST_F(ElasticsearchLogsExporterSyncTests, ResponseRecordedBeforeTheWaitIsStillSeen)
 {
@@ -456,7 +578,7 @@ const ErrorTerminalState kErrorTerminalStates[] = {
     {http_client::SessionState::Cancelled, "(manually) cancelled"},
 };
 
-// Counts the exporter's own error lines, and returns the ones that carry a given message.
+// Counts the exporter's own error lines.
 std::size_t CountExporterErrors(const std::vector<std::string> &lines)
 {
   std::size_t count = 0;

--- a/exporters/elasticsearch/test/es_log_record_exporter_test.cc
+++ b/exporters/elasticsearch/test/es_log_record_exporter_test.cc
@@ -40,14 +40,15 @@ namespace http_client = opentelemetry::ext::http::client;
 // A response shaped like a successful Elasticsearch bulk reply: the exporter looks for
 // `"failed" : 0` in the body (see ElasticsearchLogRecordExporter::Export) in addition to the
 // status code before reporting success.
+constexpr const char *kDefaultAcceptedBody = R"({"errors": false, "failed" : 0})";
+
 class FakeResponse final : public http_client::Response
 {
 public:
-  FakeResponse()
-  {
-    static const std::string kSuccessBody = R"({"errors": false, "failed" : 0})";
-    body_.assign(kSuccessBody.begin(), kSuccessBody.end());
-  }
+  explicit FakeResponse(http_client::StatusCode status = 200,
+                        const std::string &body        = kDefaultAcceptedBody)
+      : status_(status), body_(body.begin(), body.end())
+  {}
 
   const http_client::Body &GetBody() const noexcept override { return body_; }
 
@@ -66,9 +67,10 @@ public:
     return true;
   }
 
-  http_client::StatusCode GetStatusCode() const noexcept override { return 200; }
+  http_client::StatusCode GetStatusCode() const noexcept override { return status_; }
 
 private:
+  http_client::StatusCode status_;
   http_client::Body body_;
 };
 
@@ -93,11 +95,24 @@ public:
   void SetRetryPolicy(const http_client::RetryPolicy &) noexcept override {}
 };
 
-// A session whose SendRequest() answers synchronously with a successful FakeResponse, so the
-// exporter's own wait for a response returns immediately without needing a real connection.
+// What the client does with a request, called from inside SendRequest() so the exporter's own
+// wait returns without needing a connection. The default answers once, successfully, which is
+// what a case wants when the response is not the thing under test.
+using EventScript = std::function<void(http_client::EventHandler &)>;
+
+EventScript AnswerSuccessfully()
+{
+  return [](http_client::EventHandler &handler) {
+    FakeResponse response;
+    handler.OnResponse(response);
+  };
+}
+
 class FakeSession final : public http_client::Session
 {
 public:
+  explicit FakeSession(EventScript script = AnswerSuccessfully()) : script_(std::move(script)) {}
+
   std::shared_ptr<http_client::Request> CreateRequest() noexcept override
   {
     return std::make_shared<FakeRequest>();
@@ -105,27 +120,34 @@ public:
 
   void SendRequest(std::shared_ptr<http_client::EventHandler> handler) noexcept override
   {
-    FakeResponse response;
-    handler->OnResponse(response);
+    script_(*handler);
   }
 
   bool IsSessionActive() noexcept override { return true; }
   bool CancelSession() noexcept override { return true; }
   bool FinishSession() noexcept override { return true; }
+
+private:
+  EventScript script_;
 };
 
 class FakeHttpClient final : public http_client::HttpClient
 {
 public:
+  explicit FakeHttpClient(EventScript script = AnswerSuccessfully()) : script_(std::move(script)) {}
+
   std::shared_ptr<http_client::Session> CreateSession(
       opentelemetry::nostd::string_view) noexcept override
   {
-    return std::make_shared<FakeSession>();
+    return std::make_shared<FakeSession>(script_);
   }
 
   bool CancelAllSessions() noexcept override { return true; }
   bool FinishAllSessions() noexcept override { return true; }
   void SetMaxSessionsPerConnection(std::size_t) noexcept override {}
+
+private:
+  EventScript script_;
 };
 
 }  // namespace
@@ -286,68 +308,6 @@ namespace http_client = opentelemetry::ext::http::client;
 constexpr const char *kAcceptedBody =
     R"({"took":30,"errors":false,"items":[{"index":{"_index":"logs","status":201,"_shards":{"failed" : 0}}}]})";
 
-class FakeResponse : public http_client::Response
-{
-public:
-  FakeResponse(http_client::StatusCode status, const std::string &body)
-      : status_(status), body_(body.begin(), body.end())
-  {}
-  const http_client::Body &GetBody() const noexcept override { return body_; }
-  bool ForEachHeader(
-      nostd::function_ref<bool(nostd::string_view, nostd::string_view)>) const noexcept override
-  {
-    return true;
-  }
-  bool ForEachHeader(
-      const nostd::string_view &,
-      nostd::function_ref<bool(nostd::string_view, nostd::string_view)>) const noexcept override
-  {
-    return true;
-  }
-  http_client::StatusCode GetStatusCode() const noexcept override { return status_; }
-
-private:
-  http_client::StatusCode status_;
-  http_client::Body body_;
-};
-
-class FakeRequest : public http_client::Request
-{
-public:
-  void SetMethod(http_client::Method) noexcept override {}
-  void SetUri(nostd::string_view) noexcept override {}
-  void SetSslOptions(const http_client::HttpSslOptions &) noexcept override {}
-  void SetBody(http_client::Body &) noexcept override {}
-  void AddHeader(nostd::string_view, nostd::string_view) noexcept override {}
-  void ReplaceHeader(nostd::string_view, nostd::string_view) noexcept override {}
-  void SetTimeoutMs(std::chrono::milliseconds) noexcept override {}
-  void SetCompression(const http_client::Compression &) noexcept override {}
-  void EnableLogging(bool) noexcept override {}
-  void SetRetryPolicy(const http_client::RetryPolicy &) noexcept override {}
-};
-
-using EventScript = std::function<void(http_client::EventHandler &)>;
-
-class FakeSession : public http_client::Session
-{
-public:
-  explicit FakeSession(EventScript script) : script_(std::move(script)) {}
-  std::shared_ptr<http_client::Request> CreateRequest() noexcept override
-  {
-    return std::make_shared<FakeRequest>();
-  }
-  void SendRequest(std::shared_ptr<http_client::EventHandler> handler) noexcept override
-  {
-    script_(*handler);
-  }
-  bool IsSessionActive() noexcept override { return false; }
-  bool CancelSession() noexcept override { return true; }
-  bool FinishSession() noexcept override { return true; }
-
-private:
-  EventScript script_;
-};
-
 // Keeps the handler and returns, so the export reaches its wait with nothing recorded and only a
 // notification can end it.
 class DeferredSession : public http_client::Session
@@ -393,22 +353,6 @@ public:
 
 private:
   std::promise<std::shared_ptr<http_client::EventHandler>> *arrived_;
-};
-
-class FakeHttpClient : public http_client::HttpClient
-{
-public:
-  explicit FakeHttpClient(EventScript script) : script_(std::move(script)) {}
-  std::shared_ptr<http_client::Session> CreateSession(nostd::string_view) noexcept override
-  {
-    return std::make_shared<FakeSession>(script_);
-  }
-  bool CancelAllSessions() noexcept override { return true; }
-  bool FinishAllSessions() noexcept override { return true; }
-  void SetMaxSessionsPerConnection(std::size_t) noexcept override {}
-
-private:
-  EventScript script_;
 };
 
 opentelemetry::sdk::common::ExportResult ExportWith(EventScript script)

--- a/exporters/elasticsearch/test/es_log_record_exporter_test.cc
+++ b/exporters/elasticsearch/test/es_log_record_exporter_test.cc
@@ -19,6 +19,7 @@
 
 #include <gtest/gtest.h>
 #include <array>
+#include <atomic>
 #include <chrono>
 #include <cstddef>
 #include <cstdint>
@@ -26,6 +27,7 @@
 #include <initializer_list>
 #include <mutex>
 #include <string>
+#include <thread>
 #include <utility>
 #include <vector>
 #include "nlohmann/json.hpp"
@@ -438,6 +440,8 @@ private:
 // Only the event that decided the outcome reports it. A terminal failure arriving after a response
 // has already succeeded would otherwise leave an export failure in the log that the caller was
 // never given, and the result alone cannot tell the two apart.
+namespace
+{
 // The states that end the wait in failure and say so. Destroyed is terminal too, but it reports
 // the end of the session rather than an error, so it is not in this table.
 struct ErrorTerminalState
@@ -471,6 +475,7 @@ std::size_t CountExporterErrors(const std::vector<std::string> &lines)
   }
   return count;
 }
+}  // namespace
 
 // The winning side of the same rule. Without this, a recordCompletion that still records the
 // outcome but always answers "you did not decide it" passes every other case here while the
@@ -537,6 +542,71 @@ TEST_F(ElasticsearchLogsExporterSyncTests, OnlyTheFirstTerminalFailureIsReported
         << "a later failure described the outcome: " << line;
   }
   EXPECT_TRUE(found_first) << "the failure that decided the outcome was not the one reported";
+}
+
+// Everything else here delivers its callbacks one after another from inside SendRequest(), which
+// covers a completion recorded before the waiter arrives but never two callbacks at once. This
+// releases a response and a read error together. Either may win, and the point is that the result
+// and the diagnostic never disagree about which one did.
+TEST_F(ElasticsearchLogsExporterSyncTests, AResponseRacingAReadErrorAgree)
+{
+  for (int attempt = 0; attempt < 50; ++attempt)
+  {
+    auto capturing = nostd::shared_ptr<internal_log::LogHandler>(new ErrorCapturingLogHandler());
+    const auto previous = internal_log::GlobalLogHandler::GetLogHandler();
+    internal_log::GlobalLogHandler::SetLogHandler(capturing);
+
+    const auto result = ExportWith([](http_client::EventHandler &handler) {
+      std::atomic<int> at_the_line{0};
+      // This orders where the two threads start, not the two calls that follow it, so those stay
+      // unordered with respect to each other and the exporter's own mutex is what has to hold.
+      auto wait_for_the_other = [&at_the_line] {
+        at_the_line.fetch_add(1, std::memory_order_acq_rel);
+        while (at_the_line.load(std::memory_order_acquire) < 2)
+        {
+          std::this_thread::yield();
+        }
+      };
+
+      std::thread responder([&handler, &wait_for_the_other] {
+        wait_for_the_other();
+        FakeResponse response(200, kAcceptedBody);
+        handler.OnResponse(response);
+      });
+      std::thread failer([&handler, &wait_for_the_other] {
+        wait_for_the_other();
+        handler.OnEvent(http_client::SessionState::ReadError, "");
+      });
+      responder.join();
+      failer.join();
+    });
+
+    const auto errors = static_cast<ErrorCapturingLogHandler *>(capturing.get())->errors();
+    internal_log::GlobalLogHandler::SetLogHandler(previous);
+
+    const auto reported = CountExporterErrors(errors);
+    if (result == opentelemetry::sdk::common::ExportResult::kSuccess)
+    {
+      EXPECT_EQ(reported, static_cast<std::size_t>(0))
+          << "the response won and a failure was reported anyway, attempt " << attempt;
+    }
+    else
+    {
+      EXPECT_EQ(result, opentelemetry::sdk::common::ExportResult::kFailure)
+          << "attempt " << attempt;
+      EXPECT_EQ(reported, static_cast<std::size_t>(1))
+          << "the read error won and was reported " << reported << " times, attempt " << attempt;
+      bool carried_the_reason = false;
+      for (const auto &line : errors)
+      {
+        if (line.find("Read error") != std::string::npos)
+        {
+          carried_the_reason = true;
+        }
+      }
+      EXPECT_TRUE(carried_the_reason) << "the failure was not described, attempt " << attempt;
+    }
+  }
 }
 
 // The losing side, over the same table rather than three of the nine.


### PR DESCRIPTION
Fixes #4330.

`ResponseHandler::OnEvent` records a completion for each session state that ends the session. `ReadError` and `WriteError` only log, so a client that reports either of them as its last event leaves the synchronous `Export()` waiting on its condition variable with nothing left to wake it. Two lines make those two behave like the other terminal states.

### What this does not change, and one question for you

The bundled curl client dispatches nine session states and neither of these is among them, so this changes nothing for callers who use it. It matters for the `HttpClient` that the exporter's constructor accepts.

Worth putting in front of you rather than burying: `otlp_http_client.cc` handles `ReadError` and `WriteError` exactly the way the Elasticsearch exporter does today, logging at debug and carrying on. After this change the two exporters treat them differently. The `SessionState` comments say only "error reading response" and "error writing request", so there is no stated contract either way. If you would rather the two exporters stayed consistent, the alternative is to leave this alone and bound the wait instead, and I am happy to close this and open that one.

### Evidence

Removing just the two `recordCompletion()` calls and rebuilding:

| case | without the fix |
| --- | --- |
| `ReadErrorEndsTheWait` | never returns, killed at 15s |
| `WriteErrorEndsTheWait` | never returns, killed at 15s |
| `AReadErrorAfterTheHandoffEndsTheExport` | fails |
| `IoErrorBeforeAResponseKeepsTheFailure` | fails, `kSuccess` where `kFailure` is expected |
| `ProgressStatesDoNotDecideTheResult`, both `SessionDestroyed` cases | still pass |

With the fix, the synchronous build runs 14 tests green and the async build skips the 11 that need the synchronous wait. The CTest timeout is there because a regression in this area stalls the job instead of failing an assertion.

### What moved out

This pull request previously also made every terminal log line conditional on winning the completion race, and added an error line when a session is destroyed before a response arrives. That half needs a log-capturing fixture, it is a separate behaviour, and it is the reason the diff was four times this size. It is out, and I will open it separately once this one is settled. What is left is the two lines the title describes.

Verified locally: CMake in both the synchronous and async configurations with maintainer mode, Bazel, clang-format, cmake-format against the repository config, and markdownlint 0.46.0.
