### PR TITLE
[SDK] Percent-decode values from OTEL_RESOURCE_ATTRIBUTES

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,11 @@ Increment the:
 
 ## [Unreleased]
 
+* [SDK] `OTELResourceDetector` now percent-decodes values parsed from the
+  `OTEL_RESOURCE_ATTRIBUTES` environment variable, per the W3C Baggage value
+  grammar the resource spec defers to. A malformed escape sequence is left
+  in the value as-is rather than dropping the attribute.
+  [#1536](https://github.com/open-telemetry/opentelemetry-cpp/issues/1536)
 * [CODE HEALTH] Enable clang-tidy `modernize-deprecated-headers` and replace
   deprecated C headers (`stdint.h`, `stddef.h`, `stdlib.h`, `string.h`,
   `stdio.h`, `ctype.h`, `limits.h`, `assert.h`) with their C++ equivalents

--- a/sdk/src/resource/resource_detector.cc
+++ b/sdk/src/resource/resource_detector.cc
@@ -35,9 +35,10 @@ unsigned char HexDigitValue(unsigned char c) noexcept
 }
 
 // Percent-decodes a value from OTEL_RESOURCE_ATTRIBUTES, per the W3C Baggage value grammar
-// the resource spec defers to (https://github.com/open-telemetry/opentelemetry-specification/pull/2670).
-// A malformed escape sequence is left in the output as-is rather than dropping the attribute,
-// since this parser has never validated attribute syntax.
+// the resource spec defers to
+// (https://github.com/open-telemetry/opentelemetry-specification/pull/2670). A malformed escape
+// sequence is left in the output as-is rather than dropping the attribute, since this parser has
+// never validated attribute syntax.
 std::string PercentDecode(const std::string &value)
 {
   std::string decoded;
@@ -48,9 +49,9 @@ std::string PercentDecode(const std::string &value)
         IsHexDigit(static_cast<unsigned char>(value[i + 1])) &&
         IsHexDigit(static_cast<unsigned char>(value[i + 2])))
     {
-      decoded.push_back(static_cast<char>((HexDigitValue(static_cast<unsigned char>(value[i + 1]))
-                                           << 4) |
-                                          HexDigitValue(static_cast<unsigned char>(value[i + 2]))));
+      decoded.push_back(
+          static_cast<char>((HexDigitValue(static_cast<unsigned char>(value[i + 1])) << 4) |
+                            HexDigitValue(static_cast<unsigned char>(value[i + 2]))));
       i += 2;
     }
     else

--- a/sdk/src/resource/resource_detector.cc
+++ b/sdk/src/resource/resource_detector.cc
@@ -8,6 +8,7 @@
 #include "opentelemetry/semconv/service_attributes.h"
 #include "opentelemetry/version.h"
 
+#include <cctype>
 #include <cstddef>
 #include <sstream>
 #include <string>
@@ -20,6 +21,46 @@ namespace resource
 
 constexpr const char *kOtelResourceAttributes = "OTEL_RESOURCE_ATTRIBUTES";
 constexpr const char *kOtelServiceName        = "OTEL_SERVICE_NAME";
+
+namespace
+{
+bool IsHexDigit(unsigned char c) noexcept
+{
+  return std::isdigit(c) || (c >= 'A' && c <= 'F') || (c >= 'a' && c <= 'f');
+}
+
+unsigned char HexDigitValue(unsigned char c) noexcept
+{
+  return static_cast<unsigned char>(std::isdigit(c) ? c - '0' : std::toupper(c) - 'A' + 10);
+}
+
+// Percent-decodes a value from OTEL_RESOURCE_ATTRIBUTES, per the W3C Baggage value grammar
+// the resource spec defers to (https://github.com/open-telemetry/opentelemetry-specification/pull/2670).
+// A malformed escape sequence is left in the output as-is rather than dropping the attribute,
+// since this parser has never validated attribute syntax.
+std::string PercentDecode(const std::string &value)
+{
+  std::string decoded;
+  decoded.reserve(value.size());
+  for (std::size_t i = 0; i < value.size(); ++i)
+  {
+    if (value[i] == '%' && i + 2 < value.size() &&
+        IsHexDigit(static_cast<unsigned char>(value[i + 1])) &&
+        IsHexDigit(static_cast<unsigned char>(value[i + 2])))
+    {
+      decoded.push_back(static_cast<char>((HexDigitValue(static_cast<unsigned char>(value[i + 1]))
+                                           << 4) |
+                                          HexDigitValue(static_cast<unsigned char>(value[i + 2]))));
+      i += 2;
+    }
+    else
+    {
+      decoded.push_back(value[i]);
+    }
+  }
+  return decoded;
+}
+}  // namespace
 
 Resource ResourceDetector::Create(const ResourceAttributes &attributes,
                                   const std::string &schema_url)
@@ -54,7 +95,7 @@ Resource OTELResourceDetector::Detect() noexcept
       {
         std::string key   = token.substr(0, pos);
         std::string value = token.substr(pos + 1);
-        attributes[key]   = value;
+        attributes[key]   = PercentDecode(value);
       }
     }
   }

--- a/sdk/src/resource/resource_detector.cc
+++ b/sdk/src/resource/resource_detector.cc
@@ -24,11 +24,6 @@ constexpr const char *kOtelServiceName        = "OTEL_SERVICE_NAME";
 
 namespace
 {
-bool IsHexDigit(unsigned char c) noexcept
-{
-  return std::isdigit(c) || (c >= 'A' && c <= 'F') || (c >= 'a' && c <= 'f');
-}
-
 unsigned char HexDigitValue(unsigned char c) noexcept
 {
   return static_cast<unsigned char>(std::isdigit(c) ? c - '0' : std::toupper(c) - 'A' + 10);
@@ -45,19 +40,20 @@ std::string PercentDecode(const std::string &value)
   decoded.reserve(value.size());
   for (std::size_t i = 0; i < value.size(); ++i)
   {
-    if (value[i] == '%' && i + 2 < value.size() &&
-        IsHexDigit(static_cast<unsigned char>(value[i + 1])) &&
-        IsHexDigit(static_cast<unsigned char>(value[i + 2])))
+    if (value[i] == '%' && i + 2 < value.size())
     {
-      decoded.push_back(
-          static_cast<char>((HexDigitValue(static_cast<unsigned char>(value[i + 1])) << 4) |
-                            HexDigitValue(static_cast<unsigned char>(value[i + 2]))));
-      i += 2;
+      unsigned char high = static_cast<unsigned char>(value[i + 1]);
+      unsigned char low  = static_cast<unsigned char>(value[i + 2]);
+      if (std::isxdigit(high) && std::isxdigit(low))
+      {
+        unsigned char unescaped_value =
+            static_cast<unsigned char>((HexDigitValue(high) << 4) | HexDigitValue(low));
+        decoded.push_back(static_cast<char>(unescaped_value));
+        i += 2;
+        continue;
+      }
     }
-    else
-    {
-      decoded.push_back(value[i]);
-    }
+    decoded.push_back(value[i]);
   }
   return decoded;
 }

--- a/sdk/test/resource/resource_test.cc
+++ b/sdk/test/resource/resource_test.cc
@@ -238,6 +238,51 @@ TEST(ResourceTest, OtelResourceDetector)
   unsetenv("OTEL_RESOURCE_ATTRIBUTES");
 }
 
+TEST(ResourceTest, OtelResourceDetectorPercentDecodesValues)
+{
+  std::map<std::string, std::string> expected_attributes = {
+      {"key1", "hello world"}, {"key2", "a,b"}, {"key3", "100%"}};
+
+  setenv("OTEL_RESOURCE_ATTRIBUTES", "key1=hello%20world,key2=a%2Cb,key3=100%25", 1);
+
+  OTELResourceDetector detector;
+  auto resource            = detector.Detect();
+  auto received_attributes = resource.GetAttributes();
+  for (auto &e : received_attributes)
+  {
+    EXPECT_TRUE(expected_attributes.find(e.first) != expected_attributes.end());
+    if (expected_attributes.find(e.first) != expected_attributes.end())
+    {
+      EXPECT_EQ(expected_attributes.find(e.first)->second, nostd::get<std::string>(e.second));
+    }
+  }
+  EXPECT_EQ(received_attributes.size(), expected_attributes.size());
+
+  unsetenv("OTEL_RESOURCE_ATTRIBUTES");
+}
+
+TEST(ResourceTest, OtelResourceDetectorMalformedEscapeLeftAsIs)
+{
+  std::map<std::string, std::string> expected_attributes = {{"key", "100%"}, {"bad", "50%z"}};
+
+  setenv("OTEL_RESOURCE_ATTRIBUTES", "key=100%,bad=50%z", 1);
+
+  OTELResourceDetector detector;
+  auto resource            = detector.Detect();
+  auto received_attributes = resource.GetAttributes();
+  for (auto &e : received_attributes)
+  {
+    EXPECT_TRUE(expected_attributes.find(e.first) != expected_attributes.end());
+    if (expected_attributes.find(e.first) != expected_attributes.end())
+    {
+      EXPECT_EQ(expected_attributes.find(e.first)->second, nostd::get<std::string>(e.second));
+    }
+  }
+  EXPECT_EQ(received_attributes.size(), expected_attributes.size());
+
+  unsetenv("OTEL_RESOURCE_ATTRIBUTES");
+}
+
 TEST(ResourceTest, OtelResourceDetectorServiceNameOverride)
 {
   std::map<std::string, std::string> expected_attributes = {{"service.name", "new_name"}};


### PR DESCRIPTION
## Summary

Fixes #1536.

The OpenTelemetry resource specification now requires values from `OTEL_RESOURCE_ATTRIBUTES` to be decoded using the W3C Baggage value grammar. While looking into this, I noticed that `OTELResourceDetector::Detect()` was parsing the attributes but storing values exactly as they appeared in the environment.

For example:

```text
OTEL_RESOURCE_ATTRIBUTES="key=hello%20world"
```

was producing the value `hello%20world` instead of `hello world`.

This PR adds a small percent-decoding helper in `sdk/src/resource/resource_detector.cc` and applies it when parsing attribute values.

Malformed escape sequences are preserved rather than causing the attribute to be rejected, which matches the existing parser behavior of being permissive instead of validating attribute syntax.

The change is intentionally scoped to value decoding only. Parsing, trimming, and attribute key handling remain unchanged.

## Testing

Added tests covering:

* Common percent-encoded values (`%20`, `%2C`, `%25`).
* Malformed escape sequences (such as a trailing `%` or invalid hex digits).
* Existing `OTELResourceDetector` behavior to ensure there are no regressions.

The full `resource_test` suite passes locally.
