### PR TITLE
[BUG] Stop reading past a string_view that is not NUL terminated

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,8 @@ Increment the:
   [#4245](https://github.com/open-telemetry/opentelemetry-cpp/pull/4245)
 * [CONFIGURATION] Add the probability sampler to file configuration
   [#4334](https://github.com/open-telemetry/opentelemetry-cpp/pull/4334)
+* [BUG] Stop reading past a `nostd::string_view` that is not NUL terminated
+  [#4346](https://github.com/open-telemetry/opentelemetry-cpp/pull/4346)
 
 * [OTLP/HTTP] Honor `Retry-After` response header when retrying exports,
   supporting both delay-seconds and HTTP-date formats per RFC 7231 §7.1.3.

--- a/examples/http/client.cc
+++ b/examples/http/client.cc
@@ -71,7 +71,7 @@ void sendRequest(const std::string &url)
     span->SetAttribute(semconv::http::kHttpResponseStatusCode, status_code);
     result.GetResponse().ForEachHeader(
         [&span](nostd::string_view header_name, nostd::string_view header_value) {
-          span->SetAttribute("http.header." + std::string(header_name.data()), header_value);
+          span->SetAttribute("http.header." + static_cast<std::string>(header_name), header_value);
           return true;
         });
 

--- a/examples/http/client.cc
+++ b/examples/http/client.cc
@@ -71,7 +71,7 @@ void sendRequest(const std::string &url)
     span->SetAttribute(semconv::http::kHttpResponseStatusCode, status_code);
     result.GetResponse().ForEachHeader(
         [&span](nostd::string_view header_name, nostd::string_view header_value) {
-          span->SetAttribute("http.header." + static_cast<std::string>(header_name), header_value);
+          span->SetAttribute("http.header." + std::string(header_name), header_value);
           return true;
         });
 

--- a/exporters/elasticsearch/src/es_log_record_exporter.cc
+++ b/exporters/elasticsearch/src/es_log_record_exporter.cc
@@ -59,7 +59,7 @@ public:
     ss << "Status:" << response.GetStatusCode() << ", Header:";
     response.ForEachHeader([&ss](opentelemetry::nostd::string_view header_name,
                                  opentelemetry::nostd::string_view header_value) {
-      ss << "\t" << header_name.data() << ": " << header_value.data() << ",";
+      ss << "\t" << header_name << ": " << header_value << ",";
       return true;
     });
     ss << "Body:" << body;

--- a/exporters/otlp/src/otlp_http_client.cc
+++ b/exporters/otlp/src/otlp_http_client.cc
@@ -99,7 +99,7 @@ public:
     ss << "Status:" << response.GetStatusCode() << ", Header:";
     response.ForEachHeader([&ss](opentelemetry::nostd::string_view header_name,
                                  opentelemetry::nostd::string_view header_value) {
-      ss << "\t" << header_name.data() << ": " << header_value.data() << ",";
+      ss << "\t" << header_name << ": " << header_value << ",";
       return true;
     });
     ss << "Body:" << body;

--- a/ext/include/opentelemetry/ext/http/client/http_client.h
+++ b/ext/include/opentelemetry/ext/http/client/http_client.h
@@ -5,7 +5,6 @@
 
 #include <chrono>
 #include <cstdint>
-#include <cstring>
 #include <map>
 #include <memory>
 #include <string>
@@ -148,7 +147,8 @@ struct HttpSslOptions
         ssl_cipher_suite(input_ssl_cipher_suite)
   {
     /* Use SSL if url starts with "https:" */
-    if (strncmp(url.data(), "https:", 6) == 0)
+    const nostd::string_view https_scheme{"https:"};
+    if (url.substr(0, https_scheme.size()) == https_scheme)
     {
       use_ssl = true;
     }

--- a/ext/test/http/url_parser_test.cc
+++ b/ext/test/http/url_parser_test.cc
@@ -8,9 +8,13 @@
 #include <tuple>
 #include <variant>
 
+#include "opentelemetry/ext/http/client/http_client.h"
 #include "opentelemetry/ext/http/common/url_parser.h"
+#include "opentelemetry/nostd/string_view.h"
 
 namespace http_common = opentelemetry::ext::http::common;
+namespace http_client = opentelemetry::ext::http::client;
+namespace nostd       = opentelemetry::nostd;
 
 namespace
 {
@@ -140,6 +144,26 @@ TEST_P(UrlDecoderTests, BasicTests)
   const auto actual    = http_common::UrlDecoder::Decode(encoded);
 
   EXPECT_EQ(actual, expected);
+}
+
+http_client::HttpSslOptions SslOptionsFor(nostd::string_view url)
+{
+  return http_client::HttpSslOptions{url, false, "", "", "", "", "", "", "", "", "", ""};
+}
+
+// HttpSslOptions decides use_ssl from the scheme the caller passed, and the url is a string_view,
+// so it can be a window onto a longer buffer. Reading one byte past it changes the answer: a view
+// holding "https" over a buffer that continues with a colon reads as a secure scheme.
+TEST(HttpSslOptionsTests, UsesOnlyTheGivenUrlToDecideTheScheme)
+{
+  const char buffer[] = "https://example.com";
+
+  EXPECT_TRUE(SslOptionsFor(nostd::string_view{buffer}).use_ssl);
+  EXPECT_FALSE(SslOptionsFor(nostd::string_view{"http://example.com"}).use_ssl);
+
+  // The same buffer, but the caller offers only the five characters before the colon.
+  EXPECT_FALSE(SslOptionsFor(nostd::string_view{buffer, 5}).use_ssl)
+      << "read past the end of the url view";
 }
 
 }  // namespace


### PR DESCRIPTION
`nostd::string_view::data()` points at the first character of a view, not at a C string. Anything that reads until a NUL can therefore run past the end of what the caller offered. Four places do that.

## The one that changes an answer

`HttpSslOptions` decides `use_ssl` from the url it is given:

```cpp
if (strncmp(url.data(), "https:", 6) == 0)
```

`strncmp` reads up to six bytes whatever the view's length is. A view holding the five characters `https` over a buffer that continues with a colon matches, and the connection turns on TLS the caller never asked for. Measured, with the view length being the only difference:

```
  view    = https (len 5)
  old_way = 1   reads buf[5] past the view
  new_way = 0   honours the view length
```

The replacement compares within the view, and `<cstring>` was there for that one call so it goes too.

## The three that read too far

`BuildResponseLogMessage` in the Elasticsearch and the OTLP HTTP exporters streams header names and values through the `const char *` overload:

```cpp
ss << "\t" << header_name.data() << ": " << header_value.data() << ",";
```

whatever follows the view, up to the next NUL, lands in the log. `otlp_http_client.cc` already writes seven other views with their length a few lines below, so these two were the outliers. Dropping `.data()` picks up `nostd::operator<<`, which is `os.write(s.data(), s.length())`.

`examples/http/client.cc` built a span attribute name the same way, with `std::string(header_name.data())`.

## Reachability

The bundled curl client hands `ForEachHeader` views onto `std::string`, and `std::string::data()` is NUL terminated, so none of this misbehaves in tree today. `HttpClientFactory` is public API and `Response::ForEachHeader` takes `string_view`, so a client supplied through the factory can hand out views into its own receive buffer, which is where the log paths become reachable. The `HttpSslOptions` constructor is public and takes a `string_view` url directly.

## Tests

`HttpSslOptionsTests.UsesOnlyTheGivenUrlToDecideTheScheme` covers the scheme decision, including the truncated view. It fails on the old code:

```
[  FAILED  ] HttpSslOptionsTests.UsesOnlyTheGivenUrlToDecideTheScheme
```

and passes on this one. It lives in `url_parser_test`, which links `opentelemetry_ext` without curl.

The two `BuildResponseLogMessage` methods are private members of file-local classes with no seam, so they have no direct test here. Their fix routes through `nostd::operator<<`, which writes the view's length. Say the word if you would rather I opened a seam for them.

## Verification

Built with `WITH_ELASTICSEARCH=ON WITH_OTLP_HTTP=ON WITH_ZIPKIN=ON WITH_EXAMPLES_HTTP=ON` under `OTELCPP_MAINTAINER_MODE=ON`, clean. `./ci/do_ci.sh format` reports no diff.

## Not in this change

`Properties::to_vector(span<string_view>)` in the ETW exporter has the same `std::string(item.data())` shape, and on the same lines it pre-sizes the result and then appends, so it returns twice as many entries as it was given with the first half empty. That is a second, unrelated defect in a component no CI job builds, so it is not folded in here.
