### PR TITLE
[CONFIGURATION] Add SDK component builder interfaces to the registry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,10 @@ Increment the:
   deprecated C headers (`stdint.h`, `stddef.h`, `stdlib.h`, `string.h`,
   `stdio.h`, `ctype.h`, `limits.h`, `assert.h`) with their C++ equivalents
   ([#4349](https://github.com/open-telemetry/opentelemetry-cpp/pull/4349))
+
+* [CONFIGURATION] Add SDK component builder interfaces to the registry
+  [#4358](https://github.com/open-telemetry/opentelemetry-cpp/issues/4358)
+
 * [CODE HEALTH] Move remaining `misc-use-internal-linkage` classes/enums into
   anonymous namespaces: `OtlpFileSystemBackend`/`OtlpFileOstreamBackend` in
   the OTLP file exporter, `ResponseHandler`/`AsyncResponseHandler`/

--- a/sdk/include/opentelemetry/sdk/configuration/always_off_sampler_builder.h
+++ b/sdk/include/opentelemetry/sdk/configuration/always_off_sampler_builder.h
@@ -1,0 +1,38 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <memory>
+
+#include "opentelemetry/sdk/configuration/always_off_sampler_configuration.h"
+#include "opentelemetry/version.h"
+
+OPENTELEMETRY_BEGIN_NAMESPACE
+namespace sdk
+{
+namespace trace
+{
+class Sampler;
+}  // namespace trace
+
+namespace configuration
+{
+
+class AlwaysOffSamplerBuilder
+{
+public:
+  AlwaysOffSamplerBuilder()                                                = default;
+  AlwaysOffSamplerBuilder(AlwaysOffSamplerBuilder &&)                      = default;
+  AlwaysOffSamplerBuilder(const AlwaysOffSamplerBuilder &)                 = default;
+  AlwaysOffSamplerBuilder &operator=(AlwaysOffSamplerBuilder &&)           = default;
+  AlwaysOffSamplerBuilder &operator=(const AlwaysOffSamplerBuilder &other) = default;
+  virtual ~AlwaysOffSamplerBuilder()                                       = default;
+
+  virtual std::unique_ptr<opentelemetry::sdk::trace::Sampler> Build(
+      const opentelemetry::sdk::configuration::AlwaysOffSamplerConfiguration *model) const = 0;
+};
+
+}  // namespace configuration
+}  // namespace sdk
+OPENTELEMETRY_END_NAMESPACE

--- a/sdk/include/opentelemetry/sdk/configuration/always_on_sampler_builder.h
+++ b/sdk/include/opentelemetry/sdk/configuration/always_on_sampler_builder.h
@@ -1,0 +1,38 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <memory>
+
+#include "opentelemetry/sdk/configuration/always_on_sampler_configuration.h"
+#include "opentelemetry/version.h"
+
+OPENTELEMETRY_BEGIN_NAMESPACE
+namespace sdk
+{
+namespace trace
+{
+class Sampler;
+}  // namespace trace
+
+namespace configuration
+{
+
+class AlwaysOnSamplerBuilder
+{
+public:
+  AlwaysOnSamplerBuilder()                                               = default;
+  AlwaysOnSamplerBuilder(AlwaysOnSamplerBuilder &&)                      = default;
+  AlwaysOnSamplerBuilder(const AlwaysOnSamplerBuilder &)                 = default;
+  AlwaysOnSamplerBuilder &operator=(AlwaysOnSamplerBuilder &&)           = default;
+  AlwaysOnSamplerBuilder &operator=(const AlwaysOnSamplerBuilder &other) = default;
+  virtual ~AlwaysOnSamplerBuilder()                                      = default;
+
+  virtual std::unique_ptr<opentelemetry::sdk::trace::Sampler> Build(
+      const opentelemetry::sdk::configuration::AlwaysOnSamplerConfiguration *model) const = 0;
+};
+
+}  // namespace configuration
+}  // namespace sdk
+OPENTELEMETRY_END_NAMESPACE

--- a/sdk/include/opentelemetry/sdk/configuration/batch_log_record_processor_builder.h
+++ b/sdk/include/opentelemetry/sdk/configuration/batch_log_record_processor_builder.h
@@ -1,0 +1,40 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <memory>
+
+#include "opentelemetry/sdk/configuration/batch_log_record_processor_configuration.h"
+#include "opentelemetry/version.h"
+
+OPENTELEMETRY_BEGIN_NAMESPACE
+namespace sdk
+{
+namespace logs
+{
+class LogRecordExporter;
+class LogRecordProcessor;
+}  // namespace logs
+
+namespace configuration
+{
+
+class BatchLogRecordProcessorBuilder
+{
+public:
+  BatchLogRecordProcessorBuilder()                                                       = default;
+  BatchLogRecordProcessorBuilder(BatchLogRecordProcessorBuilder &&)                      = default;
+  BatchLogRecordProcessorBuilder(const BatchLogRecordProcessorBuilder &)                 = default;
+  BatchLogRecordProcessorBuilder &operator=(BatchLogRecordProcessorBuilder &&)           = default;
+  BatchLogRecordProcessorBuilder &operator=(const BatchLogRecordProcessorBuilder &other) = default;
+  virtual ~BatchLogRecordProcessorBuilder()                                              = default;
+
+  virtual std::unique_ptr<opentelemetry::sdk::logs::LogRecordProcessor> Build(
+      const opentelemetry::sdk::configuration::BatchLogRecordProcessorConfiguration *model,
+      std::unique_ptr<opentelemetry::sdk::logs::LogRecordExporter> &&exporter) const = 0;
+};
+
+}  // namespace configuration
+}  // namespace sdk
+OPENTELEMETRY_END_NAMESPACE

--- a/sdk/include/opentelemetry/sdk/configuration/batch_span_processor_builder.h
+++ b/sdk/include/opentelemetry/sdk/configuration/batch_span_processor_builder.h
@@ -1,0 +1,40 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <memory>
+
+#include "opentelemetry/sdk/configuration/batch_span_processor_configuration.h"
+#include "opentelemetry/version.h"
+
+OPENTELEMETRY_BEGIN_NAMESPACE
+namespace sdk
+{
+namespace trace
+{
+class SpanExporter;
+class SpanProcessor;
+}  // namespace trace
+
+namespace configuration
+{
+
+class BatchSpanProcessorBuilder
+{
+public:
+  BatchSpanProcessorBuilder()                                                  = default;
+  BatchSpanProcessorBuilder(BatchSpanProcessorBuilder &&)                      = default;
+  BatchSpanProcessorBuilder(const BatchSpanProcessorBuilder &)                 = default;
+  BatchSpanProcessorBuilder &operator=(BatchSpanProcessorBuilder &&)           = default;
+  BatchSpanProcessorBuilder &operator=(const BatchSpanProcessorBuilder &other) = default;
+  virtual ~BatchSpanProcessorBuilder()                                         = default;
+
+  virtual std::unique_ptr<opentelemetry::sdk::trace::SpanProcessor> Build(
+      const opentelemetry::sdk::configuration::BatchSpanProcessorConfiguration *model,
+      std::unique_ptr<opentelemetry::sdk::trace::SpanExporter> &&exporter) const = 0;
+};
+
+}  // namespace configuration
+}  // namespace sdk
+OPENTELEMETRY_END_NAMESPACE

--- a/sdk/include/opentelemetry/sdk/configuration/composable_always_off_sampler_builder.h
+++ b/sdk/include/opentelemetry/sdk/configuration/composable_always_off_sampler_builder.h
@@ -1,0 +1,40 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <memory>
+
+#include "opentelemetry/sdk/configuration/composable_always_off_sampler_configuration.h"
+#include "opentelemetry/version.h"
+
+OPENTELEMETRY_BEGIN_NAMESPACE
+namespace sdk
+{
+namespace trace
+{
+class ComposableSampler;
+}  // namespace trace
+
+namespace configuration
+{
+
+class ComposableAlwaysOffSamplerBuilder
+{
+public:
+  ComposableAlwaysOffSamplerBuilder()                                                = default;
+  ComposableAlwaysOffSamplerBuilder(ComposableAlwaysOffSamplerBuilder &&)            = default;
+  ComposableAlwaysOffSamplerBuilder(const ComposableAlwaysOffSamplerBuilder &)       = default;
+  ComposableAlwaysOffSamplerBuilder &operator=(ComposableAlwaysOffSamplerBuilder &&) = default;
+  ComposableAlwaysOffSamplerBuilder &operator=(const ComposableAlwaysOffSamplerBuilder &other) =
+      default;
+  virtual ~ComposableAlwaysOffSamplerBuilder() = default;
+
+  virtual std::unique_ptr<opentelemetry::sdk::trace::ComposableSampler> Build(
+      const opentelemetry::sdk::configuration::ComposableAlwaysOffSamplerConfiguration *model)
+      const = 0;
+};
+
+}  // namespace configuration
+}  // namespace sdk
+OPENTELEMETRY_END_NAMESPACE

--- a/sdk/include/opentelemetry/sdk/configuration/composable_always_on_sampler_builder.h
+++ b/sdk/include/opentelemetry/sdk/configuration/composable_always_on_sampler_builder.h
@@ -1,0 +1,40 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <memory>
+
+#include "opentelemetry/sdk/configuration/composable_always_on_sampler_configuration.h"
+#include "opentelemetry/version.h"
+
+OPENTELEMETRY_BEGIN_NAMESPACE
+namespace sdk
+{
+namespace trace
+{
+class ComposableSampler;
+}  // namespace trace
+
+namespace configuration
+{
+
+class ComposableAlwaysOnSamplerBuilder
+{
+public:
+  ComposableAlwaysOnSamplerBuilder()                                               = default;
+  ComposableAlwaysOnSamplerBuilder(ComposableAlwaysOnSamplerBuilder &&)            = default;
+  ComposableAlwaysOnSamplerBuilder(const ComposableAlwaysOnSamplerBuilder &)       = default;
+  ComposableAlwaysOnSamplerBuilder &operator=(ComposableAlwaysOnSamplerBuilder &&) = default;
+  ComposableAlwaysOnSamplerBuilder &operator=(const ComposableAlwaysOnSamplerBuilder &other) =
+      default;
+  virtual ~ComposableAlwaysOnSamplerBuilder() = default;
+
+  virtual std::unique_ptr<opentelemetry::sdk::trace::ComposableSampler> Build(
+      const opentelemetry::sdk::configuration::ComposableAlwaysOnSamplerConfiguration *model)
+      const = 0;
+};
+
+}  // namespace configuration
+}  // namespace sdk
+OPENTELEMETRY_END_NAMESPACE

--- a/sdk/include/opentelemetry/sdk/configuration/composable_parent_threshold_sampler_builder.h
+++ b/sdk/include/opentelemetry/sdk/configuration/composable_parent_threshold_sampler_builder.h
@@ -1,0 +1,42 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <memory>
+
+#include "opentelemetry/sdk/configuration/composable_parent_threshold_sampler_configuration.h"
+#include "opentelemetry/version.h"
+
+OPENTELEMETRY_BEGIN_NAMESPACE
+namespace sdk
+{
+namespace trace
+{
+class ComposableSampler;
+}  // namespace trace
+
+namespace configuration
+{
+
+class ComposableParentThresholdSamplerBuilder
+{
+public:
+  ComposableParentThresholdSamplerBuilder()                                           = default;
+  ComposableParentThresholdSamplerBuilder(ComposableParentThresholdSamplerBuilder &&) = default;
+  ComposableParentThresholdSamplerBuilder(const ComposableParentThresholdSamplerBuilder &) =
+      default;
+  ComposableParentThresholdSamplerBuilder &operator=(ComposableParentThresholdSamplerBuilder &&) =
+      default;
+  ComposableParentThresholdSamplerBuilder &operator=(
+      const ComposableParentThresholdSamplerBuilder &other) = default;
+  virtual ~ComposableParentThresholdSamplerBuilder()        = default;
+
+  virtual std::unique_ptr<opentelemetry::sdk::trace::ComposableSampler> Build(
+      const opentelemetry::sdk::configuration::ComposableParentThresholdSamplerConfiguration *model,
+      std::unique_ptr<opentelemetry::sdk::trace::ComposableSampler> &&root) const = 0;
+};
+
+}  // namespace configuration
+}  // namespace sdk
+OPENTELEMETRY_END_NAMESPACE

--- a/sdk/include/opentelemetry/sdk/configuration/composable_probability_sampler_builder.h
+++ b/sdk/include/opentelemetry/sdk/configuration/composable_probability_sampler_builder.h
@@ -1,0 +1,40 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <memory>
+
+#include "opentelemetry/sdk/configuration/composable_probability_sampler_configuration.h"
+#include "opentelemetry/version.h"
+
+OPENTELEMETRY_BEGIN_NAMESPACE
+namespace sdk
+{
+namespace trace
+{
+class ComposableSampler;
+}  // namespace trace
+
+namespace configuration
+{
+
+class ComposableProbabilitySamplerBuilder
+{
+public:
+  ComposableProbabilitySamplerBuilder()                                                  = default;
+  ComposableProbabilitySamplerBuilder(ComposableProbabilitySamplerBuilder &&)            = default;
+  ComposableProbabilitySamplerBuilder(const ComposableProbabilitySamplerBuilder &)       = default;
+  ComposableProbabilitySamplerBuilder &operator=(ComposableProbabilitySamplerBuilder &&) = default;
+  ComposableProbabilitySamplerBuilder &operator=(const ComposableProbabilitySamplerBuilder &other) =
+      default;
+  virtual ~ComposableProbabilitySamplerBuilder() = default;
+
+  virtual std::unique_ptr<opentelemetry::sdk::trace::ComposableSampler> Build(
+      const opentelemetry::sdk::configuration::ComposableProbabilitySamplerConfiguration *model)
+      const = 0;
+};
+
+}  // namespace configuration
+}  // namespace sdk
+OPENTELEMETRY_END_NAMESPACE

--- a/sdk/include/opentelemetry/sdk/configuration/composable_rule_based_sampler_builder.h
+++ b/sdk/include/opentelemetry/sdk/configuration/composable_rule_based_sampler_builder.h
@@ -1,0 +1,42 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <memory>
+#include <vector>
+
+#include "opentelemetry/sdk/configuration/composable_rule_based_sampler_configuration.h"
+#include "opentelemetry/version.h"
+
+OPENTELEMETRY_BEGIN_NAMESPACE
+namespace sdk
+{
+namespace trace
+{
+class ComposableSampler;
+}  // namespace trace
+
+namespace configuration
+{
+
+class ComposableRuleBasedSamplerBuilder
+{
+public:
+  ComposableRuleBasedSamplerBuilder()                                                = default;
+  ComposableRuleBasedSamplerBuilder(ComposableRuleBasedSamplerBuilder &&)            = default;
+  ComposableRuleBasedSamplerBuilder(const ComposableRuleBasedSamplerBuilder &)       = default;
+  ComposableRuleBasedSamplerBuilder &operator=(ComposableRuleBasedSamplerBuilder &&) = default;
+  ComposableRuleBasedSamplerBuilder &operator=(const ComposableRuleBasedSamplerBuilder &other) =
+      default;
+  virtual ~ComposableRuleBasedSamplerBuilder() = default;
+
+  virtual std::unique_ptr<opentelemetry::sdk::trace::ComposableSampler> Build(
+      const opentelemetry::sdk::configuration::ComposableRuleBasedSamplerConfiguration *model,
+      std::vector<std::unique_ptr<opentelemetry::sdk::trace::ComposableSampler>> &&rule_samplers)
+      const = 0;
+};
+
+}  // namespace configuration
+}  // namespace sdk
+OPENTELEMETRY_END_NAMESPACE

--- a/sdk/include/opentelemetry/sdk/configuration/container_resource_detector_builder.h
+++ b/sdk/include/opentelemetry/sdk/configuration/container_resource_detector_builder.h
@@ -1,0 +1,40 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <memory>
+
+#include "opentelemetry/sdk/configuration/container_resource_detector_configuration.h"
+#include "opentelemetry/version.h"
+
+OPENTELEMETRY_BEGIN_NAMESPACE
+namespace sdk
+{
+namespace resource
+{
+class ResourceDetector;
+}  // namespace resource
+
+namespace configuration
+{
+
+class ContainerResourceDetectorBuilder
+{
+public:
+  ContainerResourceDetectorBuilder()                                               = default;
+  ContainerResourceDetectorBuilder(ContainerResourceDetectorBuilder &&)            = default;
+  ContainerResourceDetectorBuilder(const ContainerResourceDetectorBuilder &)       = default;
+  ContainerResourceDetectorBuilder &operator=(ContainerResourceDetectorBuilder &&) = default;
+  ContainerResourceDetectorBuilder &operator=(const ContainerResourceDetectorBuilder &other) =
+      default;
+  virtual ~ContainerResourceDetectorBuilder() = default;
+
+  virtual std::unique_ptr<opentelemetry::sdk::resource::ResourceDetector> Build(
+      const opentelemetry::sdk::configuration::ContainerResourceDetectorConfiguration *model)
+      const = 0;
+};
+
+}  // namespace configuration
+}  // namespace sdk
+OPENTELEMETRY_END_NAMESPACE

--- a/sdk/include/opentelemetry/sdk/configuration/extension_metric_producer_builder.h
+++ b/sdk/include/opentelemetry/sdk/configuration/extension_metric_producer_builder.h
@@ -1,0 +1,39 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <memory>
+
+#include "opentelemetry/sdk/configuration/extension_metric_producer_configuration.h"
+#include "opentelemetry/version.h"
+
+OPENTELEMETRY_BEGIN_NAMESPACE
+namespace sdk
+{
+namespace metrics
+{
+class MetricProducer;
+}  // namespace metrics
+
+namespace configuration
+{
+
+class ExtensionMetricProducerBuilder
+{
+public:
+  ExtensionMetricProducerBuilder()                                                       = default;
+  ExtensionMetricProducerBuilder(ExtensionMetricProducerBuilder &&)                      = default;
+  ExtensionMetricProducerBuilder(const ExtensionMetricProducerBuilder &)                 = default;
+  ExtensionMetricProducerBuilder &operator=(ExtensionMetricProducerBuilder &&)           = default;
+  ExtensionMetricProducerBuilder &operator=(const ExtensionMetricProducerBuilder &other) = default;
+  virtual ~ExtensionMetricProducerBuilder()                                              = default;
+
+  virtual std::unique_ptr<opentelemetry::sdk::metrics::MetricProducer> Build(
+      const opentelemetry::sdk::configuration::ExtensionMetricProducerConfiguration *model)
+      const = 0;
+};
+
+}  // namespace configuration
+}  // namespace sdk
+OPENTELEMETRY_END_NAMESPACE

--- a/sdk/include/opentelemetry/sdk/configuration/extension_resource_detector_builder.h
+++ b/sdk/include/opentelemetry/sdk/configuration/extension_resource_detector_builder.h
@@ -1,0 +1,40 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <memory>
+
+#include "opentelemetry/sdk/configuration/extension_resource_detector_configuration.h"
+#include "opentelemetry/version.h"
+
+OPENTELEMETRY_BEGIN_NAMESPACE
+namespace sdk
+{
+namespace resource
+{
+class ResourceDetector;
+}  // namespace resource
+
+namespace configuration
+{
+
+class ExtensionResourceDetectorBuilder
+{
+public:
+  ExtensionResourceDetectorBuilder()                                               = default;
+  ExtensionResourceDetectorBuilder(ExtensionResourceDetectorBuilder &&)            = default;
+  ExtensionResourceDetectorBuilder(const ExtensionResourceDetectorBuilder &)       = default;
+  ExtensionResourceDetectorBuilder &operator=(ExtensionResourceDetectorBuilder &&) = default;
+  ExtensionResourceDetectorBuilder &operator=(const ExtensionResourceDetectorBuilder &other) =
+      default;
+  virtual ~ExtensionResourceDetectorBuilder() = default;
+
+  virtual std::unique_ptr<opentelemetry::sdk::resource::ResourceDetector> Build(
+      const opentelemetry::sdk::configuration::ExtensionResourceDetectorConfiguration *model)
+      const = 0;
+};
+
+}  // namespace configuration
+}  // namespace sdk
+OPENTELEMETRY_END_NAMESPACE

--- a/sdk/include/opentelemetry/sdk/configuration/host_resource_detector_builder.h
+++ b/sdk/include/opentelemetry/sdk/configuration/host_resource_detector_builder.h
@@ -1,0 +1,38 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <memory>
+
+#include "opentelemetry/sdk/configuration/host_resource_detector_configuration.h"
+#include "opentelemetry/version.h"
+
+OPENTELEMETRY_BEGIN_NAMESPACE
+namespace sdk
+{
+namespace resource
+{
+class ResourceDetector;
+}  // namespace resource
+
+namespace configuration
+{
+
+class HostResourceDetectorBuilder
+{
+public:
+  HostResourceDetectorBuilder()                                                    = default;
+  HostResourceDetectorBuilder(HostResourceDetectorBuilder &&)                      = default;
+  HostResourceDetectorBuilder(const HostResourceDetectorBuilder &)                 = default;
+  HostResourceDetectorBuilder &operator=(HostResourceDetectorBuilder &&)           = default;
+  HostResourceDetectorBuilder &operator=(const HostResourceDetectorBuilder &other) = default;
+  virtual ~HostResourceDetectorBuilder()                                           = default;
+
+  virtual std::unique_ptr<opentelemetry::sdk::resource::ResourceDetector> Build(
+      const opentelemetry::sdk::configuration::HostResourceDetectorConfiguration *model) const = 0;
+};
+
+}  // namespace configuration
+}  // namespace sdk
+OPENTELEMETRY_END_NAMESPACE

--- a/sdk/include/opentelemetry/sdk/configuration/jaeger_remote_sampler_builder.h
+++ b/sdk/include/opentelemetry/sdk/configuration/jaeger_remote_sampler_builder.h
@@ -1,0 +1,39 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <memory>
+
+#include "opentelemetry/sdk/configuration/jaeger_remote_sampler_configuration.h"
+#include "opentelemetry/version.h"
+
+OPENTELEMETRY_BEGIN_NAMESPACE
+namespace sdk
+{
+namespace trace
+{
+class Sampler;
+}  // namespace trace
+
+namespace configuration
+{
+
+class JaegerRemoteSamplerBuilder
+{
+public:
+  JaegerRemoteSamplerBuilder()                                                   = default;
+  JaegerRemoteSamplerBuilder(JaegerRemoteSamplerBuilder &&)                      = default;
+  JaegerRemoteSamplerBuilder(const JaegerRemoteSamplerBuilder &)                 = default;
+  JaegerRemoteSamplerBuilder &operator=(JaegerRemoteSamplerBuilder &&)           = default;
+  JaegerRemoteSamplerBuilder &operator=(const JaegerRemoteSamplerBuilder &other) = default;
+  virtual ~JaegerRemoteSamplerBuilder()                                          = default;
+
+  virtual std::unique_ptr<opentelemetry::sdk::trace::Sampler> Build(
+      const opentelemetry::sdk::configuration::JaegerRemoteSamplerConfiguration *model,
+      std::unique_ptr<opentelemetry::sdk::trace::Sampler> &&initial_sampler) const = 0;
+};
+
+}  // namespace configuration
+}  // namespace sdk
+OPENTELEMETRY_END_NAMESPACE

--- a/sdk/include/opentelemetry/sdk/configuration/logger_configurator_builder.h
+++ b/sdk/include/opentelemetry/sdk/configuration/logger_configurator_builder.h
@@ -1,0 +1,45 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <memory>
+
+#include "opentelemetry/sdk/configuration/logger_configurator_configuration.h"
+#include "opentelemetry/version.h"
+
+OPENTELEMETRY_BEGIN_NAMESPACE
+namespace sdk
+{
+namespace instrumentationscope
+{
+template <typename T>
+class ScopeConfigurator;
+}  // namespace instrumentationscope
+
+namespace logs
+{
+class LoggerConfig;
+}  // namespace logs
+
+namespace configuration
+{
+
+class LoggerConfiguratorBuilder
+{
+public:
+  LoggerConfiguratorBuilder()                                                  = default;
+  LoggerConfiguratorBuilder(LoggerConfiguratorBuilder &&)                      = default;
+  LoggerConfiguratorBuilder(const LoggerConfiguratorBuilder &)                 = default;
+  LoggerConfiguratorBuilder &operator=(LoggerConfiguratorBuilder &&)           = default;
+  LoggerConfiguratorBuilder &operator=(const LoggerConfiguratorBuilder &other) = default;
+  virtual ~LoggerConfiguratorBuilder()                                         = default;
+
+  virtual std::unique_ptr<opentelemetry::sdk::instrumentationscope::ScopeConfigurator<
+      opentelemetry::sdk::logs::LoggerConfig>>
+  Build(const opentelemetry::sdk::configuration::LoggerConfiguratorConfiguration *model) const = 0;
+};
+
+}  // namespace configuration
+}  // namespace sdk
+OPENTELEMETRY_END_NAMESPACE

--- a/sdk/include/opentelemetry/sdk/configuration/meter_configurator_builder.h
+++ b/sdk/include/opentelemetry/sdk/configuration/meter_configurator_builder.h
@@ -1,0 +1,45 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <memory>
+
+#include "opentelemetry/sdk/configuration/meter_configurator_configuration.h"
+#include "opentelemetry/version.h"
+
+OPENTELEMETRY_BEGIN_NAMESPACE
+namespace sdk
+{
+namespace instrumentationscope
+{
+template <typename T>
+class ScopeConfigurator;
+}  // namespace instrumentationscope
+
+namespace metrics
+{
+class MeterConfig;
+}  // namespace metrics
+
+namespace configuration
+{
+
+class MeterConfiguratorBuilder
+{
+public:
+  MeterConfiguratorBuilder()                                                 = default;
+  MeterConfiguratorBuilder(MeterConfiguratorBuilder &&)                      = default;
+  MeterConfiguratorBuilder(const MeterConfiguratorBuilder &)                 = default;
+  MeterConfiguratorBuilder &operator=(MeterConfiguratorBuilder &&)           = default;
+  MeterConfiguratorBuilder &operator=(const MeterConfiguratorBuilder &other) = default;
+  virtual ~MeterConfiguratorBuilder()                                        = default;
+
+  virtual std::unique_ptr<opentelemetry::sdk::instrumentationscope::ScopeConfigurator<
+      opentelemetry::sdk::metrics::MeterConfig>>
+  Build(const opentelemetry::sdk::configuration::MeterConfiguratorConfiguration *model) const = 0;
+};
+
+}  // namespace configuration
+}  // namespace sdk
+OPENTELEMETRY_END_NAMESPACE

--- a/sdk/include/opentelemetry/sdk/configuration/open_census_metric_producer_builder.h
+++ b/sdk/include/opentelemetry/sdk/configuration/open_census_metric_producer_builder.h
@@ -1,0 +1,40 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <memory>
+
+#include "opentelemetry/sdk/configuration/open_census_metric_producer_configuration.h"
+#include "opentelemetry/version.h"
+
+OPENTELEMETRY_BEGIN_NAMESPACE
+namespace sdk
+{
+namespace metrics
+{
+class MetricProducer;
+}  // namespace metrics
+
+namespace configuration
+{
+
+class OpenCensusMetricProducerBuilder
+{
+public:
+  OpenCensusMetricProducerBuilder()                                              = default;
+  OpenCensusMetricProducerBuilder(OpenCensusMetricProducerBuilder &&)            = default;
+  OpenCensusMetricProducerBuilder(const OpenCensusMetricProducerBuilder &)       = default;
+  OpenCensusMetricProducerBuilder &operator=(OpenCensusMetricProducerBuilder &&) = default;
+  OpenCensusMetricProducerBuilder &operator=(const OpenCensusMetricProducerBuilder &other) =
+      default;
+  virtual ~OpenCensusMetricProducerBuilder() = default;
+
+  virtual std::unique_ptr<opentelemetry::sdk::metrics::MetricProducer> Build(
+      const opentelemetry::sdk::configuration::OpenCensusMetricProducerConfiguration *model)
+      const = 0;
+};
+
+}  // namespace configuration
+}  // namespace sdk
+OPENTELEMETRY_END_NAMESPACE

--- a/sdk/include/opentelemetry/sdk/configuration/parent_based_sampler_builder.h
+++ b/sdk/include/opentelemetry/sdk/configuration/parent_based_sampler_builder.h
@@ -1,0 +1,43 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <memory>
+
+#include "opentelemetry/sdk/configuration/parent_based_sampler_configuration.h"
+#include "opentelemetry/version.h"
+
+OPENTELEMETRY_BEGIN_NAMESPACE
+namespace sdk
+{
+namespace trace
+{
+class Sampler;
+}  // namespace trace
+
+namespace configuration
+{
+
+class ParentBasedSamplerBuilder
+{
+public:
+  ParentBasedSamplerBuilder()                                                  = default;
+  ParentBasedSamplerBuilder(ParentBasedSamplerBuilder &&)                      = default;
+  ParentBasedSamplerBuilder(const ParentBasedSamplerBuilder &)                 = default;
+  ParentBasedSamplerBuilder &operator=(ParentBasedSamplerBuilder &&)           = default;
+  ParentBasedSamplerBuilder &operator=(const ParentBasedSamplerBuilder &other) = default;
+  virtual ~ParentBasedSamplerBuilder()                                         = default;
+
+  virtual std::unique_ptr<opentelemetry::sdk::trace::Sampler> Build(
+      const opentelemetry::sdk::configuration::ParentBasedSamplerConfiguration *model,
+      std::unique_ptr<opentelemetry::sdk::trace::Sampler> &&root,
+      std::unique_ptr<opentelemetry::sdk::trace::Sampler> &&remote_parent_sampled,
+      std::unique_ptr<opentelemetry::sdk::trace::Sampler> &&remote_parent_not_sampled,
+      std::unique_ptr<opentelemetry::sdk::trace::Sampler> &&local_parent_sampled,
+      std::unique_ptr<opentelemetry::sdk::trace::Sampler> &&local_parent_not_sampled) const = 0;
+};
+
+}  // namespace configuration
+}  // namespace sdk
+OPENTELEMETRY_END_NAMESPACE

--- a/sdk/include/opentelemetry/sdk/configuration/probability_sampler_builder.h
+++ b/sdk/include/opentelemetry/sdk/configuration/probability_sampler_builder.h
@@ -1,0 +1,38 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <memory>
+
+#include "opentelemetry/sdk/configuration/probability_sampler_configuration.h"
+#include "opentelemetry/version.h"
+
+OPENTELEMETRY_BEGIN_NAMESPACE
+namespace sdk
+{
+namespace trace
+{
+class Sampler;
+}  // namespace trace
+
+namespace configuration
+{
+
+class ProbabilitySamplerBuilder
+{
+public:
+  ProbabilitySamplerBuilder()                                                  = default;
+  ProbabilitySamplerBuilder(ProbabilitySamplerBuilder &&)                      = default;
+  ProbabilitySamplerBuilder(const ProbabilitySamplerBuilder &)                 = default;
+  ProbabilitySamplerBuilder &operator=(ProbabilitySamplerBuilder &&)           = default;
+  ProbabilitySamplerBuilder &operator=(const ProbabilitySamplerBuilder &other) = default;
+  virtual ~ProbabilitySamplerBuilder()                                         = default;
+
+  virtual std::unique_ptr<opentelemetry::sdk::trace::Sampler> Build(
+      const opentelemetry::sdk::configuration::ProbabilitySamplerConfiguration *model) const = 0;
+};
+
+}  // namespace configuration
+}  // namespace sdk
+OPENTELEMETRY_END_NAMESPACE

--- a/sdk/include/opentelemetry/sdk/configuration/process_resource_detector_builder.h
+++ b/sdk/include/opentelemetry/sdk/configuration/process_resource_detector_builder.h
@@ -1,0 +1,39 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <memory>
+
+#include "opentelemetry/sdk/configuration/process_resource_detector_configuration.h"
+#include "opentelemetry/version.h"
+
+OPENTELEMETRY_BEGIN_NAMESPACE
+namespace sdk
+{
+namespace resource
+{
+class ResourceDetector;
+}  // namespace resource
+
+namespace configuration
+{
+
+class ProcessResourceDetectorBuilder
+{
+public:
+  ProcessResourceDetectorBuilder()                                                       = default;
+  ProcessResourceDetectorBuilder(ProcessResourceDetectorBuilder &&)                      = default;
+  ProcessResourceDetectorBuilder(const ProcessResourceDetectorBuilder &)                 = default;
+  ProcessResourceDetectorBuilder &operator=(ProcessResourceDetectorBuilder &&)           = default;
+  ProcessResourceDetectorBuilder &operator=(const ProcessResourceDetectorBuilder &other) = default;
+  virtual ~ProcessResourceDetectorBuilder()                                              = default;
+
+  virtual std::unique_ptr<opentelemetry::sdk::resource::ResourceDetector> Build(
+      const opentelemetry::sdk::configuration::ProcessResourceDetectorConfiguration *model)
+      const = 0;
+};
+
+}  // namespace configuration
+}  // namespace sdk
+OPENTELEMETRY_END_NAMESPACE

--- a/sdk/include/opentelemetry/sdk/configuration/pull_metric_reader_builder.h
+++ b/sdk/include/opentelemetry/sdk/configuration/pull_metric_reader_builder.h
@@ -1,0 +1,39 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <memory>
+
+#include "opentelemetry/sdk/configuration/pull_metric_reader_configuration.h"
+#include "opentelemetry/version.h"
+
+OPENTELEMETRY_BEGIN_NAMESPACE
+namespace sdk
+{
+namespace metrics
+{
+class MetricReader;
+}  // namespace metrics
+
+namespace configuration
+{
+
+class PullMetricReaderBuilder
+{
+public:
+  PullMetricReaderBuilder()                                                = default;
+  PullMetricReaderBuilder(PullMetricReaderBuilder &&)                      = default;
+  PullMetricReaderBuilder(const PullMetricReaderBuilder &)                 = default;
+  PullMetricReaderBuilder &operator=(PullMetricReaderBuilder &&)           = default;
+  PullMetricReaderBuilder &operator=(const PullMetricReaderBuilder &other) = default;
+  virtual ~PullMetricReaderBuilder()                                       = default;
+
+  virtual std::unique_ptr<opentelemetry::sdk::metrics::MetricReader> Build(
+      const opentelemetry::sdk::configuration::PullMetricReaderConfiguration *model,
+      std::unique_ptr<opentelemetry::sdk::metrics::MetricReader> &&exporter) const = 0;
+};
+
+}  // namespace configuration
+}  // namespace sdk
+OPENTELEMETRY_END_NAMESPACE

--- a/sdk/include/opentelemetry/sdk/configuration/registry.h
+++ b/sdk/include/opentelemetry/sdk/configuration/registry.h
@@ -16,16 +16,33 @@ namespace configuration
 {
 
 // Forward declarations
+class AlwaysOffSamplerBuilder;
+class AlwaysOnSamplerBuilder;
+class BatchLogRecordProcessorBuilder;
+class BatchSpanProcessorBuilder;
+class ComposableAlwaysOffSamplerBuilder;
+class ComposableAlwaysOnSamplerBuilder;
+class ComposableParentThresholdSamplerBuilder;
+class ComposableProbabilitySamplerBuilder;
+class ComposableRuleBasedSamplerBuilder;
 class ConsoleLogRecordExporterBuilder;
 class ConsolePushMetricExporterBuilder;
 class ConsoleSpanExporterBuilder;
+class ContainerResourceDetectorBuilder;
 class ExtensionLogRecordExporterBuilder;
 class ExtensionLogRecordProcessorBuilder;
+class ExtensionMetricProducerBuilder;
 class ExtensionPullMetricExporterBuilder;
 class ExtensionPushMetricExporterBuilder;
+class ExtensionResourceDetectorBuilder;
 class ExtensionSamplerBuilder;
 class ExtensionSpanExporterBuilder;
 class ExtensionSpanProcessorBuilder;
+class HostResourceDetectorBuilder;
+class JaegerRemoteSamplerBuilder;
+class LoggerConfiguratorBuilder;
+class MeterConfiguratorBuilder;
+class OpenCensusMetricProducerBuilder;
 class OtlpFileLogRecordExporterBuilder;
 class OtlpFilePushMetricExporterBuilder;
 class OtlpFileSpanExporterBuilder;
@@ -35,9 +52,18 @@ class OtlpGrpcSpanExporterBuilder;
 class OtlpHttpLogRecordExporterBuilder;
 class OtlpHttpPushMetricExporterBuilder;
 class OtlpHttpSpanExporterBuilder;
+class ParentBasedSamplerBuilder;
 class PeriodicMetricReaderBuilder;
+class ProbabilitySamplerBuilder;
+class ProcessResourceDetectorBuilder;
 class PrometheusPullMetricExporterBuilder;
+class PullMetricReaderBuilder;
+class ServiceResourceDetectorBuilder;
+class SimpleLogRecordProcessorBuilder;
+class SimpleSpanProcessorBuilder;
 class TextMapPropagatorBuilder;
+class TraceIdRatioBasedSamplerBuilder;
+class TracerConfiguratorBuilder;
 
 class OPENTELEMETRY_EXPORT Registry
 {
@@ -120,12 +146,27 @@ public:
   void SetPrometheusPullMetricExporterBuilder(
       std::unique_ptr<PrometheusPullMetricExporterBuilder> &&builder);
 
+  const OpenCensusMetricProducerBuilder *GetOpenCensusMetricProducerBuilder() const
+  {
+    return open_census_metric_producer_builder_.get();
+  }
+
+  void SetOpenCensusMetricProducerBuilder(
+      std::unique_ptr<OpenCensusMetricProducerBuilder> &&builder);
+
   const PeriodicMetricReaderBuilder *GetPeriodicMetricReaderBuilder() const
   {
     return periodic_metric_reader_builder_.get();
   }
 
   void SetPeriodicMetricReaderBuilder(std::unique_ptr<PeriodicMetricReaderBuilder> &&builder);
+
+  const PullMetricReaderBuilder *GetPullMetricReaderBuilder() const
+  {
+    return pull_metric_reader_builder_.get();
+  }
+
+  void SetPullMetricReaderBuilder(std::unique_ptr<PullMetricReaderBuilder> &&builder);
 
   const OtlpHttpLogRecordExporterBuilder *GetOtlpHttpLogRecordBuilder() const
   {
@@ -154,6 +195,178 @@ public:
   }
 
   void SetConsoleLogRecordBuilder(std::unique_ptr<ConsoleLogRecordExporterBuilder> &&builder);
+
+  /* Samplers. */
+
+  const AlwaysOnSamplerBuilder *GetAlwaysOnSamplerBuilder() const
+  {
+    return always_on_sampler_builder_.get();
+  }
+
+  void SetAlwaysOnSamplerBuilder(std::unique_ptr<AlwaysOnSamplerBuilder> &&builder);
+
+  const AlwaysOffSamplerBuilder *GetAlwaysOffSamplerBuilder() const
+  {
+    return always_off_sampler_builder_.get();
+  }
+
+  void SetAlwaysOffSamplerBuilder(std::unique_ptr<AlwaysOffSamplerBuilder> &&builder);
+
+  const TraceIdRatioBasedSamplerBuilder *GetTraceIdRatioBasedSamplerBuilder() const
+  {
+    return trace_id_ratio_based_sampler_builder_.get();
+  }
+
+  void SetTraceIdRatioBasedSamplerBuilder(
+      std::unique_ptr<TraceIdRatioBasedSamplerBuilder> &&builder);
+
+  const ProbabilitySamplerBuilder *GetProbabilitySamplerBuilder() const
+  {
+    return probability_sampler_builder_.get();
+  }
+
+  void SetProbabilitySamplerBuilder(std::unique_ptr<ProbabilitySamplerBuilder> &&builder);
+
+  const ParentBasedSamplerBuilder *GetParentBasedSamplerBuilder() const
+  {
+    return parent_based_sampler_builder_.get();
+  }
+
+  void SetParentBasedSamplerBuilder(std::unique_ptr<ParentBasedSamplerBuilder> &&builder);
+
+  const JaegerRemoteSamplerBuilder *GetJaegerRemoteSamplerBuilder() const
+  {
+    return jaeger_remote_sampler_builder_.get();
+  }
+
+  void SetJaegerRemoteSamplerBuilder(std::unique_ptr<JaegerRemoteSamplerBuilder> &&builder);
+
+  /* Composable samplers. */
+
+  const ComposableAlwaysOnSamplerBuilder *GetComposableAlwaysOnSamplerBuilder() const
+  {
+    return composable_always_on_sampler_builder_.get();
+  }
+
+  void SetComposableAlwaysOnSamplerBuilder(
+      std::unique_ptr<ComposableAlwaysOnSamplerBuilder> &&builder);
+
+  const ComposableAlwaysOffSamplerBuilder *GetComposableAlwaysOffSamplerBuilder() const
+  {
+    return composable_always_off_sampler_builder_.get();
+  }
+
+  void SetComposableAlwaysOffSamplerBuilder(
+      std::unique_ptr<ComposableAlwaysOffSamplerBuilder> &&builder);
+
+  const ComposableProbabilitySamplerBuilder *GetComposableProbabilitySamplerBuilder() const
+  {
+    return composable_probability_sampler_builder_.get();
+  }
+
+  void SetComposableProbabilitySamplerBuilder(
+      std::unique_ptr<ComposableProbabilitySamplerBuilder> &&builder);
+
+  const ComposableParentThresholdSamplerBuilder *GetComposableParentThresholdSamplerBuilder() const
+  {
+    return composable_parent_threshold_sampler_builder_.get();
+  }
+
+  void SetComposableParentThresholdSamplerBuilder(
+      std::unique_ptr<ComposableParentThresholdSamplerBuilder> &&builder);
+
+  const ComposableRuleBasedSamplerBuilder *GetComposableRuleBasedSamplerBuilder() const
+  {
+    return composable_rule_based_sampler_builder_.get();
+  }
+
+  void SetComposableRuleBasedSamplerBuilder(
+      std::unique_ptr<ComposableRuleBasedSamplerBuilder> &&builder);
+
+  /* Processors. */
+
+  const BatchSpanProcessorBuilder *GetBatchSpanProcessorBuilder() const
+  {
+    return batch_span_processor_builder_.get();
+  }
+
+  void SetBatchSpanProcessorBuilder(std::unique_ptr<BatchSpanProcessorBuilder> &&builder);
+
+  const SimpleSpanProcessorBuilder *GetSimpleSpanProcessorBuilder() const
+  {
+    return simple_span_processor_builder_.get();
+  }
+
+  void SetSimpleSpanProcessorBuilder(std::unique_ptr<SimpleSpanProcessorBuilder> &&builder);
+
+  const BatchLogRecordProcessorBuilder *GetBatchLogRecordProcessorBuilder() const
+  {
+    return batch_log_record_processor_builder_.get();
+  }
+
+  void SetBatchLogRecordProcessorBuilder(std::unique_ptr<BatchLogRecordProcessorBuilder> &&builder);
+
+  const SimpleLogRecordProcessorBuilder *GetSimpleLogRecordProcessorBuilder() const
+  {
+    return simple_log_record_processor_builder_.get();
+  }
+
+  void SetSimpleLogRecordProcessorBuilder(
+      std::unique_ptr<SimpleLogRecordProcessorBuilder> &&builder);
+
+  /* Configurators. */
+
+  const TracerConfiguratorBuilder *GetTracerConfiguratorBuilder() const
+  {
+    return tracer_configurator_builder_.get();
+  }
+
+  void SetTracerConfiguratorBuilder(std::unique_ptr<TracerConfiguratorBuilder> &&builder);
+
+  const MeterConfiguratorBuilder *GetMeterConfiguratorBuilder() const
+  {
+    return meter_configurator_builder_.get();
+  }
+
+  void SetMeterConfiguratorBuilder(std::unique_ptr<MeterConfiguratorBuilder> &&builder);
+
+  const LoggerConfiguratorBuilder *GetLoggerConfiguratorBuilder() const
+  {
+    return logger_configurator_builder_.get();
+  }
+
+  void SetLoggerConfiguratorBuilder(std::unique_ptr<LoggerConfiguratorBuilder> &&builder);
+
+  /* Resource detectors. */
+
+  const ContainerResourceDetectorBuilder *GetContainerResourceDetectorBuilder() const
+  {
+    return container_resource_detector_builder_.get();
+  }
+
+  void SetContainerResourceDetectorBuilder(
+      std::unique_ptr<ContainerResourceDetectorBuilder> &&builder);
+
+  const HostResourceDetectorBuilder *GetHostResourceDetectorBuilder() const
+  {
+    return host_resource_detector_builder_.get();
+  }
+
+  void SetHostResourceDetectorBuilder(std::unique_ptr<HostResourceDetectorBuilder> &&builder);
+
+  const ProcessResourceDetectorBuilder *GetProcessResourceDetectorBuilder() const
+  {
+    return process_resource_detector_builder_.get();
+  }
+
+  void SetProcessResourceDetectorBuilder(std::unique_ptr<ProcessResourceDetectorBuilder> &&builder);
+
+  const ServiceResourceDetectorBuilder *GetServiceResourceDetectorBuilder() const
+  {
+    return service_resource_detector_builder_.get();
+  }
+
+  void SetServiceResourceDetectorBuilder(std::unique_ptr<ServiceResourceDetectorBuilder> &&builder);
 
   /* Extension points */
 
@@ -207,6 +420,19 @@ public:
       const std::string &name,
       std::unique_ptr<ExtensionLogRecordProcessorBuilder> &&builder);
 
+  const ExtensionMetricProducerBuilder *GetExtensionMetricProducerBuilder(
+      const std::string &name) const;
+
+  void SetExtensionMetricProducerBuilder(const std::string &name,
+                                         std::unique_ptr<ExtensionMetricProducerBuilder> &&builder);
+
+  const ExtensionResourceDetectorBuilder *GetExtensionResourceDetectorBuilder(
+      const std::string &name) const;
+
+  void SetExtensionResourceDetectorBuilder(
+      const std::string &name,
+      std::unique_ptr<ExtensionResourceDetectorBuilder> &&builder);
+
 private:
   std::unique_ptr<OtlpHttpSpanExporterBuilder> otlp_http_span_builder_;
   std::unique_ptr<OtlpGrpcSpanExporterBuilder> otlp_grpc_span_builder_;
@@ -219,11 +445,42 @@ private:
   std::unique_ptr<ConsolePushMetricExporterBuilder> console_metric_builder_;
   std::unique_ptr<PrometheusPullMetricExporterBuilder> prometheus_metric_builder_;
   std::unique_ptr<PeriodicMetricReaderBuilder> periodic_metric_reader_builder_;
+  std::unique_ptr<PullMetricReaderBuilder> pull_metric_reader_builder_;
 
   std::unique_ptr<OtlpHttpLogRecordExporterBuilder> otlp_http_log_record_builder_;
   std::unique_ptr<OtlpGrpcLogRecordExporterBuilder> otlp_grpc_log_record_builder_;
   std::unique_ptr<OtlpFileLogRecordExporterBuilder> otlp_file_log_record_builder_;
   std::unique_ptr<ConsoleLogRecordExporterBuilder> console_log_record_builder_;
+
+  std::unique_ptr<AlwaysOnSamplerBuilder> always_on_sampler_builder_;
+  std::unique_ptr<AlwaysOffSamplerBuilder> always_off_sampler_builder_;
+  std::unique_ptr<TraceIdRatioBasedSamplerBuilder> trace_id_ratio_based_sampler_builder_;
+  std::unique_ptr<ProbabilitySamplerBuilder> probability_sampler_builder_;
+  std::unique_ptr<ParentBasedSamplerBuilder> parent_based_sampler_builder_;
+  std::unique_ptr<JaegerRemoteSamplerBuilder> jaeger_remote_sampler_builder_;
+
+  std::unique_ptr<ComposableAlwaysOnSamplerBuilder> composable_always_on_sampler_builder_;
+  std::unique_ptr<ComposableAlwaysOffSamplerBuilder> composable_always_off_sampler_builder_;
+  std::unique_ptr<ComposableProbabilitySamplerBuilder> composable_probability_sampler_builder_;
+  std::unique_ptr<ComposableParentThresholdSamplerBuilder>
+      composable_parent_threshold_sampler_builder_;
+  std::unique_ptr<ComposableRuleBasedSamplerBuilder> composable_rule_based_sampler_builder_;
+
+  std::unique_ptr<BatchSpanProcessorBuilder> batch_span_processor_builder_;
+  std::unique_ptr<SimpleSpanProcessorBuilder> simple_span_processor_builder_;
+  std::unique_ptr<BatchLogRecordProcessorBuilder> batch_log_record_processor_builder_;
+  std::unique_ptr<SimpleLogRecordProcessorBuilder> simple_log_record_processor_builder_;
+
+  std::unique_ptr<TracerConfiguratorBuilder> tracer_configurator_builder_;
+  std::unique_ptr<MeterConfiguratorBuilder> meter_configurator_builder_;
+  std::unique_ptr<LoggerConfiguratorBuilder> logger_configurator_builder_;
+
+  std::unique_ptr<OpenCensusMetricProducerBuilder> open_census_metric_producer_builder_;
+
+  std::unique_ptr<ContainerResourceDetectorBuilder> container_resource_detector_builder_;
+  std::unique_ptr<HostResourceDetectorBuilder> host_resource_detector_builder_;
+  std::unique_ptr<ProcessResourceDetectorBuilder> process_resource_detector_builder_;
+  std::unique_ptr<ServiceResourceDetectorBuilder> service_resource_detector_builder_;
 
   std::map<std::string, std::unique_ptr<TextMapPropagatorBuilder>> propagator_builders_;
   std::map<std::string, std::unique_ptr<ExtensionSamplerBuilder>> sampler_builders_;
@@ -237,6 +494,9 @@ private:
       log_record_exporter_builders_;
   std::map<std::string, std::unique_ptr<ExtensionLogRecordProcessorBuilder>>
       log_record_processor_builders_;
+  std::map<std::string, std::unique_ptr<ExtensionMetricProducerBuilder>> metric_producer_builders_;
+  std::map<std::string, std::unique_ptr<ExtensionResourceDetectorBuilder>>
+      resource_detector_builders_;
 };
 
 }  // namespace configuration

--- a/sdk/include/opentelemetry/sdk/configuration/service_resource_detector_builder.h
+++ b/sdk/include/opentelemetry/sdk/configuration/service_resource_detector_builder.h
@@ -1,0 +1,39 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <memory>
+
+#include "opentelemetry/sdk/configuration/service_resource_detector_configuration.h"
+#include "opentelemetry/version.h"
+
+OPENTELEMETRY_BEGIN_NAMESPACE
+namespace sdk
+{
+namespace resource
+{
+class ResourceDetector;
+}  // namespace resource
+
+namespace configuration
+{
+
+class ServiceResourceDetectorBuilder
+{
+public:
+  ServiceResourceDetectorBuilder()                                                       = default;
+  ServiceResourceDetectorBuilder(ServiceResourceDetectorBuilder &&)                      = default;
+  ServiceResourceDetectorBuilder(const ServiceResourceDetectorBuilder &)                 = default;
+  ServiceResourceDetectorBuilder &operator=(ServiceResourceDetectorBuilder &&)           = default;
+  ServiceResourceDetectorBuilder &operator=(const ServiceResourceDetectorBuilder &other) = default;
+  virtual ~ServiceResourceDetectorBuilder()                                              = default;
+
+  virtual std::unique_ptr<opentelemetry::sdk::resource::ResourceDetector> Build(
+      const opentelemetry::sdk::configuration::ServiceResourceDetectorConfiguration *model)
+      const = 0;
+};
+
+}  // namespace configuration
+}  // namespace sdk
+OPENTELEMETRY_END_NAMESPACE

--- a/sdk/include/opentelemetry/sdk/configuration/simple_log_record_processor_builder.h
+++ b/sdk/include/opentelemetry/sdk/configuration/simple_log_record_processor_builder.h
@@ -1,0 +1,41 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <memory>
+
+#include "opentelemetry/sdk/configuration/simple_log_record_processor_configuration.h"
+#include "opentelemetry/version.h"
+
+OPENTELEMETRY_BEGIN_NAMESPACE
+namespace sdk
+{
+namespace logs
+{
+class LogRecordExporter;
+class LogRecordProcessor;
+}  // namespace logs
+
+namespace configuration
+{
+
+class SimpleLogRecordProcessorBuilder
+{
+public:
+  SimpleLogRecordProcessorBuilder()                                              = default;
+  SimpleLogRecordProcessorBuilder(SimpleLogRecordProcessorBuilder &&)            = default;
+  SimpleLogRecordProcessorBuilder(const SimpleLogRecordProcessorBuilder &)       = default;
+  SimpleLogRecordProcessorBuilder &operator=(SimpleLogRecordProcessorBuilder &&) = default;
+  SimpleLogRecordProcessorBuilder &operator=(const SimpleLogRecordProcessorBuilder &other) =
+      default;
+  virtual ~SimpleLogRecordProcessorBuilder() = default;
+
+  virtual std::unique_ptr<opentelemetry::sdk::logs::LogRecordProcessor> Build(
+      const opentelemetry::sdk::configuration::SimpleLogRecordProcessorConfiguration *model,
+      std::unique_ptr<opentelemetry::sdk::logs::LogRecordExporter> &&exporter) const = 0;
+};
+
+}  // namespace configuration
+}  // namespace sdk
+OPENTELEMETRY_END_NAMESPACE

--- a/sdk/include/opentelemetry/sdk/configuration/simple_span_processor_builder.h
+++ b/sdk/include/opentelemetry/sdk/configuration/simple_span_processor_builder.h
@@ -1,0 +1,40 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <memory>
+
+#include "opentelemetry/sdk/configuration/simple_span_processor_configuration.h"
+#include "opentelemetry/version.h"
+
+OPENTELEMETRY_BEGIN_NAMESPACE
+namespace sdk
+{
+namespace trace
+{
+class SpanExporter;
+class SpanProcessor;
+}  // namespace trace
+
+namespace configuration
+{
+
+class SimpleSpanProcessorBuilder
+{
+public:
+  SimpleSpanProcessorBuilder()                                                   = default;
+  SimpleSpanProcessorBuilder(SimpleSpanProcessorBuilder &&)                      = default;
+  SimpleSpanProcessorBuilder(const SimpleSpanProcessorBuilder &)                 = default;
+  SimpleSpanProcessorBuilder &operator=(SimpleSpanProcessorBuilder &&)           = default;
+  SimpleSpanProcessorBuilder &operator=(const SimpleSpanProcessorBuilder &other) = default;
+  virtual ~SimpleSpanProcessorBuilder()                                          = default;
+
+  virtual std::unique_ptr<opentelemetry::sdk::trace::SpanProcessor> Build(
+      const opentelemetry::sdk::configuration::SimpleSpanProcessorConfiguration *model,
+      std::unique_ptr<opentelemetry::sdk::trace::SpanExporter> &&exporter) const = 0;
+};
+
+}  // namespace configuration
+}  // namespace sdk
+OPENTELEMETRY_END_NAMESPACE

--- a/sdk/include/opentelemetry/sdk/configuration/trace_id_ratio_based_sampler_builder.h
+++ b/sdk/include/opentelemetry/sdk/configuration/trace_id_ratio_based_sampler_builder.h
@@ -1,0 +1,40 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <memory>
+
+#include "opentelemetry/sdk/configuration/trace_id_ratio_based_sampler_configuration.h"
+#include "opentelemetry/version.h"
+
+OPENTELEMETRY_BEGIN_NAMESPACE
+namespace sdk
+{
+namespace trace
+{
+class Sampler;
+}  // namespace trace
+
+namespace configuration
+{
+
+class TraceIdRatioBasedSamplerBuilder
+{
+public:
+  TraceIdRatioBasedSamplerBuilder()                                              = default;
+  TraceIdRatioBasedSamplerBuilder(TraceIdRatioBasedSamplerBuilder &&)            = default;
+  TraceIdRatioBasedSamplerBuilder(const TraceIdRatioBasedSamplerBuilder &)       = default;
+  TraceIdRatioBasedSamplerBuilder &operator=(TraceIdRatioBasedSamplerBuilder &&) = default;
+  TraceIdRatioBasedSamplerBuilder &operator=(const TraceIdRatioBasedSamplerBuilder &other) =
+      default;
+  virtual ~TraceIdRatioBasedSamplerBuilder() = default;
+
+  virtual std::unique_ptr<opentelemetry::sdk::trace::Sampler> Build(
+      const opentelemetry::sdk::configuration::TraceIdRatioBasedSamplerConfiguration *model)
+      const = 0;
+};
+
+}  // namespace configuration
+}  // namespace sdk
+OPENTELEMETRY_END_NAMESPACE

--- a/sdk/include/opentelemetry/sdk/configuration/tracer_configurator_builder.h
+++ b/sdk/include/opentelemetry/sdk/configuration/tracer_configurator_builder.h
@@ -1,0 +1,45 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <memory>
+
+#include "opentelemetry/sdk/configuration/tracer_configurator_configuration.h"
+#include "opentelemetry/version.h"
+
+OPENTELEMETRY_BEGIN_NAMESPACE
+namespace sdk
+{
+namespace instrumentationscope
+{
+template <typename T>
+class ScopeConfigurator;
+}  // namespace instrumentationscope
+
+namespace trace
+{
+class TracerConfig;
+}  // namespace trace
+
+namespace configuration
+{
+
+class TracerConfiguratorBuilder
+{
+public:
+  TracerConfiguratorBuilder()                                                  = default;
+  TracerConfiguratorBuilder(TracerConfiguratorBuilder &&)                      = default;
+  TracerConfiguratorBuilder(const TracerConfiguratorBuilder &)                 = default;
+  TracerConfiguratorBuilder &operator=(TracerConfiguratorBuilder &&)           = default;
+  TracerConfiguratorBuilder &operator=(const TracerConfiguratorBuilder &other) = default;
+  virtual ~TracerConfiguratorBuilder()                                         = default;
+
+  virtual std::unique_ptr<opentelemetry::sdk::instrumentationscope::ScopeConfigurator<
+      opentelemetry::sdk::trace::TracerConfig>>
+  Build(const opentelemetry::sdk::configuration::TracerConfiguratorConfiguration *model) const = 0;
+};
+
+}  // namespace configuration
+}  // namespace sdk
+OPENTELEMETRY_END_NAMESPACE

--- a/sdk/src/configuration/registry.cc
+++ b/sdk/src/configuration/registry.cc
@@ -9,16 +9,33 @@
 
 #include "opentelemetry/baggage/propagation/baggage_propagator.h"
 #include "opentelemetry/context/propagation/text_map_propagator.h"
+#include "opentelemetry/sdk/configuration/always_off_sampler_builder.h"
+#include "opentelemetry/sdk/configuration/always_on_sampler_builder.h"
+#include "opentelemetry/sdk/configuration/batch_log_record_processor_builder.h"
+#include "opentelemetry/sdk/configuration/batch_span_processor_builder.h"
+#include "opentelemetry/sdk/configuration/composable_always_off_sampler_builder.h"
+#include "opentelemetry/sdk/configuration/composable_always_on_sampler_builder.h"
+#include "opentelemetry/sdk/configuration/composable_parent_threshold_sampler_builder.h"
+#include "opentelemetry/sdk/configuration/composable_probability_sampler_builder.h"
+#include "opentelemetry/sdk/configuration/composable_rule_based_sampler_builder.h"
 #include "opentelemetry/sdk/configuration/console_log_record_exporter_builder.h"
 #include "opentelemetry/sdk/configuration/console_push_metric_exporter_builder.h"
 #include "opentelemetry/sdk/configuration/console_span_exporter_builder.h"
+#include "opentelemetry/sdk/configuration/container_resource_detector_builder.h"
 #include "opentelemetry/sdk/configuration/extension_log_record_exporter_builder.h"
 #include "opentelemetry/sdk/configuration/extension_log_record_processor_builder.h"
+#include "opentelemetry/sdk/configuration/extension_metric_producer_builder.h"
 #include "opentelemetry/sdk/configuration/extension_pull_metric_exporter_builder.h"
 #include "opentelemetry/sdk/configuration/extension_push_metric_exporter_builder.h"
+#include "opentelemetry/sdk/configuration/extension_resource_detector_builder.h"
 #include "opentelemetry/sdk/configuration/extension_sampler_builder.h"
 #include "opentelemetry/sdk/configuration/extension_span_exporter_builder.h"
 #include "opentelemetry/sdk/configuration/extension_span_processor_builder.h"
+#include "opentelemetry/sdk/configuration/host_resource_detector_builder.h"
+#include "opentelemetry/sdk/configuration/jaeger_remote_sampler_builder.h"
+#include "opentelemetry/sdk/configuration/logger_configurator_builder.h"
+#include "opentelemetry/sdk/configuration/meter_configurator_builder.h"
+#include "opentelemetry/sdk/configuration/open_census_metric_producer_builder.h"
 #include "opentelemetry/sdk/configuration/otlp_file_log_record_exporter_builder.h"
 #include "opentelemetry/sdk/configuration/otlp_file_push_metric_exporter_builder.h"
 #include "opentelemetry/sdk/configuration/otlp_file_span_exporter_builder.h"
@@ -28,11 +45,20 @@
 #include "opentelemetry/sdk/configuration/otlp_http_log_record_exporter_builder.h"
 #include "opentelemetry/sdk/configuration/otlp_http_push_metric_exporter_builder.h"
 #include "opentelemetry/sdk/configuration/otlp_http_span_exporter_builder.h"
+#include "opentelemetry/sdk/configuration/parent_based_sampler_builder.h"
 #include "opentelemetry/sdk/configuration/periodic_metric_reader_builder.h"
 #include "opentelemetry/sdk/configuration/periodic_metric_reader_configuration.h"
+#include "opentelemetry/sdk/configuration/probability_sampler_builder.h"
+#include "opentelemetry/sdk/configuration/process_resource_detector_builder.h"
 #include "opentelemetry/sdk/configuration/prometheus_pull_metric_exporter_builder.h"
+#include "opentelemetry/sdk/configuration/pull_metric_reader_builder.h"
 #include "opentelemetry/sdk/configuration/registry.h"
+#include "opentelemetry/sdk/configuration/service_resource_detector_builder.h"
+#include "opentelemetry/sdk/configuration/simple_log_record_processor_builder.h"
+#include "opentelemetry/sdk/configuration/simple_span_processor_builder.h"
 #include "opentelemetry/sdk/configuration/text_map_propagator_builder.h"
+#include "opentelemetry/sdk/configuration/trace_id_ratio_based_sampler_builder.h"
+#include "opentelemetry/sdk/configuration/tracer_configurator_builder.h"
 #include "opentelemetry/sdk/metrics/export/periodic_exporting_metric_reader_factory.h"
 #include "opentelemetry/sdk/metrics/export/periodic_exporting_metric_reader_options.h"
 #include "opentelemetry/sdk/metrics/metric_reader.h"
@@ -183,10 +209,21 @@ void Registry::SetPrometheusPullMetricExporterBuilder(
   prometheus_metric_builder_ = std::move(builder);
 }
 
+void Registry::SetOpenCensusMetricProducerBuilder(
+    std::unique_ptr<OpenCensusMetricProducerBuilder> &&builder)
+{
+  open_census_metric_producer_builder_ = std::move(builder);
+}
+
 void Registry::SetPeriodicMetricReaderBuilder(
     std::unique_ptr<PeriodicMetricReaderBuilder> &&builder)
 {
   periodic_metric_reader_builder_ = std::move(builder);
+}
+
+void Registry::SetPullMetricReaderBuilder(std::unique_ptr<PullMetricReaderBuilder> &&builder)
+{
+  pull_metric_reader_builder_ = std::move(builder);
 }
 
 void Registry::SetOtlpHttpLogRecordBuilder(
@@ -211,6 +248,128 @@ void Registry::SetConsoleLogRecordBuilder(
     std::unique_ptr<ConsoleLogRecordExporterBuilder> &&builder)
 {
   console_log_record_builder_ = std::move(builder);
+}
+
+void Registry::SetAlwaysOnSamplerBuilder(std::unique_ptr<AlwaysOnSamplerBuilder> &&builder)
+{
+  always_on_sampler_builder_ = std::move(builder);
+}
+
+void Registry::SetAlwaysOffSamplerBuilder(std::unique_ptr<AlwaysOffSamplerBuilder> &&builder)
+{
+  always_off_sampler_builder_ = std::move(builder);
+}
+
+void Registry::SetTraceIdRatioBasedSamplerBuilder(
+    std::unique_ptr<TraceIdRatioBasedSamplerBuilder> &&builder)
+{
+  trace_id_ratio_based_sampler_builder_ = std::move(builder);
+}
+
+void Registry::SetProbabilitySamplerBuilder(std::unique_ptr<ProbabilitySamplerBuilder> &&builder)
+{
+  probability_sampler_builder_ = std::move(builder);
+}
+
+void Registry::SetParentBasedSamplerBuilder(std::unique_ptr<ParentBasedSamplerBuilder> &&builder)
+{
+  parent_based_sampler_builder_ = std::move(builder);
+}
+
+void Registry::SetJaegerRemoteSamplerBuilder(std::unique_ptr<JaegerRemoteSamplerBuilder> &&builder)
+{
+  jaeger_remote_sampler_builder_ = std::move(builder);
+}
+
+void Registry::SetComposableAlwaysOnSamplerBuilder(
+    std::unique_ptr<ComposableAlwaysOnSamplerBuilder> &&builder)
+{
+  composable_always_on_sampler_builder_ = std::move(builder);
+}
+
+void Registry::SetComposableAlwaysOffSamplerBuilder(
+    std::unique_ptr<ComposableAlwaysOffSamplerBuilder> &&builder)
+{
+  composable_always_off_sampler_builder_ = std::move(builder);
+}
+
+void Registry::SetComposableProbabilitySamplerBuilder(
+    std::unique_ptr<ComposableProbabilitySamplerBuilder> &&builder)
+{
+  composable_probability_sampler_builder_ = std::move(builder);
+}
+
+void Registry::SetComposableParentThresholdSamplerBuilder(
+    std::unique_ptr<ComposableParentThresholdSamplerBuilder> &&builder)
+{
+  composable_parent_threshold_sampler_builder_ = std::move(builder);
+}
+
+void Registry::SetComposableRuleBasedSamplerBuilder(
+    std::unique_ptr<ComposableRuleBasedSamplerBuilder> &&builder)
+{
+  composable_rule_based_sampler_builder_ = std::move(builder);
+}
+
+void Registry::SetBatchSpanProcessorBuilder(std::unique_ptr<BatchSpanProcessorBuilder> &&builder)
+{
+  batch_span_processor_builder_ = std::move(builder);
+}
+
+void Registry::SetSimpleSpanProcessorBuilder(std::unique_ptr<SimpleSpanProcessorBuilder> &&builder)
+{
+  simple_span_processor_builder_ = std::move(builder);
+}
+
+void Registry::SetBatchLogRecordProcessorBuilder(
+    std::unique_ptr<BatchLogRecordProcessorBuilder> &&builder)
+{
+  batch_log_record_processor_builder_ = std::move(builder);
+}
+
+void Registry::SetSimpleLogRecordProcessorBuilder(
+    std::unique_ptr<SimpleLogRecordProcessorBuilder> &&builder)
+{
+  simple_log_record_processor_builder_ = std::move(builder);
+}
+
+void Registry::SetTracerConfiguratorBuilder(std::unique_ptr<TracerConfiguratorBuilder> &&builder)
+{
+  tracer_configurator_builder_ = std::move(builder);
+}
+
+void Registry::SetMeterConfiguratorBuilder(std::unique_ptr<MeterConfiguratorBuilder> &&builder)
+{
+  meter_configurator_builder_ = std::move(builder);
+}
+
+void Registry::SetLoggerConfiguratorBuilder(std::unique_ptr<LoggerConfiguratorBuilder> &&builder)
+{
+  logger_configurator_builder_ = std::move(builder);
+}
+
+void Registry::SetContainerResourceDetectorBuilder(
+    std::unique_ptr<ContainerResourceDetectorBuilder> &&builder)
+{
+  container_resource_detector_builder_ = std::move(builder);
+}
+
+void Registry::SetHostResourceDetectorBuilder(
+    std::unique_ptr<HostResourceDetectorBuilder> &&builder)
+{
+  host_resource_detector_builder_ = std::move(builder);
+}
+
+void Registry::SetProcessResourceDetectorBuilder(
+    std::unique_ptr<ProcessResourceDetectorBuilder> &&builder)
+{
+  process_resource_detector_builder_ = std::move(builder);
+}
+
+void Registry::SetServiceResourceDetectorBuilder(
+    std::unique_ptr<ServiceResourceDetectorBuilder> &&builder)
+{
+  service_resource_detector_builder_ = std::move(builder);
 }
 
 const TextMapPropagatorBuilder *Registry::GetTextMapPropagatorBuilder(const std::string &name) const
@@ -367,6 +526,46 @@ void Registry::SetExtensionLogRecordProcessorBuilder(
 {
   log_record_processor_builders_.erase(name);
   log_record_processor_builders_.insert({name, std::move(builder)});
+}
+
+const ExtensionMetricProducerBuilder *Registry::GetExtensionMetricProducerBuilder(
+    const std::string &name) const
+{
+  ExtensionMetricProducerBuilder *builder = nullptr;
+  auto search                             = metric_producer_builders_.find(name);
+  if (search != metric_producer_builders_.end())
+  {
+    builder = search->second.get();
+  }
+  return builder;
+}
+
+void Registry::SetExtensionMetricProducerBuilder(
+    const std::string &name,
+    std::unique_ptr<ExtensionMetricProducerBuilder> &&builder)
+{
+  metric_producer_builders_.erase(name);
+  metric_producer_builders_.insert({name, std::move(builder)});
+}
+
+const ExtensionResourceDetectorBuilder *Registry::GetExtensionResourceDetectorBuilder(
+    const std::string &name) const
+{
+  ExtensionResourceDetectorBuilder *builder = nullptr;
+  auto search                               = resource_detector_builders_.find(name);
+  if (search != resource_detector_builders_.end())
+  {
+    builder = search->second.get();
+  }
+  return builder;
+}
+
+void Registry::SetExtensionResourceDetectorBuilder(
+    const std::string &name,
+    std::unique_ptr<ExtensionResourceDetectorBuilder> &&builder)
+{
+  resource_detector_builders_.erase(name);
+  resource_detector_builders_.insert({name, std::move(builder)});
 }
 
 }  // namespace configuration

--- a/sdk/test/configuration/BUILD
+++ b/sdk/test/configuration/BUILD
@@ -4,6 +4,26 @@
 load("@rules_cc//cc:cc_test.bzl", "cc_test")
 
 cc_test(
+    name = "registry_test",
+    srcs = [
+        "registry_test.cc",
+    ],
+    tags = [
+        "config",
+        "test",
+    ],
+    deps = [
+        "//sdk:headers",
+        "//sdk/src/configuration:configuration_core",
+        "//sdk/src/logs",
+        "//sdk/src/metrics",
+        "//sdk/src/resource",
+        "//sdk/src/trace",
+        "@com_google_googletest//:gtest_main",
+    ],
+)
+
+cc_test(
     name = "sdk_builder_test",
     srcs = [
         "config_test_common.h",

--- a/sdk/test/configuration/CMakeLists.txt
+++ b/sdk/test/configuration/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright The OpenTelemetry Authors
 # SPDX-License-Identifier: Apache-2.0
 
-foreach(testname sdk_builder_test configured_sdk_test
+foreach(testname registry_test sdk_builder_test configured_sdk_test
                  programmatic_configuration_test)
   add_executable(${testname} "${testname}.cc")
   target_link_libraries(

--- a/sdk/test/configuration/registry_test.cc
+++ b/sdk/test/configuration/registry_test.cc
@@ -1,0 +1,555 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+#include <gtest/gtest.h>
+#include <functional>
+#include <memory>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "opentelemetry/sdk/configuration/always_off_sampler_builder.h"
+#include "opentelemetry/sdk/configuration/always_on_sampler_builder.h"
+#include "opentelemetry/sdk/configuration/batch_log_record_processor_builder.h"
+#include "opentelemetry/sdk/configuration/batch_span_processor_builder.h"
+#include "opentelemetry/sdk/configuration/composable_always_off_sampler_builder.h"
+#include "opentelemetry/sdk/configuration/composable_always_on_sampler_builder.h"
+#include "opentelemetry/sdk/configuration/composable_parent_threshold_sampler_builder.h"
+#include "opentelemetry/sdk/configuration/composable_probability_sampler_builder.h"
+#include "opentelemetry/sdk/configuration/composable_rule_based_sampler_builder.h"
+#include "opentelemetry/sdk/configuration/container_resource_detector_builder.h"
+#include "opentelemetry/sdk/configuration/extension_metric_producer_builder.h"
+#include "opentelemetry/sdk/configuration/extension_resource_detector_builder.h"
+#include "opentelemetry/sdk/configuration/host_resource_detector_builder.h"
+#include "opentelemetry/sdk/configuration/jaeger_remote_sampler_builder.h"
+#include "opentelemetry/sdk/configuration/logger_configurator_builder.h"
+#include "opentelemetry/sdk/configuration/meter_configurator_builder.h"
+#include "opentelemetry/sdk/configuration/open_census_metric_producer_builder.h"
+#include "opentelemetry/sdk/configuration/parent_based_sampler_builder.h"
+#include "opentelemetry/sdk/configuration/probability_sampler_builder.h"
+#include "opentelemetry/sdk/configuration/process_resource_detector_builder.h"
+#include "opentelemetry/sdk/configuration/pull_metric_reader_builder.h"
+#include "opentelemetry/sdk/configuration/registry.h"
+#include "opentelemetry/sdk/configuration/service_resource_detector_builder.h"
+#include "opentelemetry/sdk/configuration/simple_log_record_processor_builder.h"
+#include "opentelemetry/sdk/configuration/simple_span_processor_builder.h"
+#include "opentelemetry/sdk/configuration/trace_id_ratio_based_sampler_builder.h"
+#include "opentelemetry/sdk/configuration/tracer_configurator_builder.h"
+#include "opentelemetry/sdk/instrumentationscope/scope_configurator.h"
+#include "opentelemetry/sdk/logs/exporter.h"
+#include "opentelemetry/sdk/logs/logger_config.h"
+#include "opentelemetry/sdk/logs/processor.h"
+#include "opentelemetry/sdk/metrics/export/metric_producer.h"
+#include "opentelemetry/sdk/metrics/meter_config.h"
+#include "opentelemetry/sdk/metrics/metric_reader.h"
+#include "opentelemetry/sdk/resource/resource_detector.h"
+#include "opentelemetry/sdk/trace/exporter.h"
+#include "opentelemetry/sdk/trace/processor.h"
+#include "opentelemetry/sdk/trace/sampler.h"
+#include "opentelemetry/sdk/trace/samplers/composable_sampler.h"
+#include "opentelemetry/sdk/trace/tracer_config.h"
+
+namespace configuration = opentelemetry::sdk::configuration;
+
+namespace
+{
+
+class TestAlwaysOnSamplerBuilder : public configuration::AlwaysOnSamplerBuilder
+{
+public:
+  std::unique_ptr<opentelemetry::sdk::trace::Sampler> Build(
+      const configuration::AlwaysOnSamplerConfiguration * /* model */) const override
+  {
+    return nullptr;
+  }
+};
+
+class TestAlwaysOffSamplerBuilder : public configuration::AlwaysOffSamplerBuilder
+{
+public:
+  std::unique_ptr<opentelemetry::sdk::trace::Sampler> Build(
+      const configuration::AlwaysOffSamplerConfiguration * /* model */) const override
+  {
+    return nullptr;
+  }
+};
+
+class TestTraceIdRatioBasedSamplerBuilder : public configuration::TraceIdRatioBasedSamplerBuilder
+{
+public:
+  std::unique_ptr<opentelemetry::sdk::trace::Sampler> Build(
+      const configuration::TraceIdRatioBasedSamplerConfiguration * /* model */) const override
+  {
+    return nullptr;
+  }
+};
+
+class TestProbabilitySamplerBuilder : public configuration::ProbabilitySamplerBuilder
+{
+public:
+  std::unique_ptr<opentelemetry::sdk::trace::Sampler> Build(
+      const configuration::ProbabilitySamplerConfiguration * /* model */) const override
+  {
+    return nullptr;
+  }
+};
+
+class TestParentBasedSamplerBuilder : public configuration::ParentBasedSamplerBuilder
+{
+public:
+  std::unique_ptr<opentelemetry::sdk::trace::Sampler> Build(
+      const configuration::ParentBasedSamplerConfiguration * /* model */,
+      std::unique_ptr<opentelemetry::sdk::trace::Sampler> && /* root */,
+      std::unique_ptr<opentelemetry::sdk::trace::Sampler> && /* remote_parent_sampled */,
+      std::unique_ptr<opentelemetry::sdk::trace::Sampler> && /* remote_parent_not_sampled */,
+      std::unique_ptr<opentelemetry::sdk::trace::Sampler> && /* local_parent_sampled */,
+      std::unique_ptr<opentelemetry::sdk::trace::Sampler> && /* local_parent_not_sampled */)
+      const override
+  {
+    return nullptr;
+  }
+};
+
+class TestJaegerRemoteSamplerBuilder : public configuration::JaegerRemoteSamplerBuilder
+{
+public:
+  std::unique_ptr<opentelemetry::sdk::trace::Sampler> Build(
+      const configuration::JaegerRemoteSamplerConfiguration * /* model */,
+      std::unique_ptr<opentelemetry::sdk::trace::Sampler> && /* initial_sampler */) const override
+  {
+    return nullptr;
+  }
+};
+
+class TestComposableAlwaysOnSamplerBuilder : public configuration::ComposableAlwaysOnSamplerBuilder
+{
+public:
+  std::unique_ptr<opentelemetry::sdk::trace::ComposableSampler> Build(
+      const configuration::ComposableAlwaysOnSamplerConfiguration * /* model */) const override
+  {
+    return nullptr;
+  }
+};
+
+class TestComposableAlwaysOffSamplerBuilder
+    : public configuration::ComposableAlwaysOffSamplerBuilder
+{
+public:
+  std::unique_ptr<opentelemetry::sdk::trace::ComposableSampler> Build(
+      const configuration::ComposableAlwaysOffSamplerConfiguration * /* model */) const override
+  {
+    return nullptr;
+  }
+};
+
+class TestComposableProbabilitySamplerBuilder
+    : public configuration::ComposableProbabilitySamplerBuilder
+{
+public:
+  std::unique_ptr<opentelemetry::sdk::trace::ComposableSampler> Build(
+      const configuration::ComposableProbabilitySamplerConfiguration * /* model */) const override
+  {
+    return nullptr;
+  }
+};
+
+class TestComposableParentThresholdSamplerBuilder
+    : public configuration::ComposableParentThresholdSamplerBuilder
+{
+public:
+  std::unique_ptr<opentelemetry::sdk::trace::ComposableSampler> Build(
+      const configuration::ComposableParentThresholdSamplerConfiguration * /* model */,
+      std::unique_ptr<opentelemetry::sdk::trace::ComposableSampler> && /* root */) const override
+  {
+    return nullptr;
+  }
+};
+
+class TestComposableRuleBasedSamplerBuilder
+    : public configuration::ComposableRuleBasedSamplerBuilder
+{
+public:
+  std::unique_ptr<opentelemetry::sdk::trace::ComposableSampler> Build(
+      const configuration::ComposableRuleBasedSamplerConfiguration * /* model */,
+      std::vector<std::unique_ptr<opentelemetry::sdk::trace::ComposableSampler>>
+          && /* rule_samplers */) const override
+  {
+    return nullptr;
+  }
+};
+
+class TestBatchSpanProcessorBuilder : public configuration::BatchSpanProcessorBuilder
+{
+public:
+  std::unique_ptr<opentelemetry::sdk::trace::SpanProcessor> Build(
+      const configuration::BatchSpanProcessorConfiguration * /* model */,
+      std::unique_ptr<opentelemetry::sdk::trace::SpanExporter> && /* exporter */) const override
+  {
+    return nullptr;
+  }
+};
+
+class TestSimpleSpanProcessorBuilder : public configuration::SimpleSpanProcessorBuilder
+{
+public:
+  std::unique_ptr<opentelemetry::sdk::trace::SpanProcessor> Build(
+      const configuration::SimpleSpanProcessorConfiguration * /* model */,
+      std::unique_ptr<opentelemetry::sdk::trace::SpanExporter> && /* exporter */) const override
+  {
+    return nullptr;
+  }
+};
+
+class TestBatchLogRecordProcessorBuilder : public configuration::BatchLogRecordProcessorBuilder
+{
+public:
+  std::unique_ptr<opentelemetry::sdk::logs::LogRecordProcessor> Build(
+      const configuration::BatchLogRecordProcessorConfiguration * /* model */,
+      std::unique_ptr<opentelemetry::sdk::logs::LogRecordExporter> && /* exporter */) const override
+  {
+    return nullptr;
+  }
+};
+
+class TestSimpleLogRecordProcessorBuilder : public configuration::SimpleLogRecordProcessorBuilder
+{
+public:
+  std::unique_ptr<opentelemetry::sdk::logs::LogRecordProcessor> Build(
+      const configuration::SimpleLogRecordProcessorConfiguration * /* model */,
+      std::unique_ptr<opentelemetry::sdk::logs::LogRecordExporter> && /* exporter */) const override
+  {
+    return nullptr;
+  }
+};
+
+class TestPullMetricReaderBuilder : public configuration::PullMetricReaderBuilder
+{
+public:
+  std::unique_ptr<opentelemetry::sdk::metrics::MetricReader> Build(
+      const configuration::PullMetricReaderConfiguration * /* model */,
+      std::unique_ptr<opentelemetry::sdk::metrics::MetricReader> && /* exporter */) const override
+  {
+    return nullptr;
+  }
+};
+
+class TestOpenCensusMetricProducerBuilder : public configuration::OpenCensusMetricProducerBuilder
+{
+public:
+  std::unique_ptr<opentelemetry::sdk::metrics::MetricProducer> Build(
+      const configuration::OpenCensusMetricProducerConfiguration * /* model */) const override
+  {
+    return nullptr;
+  }
+};
+
+class TestExtensionMetricProducerBuilder : public configuration::ExtensionMetricProducerBuilder
+{
+public:
+  std::unique_ptr<opentelemetry::sdk::metrics::MetricProducer> Build(
+      const configuration::ExtensionMetricProducerConfiguration * /* model */) const override
+  {
+    return nullptr;
+  }
+};
+
+class TestContainerResourceDetectorBuilder : public configuration::ContainerResourceDetectorBuilder
+{
+public:
+  std::unique_ptr<opentelemetry::sdk::resource::ResourceDetector> Build(
+      const configuration::ContainerResourceDetectorConfiguration * /* model */) const override
+  {
+    return nullptr;
+  }
+};
+
+class TestHostResourceDetectorBuilder : public configuration::HostResourceDetectorBuilder
+{
+public:
+  std::unique_ptr<opentelemetry::sdk::resource::ResourceDetector> Build(
+      const configuration::HostResourceDetectorConfiguration * /* model */) const override
+  {
+    return nullptr;
+  }
+};
+
+class TestProcessResourceDetectorBuilder : public configuration::ProcessResourceDetectorBuilder
+{
+public:
+  std::unique_ptr<opentelemetry::sdk::resource::ResourceDetector> Build(
+      const configuration::ProcessResourceDetectorConfiguration * /* model */) const override
+  {
+    return nullptr;
+  }
+};
+
+class TestServiceResourceDetectorBuilder : public configuration::ServiceResourceDetectorBuilder
+{
+public:
+  std::unique_ptr<opentelemetry::sdk::resource::ResourceDetector> Build(
+      const configuration::ServiceResourceDetectorConfiguration * /* model */) const override
+  {
+    return nullptr;
+  }
+};
+
+class TestExtensionResourceDetectorBuilder : public configuration::ExtensionResourceDetectorBuilder
+{
+public:
+  std::unique_ptr<opentelemetry::sdk::resource::ResourceDetector> Build(
+      const configuration::ExtensionResourceDetectorConfiguration * /* model */) const override
+  {
+    return nullptr;
+  }
+};
+
+class TestTracerConfiguratorBuilder : public configuration::TracerConfiguratorBuilder
+{
+public:
+  std::unique_ptr<opentelemetry::sdk::instrumentationscope::ScopeConfigurator<
+      opentelemetry::sdk::trace::TracerConfig>>
+  Build(const configuration::TracerConfiguratorConfiguration * /* model */) const override
+  {
+    return nullptr;
+  }
+};
+
+class TestMeterConfiguratorBuilder : public configuration::MeterConfiguratorBuilder
+{
+public:
+  std::unique_ptr<opentelemetry::sdk::instrumentationscope::ScopeConfigurator<
+      opentelemetry::sdk::metrics::MeterConfig>>
+  Build(const configuration::MeterConfiguratorConfiguration * /* model */) const override
+  {
+    return nullptr;
+  }
+};
+
+class TestLoggerConfiguratorBuilder : public configuration::LoggerConfiguratorBuilder
+{
+public:
+  std::unique_ptr<opentelemetry::sdk::instrumentationscope::ScopeConfigurator<
+      opentelemetry::sdk::logs::LoggerConfig>>
+  Build(const configuration::LoggerConfiguratorConfiguration * /* model */) const override
+  {
+    return nullptr;
+  }
+};
+
+}  // namespace
+
+// Exercises the empty → set → replace lifecycle for a typed (non-named-map) registry slot.
+template <typename MockType, typename GetBuilderFn, typename SetBuilderFn>
+void TestTypedSlot(GetBuilderFn getter, SetBuilderFn setter)
+{
+  configuration::Registry registry;
+  ASSERT_EQ(std::invoke(getter, registry), nullptr);
+
+  auto first            = std::make_unique<MockType>();
+  const auto *first_ptr = first.get();
+  std::invoke(setter, registry, std::move(first));
+  ASSERT_EQ(std::invoke(getter, registry), first_ptr);
+
+  auto second            = std::make_unique<MockType>();
+  const auto *second_ptr = second.get();
+  std::invoke(setter, registry, std::move(second));
+  ASSERT_EQ(std::invoke(getter, registry), second_ptr);
+}
+
+// Exercises the empty → set → replace lifecycle for a named-map registry slot.
+template <typename MockType, typename GetBuilderFn, typename SetBuilderFn>
+void TestNamedSlot(GetBuilderFn getter, SetBuilderFn setter, const std::string &key)
+{
+  configuration::Registry registry;
+  ASSERT_EQ(std::invoke(getter, registry, key), nullptr);
+
+  auto first            = std::make_unique<MockType>();
+  const auto *first_ptr = first.get();
+  std::invoke(setter, registry, key, std::move(first));
+  ASSERT_EQ(std::invoke(getter, registry, key), first_ptr);
+  ASSERT_EQ(std::invoke(getter, registry, "other"), nullptr);
+
+  auto second            = std::make_unique<MockType>();
+  const auto *second_ptr = second.get();
+  std::invoke(setter, registry, key, std::move(second));
+  ASSERT_EQ(std::invoke(getter, registry, key), second_ptr);
+}
+
+TEST(Registry, AlwaysOnSamplerBuilder)
+{
+  TestTypedSlot<TestAlwaysOnSamplerBuilder>(&configuration::Registry::GetAlwaysOnSamplerBuilder,
+                                            &configuration::Registry::SetAlwaysOnSamplerBuilder);
+}
+
+TEST(Registry, AlwaysOffSamplerBuilder)
+{
+  TestTypedSlot<TestAlwaysOffSamplerBuilder>(&configuration::Registry::GetAlwaysOffSamplerBuilder,
+                                             &configuration::Registry::SetAlwaysOffSamplerBuilder);
+}
+
+TEST(Registry, TraceIdRatioBasedSamplerBuilder)
+{
+  TestTypedSlot<TestTraceIdRatioBasedSamplerBuilder>(
+      &configuration::Registry::GetTraceIdRatioBasedSamplerBuilder,
+      &configuration::Registry::SetTraceIdRatioBasedSamplerBuilder);
+}
+
+TEST(Registry, ProbabilitySamplerBuilder)
+{
+  TestTypedSlot<TestProbabilitySamplerBuilder>(
+      &configuration::Registry::GetProbabilitySamplerBuilder,
+      &configuration::Registry::SetProbabilitySamplerBuilder);
+}
+
+TEST(Registry, ParentBasedSamplerBuilder)
+{
+  TestTypedSlot<TestParentBasedSamplerBuilder>(
+      &configuration::Registry::GetParentBasedSamplerBuilder,
+      &configuration::Registry::SetParentBasedSamplerBuilder);
+}
+
+TEST(Registry, JaegerRemoteSamplerBuilder)
+{
+  TestTypedSlot<TestJaegerRemoteSamplerBuilder>(
+      &configuration::Registry::GetJaegerRemoteSamplerBuilder,
+      &configuration::Registry::SetJaegerRemoteSamplerBuilder);
+}
+
+TEST(Registry, ComposableAlwaysOnSamplerBuilder)
+{
+  TestTypedSlot<TestComposableAlwaysOnSamplerBuilder>(
+      &configuration::Registry::GetComposableAlwaysOnSamplerBuilder,
+      &configuration::Registry::SetComposableAlwaysOnSamplerBuilder);
+}
+
+TEST(Registry, ComposableAlwaysOffSamplerBuilder)
+{
+  TestTypedSlot<TestComposableAlwaysOffSamplerBuilder>(
+      &configuration::Registry::GetComposableAlwaysOffSamplerBuilder,
+      &configuration::Registry::SetComposableAlwaysOffSamplerBuilder);
+}
+
+TEST(Registry, ComposableProbabilitySamplerBuilder)
+{
+  TestTypedSlot<TestComposableProbabilitySamplerBuilder>(
+      &configuration::Registry::GetComposableProbabilitySamplerBuilder,
+      &configuration::Registry::SetComposableProbabilitySamplerBuilder);
+}
+
+TEST(Registry, ComposableParentThresholdSamplerBuilder)
+{
+  TestTypedSlot<TestComposableParentThresholdSamplerBuilder>(
+      &configuration::Registry::GetComposableParentThresholdSamplerBuilder,
+      &configuration::Registry::SetComposableParentThresholdSamplerBuilder);
+}
+
+TEST(Registry, ComposableRuleBasedSamplerBuilder)
+{
+  TestTypedSlot<TestComposableRuleBasedSamplerBuilder>(
+      &configuration::Registry::GetComposableRuleBasedSamplerBuilder,
+      &configuration::Registry::SetComposableRuleBasedSamplerBuilder);
+}
+
+TEST(Registry, BatchSpanProcessorBuilder)
+{
+  TestTypedSlot<TestBatchSpanProcessorBuilder>(
+      &configuration::Registry::GetBatchSpanProcessorBuilder,
+      &configuration::Registry::SetBatchSpanProcessorBuilder);
+}
+
+TEST(Registry, SimpleSpanProcessorBuilder)
+{
+  TestTypedSlot<TestSimpleSpanProcessorBuilder>(
+      &configuration::Registry::GetSimpleSpanProcessorBuilder,
+      &configuration::Registry::SetSimpleSpanProcessorBuilder);
+}
+
+TEST(Registry, BatchLogRecordProcessorBuilder)
+{
+  TestTypedSlot<TestBatchLogRecordProcessorBuilder>(
+      &configuration::Registry::GetBatchLogRecordProcessorBuilder,
+      &configuration::Registry::SetBatchLogRecordProcessorBuilder);
+}
+
+TEST(Registry, SimpleLogRecordProcessorBuilder)
+{
+  TestTypedSlot<TestSimpleLogRecordProcessorBuilder>(
+      &configuration::Registry::GetSimpleLogRecordProcessorBuilder,
+      &configuration::Registry::SetSimpleLogRecordProcessorBuilder);
+}
+
+TEST(Registry, PullMetricReaderBuilder)
+{
+  TestTypedSlot<TestPullMetricReaderBuilder>(&configuration::Registry::GetPullMetricReaderBuilder,
+                                             &configuration::Registry::SetPullMetricReaderBuilder);
+}
+
+TEST(Registry, TracerConfiguratorBuilder)
+{
+  TestTypedSlot<TestTracerConfiguratorBuilder>(
+      &configuration::Registry::GetTracerConfiguratorBuilder,
+      &configuration::Registry::SetTracerConfiguratorBuilder);
+}
+
+TEST(Registry, MeterConfiguratorBuilder)
+{
+  TestTypedSlot<TestMeterConfiguratorBuilder>(
+      &configuration::Registry::GetMeterConfiguratorBuilder,
+      &configuration::Registry::SetMeterConfiguratorBuilder);
+}
+
+TEST(Registry, LoggerConfiguratorBuilder)
+{
+  TestTypedSlot<TestLoggerConfiguratorBuilder>(
+      &configuration::Registry::GetLoggerConfiguratorBuilder,
+      &configuration::Registry::SetLoggerConfiguratorBuilder);
+}
+
+TEST(Registry, OpenCensusMetricProducerBuilder)
+{
+  TestTypedSlot<TestOpenCensusMetricProducerBuilder>(
+      &configuration::Registry::GetOpenCensusMetricProducerBuilder,
+      &configuration::Registry::SetOpenCensusMetricProducerBuilder);
+}
+
+TEST(Registry, ExtensionMetricProducerBuilder)
+{
+  TestNamedSlot<TestExtensionMetricProducerBuilder>(
+      &configuration::Registry::GetExtensionMetricProducerBuilder,
+      &configuration::Registry::SetExtensionMetricProducerBuilder, "my_producer");
+}
+
+TEST(Registry, ContainerResourceDetectorBuilder)
+{
+  TestTypedSlot<TestContainerResourceDetectorBuilder>(
+      &configuration::Registry::GetContainerResourceDetectorBuilder,
+      &configuration::Registry::SetContainerResourceDetectorBuilder);
+}
+
+TEST(Registry, HostResourceDetectorBuilder)
+{
+  TestTypedSlot<TestHostResourceDetectorBuilder>(
+      &configuration::Registry::GetHostResourceDetectorBuilder,
+      &configuration::Registry::SetHostResourceDetectorBuilder);
+}
+
+TEST(Registry, ProcessResourceDetectorBuilder)
+{
+  TestTypedSlot<TestProcessResourceDetectorBuilder>(
+      &configuration::Registry::GetProcessResourceDetectorBuilder,
+      &configuration::Registry::SetProcessResourceDetectorBuilder);
+}
+
+TEST(Registry, ServiceResourceDetectorBuilder)
+{
+  TestTypedSlot<TestServiceResourceDetectorBuilder>(
+      &configuration::Registry::GetServiceResourceDetectorBuilder,
+      &configuration::Registry::SetServiceResourceDetectorBuilder);
+}
+
+TEST(Registry, ExtensionResourceDetectorBuilder)
+{
+  TestNamedSlot<TestExtensionResourceDetectorBuilder>(
+      &configuration::Registry::GetExtensionResourceDetectorBuilder,
+      &configuration::Registry::SetExtensionResourceDetectorBuilder, "my_detector");
+}

--- a/sdk/test/configuration/registry_test.cc
+++ b/sdk/test/configuration/registry_test.cc
@@ -57,8 +57,7 @@
 #include "opentelemetry/sdk/configuration/text_map_propagator_builder.h"
 #include "opentelemetry/sdk/configuration/trace_id_ratio_based_sampler_builder.h"
 #include "opentelemetry/sdk/configuration/tracer_configurator_builder.h"
-// Complete types required: the mock builders return std::unique_ptr<T>{nullptr},
-// which instantiates ~unique_ptr<T> and needs sizeof(T).
+
 #include "opentelemetry/context/propagation/text_map_propagator.h"      // IWYU pragma: keep
 #include "opentelemetry/sdk/instrumentationscope/scope_configurator.h"  // IWYU pragma: keep
 #include "opentelemetry/sdk/logs/exporter.h"                            // IWYU pragma: keep
@@ -79,6 +78,9 @@ namespace configuration = opentelemetry::sdk::configuration;
 
 namespace
 {
+
+// ----------------------------------------------------------------------------------
+// Test SDK Component Builders
 
 class TestAlwaysOnSamplerBuilder : public configuration::AlwaysOnSamplerBuilder
 {
@@ -593,7 +595,9 @@ public:
 
 }  // namespace
 
-// Exercises the empty → set → replace lifecycle for a typed (non-named-map) registry slot.
+// ----------------------------------------------------------------------------------
+// Test Helpers
+
 template <typename MockType, typename GetBuilderFn, typename SetBuilderFn>
 void TestTypedSlot(GetBuilderFn getter, SetBuilderFn setter)
 {
@@ -611,7 +615,6 @@ void TestTypedSlot(GetBuilderFn getter, SetBuilderFn setter)
   ASSERT_EQ(std::invoke(getter, registry), second_ptr);
 }
 
-// Exercises the empty → set → replace lifecycle for a named-map registry slot.
 template <typename MockType, typename GetBuilderFn, typename SetBuilderFn>
 void TestNamedSlot(GetBuilderFn getter, SetBuilderFn setter, const std::string &key)
 {
@@ -629,6 +632,9 @@ void TestNamedSlot(GetBuilderFn getter, SetBuilderFn setter, const std::string &
   std::invoke(setter, registry, key, std::move(second));
   ASSERT_EQ(std::invoke(getter, registry, key), second_ptr);
 }
+
+// ----------------------------------------------------------------------------------
+// Test Cases
 
 TEST(Registry, AlwaysOnSamplerBuilder)
 {

--- a/sdk/test/configuration/registry_test.cc
+++ b/sdk/test/configuration/registry_test.cc
@@ -6,7 +6,7 @@
 #include <memory>
 #include <string>
 #include <utility>
-#include <vector>
+#include <vector>  // IWYU pragma: keep
 
 #include "opentelemetry/sdk/configuration/always_off_sampler_builder.h"
 #include "opentelemetry/sdk/configuration/always_on_sampler_builder.h"
@@ -35,19 +35,21 @@
 #include "opentelemetry/sdk/configuration/simple_span_processor_builder.h"
 #include "opentelemetry/sdk/configuration/trace_id_ratio_based_sampler_builder.h"
 #include "opentelemetry/sdk/configuration/tracer_configurator_builder.h"
-#include "opentelemetry/sdk/instrumentationscope/scope_configurator.h"
-#include "opentelemetry/sdk/logs/exporter.h"
-#include "opentelemetry/sdk/logs/logger_config.h"
-#include "opentelemetry/sdk/logs/processor.h"
-#include "opentelemetry/sdk/metrics/export/metric_producer.h"
-#include "opentelemetry/sdk/metrics/meter_config.h"
-#include "opentelemetry/sdk/metrics/metric_reader.h"
-#include "opentelemetry/sdk/resource/resource_detector.h"
-#include "opentelemetry/sdk/trace/exporter.h"
-#include "opentelemetry/sdk/trace/processor.h"
-#include "opentelemetry/sdk/trace/sampler.h"
-#include "opentelemetry/sdk/trace/samplers/composable_sampler.h"
-#include "opentelemetry/sdk/trace/tracer_config.h"
+// Complete types required: the mock builders return std::unique_ptr<T>{nullptr},
+// which instantiates ~unique_ptr<T> and needs sizeof(T).
+#include "opentelemetry/sdk/instrumentationscope/scope_configurator.h"  // IWYU pragma: keep
+#include "opentelemetry/sdk/logs/exporter.h"                            // IWYU pragma: keep
+#include "opentelemetry/sdk/logs/logger_config.h"                       // IWYU pragma: keep
+#include "opentelemetry/sdk/logs/processor.h"                           // IWYU pragma: keep
+#include "opentelemetry/sdk/metrics/export/metric_producer.h"           // IWYU pragma: keep
+#include "opentelemetry/sdk/metrics/meter_config.h"                     // IWYU pragma: keep
+#include "opentelemetry/sdk/metrics/metric_reader.h"                    // IWYU pragma: keep
+#include "opentelemetry/sdk/resource/resource_detector.h"               // IWYU pragma: keep
+#include "opentelemetry/sdk/trace/exporter.h"                           // IWYU pragma: keep
+#include "opentelemetry/sdk/trace/processor.h"                          // IWYU pragma: keep
+#include "opentelemetry/sdk/trace/sampler.h"                            // IWYU pragma: keep
+#include "opentelemetry/sdk/trace/samplers/composable_sampler.h"        // IWYU pragma: keep
+#include "opentelemetry/sdk/trace/tracer_config.h"                      // IWYU pragma: keep
 
 namespace configuration = opentelemetry::sdk::configuration;
 

--- a/sdk/test/configuration/registry_test.cc
+++ b/sdk/test/configuration/registry_test.cc
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include <gtest/gtest.h>
-#include <functional>
 #include <memory>
 #include <string>
 #include <utility>
@@ -127,13 +126,17 @@ class TestParentBasedSamplerBuilder : public configuration::ParentBasedSamplerBu
 public:
   std::unique_ptr<opentelemetry::sdk::trace::Sampler> Build(
       const configuration::ParentBasedSamplerConfiguration * /* model */,
-      std::unique_ptr<opentelemetry::sdk::trace::Sampler> && /* root */,
-      std::unique_ptr<opentelemetry::sdk::trace::Sampler> && /* remote_parent_sampled */,
-      std::unique_ptr<opentelemetry::sdk::trace::Sampler> && /* remote_parent_not_sampled */,
-      std::unique_ptr<opentelemetry::sdk::trace::Sampler> && /* local_parent_sampled */,
-      std::unique_ptr<opentelemetry::sdk::trace::Sampler> && /* local_parent_not_sampled */)
-      const override
+      std::unique_ptr<opentelemetry::sdk::trace::Sampler> &&root,
+      std::unique_ptr<opentelemetry::sdk::trace::Sampler> &&remote_parent_sampled,
+      std::unique_ptr<opentelemetry::sdk::trace::Sampler> &&remote_parent_not_sampled,
+      std::unique_ptr<opentelemetry::sdk::trace::Sampler> &&local_parent_sampled,
+      std::unique_ptr<opentelemetry::sdk::trace::Sampler> &&local_parent_not_sampled) const override
   {
+    auto unused_root                      = std::move(root);
+    auto unused_remote_parent_sampled     = std::move(remote_parent_sampled);
+    auto unused_remote_parent_not_sampled = std::move(remote_parent_not_sampled);
+    auto unused_local_parent_sampled      = std::move(local_parent_sampled);
+    auto unused_local_parent_not_sampled  = std::move(local_parent_not_sampled);
     return nullptr;
   }
 };
@@ -143,8 +146,9 @@ class TestJaegerRemoteSamplerBuilder : public configuration::JaegerRemoteSampler
 public:
   std::unique_ptr<opentelemetry::sdk::trace::Sampler> Build(
       const configuration::JaegerRemoteSamplerConfiguration * /* model */,
-      std::unique_ptr<opentelemetry::sdk::trace::Sampler> && /* initial_sampler */) const override
+      std::unique_ptr<opentelemetry::sdk::trace::Sampler> &&initial_sampler) const override
   {
+    auto unused = std::move(initial_sampler);
     return nullptr;
   }
 };
@@ -187,8 +191,9 @@ class TestComposableParentThresholdSamplerBuilder
 public:
   std::unique_ptr<opentelemetry::sdk::trace::ComposableSampler> Build(
       const configuration::ComposableParentThresholdSamplerConfiguration * /* model */,
-      std::unique_ptr<opentelemetry::sdk::trace::ComposableSampler> && /* root */) const override
+      std::unique_ptr<opentelemetry::sdk::trace::ComposableSampler> &&root) const override
   {
+    auto unused = std::move(root);
     return nullptr;
   }
 };
@@ -199,9 +204,10 @@ class TestComposableRuleBasedSamplerBuilder
 public:
   std::unique_ptr<opentelemetry::sdk::trace::ComposableSampler> Build(
       const configuration::ComposableRuleBasedSamplerConfiguration * /* model */,
-      std::vector<std::unique_ptr<opentelemetry::sdk::trace::ComposableSampler>>
-          && /* rule_samplers */) const override
+      std::vector<std::unique_ptr<opentelemetry::sdk::trace::ComposableSampler>> &&rule_samplers)
+      const override
   {
+    auto unused = std::move(rule_samplers);
     return nullptr;
   }
 };
@@ -211,8 +217,9 @@ class TestBatchSpanProcessorBuilder : public configuration::BatchSpanProcessorBu
 public:
   std::unique_ptr<opentelemetry::sdk::trace::SpanProcessor> Build(
       const configuration::BatchSpanProcessorConfiguration * /* model */,
-      std::unique_ptr<opentelemetry::sdk::trace::SpanExporter> && /* exporter */) const override
+      std::unique_ptr<opentelemetry::sdk::trace::SpanExporter> &&exporter) const override
   {
+    auto unused = std::move(exporter);
     return nullptr;
   }
 };
@@ -222,8 +229,9 @@ class TestSimpleSpanProcessorBuilder : public configuration::SimpleSpanProcessor
 public:
   std::unique_ptr<opentelemetry::sdk::trace::SpanProcessor> Build(
       const configuration::SimpleSpanProcessorConfiguration * /* model */,
-      std::unique_ptr<opentelemetry::sdk::trace::SpanExporter> && /* exporter */) const override
+      std::unique_ptr<opentelemetry::sdk::trace::SpanExporter> &&exporter) const override
   {
+    auto unused = std::move(exporter);
     return nullptr;
   }
 };
@@ -233,8 +241,9 @@ class TestBatchLogRecordProcessorBuilder : public configuration::BatchLogRecordP
 public:
   std::unique_ptr<opentelemetry::sdk::logs::LogRecordProcessor> Build(
       const configuration::BatchLogRecordProcessorConfiguration * /* model */,
-      std::unique_ptr<opentelemetry::sdk::logs::LogRecordExporter> && /* exporter */) const override
+      std::unique_ptr<opentelemetry::sdk::logs::LogRecordExporter> &&exporter) const override
   {
+    auto unused = std::move(exporter);
     return nullptr;
   }
 };
@@ -244,8 +253,9 @@ class TestSimpleLogRecordProcessorBuilder : public configuration::SimpleLogRecor
 public:
   std::unique_ptr<opentelemetry::sdk::logs::LogRecordProcessor> Build(
       const configuration::SimpleLogRecordProcessorConfiguration * /* model */,
-      std::unique_ptr<opentelemetry::sdk::logs::LogRecordExporter> && /* exporter */) const override
+      std::unique_ptr<opentelemetry::sdk::logs::LogRecordExporter> &&exporter) const override
   {
+    auto unused = std::move(exporter);
     return nullptr;
   }
 };
@@ -255,8 +265,9 @@ class TestPullMetricReaderBuilder : public configuration::PullMetricReaderBuilde
 public:
   std::unique_ptr<opentelemetry::sdk::metrics::MetricReader> Build(
       const configuration::PullMetricReaderConfiguration * /* model */,
-      std::unique_ptr<opentelemetry::sdk::metrics::MetricReader> && /* exporter */) const override
+      std::unique_ptr<opentelemetry::sdk::metrics::MetricReader> &&reader) const override
   {
+    auto unused = std::move(reader);
     return nullptr;
   }
 };
@@ -492,9 +503,9 @@ class TestPeriodicMetricReaderBuilder : public configuration::PeriodicMetricRead
 public:
   std::unique_ptr<opentelemetry::sdk::metrics::MetricReader> Build(
       const configuration::PeriodicMetricReaderConfiguration * /* model */,
-      std::unique_ptr<opentelemetry::sdk::metrics::PushMetricExporter> && /* exporter */)
-      const override
+      std::unique_ptr<opentelemetry::sdk::metrics::PushMetricExporter> &&exporter) const override
   {
+    auto unused = std::move(exporter);
     return nullptr;
   }
 };
@@ -598,40 +609,45 @@ public:
 // ----------------------------------------------------------------------------------
 // Test Helpers
 
+namespace
+{
+
 template <typename MockType, typename GetBuilderFn, typename SetBuilderFn>
 void TestTypedSlot(GetBuilderFn getter, SetBuilderFn setter)
 {
   configuration::Registry registry;
-  ASSERT_EQ(std::invoke(getter, registry), nullptr);
+  ASSERT_EQ((registry.*getter)(), nullptr);
 
   auto first            = std::make_unique<MockType>();
   const auto *first_ptr = first.get();
-  std::invoke(setter, registry, std::move(first));
-  ASSERT_EQ(std::invoke(getter, registry), first_ptr);
+  (registry.*setter)(std::move(first));
+  ASSERT_EQ((registry.*getter)(), first_ptr);
 
   auto second            = std::make_unique<MockType>();
   const auto *second_ptr = second.get();
-  std::invoke(setter, registry, std::move(second));
-  ASSERT_EQ(std::invoke(getter, registry), second_ptr);
+  (registry.*setter)(std::move(second));
+  ASSERT_EQ((registry.*getter)(), second_ptr);
 }
 
 template <typename MockType, typename GetBuilderFn, typename SetBuilderFn>
 void TestNamedSlot(GetBuilderFn getter, SetBuilderFn setter, const std::string &key)
 {
   configuration::Registry registry;
-  ASSERT_EQ(std::invoke(getter, registry, key), nullptr);
+  ASSERT_EQ((registry.*getter)(key), nullptr);
 
   auto first            = std::make_unique<MockType>();
   const auto *first_ptr = first.get();
-  std::invoke(setter, registry, key, std::move(first));
-  ASSERT_EQ(std::invoke(getter, registry, key), first_ptr);
-  ASSERT_EQ(std::invoke(getter, registry, "other"), nullptr);
+  (registry.*setter)(key, std::move(first));
+  ASSERT_EQ((registry.*getter)(key), first_ptr);
+  ASSERT_EQ((registry.*getter)("other"), nullptr);
 
   auto second            = std::make_unique<MockType>();
   const auto *second_ptr = second.get();
-  std::invoke(setter, registry, key, std::move(second));
-  ASSERT_EQ(std::invoke(getter, registry, key), second_ptr);
+  (registry.*setter)(key, std::move(second));
+  ASSERT_EQ((registry.*getter)(key), second_ptr);
 }
+
+}  // namespace
 
 // ----------------------------------------------------------------------------------
 // Test Cases

--- a/sdk/test/configuration/registry_test.cc
+++ b/sdk/test/configuration/registry_test.cc
@@ -17,26 +17,49 @@
 #include "opentelemetry/sdk/configuration/composable_parent_threshold_sampler_builder.h"
 #include "opentelemetry/sdk/configuration/composable_probability_sampler_builder.h"
 #include "opentelemetry/sdk/configuration/composable_rule_based_sampler_builder.h"
+#include "opentelemetry/sdk/configuration/console_log_record_exporter_builder.h"
+#include "opentelemetry/sdk/configuration/console_push_metric_exporter_builder.h"
+#include "opentelemetry/sdk/configuration/console_span_exporter_builder.h"
 #include "opentelemetry/sdk/configuration/container_resource_detector_builder.h"
+#include "opentelemetry/sdk/configuration/extension_log_record_exporter_builder.h"
+#include "opentelemetry/sdk/configuration/extension_log_record_processor_builder.h"
 #include "opentelemetry/sdk/configuration/extension_metric_producer_builder.h"
+#include "opentelemetry/sdk/configuration/extension_pull_metric_exporter_builder.h"
+#include "opentelemetry/sdk/configuration/extension_push_metric_exporter_builder.h"
 #include "opentelemetry/sdk/configuration/extension_resource_detector_builder.h"
+#include "opentelemetry/sdk/configuration/extension_sampler_builder.h"
+#include "opentelemetry/sdk/configuration/extension_span_exporter_builder.h"
+#include "opentelemetry/sdk/configuration/extension_span_processor_builder.h"
 #include "opentelemetry/sdk/configuration/host_resource_detector_builder.h"
 #include "opentelemetry/sdk/configuration/jaeger_remote_sampler_builder.h"
 #include "opentelemetry/sdk/configuration/logger_configurator_builder.h"
 #include "opentelemetry/sdk/configuration/meter_configurator_builder.h"
 #include "opentelemetry/sdk/configuration/open_census_metric_producer_builder.h"
+#include "opentelemetry/sdk/configuration/otlp_file_log_record_exporter_builder.h"
+#include "opentelemetry/sdk/configuration/otlp_file_push_metric_exporter_builder.h"
+#include "opentelemetry/sdk/configuration/otlp_file_span_exporter_builder.h"
+#include "opentelemetry/sdk/configuration/otlp_grpc_log_record_exporter_builder.h"
+#include "opentelemetry/sdk/configuration/otlp_grpc_push_metric_exporter_builder.h"
+#include "opentelemetry/sdk/configuration/otlp_grpc_span_exporter_builder.h"
+#include "opentelemetry/sdk/configuration/otlp_http_log_record_exporter_builder.h"
+#include "opentelemetry/sdk/configuration/otlp_http_push_metric_exporter_builder.h"
+#include "opentelemetry/sdk/configuration/otlp_http_span_exporter_builder.h"
 #include "opentelemetry/sdk/configuration/parent_based_sampler_builder.h"
+#include "opentelemetry/sdk/configuration/periodic_metric_reader_builder.h"
 #include "opentelemetry/sdk/configuration/probability_sampler_builder.h"
 #include "opentelemetry/sdk/configuration/process_resource_detector_builder.h"
+#include "opentelemetry/sdk/configuration/prometheus_pull_metric_exporter_builder.h"
 #include "opentelemetry/sdk/configuration/pull_metric_reader_builder.h"
 #include "opentelemetry/sdk/configuration/registry.h"
 #include "opentelemetry/sdk/configuration/service_resource_detector_builder.h"
 #include "opentelemetry/sdk/configuration/simple_log_record_processor_builder.h"
 #include "opentelemetry/sdk/configuration/simple_span_processor_builder.h"
+#include "opentelemetry/sdk/configuration/text_map_propagator_builder.h"
 #include "opentelemetry/sdk/configuration/trace_id_ratio_based_sampler_builder.h"
 #include "opentelemetry/sdk/configuration/tracer_configurator_builder.h"
 // Complete types required: the mock builders return std::unique_ptr<T>{nullptr},
 // which instantiates ~unique_ptr<T> and needs sizeof(T).
+#include "opentelemetry/context/propagation/text_map_propagator.h"      // IWYU pragma: keep
 #include "opentelemetry/sdk/instrumentationscope/scope_configurator.h"  // IWYU pragma: keep
 #include "opentelemetry/sdk/logs/exporter.h"                            // IWYU pragma: keep
 #include "opentelemetry/sdk/logs/logger_config.h"                       // IWYU pragma: keep
@@ -44,6 +67,7 @@
 #include "opentelemetry/sdk/metrics/export/metric_producer.h"           // IWYU pragma: keep
 #include "opentelemetry/sdk/metrics/meter_config.h"                     // IWYU pragma: keep
 #include "opentelemetry/sdk/metrics/metric_reader.h"                    // IWYU pragma: keep
+#include "opentelemetry/sdk/metrics/push_metric_exporter.h"             // IWYU pragma: keep
 #include "opentelemetry/sdk/resource/resource_detector.h"               // IWYU pragma: keep
 #include "opentelemetry/sdk/trace/exporter.h"                           // IWYU pragma: keep
 #include "opentelemetry/sdk/trace/processor.h"                          // IWYU pragma: keep
@@ -338,6 +362,235 @@ public:
   }
 };
 
+class TestConsoleSpanExporterBuilder : public configuration::ConsoleSpanExporterBuilder
+{
+public:
+  std::unique_ptr<opentelemetry::sdk::trace::SpanExporter> Build(
+      const configuration::ConsoleSpanExporterConfiguration * /* model */) const override
+  {
+    return nullptr;
+  }
+};
+
+class TestConsolePushMetricExporterBuilder : public configuration::ConsolePushMetricExporterBuilder
+{
+public:
+  std::unique_ptr<opentelemetry::sdk::metrics::PushMetricExporter> Build(
+      const configuration::ConsolePushMetricExporterConfiguration * /* model */) const override
+  {
+    return nullptr;
+  }
+};
+
+class TestConsoleLogRecordExporterBuilder : public configuration::ConsoleLogRecordExporterBuilder
+{
+public:
+  std::unique_ptr<opentelemetry::sdk::logs::LogRecordExporter> Build(
+      const configuration::ConsoleLogRecordExporterConfiguration * /* model */) const override
+  {
+    return nullptr;
+  }
+};
+
+class TestOtlpHttpSpanExporterBuilder : public configuration::OtlpHttpSpanExporterBuilder
+{
+public:
+  std::unique_ptr<opentelemetry::sdk::trace::SpanExporter> Build(
+      const configuration::OtlpHttpSpanExporterConfiguration * /* model */) const override
+  {
+    return nullptr;
+  }
+};
+
+class TestOtlpGrpcSpanExporterBuilder : public configuration::OtlpGrpcSpanExporterBuilder
+{
+public:
+  std::unique_ptr<opentelemetry::sdk::trace::SpanExporter> Build(
+      const configuration::OtlpGrpcSpanExporterConfiguration * /* model */) const override
+  {
+    return nullptr;
+  }
+};
+
+class TestOtlpFileSpanExporterBuilder : public configuration::OtlpFileSpanExporterBuilder
+{
+public:
+  std::unique_ptr<opentelemetry::sdk::trace::SpanExporter> Build(
+      const configuration::OtlpFileSpanExporterConfiguration * /* model */) const override
+  {
+    return nullptr;
+  }
+};
+
+class TestOtlpHttpPushMetricExporterBuilder
+    : public configuration::OtlpHttpPushMetricExporterBuilder
+{
+public:
+  std::unique_ptr<opentelemetry::sdk::metrics::PushMetricExporter> Build(
+      const configuration::OtlpHttpPushMetricExporterConfiguration * /* model */) const override
+  {
+    return nullptr;
+  }
+};
+
+class TestOtlpGrpcPushMetricExporterBuilder
+    : public configuration::OtlpGrpcPushMetricExporterBuilder
+{
+public:
+  std::unique_ptr<opentelemetry::sdk::metrics::PushMetricExporter> Build(
+      const configuration::OtlpGrpcPushMetricExporterConfiguration * /* model */) const override
+  {
+    return nullptr;
+  }
+};
+
+class TestOtlpFilePushMetricExporterBuilder
+    : public configuration::OtlpFilePushMetricExporterBuilder
+{
+public:
+  std::unique_ptr<opentelemetry::sdk::metrics::PushMetricExporter> Build(
+      const configuration::OtlpFilePushMetricExporterConfiguration * /* model */) const override
+  {
+    return nullptr;
+  }
+};
+
+class TestOtlpHttpLogRecordExporterBuilder : public configuration::OtlpHttpLogRecordExporterBuilder
+{
+public:
+  std::unique_ptr<opentelemetry::sdk::logs::LogRecordExporter> Build(
+      const configuration::OtlpHttpLogRecordExporterConfiguration * /* model */) const override
+  {
+    return nullptr;
+  }
+};
+
+class TestOtlpGrpcLogRecordExporterBuilder : public configuration::OtlpGrpcLogRecordExporterBuilder
+{
+public:
+  std::unique_ptr<opentelemetry::sdk::logs::LogRecordExporter> Build(
+      const configuration::OtlpGrpcLogRecordExporterConfiguration * /* model */) const override
+  {
+    return nullptr;
+  }
+};
+
+class TestOtlpFileLogRecordExporterBuilder : public configuration::OtlpFileLogRecordExporterBuilder
+{
+public:
+  std::unique_ptr<opentelemetry::sdk::logs::LogRecordExporter> Build(
+      const configuration::OtlpFileLogRecordExporterConfiguration * /* model */) const override
+  {
+    return nullptr;
+  }
+};
+
+class TestPeriodicMetricReaderBuilder : public configuration::PeriodicMetricReaderBuilder
+{
+public:
+  std::unique_ptr<opentelemetry::sdk::metrics::MetricReader> Build(
+      const configuration::PeriodicMetricReaderConfiguration * /* model */,
+      std::unique_ptr<opentelemetry::sdk::metrics::PushMetricExporter> && /* exporter */)
+      const override
+  {
+    return nullptr;
+  }
+};
+
+class TestPrometheusPullMetricExporterBuilder
+    : public configuration::PrometheusPullMetricExporterBuilder
+{
+public:
+  std::unique_ptr<opentelemetry::sdk::metrics::MetricReader> Build(
+      const configuration::PrometheusPullMetricExporterConfiguration * /* model */) const override
+  {
+    return nullptr;
+  }
+};
+
+class TestTextMapPropagatorBuilder : public configuration::TextMapPropagatorBuilder
+{
+public:
+  std::unique_ptr<opentelemetry::context::propagation::TextMapPropagator> Build() const override
+  {
+    return nullptr;
+  }
+};
+
+class TestExtensionSamplerBuilder : public configuration::ExtensionSamplerBuilder
+{
+public:
+  std::unique_ptr<opentelemetry::sdk::trace::Sampler> Build(
+      const configuration::ExtensionSamplerConfiguration * /* model */) const override
+  {
+    return nullptr;
+  }
+};
+
+class TestExtensionSpanExporterBuilder : public configuration::ExtensionSpanExporterBuilder
+{
+public:
+  std::unique_ptr<opentelemetry::sdk::trace::SpanExporter> Build(
+      const configuration::ExtensionSpanExporterConfiguration * /* model */) const override
+  {
+    return nullptr;
+  }
+};
+
+class TestExtensionSpanProcessorBuilder : public configuration::ExtensionSpanProcessorBuilder
+{
+public:
+  std::unique_ptr<opentelemetry::sdk::trace::SpanProcessor> Build(
+      const configuration::ExtensionSpanProcessorConfiguration * /* model */) const override
+  {
+    return nullptr;
+  }
+};
+
+class TestExtensionPushMetricExporterBuilder
+    : public configuration::ExtensionPushMetricExporterBuilder
+{
+public:
+  std::unique_ptr<opentelemetry::sdk::metrics::PushMetricExporter> Build(
+      const configuration::ExtensionPushMetricExporterConfiguration * /* model */) const override
+  {
+    return nullptr;
+  }
+};
+
+class TestExtensionPullMetricExporterBuilder
+    : public configuration::ExtensionPullMetricExporterBuilder
+{
+public:
+  std::unique_ptr<opentelemetry::sdk::metrics::MetricReader> Build(
+      const configuration::ExtensionPullMetricExporterConfiguration * /* model */) const override
+  {
+    return nullptr;
+  }
+};
+
+class TestExtensionLogRecordExporterBuilder
+    : public configuration::ExtensionLogRecordExporterBuilder
+{
+public:
+  std::unique_ptr<opentelemetry::sdk::logs::LogRecordExporter> Build(
+      const configuration::ExtensionLogRecordExporterConfiguration * /* model */) const override
+  {
+    return nullptr;
+  }
+};
+
+class TestExtensionLogRecordProcessorBuilder
+    : public configuration::ExtensionLogRecordProcessorBuilder
+{
+public:
+  std::unique_ptr<opentelemetry::sdk::logs::LogRecordProcessor> Build(
+      const configuration::ExtensionLogRecordProcessorConfiguration * /* model */) const override
+  {
+    return nullptr;
+  }
+};
+
 }  // namespace
 
 // Exercises the empty → set → replace lifecycle for a typed (non-named-map) registry slot.
@@ -554,4 +807,175 @@ TEST(Registry, ExtensionResourceDetectorBuilder)
   TestNamedSlot<TestExtensionResourceDetectorBuilder>(
       &configuration::Registry::GetExtensionResourceDetectorBuilder,
       &configuration::Registry::SetExtensionResourceDetectorBuilder, "my_detector");
+}
+
+TEST(Registry, ConsoleSpanBuilder)
+{
+  TestTypedSlot<TestConsoleSpanExporterBuilder>(&configuration::Registry::GetConsoleSpanBuilder,
+                                                &configuration::Registry::SetConsoleSpanBuilder);
+}
+
+TEST(Registry, ConsolePushMetricExporterBuilder)
+{
+  TestTypedSlot<TestConsolePushMetricExporterBuilder>(
+      &configuration::Registry::GetConsolePushMetricExporterBuilder,
+      &configuration::Registry::SetConsolePushMetricExporterBuilder);
+}
+
+TEST(Registry, ConsoleLogRecordBuilder)
+{
+  TestTypedSlot<TestConsoleLogRecordExporterBuilder>(
+      &configuration::Registry::GetConsoleLogRecordBuilder,
+      &configuration::Registry::SetConsoleLogRecordBuilder);
+}
+
+TEST(Registry, OtlpHttpSpanBuilder)
+{
+  TestTypedSlot<TestOtlpHttpSpanExporterBuilder>(&configuration::Registry::GetOtlpHttpSpanBuilder,
+                                                 &configuration::Registry::SetOtlpHttpSpanBuilder);
+}
+
+TEST(Registry, OtlpGrpcSpanBuilder)
+{
+  TestTypedSlot<TestOtlpGrpcSpanExporterBuilder>(&configuration::Registry::GetOtlpGrpcSpanBuilder,
+                                                 &configuration::Registry::SetOtlpGrpcSpanBuilder);
+}
+
+TEST(Registry, OtlpFileSpanBuilder)
+{
+  TestTypedSlot<TestOtlpFileSpanExporterBuilder>(&configuration::Registry::GetOtlpFileSpanBuilder,
+                                                 &configuration::Registry::SetOtlpFileSpanBuilder);
+}
+
+TEST(Registry, OtlpHttpPushMetricExporterBuilder)
+{
+  TestTypedSlot<TestOtlpHttpPushMetricExporterBuilder>(
+      &configuration::Registry::GetOtlpHttpPushMetricExporterBuilder,
+      &configuration::Registry::SetOtlpHttpPushMetricExporterBuilder);
+}
+
+TEST(Registry, OtlpGrpcPushMetricExporterBuilder)
+{
+  TestTypedSlot<TestOtlpGrpcPushMetricExporterBuilder>(
+      &configuration::Registry::GetOtlpGrpcPushMetricExporterBuilder,
+      &configuration::Registry::SetOtlpGrpcPushMetricExporterBuilder);
+}
+
+TEST(Registry, OtlpFilePushMetricExporterBuilder)
+{
+  TestTypedSlot<TestOtlpFilePushMetricExporterBuilder>(
+      &configuration::Registry::GetOtlpFilePushMetricExporterBuilder,
+      &configuration::Registry::SetOtlpFilePushMetricExporterBuilder);
+}
+
+TEST(Registry, OtlpHttpLogRecordBuilder)
+{
+  TestTypedSlot<TestOtlpHttpLogRecordExporterBuilder>(
+      &configuration::Registry::GetOtlpHttpLogRecordBuilder,
+      &configuration::Registry::SetOtlpHttpLogRecordBuilder);
+}
+
+TEST(Registry, OtlpGrpcLogRecordBuilder)
+{
+  TestTypedSlot<TestOtlpGrpcLogRecordExporterBuilder>(
+      &configuration::Registry::GetOtlpGrpcLogRecordBuilder,
+      &configuration::Registry::SetOtlpGrpcLogRecordBuilder);
+}
+
+TEST(Registry, OtlpFileLogRecordBuilder)
+{
+  TestTypedSlot<TestOtlpFileLogRecordExporterBuilder>(
+      &configuration::Registry::GetOtlpFileLogRecordBuilder,
+      &configuration::Registry::SetOtlpFileLogRecordBuilder);
+}
+
+TEST(Registry, PeriodicMetricReaderBuilder)
+{
+  // Registry pre-populates this slot; test replace lifecycle only.
+  configuration::Registry registry;
+  ASSERT_NE(registry.GetPeriodicMetricReaderBuilder(), nullptr);
+
+  auto first            = std::make_unique<TestPeriodicMetricReaderBuilder>();
+  const auto *first_ptr = first.get();
+  registry.SetPeriodicMetricReaderBuilder(std::move(first));
+  ASSERT_EQ(registry.GetPeriodicMetricReaderBuilder(), first_ptr);
+
+  auto second            = std::make_unique<TestPeriodicMetricReaderBuilder>();
+  const auto *second_ptr = second.get();
+  registry.SetPeriodicMetricReaderBuilder(std::move(second));
+  ASSERT_EQ(registry.GetPeriodicMetricReaderBuilder(), second_ptr);
+}
+
+TEST(Registry, PrometheusPullMetricExporterBuilder)
+{
+  TestTypedSlot<TestPrometheusPullMetricExporterBuilder>(
+      &configuration::Registry::GetPrometheusPullMetricExporterBuilder,
+      &configuration::Registry::SetPrometheusPullMetricExporterBuilder);
+}
+
+TEST(Registry, TextMapPropagatorBuilder)
+{
+  // Registry pre-populates known propagator names; use an unknown key.
+  configuration::Registry registry;
+  ASSERT_EQ(registry.GetTextMapPropagatorBuilder("custom_propagator"), nullptr);
+
+  auto first            = std::make_unique<TestTextMapPropagatorBuilder>();
+  const auto *first_ptr = first.get();
+  registry.SetTextMapPropagatorBuilder("custom_propagator", std::move(first));
+  ASSERT_EQ(registry.GetTextMapPropagatorBuilder("custom_propagator"), first_ptr);
+  ASSERT_EQ(registry.GetTextMapPropagatorBuilder("other"), nullptr);
+
+  auto second            = std::make_unique<TestTextMapPropagatorBuilder>();
+  const auto *second_ptr = second.get();
+  registry.SetTextMapPropagatorBuilder("custom_propagator", std::move(second));
+  ASSERT_EQ(registry.GetTextMapPropagatorBuilder("custom_propagator"), second_ptr);
+}
+
+TEST(Registry, ExtensionSamplerBuilder)
+{
+  TestNamedSlot<TestExtensionSamplerBuilder>(&configuration::Registry::GetExtensionSamplerBuilder,
+                                             &configuration::Registry::SetExtensionSamplerBuilder,
+                                             "my_sampler");
+}
+
+TEST(Registry, ExtensionSpanExporterBuilder)
+{
+  TestNamedSlot<TestExtensionSpanExporterBuilder>(
+      &configuration::Registry::GetExtensionSpanExporterBuilder,
+      &configuration::Registry::SetExtensionSpanExporterBuilder, "my_exporter");
+}
+
+TEST(Registry, ExtensionSpanProcessorBuilder)
+{
+  TestNamedSlot<TestExtensionSpanProcessorBuilder>(
+      &configuration::Registry::GetExtensionSpanProcessorBuilder,
+      &configuration::Registry::SetExtensionSpanProcessorBuilder, "my_processor");
+}
+
+TEST(Registry, ExtensionPushMetricExporterBuilder)
+{
+  TestNamedSlot<TestExtensionPushMetricExporterBuilder>(
+      &configuration::Registry::GetExtensionPushMetricExporterBuilder,
+      &configuration::Registry::SetExtensionPushMetricExporterBuilder, "my_exporter");
+}
+
+TEST(Registry, ExtensionPullMetricExporterBuilder)
+{
+  TestNamedSlot<TestExtensionPullMetricExporterBuilder>(
+      &configuration::Registry::GetExtensionPullMetricExporterBuilder,
+      &configuration::Registry::SetExtensionPullMetricExporterBuilder, "my_exporter");
+}
+
+TEST(Registry, ExtensionLogRecordExporterBuilder)
+{
+  TestNamedSlot<TestExtensionLogRecordExporterBuilder>(
+      &configuration::Registry::GetExtensionLogRecordExporterBuilder,
+      &configuration::Registry::SetExtensionLogRecordExporterBuilder, "my_exporter");
+}
+
+TEST(Registry, ExtensionLogRecordProcessorBuilder)
+{
+  TestNamedSlot<TestExtensionLogRecordProcessorBuilder>(
+      &configuration::Registry::GetExtensionLogRecordProcessorBuilder,
+      &configuration::Registry::SetExtensionLogRecordProcessorBuilder, "my_processor");
 }


### PR DESCRIPTION
Contributes to #4352 

This PR adds 26 new abstract builder interfaces to cover configurable SDK types in the schema. The new builders are not used yet in the SdkBuilder. The next PR will integrate them and create the SDK defaults.   

<details> <summary>New builder types added: (click to expand)</summary>


| Category | File | Builder |
|---|---|---|
| Sampler | `always_on_sampler_builder.h` | `AlwaysOnSamplerBuilder` |
| Sampler | `always_off_sampler_builder.h` | `AlwaysOffSamplerBuilder` |
| Sampler | `trace_id_ratio_based_sampler_builder.h` | `TraceIdRatioBasedSamplerBuilder` |
| Sampler | `probability_sampler_builder.h` | `ProbabilitySamplerBuilder` |
| Sampler | `parent_based_sampler_builder.h` | `ParentBasedSamplerBuilder` |
| Sampler | `jaeger_remote_sampler_builder.h` | `JaegerRemoteSamplerBuilder` |
| Composable sampler | `composable_always_on_sampler_builder.h` | `ComposableAlwaysOnSamplerBuilder` |
| Composable sampler | `composable_always_off_sampler_builder.h` | `ComposableAlwaysOffSamplerBuilder` |
| Composable sampler | `composable_probability_sampler_builder.h` | `ComposableProbabilitySamplerBuilder` |
| Composable sampler | `composable_parent_threshold_sampler_builder.h` | `ComposableParentThresholdSamplerBuilder` |
| Composable sampler | `composable_rule_based_sampler_builder.h` | `ComposableRuleBasedSamplerBuilder` |
| Span processor | `batch_span_processor_builder.h` | `BatchSpanProcessorBuilder` |
| Span processor | `simple_span_processor_builder.h` | `SimpleSpanProcessorBuilder` |
| Log processor | `batch_log_record_processor_builder.h` | `BatchLogRecordProcessorBuilder` |
| Log processor | `simple_log_record_processor_builder.h` | `SimpleLogRecordProcessorBuilder` |
| Metric reader | `pull_metric_reader_builder.h` | `PullMetricReaderBuilder` |
| Configurator | `tracer_configurator_builder.h` | `TracerConfiguratorBuilder` |
| Configurator | `meter_configurator_builder.h` | `MeterConfiguratorBuilder` |
| Configurator | `logger_configurator_builder.h` | `LoggerConfiguratorBuilder` |
| Metric producer | `open_census_metric_producer_builder.h` | `OpenCensusMetricProducerBuilder` |
| Metric producer | `extension_metric_producer_builder.h` | `ExtensionMetricProducerBuilder` |
| Resource detector | `container_resource_detector_builder.h` | `ContainerResourceDetectorBuilder` |
| Resource detector | `host_resource_detector_builder.h` | `HostResourceDetectorBuilder` |
| Resource detector | `process_resource_detector_builder.h` | `ProcessResourceDetectorBuilder` |
| Resource detector | `service_resource_detector_builder.h` | `ServiceResourceDetectorBuilder` |
| Resource detector | `extension_resource_detector_builder.h` | `ExtensionResourceDetectorBuilder` |

</details>

Assisted by: Claude 4.6

## Changes

- Adds 26 new builder interfaces
- Adds a registry test to cover all the builder accessors.  

For significant contributions please make sure you have completed the following items:

* [x] `CHANGELOG.md` updated for non-trivial changes
* [x] Unit tests have been added
* [ ] Changes in public API reviewed