### PR TITLE
[CONFIGURATION] validate and update config files to yaml schema 1.1.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1037,6 +1037,21 @@ jobs:
         name: benchmark_reports
         path: /home/runner/benchmark
 
+  validate_otel_config:
+    name: OTel Config YAML Validation
+    runs-on: ubuntu-24.04
+    steps:
+    - name: Harden the runner (Audit all outbound calls)
+      uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
+      with:
+        egress-policy: audit
+
+    - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+    - name: install dependencies
+      run: sudo ./ci/install_format_tools.sh
+    - name: validate
+      run: ./ci/do_ci.sh validate.otel.config
+
   format:
     name: Format
     runs-on: ubuntu-24.04

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,9 @@ Increment the:
 * [BUILD] Run the ext_http component install test on Windows
   [#4326](https://github.com/open-telemetry/opentelemetry-cpp/pull/4326)
 
+* [CONFIGURATION] validate and update config files to yaml schema 1.1.0
+  [#4374](https://github.com/open-telemetry/opentelemetry-cpp/pull/4374)
+
 * [SDK] Convert SpinLockMutex to std::mutex part 1
   Replace SpinLockMutex with std::mutex in SimpleProcessor,
   SimpleLogRecordProcessor, MeterContext and Meter.

--- a/ci/README.md
+++ b/ci/README.md
@@ -31,6 +31,21 @@ markdownlint .
 shellcheck --severity=error <path to shell script>.sh
 ```
 
+### OTel Configuration YAML Validation
+
+Validates all OpenTelemetry declarative configuration YAML files in the repo
+against the JSON schema pinned in `third_party_release`:
+
+```sh
+./ci/do_ci.sh validate.otel.config
+```
+
+To use a local schema file:
+
+```sh
+OTEL_CONFIG_SCHEMA=/path/to/opentelemetry_configuration.json ./ci/do_ci.sh validate.otel.config
+```
+
 ### Testing
 
 ```sh

--- a/ci/do_ci.sh
+++ b/ci/do_ci.sh
@@ -626,9 +626,10 @@ elif [[ "$1" == "bazel.ubsan" ]]; then
   bazel $BAZEL_STARTUP_OPTIONS test --config=ubsan $BAZEL_TEST_OPTIONS_ASYNC //...
   exit 0
 elif [[ "$1" == "bazel.tsan" ]]; then
-# TODO - potential race condition in Civetweb server used by prometheus-cpp during shutdown
-# https://github.com/civetweb/civetweb/issues/861, so removing prometheus from the test
-  bazel $BAZEL_STARTUP_OPTIONS test --config=tsan $BAZEL_TEST_OPTIONS_ASYNC  -- //... -//exporters/prometheus/...
+# Known intentional race in civetweb (used by prometheus-cpp) during shutdown
+# https://github.com/civetweb/civetweb/issues/1184, so excluding targets that
+# start the civetweb server from the test
+  bazel $BAZEL_STARTUP_OPTIONS test --config=tsan $BAZEL_TEST_OPTIONS_ASYNC -- //... -//exporters/prometheus/... -//examples/configuration:example_yaml_kitchen_sink
   exit 0
 elif [[ "$1" == "bazel.valgrind" ]]; then
   bazel $BAZEL_STARTUP_OPTIONS build $BAZEL_OPTIONS_ASYNC //...

--- a/ci/do_ci.sh
+++ b/ci/do_ci.sh
@@ -657,6 +657,19 @@ elif [[ "$1" == "format" ]]; then
     exit 1
   fi
   exit 0
+elif [[ "$1" == "validate.otel.config" ]]; then
+  OTELCFG_VERSION=$(grep "^opentelemetry-configuration=" "${SRC_DIR}/third_party_release" | cut -d= -f2)
+  if [[ -n "${OTEL_CONFIG_SCHEMA:-}" ]]; then
+    SCHEMA_FILE="${OTEL_CONFIG_SCHEMA}"
+    SCHEMA_TMPFILE=""
+  else
+    SCHEMA_TMPFILE=$(mktemp --suffix=.json)
+    SCHEMA_FILE="${SCHEMA_TMPFILE}"
+    curl -fsSL "https://raw.githubusercontent.com/open-telemetry/opentelemetry-configuration/${OTELCFG_VERSION}/opentelemetry_configuration.json" -o "${SCHEMA_FILE}"
+  fi
+  python3 "${SRC_DIR}/tools/validate_otel_config_yaml.py" --schema "${SCHEMA_FILE}" --schema-version "${OTELCFG_VERSION}"
+  [[ -n "${SCHEMA_TMPFILE}" ]] && rm -f "${SCHEMA_TMPFILE}"
+  exit 0
 elif [[ "$1" == "code.coverage" ]]; then
   cd "${BUILD_DIR}"
   rm -rf *

--- a/ci/install_format_tools.sh
+++ b/ci/install_format_tools.sh
@@ -22,6 +22,9 @@ apt install -y clang-format-${CLANG_VERSION} python3 python3-pip git curl
 # Install cmake_format
 pip3 install --break-system-packages cmake_format==${CMAKE_FORMAT_VERSION}
 
+# Install jsonschema and pyyaml (for YAML configuration schema validation)
+pip3 install --break-system-packages jsonschema pyyaml
+
 # Install buildifier
 curl -L -o /usr/local/bin/buildifier https://github.com/bazelbuild/buildtools/releases/download/${BUILDIFIER_VERSION}/buildifier
 chmod +x /usr/local/bin/buildifier

--- a/examples/configuration/BUILD
+++ b/examples/configuration/BUILD
@@ -4,9 +4,15 @@
 load("@rules_cc//cc:cc_test.bzl", "cc_test")
 
 cc_test(
-    name = "example_yaml",
+    name = "example_yaml_kitchen_sink",
     size = "medium",
     srcs = glob(["*.cc"]) + glob(["*.h"]),
+    args = [
+        "--test",
+        "--yaml",
+        "$(location kitchen-sink.yaml)",
+    ],
+    data = ["kitchen-sink.yaml"],
     defines = [
         "OTEL_HAVE_OTLP_HTTP",
         "OTEL_HAVE_OTLP_GRPC",
@@ -34,6 +40,36 @@ cc_test(
         "//exporters/otlp:otlp_http_metric_exporter_builder",
         "//exporters/otlp:otlp_http_span_exporter_builder",
         "//exporters/prometheus:prometheus_exporter_builder",
+        "//sdk:headers",
+        "//sdk/src/configuration",
+        "//sdk/src/logs",
+        "//sdk/src/metrics",
+        "//sdk/src/trace",
+        "@com_google_googletest//:gtest_main",
+    ],
+)
+
+cc_test(
+    name = "example_yaml_extensions",
+    size = "medium",
+    srcs = glob(["*.cc"]) + glob(["*.h"]),
+    args = [
+        "--test",
+        "--yaml",
+        "$(location extensions.yaml)",
+    ],
+    data = ["extensions.yaml"],
+    tags = [
+        "test",
+        "yaml",
+    ],
+    deps = [
+        "//api",
+        "//examples/common/logs_foo_library:common_logs_foo_library",
+        "//examples/common/metrics_foo_library:common_metrics_foo_library",
+        "//exporters/ostream:ostream_log_record_exporter_builder",
+        "//exporters/ostream:ostream_metric_exporter_builder",
+        "//exporters/ostream:ostream_span_exporter_builder",
         "//sdk:headers",
         "//sdk/src/configuration",
         "//sdk/src/logs",

--- a/examples/configuration/CMakeLists.txt
+++ b/examples/configuration/CMakeLists.txt
@@ -74,9 +74,15 @@ else()
 endif()
 
 if(BUILD_TESTING)
-  add_test(NAME examples.example_yaml_kitchen_sink
-           COMMAND $<TARGET_FILE:example_yaml> --test --yaml
-                   ${CMAKE_CURRENT_SOURCE_DIR}/kitchen-sink.yaml)
+  if(WITH_OTLP_HTTP
+     AND WITH_OTLP_GRPC
+     AND WITH_OTLP_FILE
+     AND WITH_PROMETHEUS)
+    add_test(NAME examples.example_yaml_kitchen_sink
+             COMMAND $<TARGET_FILE:example_yaml> --test --yaml
+                     ${CMAKE_CURRENT_SOURCE_DIR}/kitchen-sink.yaml)
+  endif()
+
   add_test(NAME examples.example_yaml_extensions
            COMMAND $<TARGET_FILE:example_yaml> --test --yaml
                    ${CMAKE_CURRENT_SOURCE_DIR}/extensions.yaml)

--- a/examples/configuration/CMakeLists.txt
+++ b/examples/configuration/CMakeLists.txt
@@ -74,5 +74,10 @@ else()
 endif()
 
 if(BUILD_TESTING)
-  add_test(NAME examples.example_yaml COMMAND "$<TARGET_FILE:example_yaml>")
+  add_test(NAME examples.example_yaml_kitchen_sink
+           COMMAND $<TARGET_FILE:example_yaml> --test --yaml
+                   ${CMAKE_CURRENT_SOURCE_DIR}/kitchen-sink.yaml)
+  add_test(NAME examples.example_yaml_extensions
+           COMMAND $<TARGET_FILE:example_yaml> --test --yaml
+                   ${CMAKE_CURRENT_SOURCE_DIR}/extensions.yaml)
 endif()

--- a/examples/configuration/extensions.yaml
+++ b/examples/configuration/extensions.yaml
@@ -1,82 +1,79 @@
 # Copyright The OpenTelemetry Authors
 # SPDX-License-Identifier: Apache-2.0
 
-# The file format version
-file_format: "1.0"
+# extensions.yaml demonstrates the extension points in the configuration model.
+# Each my_custom_* key maps to a builder that can be registered via Registry::SetExtension*Builder (see main.cc).
+file_format: "1.1"
 
-# Configure if the SDK is disabled or not. This is not required to be provided
-# to ensure the SDK isn't disabled, the default value when this is not provided
-# is for the SDK to be enabled.
-#
-# Environment variable: OTEL_SDK_DISABLED
+# Configure if the SDK is disabled or not.
+# If omitted or null, false is used.
 disabled: false
 
 # Configure text map context propagators.
-#
-# Environment variable: OTEL_PROPAGATORS
+# If omitted, a noop propagator is used.
 propagator:
-  # composite: [tracecontext, baggage, b3, b3multi, jaeger, xray, ottrace]
-  composite: tracecontext
+  composite:
+    - tracecontext:
 
 # Configure tracer provider.
 tracer_provider:
   # Configure span processors.
   processors:
-    # Configure a batch span processor.
-    - batch:
-        # Configure exporter.
-        #
-        # Environment variable: OTEL_TRACES_EXPORTER
-        exporter:
-          # Configure exporter to be zipkin.
-          zipkin:
-            # Configure endpoint.
-            #
-            # Environment variable: OTEL_EXPORTER_ZIPKIN_ENDPOINT
-            endpoint: http://localhost:9411/api/v2/spans
-            # Configure max time (in milliseconds) to wait for each export.
-            #
-            # Environment variable: OTEL_EXPORTER_ZIPKIN_TIMEOUT
-            timeout: 10000
     # Configure a simple span processor.
     - simple:
-        # Configure exporter.
         exporter:
-          # Configure exporter to be console.
-          console: {}
+          console:
+    # Registry::SetExtensionSpanProcessorBuilder, see custom_span_processor.cc.
     - my_custom_span_processor:
         comment: "This is a span processor extension point, with properties."
     - batch:
         exporter:
+          # Registry::SetExtensionSpanExporterBuilder, see custom_span_exporter.cc.
           my_custom_span_exporter:
             comment: "This is a span exporter extension point, with properties."
 
   # Configure the sampler.
   sampler:
+    # Registry::SetExtensionSamplerBuilder, see custom_sampler.cc.
     my_custom_sampler:
       comment: "This is a sampler extension point, with properties."
 
 meter_provider:
   readers:
+    - periodic:
+        exporter:
+          console:
     - pull:
         exporter:
+          # Registry::SetExtensionPullMetricExporterBuilder, see custom_pull_metric_exporter.cc.
           my_custom_pull_metric_exporter:
             comment: "This is a pull metric exporter extension point, with properties."
     - periodic:
         exporter:
+          # Registry::SetExtensionPushMetricExporterBuilder, see custom_push_metric_exporter.cc.
           my_custom_push_metric_exporter:
             comment: "This is a push metric exporter extension point, with properties."
+        producers:
+          # Registry::SetExtensionMetricProducerBuilder. No example implementation in this directory.
+          - my_custom_metric_producer:
+              comment: "This is a metric producer extension point, with properties."
 
 logger_provider:
   processors:
     - simple:
-        # Configure exporter.
         exporter:
-          # Configure exporter to be console.
-          console: {}
+          console:
+    # Registry::SetExtensionLogRecordProcessorBuilder, see custom_log_record_processor.cc.
     - my_custom_log_record_processor:
         comment: "This is a log record processor extension point, with properties."
     - batch:
         exporter:
+          # Registry::SetExtensionLogRecordExporterBuilder, see custom_log_record_exporter.cc.
           my_custom_log_record_exporter:
             comment: "This is a log record exporter extension point, with properties."
+resource:
+  detection/development:
+    detectors:
+      # Registry::SetExtensionResourceDetectorBuilder. No example implementation in this directory.
+      - my_custom_detector:
+          comment: "This is a resource detector extension point, with properties."

--- a/examples/configuration/kitchen-sink.yaml
+++ b/examples/configuration/kitchen-sink.yaml
@@ -227,7 +227,7 @@ meter_provider:
             host: localhost
             # Configure port.
             # If omitted or null, 9464 is used.
-            port: 9464
+            port: 19464
             # Configure if scope info metric is produced.
             # If omitted or null, true is used.
             scope_info_enabled: true

--- a/examples/configuration/kitchen-sink.yaml
+++ b/examples/configuration/kitchen-sink.yaml
@@ -11,7 +11,7 @@
 # The file format version.
 # The yaml format is documented at
 # https://github.com/open-telemetry/opentelemetry-configuration/tree/main/schema
-file_format: "1.0-rc.1"
+file_format: "1.1"
 # Configure if the SDK is disabled or not.
 # If omitted or null, false is used.
 disabled: false
@@ -54,18 +54,20 @@ logger_provider:
           # Configure exporter to be OTLP with HTTP transport.
           otlp_http:
             endpoint: http://localhost:4318/v1/logs
-            # Configure certificate used to verify a server's TLS credentials.
-            # Absolute path to certificate file in PEM format.
-            # If omitted or null, system default certificate verification is used for secure connections.
-            certificate_file: /app/cert.pem
-            # Configure mTLS private client key.
-            # Absolute path to client key file in PEM format. If set, .client_certificate must also be set.
-            # If omitted or null, mTLS is not used.
-            client_key_file: /app/cert.pem
-            # Configure mTLS client certificate.
-            # Absolute path to client certificate file in PEM format. If set, .client_key must also be set.
-            # If omitted or null, mTLS is not used.
-            client_certificate_file: /app/cert.pem
+            # Configure TLS settings.
+            tls:
+              # Configure certificate used to verify a server's TLS credentials.
+              # Absolute path to certificate file in PEM format.
+              # If omitted or null, system default certificate verification is used for secure connections.
+              ca_file: /app/cert.pem
+              # Configure mTLS private client key.
+              # Absolute path to client key file in PEM format. If set, .cert_file must also be set.
+              # If omitted or null, mTLS is not used.
+              key_file: /app/cert.pem
+              # Configure mTLS client certificate.
+              # Absolute path to client certificate file in PEM format. If set, .key_file must also be set.
+              # If omitted or null, mTLS is not used.
+              cert_file: /app/cert.pem
             # Configure headers. Entries have higher priority than entries from .headers_list.
             # If an entry's .value is null, the entry is ignored.
             headers:
@@ -96,18 +98,24 @@ logger_provider:
             # Configure endpoint.
             # If omitted or null, http://localhost:4317 is used.
             endpoint: http://localhost:4317
-            # Configure certificate used to verify a server's TLS credentials.
-            # Absolute path to certificate file in PEM format.
-            # If omitted or null, system default certificate verification is used for secure connections.
-            certificate_file: /app/cert.pem
-            # Configure mTLS private client key.
-            # Absolute path to client key file in PEM format. If set, .client_certificate must also be set.
-            # If omitted or null, mTLS is not used.
-            client_key_file: /app/cert.pem
-            # Configure mTLS client certificate.
-            # Absolute path to client certificate file in PEM format. If set, .client_key must also be set.
-            # If omitted or null, mTLS is not used.
-            client_certificate_file: /app/cert.pem
+            # Configure TLS settings.
+            tls:
+              # Configure certificate used to verify a server's TLS credentials.
+              # Absolute path to certificate file in PEM format.
+              # If omitted or null, system default certificate verification is used for secure connections.
+              ca_file: /app/cert.pem
+              # Configure mTLS private client key.
+              # Absolute path to client key file in PEM format. If set, .cert_file must also be set.
+              # If omitted or null, mTLS is not used.
+              key_file: /app/cert.pem
+              # Configure mTLS client certificate.
+              # Absolute path to client certificate file in PEM format. If set, .key_file must also be set.
+              # If omitted or null, mTLS is not used.
+              cert_file: /app/cert.pem
+              # Configure client transport security for the exporter's connection.
+              # Only applicable when .endpoint is provided without http or https scheme. Implementations may choose to ignore .insecure.
+              # If omitted or null, false is used.
+              insecure: false
             # Configure headers. Entries have higher priority than entries from .headers_list.
             # If an entry's .value is null, the entry is ignored.
             headers:
@@ -125,10 +133,6 @@ logger_provider:
             # Value must be non-negative. A value of 0 indicates no limit (infinity).
             # If omitted or null, 10000 is used.
             timeout: 10000
-            # Configure client transport security for the exporter's connection.
-            # Only applicable when .endpoint is provided without http or https scheme. Implementations may choose to ignore .insecure.
-            # If omitted or null, false is used.
-            insecure: false
     - # Configure a batch log record processor.
       batch:
         # Configure exporter.
@@ -157,6 +161,9 @@ logger_provider:
         exporter:
           # Configure exporter to be console.
           console:
+    # Configure an event to span event bridge log record processor.
+    # This type is in development and subject to breaking changes in minor versions.
+    #- event_to_span_event_bridge/development:
   # Configure log record limits. See also attribute_limits.
   limits:
     # Configure max attribute value size. Overrides .attribute_limits.attribute_value_length_limit.
@@ -173,7 +180,13 @@ logger_provider:
     # Configure the default logger config used there is no matching entry in .logger_configurator/development.loggers.
     default_config:
       # Configure if the logger is enabled or not.
-      disabled: true
+      enabled: false
+      # Configure minimum severity. Values include: trace, trace2, trace3, trace4, debug, debug2, debug3, debug4, info, info2, info3, info4, warn, warn2, warn3, warn4, error, error2, error3, error4, fatal, fatal2, fatal3, fatal4.
+      # If omitted, severity filtering is not applied.
+      minimum_severity: warn
+      # Configure if trace-based filtering is enabled. A boolean indication of whether the logger should drop log records associated with an unsampled trace.
+      # If omitted or null, false is used.
+      trace_based: false
     # Configure loggers.
     loggers:
       - # Configure logger names to match, evaluated as follows:
@@ -184,7 +197,19 @@ logger_provider:
         # The logger config.
         config:
           # Configure if the logger is enabled or not.
-          disabled: false
+          enabled: true
+      - name: com.example.foo.*
+        config:
+          enabled: true
+          # Configure minimum severity. Values include: trace, trace2, trace3, trace4, debug, debug2, debug3, debug4, info, info2, info3, info4, warn, warn2, warn3, warn4, error, error2, error3, error4, fatal, fatal2, fatal3, fatal4.
+          # If omitted, severity filtering is not applied.
+          minimum_severity: info
+          # Configure if trace-based filtering is enabled. A boolean indication of whether the logger should drop log records associated with an unsampled trace.
+          # If omitted or null, false is used.
+          trace_based: true
+      - name: noisy.*
+        config:
+          enabled: false
 # Configure meter provider.
 # If omitted, a noop meter provider is used.
 meter_provider:
@@ -203,17 +228,14 @@ meter_provider:
             # Configure port.
             # If omitted or null, 9464 is used.
             port: 9464
-            # Configure Prometheus Exporter to produce metrics without a unit suffix or UNIT metadata.
-            # If omitted or null, false is used.
-            without_units: false
-            # Configure Prometheus Exporter to produce metrics without a type suffix.
-            # If omitted or null, false is used.
-            without_type_suffix: false
-            # Configure Prometheus Exporter to produce metrics without a scope info metric.
-            # If omitted or null, false is used.
-            without_scope_info: false
-            # Configure Prometheus Exporter to add resource attributes as metrics attributes.
-            with_resource_constant_labels:
+            # Configure if scope info metric is produced.
+            # If omitted or null, true is used.
+            scope_info_enabled: true
+            # Configure if target info metric is produced.
+            # If omitted or null, true is used.
+            target_info_enabled/development: true
+            # Configure resource attributes to add as metric attributes.
+            resource_constant_labels:
               # Configure resource attributes to be included.
               # Attribute keys from resources are evaluated to match as follows:
               #  * If the value of the attribute key exactly matches.
@@ -221,7 +243,7 @@ meter_provider:
               # If omitted, no resource attributes are included.
               included:
                 - "service*"
-              # Configure resource attributes to be excluded. Applies after .with_resource_constant_labels.included (i.e. excluded has higher priority than included).
+              # Configure resource attributes to be excluded. Applies after .resource_constant_labels.included (i.e. excluded has higher priority than included).
               # Attribute keys from resources are evaluated to match as follows:
               #  * If the value of the attribute key exactly matches.
               #  * If the value of the attribute key matches the wildcard pattern, where '?' matches any single character and '*' matches any number of characters including none.
@@ -269,6 +291,9 @@ meter_provider:
         # Value must be non-negative. A value of 0 indicates no limit (infinity).
         # If omitted or null, 30000 is used.
         timeout: 30000
+        # Configure maximum export batch size. Added in schema 1.1.0.
+        # If omitted or null, no limit is used.
+        max_export_batch_size/development: 512
         # Configure exporter.
         exporter:
           # Configure exporter to be OTLP with HTTP transport.
@@ -276,18 +301,20 @@ meter_provider:
             # Configure endpoint, including the metric specific path.
             # If omitted or null, http://localhost:4318/v1/metrics is used.
             endpoint: http://localhost:4318/v1/metrics
-            # Configure certificate used to verify a server's TLS credentials.
-            # Absolute path to certificate file in PEM format.
-            # If omitted or null, system default certificate verification is used for secure connections.
-            certificate_file: /app/cert.pem
-            # Configure mTLS private client key.
-            # Absolute path to client key file in PEM format. If set, .client_certificate must also be set.
-            # If omitted or null, mTLS is not used.
-            client_key_file: /app/cert.pem
-            # Configure mTLS client certificate.
-            # Absolute path to client certificate file in PEM format. If set, .client_key must also be set.
-            # If omitted or null, mTLS is not used.
-            client_certificate_file: /app/cert.pem
+            # Configure TLS settings.
+            tls:
+              # Configure certificate used to verify a server's TLS credentials.
+              # Absolute path to certificate file in PEM format.
+              # If omitted or null, system default certificate verification is used for secure connections.
+              ca_file: /app/cert.pem
+              # Configure mTLS private client key.
+              # Absolute path to client key file in PEM format. If set, .cert_file must also be set.
+              # If omitted or null, mTLS is not used.
+              key_file: /app/cert.pem
+              # Configure mTLS client certificate.
+              # Absolute path to client certificate file in PEM format. If set, .key_file must also be set.
+              # If omitted or null, mTLS is not used.
+              cert_file: /app/cert.pem
             # Configure headers. Entries have higher priority than entries from .headers_list.
             # If an entry's .value is null, the entry is ignored.
             headers:
@@ -357,18 +384,24 @@ meter_provider:
             # Configure endpoint.
             # If omitted or null, http://localhost:4317 is used.
             endpoint: http://localhost:4317
-            # Configure certificate used to verify a server's TLS credentials.
-            # Absolute path to certificate file in PEM format.
-            # If omitted or null, system default certificate verification is used for secure connections.
-            certificate_file: /app/cert.pem
-            # Configure mTLS private client key.
-            # Absolute path to client key file in PEM format. If set, .client_certificate must also be set.
-            # If omitted or null, mTLS is not used.
-            client_key_file: /app/cert.pem
-            # Configure mTLS client certificate.
-            # Absolute path to client certificate file in PEM format. If set, .client_key must also be set.
-            # If omitted or null, mTLS is not used.
-            client_certificate_file: /app/cert.pem
+            # Configure TLS settings.
+            tls:
+              # Configure certificate used to verify a server's TLS credentials.
+              # Absolute path to certificate file in PEM format.
+              # If omitted or null, system default certificate verification is used for secure connections.
+              ca_file: /app/cert.pem
+              # Configure mTLS private client key.
+              # Absolute path to client key file in PEM format. If set, .cert_file must also be set.
+              # If omitted or null, mTLS is not used.
+              key_file: /app/cert.pem
+              # Configure mTLS client certificate.
+              # Absolute path to client certificate file in PEM format. If set, .key_file must also be set.
+              # If omitted or null, mTLS is not used.
+              cert_file: /app/cert.pem
+              # Configure client transport security for the exporter's connection.
+              # Only applicable when .endpoint is provided without http or https scheme. Implementations may choose to ignore .insecure.
+              # If omitted or null, false is used.
+              insecure: false
             # Configure headers. Entries have higher priority than entries from .headers_list.
             # If an entry's .value is null, the entry is ignored.
             headers:
@@ -386,10 +419,6 @@ meter_provider:
             # Value must be non-negative. A value of 0 indicates no limit (infinity).
             # If omitted or null, 10000 is used.
             timeout: 10000
-            # Configure client transport security for the exporter's connection.
-            # Only applicable when .endpoint is provided without http or https scheme. Implementations may choose to ignore .insecure.
-            # If omitted or null, false is used.
-            insecure: false
             # Configure temporality preference.
             # Values include: cumulative, delta, low_memory. For behavior of values, see https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/metrics/sdk_exporters/otlp.md.
             # If omitted or null, cumulative is used.
@@ -524,7 +553,7 @@ meter_provider:
     # Configure the default meter config used there is no matching entry in .meter_configurator/development.meters.
     default_config:
       # Configure if the meter is enabled or not.
-      disabled: true
+      enabled: false
     # Configure meters.
     meters:
       - # Configure meter names to match, evaluated as follows:
@@ -535,12 +564,12 @@ meter_provider:
         # The meter config.
         config:
           # Configure if the meter is enabled or not.
-          disabled: false
+          enabled: true
 # Configure text map context propagators.
 # If omitted, a noop propagator is used.
 propagator:
   # Configure the propagators in the composite text map propagator. Entries from .composite_list are appended to the list here with duplicates filtered out.
-  # Built-in propagator keys include: tracecontext, baggage, b3, b3multi, jaeger, ottrace. Known third party keys include: xray.
+  # Built-in propagator keys include: tracecontext, baggage, b3, b3multi. Known third party keys include: xray.
   # If the resolved list of propagators (from .composite and .composite_list) is empty, a noop propagator is used.
   composite:
     - # Include the w3c trace context propagator.
@@ -560,7 +589,7 @@ propagator:
 
   # Configure the propagators in the composite text map propagator. Entries are appended to .composite with duplicates filtered out.
   # The value is a comma separated list of propagator identifiers matching the format of OTEL_PROPAGATORS. See https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/configuration/sdk-environment-variables.md#general-sdk-configuration for details.
-  # Built-in propagator identifiers include: tracecontext, baggage, b3, b3multi, jaeger, ottrace. Known third party identifiers include: xray.
+  # Built-in propagator identifiers include: tracecontext, baggage, b3, b3multi. Known third party identifiers include: xray.
   # If the resolved list of propagators (from .composite and .composite_list) is empty, a noop propagator is used.
 #  composite_list: "tracecontext,baggage,b3,b3multi,jaeger,ottrace,xray"
 
@@ -595,18 +624,20 @@ tracer_provider:
             # Configure endpoint, including the trace specific path.
             # If omitted or null, http://localhost:4318/v1/traces is used.
             endpoint: http://localhost:4318/v1/traces
-            # Configure certificate used to verify a server's TLS credentials.
-            # Absolute path to certificate file in PEM format.
-            # If omitted or null, system default certificate verification is used for secure connections.
-            certificate_file: /app/cert.pem
-            # Configure mTLS private client key.
-            # Absolute path to client key file in PEM format. If set, .client_certificate must also be set.
-            # If omitted or null, mTLS is not used.
-            client_key_file: /app/cert.pem
-            # Configure mTLS client certificate.
-            # Absolute path to client certificate file in PEM format. If set, .client_key must also be set.
-            # If omitted or null, mTLS is not used.
-            client_certificate_file: /app/cert.pem
+            # Configure TLS settings.
+            tls:
+              # Configure certificate used to verify a server's TLS credentials.
+              # Absolute path to certificate file in PEM format.
+              # If omitted or null, system default certificate verification is used for secure connections.
+              ca_file: /app/cert.pem
+              # Configure mTLS private client key.
+              # Absolute path to client key file in PEM format. If set, .cert_file must also be set.
+              # If omitted or null, mTLS is not used.
+              key_file: /app/cert.pem
+              # Configure mTLS client certificate.
+              # Absolute path to client certificate file in PEM format. If set, .key_file must also be set.
+              # If omitted or null, mTLS is not used.
+              cert_file: /app/cert.pem
             # Configure headers. Entries have higher priority than entries from .headers_list.
             # If an entry's .value is null, the entry is ignored.
             headers:
@@ -637,18 +668,24 @@ tracer_provider:
             # Configure endpoint.
             # If omitted or null, http://localhost:4317 is used.
             endpoint: http://localhost:4317
-            # Configure certificate used to verify a server's TLS credentials.
-            # Absolute path to certificate file in PEM format.
-            # If omitted or null, system default certificate verification is used for secure connections.
-            certificate_file: /app/cert.pem
-            # Configure mTLS private client key.
-            # Absolute path to client key file in PEM format. If set, .client_certificate must also be set.
-            # If omitted or null, mTLS is not used.
-            client_key_file: /app/cert.pem
-            # Configure mTLS client certificate.
-            # Absolute path to client certificate file in PEM format. If set, .client_key must also be set.
-            # If omitted or null, mTLS is not used.
-            client_certificate_file: /app/cert.pem
+            # Configure TLS settings.
+            tls:
+              # Configure certificate used to verify a server's TLS credentials.
+              # Absolute path to certificate file in PEM format.
+              # If omitted or null, system default certificate verification is used for secure connections.
+              ca_file: /app/cert.pem
+              # Configure mTLS private client key.
+              # Absolute path to client key file in PEM format. If set, .cert_file must also be set.
+              # If omitted or null, mTLS is not used.
+              key_file: /app/cert.pem
+              # Configure mTLS client certificate.
+              # Absolute path to client certificate file in PEM format. If set, .key_file must also be set.
+              # If omitted or null, mTLS is not used.
+              cert_file: /app/cert.pem
+              # Configure client transport security for the exporter's connection.
+              # Only applicable when .endpoint is provided without http or https scheme. Implementations may choose to ignore .insecure.
+              # If omitted or null, false is used.
+              insecure: false
             # Configure headers. Entries have higher priority than entries from .headers_list.
             # If an entry's .value is null, the entry is ignored.
             headers:
@@ -666,10 +703,6 @@ tracer_provider:
             # Value must be non-negative. A value of 0 indicates no limit (infinity).
             # If omitted or null, 10000 is used.
             timeout: 10000
-            # Configure client transport security for the exporter's connection.
-            # Only applicable when .endpoint is provided without http or https scheme. Implementations may choose to ignore .insecure.
-            # If omitted or null, false is used.
-            insecure: false
     - # Configure a batch span processor.
       batch:
         # Configure exporter.
@@ -692,19 +725,6 @@ tracer_provider:
             # Values include stdout, or scheme+destination. For example: file:///path/to/file.jsonl.
             # If omitted or null, stdout is used.
             output_stream: stdout
-    - # Configure a batch span processor.
-      batch:
-        # Configure exporter.
-        exporter:
-          # Configure exporter to be zipkin.
-          zipkin:
-            # Configure endpoint.
-            # If omitted or null, http://localhost:9411/api/v2/spans is used.
-            endpoint: http://localhost:9411/api/v2/spans
-            # Configure max time (in milliseconds) to wait for each export.
-            # Value must be non-negative. A value of 0 indicates indefinite.
-            # If omitted or null, 10000 is used.
-            timeout: 10000
     - # Configure a simple span processor.
       simple:
         # Configure exporter.
@@ -737,19 +757,86 @@ tracer_provider:
     # Value must be non-negative.
     # If omitted or null, 128 is used.
     link_attribute_count_limit: 128
+  # Configure the trace and span ID generator.
+  # If omitted, RandomIdGenerator is used.
+  id_generator:
+    # Use the built-in random ID generator.
+    random:
   # Configure the sampler.
   # If omitted, parent based sampler with a root of always_on is used.
   sampler:
-    # Configure sampler to be parent_based.
+    # parent_based honors upstream sampling decisions; the root sampler decides new traces.
     parent_based:
-      # Configure root sampler.
+      # Configure root sampler (applies when there is no parent span).
       # If omitted or null, always_on is used.
       root:
-        # Configure sampler to be trace_id_ratio_based.
-        trace_id_ratio_based:
-          # Configure trace_id_ratio.
-          # If omitted or null, 1.0 is used.
-          ratio: 0.0001
+        # Configure sampler to be composite.
+        # This type is in development and subject to breaking changes in minor versions.
+        composite/development:
+          # Configure sampler to be rule_based.
+          # Rules are evaluated in order; the first matching rule's sampler is applied.
+          # Each rule may specify multiple conditions; all conditions must match for the rule to apply.
+          # If no conditions are specified, the rule matches all spans that reach it.
+          # If no rules match, the span is not sampled.
+          rule_based:
+            rules:
+              - # span_kinds: if the span's kind matches any listed value, the condition matches. If omitted, ignore.
+                # Values include: client, consumer, internal, producer, server.
+                span_kinds:
+                  - internal
+                sampler:
+                  # Configure sampler to be always_on.
+                  always_on:
+              - # attribute_patterns: match a single attribute's value against wildcard patterns.
+                # '?' matches any single character, '*' matches any number of characters including none. Matching is case-sensitive.
+                # Non-string attributes use their string representation (e.g., '4*' matches http.response.status_code 400-499).
+                # For array attributes, if any item matches, it is considered a match.
+                attribute_patterns:
+                  key: http.url
+                  # included: value patterns to include. If omitted, all values are included.
+                  included:
+                    - .*/health*
+                  # excluded: value patterns to exclude. Applies after included; excluded has higher priority than included.
+                  excluded:
+                    - .*/healthz/live
+                sampler:
+                  # Configure sampler to be always_off.
+                  always_off:
+              - # attribute_values: match a single attribute against exact string values.
+                # Non-string attributes use their string representation (e.g., "404" matches http.response.status_code 404).
+                # For array attributes, if any item matches, it is considered a match.
+                attribute_values:
+                  key: http.response.status_code
+                  # If the attribute's value matches any of these, the condition matches.
+                  values:
+                    - "500"
+                    - "503"
+                sampler:
+                  # Configure sampler to be always_on.
+                  always_on:
+              - span_kinds:
+                  - server
+                  - consumer
+                # parent: match by parent span type. Values include: local, none (trace root), remote. If omitted, ignore.
+                parent:
+                  - none
+                sampler:
+                  # Configure sampler to be parent_threshold.
+                  parent_threshold:
+                    # Sampler to use when there is no parent.
+                    root:
+                      # Configure sampler to be ratio-based probability sampling using W3C Trace Context Level 2 randomness features.
+                      probability:
+                        # Configure sampling ratio. Value must be in range [0.0, 1.0].
+                        # If omitted or null, 1.0 is used.
+                        ratio: 0.25
+              - # No conditions: matches all spans that reach this rule (catch-all).
+                sampler:
+                  # Configure sampler to be ratio-based probability sampling using W3C Trace Context Level 2 randomness features.
+                  probability:
+                    # Configure sampling ratio. Value must be in range [0.0, 1.0].
+                    # If omitted or null, 1.0 is used.
+                    ratio: 0.01
       # Configure remote_parent_sampled sampler.
       # If omitted or null, always_on is used.
       remote_parent_sampled:
@@ -758,25 +845,33 @@ tracer_provider:
       # Configure remote_parent_not_sampled sampler.
       # If omitted or null, always_off is used.
       remote_parent_not_sampled:
-        # Configure sampler to be always_off.
-        always_off:
+        # trace_id_ratio_based uses trace ID hash for consistent cross-service sampling.
+        # Note: The trace_id_ratio_based sampler is deprecated in favor of the probability sampler
+        trace_id_ratio_based:
+          # Configure sampling ratio. Value must be in range [0.0, 1.0].
+          # If omitted or null, 1.0 is used.
+          ratio: 0.001
       # Configure local_parent_sampled sampler.
       # If omitted or null, always_on is used.
       local_parent_sampled:
-        # Configure sampler to be always_on.
-        always_on:
+        # Configure sampler to be always_off.
+        always_off:
       # Configure local_parent_not_sampled sampler.
       # If omitted or null, always_off is used.
       local_parent_not_sampled:
-        # Configure sampler to be always_off.
-        always_off:
+        # probability/development: ratio-based probability sampling using W3C Trace Context Level 2 randomness features.
+        probability/development:
+          # Configure sampling ratio. Value must be in range [0.0, 1.0].
+          # If omitted or null, 1.0 is used.
+          ratio: 0.001
+
   # Configure tracers.
   # This type is in development and subject to breaking changes in minor versions.
   tracer_configurator/development:
     # Configure the default tracer config used there is no matching entry in .tracer_configurator/development.tracers.
     default_config:
       # Configure if the tracer is enabled or not.
-      disabled: true
+      enabled: false
     # Configure tracers.
     tracers:
       - # Configure tracer names to match, evaluated as follows:
@@ -787,7 +882,7 @@ tracer_provider:
         # The tracer config.
         config:
           # Configure if the tracer is enabled or not.
-          disabled: false
+          enabled: true
 # Configure resource for all signals.
 # If omitted, the default resource is used.
 resource:
@@ -857,6 +952,8 @@ resource:
         process:
       - # Enable the service detector, which populates service.name based on the OTEL_SERVICE_NAME environment variable and service.instance.id.
         service:
+      - # Enable an extension resource detector registered by name.
+        my_custom_detector:
   # Configure resource schema URL.
   # If omitted or null, no schema URL is used.
   schema_url: https://opentelemetry.io/schemas/1.16.0
@@ -866,17 +963,6 @@ instrumentation/development:
   # Configure general SemConv options that may apply to multiple languages and instrumentations.
   # Instrumenation may merge general config options with the language specific configuration at .instrumentation.<language>.
   general:
-    # Configure instrumentations following the peer semantic conventions.
-    # See peer semantic conventions: https://opentelemetry.io/docs/specs/semconv/attributes-registry/peer/
-    peer:
-      # Configure the service mapping for instrumentations following peer.service semantic conventions.
-      # Each entry is a key value pair where "peer" defines the IP address and "service" defines the corresponding logical name of the service.
-      # See peer.service semantic conventions: https://opentelemetry.io/docs/specs/semconv/general/attributes/#general-remote-service-attributes
-      service_mapping:
-        - peer: 1.2.3.4
-          service: FooService
-        - peer: 2.3.4.5
-          service: BarService
     # Configure instrumentations following the http semantic conventions.
     # See http semantic conventions: https://opentelemetry.io/docs/specs/semconv/http/
     http:

--- a/functional/configuration/shelltests/prometheus_translation_broken.test
+++ b/functional/configuration/shelltests/prometheus_translation_broken.test
@@ -3,6 +3,6 @@
 
 $ example_yaml --test --yaml shelltests/prometheus_translation_broken.yaml
 >
-[ERROR] <shelltests/prometheus_translation_broken.yaml>:9[10](164): Illegal TranslationStrategy: broken
+[ERROR] <shelltests/prometheus_translation_broken.yaml>:10[10](238): Illegal TranslationStrategy: broken
 FAILED TO PARSE MODEL
 >= 1

--- a/functional/configuration/shelltests/prometheus_translation_broken.yaml
+++ b/functional/configuration/shelltests/prometheus_translation_broken.yaml
@@ -1,5 +1,6 @@
 # Copyright The OpenTelemetry Authors
 # SPDX-License-Identifier: Apache-2.0
+# SKIP_SCHEMA_VALIDATION: intentionally invalid to test runtime rejection
 
 file_format: "1.0"
 

--- a/functional/configuration/shelltests/prometheus_translation_no.yaml
+++ b/functional/configuration/shelltests/prometheus_translation_no.yaml
@@ -1,5 +1,6 @@
 # Copyright The OpenTelemetry Authors
 # SPDX-License-Identifier: Apache-2.0
+# SKIP_SCHEMA_VALIDATION: translation_strategy 'NoTranslation' renamed to 'no_translation/development' in schema v1.0; C++ parser not yet updated
 
 file_format: "1.0"
 

--- a/functional/configuration/shelltests/prometheus_translation_no_utf8.yaml
+++ b/functional/configuration/shelltests/prometheus_translation_no_utf8.yaml
@@ -1,5 +1,6 @@
 # Copyright The OpenTelemetry Authors
 # SPDX-License-Identifier: Apache-2.0
+# SKIP_SCHEMA_VALIDATION: translation_strategy 'NoUTF8EscapingWithSuffixes' renamed to 'no_utf8_escaping_with_suffixes/development' in schema v1.0; C++ parser not yet updated
 
 file_format: "1.0"
 

--- a/functional/configuration/shelltests/prometheus_translation_with_suffixes.yaml
+++ b/functional/configuration/shelltests/prometheus_translation_with_suffixes.yaml
@@ -1,5 +1,6 @@
 # Copyright The OpenTelemetry Authors
 # SPDX-License-Identifier: Apache-2.0
+# SKIP_SCHEMA_VALIDATION: translation_strategy 'UnderscoreEscapingWithSuffixes' renamed to 'underscore_escaping_with_suffixes' in schema v1.0; C++ parser not yet updated
 
 file_format: "1.0"
 

--- a/functional/configuration/shelltests/prometheus_translation_without_suffixes.yaml
+++ b/functional/configuration/shelltests/prometheus_translation_without_suffixes.yaml
@@ -1,5 +1,6 @@
 # Copyright The OpenTelemetry Authors
 # SPDX-License-Identifier: Apache-2.0
+# SKIP_SCHEMA_VALIDATION: translation_strategy 'UnderscoreEscapingWithoutSuffixes' renamed to 'underscore_escaping_without_suffixes/development' in schema v1.0; C++ parser not yet updated
 
 file_format: "1.0"
 

--- a/functional/configuration/shelltests/propagator_broken.test
+++ b/functional/configuration/shelltests/propagator_broken.test
@@ -3,6 +3,6 @@
 
 $ example_yaml --test --yaml shelltests/propagator_broken.yaml
 >
-[ERROR] <shelltests/propagator_broken.yaml>:10[6](206): Illegal composite child 2, properties count: 3
+[ERROR] <shelltests/propagator_broken.yaml>:11[6](280): Illegal composite child 2, properties count: 3
 FAILED TO PARSE MODEL
 >= 1

--- a/functional/configuration/shelltests/propagator_broken.yaml
+++ b/functional/configuration/shelltests/propagator_broken.yaml
@@ -1,5 +1,6 @@
 # Copyright The OpenTelemetry Authors
 # SPDX-License-Identifier: Apache-2.0
+# SKIP_SCHEMA_VALIDATION: intentionally invalid to test runtime rejection
 
 file_format: "1.0"
 

--- a/functional/configuration/shelltests/sampler_jaeger.yaml
+++ b/functional/configuration/shelltests/sampler_jaeger.yaml
@@ -1,5 +1,6 @@
 # Copyright The OpenTelemetry Authors
 # SPDX-License-Identifier: Apache-2.0
+# SKIP_SCHEMA_VALIDATION: intentionally invalid to test runtime rejection
 
 file_format: "1.0"
 

--- a/third_party_release
+++ b/third_party_release
@@ -22,6 +22,7 @@ benchmark=v1.9.4
 googletest=v1.17.0
 ms-gsl=v4.2.1
 nlohmann-json=v3.12.0
+opentelemetry-configuration=v1.1.0
 opentelemetry-proto=v1.10.0
 opentracing-cpp=v1.6.0
 prometheus-cpp=v1.3.0

--- a/tools/validate_otel_config_yaml.py
+++ b/tools/validate_otel_config_yaml.py
@@ -1,0 +1,157 @@
+#!/usr/bin/env python3
+
+# Copyright The OpenTelemetry Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Validate OpenTelemetry YAML configuration files against the JSON schema."""
+
+import argparse
+import glob
+import json
+import os
+import sys
+from typing import Any
+
+import jsonschema
+import yaml
+
+
+# Files with this marker in a YAML comment are intentionally invalid and skipped.
+_SKIP_MARKER = "SKIP_SCHEMA_VALIDATION"
+
+
+class _VersionError(Exception):
+    pass
+
+
+def _load_schema(path: str) -> dict[str, Any]:
+    try:
+        with open(path, encoding="utf-8") as f:
+            schema = json.load(f)
+    except FileNotFoundError:
+        print(f"ERROR: schema file not found: {path}", file=sys.stderr)
+        sys.exit(1)
+    except json.JSONDecodeError as e:
+        print(f"ERROR: invalid JSON in schema file: {e}", file=sys.stderr)
+        sys.exit(1)
+    try:
+        jsonschema.Draft202012Validator.check_schema(schema)
+    except jsonschema.exceptions.SchemaError as e:
+        print(f"ERROR: schema is not valid JSON Schema: {e.message}", file=sys.stderr)
+        sys.exit(1)
+    return schema
+
+def _parse_version(ver: str) -> tuple[int, int] | None:
+    """Return (major, minor) from a version string like 'v1.1.0' or '1.0'."""
+    try:
+        major, minor, *_ = ver.lstrip("v").split(".")
+        return (int(major), int(minor))
+    except ValueError:
+        return None
+
+
+def _validate_file(
+    path: str,
+    schema: dict[str, Any],
+    schema_version_tuple: tuple[int, int] | None = None,
+) -> str | list[jsonschema.exceptions.ValidationError]:
+    """Return a skip-reason string, or a list of jsonschema errors (empty on success)."""
+    with open(path, encoding="utf-8") as f:
+        raw = f.read()
+    comment = next(
+        (line for line in raw.splitlines() if line.lstrip().startswith("#") and _SKIP_MARKER in line),
+        None,
+    )
+    if comment is not None:
+        reason = comment.split(_SKIP_MARKER, 1)[1].lstrip(": ").strip()
+        return reason or "marked as skip"
+    doc = yaml.safe_load(raw)
+    if not isinstance(doc, dict) or not isinstance(doc.get("file_format"), str):
+        return "no valid file_format"
+    if schema_version_tuple is not None:
+        file_ver = _parse_version(doc["file_format"])
+        if file_ver is not None and file_ver > schema_version_tuple:
+            raise _VersionError(
+                f"file_format {doc['file_format']} is newer than pinned schema "
+                f"{'.'.join(str(x) for x in schema_version_tuple)} — update third_party_release"
+            )
+    return list(jsonschema.Draft202012Validator(schema).iter_errors(doc))
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "files",
+        nargs="*",
+        help="YAML files to validate (defaults to examples/configuration/*.yaml "
+             "and functional/configuration/shelltests/*.yaml)",
+    )
+    parser.add_argument(
+        "--schema",
+        required=True,
+        metavar="PATH",
+        help="Path to opentelemetry_configuration.json (from "
+             "https://github.com/open-telemetry/opentelemetry-configuration)",
+    )
+    parser.add_argument(
+        "--schema-version",
+        metavar="VERSION",
+        help="Schema version for display and version-mismatch checks (e.g. v1.1.0)",
+    )
+    args = parser.parse_args()
+    schema = _load_schema(args.schema)
+    schema_version_tuple = _parse_version(args.schema_version) if args.schema_version else None
+
+    print(f"Schema: {args.schema_version or args.schema}\n")
+
+    repo_root = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+    files: list[str] = args.files or sorted(
+        glob.glob(os.path.join(repo_root, "examples", "configuration", "*.yaml"))
+        + glob.glob(os.path.join(repo_root, "functional", "configuration", "shelltests", "*.yaml"))
+    )
+    if not files:
+        print("ERROR: no YAML files found to validate.", file=sys.stderr)
+        sys.exit(1)
+
+    def rel(path: str) -> str:
+        return os.path.relpath(path, repo_root)
+
+    skipped: list[str] = []
+    failed: list[str] = []
+
+    def _fail(path: str, tag: str, detail: object) -> None:
+        failed.append(path)
+        print(f"FAIL: {rel(path)}")
+        print(f"  [{tag}] {detail}")
+
+    for path in files:
+        try:
+            result = _validate_file(path, schema, schema_version_tuple)
+        except _VersionError as e:
+            _fail(path, "version", e); continue
+        except yaml.YAMLError as e:
+            _fail(path, "yaml", e); continue
+        except OSError as e:
+            _fail(path, "error", e); continue
+        if isinstance(result, str):
+            skipped.append(path)
+            print(f"SKIP: {rel(path)}")
+            print(f"      {result}")
+        elif result:
+            failed.append(path)
+            print(f"FAIL: {rel(path)}")
+            for err in result:
+                loc = " > ".join(str(p) for p in err.absolute_path) or "(root)"
+                print(f"  [{loc}] {err.message}")
+        else:
+            print(f"OK:   {rel(path)}")
+
+    if failed:
+        print(f"\n{len(failed)} file(s) failed validation.")
+        sys.exit(1)
+
+    validated = len(files) - len(skipped)
+    print(f"\nAll {validated} file(s) passed validation ({len(skipped)} skipped).")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Followup to: #4340

Adds a script and test to validate the otel-config yaml files against the schema and update files as needed.  

## Changes
- Adds an entry in third_party_release for the `opentelemetry-configuration` schema version
- Adds a python script to validate the otel-confg yaml files against the schema version
- Adds a github job in the CI workflow to validate the config files in `examples` and `functional`. 
- Updates the example `kitchen-sink.yaml` and `extnesions.yaml` to the 1.1 schema
- Update the CMake and Bazel tests to run the example with those two files using the `--test` arg.

For significant contributions please make sure you have completed the following items:

* [x] `CHANGELOG.md` updated for non-trivial changes
* [x] Unit tests have been added
* [ ] Changes in public API reviewed