### PR TITLE
[CODE HEALTH] Qualify C library calls with std:: after modernize-deprecated-headers

### DIFF
--- a/api/include/opentelemetry/common/kv_properties.h
+++ b/api/include/opentelemetry/common/kv_properties.h
@@ -192,7 +192,7 @@ public:
     nostd::unique_ptr<const char[]> CopyStringToPointer(nostd::string_view str)
     {
       char *temp = new char[str.size() + 1];
-      memcpy(temp, str.data(), str.size());
+      std::memcpy(temp, str.data(), str.size());
       temp[str.size()] = '\0';
       return nostd::unique_ptr<const char[]>(temp);
     }

--- a/api/include/opentelemetry/common/string_util.h
+++ b/api/include/opentelemetry/common/string_util.h
@@ -27,11 +27,11 @@ public:
     {
       return nostd::string_view();
     }
-    while (left <= right && isspace(str[left]))
+    while (left <= right && std::isspace(str[left]))
     {
       left++;
     }
-    while (left <= right && isspace(str[right]))
+    while (left <= right && std::isspace(str[right]))
     {
       right--;
     }

--- a/api/include/opentelemetry/trace/span_id.h
+++ b/api/include/opentelemetry/trace/span_id.h
@@ -23,7 +23,10 @@ public:
   SpanId() noexcept = default;
 
   // Creates a SpanId with the given ID.
-  explicit SpanId(nostd::span<const uint8_t, kSize> id) noexcept { memcpy(rep_, id.data(), kSize); }
+  explicit SpanId(nostd::span<const uint8_t, kSize> id) noexcept
+  {
+    std::memcpy(rep_, id.data(), kSize);
+  }
 
   // Populates the buffer with the lowercase base16 representation of the ID.
   void ToLowerBase16(nostd::span<char, 2 * kSize> buffer) const noexcept
@@ -42,7 +45,10 @@ public:
     return nostd::span<const uint8_t, kSize>(rep_);
   }
 
-  bool operator==(const SpanId &that) const noexcept { return memcmp(rep_, that.rep_, kSize) == 0; }
+  bool operator==(const SpanId &that) const noexcept
+  {
+    return std::memcmp(rep_, that.rep_, kSize) == 0;
+  }
 
   bool operator!=(const SpanId &that) const noexcept { return !(*this == that); }
 
@@ -50,13 +56,13 @@ public:
   bool IsValid() const noexcept
   {
     static constexpr uint8_t kEmptyRep[kSize] = {0};
-    return memcmp(rep_, kEmptyRep, kSize) != 0;
+    return std::memcmp(rep_, kEmptyRep, kSize) != 0;
   }
 
   // Copies the opaque SpanId data to dest.
   void CopyBytesTo(nostd::span<uint8_t, kSize> dest) const noexcept
   {
-    memcpy(dest.data(), rep_, kSize);
+    std::memcpy(dest.data(), rep_, kSize);
   }
 
 private:

--- a/api/include/opentelemetry/trace/trace_id.h
+++ b/api/include/opentelemetry/trace/trace_id.h
@@ -28,7 +28,7 @@ public:
   // Creates a TraceId with the given ID.
   explicit TraceId(nostd::span<const uint8_t, kSize> id) noexcept
   {
-    memcpy(rep_, id.data(), kSize);
+    std::memcpy(rep_, id.data(), kSize);
   }
 
   // Populates the buffer with the lowercase base16 representation of the ID.
@@ -50,7 +50,7 @@ public:
 
   bool operator==(const TraceId &that) const noexcept
   {
-    return memcmp(rep_, that.rep_, kSize) == 0;
+    return std::memcmp(rep_, that.rep_, kSize) == 0;
   }
 
   bool operator!=(const TraceId &that) const noexcept { return !(*this == that); }
@@ -61,7 +61,7 @@ public:
   // Copies the opaque TraceId data to dest.
   void CopyBytesTo(nostd::span<uint8_t, kSize> dest) const noexcept
   {
-    memcpy(dest.data(), rep_, kSize);
+    std::memcpy(dest.data(), rep_, kSize);
   }
 
 private:

--- a/api/include/opentelemetry/trace/trace_state.h
+++ b/api/include/opentelemetry/trace/trace_state.h
@@ -322,7 +322,10 @@ private:
   }
 #endif
 
-  static bool IsLowerCaseAlphaOrDigit(char c) noexcept { return isdigit(c) || islower(c); }
+  static bool IsLowerCaseAlphaOrDigit(char c) noexcept
+  {
+    return std::isdigit(c) || std::islower(c);
+  }
 
 private:
   // Store entries in a C-style array to avoid using std::array or std::vector.

--- a/api/test/common/string_util_test.cc
+++ b/api/test/common/string_util_test.cc
@@ -22,7 +22,8 @@ TEST(StringUtilTest, TrimStringWithIndex)
                    {"   k1=v1 ", "k1=v1"}, {"  ", ""}};
   for (auto &testcase : testcases)
   {
-    EXPECT_EQ(StringUtil::Trim(testcase.input, 0, strlen(testcase.input) - 1), testcase.expected);
+    EXPECT_EQ(StringUtil::Trim(testcase.input, 0, std::strlen(testcase.input) - 1),
+              testcase.expected);
   }
 }
 

--- a/api/test/core/version_test.cc
+++ b/api/test/core/version_test.cc
@@ -11,8 +11,8 @@
 TEST(VersionTest, Consistency)
 {
   char expected[10];
-  snprintf(expected, sizeof(expected), "%d.%d.%d", OPENTELEMETRY_VERSION_MAJOR,
-           OPENTELEMETRY_VERSION_MINOR, OPENTELEMETRY_VERSION_PATCH);
+  std::snprintf(expected, sizeof(expected), "%d.%d.%d", OPENTELEMETRY_VERSION_MAJOR,
+                OPENTELEMETRY_VERSION_MINOR, OPENTELEMETRY_VERSION_PATCH);
 
   std::string actual = OPENTELEMETRY_VERSION;
   /* OPENTELEMETRY_VERSION may contain a -dev suffix */

--- a/api/test/trace/span_id_test.cc
+++ b/api/test/trace/span_id_test.cc
@@ -52,6 +52,6 @@ TEST(SpanIdTest, CopyBytesTo)
   SpanId id(src);
   uint8_t buf[8];
   id.CopyBytesTo(buf);
-  EXPECT_TRUE(memcmp(src, buf, 8) == 0);
+  EXPECT_TRUE(std::memcmp(src, buf, 8) == 0);
 }
 }  // namespace

--- a/api/test/trace/trace_id_test.cc
+++ b/api/test/trace/trace_id_test.cc
@@ -53,6 +53,6 @@ TEST(TraceIdTest, CopyBytesTo)
   TraceId id(src);
   uint8_t buf[TraceId::kSize];
   id.CopyBytesTo(buf);
-  EXPECT_TRUE(memcmp(src, buf, sizeof(buf)) == 0);
+  EXPECT_TRUE(std::memcmp(src, buf, sizeof(buf)) == 0);
 }
 }  // namespace

--- a/examples/batch/main.cc
+++ b/examples/batch/main.cc
@@ -102,7 +102,7 @@ int main(int /* argc */, char ** /* argv */)
 
   // Shutdown and drain queue
   StartAndEndSpans();
-  printf("Shutting down and draining queue.... \n");
+  std::printf("Shutting down and draining queue.... \n");
   std::this_thread::sleep_for(std::chrono::milliseconds(2000));
 
   // We invoke the processor destructor

--- a/examples/configuration/main.cc
+++ b/examples/configuration/main.cc
@@ -83,16 +83,16 @@ public:
       case opentelemetry::sdk::common::internal_log::LogLevel::None:
         break;
       case opentelemetry::sdk::common::internal_log::LogLevel::Error:
-        fprintf(stdout, "[ERROR] %s\n", msg);
+        std::fprintf(stdout, "[ERROR] %s\n", msg);
         break;
       case opentelemetry::sdk::common::internal_log::LogLevel::Warning:
-        fprintf(stdout, "[WARNING] %s\n", msg);
+        std::fprintf(stdout, "[WARNING] %s\n", msg);
         break;
       case opentelemetry::sdk::common::internal_log::LogLevel::Info:
-        fprintf(stdout, "[INFO] %s\n", msg);
+        std::fprintf(stdout, "[INFO] %s\n", msg);
         break;
       case opentelemetry::sdk::common::internal_log::LogLevel::Debug:
-        fprintf(stdout, "[DEBUG] %s\n", msg);
+        std::fprintf(stdout, "[DEBUG] %s\n", msg);
         break;
     }
   }
@@ -115,12 +115,12 @@ void PrintModelParsedForTesting(bool pass)
   {
     if (pass)
     {
-      fprintf(stdout, "MODEL PARSED\n");
+      std::fprintf(stdout, "MODEL PARSED\n");
     }
     else
     {
-      fprintf(stdout, "FAILED TO PARSE MODEL\n");
-      exit(1);
+      std::fprintf(stdout, "FAILED TO PARSE MODEL\n");
+      std::exit(1);
     }
   }
 }
@@ -131,12 +131,12 @@ void PrintSdkCreatedForTesting(bool pass)
   {
     if (pass)
     {
-      fprintf(stdout, "SDK CREATED\n");
+      std::fprintf(stdout, "SDK CREATED\n");
     }
     else
     {
-      fprintf(stdout, "FAILED TO CREATE SDK\n");
-      exit(2);
+      std::fprintf(stdout, "FAILED TO CREATE SDK\n");
+      std::exit(2);
     }
   }
 }
@@ -259,7 +259,7 @@ void CleanupOtel()
 }
 }  // namespace
 
-static void usage(FILE *out)
+static void usage(std::FILE *out)
 {
   static const char *msg =
       "Usage: example_yaml [options]\n"
@@ -284,7 +284,7 @@ static void usage(FILE *out)
       "  --no-registry\n"
       "    Run with an empty registry\n";
 
-  fprintf(out, "%s", msg);
+  std::fprintf(out, "%s", msg);
 }
 
 static int parse_args(int argc, char *argv[])
@@ -294,7 +294,7 @@ static int parse_args(int argc, char *argv[])
 
   while (remaining_argc > 0)
   {
-    if (strcmp(*remaining_argv, "--help") == 0)
+    if (std::strcmp(*remaining_argv, "--help") == 0)
     {
       opt_help = true;
       return 0;
@@ -302,7 +302,7 @@ static int parse_args(int argc, char *argv[])
 
     if (remaining_argc >= 2)
     {
-      if (strcmp(*remaining_argv, "--yaml") == 0)
+      if (std::strcmp(*remaining_argv, "--yaml") == 0)
       {
         remaining_argc--;
         remaining_argv++;
@@ -313,7 +313,7 @@ static int parse_args(int argc, char *argv[])
       }
     }
 
-    if (strcmp(*remaining_argv, "--debug") == 0)
+    if (std::strcmp(*remaining_argv, "--debug") == 0)
     {
       remaining_argc--;
       remaining_argv++;
@@ -321,7 +321,7 @@ static int parse_args(int argc, char *argv[])
       continue;
     }
 
-    if (strcmp(*remaining_argv, "--test") == 0)
+    if (std::strcmp(*remaining_argv, "--test") == 0)
     {
       remaining_argc--;
       remaining_argv++;
@@ -329,7 +329,7 @@ static int parse_args(int argc, char *argv[])
       continue;
     }
 
-    if (strcmp(*remaining_argv, "--no-registry") == 0)
+    if (std::strcmp(*remaining_argv, "--no-registry") == 0)
     {
       remaining_argc--;
       remaining_argv++;

--- a/exporters/etw/include/opentelemetry/exporters/etw/etw_config.h
+++ b/exporters/etw/include/opentelemetry/exporters/etw/etw_config.h
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #pragma once
+#include <cstring>
 #include <map>
 
 #if defined(OPENTELEMETRY_ATTRIBUTE_TIMESTAMP_PREVIEW)
@@ -225,7 +226,7 @@ static inline std::string ToLowerBase16(const T &id)
 static inline bool CopySpanIdToActivityId(const opentelemetry::trace::SpanId &span_id,
                                           GUID &outGuid)
 {
-  memset(&outGuid, 0, sizeof(outGuid));
+  std::memset(&outGuid, 0, sizeof(outGuid));
   if (!span_id.IsValid())
   {
     return false;

--- a/exporters/etw/include/opentelemetry/exporters/etw/utils.h
+++ b/exporters/etw/include/opentelemetry/exporters/etw/utils.h
@@ -5,6 +5,8 @@
 
 #include <algorithm>
 #include <chrono>
+#include <cstdio>
+#include <cstring>
 #include <ctime>
 #include <iomanip>
 #include <locale>
@@ -260,7 +262,7 @@ static inline std::string formatUtcTimestampNsAsISO8601(int64_t timestampNs)
   tm tm;
   if (::_gmtime64_s(&tm, &seconds) != 0)
   {
-    memset(&tm, 0, sizeof(tm));
+    std::memset(&tm, 0, sizeof(tm));
   }
   ::_snprintf_s(buf, _TRUNCATE, "%04d-%02d-%02dT%02d:%02d:%02d.%09dZ", 1900 + tm.tm_year,
                 1 + tm.tm_mon, tm.tm_mday, tm.tm_hour, tm.tm_min, tm.tm_sec, nanoseconds);
@@ -271,10 +273,10 @@ static inline std::string formatUtcTimestampNsAsISO8601(int64_t timestampNs)
   bool valid = (gmtime_r(&seconds, &tm) != NULL);
   if (!valid)
   {
-    memset(&tm, 0, sizeof(tm));
+    std::memset(&tm, 0, sizeof(tm));
   }
-  (void)snprintf(buf, sizeof(buf), "%04d-%02d-%02dT%02d:%02d:%02d.%09dZ", 1900 + tm.tm_year,
-                 1 + tm.tm_mon, tm.tm_mday, tm.tm_hour, tm.tm_min, tm.tm_sec, nanoseconds);
+  (void)std::snprintf(buf, sizeof(buf), "%04d-%02d-%02dT%02d:%02d:%02d.%09dZ", 1900 + tm.tm_year,
+                      1 + tm.tm_mon, tm.tm_mday, tm.tm_hour, tm.tm_min, tm.tm_sec, nanoseconds);
 #endif
   return buf;
 }

--- a/exporters/etw/include/opentelemetry/exporters/etw/uuid.h
+++ b/exporters/etw/include/opentelemetry/exporters/etw/uuid.h
@@ -199,7 +199,7 @@ struct UUID
     this->Data1 = uuid.Data1;
     this->Data2 = uuid.Data2;
     this->Data3 = uuid.Data3;
-    memcpy(&(this->Data4[0]), &(uuid.Data4[0]), sizeof(uuid.Data4));
+    std::memcpy(&(this->Data4[0]), &(uuid.Data4[0]), sizeof(uuid.Data4));
   }
 
 #ifdef _WIN32
@@ -382,7 +382,7 @@ struct UUID
   bool operator==(UUID const &other) const
   {
     return Data1 == other.Data1 && Data2 == other.Data2 && Data3 == other.Data3 &&
-           (0 == memcmp(Data4, other.Data4, sizeof(Data4)));
+           (0 == std::memcmp(Data4, other.Data4, sizeof(Data4)));
   }
 
   /// <summary>
@@ -392,7 +392,7 @@ struct UUID
   bool operator<(UUID const &other) const
   {
     return Data1 < other.Data1 || Data2 < other.Data2 || Data3 == other.Data3 ||
-           (memcmp(Data4, other.Data4, sizeof(Data4)) < 0);
+           (std::memcmp(Data4, other.Data4, sizeof(Data4)) < 0);
   }
 };
 #pragma pack(pop) /* restore original alignment from stack */

--- a/exporters/otlp/src/otlp_file_client.cc
+++ b/exporters/otlp/src/otlp_file_client.cc
@@ -92,7 +92,7 @@
 #  endif
 #else
 #  define OTLP_FILE_SNPRINTF(buffer, bufsz, fmt, args...) \
-    snprintf(buffer, static_cast<size_t>(bufsz), fmt, ##args)
+    std::snprintf(buffer, static_cast<size_t>(bufsz), fmt, ##args)
 #endif
 
 #if (defined(_MSC_VER) && _MSC_VER >= 1600) || \
@@ -100,7 +100,7 @@
 #  define OTLP_FILE_OPEN(f, path, mode) fopen_s(&f, path, mode)
 #else
 #  include <cerrno>
-#  define OTLP_FILE_OPEN(f, path, mode) f = fopen(path, mode)
+#  define OTLP_FILE_OPEN(f, path, mode) f = std::fopen(path, mode)
 #endif
 
 #include "opentelemetry/exporters/otlp/otlp_file_client.h"
@@ -416,7 +416,8 @@ static std::size_t FormatPath(char *buff,
             snprintf_s(&buff[ret], bufz - ret, "%llu", static_cast<unsigned long long>(value));
 #  endif
 #else
-        auto res = snprintf(&buff[ret], bufz - ret, "%llu", static_cast<unsigned long long>(value));
+        auto res =
+            std::snprintf(&buff[ret], bufz - ret, "%llu", static_cast<unsigned long long>(value));
 #endif
         if (res < 0)
         {
@@ -551,12 +552,12 @@ public:
     char *token   = SAFE_STRTOK_S(&path_buffer[0], "\\/", &saveptr);
     while (nullptr != token)
     {
-      if (0 != strlen(token))
+      if (0 != std::strlen(token))
       {
         if (normalize)
         {
           // Normalize path
-          if (0 == strcmp("..", token))
+          if (0 == std::strcmp("..", token))
           {
             if (!out.empty() && out.back() != "..")
             {
@@ -567,7 +568,7 @@ public:
               out.push_back(token);
             }
           }
-          else if (0 != strcmp(".", token))
+          else if (0 != std::strcmp(".", token))
           {
             out.push_back(token);
           }
@@ -606,7 +607,7 @@ public:
     std::string current_path;
     if (nullptr != dir_path && ('/' == *dir_path || '\\' == *dir_path))
     {
-      current_path.reserve(strlen(dir_path) + 4);
+      current_path.reserve(std::strlen(dir_path) + 4);
       current_path = *dir_path;
 
       // NFS Supporting
@@ -1268,7 +1269,7 @@ private:
 
     if (destroy_content && FileSystemUtil::IsExist(file_path))
     {
-      FILE *trunc_file = nullptr;
+      std::FILE *trunc_file = nullptr;
       OTLP_FILE_OPEN(trunc_file, file_path, "wb");
       if (nullptr == trunc_file)
       {
@@ -1277,7 +1278,7 @@ private:
                                 << " failed with pattern: " << options_.file_pattern);
         return nullptr;
       }
-      fclose(trunc_file);
+      std::fclose(trunc_file);
     }
 
     std::FILE *new_file = nullptr;
@@ -1342,9 +1343,10 @@ private:
                                                            << alias_file_path
                                                            << " failed, errno: " << res);
 #  else
-        OTEL_INTERNAL_LOG_ERROR("[OTLP FILE Client] Link "
-                                << file_->file_path << " to " << alias_file_path
-                                << " failed, errno: " << res << ", message: " << strerror(res));
+        OTEL_INTERNAL_LOG_ERROR("[OTLP FILE Client] Link " << file_->file_path << " to "
+                                                           << alias_file_path
+                                                           << " failed, errno: " << res
+                                                           << ", message: " << std::strerror(res));
 #  endif
         return file_->current_file;
       }

--- a/exporters/otlp/test/otlp_log_recordable_test.cc
+++ b/exporters/otlp/test/otlp_log_recordable_test.cc
@@ -87,9 +87,9 @@ TEST(OtlpLogRecordable, Basic)
   common::AttributeValue byte_val(
       nostd::span<const uint8_t>{reinterpret_cast<const uint8_t *>(byte_arr), 5});
   rec.SetBody(byte_val);
-  EXPECT_TRUE(0 ==
-              memcmp(reinterpret_cast<const void *>(rec.log_record().body().bytes_value().data()),
-                     reinterpret_cast<const void *>(byte_arr), 5));
+  EXPECT_TRUE(
+      0 == std::memcmp(reinterpret_cast<const void *>(rec.log_record().body().bytes_value().data()),
+                       reinterpret_cast<const void *>(byte_arr), 5));
   EXPECT_EQ(rec.log_record().body().bytes_value().size(), 5);
 
 #if defined(ENABLE_OTLP_UTF8_VALIDITY)
@@ -97,9 +97,9 @@ TEST(OtlpLogRecordable, Basic)
   const char byte_body[] = {'\x80', '\x81', '\x82', '\x83', '\x84'};
   nostd::string_view byte_body_view(byte_body, 5);
   rec.SetBody(byte_body_view);
-  EXPECT_TRUE(0 ==
-              memcmp(reinterpret_cast<const void *>(rec.log_record().body().bytes_value().data()),
-                     reinterpret_cast<const void *>(byte_body), 5));
+  EXPECT_TRUE(
+      0 == std::memcmp(reinterpret_cast<const void *>(rec.log_record().body().bytes_value().data()),
+                       reinterpret_cast<const void *>(byte_body), 5));
   EXPECT_EQ(rec.log_record().body().bytes_value().size(), 5);
 #endif
 }
@@ -175,18 +175,18 @@ TEST(OtlpLogRecordable, SetSingleAttribute)
     else if (attribute.key() == byte_key)
     {
       ++checked_attributes;
-      EXPECT_TRUE(0 ==
-                  memcmp(reinterpret_cast<const void *>(attribute.value().bytes_value().data()),
-                         reinterpret_cast<const void *>(byte_arr), 4));
+      EXPECT_TRUE(
+          0 == std::memcmp(reinterpret_cast<const void *>(attribute.value().bytes_value().data()),
+                           reinterpret_cast<const void *>(byte_arr), 4));
       EXPECT_EQ(attribute.value().bytes_value().size(), 4);
     }
 #if defined(ENABLE_OTLP_UTF8_VALIDITY)
     else if (attribute.key() == non_utf8_string_key)
     {
       ++checked_attributes;
-      EXPECT_TRUE(0 ==
-                  memcmp(reinterpret_cast<const void *>(attribute.value().bytes_value().data()),
-                         reinterpret_cast<const void *>(non_utf8_string_arr), 4));
+      EXPECT_TRUE(
+          0 == std::memcmp(reinterpret_cast<const void *>(attribute.value().bytes_value().data()),
+                           reinterpret_cast<const void *>(non_utf8_string_arr), 4));
       EXPECT_EQ(attribute.value().bytes_value().size(), 4);
     }
 #endif

--- a/ext/include/opentelemetry/ext/http/server/http_server.h
+++ b/ext/include/opentelemetry/ext/http/server/http_server.h
@@ -5,7 +5,10 @@
 
 #include <cerrno>
 #include <cstdint>
+#include <cstdio>
 #include <cstdlib>
+#include <cstring>
+#include <ctime>
 #include <functional>
 #include <list>
 #include <map>
@@ -15,7 +18,7 @@
 #ifdef HAVE_HTTP_DEBUG
 #  ifdef LOG_TRACE
 #    undef LOG_TRACE
-#    define LOG_TRACE(x, ...) printf(x "\n", __VA_ARGS__)
+#    define LOG_TRACE(x, ...) std::printf(x "\n", __VA_ARGS__)
 #  endif
 #endif
 
@@ -775,7 +778,8 @@ protected:
       for (auto &handler : m_handlers)
       {
         if (conn.request.uri.length() >= handler.first.length() &&
-            strncmp(conn.request.uri.c_str(), handler.first.c_str(), handler.first.length()) == 0)
+            std::strncmp(conn.request.uri.c_str(), handler.first.c_str(), handler.first.length()) ==
+                0)
         {
           LOG_TRACE("HttpServer: [%s] using handler for %s", conn.request.client.c_str(),
                     handler.first.c_str());
@@ -804,22 +808,22 @@ protected:
 
     conn.response.headers["Host"]           = m_serverHost;
     conn.response.headers["Connection"]     = (conn.keepalive ? "keep-alive" : "close");
-    conn.response.headers["Date"]           = formatTimestamp(time(nullptr));
+    conn.response.headers["Date"]           = formatTimestamp(std::time(nullptr));
     conn.response.headers["Content-Length"] = std::to_string(conn.response.body.size());
 
     return RequestOutcome::SendResponse;
   }
 
-  static std::string formatTimestamp(time_t time)
+  static std::string formatTimestamp(std::time_t time)
   {
-    tm tm{};
+    std::tm tm{};
 #ifdef _WIN32
     gmtime_s(&tm, &time);
 #else
     gmtime_r(&time, &tm);
 #endif
     char buf[32];
-    strftime(buf, sizeof(buf), "%a, %d %b %Y %H:%M:%S GMT", &tm);
+    std::strftime(buf, sizeof(buf), "%a, %d %b %Y %H:%M:%S GMT", &tm);
     return buf;
   }
 

--- a/ext/include/opentelemetry/ext/http/server/socket_tools.h
+++ b/ext/include/opentelemetry/ext/http/server/socket_tools.h
@@ -8,6 +8,7 @@
 #include <cerrno>
 #include <cstddef>
 #include <cstdint>
+#include <cstdio>
 #include <cstdlib>
 #include <cstring>
 #include <iostream>
@@ -59,11 +60,11 @@
 // Log to console if there's no standard log facility defined
 #  include <cstdio>
 #  ifndef LOG_DEBUG
-#    define LOG_DEBUG(fmt_, ...) printf(" " fmt_ "\n", ##__VA_ARGS__)
-#    define LOG_TRACE(fmt_, ...) printf(" " fmt_ "\n", ##__VA_ARGS__)
-#    define LOG_INFO(fmt_, ...) printf(" " fmt_ "\n", ##__VA_ARGS__)
-#    define LOG_WARN(fmt_, ...) printf(" " fmt_ "\n", ##__VA_ARGS__)
-#    define LOG_ERROR(fmt_, ...) printf(" " fmt_ "\n", ##__VA_ARGS__)
+#    define LOG_DEBUG(fmt_, ...) std::printf(" " fmt_ "\n", ##__VA_ARGS__)
+#    define LOG_TRACE(fmt_, ...) std::printf(" " fmt_ "\n", ##__VA_ARGS__)
+#    define LOG_INFO(fmt_, ...) std::printf(" " fmt_ "\n", ##__VA_ARGS__)
+#    define LOG_WARN(fmt_, ...) std::printf(" " fmt_ "\n", ##__VA_ARGS__)
+#    define LOG_ERROR(fmt_, ...) std::printf(" " fmt_ "\n", ##__VA_ARGS__)
 #  endif
 #endif
 
@@ -202,8 +203,8 @@ struct SocketAddr
     sockaddr_in parsed{};
     parsed.sin_family = AF_INET;
 
-    char const *colon          = strchr(addr, ':');
-    char const *hostEnd        = colon ? colon : addr + strlen(addr);
+    char const *colon          = std::strchr(addr, ':');
+    char const *hostEnd        = colon ? colon : addr + std::strlen(addr);
     ptrdiff_t const hostLength = hostEnd - addr;
 
     // Reject a host that would not fit rather than truncating it into a different valid address
@@ -213,7 +214,7 @@ struct SocketAddr
     if (ok)
     {
       char host[16];
-      memcpy(host, addr, static_cast<size_t>(hostLength));
+      std::memcpy(host, addr, static_cast<size_t>(hostLength));
       host[hostLength] = '\0';
       ok               = (::inet_pton(AF_INET, host, &parsed.sin_addr) == 1);
     }
@@ -252,7 +253,7 @@ struct SocketAddr
 
     if (ok)
     {
-      memcpy(&m_data, &parsed, sizeof(parsed));
+      std::memcpy(&m_data, &parsed, sizeof(parsed));
     }
     else
     {
@@ -275,7 +276,7 @@ struct SocketAddr
         // Copy out rather than binding a sockaddr_in glvalue to sockaddr storage, which is an
         // alignment/type-access issue (see the constructor and #4307).
         sockaddr_in inet4{};
-        memcpy(&inet4, &m_data, sizeof(inet4));
+        std::memcpy(&inet4, &m_data, sizeof(inet4));
         return ntohs(inet4.sin_port);
       }
 
@@ -292,7 +293,7 @@ struct SocketAddr
     {
       case AF_INET: {
         sockaddr_in inet4{};
-        memcpy(&inet4, &m_data, sizeof(inet4));
+        std::memcpy(&inet4, &m_data, sizeof(inet4));
         u_long addr = ntohl(inet4.sin_addr.s_addr);
         os << (addr >> 24) << '.' << ((addr >> 16) & 255) << '.' << ((addr >> 8) & 255) << '.'
            << (addr & 255);

--- a/ext/src/http/client/curl/http_operation_curl.cc
+++ b/ext/src/http/client/curl/http_operation_curl.cc
@@ -329,7 +329,7 @@ size_t HttpOperation::ReadMemoryCallback(char *buffer, size_t size, size_t nitem
     nwrite = self->request_body_.size() - self->request_nwrite_;
   }
 
-  memcpy(buffer, &self->request_body_[self->request_nwrite_], nwrite);
+  std::memcpy(buffer, &self->request_body_[self->request_nwrite_], nwrite);
   self->request_nwrite_ += nwrite;
   return nwrite;
 }

--- a/ext/test/http/curl_http_test.cc
+++ b/ext/test/http/curl_http_test.cc
@@ -242,7 +242,7 @@ TEST_F(BasicCurlHttpTests, HttpRequest)
 {
   curl::Request req;
   const char *b           = "test-data";
-  http_client::Body body  = {b, b + strlen(b)};
+  http_client::Body body  = {b, b + std::strlen(b)};
   http_client::Body body1 = body;
   req.SetBody(body);
   ASSERT_EQ(req.body_, body1);
@@ -266,7 +266,7 @@ TEST_F(BasicCurlHttpTests, HttpResponse)
   res.headers_ = m1;
 
   const char *b          = "test-data";
-  http_client::Body body = {b, b + strlen(b)};
+  http_client::Body body = {b, b + std::strlen(b)};
   int count              = 0;
   res.ForEachHeader("name1", [&count](nostd::string_view name, nostd::string_view value) {
     if (name != "name1")
@@ -318,7 +318,7 @@ TEST_F(BasicCurlHttpTests, SendPostRequest)
   request->SetMethod(http_client::Method::Post);
 
   const char *b          = "test-data";
-  http_client::Body body = {b, b + strlen(b)};
+  http_client::Body body = {b, b + std::strlen(b)};
   request->SetBody(body);
   request->AddHeader("Content-Type", "text/plain");
   auto handler = std::make_shared<PostEventHandler>();
@@ -355,7 +355,7 @@ TEST_F(BasicCurlHttpTests, CurlHttpOperations)
   GetEventHandler *handler = new GetEventHandler();
 
   const char *b          = "test-data";
-  http_client::Body body = {b, b + strlen(b)};
+  http_client::Body body = {b, b + std::strlen(b)};
 
   http_client::Headers headers = {
       {"name1", "value1_1"}, {"name1", "value1_2"}, {"name2", "value3"}, {"name3", "value3"}};

--- a/ext/test/w3c_tracecontext_http_test_server/main.cc
+++ b/ext/test/w3c_tracecontext_http_test_server/main.cc
@@ -55,7 +55,7 @@ static bool equalsIgnoreCase(const std::string &str1, const std::string &str2)
   }
   for (size_t i = 0; i < str1.length(); i++)
   {
-    if (tolower(str1[i]) != tolower(str2[i]))
+    if (std::tolower(str1[i]) != std::tolower(str2[i]))
     {
       return false;
     }

--- a/functional/otlp/func_grpc_main.cc
+++ b/functional/otlp/func_grpc_main.cc
@@ -209,7 +209,7 @@ static void instrumented_payload(const otlp::OtlpGrpcExporterOptions &opts)
   cleanup();
 }
 
-static void usage(FILE *out)
+static void usage(std::FILE *out)
 {
   static const char *msg =
       "Usage: func_otlp_grpc [options] test_name\n"
@@ -222,7 +222,7 @@ static void usage(FILE *out)
       "                      - none: no endpoint\n"
       "                      - http: http endpoint\n"
       "                      - https: https endpoint\n";
-  fprintf(out, "%s", msg);
+  std::fprintf(out, "%s", msg);
 }
 
 static int parse_args(int argc, char *argv[])
@@ -232,19 +232,19 @@ static int parse_args(int argc, char *argv[])
 
   while (remaining_argc > 0)
   {
-    if (strcmp(*remaining_argv, "--help") == 0)
+    if (std::strcmp(*remaining_argv, "--help") == 0)
     {
       opt_help = true;
       return 0;
     }
 
-    if (strcmp(*remaining_argv, "--list") == 0)
+    if (std::strcmp(*remaining_argv, "--list") == 0)
     {
       opt_list = true;
       return 0;
     }
 
-    if (strcmp(*remaining_argv, "--debug") == 0)
+    if (std::strcmp(*remaining_argv, "--debug") == 0)
     {
       opt_debug = true;
       remaining_argc--;
@@ -254,7 +254,7 @@ static int parse_args(int argc, char *argv[])
 
     if (remaining_argc >= 2)
     {
-      if (strcmp(*remaining_argv, "--cert-dir") == 0)
+      if (std::strcmp(*remaining_argv, "--cert-dir") == 0)
       {
         remaining_argc--;
         remaining_argv++;
@@ -264,7 +264,7 @@ static int parse_args(int argc, char *argv[])
         continue;
       }
 
-      if (strcmp(*remaining_argv, "--endpoint") == 0)
+      if (std::strcmp(*remaining_argv, "--endpoint") == 0)
       {
         remaining_argc--;
         remaining_argv++;
@@ -274,7 +274,7 @@ static int parse_args(int argc, char *argv[])
         continue;
       }
 
-      if (strcmp(*remaining_argv, "--mode") == 0)
+      if (std::strcmp(*remaining_argv, "--mode") == 0)
       {
         remaining_argc--;
         remaining_argv++;

--- a/functional/otlp/func_http_main.cc
+++ b/functional/otlp/func_http_main.cc
@@ -226,7 +226,7 @@ static void instrumented_payload(const otlp::OtlpHttpExporterOptions &opts)
   cleanup();
 }
 
-static void usage(FILE *out)
+static void usage(std::FILE *out)
 {
   static const char *msg =
       "Usage: func_otlp_http [options] test_name\n"
@@ -239,7 +239,7 @@ static void usage(FILE *out)
       "                      - none: no endpoint\n"
       "                      - http: http endpoint\n"
       "                      - https: https endpoint\n";
-  fprintf(out, "%s", msg);
+  std::fprintf(out, "%s", msg);
 }
 
 static int parse_args(int argc, char *argv[])
@@ -249,19 +249,19 @@ static int parse_args(int argc, char *argv[])
 
   while (remaining_argc > 0)
   {
-    if (strcmp(*remaining_argv, "--help") == 0)
+    if (std::strcmp(*remaining_argv, "--help") == 0)
     {
       opt_help = true;
       return 0;
     }
 
-    if (strcmp(*remaining_argv, "--list") == 0)
+    if (std::strcmp(*remaining_argv, "--list") == 0)
     {
       opt_list = true;
       return 0;
     }
 
-    if (strcmp(*remaining_argv, "--debug") == 0)
+    if (std::strcmp(*remaining_argv, "--debug") == 0)
     {
       opt_debug = true;
       remaining_argc--;
@@ -271,7 +271,7 @@ static int parse_args(int argc, char *argv[])
 
     if (remaining_argc >= 2)
     {
-      if (strcmp(*remaining_argv, "--cert-dir") == 0)
+      if (std::strcmp(*remaining_argv, "--cert-dir") == 0)
       {
         remaining_argc--;
         remaining_argv++;
@@ -281,7 +281,7 @@ static int parse_args(int argc, char *argv[])
         continue;
       }
 
-      if (strcmp(*remaining_argv, "--endpoint") == 0)
+      if (std::strcmp(*remaining_argv, "--endpoint") == 0)
       {
         remaining_argc--;
         remaining_argv++;
@@ -291,7 +291,7 @@ static int parse_args(int argc, char *argv[])
         continue;
       }
 
-      if (strcmp(*remaining_argv, "--mode") == 0)
+      if (std::strcmp(*remaining_argv, "--mode") == 0)
       {
         remaining_argc--;
         remaining_argv++;

--- a/sdk/src/common/random.cc
+++ b/sdk/src/common/random.cc
@@ -74,11 +74,11 @@ void Random::GenerateRandomBuffer(opentelemetry::nostd::span<uint8_t> buffer) no
     uint64_t value = GenerateRandom64();
     if (i + sizeof(uint64_t) <= buf_size)
     {
-      memcpy(&buffer[i], &value, sizeof(uint64_t));
+      std::memcpy(&buffer[i], &value, sizeof(uint64_t));
     }
     else
     {
-      memcpy(&buffer[i], &value, buf_size - i);
+      std::memcpy(&buffer[i], &value, buf_size - i);
     }
   }
 }

--- a/sdk/src/configuration/document_node.cc
+++ b/sdk/src/configuration/document_node.cc
@@ -242,7 +242,7 @@ size_t DocumentNode::IntegerFromString(const std::string &value) const
   const char *ptr = value.c_str();
   char *end       = nullptr;
   size_t len      = value.length();
-  size_t val      = strtoll(ptr, &end, 10);
+  size_t val      = std::strtoll(ptr, &end, 10);
   if (ptr + len != end)
   {
     std::string message("Illegal integer value: ");
@@ -285,7 +285,7 @@ double DocumentNode::DoubleFromString(const std::string &value) const
   const char *ptr = value.c_str();
   char *end       = nullptr;
   size_t len      = value.length();
-  double val      = strtod(ptr, &end);
+  double val      = std::strtod(ptr, &end);
   if (ptr + len != end)
   {
     std::string message("Illegal double value: ");

--- a/sdk/src/metrics/instrument_metadata_validator.cc
+++ b/sdk/src/metrics/instrument_metadata_validator.cc
@@ -5,12 +5,11 @@
 #include "opentelemetry/nostd/string_view.h"
 #include "opentelemetry/version.h"
 
-#include <cctype>
-
 #if OPENTELEMETRY_HAVE_WORKING_REGEX
 #  include <regex>
 #else
 #  include <algorithm>
+#  include <cctype>
 #endif
 
 OPENTELEMETRY_BEGIN_NAMESPACE

--- a/sdk/src/metrics/instrument_metadata_validator.cc
+++ b/sdk/src/metrics/instrument_metadata_validator.cc
@@ -5,6 +5,8 @@
 #include "opentelemetry/nostd/string_view.h"
 #include "opentelemetry/version.h"
 
+#include <cctype>
+
 #if OPENTELEMETRY_HAVE_WORKING_REGEX
 #  include <regex>
 #else
@@ -46,14 +48,14 @@ bool InstrumentMetaDataValidator::ValidateName(nostd::string_view name) const
     return false;
   }
   // first char should be alpha
-  if (!isalpha(name[0]))
+  if (!std::isalpha(name[0]))
   {
     return false;
   }
   // subsequent chars should be either of alphabets, digits, underscore,
   // minus, dot, slash
   return !std::any_of(std::next(name.begin()), name.end(), [](char c) {
-    return !isalnum(c) && (c != '-') && (c != '_') && (c != '.') && (c != '/');
+    return !std::isalnum(c) && (c != '-') && (c != '_') && (c != '.') && (c != '/');
   });
 #endif
 }

--- a/sdk/test/common/empty_attributes_test.cc
+++ b/sdk/test/common/empty_attributes_test.cc
@@ -21,7 +21,7 @@ TEST(EmptyAttributesTest, TestMemory)
 {
   auto attributes1 = opentelemetry::sdk::GetEmptyAttributes();
   auto attributes2 = opentelemetry::sdk::GetEmptyAttributes();
-  EXPECT_EQ(memcmp(static_cast<void *>(&attributes1), static_cast<void *>(&attributes2),
-                   sizeof(attributes1)),
+  EXPECT_EQ(std::memcmp(static_cast<void *>(&attributes1), static_cast<void *>(&attributes2),
+                        sizeof(attributes1)),
             0);  // NOLINT
 }

--- a/sdk/test/common/global_log_handle_singleton_lifetime_test.cc
+++ b/sdk/test/common/global_log_handle_singleton_lifetime_test.cc
@@ -28,7 +28,7 @@ public:
     if (!custom_handler_destroyed || handle)
     {
       OTEL_INTERNAL_LOG_ERROR("GlobalLogHandler must be destroyed before the checker");
-      abort();
+      std::abort();
     }
     std::cout << "GlobalLogHandlerChecker destroyed and check pass.\n";
   }

--- a/sdk/test/common/global_log_handle_test.cc
+++ b/sdk/test/common/global_log_handle_test.cc
@@ -24,19 +24,19 @@ public:
   {
     if (level == opentelemetry::sdk::common::internal_log::LogLevel::Debug)
     {
-      EXPECT_EQ(0, strncmp(msg, "Debug message", 13));
+      EXPECT_EQ(0, std::strncmp(msg, "Debug message", 13));
     }
     else if (level == opentelemetry::sdk::common::internal_log::LogLevel::Error)
     {
-      EXPECT_EQ(0, strncmp(msg, "Error message", 13));
+      EXPECT_EQ(0, std::strncmp(msg, "Error message", 13));
     }
     else if (level == opentelemetry::sdk::common::internal_log::LogLevel::Info)
     {
-      EXPECT_EQ(0, strncmp(msg, "Info message", 12));
+      EXPECT_EQ(0, std::strncmp(msg, "Info message", 12));
     }
     else if (level == opentelemetry::sdk::common::internal_log::LogLevel::Warning)
     {
-      EXPECT_EQ(0, strncmp(msg, "Warning message", 15));
+      EXPECT_EQ(0, std::strncmp(msg, "Warning message", 15));
     }
     ++count;
   }

--- a/sdk/test/common/random_fork_test.cc
+++ b/sdk/test/common/random_fork_test.cc
@@ -29,7 +29,7 @@ int main()
   if (fork() == 0)
   {
     *child_id = Random::GenerateRandom64();
-    exit(EXIT_SUCCESS);
+    std::exit(EXIT_SUCCESS);
   }
   else
   {

--- a/sdk/test/metrics/base2_exponential_histogram_indexer_test.cc
+++ b/sdk/test/metrics/base2_exponential_histogram_indexer_test.cc
@@ -16,14 +16,14 @@ TEST(Base2ExponentialHistogramIndexerTest, ScaleOne)
   auto compute_index = [indexer](double value) { return indexer.ComputeIndex(value); };
 
   EXPECT_EQ(compute_index(std::numeric_limits<double>::max()), 2047);
-  EXPECT_EQ(compute_index(strtod("0x1p1023", nullptr)), 2045);
-  EXPECT_EQ(compute_index(strtod("0x1.1p1023", nullptr)), 2046);
-  EXPECT_EQ(compute_index(strtod("0x1p1022", nullptr)), 2043);
-  EXPECT_EQ(compute_index(strtod("0x1.1p1022", nullptr)), 2044);
-  EXPECT_EQ(compute_index(strtod("0x1p-1022", nullptr)), -2045);
-  EXPECT_EQ(compute_index(strtod("0x1.1p-1022", nullptr)), -2044);
-  EXPECT_EQ(compute_index(strtod("0x1p-1021", nullptr)), -2043);
-  EXPECT_EQ(compute_index(strtod("0x1.1p-1021", nullptr)), -2042);
+  EXPECT_EQ(compute_index(std::strtod("0x1p1023", nullptr)), 2045);
+  EXPECT_EQ(compute_index(std::strtod("0x1.1p1023", nullptr)), 2046);
+  EXPECT_EQ(compute_index(std::strtod("0x1p1022", nullptr)), 2043);
+  EXPECT_EQ(compute_index(std::strtod("0x1.1p1022", nullptr)), 2044);
+  EXPECT_EQ(compute_index(std::strtod("0x1p-1022", nullptr)), -2045);
+  EXPECT_EQ(compute_index(std::strtod("0x1.1p-1022", nullptr)), -2044);
+  EXPECT_EQ(compute_index(std::strtod("0x1p-1021", nullptr)), -2043);
+  EXPECT_EQ(compute_index(std::strtod("0x1.1p-1021", nullptr)), -2042);
   EXPECT_EQ(compute_index(std::numeric_limits<double>::min()), -2045);
   EXPECT_EQ(compute_index(std::numeric_limits<double>::denorm_min()), -2149);
   EXPECT_EQ(compute_index(15.0), 7);
@@ -48,15 +48,15 @@ TEST(Base2ExponentialHistogramIndexerTest, ScaleZero)
   // Near +Inf.
   // Use constant for exp, as max_exponent constant includes bias.
   EXPECT_EQ(compute_index(std::numeric_limits<double>::max()), 1023);
-  EXPECT_EQ(compute_index(strtod("0x1p1023", nullptr)), 1022);
-  EXPECT_EQ(compute_index(strtod("0x1.1p1023", nullptr)), 1023);
-  EXPECT_EQ(compute_index(strtod("0x1p1022", nullptr)), 1021);
-  EXPECT_EQ(compute_index(strtod("0x1.1p1022", nullptr)), 1022);
+  EXPECT_EQ(compute_index(std::strtod("0x1p1023", nullptr)), 1022);
+  EXPECT_EQ(compute_index(std::strtod("0x1.1p1023", nullptr)), 1023);
+  EXPECT_EQ(compute_index(std::strtod("0x1p1022", nullptr)), 1021);
+  EXPECT_EQ(compute_index(std::strtod("0x1.1p1022", nullptr)), 1022);
   // Near 0.
-  EXPECT_EQ(compute_index(strtod("0x1p-1022", nullptr)), -1023);
-  EXPECT_EQ(compute_index(strtod("0x1.1p-1022", nullptr)), -1022);
-  EXPECT_EQ(compute_index(strtod("0x1p-1021", nullptr)), -1022);
-  EXPECT_EQ(compute_index(strtod("0x1.1p-1021", nullptr)), -1021);
+  EXPECT_EQ(compute_index(std::strtod("0x1p-1022", nullptr)), -1023);
+  EXPECT_EQ(compute_index(std::strtod("0x1.1p-1022", nullptr)), -1022);
+  EXPECT_EQ(compute_index(std::strtod("0x1p-1021", nullptr)), -1022);
+  EXPECT_EQ(compute_index(std::strtod("0x1.1p-1021", nullptr)), -1021);
   EXPECT_EQ(compute_index(std::numeric_limits<double>::min()), -1023);
   EXPECT_EQ(compute_index(std::numeric_limits<double>::denorm_min()), -1075);
   // Near 1.
@@ -106,76 +106,76 @@ TEST(Base2ExponentialHistogramIndexerTest, ScaleNegativeFour)
   const Base2ExponentialHistogramIndexer indexer{-4};
   auto compute_index = [indexer](double value) { return indexer.ComputeIndex(value); };
 
-  EXPECT_EQ(compute_index(strtod("0x1p0", nullptr)), -1);
-  EXPECT_EQ(compute_index(strtod("0x10p0", nullptr)), 0);
-  EXPECT_EQ(compute_index(strtod("0x100p0", nullptr)), 0);
-  EXPECT_EQ(compute_index(strtod("0x1000p0", nullptr)), 0);
-  EXPECT_EQ(compute_index(strtod("0x10000p0", nullptr)), 0);  // Base == 2**16
-  EXPECT_EQ(compute_index(strtod("0x100000p0", nullptr)), 1);
-  EXPECT_EQ(compute_index(strtod("0x1000000p0", nullptr)), 1);
-  EXPECT_EQ(compute_index(strtod("0x10000000p0", nullptr)), 1);
-  EXPECT_EQ(compute_index(strtod("0x100000000p0", nullptr)), 1);  // == 2**32
-  EXPECT_EQ(compute_index(strtod("0x1000000000p0", nullptr)), 2);
-  EXPECT_EQ(compute_index(strtod("0x10000000000p0", nullptr)), 2);
-  EXPECT_EQ(compute_index(strtod("0x100000000000p0", nullptr)), 2);
-  EXPECT_EQ(compute_index(strtod("0x1000000000000p0", nullptr)), 2);  // 2**48
-  EXPECT_EQ(compute_index(strtod("0x10000000000000p0", nullptr)), 3);
-  EXPECT_EQ(compute_index(strtod("0x100000000000000p0", nullptr)), 3);
-  EXPECT_EQ(compute_index(strtod("0x1000000000000000p0", nullptr)), 3);
-  EXPECT_EQ(compute_index(strtod("0x10000000000000000p0", nullptr)), 3);  // 2**64
-  EXPECT_EQ(compute_index(strtod("0x100000000000000000p0", nullptr)), 4);
-  EXPECT_EQ(compute_index(strtod("0x1000000000000000000p0", nullptr)), 4);
-  EXPECT_EQ(compute_index(strtod("0x10000000000000000000p0", nullptr)), 4);
-  EXPECT_EQ(compute_index(strtod("0x100000000000000000000p0", nullptr)), 4);
-  EXPECT_EQ(compute_index(strtod("0x1000000000000000000000p0", nullptr)), 5);
-  EXPECT_EQ(compute_index(1 / strtod("0x1p0", nullptr)), -1);
-  EXPECT_EQ(compute_index(1 / strtod("0x10p0", nullptr)), -1);
-  EXPECT_EQ(compute_index(1 / strtod("0x100p0", nullptr)), -1);
-  EXPECT_EQ(compute_index(1 / strtod("0x1000p0", nullptr)), -1);
-  EXPECT_EQ(compute_index(1 / strtod("0x10000p0", nullptr)), -2);  // 2**-16
-  EXPECT_EQ(compute_index(1 / strtod("0x100000p0", nullptr)), -2);
-  EXPECT_EQ(compute_index(1 / strtod("0x1000000p0", nullptr)), -2);
-  EXPECT_EQ(compute_index(1 / strtod("0x10000000p0", nullptr)), -2);
-  EXPECT_EQ(compute_index(1 / strtod("0x100000000p0", nullptr)), -3);  // 2**-32
-  EXPECT_EQ(compute_index(1 / strtod("0x1000000000p0", nullptr)), -3);
-  EXPECT_EQ(compute_index(1 / strtod("0x10000000000p0", nullptr)), -3);
-  EXPECT_EQ(compute_index(1 / strtod("0x100000000000p0", nullptr)), -3);
-  EXPECT_EQ(compute_index(1 / strtod("0x1000000000000p0", nullptr)), -4);  // 2**-48
-  EXPECT_EQ(compute_index(1 / strtod("0x10000000000000p0", nullptr)), -4);
-  EXPECT_EQ(compute_index(1 / strtod("0x100000000000000p0", nullptr)), -4);
-  EXPECT_EQ(compute_index(1 / strtod("0x1000000000000000p0", nullptr)), -4);
-  EXPECT_EQ(compute_index(1 / strtod("0x10000000000000000p0", nullptr)), -5);  // 2**-64
-  EXPECT_EQ(compute_index(1 / strtod("0x100000000000000000p0", nullptr)), -5);
+  EXPECT_EQ(compute_index(std::strtod("0x1p0", nullptr)), -1);
+  EXPECT_EQ(compute_index(std::strtod("0x10p0", nullptr)), 0);
+  EXPECT_EQ(compute_index(std::strtod("0x100p0", nullptr)), 0);
+  EXPECT_EQ(compute_index(std::strtod("0x1000p0", nullptr)), 0);
+  EXPECT_EQ(compute_index(std::strtod("0x10000p0", nullptr)), 0);  // Base == 2**16
+  EXPECT_EQ(compute_index(std::strtod("0x100000p0", nullptr)), 1);
+  EXPECT_EQ(compute_index(std::strtod("0x1000000p0", nullptr)), 1);
+  EXPECT_EQ(compute_index(std::strtod("0x10000000p0", nullptr)), 1);
+  EXPECT_EQ(compute_index(std::strtod("0x100000000p0", nullptr)), 1);  // == 2**32
+  EXPECT_EQ(compute_index(std::strtod("0x1000000000p0", nullptr)), 2);
+  EXPECT_EQ(compute_index(std::strtod("0x10000000000p0", nullptr)), 2);
+  EXPECT_EQ(compute_index(std::strtod("0x100000000000p0", nullptr)), 2);
+  EXPECT_EQ(compute_index(std::strtod("0x1000000000000p0", nullptr)), 2);  // 2**48
+  EXPECT_EQ(compute_index(std::strtod("0x10000000000000p0", nullptr)), 3);
+  EXPECT_EQ(compute_index(std::strtod("0x100000000000000p0", nullptr)), 3);
+  EXPECT_EQ(compute_index(std::strtod("0x1000000000000000p0", nullptr)), 3);
+  EXPECT_EQ(compute_index(std::strtod("0x10000000000000000p0", nullptr)), 3);  // 2**64
+  EXPECT_EQ(compute_index(std::strtod("0x100000000000000000p0", nullptr)), 4);
+  EXPECT_EQ(compute_index(std::strtod("0x1000000000000000000p0", nullptr)), 4);
+  EXPECT_EQ(compute_index(std::strtod("0x10000000000000000000p0", nullptr)), 4);
+  EXPECT_EQ(compute_index(std::strtod("0x100000000000000000000p0", nullptr)), 4);
+  EXPECT_EQ(compute_index(std::strtod("0x1000000000000000000000p0", nullptr)), 5);
+  EXPECT_EQ(compute_index(1 / std::strtod("0x1p0", nullptr)), -1);
+  EXPECT_EQ(compute_index(1 / std::strtod("0x10p0", nullptr)), -1);
+  EXPECT_EQ(compute_index(1 / std::strtod("0x100p0", nullptr)), -1);
+  EXPECT_EQ(compute_index(1 / std::strtod("0x1000p0", nullptr)), -1);
+  EXPECT_EQ(compute_index(1 / std::strtod("0x10000p0", nullptr)), -2);  // 2**-16
+  EXPECT_EQ(compute_index(1 / std::strtod("0x100000p0", nullptr)), -2);
+  EXPECT_EQ(compute_index(1 / std::strtod("0x1000000p0", nullptr)), -2);
+  EXPECT_EQ(compute_index(1 / std::strtod("0x10000000p0", nullptr)), -2);
+  EXPECT_EQ(compute_index(1 / std::strtod("0x100000000p0", nullptr)), -3);  // 2**-32
+  EXPECT_EQ(compute_index(1 / std::strtod("0x1000000000p0", nullptr)), -3);
+  EXPECT_EQ(compute_index(1 / std::strtod("0x10000000000p0", nullptr)), -3);
+  EXPECT_EQ(compute_index(1 / std::strtod("0x100000000000p0", nullptr)), -3);
+  EXPECT_EQ(compute_index(1 / std::strtod("0x1000000000000p0", nullptr)), -4);  // 2**-48
+  EXPECT_EQ(compute_index(1 / std::strtod("0x10000000000000p0", nullptr)), -4);
+  EXPECT_EQ(compute_index(1 / std::strtod("0x100000000000000p0", nullptr)), -4);
+  EXPECT_EQ(compute_index(1 / std::strtod("0x1000000000000000p0", nullptr)), -4);
+  EXPECT_EQ(compute_index(1 / std::strtod("0x10000000000000000p0", nullptr)), -5);  // 2**-64
+  EXPECT_EQ(compute_index(1 / std::strtod("0x100000000000000000p0", nullptr)), -5);
   // Max values.
   EXPECT_EQ(compute_index(0x1.FFFFFFFFFFFFFp1023), 63);
-  EXPECT_EQ(compute_index(strtod("0x1p1023", nullptr)), 63);
-  EXPECT_EQ(compute_index(strtod("0x1p1019", nullptr)), 63);
-  EXPECT_EQ(compute_index(strtod("0x1p1009", nullptr)), 63);
-  EXPECT_EQ(compute_index(strtod("0x1p1008", nullptr)), 62);
-  EXPECT_EQ(compute_index(strtod("0x1p1007", nullptr)), 62);
-  EXPECT_EQ(compute_index(strtod("0x1p1000", nullptr)), 62);
-  EXPECT_EQ(compute_index(strtod("0x1p0993", nullptr)), 62);
-  EXPECT_EQ(compute_index(strtod("0x1p0992", nullptr)), 61);
-  EXPECT_EQ(compute_index(strtod("0x1p0991", nullptr)), 61);
+  EXPECT_EQ(compute_index(std::strtod("0x1p1023", nullptr)), 63);
+  EXPECT_EQ(compute_index(std::strtod("0x1p1019", nullptr)), 63);
+  EXPECT_EQ(compute_index(std::strtod("0x1p1009", nullptr)), 63);
+  EXPECT_EQ(compute_index(std::strtod("0x1p1008", nullptr)), 62);
+  EXPECT_EQ(compute_index(std::strtod("0x1p1007", nullptr)), 62);
+  EXPECT_EQ(compute_index(std::strtod("0x1p1000", nullptr)), 62);
+  EXPECT_EQ(compute_index(std::strtod("0x1p0993", nullptr)), 62);
+  EXPECT_EQ(compute_index(std::strtod("0x1p0992", nullptr)), 61);
+  EXPECT_EQ(compute_index(std::strtod("0x1p0991", nullptr)), 61);
   // Min and subnormal values.
-  EXPECT_EQ(compute_index(strtod("0x1p-1074", nullptr)), -68);
-  EXPECT_EQ(compute_index(strtod("0x1p-1073", nullptr)), -68);
-  EXPECT_EQ(compute_index(strtod("0x1p-1072", nullptr)), -68);
-  EXPECT_EQ(compute_index(strtod("0x1p-1057", nullptr)), -67);
-  EXPECT_EQ(compute_index(strtod("0x1p-1056", nullptr)), -67);
-  EXPECT_EQ(compute_index(strtod("0x1p-1041", nullptr)), -66);
-  EXPECT_EQ(compute_index(strtod("0x1p-1040", nullptr)), -66);
-  EXPECT_EQ(compute_index(strtod("0x1p-1025", nullptr)), -65);
-  EXPECT_EQ(compute_index(strtod("0x1p-1024", nullptr)), -65);
-  EXPECT_EQ(compute_index(strtod("0x1p-1023", nullptr)), -64);
-  EXPECT_EQ(compute_index(strtod("0x1p-1022", nullptr)), -64);
-  EXPECT_EQ(compute_index(strtod("0x1p-1009", nullptr)), -64);
-  EXPECT_EQ(compute_index(strtod("0x1p-1008", nullptr)), -64);
-  EXPECT_EQ(compute_index(strtod("0x1p-1007", nullptr)), -63);
-  EXPECT_EQ(compute_index(strtod("0x1p-0993", nullptr)), -63);
-  EXPECT_EQ(compute_index(strtod("0x1p-0992", nullptr)), -63);
-  EXPECT_EQ(compute_index(strtod("0x1p-0991", nullptr)), -62);
-  EXPECT_EQ(compute_index(strtod("0x1p-0977", nullptr)), -62);
-  EXPECT_EQ(compute_index(strtod("0x1p-0976", nullptr)), -62);
-  EXPECT_EQ(compute_index(strtod("0x1p-0975", nullptr)), -61);
+  EXPECT_EQ(compute_index(std::strtod("0x1p-1074", nullptr)), -68);
+  EXPECT_EQ(compute_index(std::strtod("0x1p-1073", nullptr)), -68);
+  EXPECT_EQ(compute_index(std::strtod("0x1p-1072", nullptr)), -68);
+  EXPECT_EQ(compute_index(std::strtod("0x1p-1057", nullptr)), -67);
+  EXPECT_EQ(compute_index(std::strtod("0x1p-1056", nullptr)), -67);
+  EXPECT_EQ(compute_index(std::strtod("0x1p-1041", nullptr)), -66);
+  EXPECT_EQ(compute_index(std::strtod("0x1p-1040", nullptr)), -66);
+  EXPECT_EQ(compute_index(std::strtod("0x1p-1025", nullptr)), -65);
+  EXPECT_EQ(compute_index(std::strtod("0x1p-1024", nullptr)), -65);
+  EXPECT_EQ(compute_index(std::strtod("0x1p-1023", nullptr)), -64);
+  EXPECT_EQ(compute_index(std::strtod("0x1p-1022", nullptr)), -64);
+  EXPECT_EQ(compute_index(std::strtod("0x1p-1009", nullptr)), -64);
+  EXPECT_EQ(compute_index(std::strtod("0x1p-1008", nullptr)), -64);
+  EXPECT_EQ(compute_index(std::strtod("0x1p-1007", nullptr)), -63);
+  EXPECT_EQ(compute_index(std::strtod("0x1p-0993", nullptr)), -63);
+  EXPECT_EQ(compute_index(std::strtod("0x1p-0992", nullptr)), -63);
+  EXPECT_EQ(compute_index(std::strtod("0x1p-0991", nullptr)), -62);
+  EXPECT_EQ(compute_index(std::strtod("0x1p-0977", nullptr)), -62);
+  EXPECT_EQ(compute_index(std::strtod("0x1p-0976", nullptr)), -62);
+  EXPECT_EQ(compute_index(std::strtod("0x1p-0975", nullptr)), -61);
 }


### PR DESCRIPTION
Fixes #4354

## Changes

Follow-up to #4349. Swapping deprecated C headers for their C++ equivalents left the underlying library calls unqualified (`memcpy`, `strcmp`, `isspace`, `strtod`, `snprintf`, `strftime`, etc.), relying on most implementations also exposing these names in the global namespace, which the standard does not guarantee.

Adds `std::` to call sites for the functions covered by `<cstring>`, `<cctype>`, `<cstdlib>`, `<cstdio>`, and `<ctime>`, plus the `FILE` and `tm` types, across `api`, `sdk`, `exporters`, `ext`, `examples`, and `functional`. Also adds a couple of `#include`s that were missing and relied on transitive inclusion.

Left untouched, per review feedback on #4349:

* Vendored code (`api/include/opentelemetry/nostd/internal/absl`, `exporters/etw/include/opentelemetry/exporters/etw/TraceLoggingDynamic.h`)
* Call sites already qualified with `::` (explicit global scope), since that looked like a deliberate choice rather than an oversight
* Platform-specific functions with no `std::` form (`gmtime_r`/`gmtime_s`, `strtok_s`/`strtok_r`)

## Test plan

- [x] Full local build (`cmake --build .`) with `BUILD_TESTING`, `WITH_EXAMPLES`, `WITH_FUNC_TESTS`, `WITH_OTLP_FILE`, `WITH_OTLP_HTTP`, `WITH_CONFIGURATION`, and `WITH_EXAMPLES_HTTP` enabled, 0 errors, 0 warnings.
- [x] `ctest` on both configs, 796/796 and 1233/1237 passed (the 4 failures were `ext.http.curl` timing tests that are flaky under parallel load in this environment; all pass at `-j1`).
