### PR TITLE
[CONFIGURATION] file configuration - yaml schema 1.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -89,6 +89,9 @@ Increment the:
 * [SDK] Implement the ProbabilitySampler
   [#4135](https://github.com/open-telemetry/opentelemetry-cpp/pull/4135)
 
+* [CONFIGURATION] file configuration - yaml schema 1.1.0
+  [#4340](https://github.com/open-telemetry/opentelemetry-cpp/pull/4340)
+
 Breaking changes:
 
 * [METRICS SDK] Rename Base2 Exponential Histogram Aggregation config field

--- a/exporters/prometheus/src/prometheus_pull_builder.cc
+++ b/exporters/prometheus/src/prometheus_pull_builder.cc
@@ -65,10 +65,10 @@ std::unique_ptr<opentelemetry::sdk::metrics::MetricReader> PrometheusPullBuilder
       break;
   }
 
-  if (model->with_resource_constant_labels != nullptr)
+  if (model->resource_constant_labels != nullptr)
   {
-    // FIXME: with_resource_constant_labels
-    OTEL_INTERNAL_LOG_WARN("[Prometheus Exporter] with_resource_constant_labels not supported");
+    // FIXME: resource_constant_labels
+    OTEL_INTERNAL_LOG_WARN("[Prometheus Exporter] resource_constant_labels not supported");
   }
 
   return PrometheusExporterFactory::Create(options);

--- a/exporters/prometheus/src/prometheus_pull_builder.cc
+++ b/exporters/prometheus/src/prometheus_pull_builder.cc
@@ -39,7 +39,7 @@ std::unique_ptr<opentelemetry::sdk::metrics::MetricReader> PrometheusPullBuilder
 
   options.url                  = url;
   options.populate_target_info = model->target_info_enabled;
-  options.without_otel_scope   = model->scope_info_enabled;
+  options.without_otel_scope   = !model->scope_info_enabled;
 
   switch (model->translation_strategy)
   {

--- a/exporters/prometheus/src/prometheus_pull_builder.cc
+++ b/exporters/prometheus/src/prometheus_pull_builder.cc
@@ -38,8 +38,8 @@ std::unique_ptr<opentelemetry::sdk::metrics::MetricReader> PrometheusPullBuilder
   url.append(std::to_string(model->port));
 
   options.url                  = url;
-  options.populate_target_info = !model->without_target_info;
-  options.without_otel_scope   = model->without_scope_info;
+  options.populate_target_info = model->target_info_enabled;
+  options.without_otel_scope   = model->scope_info_enabled;
 
   switch (model->translation_strategy)
   {

--- a/functional/configuration/shelltests/prometheus_translation_no.test
+++ b/functional/configuration/shelltests/prometheus_translation_no.test
@@ -5,6 +5,6 @@ $ example_yaml --test --yaml shelltests/prometheus_translation_no.yaml
 >
 MODEL PARSED
 [WARNING] [Prometheus Exporter] NoTranslation not supported
-[WARNING] [Prometheus Exporter] with_resource_constant_labels not supported
+[WARNING] [Prometheus Exporter] resource_constant_labels not supported
 SDK CREATED
 >= 0

--- a/install/test/src/test_exporters_prometheus_builder.cc
+++ b/install/test/src/test_exporters_prometheus_builder.cc
@@ -13,7 +13,7 @@ TEST(ExportersPrometheusBuilderInstall, PrometheusPullBuilder)
   opentelemetry::sdk::configuration::PrometheusPullMetricExporterConfiguration model;
   model.host               = "localhost";
   model.port               = 1234;
-  model.without_scope_info = false;
+  model.scope_info_enabled = true;
 
   auto exporter = builder->Build(&model);
   ASSERT_TRUE(exporter != nullptr);

--- a/sdk/include/opentelemetry/sdk/configuration/prometheus_pull_metric_exporter_configuration.h
+++ b/sdk/include/opentelemetry/sdk/configuration/prometheus_pull_metric_exporter_configuration.h
@@ -27,7 +27,7 @@ public:
   static constexpr const char *kDefaultHost       = "localhost";
   static constexpr std::size_t kDefaultPort       = 9464;
   static constexpr bool kDefaultScopeInfoEnabled  = true;
-  static constexpr bool kDefaultTargetInfoEnabled = false;
+  static constexpr bool kDefaultTargetInfoEnabled = true;
   static constexpr TranslationStrategy kDefaultTranslationStrategy =
       TranslationStrategy::UnderscoreEscapingWithSuffixes;
 
@@ -40,7 +40,7 @@ public:
   std::size_t port{kDefaultPort};
   bool scope_info_enabled{kDefaultScopeInfoEnabled};
   bool target_info_enabled{kDefaultTargetInfoEnabled};
-  std::unique_ptr<IncludeExcludeConfiguration> with_resource_constant_labels;
+  std::unique_ptr<IncludeExcludeConfiguration> resource_constant_labels;
   TranslationStrategy translation_strategy{kDefaultTranslationStrategy};
 };
 

--- a/sdk/include/opentelemetry/sdk/configuration/prometheus_pull_metric_exporter_configuration.h
+++ b/sdk/include/opentelemetry/sdk/configuration/prometheus_pull_metric_exporter_configuration.h
@@ -26,8 +26,8 @@ class PrometheusPullMetricExporterConfiguration : public PullMetricExporterConfi
 public:
   static constexpr const char *kDefaultHost       = "localhost";
   static constexpr std::size_t kDefaultPort       = 9464;
-  static constexpr bool kDefaultWithoutScopeInfo  = false;  // schema: scope_info_enabled=true
-  static constexpr bool kDefaultWithoutTargetInfo = false;  // schema: target_info_enabled=true
+  static constexpr bool kDefaultScopeInfoEnabled  = true;
+  static constexpr bool kDefaultTargetInfoEnabled = false;
   static constexpr TranslationStrategy kDefaultTranslationStrategy =
       TranslationStrategy::UnderscoreEscapingWithSuffixes;
 
@@ -38,8 +38,8 @@ public:
 
   std::string host{kDefaultHost};
   std::size_t port{kDefaultPort};
-  bool without_scope_info{kDefaultWithoutScopeInfo};
-  bool without_target_info{kDefaultWithoutTargetInfo};
+  bool scope_info_enabled{kDefaultScopeInfoEnabled};
+  bool target_info_enabled{kDefaultTargetInfoEnabled};
   std::unique_ptr<IncludeExcludeConfiguration> with_resource_constant_labels;
   TranslationStrategy translation_strategy{kDefaultTranslationStrategy};
 };

--- a/sdk/src/configuration/configuration_parser.cc
+++ b/sdk/src/configuration/configuration_parser.cc
@@ -933,9 +933,9 @@ ConfigurationParser::ParsePrometheusPullMetricExporterConfiguration(
   model->host = node->GetString("host", Config::kDefaultHost);
   model->port = node->GetInteger("port", Config::kDefaultPort);
 
-  // Properties renamed in schema 1.1.0
   if ((version_major_ == 1) && (version_minor_ >= 1))
   {
+    // Properties renamed in schema 1.1.0
     model->scope_info_enabled =
         node->GetBoolean("scope_info_enabled", Config::kDefaultScopeInfoEnabled);
     model->target_info_enabled =
@@ -944,11 +944,12 @@ ConfigurationParser::ParsePrometheusPullMetricExporterConfiguration(
     child = node->GetChildNode("resource_constant_labels");
     if (child)
     {
-      model->with_resource_constant_labels = ParseIncludeExcludeConfiguration(child);
+      model->resource_constant_labels = ParseIncludeExcludeConfiguration(child);
     }
   }
   else
   {
+    // Old properties name in schema 1.0.0
     bool without_scope_info  = node->GetBoolean("without_scope_info", false);
     bool without_target_info = node->GetBoolean("without_target_info", false);
 
@@ -958,7 +959,7 @@ ConfigurationParser::ParsePrometheusPullMetricExporterConfiguration(
     child = node->GetChildNode("with_resource_constant_labels");
     if (child)
     {
-      model->with_resource_constant_labels = ParseIncludeExcludeConfiguration(child);
+      model->resource_constant_labels = ParseIncludeExcludeConfiguration(child);
     }
   }
 

--- a/sdk/src/configuration/configuration_parser.cc
+++ b/sdk/src/configuration/configuration_parser.cc
@@ -548,8 +548,18 @@ ConfigurationParser::ParseBatchLogRecordProcessorConfiguration(
   model->schedule_delay = node->GetInteger("schedule_delay", Config::kDefaultScheduleDelayMs);
   model->export_timeout = node->GetInteger("export_timeout", Config::kDefaultExportTimeoutMs);
   model->max_queue_size = node->GetInteger("max_queue_size", Config::kDefaultMaxQueueSize);
-  model->max_export_batch_size =
-      node->GetInteger("max_export_batch_size", Config::kDefaultMaxExportBatchSize);
+
+  // max_export_batch_size/development added in schema 1.1.0
+  if ((version_major_ == 1) && (version_minor_ >= 1))
+  {
+    model->max_export_batch_size =
+        node->GetInteger("max_export_batch_size/development", Config::kDefaultMaxExportBatchSize);
+  }
+  else
+  {
+    // Not configurable in yaml 1.0.0
+    model->max_export_batch_size = Config::kDefaultMaxExportBatchSize;
+  }
 
   child           = node->GetRequiredChildNode("exporter");
   model->exporter = ParseLogRecordExporterConfiguration(child);
@@ -922,15 +932,34 @@ ConfigurationParser::ParsePrometheusPullMetricExporterConfiguration(
 
   model->host = node->GetString("host", Config::kDefaultHost);
   model->port = node->GetInteger("port", Config::kDefaultPort);
-  model->without_scope_info =
-      node->GetBoolean("without_scope_info", Config::kDefaultWithoutScopeInfo);
-  model->without_target_info =
-      node->GetBoolean("without_target_info", Config::kDefaultWithoutTargetInfo);
 
-  child = node->GetChildNode("with_resource_constant_labels");
-  if (child)
+  // Properties renamed in schema 1.1.0
+  if ((version_major_ == 1) && (version_minor_ >= 1))
   {
-    model->with_resource_constant_labels = ParseIncludeExcludeConfiguration(child);
+    model->scope_info_enabled =
+        node->GetBoolean("scope_info_enabled", Config::kDefaultScopeInfoEnabled);
+    model->target_info_enabled =
+        node->GetBoolean("target_info_enabled/development", Config::kDefaultTargetInfoEnabled);
+
+    child = node->GetChildNode("resource_constant_labels");
+    if (child)
+    {
+      model->with_resource_constant_labels = ParseIncludeExcludeConfiguration(child);
+    }
+  }
+  else
+  {
+    bool without_scope_info  = node->GetBoolean("without_scope_info", false);
+    bool without_target_info = node->GetBoolean("without_target_info", false);
+
+    model->scope_info_enabled  = !without_scope_info;
+    model->target_info_enabled = !without_target_info;
+
+    child = node->GetChildNode("with_resource_constant_labels");
+    if (child)
+    {
+      model->with_resource_constant_labels = ParseIncludeExcludeConfiguration(child);
+    }
   }
 
   std::string translation_strategy =
@@ -2218,8 +2247,18 @@ ConfigurationParser::ParseBatchSpanProcessorConfiguration(
   model->schedule_delay = node->GetInteger("schedule_delay", Config::kDefaultScheduleDelayMs);
   model->export_timeout = node->GetInteger("export_timeout", Config::kDefaultExportTimeoutMs);
   model->max_queue_size = node->GetInteger("max_queue_size", Config::kDefaultMaxQueueSize);
-  model->max_export_batch_size =
-      node->GetInteger("max_export_batch_size", Config::kDefaultMaxExportBatchSize);
+
+  // max_export_batch_size/development added in schema 1.1.0
+  if ((version_major_ == 1) && (version_minor_ >= 1))
+  {
+    model->max_export_batch_size =
+        node->GetInteger("max_export_batch_size/development", Config::kDefaultMaxExportBatchSize);
+  }
+  else
+  {
+    // Not configurable in yaml 1.0.0
+    model->max_export_batch_size = Config::kDefaultMaxExportBatchSize;
+  }
 
   child           = node->GetRequiredChildNode("exporter");
   model->exporter = ParseSpanExporterConfiguration(child);
@@ -2779,7 +2818,7 @@ std::unique_ptr<Configuration> ConfigurationParser::Parse(std::unique_ptr<Docume
       throw InvalidSchemaException(node->Location(), message);
     }
 
-    if (minor != 0)
+    if (minor > 1)
     {
       std::string message("Unsupported file_format, major = ");
       message.append(std::to_string(major));

--- a/sdk/test/configuration/yaml_logs_test.cc
+++ b/sdk/test/configuration/yaml_logs_test.cc
@@ -103,7 +103,7 @@ logger_provider:
 TEST(YamlLogs, default_batch_processor)
 {
   std::string yaml = R"(
-file_format: "1.0-logs"
+file_format: "1.1-logs"
 logger_provider:
   processors:
     - batch:
@@ -132,14 +132,14 @@ logger_provider:
 TEST(YamlLogs, batch_processor)
 {
   std::string yaml = R"(
-file_format: "1.0-logs"
+file_format: "1.1-logs"
 logger_provider:
   processors:
     - batch:
         schedule_delay: 5555
         export_timeout: 33333
         max_queue_size: 1234
-        max_export_batch_size: 256
+        max_export_batch_size/development: 256
         exporter:
           console:
 )";

--- a/sdk/test/configuration/yaml_metrics_test.cc
+++ b/sdk/test/configuration/yaml_metrics_test.cc
@@ -594,7 +594,7 @@ meter_provider:
 #endif
 }
 
-TEST(YamlMetrics, default_prometheus)
+TEST(YamlMetrics, default_prometheus_1_0)
 {
   std::string yaml = R"(
 file_format: "1.0-metrics"
@@ -620,14 +620,47 @@ meter_provider:
       opentelemetry::sdk::configuration::PrometheusPullMetricExporterConfiguration *>(exporter);
   ASSERT_EQ(prometheus->host, "localhost");
   ASSERT_EQ(prometheus->port, 9464);
-  ASSERT_EQ(prometheus->without_scope_info, false);
-  ASSERT_EQ(prometheus->without_target_info, false);
+  ASSERT_EQ(prometheus->scope_info_enabled, true);
+  ASSERT_EQ(prometheus->target_info_enabled, true);
   ASSERT_EQ(prometheus->translation_strategy,
             opentelemetry::sdk::configuration::TranslationStrategy::UnderscoreEscapingWithSuffixes);
   ASSERT_EQ(prometheus->with_resource_constant_labels, nullptr);
 }
 
-TEST(YamlMetrics, prometheus)
+TEST(YamlMetrics, default_prometheus_1_1)
+{
+  std::string yaml = R"(
+file_format: "1.1-metrics"
+meter_provider:
+  readers:
+    - pull:
+        exporter:
+          prometheus/development:
+)";
+
+  auto config = DoParse(yaml);
+  ASSERT_NE(config, nullptr);
+  ASSERT_NE(config->meter_provider, nullptr);
+  ASSERT_EQ(config->meter_provider->readers.size(), 1);
+  auto *reader = config->meter_provider->readers[0].get();
+  ASSERT_NE(reader, nullptr);
+  auto *pull =
+      reinterpret_cast<opentelemetry::sdk::configuration::PullMetricReaderConfiguration *>(reader);
+  ASSERT_NE(pull->exporter, nullptr);
+  auto *exporter = pull->exporter.get();
+  ASSERT_NE(exporter, nullptr);
+  auto *prometheus = reinterpret_cast<
+      opentelemetry::sdk::configuration::PrometheusPullMetricExporterConfiguration *>(exporter);
+  ASSERT_EQ(prometheus->host, "localhost");
+  ASSERT_EQ(prometheus->port, 9464);
+  ASSERT_EQ(prometheus->scope_info_enabled, true);
+  ASSERT_EQ(prometheus->target_info_enabled, true);
+  ASSERT_EQ(prometheus->translation_strategy,
+            opentelemetry::sdk::configuration::TranslationStrategy::UnderscoreEscapingWithSuffixes);
+  ASSERT_EQ(prometheus->with_resource_constant_labels, nullptr);
+}
+
+TEST(YamlMetrics, prometheus_1_0)
 {
   std::string yaml = R"(
 file_format: "1.0-metrics"
@@ -664,8 +697,59 @@ meter_provider:
       opentelemetry::sdk::configuration::PrometheusPullMetricExporterConfiguration *>(exporter);
   ASSERT_EQ(prometheus->host, "prometheus");
   ASSERT_EQ(prometheus->port, 1234);
-  ASSERT_EQ(prometheus->without_scope_info, true);
-  ASSERT_EQ(prometheus->without_target_info, true);
+  ASSERT_EQ(prometheus->scope_info_enabled, false);
+  ASSERT_EQ(prometheus->target_info_enabled, false);
+  ASSERT_EQ(prometheus->translation_strategy,
+            opentelemetry::sdk::configuration::TranslationStrategy::NoUTF8EscapingWithSuffixes);
+  ASSERT_NE(prometheus->with_resource_constant_labels, nullptr);
+  ASSERT_NE(prometheus->with_resource_constant_labels->included, nullptr);
+  ASSERT_EQ(prometheus->with_resource_constant_labels->included->string_array.size(), 2);
+  ASSERT_EQ(prometheus->with_resource_constant_labels->included->string_array[0], "foo.in");
+  ASSERT_EQ(prometheus->with_resource_constant_labels->included->string_array[1], "bar.in");
+  ASSERT_NE(prometheus->with_resource_constant_labels->excluded, nullptr);
+  ASSERT_EQ(prometheus->with_resource_constant_labels->excluded->string_array.size(), 1);
+  ASSERT_EQ(prometheus->with_resource_constant_labels->excluded->string_array[0], "baz.ex");
+}
+
+TEST(YamlMetrics, prometheus_1_1)
+{
+  std::string yaml = R"(
+file_format: "1.1-metrics"
+meter_provider:
+  readers:
+    - pull:
+        exporter:
+          prometheus/development:
+            host: "prometheus"
+            port: 1234
+            scope_info_enabled: false
+            target_info_enabled: false
+            translation_strategy: NoUTF8EscapingWithSuffixes
+            with_resource_constant_labels:
+              included:
+                - "foo.in"
+                - "bar.in"
+              excluded:
+                - "baz.ex"
+)";
+
+  auto config = DoParse(yaml);
+  ASSERT_NE(config, nullptr);
+  ASSERT_NE(config->meter_provider, nullptr);
+  ASSERT_EQ(config->meter_provider->readers.size(), 1);
+  auto *reader = config->meter_provider->readers[0].get();
+  ASSERT_NE(reader, nullptr);
+  auto *pull =
+      reinterpret_cast<opentelemetry::sdk::configuration::PullMetricReaderConfiguration *>(reader);
+  ASSERT_NE(pull->exporter, nullptr);
+  auto *exporter = pull->exporter.get();
+  ASSERT_NE(exporter, nullptr);
+  auto *prometheus = reinterpret_cast<
+      opentelemetry::sdk::configuration::PrometheusPullMetricExporterConfiguration *>(exporter);
+  ASSERT_EQ(prometheus->host, "prometheus");
+  ASSERT_EQ(prometheus->port, 1234);
+  ASSERT_EQ(prometheus->scope_info_enabled, false);
+  ASSERT_EQ(prometheus->target_info_enabled, false);
   ASSERT_EQ(prometheus->translation_strategy,
             opentelemetry::sdk::configuration::TranslationStrategy::NoUTF8EscapingWithSuffixes);
   ASSERT_NE(prometheus->with_resource_constant_labels, nullptr);

--- a/sdk/test/configuration/yaml_metrics_test.cc
+++ b/sdk/test/configuration/yaml_metrics_test.cc
@@ -624,7 +624,7 @@ meter_provider:
   ASSERT_EQ(prometheus->target_info_enabled, true);
   ASSERT_EQ(prometheus->translation_strategy,
             opentelemetry::sdk::configuration::TranslationStrategy::UnderscoreEscapingWithSuffixes);
-  ASSERT_EQ(prometheus->with_resource_constant_labels, nullptr);
+  ASSERT_EQ(prometheus->resource_constant_labels, nullptr);
 }
 
 TEST(YamlMetrics, default_prometheus_1_1)
@@ -657,7 +657,7 @@ meter_provider:
   ASSERT_EQ(prometheus->target_info_enabled, true);
   ASSERT_EQ(prometheus->translation_strategy,
             opentelemetry::sdk::configuration::TranslationStrategy::UnderscoreEscapingWithSuffixes);
-  ASSERT_EQ(prometheus->with_resource_constant_labels, nullptr);
+  ASSERT_EQ(prometheus->resource_constant_labels, nullptr);
 }
 
 TEST(YamlMetrics, prometheus_1_0)
@@ -701,14 +701,14 @@ meter_provider:
   ASSERT_EQ(prometheus->target_info_enabled, false);
   ASSERT_EQ(prometheus->translation_strategy,
             opentelemetry::sdk::configuration::TranslationStrategy::NoUTF8EscapingWithSuffixes);
-  ASSERT_NE(prometheus->with_resource_constant_labels, nullptr);
-  ASSERT_NE(prometheus->with_resource_constant_labels->included, nullptr);
-  ASSERT_EQ(prometheus->with_resource_constant_labels->included->string_array.size(), 2);
-  ASSERT_EQ(prometheus->with_resource_constant_labels->included->string_array[0], "foo.in");
-  ASSERT_EQ(prometheus->with_resource_constant_labels->included->string_array[1], "bar.in");
-  ASSERT_NE(prometheus->with_resource_constant_labels->excluded, nullptr);
-  ASSERT_EQ(prometheus->with_resource_constant_labels->excluded->string_array.size(), 1);
-  ASSERT_EQ(prometheus->with_resource_constant_labels->excluded->string_array[0], "baz.ex");
+  ASSERT_NE(prometheus->resource_constant_labels, nullptr);
+  ASSERT_NE(prometheus->resource_constant_labels->included, nullptr);
+  ASSERT_EQ(prometheus->resource_constant_labels->included->string_array.size(), 2);
+  ASSERT_EQ(prometheus->resource_constant_labels->included->string_array[0], "foo.in");
+  ASSERT_EQ(prometheus->resource_constant_labels->included->string_array[1], "bar.in");
+  ASSERT_NE(prometheus->resource_constant_labels->excluded, nullptr);
+  ASSERT_EQ(prometheus->resource_constant_labels->excluded->string_array.size(), 1);
+  ASSERT_EQ(prometheus->resource_constant_labels->excluded->string_array[0], "baz.ex");
 }
 
 TEST(YamlMetrics, prometheus_1_1)
@@ -723,9 +723,9 @@ meter_provider:
             host: "prometheus"
             port: 1234
             scope_info_enabled: false
-            target_info_enabled: false
+            target_info_enabled/development: false
             translation_strategy: NoUTF8EscapingWithSuffixes
-            with_resource_constant_labels:
+            resource_constant_labels:
               included:
                 - "foo.in"
                 - "bar.in"
@@ -752,14 +752,14 @@ meter_provider:
   ASSERT_EQ(prometheus->target_info_enabled, false);
   ASSERT_EQ(prometheus->translation_strategy,
             opentelemetry::sdk::configuration::TranslationStrategy::NoUTF8EscapingWithSuffixes);
-  ASSERT_NE(prometheus->with_resource_constant_labels, nullptr);
-  ASSERT_NE(prometheus->with_resource_constant_labels->included, nullptr);
-  ASSERT_EQ(prometheus->with_resource_constant_labels->included->string_array.size(), 2);
-  ASSERT_EQ(prometheus->with_resource_constant_labels->included->string_array[0], "foo.in");
-  ASSERT_EQ(prometheus->with_resource_constant_labels->included->string_array[1], "bar.in");
-  ASSERT_NE(prometheus->with_resource_constant_labels->excluded, nullptr);
-  ASSERT_EQ(prometheus->with_resource_constant_labels->excluded->string_array.size(), 1);
-  ASSERT_EQ(prometheus->with_resource_constant_labels->excluded->string_array[0], "baz.ex");
+  ASSERT_NE(prometheus->resource_constant_labels, nullptr);
+  ASSERT_NE(prometheus->resource_constant_labels->included, nullptr);
+  ASSERT_EQ(prometheus->resource_constant_labels->included->string_array.size(), 2);
+  ASSERT_EQ(prometheus->resource_constant_labels->included->string_array[0], "foo.in");
+  ASSERT_EQ(prometheus->resource_constant_labels->included->string_array[1], "bar.in");
+  ASSERT_NE(prometheus->resource_constant_labels->excluded, nullptr);
+  ASSERT_EQ(prometheus->resource_constant_labels->excluded->string_array.size(), 1);
+  ASSERT_EQ(prometheus->resource_constant_labels->excluded->string_array[0], "baz.ex");
 }
 
 TEST(YamlMetrics, empty_views)

--- a/sdk/test/configuration/yaml_test.cc
+++ b/sdk/test/configuration/yaml_test.cc
@@ -86,14 +86,14 @@ file_format: "2.0"
 TEST(Yaml, unsupported_new_minor_format)
 {
   std::string yaml = R"(
-file_format: "1.1"
+file_format: "1.2"
 )";
 
   auto config = DoParse(yaml);
   ASSERT_EQ(config, nullptr);
 }
 
-TEST(Yaml, just_format)
+TEST(Yaml, just_format_1_0)
 {
   std::string yaml = R"(
 file_format: "1.0-rc.1"
@@ -102,6 +102,18 @@ file_format: "1.0-rc.1"
   auto config = DoParse(yaml);
   ASSERT_NE(config, nullptr);
   ASSERT_EQ(config->file_format, "1.0-rc.1");
+}
+
+TEST(Yaml, just_format_1_1)
+{
+  // 1.1.0 released 2026-06-05
+  std::string yaml = R"(
+file_format: "1.1"
+)";
+
+  auto config = DoParse(yaml);
+  ASSERT_NE(config, nullptr);
+  ASSERT_EQ(config->file_format, "1.1");
 }
 
 TEST(Yaml, disabled)

--- a/sdk/test/configuration/yaml_trace_test.cc
+++ b/sdk/test/configuration/yaml_trace_test.cc
@@ -198,7 +198,7 @@ tracer_provider:
 TEST(YamlTrace, default_batch_processor)
 {
   std::string yaml = R"(
-file_format: "1.0-trace"
+file_format: "1.1-trace"
 tracer_provider:
   processors:
     - batch:
@@ -227,14 +227,14 @@ tracer_provider:
 TEST(YamlTrace, batch_processor)
 {
   std::string yaml = R"(
-file_format: "1.0-trace"
+file_format: "1.1-trace"
 tracer_provider:
   processors:
     - batch:
         schedule_delay: 5555
         export_timeout: 33333
         max_queue_size: 1234
-        max_export_batch_size: 256
+        max_export_batch_size/development: 256
         exporter:
           console:
 )";


### PR DESCRIPTION
Fixes # (issue)

## Changes

Please provide a brief description of the changes here.

* In the YAML parser, implement support for schema version 1.1.0
* Adjust parser for max_export_batch_size:
  * https://github.com/open-telemetry/opentelemetry-configuration/pull/610
  * the proper name is `max_export_batch_size/development`
  * this property exists in 1.1.0 but not in 1.0.0
* Adjust parser for the prometheus exporter:
  * https://github.com/open-telemetry/opentelemetry-configuration/pull/612
  * this change is effective in 1.1.0 only, 1.0.0 is unchanged.

For significant contributions please make sure you have completed the following items:

* [ ] `CHANGELOG.md` updated for non-trivial changes
* [ ] Unit tests have been added
* [ ] Changes in public API reviewed