### PR TITLE
[BUG] Report one outcome when a curl session is cancelled after the response arrives

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@ Increment the:
 
 ## [Unreleased]
 
+* [BUG] Report one outcome per request when a curl session is cancelled after
+  the response arrives
+  ([#4363](https://github.com/open-telemetry/opentelemetry-cpp/pull/4363))
+
 * [CODE HEALTH] Enable clang-tidy `modernize-deprecated-headers` and replace
   deprecated C headers (`stdint.h`, `stddef.h`, `stdlib.h`, `string.h`,
   `stdio.h`, `ctype.h`, `limits.h`, `assert.h`) with their C++ equivalents

--- a/ext/src/http/client/curl/http_client_curl.cc
+++ b/ext/src/http/client/curl/http_client_curl.cc
@@ -207,8 +207,8 @@ void Session::SendRequest(
                         http_request_->is_log_enabled_, http_request_->retry_policy_));
   bool success =
       CURLE_OK == curl_operation_->SendAsync(this, [this, callback](HttpOperation &operation) {
-        // Both can hold at once. Cancelling only raises a flag, and the transfer may already
-        // have been answered, so the response is reported and one request finishes once.
+        // Both can hold at once: cancelling only raises a flag, and the transfer may already
+        // have been answered. A request that was answered is reported as answered.
         if (operation.GetSessionState() == opentelemetry::ext::http::client::SessionState::Response)
         {
           // we have a http response

--- a/ext/src/http/client/curl/http_client_curl.cc
+++ b/ext/src/http/client/curl/http_client_curl.cc
@@ -207,12 +207,8 @@ void Session::SendRequest(
                         http_request_->is_log_enabled_, http_request_->retry_policy_));
   bool success =
       CURLE_OK == curl_operation_->SendAsync(this, [this, callback](HttpOperation &operation) {
-        if (operation.WasAborted())
-        {
-          // Manually cancelled
-          callback->OnEvent(opentelemetry::ext::http::client::SessionState::Cancelled, "");
-        }
-
+        // Both can hold at once. Cancelling only raises a flag, and the transfer may already
+        // have been answered, so the response is reported and one request finishes once.
         if (operation.GetSessionState() == opentelemetry::ext::http::client::SessionState::Response)
         {
           // we have a http response
@@ -221,6 +217,11 @@ void Session::SendRequest(
           response->body_        = operation.GetResponseBody();
           response->status_code_ = operation.GetResponseCode();
           callback->OnResponse(*response);
+        }
+        else if (operation.WasAborted())
+        {
+          // Manually cancelled
+          callback->OnEvent(opentelemetry::ext::http::client::SessionState::Cancelled, "");
         }
         is_session_active_.store(false, std::memory_order_release);
       });

--- a/ext/test/http/curl_http_test.cc
+++ b/ext/test/http/curl_http_test.cc
@@ -70,6 +70,36 @@ public:
   std::atomic<bool> got_response_;
 };
 
+// Cancels from inside the Response event, which is the one moment both arms of the completion
+// callback are eligible: DispatchEvent notifies the handler before it stores the new state, and
+// the callback runs after both, so it sees an aborted operation that also has a response.
+class CancelAtResponseHandler : public CustomEventHandler
+{
+public:
+  void OnResponse(http_client::Response & /* response */) noexcept override
+  {
+    terminal_count_.fetch_add(1, std::memory_order_release);
+    got_response_.store(true, std::memory_order_release);
+  }
+
+  void OnEvent(http_client::SessionState state, nostd::string_view /* reason */) noexcept override
+  {
+    if (state == http_client::SessionState::Cancelled)
+    {
+      terminal_count_.fetch_add(1, std::memory_order_release);
+    }
+    else if (state == http_client::SessionState::Response && session_ != nullptr)
+    {
+      auto *session = session_;
+      session_      = nullptr;
+      session->CancelSession();
+    }
+  }
+
+  http_client::Session *session_ = nullptr;
+  std::atomic<int> terminal_count_{0};
+};
+
 class GetEventHandler : public CustomEventHandler
 {
 public:
@@ -460,6 +490,31 @@ TEST_F(BasicCurlHttpTests, ExponentialBackoffRetry)
   ASSERT_FALSE(operation.IsRetryable());
 }
 #endif  // ENABLE_OTLP_RETRY_PREVIEW
+
+// A cancel that arrives once the server has answered used to deliver Cancelled and the response,
+// so a handler treating either as terminal saw one request finish twice.
+TEST_F(BasicCurlHttpTests, ACancelAfterTheResponseReportsOneOutcome)
+{
+  received_requests_.clear();
+  auto session_manager = std::make_shared<http_client::curl::HttpCurlClientFactory>()->Create();
+  EXPECT_TRUE(session_manager != nullptr);
+
+  auto session = session_manager->CreateSession("http://127.0.0.1:19000");
+  auto request = session->CreateRequest();
+  request->SetUri("get/");
+
+  auto handler      = std::make_shared<CancelAtResponseHandler>();
+  handler->session_ = session.get();
+
+  session->SendRequest(handler);
+  ASSERT_TRUE(waitForRequests(30, 1));
+  session->FinishSession();
+
+  EXPECT_TRUE(handler->got_response_.load(std::memory_order_acquire));
+  EXPECT_EQ(1, handler->terminal_count_.load(std::memory_order_acquire));
+
+  session_manager->FinishAllSessions();
+}
 
 TEST_F(BasicCurlHttpTests, SendGetRequestSync)
 {

--- a/ext/test/http/curl_http_test.cc
+++ b/ext/test/http/curl_http_test.cc
@@ -70,10 +70,11 @@ public:
   std::atomic<bool> got_response_;
 };
 
-// Cancels from inside the Response event, which is the one moment both arms of the completion
-// callback are eligible: DispatchEvent notifies the handler before it stores the new state, and
-// the callback runs after both, so it sees an aborted operation that also has a response.
-class CancelAtResponseHandler : public CustomEventHandler
+// Counts the terminal notifications one request produces. Set cancel_at_response_ to cancel from
+// inside the Response event, which is the one moment both arms of the completion callback are
+// eligible: DispatchEvent notifies the handler before it stores the new state, and the callback
+// runs after both, so it sees an aborted operation that also has a response.
+class TerminalCountingHandler : public CustomEventHandler
 {
 public:
   void OnResponse(http_client::Response & /* response */) noexcept override
@@ -88,15 +89,15 @@ public:
     {
       terminal_count_.fetch_add(1, std::memory_order_release);
     }
-    else if (state == http_client::SessionState::Response && session_ != nullptr)
+    else if (state == http_client::SessionState::Response && cancel_at_response_ != nullptr)
     {
-      auto *session = session_;
-      session_      = nullptr;
+      auto *session       = cancel_at_response_;
+      cancel_at_response_ = nullptr;
       session->CancelSession();
     }
   }
 
-  http_client::Session *session_ = nullptr;
+  http_client::Session *cancel_at_response_ = nullptr;
   std::atomic<int> terminal_count_{0};
 };
 
@@ -503,8 +504,8 @@ TEST_F(BasicCurlHttpTests, ACancelAfterTheResponseReportsOneOutcome)
   auto request = session->CreateRequest();
   request->SetUri("get/");
 
-  auto handler      = std::make_shared<CancelAtResponseHandler>();
-  handler->session_ = session.get();
+  auto handler                 = std::make_shared<TerminalCountingHandler>();
+  handler->cancel_at_response_ = session.get();
 
   session->SendRequest(handler);
   ASSERT_TRUE(waitForRequests(30, 1));
@@ -512,6 +513,36 @@ TEST_F(BasicCurlHttpTests, ACancelAfterTheResponseReportsOneOutcome)
 
   EXPECT_TRUE(handler->got_response_.load(std::memory_order_acquire));
   EXPECT_EQ(1, handler->terminal_count_.load(std::memory_order_acquire));
+
+  session_manager->FinishAllSessions();
+}
+
+// The other arm of the same callback, which nothing exercised. The server handler takes
+// mtx_requests before it answers, so holding it keeps a response from racing the cancel, and the
+// abort is torn down through Session::FinishOperation while the transfer is still in flight.
+TEST_F(BasicCurlHttpTests, ACancelBeforeTheResponseReportsCancelled)
+{
+  received_requests_.clear();
+  auto session_manager = std::make_shared<http_client::curl::HttpCurlClientFactory>()->Create();
+  EXPECT_TRUE(session_manager != nullptr);
+
+  auto session = session_manager->CreateSession("http://127.0.0.1:19000");
+  auto request = session->CreateRequest();
+  request->SetUri("get/");
+
+  auto handler = std::make_shared<TerminalCountingHandler>();
+
+  {
+    std::unique_lock<std::mutex> lock_requests(mtx_requests);
+    session->SendRequest(handler);
+    session->CancelSession();
+    session->FinishSession();
+  }
+
+  EXPECT_FALSE(handler->got_response_.load(std::memory_order_acquire));
+  // At least one, not exactly one: Cleanup dispatches Cancelled itself while the state is still
+  // in flight, and this callback adds another. That doubling is not what this change decides.
+  EXPECT_GE(handler->terminal_count_.load(std::memory_order_acquire), 1);
 
   session_manager->FinishAllSessions();
 }

--- a/ext/test/http/curl_http_test.cc
+++ b/ext/test/http/curl_http_test.cc
@@ -83,11 +83,17 @@ public:
     got_response_.store(true, std::memory_order_release);
   }
 
-  void OnEvent(http_client::SessionState state, nostd::string_view /* reason */) noexcept override
+  void OnEvent(http_client::SessionState state, nostd::string_view reason) noexcept override
   {
     if (state == http_client::SessionState::Cancelled)
     {
       terminal_count_.fetch_add(1, std::memory_order_release);
+      // Cleanup dispatches its own Cancelled carrying a curl message, and GetCurlErrorMessage
+      // never yields an empty one, so an empty reason is the completion callback and only it.
+      if (reason.empty())
+      {
+        cancelled_from_callback_.fetch_add(1, std::memory_order_release);
+      }
     }
     else if (state == http_client::SessionState::Response && cancel_at_response_ != nullptr)
     {
@@ -99,6 +105,7 @@ public:
 
   http_client::Session *cancel_at_response_ = nullptr;
   std::atomic<int> terminal_count_{0};
+  std::atomic<int> cancelled_from_callback_{0};
 };
 
 class GetEventHandler : public CustomEventHandler
@@ -540,9 +547,10 @@ TEST_F(BasicCurlHttpTests, ACancelBeforeTheResponseReportsCancelled)
   }
 
   EXPECT_FALSE(handler->got_response_.load(std::memory_order_acquire));
-  // At least one, not exactly one: Cleanup dispatches Cancelled itself while the state is still
-  // in flight, and this callback adds another. That doubling is not what this change decides.
-  EXPECT_GE(handler->terminal_count_.load(std::memory_order_acquire), 1);
+  // Counted by its empty reason so the assertion holds the arm this covers rather than whatever
+  // else reports a cancel. Two arrive in all, the other from Cleanup, and the total is left
+  // unasserted because that doubling is not what this change decides.
+  EXPECT_EQ(1, handler->cancelled_from_callback_.load(std::memory_order_acquire));
 
   session_manager->FinishAllSessions();
 }


### PR DESCRIPTION
Part of #4360, which lists three problems in the shared curl client's callback contract.
This is only the one with a single obvious answer. The other two need a decision I would
rather hear first, and they are still open on the issue.

## What happens

`Session::SendRequest` passes this completion callback to `SendAsync`:

```cpp
if (operation.WasAborted())
{
  callback->OnEvent(SessionState::Cancelled, "");
}

if (operation.GetSessionState() == SessionState::Response)
{
  ...
  callback->OnResponse(*response);
}
```

Two independent `if`s, and the two conditions are not exclusive. `HttpOperation::Abort`
raises `is_aborted_` and schedules the abort; it does not touch the session state. So a
transfer that has already been answered, and then cancelled, satisfies both, and the handler
is told the request was cancelled and given its response.

The window is not narrow. `PerformCurlMessage` dispatches `Response` and then calls
`Cleanup`, which is where the completion callback runs, and nothing between them is
synchronised against `Abort`. `HttpClient::CancelAllSessions` is what `Shutdown` calls, so
shutting down while a response is arriving lands in it.

## What it costs in tree

`OtlpHttpClient::ResponseHandler` already guards against being finished twice: both
`OnResponse` and the terminal `OnEvent` states take `stopping_` with a compare and exchange,
and only the winner calls `Unbind`. Because the client delivers `Cancelled` first, the
winner is the failure. `Unbind` moves the result callback out, so the response that follows
finds nothing to report and the export is recorded as failed while the server has it.

That is the reason to fix it here rather than in the consumers. A first writer guard cannot
pick the right outcome when it is handed the wrong one first.

## Why the response wins

The state only reaches `Response` when the transfer succeeded: on a non-`CURLE_OK` result
`PerformCurlMessage` dispatches `ConnectFailed` or `SendFailed` first, which moves the state
out of the `Connecting`/`Connected`/`Sending` chain the `Response` transition needs. A
`Response` state therefore means the server answered.

That also makes it the safer of the two to report. Telling a caller its request was
cancelled when the server had already accepted it invites a retry, and for an exporter that
means writing the same batch twice.

`Cancelled` is unchanged for a cancel that lands while the request is still in flight, which
is the case it was written for.

## What this leaves

The `Cancelled` arm can still double up with what `Cleanup` sends. `Cleanup` dispatches
`Cancelled` itself whenever the state is still `Created`, `Connecting`, `Connected` or
`Sending`, and then runs this callback, so an operation aborted in flight and torn down
through `Session::FinishOperation` reports `Cancelled` twice. The second case below measures
exactly that, two notifications for one request, which is why it asserts at least one rather
than one. An aborted operation whose transfer failed is the same shape, the failure state and
then `Cancelled`.

Each of those says one thing twice rather than two different things, and the consumers
collapse them: `OtlpHttpClient` through `stopping_`, the Elasticsearch synchronous handler
through `recordCompletion`, and its asynchronous handler not at all, which is #4338.

Dropping this arm entirely would close those too, but that decides which layer owns the
event rather than correcting an outcome, and it is the third item on #4360. What this change
covers is the one pairing where the two notifications disagree and the wrong one wins.

## Test

`ACancelAfterTheResponseReportsOneOutcome` cancels from inside the handler's `Response`
event. That is not a lucky interleaving: `DispatchEvent` notifies the handler and only then
stores the new state, and the completion callback runs after both, so by the time it is
reached the operation is aborted and its state is `Response`. Cancelling from the handler
also keeps `CancelSession` on the thread that owns the curl handle, which is where the
background loop already is.

The handler counts terminal notifications and the case asserts one.

| | terminal notifications |
| --- | --- |
| `http_client_curl.cc` reverted to `main`, test kept | `Expected equality of these values: 1 ... Which is: 2` |
| this branch | 1 |

`ACancelBeforeTheResponseReportsCancelled` covers the other arm, which nothing in the suite
reached, so the line that reports a cancelled request was never run and Codecov saw the patch
at 50 per cent. The server handler takes `mtx_requests` before it answers, so holding it keeps
a response from racing the cancel, and the abort is torn down through
`Session::FinishOperation` while the transfer is still in flight.

Two `Cancelled` arrive, one from `Cleanup` and one from this callback, so counting them all
would stay green whether or not the arm ran. `GetCurlErrorMessage` never yields an empty
string, so `Cleanup`'s carries a reason and the callback's never does, and the case counts the
empty one. Deleting the arm turns it red at 0 against 1. The total is deliberately not
asserted, since the doubling is the separate question above.

This one characterises rather than reproduces: it passes on `main` too, where the same arm
runs from the first `if`. What it adds is that the line cannot go uncovered again unnoticed.

gcov on the changed lines, from the suite: the response test drives `OnResponse` 24 times, the
`else if` is evaluated 7 times, and its body runs once, where before it ran not at all.

21 of 21 in `curl_http_test`, clang-format clean, and clang-tidy under the CI header filters
reports the same set as `main` for both files.

## Checklist

* [x] `CHANGELOG.md` updated for non-trivial changes
* [x] Unit tests have been added
* [x] Changes in public API reviewed: no signatures change. A handler that used to receive
  `Cancelled` followed by `OnResponse` for one request now receives only `OnResponse`. For the
  OTLP HTTP exporter that turns a shutdown racing a response from a reported failure into the
  result the server actually returned.
