### PR TITLE
[CODE HEALTH] Move remaining misc-use-internal-linkage sites into anonymous namespaces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,12 @@ Increment the:
 
 ## [Unreleased]
 
+* [CODE HEALTH] Move remaining `misc-use-internal-linkage` classes/enums into
+  anonymous namespaces: `OtlpFileSystemBackend`/`OtlpFileOstreamBackend` in
+  the OTLP file exporter, `ResponseHandler`/`AsyncResponseHandler`/
+  `json_assign_visitor` in the Elasticsearch log exporter, and the
+  `TestMode`/`test_mode` enums in the OTLP functional test binaries.
+  [#4196](https://github.com/open-telemetry/opentelemetry-cpp/issues/4196)
 * [METRICS SDK] Fix Windows metrics tail latency on the synchronous record path:
   `SyncMetricStorage::attribute_hashmap_lock_` now uses `std::mutex` instead of
   `common::SpinLockMutex`. The spin lock's final `sleep_for(1ms)` back-off is

--- a/exporters/elasticsearch/src/es_log_record_exporter.cc
+++ b/exporters/elasticsearch/src/es_log_record_exporter.cc
@@ -41,6 +41,8 @@ namespace exporter
 {
 namespace logs
 {
+namespace
+{
 /**
  * This class handles the response message from the Elasticsearch request
  */
@@ -349,6 +351,7 @@ private:
   bool console_debug_ = false;
 };
 #endif
+}  // namespace
 
 ElasticsearchLogRecordExporter::ElasticsearchLogRecordExporter()
     : ElasticsearchLogRecordExporter(ElasticsearchExporterOptions())

--- a/exporters/elasticsearch/src/es_log_recordable.cc
+++ b/exporters/elasticsearch/src/es_log_recordable.cc
@@ -31,6 +31,8 @@
 
 namespace nlohmann
 {
+namespace
+{
 template <class T>
 struct json_assign_visitor
 {
@@ -53,6 +55,7 @@ struct json_assign_visitor
     }
   }
 };
+}  // namespace
 
 template <>
 struct adl_serializer<opentelemetry::sdk::common::OwnedAttributeValue>

--- a/exporters/otlp/src/otlp_file_client.cc
+++ b/exporters/otlp/src/otlp_file_client.cc
@@ -973,7 +973,6 @@ void ConvertListFieldToJson(nlohmann::json &value,
 
 // NOLINTEND(misc-no-recursion) suppressing for performance as if implemented with stack needs
 // Dynamic memory allocation
-}  // namespace
 
 class OPENTELEMETRY_LOCAL_SYMBOL OtlpFileSystemBackend : public OtlpFileAppender
 {
@@ -1615,6 +1614,7 @@ public:
 private:
   std::reference_wrapper<std::ostream> os_;
 };
+}  // namespace
 
 OtlpFileClient::OtlpFileClient(OtlpFileClientOptions &&options,
                                OtlpFileClientRuntimeOptions &&runtime_options)

--- a/functional/otlp/func_grpc_main.cc
+++ b/functional/otlp/func_grpc_main.cc
@@ -39,12 +39,15 @@ const int TEST_FAILED = 1;
   Command line parameters.
 */
 
+namespace
+{
 enum class TestMode : std::uint8_t
 {
   kNone,
   kHttp,
   kHttps
 };
+}  // namespace
 
 static bool opt_help   = false;
 static bool opt_list   = false;

--- a/functional/otlp/func_http_main.cc
+++ b/functional/otlp/func_http_main.cc
@@ -38,12 +38,15 @@ const int TEST_FAILED = 1;
   Command line parameters.
 */
 
+namespace
+{
 enum test_mode : std::uint8_t
 {
   MODE_NONE,
   MODE_HTTP,
   MODE_HTTPS
 };
+}  // namespace
 
 static bool opt_help   = false;
 static bool opt_list   = false;


### PR DESCRIPTION
## Summary

Closes the last four sites left open on #4196 after the earlier batch of PRs (#4199, #4200, #4217, #4225, #4231, #4286, #4301, #4302, #4303):

- `exporters/otlp/src/otlp_file_client.cc`: `OtlpFileSystemBackend` and `OtlpFileOstreamBackend` extended into the file's existing anonymous namespace
- `exporters/elasticsearch/src/es_log_record_exporter.cc`: `ResponseHandler` and `AsyncResponseHandler` wrapped in an anonymous namespace
- `exporters/elasticsearch/src/es_log_recordable.cc`: `json_assign_visitor` wrapped in an anonymous namespace nested inside `namespace nlohmann`
- `functional/otlp/func_grpc_main.cc` / `func_http_main.cc`: the `TestMode` / `test_mode` enums (declared before the file's existing anonymous namespace block, since the `static` variable using them is referenced throughout the whole translation unit) each given their own small anonymous-namespace wrap

All four are file-local classes/enums with no header exposure, so this is a mechanical, low-risk change with no behavior difference.

## Test plan

- [x] `opentelemetry_exporter_otlp_file_client` builds clean (`WITH_OTLP_FILE=ON`)
- [x] `opentelemetry_exporter_elasticsearch_logs` builds clean (`WITH_ELASTICSEARCH=ON`), confirmed via object-file timestamps newer than the source edits
- [x] `functional/otlp/func_http_main.cc` compiles clean via direct compiler invocation (`WITH_OTLP_HTTP=ON`)
- [x] `functional/otlp/func_grpc_main.cc` syntax-checked clean (`-fsyntax-only`) using the project's real include paths (gRPC dependency build was skipped locally to avoid a slow from-source clone; the file itself doesn't depend on gRPC headers)

Fixes #4196