### PR TITLE
[CODE HEALTH] Enable clang-tidy modernize-deprecated-headers and fix violations

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -58,7 +58,6 @@ Checks: >
   -modernize-use-nodiscard,
   -modernize-use-scoped-lock,
   -modernize-use-trailing-return-type,
-  -modernize-deprecated-headers,
   -modernize-loop-convert,
   -modernize-pass-by-value,
   -modernize-use-equals-default,

--- a/.iwyu.imp
+++ b/.iwyu.imp
@@ -8,8 +8,8 @@
   { "include": ["<bits/chrono.h>", "private", "<chrono>", "public"] },
   { "include": ["<bits/std_abs.h>", "private", "<cstdlib>", "public"] },
   { "include": ["<ext/alloc_traits.h>", "private", "<memory>", "public"] },
-  { "include": ["<bits/types/struct_tm.h>", "private", "<time.h>", "public"] },
-  { "include": ["<bits/types/struct_FILE.h>", "private", "<stdio.h>", "public"] },
+  { "include": ["<bits/types/struct_tm.h>", "private", "<ctime>", "public"] },
+  { "include": ["<bits/types/struct_FILE.h>", "private", "<cstdio>", "public"] },
 
   # Work around for ryml
   { "include": ["<c4/std/string.hpp>", "private", "<ryml_std.hpp>", "public"] },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@ Increment the:
 
 ## [Unreleased]
 
+* [CODE HEALTH] Enable clang-tidy `modernize-deprecated-headers` and replace
+  deprecated C headers (`stdint.h`, `stddef.h`, `stdlib.h`, `string.h`,
+  `stdio.h`, `ctype.h`, `limits.h`, `assert.h`) with their C++ equivalents
+  ([#4349](https://github.com/open-telemetry/opentelemetry-cpp/pull/4349))
 * [METRICS SDK] Fix Windows metrics tail latency on the synchronous record path:
   `SyncMetricStorage::attribute_hashmap_lock_` now uses `std::mutex` instead of
   `common::SpinLockMutex`. The spin lock's final `sleep_for(1ms)` back-off is

--- a/api/include/opentelemetry/common/key_value_iterable_view.h
+++ b/api/include/opentelemetry/common/key_value_iterable_view.h
@@ -3,7 +3,7 @@
 
 #pragma once
 
-#include <stddef.h>
+#include <cstddef>
 #include <initializer_list>
 #include <iterator>
 #include <type_traits>

--- a/api/include/opentelemetry/common/string_util.h
+++ b/api/include/opentelemetry/common/string_util.h
@@ -3,7 +3,7 @@
 
 #pragma once
 
-#include <ctype.h>
+#include <cctype>
 
 #include "opentelemetry/common/macros.h"
 

--- a/api/include/opentelemetry/context/runtime_context.h
+++ b/api/include/opentelemetry/context/runtime_context.h
@@ -3,8 +3,8 @@
 
 #pragma once
 
-#include <cstddef>
 #include <algorithm>
+#include <cstddef>
 
 #include "opentelemetry/common/macros.h"
 #include "opentelemetry/context/context.h"

--- a/api/include/opentelemetry/context/runtime_context.h
+++ b/api/include/opentelemetry/context/runtime_context.h
@@ -3,7 +3,7 @@
 
 #pragma once
 
-#include <stddef.h>
+#include <cstddef>
 #include <algorithm>
 
 #include "opentelemetry/common/macros.h"

--- a/api/include/opentelemetry/logs/logger.h
+++ b/api/include/opentelemetry/logs/logger.h
@@ -3,7 +3,7 @@
 
 #pragma once
 
-#include <stdint.h>
+#include <cstdint>
 #include <type_traits>
 #include <utility>
 

--- a/api/include/opentelemetry/nostd/internal/absl/base/config.h
+++ b/api/include/opentelemetry/nostd/internal/absl/base/config.h
@@ -49,7 +49,7 @@
 #define OTABSL_BASE_CONFIG_H_
 
 // Included for the __GLIBC__ macro (or similar macros on other systems).
-#include <limits.h>
+#include <climits>
 
 #ifdef __cplusplus
 // Included for __GLIBCXX__, _LIBCPP_VERSION

--- a/api/include/opentelemetry/nostd/internal/absl/base/config.h
+++ b/api/include/opentelemetry/nostd/internal/absl/base/config.h
@@ -49,7 +49,7 @@
 #define OTABSL_BASE_CONFIG_H_
 
 // Included for the __GLIBC__ macro (or similar macros on other systems).
-#include <climits>
+#include <limits.h>
 
 #ifdef __cplusplus
 // Included for __GLIBCXX__, _LIBCPP_VERSION

--- a/api/include/opentelemetry/nostd/internal/absl/base/policy_checks.h
+++ b/api/include/opentelemetry/nostd/internal/absl/base/policy_checks.h
@@ -25,7 +25,7 @@
 #define OTABSL_BASE_POLICY_CHECKS_H_
 
 // Included for the __GLIBC_PREREQ macro used below.
-#include <climits>
+#include <limits.h>
 
 // Included for the _STLPORT_VERSION macro used below.
 #if defined(__cplusplus)

--- a/api/include/opentelemetry/nostd/internal/absl/base/policy_checks.h
+++ b/api/include/opentelemetry/nostd/internal/absl/base/policy_checks.h
@@ -25,7 +25,7 @@
 #define OTABSL_BASE_POLICY_CHECKS_H_
 
 // Included for the __GLIBC_PREREQ macro used below.
-#include <limits.h>
+#include <climits>
 
 // Included for the _STLPORT_VERSION macro used below.
 #if defined(__cplusplus)

--- a/api/include/opentelemetry/nostd/internal/absl/meta/type_traits.h
+++ b/api/include/opentelemetry/nostd/internal/absl/meta/type_traits.h
@@ -35,7 +35,7 @@
 #ifndef OTABSL_META_TYPE_TRAITS_H_
 #define OTABSL_META_TYPE_TRAITS_H_
 
-#include <stddef.h>
+#include <cstddef>
 #include <functional>
 #include <type_traits>
 

--- a/api/include/opentelemetry/nostd/internal/absl/meta/type_traits.h
+++ b/api/include/opentelemetry/nostd/internal/absl/meta/type_traits.h
@@ -35,7 +35,7 @@
 #ifndef OTABSL_META_TYPE_TRAITS_H_
 #define OTABSL_META_TYPE_TRAITS_H_
 
-#include <cstddef>
+#include <stddef.h>
 #include <functional>
 #include <type_traits>
 

--- a/api/include/opentelemetry/trace/noop.h
+++ b/api/include/opentelemetry/trace/noop.h
@@ -7,7 +7,7 @@
 // This file is part of the internal implementation of OpenTelemetry. Nothing in this file should be
 // used directly. Please refer to span.h and tracer.h for documentation on these interfaces.
 
-#include <stdint.h>
+#include <cstdint>
 #include <utility>
 
 #include "opentelemetry/common/attribute_value.h"

--- a/api/include/opentelemetry/trace/span_context.h
+++ b/api/include/opentelemetry/trace/span_context.h
@@ -3,7 +3,7 @@
 
 #pragma once
 
-#include <stdint.h>
+#include <cstdint>
 
 #include <utility>
 

--- a/api/include/opentelemetry/trace/trace_state.h
+++ b/api/include/opentelemetry/trace/trace_state.h
@@ -3,7 +3,7 @@
 
 #pragma once
 
-#include <ctype.h>
+#include <cctype>
 #include <cstddef>
 #include <string>
 #include <vector>

--- a/api/test/baggage/baggage_benchmark.cc
+++ b/api/test/baggage/baggage_benchmark.cc
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include <benchmark/benchmark.h>
-#include <stddef.h>
+#include <cstddef>
 #include <string>
 
 #include "opentelemetry/baggage/baggage.h"

--- a/api/test/baggage/baggage_test.cc
+++ b/api/test/baggage/baggage_test.cc
@@ -1,9 +1,9 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-#include <assert.h>
+#include <cassert>
 #include <gtest/gtest.h>
-#include <stddef.h>
+#include <cstddef>
 #include <string>
 #include <vector>
 

--- a/api/test/baggage/baggage_test.cc
+++ b/api/test/baggage/baggage_test.cc
@@ -1,8 +1,8 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-#include <cassert>
 #include <gtest/gtest.h>
+#include <cassert>
 #include <cstddef>
 #include <string>
 #include <vector>

--- a/api/test/common/kv_properties_test.cc
+++ b/api/test/common/kv_properties_test.cc
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include <gtest/gtest.h>
-#include <stddef.h>
+#include <cstddef>
 #include <string>
 #include <utility>
 #include <vector>

--- a/api/test/common/string_util_test.cc
+++ b/api/test/common/string_util_test.cc
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include <gtest/gtest.h>
-#include <string.h>
+#include <cstring>
 #include <string>
 
 #include <opentelemetry/common/string_util.h>

--- a/api/test/context/context_test.cc
+++ b/api/test/context/context_test.cc
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include <gtest/gtest.h>
-#include <stdint.h>
+#include <cstdint>
 #include <map>
 #include <string>
 

--- a/api/test/context/propagation/composite_propagator_test.cc
+++ b/api/test/context/propagation/composite_propagator_test.cc
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include <gtest/gtest.h>
-#include <stdint.h>
+#include <cstdint>
 #include <map>
 #include <string>
 #include <utility>

--- a/api/test/context/propagation/environment_carrier_test.cc
+++ b/api/test/context/propagation/environment_carrier_test.cc
@@ -2,8 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include <gtest/gtest.h>
-#include <stdint.h>
-#include <stdlib.h>
+#include <cstdint>
+#include <cstdlib>
 #include <map>
 #include <string>
 #include <utility>

--- a/api/test/context/runtime_context_test.cc
+++ b/api/test/context/runtime_context_test.cc
@@ -2,8 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include <gtest/gtest.h>
-#include <stddef.h>
-#include <stdint.h>
+#include <cstddef>
+#include <cstdint>
 #include <algorithm>
 #include <map>
 #include <string>

--- a/api/test/context/runtime_context_test.cc
+++ b/api/test/context/runtime_context_test.cc
@@ -2,9 +2,9 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include <gtest/gtest.h>
+#include <algorithm>
 #include <cstddef>
 #include <cstdint>
-#include <algorithm>
 #include <map>
 #include <string>
 #include <utility>

--- a/api/test/core/timestamp_test.cc
+++ b/api/test/core/timestamp_test.cc
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include <gtest/gtest.h>
-#include <stdlib.h>
 #include <chrono>
 #include <cstdlib>
 #include <string>

--- a/api/test/core/version_test.cc
+++ b/api/test/core/version_test.cc
@@ -2,8 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include <gtest/gtest.h>
-#include <stdio.h>
-#include <string.h>
+#include <cstdio>
+#include <cstring>
 #include <string>
 
 #include "opentelemetry/version.h"

--- a/api/test/logs/logger_benchmark.cc
+++ b/api/test/logs/logger_benchmark.cc
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include <benchmark/benchmark.h>
-#include <stdint.h>
+#include <cstdint>
 #include <condition_variable>
 #include <cstddef>
 #include <functional>

--- a/api/test/logs/logger_benchmark.cc
+++ b/api/test/logs/logger_benchmark.cc
@@ -2,9 +2,9 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include <benchmark/benchmark.h>
-#include <cstdint>
 #include <condition_variable>
 #include <cstddef>
+#include <cstdint>
 #include <functional>
 #include <mutex>
 #include <thread>

--- a/api/test/logs/logger_test.cc
+++ b/api/test/logs/logger_test.cc
@@ -2,8 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include <gtest/gtest.h>
-#include <stddef.h>
-#include <stdint.h>
+#include <cstddef>
+#include <cstdint>
 #include <map>
 #include <string>
 #include <utility>

--- a/api/test/metrics/noop_sync_instrument_test.cc
+++ b/api/test/metrics/noop_sync_instrument_test.cc
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include <gtest/gtest.h>
-#include <stdint.h>
+#include <cstdint>
 #include <map>
 #include <memory>
 #include <string>

--- a/api/test/nostd/shared_ptr_test.cc
+++ b/api/test/nostd/shared_ptr_test.cc
@@ -2,8 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include <gtest/gtest.h>
-#include <cstddef>
 #include <algorithm>
+#include <cstddef>
 #include <string>
 #include <utility>
 #include <vector>

--- a/api/test/nostd/shared_ptr_test.cc
+++ b/api/test/nostd/shared_ptr_test.cc
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include <gtest/gtest.h>
-#include <stddef.h>
+#include <cstddef>
 #include <algorithm>
 #include <string>
 #include <utility>

--- a/api/test/nostd/span_test.cc
+++ b/api/test/nostd/span_test.cc
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include <gtest/gtest.h>
-#include <stddef.h>
+#include <cstddef>
 #include <algorithm>
 #include <array>
 #include <iterator>

--- a/api/test/nostd/span_test.cc
+++ b/api/test/nostd/span_test.cc
@@ -2,9 +2,9 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include <gtest/gtest.h>
-#include <cstddef>
 #include <algorithm>
 #include <array>
+#include <cstddef>
 #include <iterator>
 #include <list>
 #include <string>

--- a/api/test/singleton/singleton_test.cc
+++ b/api/test/singleton/singleton_test.cc
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include <gtest/gtest.h>
-#include <stdint.h>  // IWYU pragma: keep
+#include <cstdint>  // IWYU pragma: keep
 #include <string>
 
 #ifdef _WIN32

--- a/api/test/trace/context_test.cc
+++ b/api/test/trace/context_test.cc
@@ -3,7 +3,7 @@
 
 #include <gtest/gtest.h>
 
-#include <stdint.h>
+#include <cstdint>
 #include <string>
 
 #include "opentelemetry/context/context.h"

--- a/api/test/trace/noop_test.cc
+++ b/api/test/trace/noop_test.cc
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include <gtest/gtest.h>
-#include <stdint.h>
+#include <cstdint>
 #include <initializer_list>
 #include <map>
 #include <string>

--- a/api/test/trace/propagation/b3_propagation_test.cc
+++ b/api/test/trace/propagation/b3_propagation_test.cc
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include <gtest/gtest.h>
-#include <stdint.h>
+#include <cstdint>
 #include <map>
 #include <string>
 #include <utility>

--- a/api/test/trace/propagation/detail/hex_test.cc
+++ b/api/test/trace/propagation/detail/hex_test.cc
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include <gtest/gtest.h>
-#include <stdint.h>
+#include <cstdint>
 #include <string>
 
 #include "opentelemetry/trace/propagation/detail/hex.h"

--- a/api/test/trace/propagation/detail/string_test.cc
+++ b/api/test/trace/propagation/detail/string_test.cc
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include <gtest/gtest.h>
-#include <stddef.h>
+#include <cstddef>
 #include <ostream>
 #include <string>
 #include <vector>

--- a/api/test/trace/propagation/http_text_format_test.cc
+++ b/api/test/trace/propagation/http_text_format_test.cc
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include <gtest/gtest.h>
-#include <stdint.h>
+#include <cstdint>
 #include <map>
 #include <string>
 #include <utility>

--- a/api/test/trace/propagation/jaeger_propagation_test.cc
+++ b/api/test/trace/propagation/jaeger_propagation_test.cc
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include <gtest/gtest.h>
-#include <stdint.h>
+#include <cstdint>
 #include <map>
 #include <string>
 #include <utility>

--- a/api/test/trace/trace_flags_test.cc
+++ b/api/test/trace/trace_flags_test.cc
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include <gtest/gtest.h>
-#include <stdint.h>
+#include <cstdint>
 #include <string>
 
 #include "opentelemetry/nostd/span.h"

--- a/api/test/trace/trace_state_test.cc
+++ b/api/test/trace/trace_state_test.cc
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include <gtest/gtest.h>
-#include <stddef.h>
+#include <cstddef>
 #include <string>
 
 #include "opentelemetry/nostd/function_ref.h"

--- a/examples/batch/main.cc
+++ b/examples/batch/main.cc
@@ -1,9 +1,9 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
+#include <chrono>
 #include <cstdint>
 #include <cstdio>
-#include <chrono>
 #include <iostream>
 #include <string>
 #include <thread>

--- a/examples/batch/main.cc
+++ b/examples/batch/main.cc
@@ -1,8 +1,8 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-#include <stdint.h>
-#include <stdio.h>
+#include <cstdint>
+#include <cstdio>
 #include <chrono>
 #include <iostream>
 #include <string>

--- a/examples/common/metrics_foo_library/foo_library.cc
+++ b/examples/common/metrics_foo_library/foo_library.cc
@@ -1,8 +1,8 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-#include <stdint.h>
-#include <stdlib.h>
+#include <cstdint>
+#include <cstdlib>
 #include <chrono>
 #include <cmath>
 #include <map>

--- a/examples/common/metrics_foo_library/foo_library.cc
+++ b/examples/common/metrics_foo_library/foo_library.cc
@@ -1,10 +1,10 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-#include <cstdint>
-#include <cstdlib>
 #include <chrono>
 #include <cmath>
+#include <cstdint>
+#include <cstdlib>
 #include <map>
 #include <random>
 #include <thread>

--- a/examples/configuration/main.cc
+++ b/examples/configuration/main.cc
@@ -1,9 +1,9 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-#include <stdio.h>
-#include <stdlib.h>
-#include <string.h>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
 #include <string>
 
 #include "opentelemetry/exporters/ostream/console_log_record_builder.h"

--- a/examples/grpc/client.cc
+++ b/examples/grpc/client.cc
@@ -8,7 +8,7 @@
 #include <grpcpp/security/credentials.h>
 #include <grpcpp/support/status.h>
 
-#include <stdint.h>
+#include <cstdint>
 #include <cstdlib>
 #include <iostream>
 #include <string>

--- a/examples/grpc/server.cc
+++ b/examples/grpc/server.cc
@@ -7,7 +7,7 @@
 #include <grpcpp/server_context.h>
 #include <grpcpp/support/status.h>
 #include <grpcpp/support/string_ref.h>
-#include <stdint.h>
+#include <cstdint>
 #include <cstdlib>
 #include <iostream>
 #include <map>

--- a/examples/http/client.cc
+++ b/examples/http/client.cc
@@ -20,7 +20,7 @@
 #include "opentelemetry/trace/tracer.h"
 #include "tracer_common.h"
 
-#include <stdint.h>
+#include <cstdint>
 #include <cstdlib>
 #include <map>
 #include <string>

--- a/examples/http/server.h
+++ b/examples/http/server.h
@@ -5,7 +5,7 @@
 
 #include "opentelemetry/ext/http/server/http_server.h"
 
-#include <stdint.h>
+#include <cstdint>
 #include <atomic>
 #include <string>
 

--- a/examples/http/server.h
+++ b/examples/http/server.h
@@ -5,8 +5,8 @@
 
 #include "opentelemetry/ext/http/server/http_server.h"
 
-#include <cstdint>
 #include <atomic>
+#include <cstdint>
 #include <string>
 
 namespace http_example

--- a/examples/plugin/plugin/tracer.h
+++ b/examples/plugin/plugin/tracer.h
@@ -3,7 +3,7 @@
 
 #pragma once
 
-#include <stdint.h>  // IWYU pragma: keep
+#include <cstdint>  // IWYU pragma: keep
 
 #include "opentelemetry/common/key_value_iterable.h"
 #include "opentelemetry/nostd/shared_ptr.h"

--- a/exporters/elasticsearch/include/opentelemetry/exporters/elasticsearch/es_log_recordable.h
+++ b/exporters/elasticsearch/include/opentelemetry/exporters/elasticsearch/es_log_recordable.h
@@ -3,7 +3,7 @@
 
 #pragma once
 
-#include <stdint.h>
+#include <cstdint>
 #include <string>
 #include "nlohmann/json.hpp"
 

--- a/exporters/elasticsearch/src/es_log_recordable.cc
+++ b/exporters/elasticsearch/src/es_log_recordable.cc
@@ -15,7 +15,6 @@
 #include "opentelemetry/trace/trace_id.h"
 #include "opentelemetry/version.h"
 
-#include <stdint.h>
 #include <chrono>
 #include <cstdint>
 #include <cstdio>

--- a/exporters/etw/include/opentelemetry/exporters/etw/TraceLoggingDynamic.h
+++ b/exporters/etw/include/opentelemetry/exporters/etw/TraceLoggingDynamic.h
@@ -21,7 +21,7 @@ Environment:
 #pragma once
 #include <windows.h>
 #include <evntprov.h>
-#include <cstdlib> // byteswap
+#include <stdlib.h> // byteswap
 
 namespace tld
 {

--- a/exporters/etw/include/opentelemetry/exporters/etw/TraceLoggingDynamic.h
+++ b/exporters/etw/include/opentelemetry/exporters/etw/TraceLoggingDynamic.h
@@ -21,7 +21,7 @@ Environment:
 #pragma once
 #include <windows.h>
 #include <evntprov.h>
-#include <stdlib.h> // byteswap
+#include <cstdlib> // byteswap
 
 namespace tld
 {

--- a/exporters/memory/include/opentelemetry/exporters/memory/in_memory_metric_data.h
+++ b/exporters/memory/include/opentelemetry/exporters/memory/in_memory_metric_data.h
@@ -3,7 +3,7 @@
 
 #pragma once
 
-#include <stddef.h>
+#include <cstddef>
 #include <map>
 #include <memory>
 #include <string>

--- a/exporters/memory/include/opentelemetry/exporters/memory/in_memory_span_data.h
+++ b/exporters/memory/include/opentelemetry/exporters/memory/in_memory_span_data.h
@@ -3,7 +3,7 @@
 
 #pragma once
 
-#include <stddef.h>
+#include <cstddef>
 #include <memory>
 #include <vector>
 

--- a/exporters/memory/include/opentelemetry/exporters/memory/in_memory_span_exporter.h
+++ b/exporters/memory/include/opentelemetry/exporters/memory/in_memory_span_exporter.h
@@ -3,9 +3,9 @@
 
 #pragma once
 
-#include <cstddef>
 #include <atomic>
 #include <chrono>
+#include <cstddef>
 #include <memory>
 #include <ostream>
 #include <utility>

--- a/exporters/memory/include/opentelemetry/exporters/memory/in_memory_span_exporter.h
+++ b/exporters/memory/include/opentelemetry/exporters/memory/in_memory_span_exporter.h
@@ -3,7 +3,7 @@
 
 #pragma once
 
-#include <stddef.h>
+#include <cstddef>
 #include <atomic>
 #include <chrono>
 #include <memory>

--- a/exporters/memory/include/opentelemetry/exporters/memory/in_memory_span_exporter_factory.h
+++ b/exporters/memory/include/opentelemetry/exporters/memory/in_memory_span_exporter_factory.h
@@ -3,7 +3,7 @@
 
 #pragma once
 
-#include <stddef.h>
+#include <cstddef>
 #include <memory>
 
 #include "opentelemetry/exporters/memory/in_memory_span_data.h"

--- a/exporters/memory/src/in_memory_metric_data.cc
+++ b/exporters/memory/src/in_memory_metric_data.cc
@@ -1,7 +1,7 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-#include <stddef.h>
+#include <cstddef>
 #include <map>
 #include <memory>
 #include <string>

--- a/exporters/ostream/src/metric_exporter.cc
+++ b/exporters/ostream/src/metric_exporter.cc
@@ -1,10 +1,10 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-#include <cstdint>
 #include <algorithm>
 #include <atomic>
 #include <chrono>
+#include <cstdint>
 #include <ctime>
 #include <iterator>
 #include <map>

--- a/exporters/ostream/src/metric_exporter.cc
+++ b/exporters/ostream/src/metric_exporter.cc
@@ -1,7 +1,7 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-#include <stdint.h>
+#include <cstdint>
 #include <algorithm>
 #include <atomic>
 #include <chrono>

--- a/exporters/ostream/test/ostream_span_test.cc
+++ b/exporters/ostream/test/ostream_span_test.cc
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include <gtest/gtest.h>
-#include <stdint.h>
+#include <cstdint>
 #include <array>
 #include <chrono>
 #include <initializer_list>

--- a/exporters/ostream/test/ostream_span_test.cc
+++ b/exporters/ostream/test/ostream_span_test.cc
@@ -2,9 +2,9 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include <gtest/gtest.h>
-#include <cstdint>
 #include <array>
 #include <chrono>
+#include <cstdint>
 #include <initializer_list>
 #include <iostream>
 #include <sstream>

--- a/exporters/otlp/include/opentelemetry/exporters/otlp/otlp_environment.h
+++ b/exporters/otlp/include/opentelemetry/exporters/otlp/otlp_environment.h
@@ -3,7 +3,7 @@
 
 #pragma once
 
-#include <ctype.h>
+#include <cctype>
 #include <algorithm>
 #include <chrono>
 #include <map>

--- a/exporters/otlp/include/opentelemetry/exporters/otlp/otlp_environment.h
+++ b/exporters/otlp/include/opentelemetry/exporters/otlp/otlp_environment.h
@@ -3,8 +3,8 @@
 
 #pragma once
 
-#include <cctype>
 #include <algorithm>
+#include <cctype>
 #include <chrono>
 #include <map>
 #include <string>

--- a/exporters/otlp/include/opentelemetry/exporters/otlp/otlp_log_recordable.h
+++ b/exporters/otlp/include/opentelemetry/exporters/otlp/otlp_log_recordable.h
@@ -3,7 +3,7 @@
 
 #pragma once
 
-#include <stdint.h>
+#include <cstdint>
 
 #include "opentelemetry/common/attribute_value.h"
 #include "opentelemetry/sdk/instrumentationscope/instrumentation_scope.h"

--- a/exporters/otlp/src/otlp_file_client.cc
+++ b/exporters/otlp/src/otlp_file_client.cc
@@ -24,11 +24,10 @@
 #if defined(HAVE_GSL)
 #  include <gsl/gsl>
 #else
-#  include <assert.h>
+#  include <cassert>
 #endif
 
 #ifdef _MSC_VER
-#  include <string.h>
 #  define strcasecmp _stricmp
 #else
 #  include <strings.h>
@@ -100,7 +99,7 @@
     (defined(__STDC_VERSION__) && __STDC_VERSION__ >= 201112L)
 #  define OTLP_FILE_OPEN(f, path, mode) fopen_s(&f, path, mode)
 #else
-#  include <errno.h>
+#  include <cerrno>
 #  define OTLP_FILE_OPEN(f, path, mode) f = fopen(path, mode)
 #endif
 

--- a/exporters/otlp/src/otlp_file_client.cc
+++ b/exporters/otlp/src/otlp_file_client.cc
@@ -3,7 +3,7 @@
 
 #include <nlohmann/json.hpp>
 
-#include <limits.h>
+#include <climits>
 #include <atomic>
 #include <chrono>
 #include <condition_variable>

--- a/exporters/otlp/src/otlp_file_client.cc
+++ b/exporters/otlp/src/otlp_file_client.cc
@@ -3,9 +3,9 @@
 
 #include <nlohmann/json.hpp>
 
-#include <climits>
 #include <atomic>
 #include <chrono>
+#include <climits>
 #include <condition_variable>
 #include <cstdint>
 #include <cstdio>

--- a/exporters/otlp/src/otlp_grpc_client.cc
+++ b/exporters/otlp/src/otlp_grpc_client.cc
@@ -7,7 +7,7 @@
 #include <grpcpp/resource_quota.h>
 #include <grpcpp/security/credentials.h>
 #include <grpcpp/support/channel_arguments.h>
-#include <stdint.h>
+#include <cstdint>
 #include <atomic>
 #include <chrono>
 #include <fstream>

--- a/exporters/otlp/src/otlp_grpc_client.cc
+++ b/exporters/otlp/src/otlp_grpc_client.cc
@@ -7,9 +7,9 @@
 #include <grpcpp/resource_quota.h>
 #include <grpcpp/security/credentials.h>
 #include <grpcpp/support/channel_arguments.h>
-#include <cstdint>
 #include <atomic>
 #include <chrono>
+#include <cstdint>
 #include <fstream>
 #include <iterator>
 #include <memory>

--- a/exporters/otlp/src/otlp_http_client.cc
+++ b/exporters/otlp/src/otlp_http_client.cc
@@ -19,7 +19,7 @@
 #if defined(HAVE_GSL)
 #  include <gsl/gsl>
 #else
-#  include <assert.h>
+#  include <cassert>
 #endif
 
 #include "nlohmann/json.hpp"

--- a/exporters/otlp/src/otlp_metric_utils.cc
+++ b/exporters/otlp/src/otlp_metric_utils.cc
@@ -1,7 +1,7 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-#include <stdint.h>
+#include <cstdint>
 #include <memory>
 #include <utility>
 #include <vector>

--- a/exporters/otlp/test/otlp_file_exporter_test.cc
+++ b/exporters/otlp/test/otlp_file_exporter_test.cc
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include <gtest/gtest.h>
-#include <stddef.h>
+#include <cstddef>
 #include <chrono>
 #include <cstdint>
 #include <functional>

--- a/exporters/otlp/test/otlp_file_exporter_test.cc
+++ b/exporters/otlp/test/otlp_file_exporter_test.cc
@@ -2,8 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include <gtest/gtest.h>
-#include <cstddef>
 #include <chrono>
+#include <cstddef>
 #include <cstdint>
 #include <functional>
 #include <nlohmann/json.hpp>

--- a/exporters/otlp/test/otlp_file_log_record_exporter_test.cc
+++ b/exporters/otlp/test/otlp_file_log_record_exporter_test.cc
@@ -2,8 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include <gtest/gtest.h>
-#include <stddef.h>
-#include <stdint.h>
+#include <cstddef>
+#include <cstdint>
 #include <chrono>
 #include <functional>
 #include <nlohmann/json.hpp>

--- a/exporters/otlp/test/otlp_file_log_record_exporter_test.cc
+++ b/exporters/otlp/test/otlp_file_log_record_exporter_test.cc
@@ -2,9 +2,9 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include <gtest/gtest.h>
+#include <chrono>
 #include <cstddef>
 #include <cstdint>
-#include <chrono>
 #include <functional>
 #include <nlohmann/json.hpp>
 #include <sstream>

--- a/exporters/otlp/test/otlp_grpc_log_record_exporter_test.cc
+++ b/exporters/otlp/test/otlp_grpc_log_record_exporter_test.cc
@@ -4,10 +4,10 @@
 #include <grpc/support/port_platform.h>
 #include <grpcpp/grpcpp.h>
 #include <grpcpp/support/status.h>
-#include <cstdint>
-#include <cstdlib>
 #include <algorithm>
 #include <chrono>
+#include <cstdint>
+#include <cstdlib>
 #include <functional>
 #include <string>
 #include <unordered_map>

--- a/exporters/otlp/test/otlp_grpc_log_record_exporter_test.cc
+++ b/exporters/otlp/test/otlp_grpc_log_record_exporter_test.cc
@@ -4,8 +4,8 @@
 #include <grpc/support/port_platform.h>
 #include <grpcpp/grpcpp.h>
 #include <grpcpp/support/status.h>
-#include <stdint.h>
-#include <stdlib.h>
+#include <cstdint>
+#include <cstdlib>
 #include <algorithm>
 #include <chrono>
 #include <functional>

--- a/exporters/otlp/test/otlp_log_recordable_test.cc
+++ b/exporters/otlp/test/otlp_log_recordable_test.cc
@@ -2,8 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include <gtest/gtest.h>
-#include <cstdint>
 #include <chrono>
+#include <cstdint>
 #include <cstring>
 #include <memory>
 #include <string>

--- a/exporters/otlp/test/otlp_log_recordable_test.cc
+++ b/exporters/otlp/test/otlp_log_recordable_test.cc
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include <gtest/gtest.h>
-#include <stdint.h>
+#include <cstdint>
 #include <chrono>
 #include <cstring>
 #include <memory>

--- a/exporters/prometheus/test/collector_test.cc
+++ b/exporters/prometheus/test/collector_test.cc
@@ -3,8 +3,8 @@
 
 #include <gtest/gtest.h>
 #include <prometheus/metric_family.h>
-#include <cstddef>
 #include <chrono>
+#include <cstddef>
 #include <string>
 #include <thread>
 #include <vector>

--- a/exporters/prometheus/test/collector_test.cc
+++ b/exporters/prometheus/test/collector_test.cc
@@ -3,7 +3,7 @@
 
 #include <gtest/gtest.h>
 #include <prometheus/metric_family.h>
-#include <stddef.h>
+#include <cstddef>
 #include <chrono>
 #include <string>
 #include <thread>

--- a/exporters/prometheus/test/exporter_utils_test.cc
+++ b/exporters/prometheus/test/exporter_utils_test.cc
@@ -5,7 +5,7 @@
 #include <prometheus/client_metric.h>
 #include <prometheus/metric_family.h>
 #include <prometheus/metric_type.h>
-#include <stddef.h>
+#include <cstddef>
 #include <limits>
 #include <list>
 #include <string>

--- a/exporters/zipkin/src/recordable.cc
+++ b/exporters/zipkin/src/recordable.cc
@@ -1,7 +1,7 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-#include <stdint.h>
+#include <cstdint>
 #include <chrono>
 #include <string>
 #include <unordered_map>

--- a/exporters/zipkin/src/recordable.cc
+++ b/exporters/zipkin/src/recordable.cc
@@ -1,8 +1,8 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-#include <cstdint>
 #include <chrono>
+#include <cstdint>
 #include <string>
 #include <unordered_map>
 

--- a/ext/src/http/client/curl/http_operation_curl.cc
+++ b/ext/src/http/client/curl/http_operation_curl.cc
@@ -8,7 +8,7 @@
 #  include <array>
 #endif  // ENABLE_OTLP_RETRY_PREVIEW
 
-#include <stdint.h>
+#include <cstdint>
 #include <algorithm>
 #include <atomic>
 #include <chrono>

--- a/ext/src/http/client/curl/http_operation_curl.cc
+++ b/ext/src/http/client/curl/http_operation_curl.cc
@@ -8,11 +8,11 @@
 #  include <array>
 #endif  // ENABLE_OTLP_RETRY_PREVIEW
 
-#include <cstdint>
 #include <algorithm>
 #include <atomic>
 #include <chrono>
 #include <cmath>
+#include <cstdint>
 #include <cstring>
 #include <functional>
 #include <future>

--- a/ext/src/http/client/curl/http_operation_curl.cc
+++ b/ext/src/http/client/curl/http_operation_curl.cc
@@ -25,7 +25,6 @@
 #include <vector>
 
 #ifdef _MSC_VER
-#  include <string.h>
 #  define strncasecmp _strnicmp
 #else
 #  include <strings.h>

--- a/ext/test/http/curl_http_test.cc
+++ b/ext/test/http/curl_http_test.cc
@@ -13,10 +13,10 @@
 #  include <numeric>
 #endif  // ENABLE_OTLP_COMPRESSION_PREVIEW
 
-#include <cstring>
 #include <atomic>
 #include <chrono>
 #include <condition_variable>
+#include <cstring>
 #include <map>
 #include <memory>
 #include <mutex>

--- a/ext/test/http/curl_http_test.cc
+++ b/ext/test/http/curl_http_test.cc
@@ -13,7 +13,7 @@
 #  include <numeric>
 #endif  // ENABLE_OTLP_COMPRESSION_PREVIEW
 
-#include <string.h>
+#include <cstring>
 #include <atomic>
 #include <chrono>
 #include <condition_variable>

--- a/ext/test/w3c_tracecontext_http_test_server/main.cc
+++ b/ext/test/w3c_tracecontext_http_test_server/main.cc
@@ -1,10 +1,10 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-#include <cctype>
-#include <cstdint>
 #include <atomic>
+#include <cctype>
 #include <chrono>
+#include <cstdint>
 #include <cstdlib>
 #include <functional>
 #include <iostream>

--- a/ext/test/w3c_tracecontext_http_test_server/main.cc
+++ b/ext/test/w3c_tracecontext_http_test_server/main.cc
@@ -1,8 +1,8 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-#include <ctype.h>
-#include <stdint.h>
+#include <cctype>
+#include <cstdint>
 #include <atomic>
 #include <chrono>
 #include <cstdlib>

--- a/functional/otlp/func_grpc_main.cc
+++ b/functional/otlp/func_grpc_main.cc
@@ -1,8 +1,8 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-#include <stdio.h>
-#include <string.h>
+#include <cstdio>
+#include <cstring>
 #include <chrono>
 #include <cstdint>
 #include <iostream>

--- a/functional/otlp/func_grpc_main.cc
+++ b/functional/otlp/func_grpc_main.cc
@@ -1,10 +1,10 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-#include <cstdio>
-#include <cstring>
 #include <chrono>
 #include <cstdint>
+#include <cstdio>
+#include <cstring>
 #include <iostream>
 #include <string>
 #include <utility>

--- a/functional/otlp/func_http_main.cc
+++ b/functional/otlp/func_http_main.cc
@@ -1,8 +1,8 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-#include <stdio.h>
-#include <string.h>
+#include <cstdio>
+#include <cstring>
 #include <cstdint>
 #include <iostream>
 #include <string>

--- a/functional/otlp/func_http_main.cc
+++ b/functional/otlp/func_http_main.cc
@@ -1,9 +1,9 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
+#include <cstdint>
 #include <cstdio>
 #include <cstring>
-#include <cstdint>
 #include <iostream>
 #include <string>
 #include <utility>

--- a/opentracing-shim/include/opentelemetry/opentracingshim/shim_utils.h
+++ b/opentracing-shim/include/opentelemetry/opentracingshim/shim_utils.h
@@ -5,7 +5,7 @@
 
 #pragma once
 
-#include <stdint.h>
+#include <cstdint>
 #include <algorithm>
 #include <cstddef>
 #include <initializer_list>

--- a/opentracing-shim/include/opentelemetry/opentracingshim/shim_utils.h
+++ b/opentracing-shim/include/opentelemetry/opentracingshim/shim_utils.h
@@ -5,9 +5,9 @@
 
 #pragma once
 
-#include <cstdint>
 #include <algorithm>
 #include <cstddef>
+#include <cstdint>
 #include <initializer_list>
 #include <string>
 #include <utility>

--- a/opentracing-shim/test/shim_utils_test.cc
+++ b/opentracing-shim/test/shim_utils_test.cc
@@ -4,8 +4,8 @@
  */
 
 #include <gtest/gtest.h>
-#include <cstdint>
 #include <chrono>
+#include <cstdint>
 #include <map>
 #include <string>
 #include <tuple>

--- a/opentracing-shim/test/shim_utils_test.cc
+++ b/opentracing-shim/test/shim_utils_test.cc
@@ -4,7 +4,7 @@
  */
 
 #include <gtest/gtest.h>
-#include <stdint.h>
+#include <cstdint>
 #include <chrono>
 #include <map>
 #include <string>

--- a/opentracing-shim/test/span_shim_test.cc
+++ b/opentracing-shim/test/span_shim_test.cc
@@ -4,7 +4,7 @@
  */
 
 #include <gtest/gtest.h>
-#include <stdint.h>
+#include <cstdint>
 #include <chrono>
 #include <functional>
 #include <initializer_list>

--- a/opentracing-shim/test/span_shim_test.cc
+++ b/opentracing-shim/test/span_shim_test.cc
@@ -4,8 +4,8 @@
  */
 
 #include <gtest/gtest.h>
-#include <cstdint>
 #include <chrono>
+#include <cstdint>
 #include <functional>
 #include <initializer_list>
 #include <string>

--- a/opentracing-shim/test/tracer_shim_test.cc
+++ b/opentracing-shim/test/tracer_shim_test.cc
@@ -4,7 +4,7 @@
  */
 
 #include <gtest/gtest.h>
-#include <stdint.h>
+#include <cstdint>
 #include <iostream>
 #include <string>
 #include <system_error>

--- a/resource_detectors/include/opentelemetry/resource_detectors/detail/process_detector_utils.h
+++ b/resource_detectors/include/opentelemetry/resource_detectors/detail/process_detector_utils.h
@@ -3,7 +3,7 @@
 
 #pragma once
 
-#include <stdint.h>
+#include <cstdint>
 #include <string>
 #include <vector>
 

--- a/resource_detectors/src/process_detector.cc
+++ b/resource_detectors/src/process_detector.cc
@@ -10,7 +10,7 @@
 #include "opentelemetry/semconv/incubating/process_attributes.h"
 #include "opentelemetry/version.h"
 
-#include <stdint.h>
+#include <cstdint>
 #include <exception>
 #include <ostream>
 #include <string>

--- a/resource_detectors/test/process_detector_test.cc
+++ b/resource_detectors/test/process_detector_test.cc
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include <gtest/gtest.h>
-#include <stdint.h>
+#include <cstdint>
 #include <fstream>
 #include <string>
 #include <vector>

--- a/sdk/include/opentelemetry/sdk/common/attributemap_hash.h
+++ b/sdk/include/opentelemetry/sdk/common/attributemap_hash.h
@@ -3,7 +3,7 @@
 
 #pragma once
 
-#include <stddef.h>
+#include <cstddef>
 #include <functional>
 #include <string>
 #include <utility>

--- a/sdk/include/opentelemetry/sdk/common/circular_buffer_range.h
+++ b/sdk/include/opentelemetry/sdk/common/circular_buffer_range.h
@@ -3,7 +3,7 @@
 
 #pragma once
 
-#include <stddef.h>
+#include <cstddef>
 #include <cassert>
 #include <type_traits>
 

--- a/sdk/include/opentelemetry/sdk/common/circular_buffer_range.h
+++ b/sdk/include/opentelemetry/sdk/common/circular_buffer_range.h
@@ -3,8 +3,8 @@
 
 #pragma once
 
-#include <cstddef>
 #include <cassert>
+#include <cstddef>
 #include <type_traits>
 
 #include "opentelemetry/nostd/span.h"

--- a/sdk/include/opentelemetry/sdk/common/empty_attributes.h
+++ b/sdk/include/opentelemetry/sdk/common/empty_attributes.h
@@ -3,7 +3,7 @@
 
 #pragma once
 
-#include <stdint.h>
+#include <cstdint>
 #include <array>
 #include <string>
 #include <utility>

--- a/sdk/include/opentelemetry/sdk/common/empty_attributes.h
+++ b/sdk/include/opentelemetry/sdk/common/empty_attributes.h
@@ -3,8 +3,8 @@
 
 #pragma once
 
-#include <cstdint>
 #include <array>
+#include <cstdint>
 #include <string>
 #include <utility>
 

--- a/sdk/include/opentelemetry/sdk/configuration/ryml_document_node.h
+++ b/sdk/include/opentelemetry/sdk/configuration/ryml_document_node.h
@@ -3,7 +3,7 @@
 
 #pragma once
 
-#include <stddef.h>
+#include <cstddef>
 #include <cstdint>
 #include <memory>
 #include <ryml.hpp>

--- a/sdk/include/opentelemetry/sdk/logs/batch_log_record_processor.h
+++ b/sdk/include/opentelemetry/sdk/logs/batch_log_record_processor.h
@@ -3,7 +3,7 @@
 
 #pragma once
 
-#include <stddef.h>
+#include <cstddef>
 #include <atomic>
 #include <chrono>
 #include <condition_variable>

--- a/sdk/include/opentelemetry/sdk/logs/batch_log_record_processor.h
+++ b/sdk/include/opentelemetry/sdk/logs/batch_log_record_processor.h
@@ -3,10 +3,10 @@
 
 #pragma once
 
-#include <cstddef>
 #include <atomic>
 #include <chrono>
 #include <condition_variable>
+#include <cstddef>
 #include <cstdint>
 #include <memory>
 #include <mutex>

--- a/sdk/include/opentelemetry/sdk/logs/multi_recordable.h
+++ b/sdk/include/opentelemetry/sdk/logs/multi_recordable.h
@@ -3,7 +3,7 @@
 
 #pragma once
 
-#include <stdint.h>
+#include <cstdint>
 #include <cstddef>
 #include <memory>
 #include <unordered_map>

--- a/sdk/include/opentelemetry/sdk/logs/multi_recordable.h
+++ b/sdk/include/opentelemetry/sdk/logs/multi_recordable.h
@@ -3,8 +3,8 @@
 
 #pragma once
 
-#include <cstdint>
 #include <cstddef>
+#include <cstdint>
 #include <memory>
 #include <unordered_map>
 

--- a/sdk/include/opentelemetry/sdk/logs/readable_log_record.h
+++ b/sdk/include/opentelemetry/sdk/logs/readable_log_record.h
@@ -3,7 +3,7 @@
 
 #pragma once
 
-#include <stdint.h>
+#include <cstdint>
 #include <string>
 #include <unordered_map>
 

--- a/sdk/include/opentelemetry/sdk/metrics/aggregation/aggregation.h
+++ b/sdk/include/opentelemetry/sdk/metrics/aggregation/aggregation.h
@@ -3,7 +3,7 @@
 
 #pragma once
 
-#include <stdint.h>
+#include <cstdint>
 #include <memory>
 #include "opentelemetry/sdk/metrics/data/metric_data.h"
 #include "opentelemetry/version.h"

--- a/sdk/include/opentelemetry/sdk/metrics/aggregation/base2_exponential_histogram_aggregation.h
+++ b/sdk/include/opentelemetry/sdk/metrics/aggregation/base2_exponential_histogram_aggregation.h
@@ -3,7 +3,7 @@
 
 #pragma once
 
-#include <stdint.h>
+#include <cstdint>
 #include <memory>
 
 #include "opentelemetry/common/spin_lock_mutex.h"

--- a/sdk/include/opentelemetry/sdk/metrics/aggregation/base2_exponential_histogram_indexer.h
+++ b/sdk/include/opentelemetry/sdk/metrics/aggregation/base2_exponential_histogram_indexer.h
@@ -3,7 +3,7 @@
 
 #pragma once
 
-#include <stdint.h>
+#include <cstdint>
 
 #include "opentelemetry/version.h"
 

--- a/sdk/include/opentelemetry/sdk/metrics/aggregation/histogram_aggregation.h
+++ b/sdk/include/opentelemetry/sdk/metrics/aggregation/histogram_aggregation.h
@@ -3,9 +3,9 @@
 
 #pragma once
 
+#include <algorithm>
 #include <cstddef>
 #include <cstdint>
-#include <algorithm>
 #include <memory>
 #include <vector>
 

--- a/sdk/include/opentelemetry/sdk/metrics/aggregation/histogram_aggregation.h
+++ b/sdk/include/opentelemetry/sdk/metrics/aggregation/histogram_aggregation.h
@@ -3,8 +3,8 @@
 
 #pragma once
 
-#include <stddef.h>
-#include <stdint.h>
+#include <cstddef>
+#include <cstdint>
 #include <algorithm>
 #include <memory>
 #include <vector>

--- a/sdk/include/opentelemetry/sdk/metrics/aggregation/lastvalue_aggregation.h
+++ b/sdk/include/opentelemetry/sdk/metrics/aggregation/lastvalue_aggregation.h
@@ -3,7 +3,7 @@
 
 #pragma once
 
-#include <stdint.h>
+#include <cstdint>
 #include <memory>
 
 #include "opentelemetry/common/spin_lock_mutex.h"

--- a/sdk/include/opentelemetry/sdk/metrics/aggregation/sum_aggregation.h
+++ b/sdk/include/opentelemetry/sdk/metrics/aggregation/sum_aggregation.h
@@ -3,7 +3,7 @@
 
 #pragma once
 
-#include <stdint.h>
+#include <cstdint>
 #include <memory>
 
 #include "opentelemetry/common/spin_lock_mutex.h"

--- a/sdk/include/opentelemetry/sdk/metrics/exemplar/no_exemplar_reservoir.h
+++ b/sdk/include/opentelemetry/sdk/metrics/exemplar/no_exemplar_reservoir.h
@@ -5,7 +5,7 @@
 
 #ifdef ENABLE_METRICS_EXEMPLAR_PREVIEW
 
-#  include <stdint.h>
+#  include <cstdint>
 #  include <memory>
 #  include <vector>
 

--- a/sdk/include/opentelemetry/sdk/metrics/exemplar/reservoir_cell.h
+++ b/sdk/include/opentelemetry/sdk/metrics/exemplar/reservoir_cell.h
@@ -5,8 +5,8 @@
 
 #ifdef ENABLE_METRICS_EXEMPLAR_PREVIEW
 
-#  include <stdint.h>
 #  include <chrono>
+#  include <cstdint>
 #  include <map>
 #  include <memory>
 #  include <utility>

--- a/sdk/include/opentelemetry/sdk/metrics/state/attributes_hashmap.h
+++ b/sdk/include/opentelemetry/sdk/metrics/state/attributes_hashmap.h
@@ -3,7 +3,7 @@
 
 #pragma once
 
-#include <stddef.h>
+#include <cstddef>
 #include <functional>
 #include <memory>
 #include <string>

--- a/sdk/include/opentelemetry/sdk/metrics/state/filtered_ordered_attribute_map.h
+++ b/sdk/include/opentelemetry/sdk/metrics/state/filtered_ordered_attribute_map.h
@@ -3,7 +3,7 @@
 
 #pragma once
 
-#include <stddef.h>
+#include <cstddef>
 #include <initializer_list>
 #include <limits>
 #include <map>

--- a/sdk/include/opentelemetry/sdk/metrics/state/multi_metric_storage.h
+++ b/sdk/include/opentelemetry/sdk/metrics/state/multi_metric_storage.h
@@ -3,7 +3,7 @@
 
 #pragma once
 
-#include <stdint.h>
+#include <cstdint>
 #include <memory>
 #include <unordered_map>
 #include <vector>

--- a/sdk/include/opentelemetry/sdk/metrics/state/sync_metric_storage.h
+++ b/sdk/include/opentelemetry/sdk/metrics/state/sync_metric_storage.h
@@ -3,8 +3,8 @@
 
 #pragma once
 
-#include <stddef.h>
-#include <stdint.h>
+#include <cstddef>
+#include <cstdint>
 #include <functional>
 #include <memory>
 #include <mutex>

--- a/sdk/include/opentelemetry/sdk/metrics/sync_instruments.h
+++ b/sdk/include/opentelemetry/sdk/metrics/sync_instruments.h
@@ -3,7 +3,7 @@
 
 #pragma once
 
-#include <stdint.h>
+#include <cstdint>
 #include <memory>
 #include <utility>
 

--- a/sdk/include/opentelemetry/sdk/trace/batch_span_processor.h
+++ b/sdk/include/opentelemetry/sdk/trace/batch_span_processor.h
@@ -3,7 +3,7 @@
 
 #pragma once
 
-#include <stddef.h>
+#include <cstddef>
 #include <atomic>
 #include <chrono>
 #include <condition_variable>

--- a/sdk/include/opentelemetry/sdk/trace/batch_span_processor.h
+++ b/sdk/include/opentelemetry/sdk/trace/batch_span_processor.h
@@ -3,10 +3,10 @@
 
 #pragma once
 
-#include <cstddef>
 #include <atomic>
 #include <chrono>
 #include <condition_variable>
+#include <cstddef>
 #include <cstdint>
 #include <memory>
 #include <mutex>

--- a/sdk/include/opentelemetry/sdk/trace/samplers/probability.h
+++ b/sdk/include/opentelemetry/sdk/trace/samplers/probability.h
@@ -3,7 +3,7 @@
 
 #pragma once
 
-#include <stdint.h>
+#include <cstdint>
 #include <string>
 
 #include "opentelemetry/nostd/string_view.h"

--- a/sdk/include/opentelemetry/sdk/trace/samplers/trace_id_ratio.h
+++ b/sdk/include/opentelemetry/sdk/trace/samplers/trace_id_ratio.h
@@ -3,7 +3,7 @@
 
 #pragma once
 
-#include <stdint.h>
+#include <cstdint>
 #include <string>
 
 #include "opentelemetry/nostd/string_view.h"

--- a/sdk/include/opentelemetry/sdk/trace/tracer.h
+++ b/sdk/include/opentelemetry/sdk/trace/tracer.h
@@ -3,7 +3,7 @@
 
 #pragma once
 
-#include <stdint.h>
+#include <cstdint>
 
 #include <atomic>
 #include <mutex>

--- a/sdk/src/common/base64.cc
+++ b/sdk/src/common/base64.cc
@@ -6,7 +6,7 @@
 #if defined(HAVE_GSL)
 #  include <gsl/gsl>
 #else
-#  include <assert.h>
+#  include <cassert>
 #endif
 #include <cstring>
 #include <limits>

--- a/sdk/src/common/empty_attributes.cc
+++ b/sdk/src/common/empty_attributes.cc
@@ -1,7 +1,7 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-#include <stdint.h>
+#include <cstdint>
 #include <array>
 #include <string>
 #include <utility>

--- a/sdk/src/common/empty_attributes.cc
+++ b/sdk/src/common/empty_attributes.cc
@@ -1,8 +1,8 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-#include <cstdint>
 #include <array>
+#include <cstdint>
 #include <string>
 #include <utility>
 

--- a/sdk/src/common/env_variables.cc
+++ b/sdk/src/common/env_variables.cc
@@ -4,7 +4,7 @@
 #include "opentelemetry/sdk/common/env_variables.h"
 
 #ifdef _MSC_VER
-#  include <string.h>
+#  include <cstring>
 #  define strcasecmp _stricmp
 #else
 #  include <strings.h>

--- a/sdk/src/common/random.h
+++ b/sdk/src/common/random.h
@@ -3,7 +3,7 @@
 
 #pragma once
 
-#include <stdint.h>
+#include <cstdint>
 
 #include "opentelemetry/nostd/span.h"
 #include "opentelemetry/version.h"

--- a/sdk/src/configuration/configuration_parser.cc
+++ b/sdk/src/configuration/configuration_parser.cc
@@ -1,7 +1,7 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-#include <stdio.h>
+#include <cstdio>
 #include <cstddef>
 #include <cstdint>
 #include <fstream>

--- a/sdk/src/configuration/configuration_parser.cc
+++ b/sdk/src/configuration/configuration_parser.cc
@@ -1,9 +1,9 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-#include <cstdio>
 #include <cstddef>
 #include <cstdint>
+#include <cstdio>
 #include <fstream>
 #include <limits>
 #include <map>

--- a/sdk/src/configuration/ryml_document_node.cc
+++ b/sdk/src/configuration/ryml_document_node.cc
@@ -1,7 +1,7 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-#include <stddef.h>
+#include <cstddef>
 #include <cstdint>
 #include <memory>
 #include <ostream>

--- a/sdk/src/logs/batch_log_record_processor.cc
+++ b/sdk/src/logs/batch_log_record_processor.cc
@@ -1,10 +1,10 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-#include <cstddef>
 #include <atomic>
 #include <chrono>
 #include <condition_variable>
+#include <cstddef>
 #include <cstdint>
 #include <memory>
 #include <mutex>

--- a/sdk/src/logs/batch_log_record_processor.cc
+++ b/sdk/src/logs/batch_log_record_processor.cc
@@ -1,7 +1,7 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-#include <stddef.h>
+#include <cstddef>
 #include <atomic>
 #include <chrono>
 #include <condition_variable>

--- a/sdk/src/logs/logger.cc
+++ b/sdk/src/logs/logger.cc
@@ -1,9 +1,9 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-#include <cstdint>
 #include <atomic>
 #include <chrono>
+#include <cstdint>
 #include <string>
 #include <utility>
 

--- a/sdk/src/logs/logger.cc
+++ b/sdk/src/logs/logger.cc
@@ -1,7 +1,7 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-#include <stdint.h>
+#include <cstdint>
 #include <atomic>
 #include <chrono>
 #include <string>

--- a/sdk/src/logs/multi_recordable.cc
+++ b/sdk/src/logs/multi_recordable.cc
@@ -1,7 +1,7 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-#include <stdint.h>
+#include <cstdint>
 #include <cstddef>
 #include <memory>
 #include <unordered_map>

--- a/sdk/src/logs/multi_recordable.cc
+++ b/sdk/src/logs/multi_recordable.cc
@@ -1,8 +1,8 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-#include <cstdint>
 #include <cstddef>
+#include <cstdint>
 #include <memory>
 #include <unordered_map>
 #include <utility>

--- a/sdk/src/logs/read_write_log_record.cc
+++ b/sdk/src/logs/read_write_log_record.cc
@@ -1,7 +1,7 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-#include <stdint.h>
+#include <cstdint>
 #include <chrono>
 #include <memory>
 #include <string>

--- a/sdk/src/logs/read_write_log_record.cc
+++ b/sdk/src/logs/read_write_log_record.cc
@@ -1,8 +1,8 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-#include <cstdint>
 #include <chrono>
+#include <cstdint>
 #include <memory>
 #include <string>
 #include <unordered_map>

--- a/sdk/src/metrics/aggregation/base2_exponential_histogram_aggregation.cc
+++ b/sdk/src/metrics/aggregation/base2_exponential_histogram_aggregation.cc
@@ -1,10 +1,10 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-#include <cstddef>
-#include <cstdint>
 #include <algorithm>
 #include <cassert>
+#include <cstddef>
+#include <cstdint>
 #include <limits>
 #include <memory>
 #include <mutex>

--- a/sdk/src/metrics/aggregation/base2_exponential_histogram_aggregation.cc
+++ b/sdk/src/metrics/aggregation/base2_exponential_histogram_aggregation.cc
@@ -1,8 +1,8 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-#include <stddef.h>
-#include <stdint.h>
+#include <cstddef>
+#include <cstdint>
 #include <algorithm>
 #include <cassert>
 #include <limits>

--- a/sdk/src/metrics/aggregation/histogram_aggregation.cc
+++ b/sdk/src/metrics/aggregation/histogram_aggregation.cc
@@ -1,8 +1,8 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-#include <cstddef>
 #include <algorithm>
+#include <cstddef>
 #include <cstdint>
 #include <limits>
 #include <memory>

--- a/sdk/src/metrics/aggregation/histogram_aggregation.cc
+++ b/sdk/src/metrics/aggregation/histogram_aggregation.cc
@@ -1,7 +1,7 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-#include <stddef.h>
+#include <cstddef>
 #include <algorithm>
 #include <cstdint>
 #include <limits>

--- a/sdk/src/metrics/aggregation/lastvalue_aggregation.cc
+++ b/sdk/src/metrics/aggregation/lastvalue_aggregation.cc
@@ -1,8 +1,8 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-#include <cstdint>
 #include <chrono>
+#include <cstdint>
 #include <memory>
 #include <mutex>
 

--- a/sdk/src/metrics/aggregation/lastvalue_aggregation.cc
+++ b/sdk/src/metrics/aggregation/lastvalue_aggregation.cc
@@ -1,7 +1,7 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-#include <stdint.h>
+#include <cstdint>
 #include <chrono>
 #include <memory>
 #include <mutex>

--- a/sdk/src/metrics/aggregation/sum_aggregation.cc
+++ b/sdk/src/metrics/aggregation/sum_aggregation.cc
@@ -1,7 +1,7 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-#include <stdint.h>
+#include <cstdint>
 #include <memory>
 #include <mutex>
 #include <ostream>

--- a/sdk/src/metrics/data/circular_buffer.cc
+++ b/sdk/src/metrics/data/circular_buffer.cc
@@ -1,7 +1,7 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-#include <stddef.h>
+#include <cstddef>
 #include <cassert>
 #include <cstdint>
 #include <limits>

--- a/sdk/src/metrics/data/circular_buffer.cc
+++ b/sdk/src/metrics/data/circular_buffer.cc
@@ -1,8 +1,8 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-#include <cstddef>
 #include <cassert>
+#include <cstddef>
 #include <cstdint>
 #include <limits>
 #include <utility>

--- a/sdk/src/metrics/exemplar/reservoir.cc
+++ b/sdk/src/metrics/exemplar/reservoir.cc
@@ -3,7 +3,7 @@
 
 #ifdef ENABLE_METRICS_EXEMPLAR_PREVIEW
 
-#  include <stddef.h>
+#  include <cstddef>
 
 #  include "opentelemetry/nostd/shared_ptr.h"
 #  include "opentelemetry/sdk/metrics/exemplar/aligned_histogram_bucket_exemplar_reservoir.h"

--- a/sdk/src/metrics/state/sync_metric_storage.cc
+++ b/sdk/src/metrics/state/sync_metric_storage.cc
@@ -16,7 +16,7 @@
 #include "opentelemetry/version.h"
 
 #ifdef OPENTELEMETRY_HAVE_METRICS_BOUND_INSTRUMENTS_PREVIEW
-#  include <stdint.h>
+#  include <cstdint>
 #  include <functional>
 #  include <unordered_map>
 #  include <unordered_set>

--- a/sdk/src/metrics/sync_instruments.cc
+++ b/sdk/src/metrics/sync_instruments.cc
@@ -1,7 +1,7 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-#include <stdint.h>
+#include <cstdint>
 #include <limits>
 #include <ostream>
 #include <string>

--- a/sdk/src/resource/resource_detector.cc
+++ b/sdk/src/resource/resource_detector.cc
@@ -8,7 +8,7 @@
 #include "opentelemetry/semconv/service_attributes.h"
 #include "opentelemetry/version.h"
 
-#include <stddef.h>
+#include <cstddef>
 #include <sstream>
 #include <string>
 

--- a/sdk/src/trace/batch_span_processor.cc
+++ b/sdk/src/trace/batch_span_processor.cc
@@ -1,10 +1,10 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-#include <cstddef>
 #include <atomic>
 #include <chrono>
 #include <condition_variable>
+#include <cstddef>
 #include <cstdint>
 #include <memory>
 #include <mutex>

--- a/sdk/src/trace/batch_span_processor.cc
+++ b/sdk/src/trace/batch_span_processor.cc
@@ -1,7 +1,7 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-#include <stddef.h>
+#include <cstddef>
 #include <atomic>
 #include <chrono>
 #include <condition_variable>

--- a/sdk/src/trace/random_id_generator.cc
+++ b/sdk/src/trace/random_id_generator.cc
@@ -1,7 +1,7 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-#include <stdint.h>
+#include <cstdint>
 
 #include "opentelemetry/nostd/span.h"
 #include "opentelemetry/sdk/trace/random_id_generator.h"

--- a/sdk/src/trace/tracer.cc
+++ b/sdk/src/trace/tracer.cc
@@ -1,7 +1,7 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-#include <stdint.h>
+#include <cstdint>
 #include <chrono>
 #include <map>
 #include <mutex>

--- a/sdk/src/trace/tracer.cc
+++ b/sdk/src/trace/tracer.cc
@@ -1,8 +1,8 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-#include <cstdint>
 #include <chrono>
+#include <cstdint>
 #include <map>
 #include <mutex>
 #include <new>

--- a/sdk/test/common/attribute_utils_test.cc
+++ b/sdk/test/common/attribute_utils_test.cc
@@ -2,8 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include <gtest/gtest.h>
-#include <cstdint>
 #include <array>
+#include <cstdint>
 #include <initializer_list>
 #include <map>
 #include <string>

--- a/sdk/test/common/attribute_utils_test.cc
+++ b/sdk/test/common/attribute_utils_test.cc
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include <gtest/gtest.h>
-#include <stdint.h>
+#include <cstdint>
 #include <array>
 #include <initializer_list>
 #include <map>

--- a/sdk/test/common/circular_buffer_benchmark.cc
+++ b/sdk/test/common/circular_buffer_benchmark.cc
@@ -1,7 +1,7 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-#include <stddef.h>
+#include <cstddef>
 #include <atomic>
 #include <cstdint>
 #include <exception>

--- a/sdk/test/common/circular_buffer_benchmark.cc
+++ b/sdk/test/common/circular_buffer_benchmark.cc
@@ -1,8 +1,8 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-#include <cstddef>
 #include <atomic>
+#include <cstddef>
 #include <cstdint>
 #include <exception>
 #include <functional>

--- a/sdk/test/common/circular_buffer_test.cc
+++ b/sdk/test/common/circular_buffer_test.cc
@@ -2,10 +2,10 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include <gtest/gtest.h>
-#include <cstddef>
 #include <algorithm>
 #include <atomic>
 #include <cassert>
+#include <cstddef>
 #include <cstdint>
 #include <functional>
 #include <initializer_list>

--- a/sdk/test/common/circular_buffer_test.cc
+++ b/sdk/test/common/circular_buffer_test.cc
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include <gtest/gtest.h>
-#include <stddef.h>
+#include <cstddef>
 #include <algorithm>
 #include <atomic>
 #include <cassert>

--- a/sdk/test/common/empty_attributes_test.cc
+++ b/sdk/test/common/empty_attributes_test.cc
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include <gtest/gtest.h>
-#include <string.h>
+#include <cstring>
 #include <array>
 #include <string>
 #include <utility>

--- a/sdk/test/common/empty_attributes_test.cc
+++ b/sdk/test/common/empty_attributes_test.cc
@@ -2,8 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include <gtest/gtest.h>
-#include <cstring>
 #include <array>
+#include <cstring>
 #include <string>
 #include <utility>
 

--- a/sdk/test/common/random_fork_test.cc
+++ b/sdk/test/common/random_fork_test.cc
@@ -7,10 +7,10 @@
 // See https://github.com/opentracing-contrib/nginx-opentracing/issues/52
 #  include "src/common/random.h"
 
-#  include <stdint.h>
 #  include <sys/mman.h>
 #  include <sys/wait.h>
 #  include <unistd.h>
+#  include <cstdint>
 #  include <cstdlib>
 #  include <iostream>
 

--- a/sdk/test/configuration/yaml_test.cc
+++ b/sdk/test/configuration/yaml_test.cc
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include <gtest/gtest.h>
-#include <stdlib.h>
+#include <cstdlib>
 #include <memory>
 #include <string>
 

--- a/sdk/test/instrumentationscope/instrumentationscope_test.cc
+++ b/sdk/test/instrumentationscope/instrumentationscope_test.cc
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include <gtest/gtest.h>
-#include <stdint.h>
+#include <cstdint>
 #include <initializer_list>
 #include <string>
 #include <unordered_map>

--- a/sdk/test/logs/batch_log_record_processor_test.cc
+++ b/sdk/test/logs/batch_log_record_processor_test.cc
@@ -2,8 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include <gtest/gtest.h>
-#include <stdint.h>
-#include <stdlib.h>
+#include <cstdint>
+#include <cstdlib>
 #include <atomic>
 #include <chrono>
 #include <cstddef>

--- a/sdk/test/logs/batch_log_record_processor_test.cc
+++ b/sdk/test/logs/batch_log_record_processor_test.cc
@@ -2,11 +2,11 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include <gtest/gtest.h>
-#include <cstdint>
-#include <cstdlib>
 #include <atomic>
 #include <chrono>
 #include <cstddef>
+#include <cstdint>
+#include <cstdlib>
 #include <memory>
 #include <string>
 #include <thread>

--- a/sdk/test/logs/log_record_limits_test.cc
+++ b/sdk/test/logs/log_record_limits_test.cc
@@ -2,9 +2,9 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include <gtest/gtest.h>
-#include <cstdint>
 #include <chrono>
 #include <cstddef>
+#include <cstdint>
 #include <memory>
 #include <string>
 #include <unordered_map>

--- a/sdk/test/logs/log_record_limits_test.cc
+++ b/sdk/test/logs/log_record_limits_test.cc
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include <gtest/gtest.h>
-#include <stdint.h>
+#include <cstdint>
 #include <chrono>
 #include <cstddef>
 #include <memory>

--- a/sdk/test/logs/log_record_test.cc
+++ b/sdk/test/logs/log_record_test.cc
@@ -2,8 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include <gtest/gtest.h>
-#include <cstdint>
 #include <chrono>
+#include <cstdint>
 #include <cstdlib>
 #include <initializer_list>
 #include <string>

--- a/sdk/test/logs/log_record_test.cc
+++ b/sdk/test/logs/log_record_test.cc
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include <gtest/gtest.h>
-#include <stdint.h>
+#include <cstdint>
 #include <chrono>
 #include <cstdlib>
 #include <initializer_list>

--- a/sdk/test/logs/logger_provider_sdk_test.cc
+++ b/sdk/test/logs/logger_provider_sdk_test.cc
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include <gtest/gtest.h>
-#include <stdint.h>
+#include <cstdint>
 #include <atomic>
 #include <chrono>
 #include <cstddef>

--- a/sdk/test/logs/logger_provider_sdk_test.cc
+++ b/sdk/test/logs/logger_provider_sdk_test.cc
@@ -2,10 +2,10 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include <gtest/gtest.h>
-#include <cstdint>
 #include <atomic>
 #include <chrono>
 #include <cstddef>
+#include <cstdint>
 #include <future>
 #include <mutex>
 #include <string>

--- a/sdk/test/logs/logger_provider_set_test.cc
+++ b/sdk/test/logs/logger_provider_set_test.cc
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include <gtest/gtest.h>
-#include <stdlib.h>
+#include <cstdlib>
 #include <string>
 
 #include "opentelemetry/logs/event_logger.h"           // IWYU pragma: keep

--- a/sdk/test/logs/logger_sdk_test.cc
+++ b/sdk/test/logs/logger_sdk_test.cc
@@ -45,7 +45,7 @@
 #include "opentelemetry/trace/tracer.h"
 
 #if OPENTELEMETRY_ABI_VERSION_NO >= 2
-#  include <stddef.h>
+#  include <cstddef>
 
 #  include "opentelemetry/context/context.h"
 #  include "opentelemetry/nostd/span.h"

--- a/sdk/test/logs/logger_sdk_test.cc
+++ b/sdk/test/logs/logger_sdk_test.cc
@@ -2,9 +2,9 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include <gtest/gtest.h>
-#include <cstdint>
 #include <array>
 #include <chrono>
+#include <cstdint>
 #include <functional>
 #include <string>
 #include <utility>

--- a/sdk/test/logs/logger_sdk_test.cc
+++ b/sdk/test/logs/logger_sdk_test.cc
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include <gtest/gtest.h>
-#include <stdint.h>
+#include <cstdint>
 #include <array>
 #include <chrono>
 #include <functional>

--- a/sdk/test/logs/simple_log_record_processor_test.cc
+++ b/sdk/test/logs/simple_log_record_processor_test.cc
@@ -2,8 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include <gtest/gtest.h>
-#include <stddef.h>
-#include <stdint.h>
+#include <cstddef>
+#include <cstdint>
 #include <chrono>
 #include <memory>
 #include <string>

--- a/sdk/test/logs/simple_log_record_processor_test.cc
+++ b/sdk/test/logs/simple_log_record_processor_test.cc
@@ -2,9 +2,9 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include <gtest/gtest.h>
+#include <chrono>
 #include <cstddef>
 #include <cstdint>
-#include <chrono>
 #include <memory>
 #include <string>
 #include <utility>

--- a/sdk/test/metrics/aggregation_test.cc
+++ b/sdk/test/metrics/aggregation_test.cc
@@ -2,9 +2,9 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include <gtest/gtest.h>
+#include <algorithm>
 #include <cstddef>
 #include <cstdint>
-#include <algorithm>
 #include <limits>
 #include <memory>
 #include <string>

--- a/sdk/test/metrics/aggregation_test.cc
+++ b/sdk/test/metrics/aggregation_test.cc
@@ -2,8 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include <gtest/gtest.h>
-#include <stddef.h>
-#include <stdint.h>
+#include <cstddef>
+#include <cstdint>
 #include <algorithm>
 #include <limits>
 #include <memory>

--- a/sdk/test/metrics/attributes_hashmap_benchmark.cc
+++ b/sdk/test/metrics/attributes_hashmap_benchmark.cc
@@ -2,8 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include <benchmark/benchmark.h>
-#include <stddef.h>
-#include <stdint.h>
+#include <cstddef>
+#include <cstdint>
 #include <functional>
 #include <memory>
 #include <mutex>

--- a/sdk/test/metrics/attributes_hashmap_test.cc
+++ b/sdk/test/metrics/attributes_hashmap_test.cc
@@ -2,8 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include <gtest/gtest.h>
-#include <stddef.h>
-#include <stdint.h>
+#include <cstddef>
+#include <cstdint>
 #include <functional>
 #include <memory>
 #include <string>

--- a/sdk/test/metrics/base2_exponential_histogram_indexer_benchmark.cc
+++ b/sdk/test/metrics/base2_exponential_histogram_indexer_benchmark.cc
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include <benchmark/benchmark.h>
-#include <stdint.h>
+#include <cstdint>
 #include <array>
 #include <random>
 

--- a/sdk/test/metrics/base2_exponential_histogram_indexer_benchmark.cc
+++ b/sdk/test/metrics/base2_exponential_histogram_indexer_benchmark.cc
@@ -2,8 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include <benchmark/benchmark.h>
-#include <cstdint>
 #include <array>
+#include <cstdint>
 #include <random>
 
 #include "opentelemetry/sdk/metrics/aggregation/base2_exponential_histogram_indexer.h"

--- a/sdk/test/metrics/base2_exponential_histogram_indexer_test.cc
+++ b/sdk/test/metrics/base2_exponential_histogram_indexer_test.cc
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include <gtest/gtest.h>
-#include <stdlib.h>
+#include <cstdlib>
 #include <limits>
 #include <string>
 

--- a/sdk/test/metrics/bound_sync_instruments_test.cc
+++ b/sdk/test/metrics/bound_sync_instruments_test.cc
@@ -6,9 +6,9 @@
 #ifdef OPENTELEMETRY_HAVE_METRICS_BOUND_INSTRUMENTS_PREVIEW
 
 #  include <gtest/gtest.h>
-#  include <stddef.h>
-#  include <stdint.h>
 #  include <chrono>
+#  include <cstddef>
+#  include <cstdint>
 #  include <limits>
 #  include <map>
 #  include <memory>

--- a/sdk/test/metrics/cardinality_limit_test.cc
+++ b/sdk/test/metrics/cardinality_limit_test.cc
@@ -2,9 +2,9 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include <gtest/gtest.h>
+#include <chrono>
 #include <cstddef>
 #include <cstdint>
-#include <chrono>
 #include <functional>
 #include <map>
 #include <memory>

--- a/sdk/test/metrics/cardinality_limit_test.cc
+++ b/sdk/test/metrics/cardinality_limit_test.cc
@@ -2,8 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include <gtest/gtest.h>
-#include <stddef.h>
-#include <stdint.h>
+#include <cstddef>
+#include <cstdint>
 #include <chrono>
 #include <functional>
 #include <map>

--- a/sdk/test/metrics/circular_buffer_counter_benchmark.cc
+++ b/sdk/test/metrics/circular_buffer_counter_benchmark.cc
@@ -2,8 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include <benchmark/benchmark.h>
-#include <stddef.h>
-#include <stdint.h>
+#include <cstddef>
+#include <cstdint>
 
 #include "opentelemetry/sdk/metrics/data/circular_buffer.h"
 

--- a/sdk/test/metrics/exemplar/aligned_histogram_bucket_exemplar_reservoir_test.cc
+++ b/sdk/test/metrics/exemplar/aligned_histogram_bucket_exemplar_reservoir_test.cc
@@ -4,8 +4,8 @@
 #ifdef ENABLE_METRICS_EXEMPLAR_PREVIEW
 
 #  include <gtest/gtest.h>
-#  include <stdint.h>
 #  include <chrono>
+#  include <cstdint>
 #  include <memory>
 #  include <string>
 #  include <vector>

--- a/sdk/test/metrics/exemplar/no_exemplar_reservoir_test.cc
+++ b/sdk/test/metrics/exemplar/no_exemplar_reservoir_test.cc
@@ -4,8 +4,8 @@
 #ifdef ENABLE_METRICS_EXEMPLAR_PREVIEW
 
 #  include <gtest/gtest.h>
-#  include <stdint.h>
 #  include <chrono>
+#  include <cstdint>
 #  include <memory>
 #  include <string>
 #  include <vector>

--- a/sdk/test/metrics/exemplar/reservoir_cell_test.cc
+++ b/sdk/test/metrics/exemplar/reservoir_cell_test.cc
@@ -4,7 +4,7 @@
 #ifdef ENABLE_METRICS_EXEMPLAR_PREVIEW
 
 #  include <gtest/gtest.h>
-#  include <stdint.h>
+#  include <cstdint>
 #  include <memory>
 #  include <string>
 #  include <utility>

--- a/sdk/test/metrics/histogram_aggregation_benchmark.cc
+++ b/sdk/test/metrics/histogram_aggregation_benchmark.cc
@@ -2,8 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include <benchmark/benchmark.h>
-#include <stddef.h>
-#include <stdint.h>
+#include <cstddef>
+#include <cstdint>
 #include <chrono>
 #include <cmath>
 #include <functional>

--- a/sdk/test/metrics/histogram_aggregation_benchmark.cc
+++ b/sdk/test/metrics/histogram_aggregation_benchmark.cc
@@ -2,10 +2,10 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include <benchmark/benchmark.h>
-#include <cstddef>
-#include <cstdint>
 #include <chrono>
 #include <cmath>
+#include <cstddef>
+#include <cstdint>
 #include <functional>
 #include <initializer_list>  // IWYU pragma: keep
 #include <random>

--- a/sdk/test/metrics/histogram_aggregation_test.cc
+++ b/sdk/test/metrics/histogram_aggregation_test.cc
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include <gtest/gtest.h>
-#include <stdint.h>
+#include <cstdint>
 #include <initializer_list>
 #include <string>
 #include <utility>

--- a/sdk/test/metrics/instrument_metadata_validator_test.cc
+++ b/sdk/test/metrics/instrument_metadata_validator_test.cc
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include <gtest/gtest.h>
-#include <stddef.h>
+#include <cstddef>
 #include <string>
 #include <vector>
 

--- a/sdk/test/metrics/meter_provider_sdk_test.cc
+++ b/sdk/test/metrics/meter_provider_sdk_test.cc
@@ -24,7 +24,7 @@
 #include "opentelemetry/test_common/sdk/common/scoped_test_log_handler.h"
 
 #if OPENTELEMETRY_ABI_VERSION_NO >= 2
-#  include <stdint.h>
+#  include <cstdint>
 #  include <initializer_list>
 #  include <map>
 #  include <unordered_map>

--- a/sdk/test/metrics/meter_provider_set_test.cc
+++ b/sdk/test/metrics/meter_provider_set_test.cc
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include <gtest/gtest.h>
-#include <stdlib.h>
+#include <cstdlib>
 #include <string>
 
 #include "opentelemetry/metrics/meter_provider.h"

--- a/sdk/test/metrics/meter_test.cc
+++ b/sdk/test/metrics/meter_test.cc
@@ -2,11 +2,11 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include <gtest/gtest.h>
-#include <cstddef>
-#include <cstdint>
 #include <algorithm>
 #include <atomic>
 #include <chrono>
+#include <cstddef>
+#include <cstdint>
 #include <initializer_list>  // IWYU pragma: keep
 #include <iostream>
 #include <string>

--- a/sdk/test/metrics/meter_test.cc
+++ b/sdk/test/metrics/meter_test.cc
@@ -2,8 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include <gtest/gtest.h>
-#include <stddef.h>
-#include <stdint.h>
+#include <cstddef>
+#include <cstdint>
 #include <algorithm>
 #include <atomic>
 #include <chrono>

--- a/sdk/test/metrics/metric_collector_test.cc
+++ b/sdk/test/metrics/metric_collector_test.cc
@@ -2,8 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include <gtest/gtest.h>
-#include <stddef.h>
-#include <stdint.h>
+#include <cstddef>
+#include <cstdint>
 #include <map>
 #include <memory>
 #include <string>

--- a/sdk/test/metrics/metric_test_stress.cc
+++ b/sdk/test/metrics/metric_test_stress.cc
@@ -3,10 +3,10 @@
 
 #include <gtest/gtest.h>
 
-#include <cstdint>
 #include <algorithm>
 #include <atomic>
 #include <chrono>
+#include <cstdint>
 #include <initializer_list>  // IWYU pragma: keep
 #include <random>
 #include <string>

--- a/sdk/test/metrics/metric_test_stress.cc
+++ b/sdk/test/metrics/metric_test_stress.cc
@@ -3,7 +3,7 @@
 
 #include <gtest/gtest.h>
 
-#include <stdint.h>
+#include <cstdint>
 #include <algorithm>
 #include <atomic>
 #include <chrono>

--- a/sdk/test/metrics/multi_metric_storage_test.cc
+++ b/sdk/test/metrics/multi_metric_storage_test.cc
@@ -2,8 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include <gtest/gtest.h>
-#include <stddef.h>
-#include <stdint.h>
+#include <cstddef>
+#include <cstdint>
 #include <string>
 
 #include "opentelemetry/context/context.h"

--- a/sdk/test/metrics/periodic_exporting_metric_reader_test.cc
+++ b/sdk/test/metrics/periodic_exporting_metric_reader_test.cc
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include <gtest/gtest.h>
-#include <stddef.h>
+#include <cstddef>
 #include <chrono>
 #include <cstdlib>
 #include <memory>

--- a/sdk/test/metrics/periodic_exporting_metric_reader_test.cc
+++ b/sdk/test/metrics/periodic_exporting_metric_reader_test.cc
@@ -2,8 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include <gtest/gtest.h>
-#include <cstddef>
 #include <chrono>
+#include <cstddef>
 #include <cstdlib>
 #include <memory>
 #include <string>

--- a/sdk/test/metrics/sum_aggregation_benchmark.cc
+++ b/sdk/test/metrics/sum_aggregation_benchmark.cc
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include <benchmark/benchmark.h>
-#include <stddef.h>
+#include <cstddef>
 #include <chrono>
 #include <functional>
 #include <initializer_list>

--- a/sdk/test/metrics/sum_aggregation_benchmark.cc
+++ b/sdk/test/metrics/sum_aggregation_benchmark.cc
@@ -2,8 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include <benchmark/benchmark.h>
-#include <cstddef>
 #include <chrono>
+#include <cstddef>
 #include <functional>
 #include <initializer_list>
 #include <random>

--- a/sdk/test/metrics/sum_aggregation_test.cc
+++ b/sdk/test/metrics/sum_aggregation_test.cc
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include <gtest/gtest.h>
-#include <stddef.h>
+#include <cstddef>
 #include <initializer_list>
 #include <map>
 #include <string>

--- a/sdk/test/metrics/sync_metric_storage_counter_test.cc
+++ b/sdk/test/metrics/sync_metric_storage_counter_test.cc
@@ -2,8 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include <gtest/gtest.h>
-#include <stddef.h>
-#include <stdint.h>
+#include <cstddef>
+#include <cstdint>
 #include <chrono>
 #include <map>
 #include <memory>

--- a/sdk/test/metrics/sync_metric_storage_counter_test.cc
+++ b/sdk/test/metrics/sync_metric_storage_counter_test.cc
@@ -2,9 +2,9 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include <gtest/gtest.h>
+#include <chrono>
 #include <cstddef>
 #include <cstdint>
-#include <chrono>
 #include <map>
 #include <memory>
 #include <string>

--- a/sdk/test/metrics/sync_metric_storage_gauge_test.cc
+++ b/sdk/test/metrics/sync_metric_storage_gauge_test.cc
@@ -9,9 +9,9 @@
 #include "opentelemetry/sdk/metrics/instruments.h"
 
 #if OPENTELEMETRY_ABI_VERSION_NO >= 2
-#  include <stddef.h>
-#  include <stdint.h>
 #  include <chrono>
+#  include <cstddef>
+#  include <cstdint>
 #  include <map>
 #  include <memory>
 #  include <utility>

--- a/sdk/test/metrics/sync_metric_storage_histogram_test.cc
+++ b/sdk/test/metrics/sync_metric_storage_histogram_test.cc
@@ -2,8 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include <gtest/gtest.h>
-#include <stddef.h>
-#include <stdint.h>
+#include <cstddef>
+#include <cstdint>
 #include <chrono>
 #include <map>
 #include <memory>

--- a/sdk/test/metrics/sync_metric_storage_histogram_test.cc
+++ b/sdk/test/metrics/sync_metric_storage_histogram_test.cc
@@ -2,9 +2,9 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include <gtest/gtest.h>
+#include <chrono>
 #include <cstddef>
 #include <cstdint>
-#include <chrono>
 #include <map>
 #include <memory>
 #include <string>

--- a/sdk/test/metrics/sync_metric_storage_up_down_counter_test.cc
+++ b/sdk/test/metrics/sync_metric_storage_up_down_counter_test.cc
@@ -2,8 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include <gtest/gtest.h>
-#include <stddef.h>
-#include <stdint.h>
+#include <cstddef>
+#include <cstdint>
 #include <chrono>
 #include <map>
 #include <memory>

--- a/sdk/test/metrics/sync_metric_storage_up_down_counter_test.cc
+++ b/sdk/test/metrics/sync_metric_storage_up_down_counter_test.cc
@@ -2,9 +2,9 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include <gtest/gtest.h>
+#include <chrono>
 #include <cstddef>
 #include <cstdint>
-#include <chrono>
 #include <map>
 #include <memory>
 #include <string>

--- a/sdk/test/resource/resource_test.cc
+++ b/sdk/test/resource/resource_test.cc
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include <gtest/gtest.h>
-#include <stdint.h>
+#include <cstdint>
 #include <cstdlib>
 #include <map>
 #include <string>

--- a/sdk/test/trace/always_on_sampler_test.cc
+++ b/sdk/test/trace/always_on_sampler_test.cc
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include <gtest/gtest.h>
-#include <stdint.h>
+#include <cstdint>
 #include <map>
 #include <string>
 #include <utility>

--- a/sdk/test/trace/batch_span_processor_test.cc
+++ b/sdk/test/trace/batch_span_processor_test.cc
@@ -2,11 +2,11 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include <gtest/gtest.h>
-#include <cstdlib>
 #include <algorithm>
 #include <atomic>
 #include <chrono>
 #include <cstddef>
+#include <cstdlib>
 #include <string>
 #include <thread>
 #include <utility>

--- a/sdk/test/trace/batch_span_processor_test.cc
+++ b/sdk/test/trace/batch_span_processor_test.cc
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include <gtest/gtest.h>
-#include <stdlib.h>
+#include <cstdlib>
 #include <algorithm>
 #include <atomic>
 #include <chrono>

--- a/sdk/test/trace/composable_sampler_test.cc
+++ b/sdk/test/trace/composable_sampler_test.cc
@@ -1,7 +1,7 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-#include <stddef.h>
+#include <cstddef>
 #include <cstdint>
 #include <map>
 #include <string>

--- a/sdk/test/trace/probability_sampler_test.cc
+++ b/sdk/test/trace/probability_sampler_test.cc
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include <gtest/gtest.h>
-#include <stdint.h>
+#include <cstdint>
 #include <cmath>
 #include <initializer_list>
 #include <map>

--- a/sdk/test/trace/probability_sampler_test.cc
+++ b/sdk/test/trace/probability_sampler_test.cc
@@ -2,8 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include <gtest/gtest.h>
-#include <cstdint>
 #include <cmath>
+#include <cstdint>
 #include <initializer_list>
 #include <map>
 #include <string>

--- a/sdk/test/trace/trace_id_ratio_sampler_test.cc
+++ b/sdk/test/trace/trace_id_ratio_sampler_test.cc
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include <gtest/gtest.h>
-#include <stdint.h>
+#include <cstdint>
 #include <map>
 #include <string>
 #include <utility>

--- a/sdk/test/trace/tracer_provider_set_test.cc
+++ b/sdk/test/trace/tracer_provider_set_test.cc
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include <gtest/gtest.h>
-#include <stdlib.h>
+#include <cstdlib>
 #include <string>
 
 #include "opentelemetry/nostd/shared_ptr.h"

--- a/sdk/test/trace/tracer_provider_test.cc
+++ b/sdk/test/trace/tracer_provider_test.cc
@@ -2,10 +2,10 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include <gtest/gtest.h>
-#include <cstdlib>
 #include <atomic>
 #include <cstddef>
 #include <cstdint>
+#include <cstdlib>
 #include <future>
 #include <limits>
 #include <string>

--- a/sdk/test/trace/tracer_provider_test.cc
+++ b/sdk/test/trace/tracer_provider_test.cc
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include <gtest/gtest.h>
-#include <stdlib.h>
+#include <cstdlib>
 #include <atomic>
 #include <cstddef>
 #include <cstdint>

--- a/sdk/test/trace/tracer_test.cc
+++ b/sdk/test/trace/tracer_test.cc
@@ -1,7 +1,7 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-#include <assert.h>
+#include <cassert>
 #include <gtest/gtest.h>
 #include <chrono>
 #include <cstdint>

--- a/sdk/test/trace/tracer_test.cc
+++ b/sdk/test/trace/tracer_test.cc
@@ -1,8 +1,8 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-#include <cassert>
 #include <gtest/gtest.h>
+#include <cassert>
 #include <chrono>
 #include <cstdint>
 #include <functional>

--- a/test_common/include/opentelemetry/test_common/ext/http/client/nosend/http_client_nosend.h
+++ b/test_common/include/opentelemetry/test_common/ext/http/client/nosend/http_client_nosend.h
@@ -4,9 +4,9 @@
 #pragma once
 
 #include <gmock/gmock.h>
-#include <cstdint>
 #include <chrono>
 #include <cstddef>
+#include <cstdint>
 #include <memory>
 #include <string>
 #include <utility>

--- a/test_common/include/opentelemetry/test_common/ext/http/client/nosend/http_client_nosend.h
+++ b/test_common/include/opentelemetry/test_common/ext/http/client/nosend/http_client_nosend.h
@@ -4,7 +4,7 @@
 #pragma once
 
 #include <gmock/gmock.h>
-#include <stdint.h>
+#include <cstdint>
 #include <chrono>
 #include <cstddef>
 #include <memory>

--- a/test_common/src/http/client/nosend/http_client_nosend.cc
+++ b/test_common/src/http/client/nosend/http_client_nosend.cc
@@ -1,8 +1,8 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-#include <cstdint>
 #include <cstddef>
+#include <cstdint>
 #include <map>
 #include <memory>
 #include <string>

--- a/test_common/src/http/client/nosend/http_client_nosend.cc
+++ b/test_common/src/http/client/nosend/http_client_nosend.cc
@@ -1,7 +1,7 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-#include <stdint.h>
+#include <cstdint>
 #include <cstddef>
 #include <map>
 #include <memory>


### PR DESCRIPTION
Fixes #4348

## Changes

Enables the `modernize-deprecated-headers` clang-tidy check, which was disabled in `.clang-tidy`, and replaces deprecated C headers with their C++ equivalents (`stdint.h` -> `cstdint`, `stddef.h` -> `cstddef`, `stdlib.h` -> `cstdlib`, `string.h` -> `cstring`, `stdio.h` -> `cstdio`, `ctype.h` -> `cctype`, `limits.h` -> `climits`, `assert.h` -> `cassert`) across `api`, `sdk`, `exporters`, `ext`, `examples`, `opentracing-shim`, `resource_detectors`, `test_common`, and `functional`.

As noted in the issue, IWYU was still recommending the deprecated headers, so `.iwyu.imp` is updated first to map `struct tm`/`struct FILE` usages to `<ctime>`/`<cstdio>` instead of `<time.h>`/`<stdio.h>`.

Two now-duplicate includes that this change surfaced were also removed, in `api/test/core/timestamp_test.cc` and `exporters/elasticsearch/src/es_log_recordable.cc`.

* [x] `CHANGELOG.md` updated for non-trivial changes
* [ ] Unit tests have been added
* [ ] Changes in public API reviewed