### PR TITLE
[OTLP EXPORTERS] add otlp_common target for shared otlp utils 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,9 @@ Increment the:
 * [BUG] Stop reading past a `nostd::string_view` that is not NUL terminated
   [#4346](https://github.com/open-telemetry/opentelemetry-cpp/pull/4346)
 
+* [OTLP EXPORTERS] add otlp_common target for shared otlp utils
+  [#4333](https://github.com/open-telemetry/opentelemetry-cpp/pull/4333)
+
 * [OTLP/HTTP] Honor `Retry-After` response header when retrying exports,
   supporting both delay-seconds and HTTP-date formats per RFC 7231 §7.1.3.
   [#4172](https://github.com/open-telemetry/opentelemetry-cpp/issues/4172)

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -252,7 +252,8 @@ build configuration.
 | **exporters_ostream**      | opentelemetry-cpp::ostream_log_record_exporter                                                   |
 |                            | opentelemetry-cpp::ostream_metrics_exporter                                                      |
 |                            | opentelemetry-cpp::ostream_span_exporter                                                         |
-| **exporters_otlp_common**  | opentelemetry-cpp::proto                                                                         |
+| **exporters_otlp_common**  | opentelemetry-cpp::otlp_common                                                                   |
+|                            | opentelemetry-cpp::proto                                                                         |
 |                            | opentelemetry-cpp::otlp_recordable                                                               |
 | **exporters_otlp_file**    | opentelemetry-cpp::otlp_file_client                                                              |
 |                            | opentelemetry-cpp::otlp_file_exporter                                                            |

--- a/cmake/templates/opentelemetry-cpp-config.cmake.in
+++ b/cmake/templates/opentelemetry-cpp-config.cmake.in
@@ -108,6 +108,7 @@
 #   opentelemetry-cpp::ostream_metrics_exporter          - Imported target of COMPONENT exporters_ostream
 #   opentelemetry-cpp::ostream_span_exporter             - Imported target of COMPONENT exporters_ostream
 #   opentelemetry-cpp::proto                             - Imported target of COMPONENT exporters_otlp_common
+#   opentelemetry-cpp::otlp_common                       - Imported target of COMPONENT exporters_otlp_common
 #   opentelemetry-cpp::otlp_recordable                   - Imported target of COMPONENT exporters_otlp_common
 #   opentelemetry-cpp::otlp_file_client                  - Imported target of COMPONENT exporters_otlp_file
 #   opentelemetry-cpp::otlp_file_exporter                - Imported target of COMPONENT exporters_otlp_file

--- a/exporters/otlp/BUILD
+++ b/exporters/otlp/BUILD
@@ -22,9 +22,24 @@ cc_library(
 )
 
 cc_library(
-    name = "otlp_recordable",
+    name = "otlp_common",
     srcs = [
         "src/otlp_environment.cc",
+    ],
+    hdrs = [
+        "include/opentelemetry/exporters/otlp/otlp_environment.h",
+    ],
+    strip_include_prefix = "include",
+    tags = ["otlp"],
+    deps = [
+        "//api",
+        "//sdk/src/common:env_variables",
+    ],
+)
+
+cc_library(
+    name = "otlp_recordable",
+    srcs = [
         "src/otlp_log_recordable.cc",
         "src/otlp_metric_utils.cc",
         "src/otlp_populate_attribute_utils.cc",
@@ -32,7 +47,6 @@ cc_library(
         "src/otlp_recordable_utils.cc",
     ],
     hdrs = [
-        "include/opentelemetry/exporters/otlp/otlp_environment.h",
         "include/opentelemetry/exporters/otlp/otlp_log_recordable.h",
         "include/opentelemetry/exporters/otlp/otlp_metric_utils.h",
         "include/opentelemetry/exporters/otlp/otlp_populate_attribute_utils.h",
@@ -98,6 +112,7 @@ cc_library(
         "otlp_grpc",
     ],
     deps = [
+        ":otlp_common",
         "//ext:headers",
         "//sdk/src/common:global_log_handler",
         "@com_github_grpc_grpc//:grpc++",
@@ -144,6 +159,7 @@ cc_library(
         "otlp_grpc",
     ],
     deps = [
+        ":otlp_common",
         ":otlp_recordable",
         ":otlp_grpc_client",
         "//ext:headers",
@@ -237,6 +253,7 @@ cc_library(
         "otlp_http",
     ],
     deps = [
+        ":otlp_common",
         ":otlp_http_client",
         ":otlp_recordable",
         "//sdk/src/trace",
@@ -313,6 +330,7 @@ cc_library(
         "otlp_file",
     ],
     deps = [
+        ":otlp_common",
         ":otlp_file_client",
         ":otlp_recordable",
         "//sdk/src/trace",
@@ -361,6 +379,7 @@ cc_library(
         "otlp_grpc_metric",
     ],
     deps = [
+        ":otlp_common",
         ":otlp_recordable",
         ":otlp_grpc_client",
         "//ext:headers",
@@ -413,6 +432,7 @@ cc_library(
         "otlp_http_metric",
     ],
     deps = [
+        ":otlp_common",
         ":otlp_http_client",
         ":otlp_recordable",
         "//sdk/src/metrics",
@@ -461,6 +481,7 @@ cc_library(
         "otlp_file_metric",
     ],
     deps = [
+        ":otlp_common",
         ":otlp_file_client",
         ":otlp_recordable",
         "//sdk/src/metrics",
@@ -509,6 +530,7 @@ cc_library(
         "otlp_http_log",
     ],
     deps = [
+        ":otlp_common",
         ":otlp_http_client",
         ":otlp_recordable",
         "//sdk/src/logs",
@@ -557,6 +579,7 @@ cc_library(
         "otlp_file_log",
     ],
     deps = [
+        ":otlp_common",
         ":otlp_file_client",
         ":otlp_recordable",
         "//sdk/src/logs",
@@ -606,6 +629,7 @@ cc_library(
         "otlp_grpc_log",
     ],
     deps = [
+        ":otlp_common",
         ":otlp_recordable",
         ":otlp_grpc_client",
         "//ext:headers",

--- a/exporters/otlp/CMakeLists.txt
+++ b/exporters/otlp/CMakeLists.txt
@@ -10,18 +10,33 @@ else()
 endif()
 
 #
+# opentelemetry_otlp_common
+#
+
+add_library(opentelemetry_otlp_common ${OPENTELEMETRY_OTLP_TARGETS_LIB_TYPE}
+                                      src/otlp_environment.cc)
+set_target_properties(opentelemetry_otlp_common PROPERTIES EXPORT_NAME
+                                                           otlp_common)
+set_target_version(opentelemetry_otlp_common)
+
+target_include_directories(
+  opentelemetry_otlp_common
+  PUBLIC "$<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}/include>"
+         "$<INSTALL_INTERFACE:include>")
+
+target_link_libraries(opentelemetry_otlp_common PUBLIC opentelemetry_common)
+
+set(OPENTELEMETRY_OTLP_TARGETS opentelemetry_otlp_common)
+
+#
 # opentelemetry_otlp_recordable
 #
 
 add_library(
   opentelemetry_otlp_recordable
-  ${OPENTELEMETRY_OTLP_TARGETS_LIB_TYPE}
-  src/otlp_environment.cc
-  src/otlp_log_recordable.cc
-  src/otlp_recordable.cc
-  src/otlp_populate_attribute_utils.cc
-  src/otlp_recordable_utils.cc
-  src/otlp_metric_utils.cc)
+  ${OPENTELEMETRY_OTLP_TARGETS_LIB_TYPE} src/otlp_log_recordable.cc
+  src/otlp_recordable.cc src/otlp_populate_attribute_utils.cc
+  src/otlp_recordable_utils.cc src/otlp_metric_utils.cc)
 set_target_properties(opentelemetry_otlp_recordable PROPERTIES EXPORT_NAME
                                                                otlp_recordable)
 set_target_version(opentelemetry_otlp_recordable)
@@ -31,18 +46,16 @@ target_include_directories(
   PUBLIC "$<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}/include>"
          "$<INSTALL_INTERFACE:include>")
 
-set(OPENTELEMETRY_OTLP_TARGETS opentelemetry_otlp_recordable)
+list(APPEND OPENTELEMETRY_OTLP_TARGETS opentelemetry_otlp_recordable)
+
+target_link_libraries(opentelemetry_otlp_recordable
+                      PUBLIC opentelemetry_logs opentelemetry_metrics)
 
 if(WITH_OTLP_UTF8_VALIDITY AND TARGET utf8_range::utf8_validity)
-  target_link_libraries(
-    opentelemetry_otlp_recordable
-    PUBLIC opentelemetry_logs opentelemetry_metrics
-    PRIVATE utf8_range::utf8_validity)
+  target_link_libraries(opentelemetry_otlp_recordable
+                        PRIVATE utf8_range::utf8_validity)
   target_compile_definitions(opentelemetry_otlp_recordable
                              PRIVATE ENABLE_OTLP_UTF8_VALIDITY)
-else()
-  target_link_libraries(opentelemetry_otlp_recordable
-                        PUBLIC opentelemetry_logs opentelemetry_metrics)
 endif()
 
 #
@@ -65,6 +78,11 @@ target_link_libraries(opentelemetry_exporter_otlp_builder_utils
                       PUBLIC opentelemetry_otlp_recordable)
 
 if(OPENTELEMETRY_INSTALL)
+  opentelemetry_add_pkgconfig(
+    otlp_common "OpenTelemetry OTLP - Common"
+    "Common environment variable reading for OTLP exporters."
+    "opentelemetry_common")
+
   opentelemetry_add_pkgconfig(
     otlp_recordable
     "OpenTelemetry OTLP - Recordable"
@@ -109,7 +127,7 @@ if(WITH_OTLP_GRPC)
   # targets that depend on opentelemetry_proto_grpc.
   target_link_libraries(
     opentelemetry_exporter_otlp_grpc_client
-    PUBLIC opentelemetry_sdk opentelemetry_common
+    PUBLIC opentelemetry_common opentelemetry_otlp_common
            # gRPC::grpc++ must be linked before opentelemetry_proto_grpc.
            "$<BUILD_INTERFACE:opentelemetry_proto_grpc>"
     PRIVATE "$<INSTALL_INTERFACE:opentelemetry_proto_grpc>" gRPC::grpc++
@@ -145,7 +163,7 @@ if(WITH_OTLP_GRPC)
 
   target_link_libraries(
     opentelemetry_exporter_otlp_grpc
-    PUBLIC opentelemetry_otlp_recordable
+    PUBLIC opentelemetry_otlp_common opentelemetry_otlp_recordable
            opentelemetry_exporter_otlp_grpc_client)
 
   list(APPEND OPENTELEMETRY_OTLP_GRPC_TARGETS opentelemetry_exporter_otlp_grpc)
@@ -186,7 +204,7 @@ if(WITH_OTLP_GRPC)
 
   target_link_libraries(
     opentelemetry_exporter_otlp_grpc_log
-    PUBLIC opentelemetry_otlp_recordable
+    PUBLIC opentelemetry_otlp_common opentelemetry_otlp_recordable
            opentelemetry_exporter_otlp_grpc_client)
 
   list(APPEND OPENTELEMETRY_OTLP_GRPC_TARGETS
@@ -229,7 +247,7 @@ if(WITH_OTLP_GRPC)
 
   target_link_libraries(
     opentelemetry_exporter_otlp_grpc_metrics
-    PUBLIC opentelemetry_otlp_recordable
+    PUBLIC opentelemetry_otlp_common opentelemetry_otlp_recordable
            opentelemetry_exporter_otlp_grpc_client)
 
   list(APPEND OPENTELEMETRY_OTLP_GRPC_TARGETS
@@ -262,9 +280,11 @@ if(WITH_OTLP_GRPC)
       "gRPC client for OTLP protocol." "opentelemetry_api opentelemetry_common")
 
     opentelemetry_add_pkgconfig(
-      exporter_otlp_grpc "OpenTelemetry OTLP - gRPC Span Exporter"
+      exporter_otlp_grpc
+      "OpenTelemetry OTLP - gRPC Span Exporter"
       "Exports trace spans via OTLP gRPC."
-      "opentelemetry_otlp_recordable opentelemetry_exporter_otlp_grpc_client")
+      "opentelemetry_otlp_common opentelemetry_otlp_recordable opentelemetry_exporter_otlp_grpc_client"
+    )
 
     opentelemetry_add_pkgconfig(
       exporter_otlp_grpc_builder
@@ -274,9 +294,11 @@ if(WITH_OTLP_GRPC)
     )
 
     opentelemetry_add_pkgconfig(
-      exporter_otlp_grpc_log "OpenTelemetry OTLP - gRPC Log Exporter"
+      exporter_otlp_grpc_log
+      "OpenTelemetry OTLP - gRPC Log Exporter"
       "Exports log records via OTLP gRPC."
-      "opentelemetry_otlp_recordable opentelemetry_exporter_otlp_grpc_client")
+      "opentelemetry_otlp_common opentelemetry_otlp_recordable opentelemetry_exporter_otlp_grpc_client"
+    )
 
     opentelemetry_add_pkgconfig(
       exporter_otlp_grpc_log_builder
@@ -286,9 +308,11 @@ if(WITH_OTLP_GRPC)
     )
 
     opentelemetry_add_pkgconfig(
-      exporter_otlp_grpc_metrics "OpenTelemetry OTLP - gRPC Metric Exporter"
+      exporter_otlp_grpc_metrics
+      "OpenTelemetry OTLP - gRPC Metric Exporter"
       "Exports metrics via OTLP gRPC."
-      "opentelemetry_otlp_recordable opentelemetry_exporter_otlp_grpc_client")
+      "opentelemetry_otlp_common opentelemetry_otlp_recordable opentelemetry_exporter_otlp_grpc_client"
+    )
 
     opentelemetry_add_pkgconfig(
       exporter_otlp_grpc_metric_builder
@@ -316,8 +340,7 @@ if(WITH_OTLP_HTTP)
 
   target_link_libraries(
     opentelemetry_exporter_otlp_http_client
-    PUBLIC opentelemetry_sdk opentelemetry_ext
-           "$<BUILD_INTERFACE:opentelemetry_proto>"
+    PUBLIC opentelemetry_ext "$<BUILD_INTERFACE:opentelemetry_proto>"
     PRIVATE "$<INSTALL_INTERFACE:opentelemetry_proto>"
             "$<BUILD_INTERFACE:nlohmann_json::nlohmann_json>")
 
@@ -349,7 +372,7 @@ if(WITH_OTLP_HTTP)
 
   target_link_libraries(
     opentelemetry_exporter_otlp_http
-    PUBLIC opentelemetry_otlp_recordable
+    PUBLIC opentelemetry_otlp_common opentelemetry_otlp_recordable
            opentelemetry_exporter_otlp_http_client)
 
   list(APPEND OPENTELEMETRY_OTLP_HTTP_TARGETS opentelemetry_exporter_otlp_http)
@@ -390,7 +413,7 @@ if(WITH_OTLP_HTTP)
 
   target_link_libraries(
     opentelemetry_exporter_otlp_http_log
-    PUBLIC opentelemetry_otlp_recordable
+    PUBLIC opentelemetry_otlp_common opentelemetry_otlp_recordable
            opentelemetry_exporter_otlp_http_client)
 
   list(APPEND OPENTELEMETRY_OTLP_HTTP_TARGETS
@@ -433,7 +456,7 @@ if(WITH_OTLP_HTTP)
 
   target_link_libraries(
     opentelemetry_exporter_otlp_http_metric
-    PUBLIC opentelemetry_otlp_recordable
+    PUBLIC opentelemetry_otlp_common opentelemetry_otlp_recordable
            opentelemetry_exporter_otlp_http_client)
 
   list(APPEND OPENTELEMETRY_OTLP_HTTP_TARGETS
@@ -466,9 +489,11 @@ if(WITH_OTLP_HTTP)
       "HTTP client for OTLP protocol." "opentelemetry_api")
 
     opentelemetry_add_pkgconfig(
-      exporter_otlp_http "OpenTelemetry OTLP - HTTP Span Exporter"
+      exporter_otlp_http
+      "OpenTelemetry OTLP - HTTP Span Exporter"
       "Exports trace spans via OTLP HTTP."
-      "opentelemetry_otlp_recordable opentelemetry_exporter_otlp_http_client")
+      "opentelemetry_otlp_common opentelemetry_otlp_recordable opentelemetry_exporter_otlp_http_client"
+    )
 
     opentelemetry_add_pkgconfig(
       exporter_otlp_http_builder
@@ -478,9 +503,11 @@ if(WITH_OTLP_HTTP)
     )
 
     opentelemetry_add_pkgconfig(
-      exporter_otlp_http_log "OpenTelemetry OTLP - HTTP Log Exporter"
+      exporter_otlp_http_log
+      "OpenTelemetry OTLP - HTTP Log Exporter"
       "Exports log records via OTLP HTTP."
-      "opentelemetry_otlp_recordable opentelemetry_exporter_otlp_http_client")
+      "opentelemetry_otlp_common opentelemetry_otlp_recordable opentelemetry_exporter_otlp_http_client"
+    )
 
     opentelemetry_add_pkgconfig(
       exporter_otlp_http_log_builder
@@ -490,9 +517,11 @@ if(WITH_OTLP_HTTP)
     )
 
     opentelemetry_add_pkgconfig(
-      exporter_otlp_http_metric "OpenTelemetry OTLP - HTTP Metric Exporter"
+      exporter_otlp_http_metric
+      "OpenTelemetry OTLP - HTTP Metric Exporter"
       "Exports metrics via OTLP HTTP."
-      "opentelemetry_otlp_recordable opentelemetry_exporter_otlp_http_client")
+      "opentelemetry_otlp_common opentelemetry_otlp_recordable opentelemetry_exporter_otlp_http_client"
+    )
 
     opentelemetry_add_pkgconfig(
       exporter_otlp_http_metric_builder
@@ -546,7 +575,7 @@ if(WITH_OTLP_FILE)
 
   target_link_libraries(
     opentelemetry_exporter_otlp_file
-    PUBLIC opentelemetry_otlp_recordable
+    PUBLIC opentelemetry_otlp_common opentelemetry_otlp_recordable
            opentelemetry_exporter_otlp_file_client)
 
   list(APPEND OPENTELEMETRY_OTLP_FILE_TARGETS opentelemetry_exporter_otlp_file)
@@ -587,7 +616,7 @@ if(WITH_OTLP_FILE)
 
   target_link_libraries(
     opentelemetry_exporter_otlp_file_log
-    PUBLIC opentelemetry_otlp_recordable
+    PUBLIC opentelemetry_otlp_common opentelemetry_otlp_recordable
            opentelemetry_exporter_otlp_file_client)
 
   list(APPEND OPENTELEMETRY_OTLP_FILE_TARGETS
@@ -630,7 +659,7 @@ if(WITH_OTLP_FILE)
 
   target_link_libraries(
     opentelemetry_exporter_otlp_file_metric
-    PUBLIC opentelemetry_otlp_recordable
+    PUBLIC opentelemetry_otlp_common opentelemetry_otlp_recordable
            opentelemetry_exporter_otlp_file_client)
 
   list(APPEND OPENTELEMETRY_OTLP_FILE_TARGETS
@@ -663,9 +692,11 @@ if(WITH_OTLP_FILE)
       "File client for OTLP protocol." "opentelemetry_api opentelemetry_common")
 
     opentelemetry_add_pkgconfig(
-      exporter_otlp_file "OpenTelemetry OTLP - File Span Exporter"
+      exporter_otlp_file
+      "OpenTelemetry OTLP - File Span Exporter"
       "Exports trace spans to file via OTLP."
-      "opentelemetry_otlp_recordable opentelemetry_exporter_otlp_file_client")
+      "opentelemetry_otlp_common opentelemetry_otlp_recordable opentelemetry_exporter_otlp_file_client"
+    )
 
     opentelemetry_add_pkgconfig(
       exporter_otlp_file_builder
@@ -675,9 +706,11 @@ if(WITH_OTLP_FILE)
     )
 
     opentelemetry_add_pkgconfig(
-      exporter_otlp_file_log "OpenTelemetry OTLP - File Log Exporter"
+      exporter_otlp_file_log
+      "OpenTelemetry OTLP - File Log Exporter"
       "Exports log records to file via OTLP."
-      "opentelemetry_otlp_recordable opentelemetry_exporter_otlp_file_client")
+      "opentelemetry_otlp_common opentelemetry_otlp_recordable opentelemetry_exporter_otlp_file_client"
+    )
 
     opentelemetry_add_pkgconfig(
       exporter_otlp_file_log_builder
@@ -687,9 +720,11 @@ if(WITH_OTLP_FILE)
     )
 
     opentelemetry_add_pkgconfig(
-      exporter_otlp_file_metric "OpenTelemetry OTLP - File Metric Exporter"
+      exporter_otlp_file_metric
+      "OpenTelemetry OTLP - File Metric Exporter"
       "Exports metrics to file via OTLP."
-      "opentelemetry_otlp_recordable opentelemetry_exporter_otlp_file_client")
+      "opentelemetry_otlp_common opentelemetry_otlp_recordable opentelemetry_exporter_otlp_file_client"
+    )
 
     opentelemetry_add_pkgconfig(
       exporter_otlp_file_metric_builder
@@ -709,6 +744,7 @@ otel_add_component(
   COMPONENT
   exporters_otlp_common
   TARGETS
+  opentelemetry_otlp_common
   opentelemetry_otlp_recordable
   opentelemetry_proto
   FILES_DIRECTORY

--- a/install/test/cmake/component_tests/exporters_otlp_common/CMakeLists.txt
+++ b/install/test/cmake/component_tests/exporters_otlp_common/CMakeLists.txt
@@ -17,7 +17,7 @@ add_executable(exporters_otlp_common_test
                ${INSTALL_TEST_SRC_DIR}/test_exporters_otlp_common.cc)
 target_link_libraries(
   exporters_otlp_common_test
-  PRIVATE opentelemetry-cpp::proto opentelemetry-cpp::otlp_recordable
-          GTest::gtest GTest::gtest_main)
+  PRIVATE opentelemetry-cpp::otlp_common opentelemetry-cpp::proto
+          opentelemetry-cpp::otlp_recordable GTest::gtest GTest::gtest_main)
 
 gtest_discover_tests(exporters_otlp_common_test)

--- a/install/test/cmake/fetch_content_test/CMakeLists.txt
+++ b/install/test/cmake/fetch_content_test/CMakeLists.txt
@@ -91,6 +91,8 @@ target_link_libraries(
           opentelemetry-cpp::ostream_metrics_exporter_builder
           opentelemetry-cpp::ostream_span_exporter
           opentelemetry-cpp::ostream_span_exporter_builder
+          opentelemetry-cpp::otlp_common
+          opentelemetry-cpp::otlp_recordable
           opentelemetry-cpp::otlp_file_exporter
           opentelemetry-cpp::otlp_file_exporter_builder
           opentelemetry-cpp::otlp_file_log_record_exporter

--- a/install/test/src/test_exporters_otlp_common.cc
+++ b/install/test/src/test_exporters_otlp_common.cc
@@ -17,6 +17,7 @@
 #include "opentelemetry/exporters/otlp/protobuf_include_suffix.h"  // IWYU pragma: keep
 // clang-format on
 
+#include <opentelemetry/exporters/otlp/otlp_environment.h>
 #include <opentelemetry/exporters/otlp/otlp_log_recordable.h>
 #include <opentelemetry/exporters/otlp/otlp_metric_utils.h>
 #include <opentelemetry/exporters/otlp/otlp_recordable.h>
@@ -57,6 +58,11 @@ static metrics_sdk::MetricData CreateSumAggregationData()
   point_data_attr.push_back(point_data_attr_2);
   data.point_data_attr_ = std::move(point_data_attr);
   return data;
+}
+
+TEST(ExportersOtlpCommon, OtlpEnvironmentDefaults)
+{
+  EXPECT_FALSE(otlp_exporter::GetOtlpDefaultGrpcTracesEndpoint().empty());
 }
 
 TEST(ExportersOtlpCommon, OtlpSpanRecordable)


### PR DESCRIPTION
Contributes to #4239 and #4249

Adds an otlp_common target/library to hold the common utilities (just otlp_envornment.<h,cc> for now). 

## Changes

- update cmake and bazel build scripts to create opentelemetry-cpp::otlp_common 
- update the docs to add the new target. 
- update the cmake install test to cover the new target. 

For significant contributions please make sure you have completed the following items:

* [x] `CHANGELOG.md` updated for non-trivial changes
* [ ] Unit tests have been added
* [ ] Changes in public API reviewed