### PR TITLE
[BUG] Stop OTLP ForceFlush returning on the first notification and overrunning its deadline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,9 @@ Increment the:
   [#4334](https://github.com/open-telemetry/opentelemetry-cpp/pull/4334)
 * [BUG] Stop reading past a `nostd::string_view` that is not NUL terminated
   [#4346](https://github.com/open-telemetry/opentelemetry-cpp/pull/4346)
+* [BUG] Stop OTLP `ForceFlush` returning on the first notification and
+  overrunning the caller's deadline
+  [#4357](https://github.com/open-telemetry/opentelemetry-cpp/pull/4357)
 
 * [OTLP/HTTP] Honor `Retry-After` response header when retrying exports,
   supporting both delay-seconds and HTTP-date formats per RFC 7231 §7.1.3.

--- a/exporters/otlp/src/otlp_grpc_client.cc
+++ b/exporters/otlp/src/otlp_grpc_client.cc
@@ -757,20 +757,20 @@ bool OtlpGrpcClient::ForceFlush(
   while (timeout_steady > std::chrono::steady_clock::duration::zero() &&
          request_counter > async_data_->finished_request_counter.load(std::memory_order_acquire))
   {
-    // When changes of running_sessions_ and notify_one/notify_all happen between predicate
-    // checking and waiting, we should not wait forever.We should cleanup gc sessions here as soon
-    // as possible to call FinishSession() and cleanup resources.
+    // A completion can land between the loop condition and the wait, so the wait is bounded and the
+    // condition re-read on every wakeup. Never wait past the caller's deadline.
+    const std::chrono::steady_clock::duration wait_interval =
+        (std::min)(std::chrono::duration_cast<std::chrono::steady_clock::duration>(
+                       async_data_->export_timeout),
+                   timeout_steady);
+
     std::chrono::steady_clock::time_point start_timepoint = std::chrono::steady_clock::now();
-    if (std::cv_status::timeout !=
-        async_data_->session_waker.wait_for(lock, async_data_->export_timeout))
-    {
-      break;
-    }
+    async_data_->session_waker.wait_for(lock, wait_interval);
 
     timeout_steady -= std::chrono::steady_clock::now() - start_timepoint;
   }
 
-  return timeout_steady > std::chrono::steady_clock::duration::zero();
+  return request_counter <= async_data_->finished_request_counter.load(std::memory_order_acquire);
 #else
   return true;
 #endif

--- a/exporters/otlp/src/otlp_http_client.cc
+++ b/exporters/otlp/src/otlp_http_client.cc
@@ -878,13 +878,6 @@ bool OtlpHttpClient::ForceFlush(std::chrono::microseconds timeout) noexcept
   // What the wait was for, rather than what is left of the deadline. A session that finishes
   // between the last check and the last wait takes its notification with it, and the flush it was
   // holding up has happened.
-  {
-    std::lock_guard<std::recursive_mutex> guard{session_manager_lock_};
-    if (running_sessions_.empty())
-    {
-      return true;
-    }
-  }
   return finished_session_counter_.load(std::memory_order_acquire) >= wait_counter;
 }
 

--- a/exporters/otlp/src/otlp_http_client.cc
+++ b/exporters/otlp/src/otlp_http_client.cc
@@ -1,6 +1,7 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
+#include <algorithm>
 #include <atomic>
 #include <chrono>
 #include <condition_variable>
@@ -857,8 +858,12 @@ bool OtlpHttpClient::ForceFlush(std::chrono::microseconds timeout) noexcept
     // When changes of running_sessions_ and notify_one/notify_all happen between predicate
     // checking and waiting, we should not wait forever.We should cleanup gc sessions here as soon
     // as possible to call FinishSession() and cleanup resources.
+    const std::chrono::steady_clock::duration wait_interval = (std::min)(
+        std::chrono::duration_cast<std::chrono::steady_clock::duration>(options_.timeout),
+        timeout_steady);
+
     std::chrono::steady_clock::time_point start_timepoint = std::chrono::steady_clock::now();
-    if (std::cv_status::timeout == session_waker_.wait_for(lock, options_.timeout))
+    if (std::cv_status::timeout == session_waker_.wait_for(lock, wait_interval))
     {
       cleanupGCSessions();
     }
@@ -870,7 +875,17 @@ bool OtlpHttpClient::ForceFlush(std::chrono::microseconds timeout) noexcept
     timeout_steady -= std::chrono::steady_clock::now() - start_timepoint;
   }
 
-  return timeout_steady > std::chrono::steady_clock::duration::zero();
+  // What the wait was for, rather than what is left of the deadline. A session that finishes
+  // between the last check and the last wait takes its notification with it, and the flush it was
+  // holding up has happened.
+  {
+    std::lock_guard<std::recursive_mutex> guard{session_manager_lock_};
+    if (running_sessions_.empty())
+    {
+      return true;
+    }
+  }
+  return finished_session_counter_.load(std::memory_order_acquire) >= wait_counter;
 }
 
 bool OtlpHttpClient::Shutdown(std::chrono::microseconds timeout) noexcept

--- a/exporters/otlp/test/otlp_grpc_exporter_test.cc
+++ b/exporters/otlp/test/otlp_grpc_exporter_test.cc
@@ -353,7 +353,8 @@ TEST_F(OtlpGrpcExporterFlushTestPeer, ForceFlushReturnsWithinTheCallerDeadline)
       std::chrono::steady_clock::now() - started);
 
   EXPECT_FALSE(flushed);
-  EXPECT_LT(elapsed.count(), 5000);
+  EXPECT_LT(elapsed.count(), 1000)
+      << "waited on the export timeout rather than the one it was given";
 }
 
 // A completion for one request used to end the wait for every other request, and the leftover

--- a/exporters/otlp/test/otlp_grpc_exporter_test.cc
+++ b/exporters/otlp/test/otlp_grpc_exporter_test.cc
@@ -40,7 +40,13 @@
 #  include <grpcpp/grpcpp.h>
 #  include <gtest/gtest.h>
 #  include <algorithm>
+#  include <chrono>
+#  include <cstddef>
+#  include <functional>
 #  include <future>
+#  include <memory>
+#  include <mutex>
+#  include <thread>
 #  include <utility>
 #  include <vector>
 
@@ -86,6 +92,13 @@ public:
         ::opentelemetry::proto::collector::trace::v1::ExportTraceServiceResponse *response,
         std::function<void(::grpc::Status)> callback) override
     {
+      if (stub_->defer_completions_)
+      {
+        std::lock_guard<std::mutex> guard(stub_->deferred_lock_);
+        stub_->deferred_.push_back(std::move(callback));
+        return;
+      }
+
       stub_->last_async_status_ = stub_->Export(context, *request, response);
       callback(stub_->last_async_status_);
     }
@@ -118,8 +131,46 @@ public:
 
   ::grpc::Status GetLastAsyncStatus() const noexcept { return last_async_status_; }
 
+  // Keep the completion callbacks instead of running them inline, so a test can call ForceFlush()
+  // with requests still in flight. Call before the first export.
+  void DeferCompletions() noexcept { defer_completions_ = true; }
+
+  std::size_t DeferredCount()
+  {
+    std::lock_guard<std::mutex> guard(deferred_lock_);
+    return deferred_.size();
+  }
+
+  // Completes whichever deferred request has been waiting longest, false when there is none.
+  bool CompleteOneDeferred()
+  {
+    std::function<void(::grpc::Status)> callback;
+    {
+      std::lock_guard<std::mutex> guard(deferred_lock_);
+      if (deferred_.empty())
+      {
+        return false;
+      }
+      callback = std::move(deferred_.front());
+      deferred_.erase(deferred_.begin());
+    }
+
+    callback(::grpc::Status::OK);
+    return true;
+  }
+
+  void CompleteAllDeferred()
+  {
+    while (CompleteOneDeferred())
+    {
+    }
+  }
+
 private:
   ::grpc::Status last_async_status_;
+  bool defer_completions_{false};
+  std::mutex deferred_lock_;
+  std::vector<std::function<void(::grpc::Status)>> deferred_;
   async_interface async_interface_;
 };
 
@@ -242,6 +293,90 @@ TEST_F(OtlpGrpcExporterTestPeer, ExportPartialSuccess)
   EXPECT_TRUE(contains("partial success"));
   EXPECT_TRUE(contains("21 span(s) rejected"));
   EXPECT_TRUE(contains("too many spans!!"));
+}
+
+// ForceFlush() only has requests to wait for when the client tracks them, which it does under
+// ENABLE_ASYNC_EXPORT. gtest_add_tests registers by source text, so the cases below have to exist
+// in every build and opt out here rather than be compiled away.
+class OtlpGrpcExporterFlushTestPeer : public OtlpGrpcExporterTestPeer
+{
+protected:
+  void SetUp() override
+  {
+#  if !defined(ENABLE_ASYNC_EXPORT)
+    GTEST_SKIP() << "ForceFlush has no in-flight requests to wait for without async export";
+#  endif
+  }
+};
+
+// The wait is bounded by the exporter's timeout, so a caller asking for less than that used to
+// wait for the larger of the two.
+TEST_F(OtlpGrpcExporterFlushTestPeer, ForceFlushReturnsWithinTheCallerDeadline)
+{
+  auto *mock_stub = new OtlpMockTraceServiceStub();
+  mock_stub->DeferCompletions();
+  std::unique_ptr<proto::collector::trace::v1::TraceService::StubInterface> stub_interface(
+      mock_stub);
+  auto exporter = GetExporter(stub_interface);
+
+  auto recordable = exporter->MakeRecordable();
+  recordable->SetName("Test span");
+  nostd::span<std::unique_ptr<sdk::trace::Recordable>> batch(&recordable, 1);
+  exporter->Export(batch);
+  ASSERT_EQ(1u, mock_stub->DeferredCount());
+
+  const auto started = std::chrono::steady_clock::now();
+  const bool flushed = exporter->ForceFlush(std::chrono::milliseconds{50});
+  const auto elapsed = std::chrono::duration_cast<std::chrono::milliseconds>(
+      std::chrono::steady_clock::now() - started);
+
+  EXPECT_FALSE(flushed);
+  EXPECT_LT(elapsed.count(), 5000);
+
+  mock_stub->CompleteAllDeferred();
+}
+
+// A completion for one request used to end the wait for every other request, and the leftover
+// deadline was then reported as success.
+TEST_F(OtlpGrpcExporterFlushTestPeer, ForceFlushKeepsWaitingWhenAnotherRequestCompletes)
+{
+  auto *mock_stub = new OtlpMockTraceServiceStub();
+  mock_stub->DeferCompletions();
+  std::unique_ptr<proto::collector::trace::v1::TraceService::StubInterface> stub_interface(
+      mock_stub);
+  auto exporter = GetExporter(stub_interface);
+
+  auto first = exporter->MakeRecordable();
+  first->SetName("Test span 1");
+  nostd::span<std::unique_ptr<sdk::trace::Recordable>> first_batch(&first, 1);
+  exporter->Export(first_batch);
+
+  auto second = exporter->MakeRecordable();
+  second->SetName("Test span 2");
+  nostd::span<std::unique_ptr<sdk::trace::Recordable>> second_batch(&second, 1);
+  exporter->Export(second_batch);
+
+  ASSERT_EQ(2u, mock_stub->DeferredCount());
+
+  // Completed once the flush below is parked, so it arrives as a notification rather than as a
+  // counter the loop condition reads on its way in.
+  std::thread completer([mock_stub] {
+    std::this_thread::sleep_for(std::chrono::milliseconds{100});
+    mock_stub->CompleteOneDeferred();
+  });
+
+  const auto started = std::chrono::steady_clock::now();
+  const bool flushed = exporter->ForceFlush(std::chrono::milliseconds{1000});
+  const auto elapsed = std::chrono::duration_cast<std::chrono::milliseconds>(
+      std::chrono::steady_clock::now() - started);
+  completer.join();
+
+  EXPECT_FALSE(flushed);
+  // Ran its own deadline down rather than returning on the notification.
+  EXPECT_GE(elapsed.count(), 500);
+  EXPECT_EQ(1u, mock_stub->DeferredCount());
+
+  mock_stub->CompleteAllDeferred();
 }
 
 // Create spans, let processor call Export()

--- a/exporters/otlp/test/otlp_grpc_exporter_test.cc
+++ b/exporters/otlp/test/otlp_grpc_exporter_test.cc
@@ -186,6 +186,8 @@ public:
 
   DrainDeferredCompletions(const DrainDeferredCompletions &)            = delete;
   DrainDeferredCompletions &operator=(const DrainDeferredCompletions &) = delete;
+  DrainDeferredCompletions(DrainDeferredCompletions &&)                 = delete;
+  DrainDeferredCompletions &operator=(DrainDeferredCompletions &&)      = delete;
 
 private:
   OtlpMockTraceServiceStub *stub_;
@@ -312,6 +314,8 @@ TEST_F(OtlpGrpcExporterTestPeer, ExportPartialSuccess)
   EXPECT_TRUE(contains("too many spans!!"));
 }
 
+namespace
+{
 // ForceFlush() only has requests to wait for when the client tracks them, which it does under
 // ENABLE_ASYNC_EXPORT. gtest_add_tests registers by source text, so the cases below have to exist
 // in every build and opt out here rather than be compiled away.
@@ -393,6 +397,7 @@ TEST_F(OtlpGrpcExporterFlushTestPeer, ForceFlushKeepsWaitingWhenAnotherRequestCo
   EXPECT_GE(elapsed.count(), 500);
   EXPECT_EQ(1u, mock_stub->DeferredCount());
 }
+}  // namespace
 
 // Create spans, let processor call Export()
 TEST_F(OtlpGrpcExporterTestPeer, ExportIntegrationTest)

--- a/exporters/otlp/test/otlp_grpc_exporter_test.cc
+++ b/exporters/otlp/test/otlp_grpc_exporter_test.cc
@@ -174,6 +174,23 @@ private:
   async_interface async_interface_;
 };
 
+// Completes whatever is still deferred on the way out. ~OtlpGrpcClient waits for
+// running_requests to reach zero with no deadline, and TryCancel() cannot move it for a request
+// the stub is holding, so an assertion that ends a case early would hang the binary instead of
+// failing it. Declare after the exporter, so this runs first.
+class DrainDeferredCompletions
+{
+public:
+  explicit DrainDeferredCompletions(OtlpMockTraceServiceStub *stub) noexcept : stub_(stub) {}
+  ~DrainDeferredCompletions() { stub_->CompleteAllDeferred(); }
+
+  DrainDeferredCompletions(const DrainDeferredCompletions &)            = delete;
+  DrainDeferredCompletions &operator=(const DrainDeferredCompletions &) = delete;
+
+private:
+  OtlpMockTraceServiceStub *stub_;
+};
+
 using opentelemetry::test_common::ScopedTestLogHandler;
 }  // namespace
 
@@ -318,6 +335,7 @@ TEST_F(OtlpGrpcExporterFlushTestPeer, ForceFlushReturnsWithinTheCallerDeadline)
   std::unique_ptr<proto::collector::trace::v1::TraceService::StubInterface> stub_interface(
       mock_stub);
   auto exporter = GetExporter(stub_interface);
+  DrainDeferredCompletions drain{mock_stub};
 
   auto recordable = exporter->MakeRecordable();
   recordable->SetName("Test span");
@@ -332,8 +350,6 @@ TEST_F(OtlpGrpcExporterFlushTestPeer, ForceFlushReturnsWithinTheCallerDeadline)
 
   EXPECT_FALSE(flushed);
   EXPECT_LT(elapsed.count(), 5000);
-
-  mock_stub->CompleteAllDeferred();
 }
 
 // A completion for one request used to end the wait for every other request, and the leftover
@@ -345,6 +361,7 @@ TEST_F(OtlpGrpcExporterFlushTestPeer, ForceFlushKeepsWaitingWhenAnotherRequestCo
   std::unique_ptr<proto::collector::trace::v1::TraceService::StubInterface> stub_interface(
       mock_stub);
   auto exporter = GetExporter(stub_interface);
+  DrainDeferredCompletions drain{mock_stub};
 
   auto first = exporter->MakeRecordable();
   first->SetName("Test span 1");
@@ -375,8 +392,6 @@ TEST_F(OtlpGrpcExporterFlushTestPeer, ForceFlushKeepsWaitingWhenAnotherRequestCo
   // Ran its own deadline down rather than returning on the notification.
   EXPECT_GE(elapsed.count(), 500);
   EXPECT_EQ(1u, mock_stub->DeferredCount());
-
-  mock_stub->CompleteAllDeferred();
 }
 
 // Create spans, let processor call Export()

--- a/exporters/otlp/test/otlp_http_exporter_custom_client_test.cc
+++ b/exporters/otlp/test/otlp_http_exporter_custom_client_test.cc
@@ -4,13 +4,25 @@
 #ifndef OPENTELEMETRY_STL_VERSION
 
 #  include <chrono>
+#  include <memory>
+#  include <utility>
 
 #  include "opentelemetry/exporters/otlp/otlp_http_client.h"
 #  include "opentelemetry/exporters/otlp/otlp_http_exporter.h"
 #  include "opentelemetry/exporters/otlp/otlp_http_exporter_factory.h"
 #  include "opentelemetry/exporters/otlp/otlp_http_exporter_options.h"
 #  include "opentelemetry/exporters/otlp/otlp_http_exporter_runtime_options.h"
+
+#  include "opentelemetry/exporters/otlp/protobuf_include_prefix.h"
+
+#  include <google/protobuf/arena.h>
+#  include "opentelemetry/proto/collector/trace/v1/trace_service.pb.h"
+
+#  include "opentelemetry/exporters/otlp/protobuf_include_suffix.h"
+
+#  include "opentelemetry/ext/http/client/http_client.h"
 #  include "opentelemetry/ext/http/client/http_client_factory.h"
+#  include "opentelemetry/sdk/common/exporter_utils.h"
 #  include "opentelemetry/sdk/trace/batch_span_processor.h"
 #  include "opentelemetry/sdk/trace/batch_span_processor_options.h"
 #  include "opentelemetry/sdk/trace/tracer_provider.h"
@@ -33,12 +45,13 @@ namespace http_client = opentelemetry::ext::http::client;
 using NosendHttpClientFactory =
     opentelemetry::test_common::ext::http::client::nosend::HttpClientFactoryNosend;
 
-static OtlpHttpClientOptions MakeOtlpHttpClientOptions()
+static OtlpHttpClientOptions MakeOtlpHttpClientOptions(
+    std::chrono::system_clock::duration timeout = std::chrono::system_clock::duration::zero())
 {
   std::shared_ptr<opentelemetry::sdk::common::ThreadInstrumentation> not_instrumented;
   OtlpHttpExporterOptions options;
   options.console_debug                   = true;
-  options.timeout                         = std::chrono::system_clock::duration::zero();
+  options.timeout                         = timeout;
   options.retry_policy_max_attempts       = 0U;
   options.retry_policy_initial_backoff    = std::chrono::duration<float>::zero();
   options.retry_policy_max_backoff        = std::chrono::duration<float>::zero();
@@ -143,6 +156,52 @@ TEST_F(OtlpHttpExporterCustomClientTestPeer, ExportCallsSendRequest)
           });
 
   provider->ForceFlush();
+}
+
+TEST_F(OtlpHttpExporterCustomClientTestPeer, ForceFlushReturnsWithinTheCallerDeadline)
+{
+  auto client         = http_client::HttpClientTestFactory::Create();
+  auto no_send_client = std::static_pointer_cast<http_client::nosend::HttpClient>(client);
+  auto session = std::static_pointer_cast<http_client::nosend::Session>(no_send_client->session_);
+
+  // Hold the request open, so ForceFlush has something to wait for.
+  std::shared_ptr<opentelemetry::ext::http::client::EventHandler> pending;
+  EXPECT_CALL(*session, SendRequest)
+      .WillRepeatedly(
+          [&pending](std::shared_ptr<opentelemetry::ext::http::client::EventHandler> callback) {
+            pending = std::move(callback);
+          });
+
+  // A client timeout far longer than the deadline ForceFlush is given below.
+  OtlpHttpClient otlp_client(MakeOtlpHttpClientOptions(std::chrono::seconds{30}), client);
+
+  auto arena = std::make_unique<google::protobuf::Arena>();
+  auto *request =
+      google::protobuf::Arena::Create<proto::collector::trace::v1::ExportTraceServiceRequest>(
+          arena.get());
+  auto *response =
+      google::protobuf::Arena::Create<proto::collector::trace::v1::ExportTraceServiceResponse>(
+          arena.get());
+
+  // A non-zero request budget keeps the export asynchronous, so it returns while the session runs.
+  otlp_client.Export(
+      *request, std::move(arena), response,
+      [](opentelemetry::sdk::common::ExportResult, google::protobuf::Message *) { return true; },
+      1);
+  ASSERT_NE(pending, nullptr);
+
+  const auto started = std::chrono::steady_clock::now();
+  const bool flushed = otlp_client.ForceFlush(std::chrono::milliseconds{50});
+  const auto elapsed = std::chrono::duration_cast<std::chrono::milliseconds>(
+                           std::chrono::steady_clock::now() - started)
+                           .count();
+
+  EXPECT_FALSE(flushed);
+  EXPECT_LT(elapsed, 1000) << "waited on the client timeout rather than the one it was given";
+
+  // Complete the export, or the client destructor waits on it.
+  http_client::nosend::Response sent;
+  sent.Finish(*pending);
 }
 
 }  // namespace otlp

--- a/exporters/otlp/test/otlp_http_exporter_custom_client_test.cc
+++ b/exporters/otlp/test/otlp_http_exporter_custom_client_test.cc
@@ -90,6 +90,23 @@ public:
     auto http_client = http_client::HttpClientTestFactory::Create();
     return {new OtlpHttpClient(MakeOtlpHttpClientOptions(), http_client), http_client};
   }
+
+  // A non-zero request budget keeps the export asynchronous, so it returns while the session runs.
+  static void ExportOneRequest(OtlpHttpClient &otlp_client)
+  {
+    auto arena = std::make_unique<google::protobuf::Arena>();
+    auto *request =
+        google::protobuf::Arena::Create<proto::collector::trace::v1::ExportTraceServiceRequest>(
+            arena.get());
+    auto *response =
+        google::protobuf::Arena::Create<proto::collector::trace::v1::ExportTraceServiceResponse>(
+            arena.get());
+
+    otlp_client.Export(
+        *request, std::move(arena), response,
+        [](opentelemetry::sdk::common::ExportResult, google::protobuf::Message *) { return true; },
+        1);
+  }
 };
 
 TEST_F(OtlpHttpExporterCustomClientTestPeer, FactoryInjectionCreatesExporter)
@@ -175,19 +192,7 @@ TEST_F(OtlpHttpExporterCustomClientTestPeer, ForceFlushReturnsWithinTheCallerDea
   // A client timeout far longer than the deadline ForceFlush is given below.
   OtlpHttpClient otlp_client(MakeOtlpHttpClientOptions(std::chrono::seconds{30}), client);
 
-  auto arena = std::make_unique<google::protobuf::Arena>();
-  auto *request =
-      google::protobuf::Arena::Create<proto::collector::trace::v1::ExportTraceServiceRequest>(
-          arena.get());
-  auto *response =
-      google::protobuf::Arena::Create<proto::collector::trace::v1::ExportTraceServiceResponse>(
-          arena.get());
-
-  // A non-zero request budget keeps the export asynchronous, so it returns while the session runs.
-  otlp_client.Export(
-      *request, std::move(arena), response,
-      [](opentelemetry::sdk::common::ExportResult, google::protobuf::Message *) { return true; },
-      1);
+  ExportOneRequest(otlp_client);
   ASSERT_NE(pending, nullptr);
 
   const auto started = std::chrono::steady_clock::now();
@@ -202,6 +207,32 @@ TEST_F(OtlpHttpExporterCustomClientTestPeer, ForceFlushReturnsWithinTheCallerDea
   // Complete the export, or the client destructor waits on it.
   http_client::nosend::Response sent;
   sent.Finish(*pending);
+}
+
+// The result is the finished counter alone, so a flush with nothing left to wait for has to say
+// so. Guards the counter against the session bookkeeping it is derived from.
+TEST_F(OtlpHttpExporterCustomClientTestPeer, ForceFlushReportsSuccessOnceTheSessionIsDone)
+{
+  auto client         = http_client::HttpClientTestFactory::Create();
+  auto no_send_client = std::static_pointer_cast<http_client::nosend::HttpClient>(client);
+  auto session = std::static_pointer_cast<http_client::nosend::Session>(no_send_client->session_);
+
+  std::shared_ptr<opentelemetry::ext::http::client::EventHandler> pending;
+  EXPECT_CALL(*session, SendRequest)
+      .WillRepeatedly(
+          [&pending](std::shared_ptr<opentelemetry::ext::http::client::EventHandler> callback) {
+            pending = std::move(callback);
+          });
+
+  OtlpHttpClient otlp_client(MakeOtlpHttpClientOptions(std::chrono::seconds{30}), client);
+
+  ExportOneRequest(otlp_client);
+  ASSERT_NE(pending, nullptr);
+
+  http_client::nosend::Response sent;
+  sent.Finish(*pending);
+
+  EXPECT_TRUE(otlp_client.ForceFlush(std::chrono::milliseconds{50}));
 }
 
 }  // namespace otlp


### PR DESCRIPTION
Towards #4339. @owent confirmed the inverted comparison and suggested bounding the wait by the caller's remaining time, which is what this does. It does not close the issue; see "What this leaves" below.

## OTLP gRPC reported the whole flush done on one completion

`OtlpGrpcClient::ForceFlush` left its wait loop on any notification:

```cpp
if (std::cv_status::timeout !=
    async_data_->session_waker.wait_for(lock, async_data_->export_timeout))
{
  break;
}
```

`std::cv_status::timeout != status` is true when the wait was **notified**, and the loop condition is the only place `finished_request_counter` is read, so the `break` skipped it. One finished request out of many ended the wait, and the function then returned the leftover duration rather than the predicate.

Rather than inverting the test I dropped the `break` and let the loop condition decide, which is what the `==` form reduces to once the wait is bounded. The bounded `wait_for` is what covers a notification lost between the check and the wait; the `break` was not doing that. The return is the counter predicate now.

The comment above it described `running_sessions_` and gc session cleanup, neither of which exists in the gRPC client. It is a verbatim copy of the `OtlpHttpClient` one, down to the missing space in `forever.We`, so it is replaced rather than kept.

## Both clients waited on the exporter's timeout, not the caller's

`ForceFlush(1ms)` could block for the full configured export timeout. The wait interval is `min(configured timeout, caller's remaining time)` now, as suggested. No notification path and no lock discipline changes.

`OtlpHttpClient::Shutdown` is where that shows up in practice:

```cpp
// Wait util all sessions are canceled.
while (cleanupGCSessions())
{
  ForceFlush(std::chrono::milliseconds{1});
}
```

Each of those calls could take `options_.timeout`, so shutdown cost a multiple of the export timeout rather than a multiple of 1 ms.

## The result is the predicate, on both clients

Both loops used to end by returning what was left of the deadline. A completion that lands between the last check and the last wait takes its notification with it, and the wait then consumes the rest of the deadline and reports a timeout for work that had already finished. Each client now returns the condition it was waiting on.

## One thing I tried and backed out

`OtlpGrpcClient` increments `finished_request_counter` before it runs `grpc_async_callback`, which is where the `ExportResult` reaches the caller, so a bounded wait can see the counter satisfied while the result is still on its way. Moving the increment after the callback closes that, and I had it that way for a while.

It is not worth it here. `DelegateAsyncExport` is public and takes the callback, so a caller whose callback calls `ForceFlush()` would wait for an increment that cannot happen until the callback returns, and the no-deadline form of that wait never ends. Trading a bounded early signal for an unbounded self-wait is the wrong way round, and neither of the two bugs this PR fixes needs the change. Where a request counts as finished belongs with the identity work #4339 still needs.

## Test

In `otlp_http_exporter_custom_client_test.cc`, `ForceFlushReturnsWithinTheCallerDeadline` holds a request open with the nosend HTTP client and asserts `ForceFlush(50ms)` returns inside its deadline against a 30 second client timeout. It drives `OtlpHttpClient::Export` directly with a non-zero request budget, so it does not depend on `ENABLE_ASYNC_EXPORT`.

| | result | elapsed |
| --- | --- | --- |
| `otlp_http_client.cc` reverted to `main`, test kept | `Expected: (elapsed) < (1000), actual: 30000 vs 1000` | 30000 ms |
| this branch | passed | 50 ms |

`ForceFlushReportsSuccessOnceTheSessionIsDone` covers the other side of the new return, that a flush with nothing left to wait for says so. Nothing was asserting the return value on that path. It passes on `main` as well, where the old `timeout_steady > 0` happened to agree, so it guards the predicate rather than reproducing a bug.

Built and run in two configurations, `WITH_ASYNC_EXPORT_PREVIEW` off and on, seven of seven passing in both, whole file 51 ms.

The file carries the `#ifndef OPENTELEMETRY_STL_VERSION` guard its neighbours in `exporters/otlp/test` already use, so like them it builds under `WITH_STL=OFF` and is empty in the `cmake.c++*.stl.test` jobs.

The gRPC half is covered through the stub. `OtlpGrpcClientAsyncData` is defined in the `.cc`, so no test can read `finished_request_counter` directly, but it does not have to: `OtlpMockTraceServiceStub` was running the completion callback inline, so every request was already finished by the time `ForceFlush` could be called and the loop never had anything to wait for. Holding the callback instead leaves the request in flight, which is all these two cases need.

In `otlp_grpc_exporter_test.cc`, `OtlpGrpcExporterFlushTestPeer` carries two cases. `ForceFlushReturnsWithinTheCallerDeadline` asks for 50 ms against the 10 second export timeout. `ForceFlushKeepsWaitingWhenAnotherRequestCompletes` leaves two requests in flight and completes one while the flush is parked, which is the notification that used to end the wait.

| | result | elapsed |
| --- | --- | --- |
| `otlp_grpc_client.cc` reverted to `main`, tests kept | `Expected: (elapsed.count()) < (5000), actual: 10000 vs 5000` | 10000 ms |
| same, second case | `Value of: flushed / Actual: true / Expected: false` | 100 ms |
| this branch | both passed | 59 ms, 1006 ms |

The second row is the bug in one line: the flush returned success at the exact moment a different request completed, with the one it was waiting for still in flight.

56 of 56 with `WITH_ASYNC_EXPORT_PREVIEW=ON`. With it off the client tracks no in-flight requests, so the two cases skip in the fixture rather than being compiled away. `gtest_add_tests` registers from the source text, so an `#if`-ed out case is still registered with CTest and then passes without running. CTest lists both, and the binary reports 54 passed, 2 skipped.

## What this leaves

`ForceFlush` still does not fully meet the contract in your point 1. Both clients snapshot a monotonic total and wait for the finished total to reach it, so a request that starts **after** the call can satisfy the snapshot while one that was pending **before** it is still running. On entry `started=10 finished=8`; two new requests start and finish; finished reaches 10 and the wait ends with the original two in flight.

Reading both clients for that follow-up turned up four more places where the boundary sits in the wrong spot, all of them on `main` and none of them touched here:

* a request is not registered until after the exporter has serialised it, so a flush
during `PopulateRequest` sees nothing;
* the HTTP registration is two steps, the `running_sessions_` insert under the lock and
`start_session_counter_` after it;
* the HTTP loop leaves on `running_sessions_.empty()`, which counts sessions started
after the call, so a flush can also wait too long;
* `Unbind` runs the caller's callback before `ReleaseSession`, deliberately, because the
response lives in an arena the session data owns.

All five want the same thing, a token issued at the exporter's `Export` entry rather than a counting total, which also settles the wrap a monotonic total has on a 32 bit target. That is a change to both hot paths, so I kept it out of one you had already scoped and wrote the set up on #4339 instead. Happy to send it as a follow-up.

## Behaviour change worth knowing

`OtlpGrpcClient::Shutdown()` defaults to a timeout of 0, documented as "no timeout is applied". With the `break` gone that call waits for outstanding requests instead of returning after the first completion, so an application that exported and exited immediately will now see the export finish rather than be cancelled.

It does not wait indefinitely under a normal configuration: a call sets `context->set_deadline(now() + options.timeout)` whenever `options.timeout` is positive, so each one completes or fails within the export timeout and increments the counter either way. A caller that wants the old return-early behaviour can pass an explicit short timeout.

## One thing I noticed but did not touch

`OtlpGrpcClientOptions::timeout` and `OtlpHttpClientOptions::timeout` both default to a zero duration, and the exporters fill in a real value. If a client is left with zero, `set_deadline` is skipped, and in `ForceFlush` the wait interval is zero as well, so the loop spins instead of sleeping. `main` does the same thing there, since `wait_for(lock, 0)` returns `cv_status::timeout` and the old `!=` test then did not break either, so this is not something the PR changes. I left it alone because the sensible re-check interval for "no configured timeout" is a policy call, and falling back to the caller's remaining time would reintroduce the overflow that `AdjustWaitForTimeout` exists to avoid. A sketch of the policy is on #4339 with the rest of the follow-up.

## Checklist

* [x] `CHANGELOG.md` updated for non-trivial changes
* [x] Unit tests have been added
* [x] Changes in public API reviewed: no signature changes, but `ForceFlush` returns
`false` in cases where it used to return `true`, and a default `Shutdown()` now waits. Both are described above.

## CI note

`func_otlp_grpc` has a pre-existing nondeterministic double free that aborts after the tests report passing, and it reds gcc-14 and clang-18 on `main` as well. It is not related to this change.


