### PR TITLE
[CONFIGURATION] Decouple SDK includes from builder interface classes

### DIFF
--- a/sdk/include/opentelemetry/sdk/configuration/console_log_record_exporter_builder.h
+++ b/sdk/include/opentelemetry/sdk/configuration/console_log_record_exporter_builder.h
@@ -6,12 +6,16 @@
 #include <memory>
 
 #include "opentelemetry/sdk/configuration/console_log_record_exporter_configuration.h"
-#include "opentelemetry/sdk/logs/exporter.h"
 #include "opentelemetry/version.h"
 
 OPENTELEMETRY_BEGIN_NAMESPACE
 namespace sdk
 {
+namespace logs
+{
+class LogRecordExporter;
+}  // namespace logs
+
 namespace configuration
 {
 

--- a/sdk/include/opentelemetry/sdk/configuration/console_push_metric_exporter_builder.h
+++ b/sdk/include/opentelemetry/sdk/configuration/console_push_metric_exporter_builder.h
@@ -6,12 +6,16 @@
 #include <memory>
 
 #include "opentelemetry/sdk/configuration/console_push_metric_exporter_configuration.h"
-#include "opentelemetry/sdk/metrics/push_metric_exporter.h"
 #include "opentelemetry/version.h"
 
 OPENTELEMETRY_BEGIN_NAMESPACE
 namespace sdk
 {
+namespace metrics
+{
+class PushMetricExporter;
+}  // namespace metrics
+
 namespace configuration
 {
 

--- a/sdk/include/opentelemetry/sdk/configuration/console_span_exporter_builder.h
+++ b/sdk/include/opentelemetry/sdk/configuration/console_span_exporter_builder.h
@@ -6,12 +6,16 @@
 #include <memory>
 
 #include "opentelemetry/sdk/configuration/console_span_exporter_configuration.h"
-#include "opentelemetry/sdk/trace/exporter.h"
 #include "opentelemetry/version.h"
 
 OPENTELEMETRY_BEGIN_NAMESPACE
 namespace sdk
 {
+namespace trace
+{
+class SpanExporter;
+}  // namespace trace
+
 namespace configuration
 {
 

--- a/sdk/include/opentelemetry/sdk/configuration/extension_log_record_exporter_builder.h
+++ b/sdk/include/opentelemetry/sdk/configuration/extension_log_record_exporter_builder.h
@@ -6,12 +6,16 @@
 #include <memory>
 
 #include "opentelemetry/sdk/configuration/extension_log_record_exporter_configuration.h"
-#include "opentelemetry/sdk/logs/exporter.h"
 #include "opentelemetry/version.h"
 
 OPENTELEMETRY_BEGIN_NAMESPACE
 namespace sdk
 {
+namespace logs
+{
+class LogRecordExporter;
+}  // namespace logs
+
 namespace configuration
 {
 

--- a/sdk/include/opentelemetry/sdk/configuration/extension_log_record_processor_builder.h
+++ b/sdk/include/opentelemetry/sdk/configuration/extension_log_record_processor_builder.h
@@ -6,12 +6,16 @@
 #include <memory>
 
 #include "opentelemetry/sdk/configuration/extension_log_record_processor_configuration.h"
-#include "opentelemetry/sdk/logs/processor.h"
 #include "opentelemetry/version.h"
 
 OPENTELEMETRY_BEGIN_NAMESPACE
 namespace sdk
 {
+namespace logs
+{
+class LogRecordProcessor;
+}  // namespace logs
+
 namespace configuration
 {
 

--- a/sdk/include/opentelemetry/sdk/configuration/extension_pull_metric_exporter_builder.h
+++ b/sdk/include/opentelemetry/sdk/configuration/extension_pull_metric_exporter_builder.h
@@ -6,12 +6,16 @@
 #include <memory>
 
 #include "opentelemetry/sdk/configuration/extension_pull_metric_exporter_configuration.h"
-#include "opentelemetry/sdk/metrics/metric_reader.h"
 #include "opentelemetry/version.h"
 
 OPENTELEMETRY_BEGIN_NAMESPACE
 namespace sdk
 {
+namespace metrics
+{
+class MetricReader;
+}  // namespace metrics
+
 namespace configuration
 {
 

--- a/sdk/include/opentelemetry/sdk/configuration/extension_push_metric_exporter_builder.h
+++ b/sdk/include/opentelemetry/sdk/configuration/extension_push_metric_exporter_builder.h
@@ -6,12 +6,16 @@
 #include <memory>
 
 #include "opentelemetry/sdk/configuration/extension_push_metric_exporter_configuration.h"
-#include "opentelemetry/sdk/metrics/push_metric_exporter.h"
 #include "opentelemetry/version.h"
 
 OPENTELEMETRY_BEGIN_NAMESPACE
 namespace sdk
 {
+namespace metrics
+{
+class PushMetricExporter;
+}  // namespace metrics
+
 namespace configuration
 {
 

--- a/sdk/include/opentelemetry/sdk/configuration/extension_sampler_builder.h
+++ b/sdk/include/opentelemetry/sdk/configuration/extension_sampler_builder.h
@@ -6,12 +6,16 @@
 #include <memory>
 
 #include "opentelemetry/sdk/configuration/extension_sampler_configuration.h"
-#include "opentelemetry/sdk/trace/sampler.h"
 #include "opentelemetry/version.h"
 
 OPENTELEMETRY_BEGIN_NAMESPACE
 namespace sdk
 {
+namespace trace
+{
+class Sampler;
+}  // namespace trace
+
 namespace configuration
 {
 

--- a/sdk/include/opentelemetry/sdk/configuration/extension_span_exporter_builder.h
+++ b/sdk/include/opentelemetry/sdk/configuration/extension_span_exporter_builder.h
@@ -6,12 +6,16 @@
 #include <memory>
 
 #include "opentelemetry/sdk/configuration/extension_span_exporter_configuration.h"
-#include "opentelemetry/sdk/trace/exporter.h"
 #include "opentelemetry/version.h"
 
 OPENTELEMETRY_BEGIN_NAMESPACE
 namespace sdk
 {
+namespace trace
+{
+class SpanExporter;
+}  // namespace trace
+
 namespace configuration
 {
 

--- a/sdk/include/opentelemetry/sdk/configuration/extension_span_processor_builder.h
+++ b/sdk/include/opentelemetry/sdk/configuration/extension_span_processor_builder.h
@@ -6,12 +6,16 @@
 #include <memory>
 
 #include "opentelemetry/sdk/configuration/extension_span_processor_configuration.h"
-#include "opentelemetry/sdk/trace/processor.h"
 #include "opentelemetry/version.h"
 
 OPENTELEMETRY_BEGIN_NAMESPACE
 namespace sdk
 {
+namespace trace
+{
+class SpanProcessor;
+}  // namespace trace
+
 namespace configuration
 {
 

--- a/sdk/include/opentelemetry/sdk/configuration/otlp_file_log_record_exporter_builder.h
+++ b/sdk/include/opentelemetry/sdk/configuration/otlp_file_log_record_exporter_builder.h
@@ -6,12 +6,16 @@
 #include <memory>
 
 #include "opentelemetry/sdk/configuration/otlp_file_log_record_exporter_configuration.h"
-#include "opentelemetry/sdk/logs/exporter.h"
 #include "opentelemetry/version.h"
 
 OPENTELEMETRY_BEGIN_NAMESPACE
 namespace sdk
 {
+namespace logs
+{
+class LogRecordExporter;
+}  // namespace logs
+
 namespace configuration
 {
 

--- a/sdk/include/opentelemetry/sdk/configuration/otlp_file_push_metric_exporter_builder.h
+++ b/sdk/include/opentelemetry/sdk/configuration/otlp_file_push_metric_exporter_builder.h
@@ -7,12 +7,16 @@
 
 #include "opentelemetry/sdk/configuration/otlp_file_push_metric_exporter_configuration.h"
 #include "opentelemetry/sdk/configuration/push_metric_exporter_configuration.h"
-#include "opentelemetry/sdk/metrics/push_metric_exporter.h"
 #include "opentelemetry/version.h"
 
 OPENTELEMETRY_BEGIN_NAMESPACE
 namespace sdk
 {
+namespace metrics
+{
+class PushMetricExporter;
+}  // namespace metrics
+
 namespace configuration
 {
 

--- a/sdk/include/opentelemetry/sdk/configuration/otlp_file_span_exporter_builder.h
+++ b/sdk/include/opentelemetry/sdk/configuration/otlp_file_span_exporter_builder.h
@@ -6,12 +6,16 @@
 #include <memory>
 
 #include "opentelemetry/sdk/configuration/otlp_file_span_exporter_configuration.h"
-#include "opentelemetry/sdk/trace/exporter.h"
 #include "opentelemetry/version.h"
 
 OPENTELEMETRY_BEGIN_NAMESPACE
 namespace sdk
 {
+namespace trace
+{
+class SpanExporter;
+}  // namespace trace
+
 namespace configuration
 {
 

--- a/sdk/include/opentelemetry/sdk/configuration/otlp_grpc_log_record_exporter_builder.h
+++ b/sdk/include/opentelemetry/sdk/configuration/otlp_grpc_log_record_exporter_builder.h
@@ -6,12 +6,16 @@
 #include <memory>
 
 #include "opentelemetry/sdk/configuration/otlp_grpc_log_record_exporter_configuration.h"
-#include "opentelemetry/sdk/logs/exporter.h"
 #include "opentelemetry/version.h"
 
 OPENTELEMETRY_BEGIN_NAMESPACE
 namespace sdk
 {
+namespace logs
+{
+class LogRecordExporter;
+}  // namespace logs
+
 namespace configuration
 {
 

--- a/sdk/include/opentelemetry/sdk/configuration/otlp_grpc_push_metric_exporter_builder.h
+++ b/sdk/include/opentelemetry/sdk/configuration/otlp_grpc_push_metric_exporter_builder.h
@@ -7,12 +7,16 @@
 
 #include "opentelemetry/sdk/configuration/otlp_grpc_push_metric_exporter_configuration.h"
 #include "opentelemetry/sdk/configuration/push_metric_exporter_configuration.h"
-#include "opentelemetry/sdk/metrics/push_metric_exporter.h"
 #include "opentelemetry/version.h"
 
 OPENTELEMETRY_BEGIN_NAMESPACE
 namespace sdk
 {
+namespace metrics
+{
+class PushMetricExporter;
+}  // namespace metrics
+
 namespace configuration
 {
 

--- a/sdk/include/opentelemetry/sdk/configuration/otlp_grpc_span_exporter_builder.h
+++ b/sdk/include/opentelemetry/sdk/configuration/otlp_grpc_span_exporter_builder.h
@@ -6,12 +6,16 @@
 #include <memory>
 
 #include "opentelemetry/sdk/configuration/otlp_grpc_span_exporter_configuration.h"
-#include "opentelemetry/sdk/trace/exporter.h"
 #include "opentelemetry/version.h"
 
 OPENTELEMETRY_BEGIN_NAMESPACE
 namespace sdk
 {
+namespace trace
+{
+class SpanExporter;
+}  // namespace trace
+
 namespace configuration
 {
 

--- a/sdk/include/opentelemetry/sdk/configuration/otlp_http_log_record_exporter_builder.h
+++ b/sdk/include/opentelemetry/sdk/configuration/otlp_http_log_record_exporter_builder.h
@@ -6,12 +6,16 @@
 #include <memory>
 
 #include "opentelemetry/sdk/configuration/otlp_http_log_record_exporter_configuration.h"
-#include "opentelemetry/sdk/logs/exporter.h"
 #include "opentelemetry/version.h"
 
 OPENTELEMETRY_BEGIN_NAMESPACE
 namespace sdk
 {
+namespace logs
+{
+class LogRecordExporter;
+}  // namespace logs
+
 namespace configuration
 {
 

--- a/sdk/include/opentelemetry/sdk/configuration/otlp_http_push_metric_exporter_builder.h
+++ b/sdk/include/opentelemetry/sdk/configuration/otlp_http_push_metric_exporter_builder.h
@@ -7,12 +7,16 @@
 
 #include "opentelemetry/sdk/configuration/otlp_http_push_metric_exporter_configuration.h"
 #include "opentelemetry/sdk/configuration/push_metric_exporter_configuration.h"
-#include "opentelemetry/sdk/metrics/push_metric_exporter.h"
 #include "opentelemetry/version.h"
 
 OPENTELEMETRY_BEGIN_NAMESPACE
 namespace sdk
 {
+namespace metrics
+{
+class PushMetricExporter;
+}  // namespace metrics
+
 namespace configuration
 {
 

--- a/sdk/include/opentelemetry/sdk/configuration/otlp_http_span_exporter_builder.h
+++ b/sdk/include/opentelemetry/sdk/configuration/otlp_http_span_exporter_builder.h
@@ -6,12 +6,16 @@
 #include <memory>
 
 #include "opentelemetry/sdk/configuration/otlp_http_span_exporter_configuration.h"
-#include "opentelemetry/sdk/trace/exporter.h"
 #include "opentelemetry/version.h"
 
 OPENTELEMETRY_BEGIN_NAMESPACE
 namespace sdk
 {
+namespace trace
+{
+class SpanExporter;
+}  // namespace trace
+
 namespace configuration
 {
 

--- a/sdk/include/opentelemetry/sdk/configuration/periodic_metric_reader_builder.h
+++ b/sdk/include/opentelemetry/sdk/configuration/periodic_metric_reader_builder.h
@@ -6,13 +6,17 @@
 #include <memory>
 
 #include "opentelemetry/sdk/configuration/periodic_metric_reader_configuration.h"
-#include "opentelemetry/sdk/metrics/metric_reader.h"
-#include "opentelemetry/sdk/metrics/push_metric_exporter.h"
 #include "opentelemetry/version.h"
 
 OPENTELEMETRY_BEGIN_NAMESPACE
 namespace sdk
 {
+namespace metrics
+{
+class MetricReader;
+class PushMetricExporter;
+}  // namespace metrics
+
 namespace configuration
 {
 

--- a/sdk/include/opentelemetry/sdk/configuration/prometheus_pull_metric_exporter_builder.h
+++ b/sdk/include/opentelemetry/sdk/configuration/prometheus_pull_metric_exporter_builder.h
@@ -6,12 +6,16 @@
 #include <memory>
 
 #include "opentelemetry/sdk/configuration/prometheus_pull_metric_exporter_configuration.h"
-#include "opentelemetry/sdk/metrics/metric_reader.h"
 #include "opentelemetry/version.h"
 
 OPENTELEMETRY_BEGIN_NAMESPACE
 namespace sdk
 {
+namespace metrics
+{
+class MetricReader;
+}  // namespace metrics
+
 namespace configuration
 {
 


### PR DESCRIPTION
Contributes to #4352

Follow up to #4335 to continue breaking dependencies between `configuration_core` and the SDK signal libraries.

The goal is to decouple the abstract builder headers from the SDK component headers. After this change, including an abstract builder header no longer pulls in the SDK headers of the component it builds. The SDK type is forward declared. The requirement for the complete type is deferred to the translation units that implement or invoke a builder, which by definition already include the concrete SDK header and link that signal's library. 

This makes the contract for `configuration_core` more explicit in that it provides the
abstract builder headers without transitively providing the SDK signal headers.

## Changes

- Replace SDK component includes with forward declarations in the abstract builder headers

For significant contributions please make sure you have completed the following items:

* [ ] `CHANGELOG.md` updated for non-trivial changes
* [ ] Unit tests have been added
* [ ] Changes in public API reviewed