### PR TITLE
[CONFIGURATION] Update prometheus config to schema v1.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -183,6 +183,14 @@ Breaking changes:
   * The public configuration member `max_buckets_` was renamed to `max_size_` to
     match the configuration schema. Please adjust SDK configuration accordingly.
 
+* [CONFIGURATION] Update prometheus config to schema v1.1.0
+  [#4383](https://github.com/open-telemetry/opentelemetry-cpp/pull/4383)
+  * The following YAML values for `translation_strategy` have been replaced
+    * `UnderscoreEscapingWithSuffixes` is replaced by `underscore_escaping_with_suffixes`
+    * `UnderscoreEscapingWithoutSuffixes` is replaced by `underscore_escaping_without_suffixes/development`
+    * `NoUTF8EscapingWithSuffixes` is replaced by `no_utf8_escaping_with_suffixes/development`
+    * `NoTranslation` is replaced by `no_translation/development`
+
 ## [1.28.0] 2026-07-16
 
 * [RELEASE] Bump main branch to 1.28.0-dev

--- a/examples/configuration/kitchen-sink.yaml
+++ b/examples/configuration/kitchen-sink.yaml
@@ -250,6 +250,10 @@ meter_provider:
               # If omitted, .included resource attributes are included.
               excluded:
                 - "service.attr1"
+            # Configure how metric names are translated to Prometheus metric names.
+            # If omitted or null, underscore_escaping_with_suffixes is used.
+            # Values include: underscore_escaping_with_suffixes, underscore_escaping_without_suffixes/development, no_utf8_escaping_with_suffixes/development, no_translation/development
+            translation_strategy: underscore_escaping_with_suffixes
         # Configure metric producers.
         producers:
           - # Configure metric producer to be opencensus.
@@ -344,10 +348,6 @@ meter_provider:
             # Values include: explicit_bucket_histogram, base2_exponential_bucket_histogram. For behavior of values, see https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/metrics/sdk_exporters/otlp.md.
             # If omitted or null, explicit_bucket_histogram is used.
             default_histogram_aggregation: base2_exponential_bucket_histogram
-        # Configure metric producers.
-        producers:
-          - # Configure metric producer to be prometheus.
-            prometheus:
         # Configure cardinality limits.
         cardinality_limits:
           # Configure default cardinality limit for all instrument types.

--- a/exporters/prometheus/src/prometheus_pull_builder.cc
+++ b/exporters/prometheus/src/prometheus_pull_builder.cc
@@ -53,13 +53,14 @@ std::unique_ptr<opentelemetry::sdk::metrics::MetricReader> PrometheusPullBuilder
       break;
     case sdk::configuration::TranslationStrategy::NoUTF8EscapingWithSuffixes:
       // FIXME: no flag to disable UnderscoreEscaping
-      OTEL_INTERNAL_LOG_WARN("[Prometheus Exporter] NoUTF8EscapingWithSuffixes not supported");
+      OTEL_INTERNAL_LOG_WARN(
+          "[Prometheus Exporter] no_utf8_escaping_with_suffixes/development not supported");
       options.without_units       = false;
       options.without_type_suffix = false;
       break;
     case sdk::configuration::TranslationStrategy::NoTranslation:
       // FIXME: no flag to disable UnderscoreEscaping
-      OTEL_INTERNAL_LOG_WARN("[Prometheus Exporter] NoTranslation not supported");
+      OTEL_INTERNAL_LOG_WARN("[Prometheus Exporter] no_translation/development not supported");
       options.without_units       = true;
       options.without_type_suffix = true;
       break;

--- a/functional/configuration/shelltests/prometheus_translation_no.test
+++ b/functional/configuration/shelltests/prometheus_translation_no.test
@@ -4,7 +4,7 @@
 $ example_yaml --test --yaml shelltests/prometheus_translation_no.yaml
 >
 MODEL PARSED
-[WARNING] [Prometheus Exporter] NoTranslation not supported
+[WARNING] [Prometheus Exporter] no_translation/development not supported
 [WARNING] [Prometheus Exporter] resource_constant_labels not supported
 SDK CREATED
 >= 0

--- a/functional/configuration/shelltests/prometheus_translation_no.yaml
+++ b/functional/configuration/shelltests/prometheus_translation_no.yaml
@@ -1,8 +1,7 @@
 # Copyright The OpenTelemetry Authors
 # SPDX-License-Identifier: Apache-2.0
-# SKIP_SCHEMA_VALIDATION: translation_strategy 'NoTranslation' renamed to 'no_translation/development' in schema v1.0; C++ parser not yet updated
 
-file_format: "1.0"
+file_format: "1.1"
 
 meter_provider:
   readers:
@@ -11,8 +10,8 @@ meter_provider:
           prometheus/development:
             host: localhost
             port: 9464
-            without_scope_info: false
-            translation_strategy: NoTranslation
-            with_resource_constant_labels:
+            scope_info_enabled: true
+            translation_strategy: no_translation/development
+            resource_constant_labels:
               included:
                 - "not supported"

--- a/functional/configuration/shelltests/prometheus_translation_no_utf8.test
+++ b/functional/configuration/shelltests/prometheus_translation_no_utf8.test
@@ -4,6 +4,6 @@
 $ example_yaml --test --yaml shelltests/prometheus_translation_no_utf8.yaml
 >
 MODEL PARSED
-[WARNING] [Prometheus Exporter] NoUTF8EscapingWithSuffixes not supported
+[WARNING] [Prometheus Exporter] no_utf8_escaping_with_suffixes/development not supported
 SDK CREATED
 >= 0

--- a/functional/configuration/shelltests/prometheus_translation_no_utf8.yaml
+++ b/functional/configuration/shelltests/prometheus_translation_no_utf8.yaml
@@ -1,8 +1,7 @@
 # Copyright The OpenTelemetry Authors
 # SPDX-License-Identifier: Apache-2.0
-# SKIP_SCHEMA_VALIDATION: translation_strategy 'NoUTF8EscapingWithSuffixes' renamed to 'no_utf8_escaping_with_suffixes/development' in schema v1.0; C++ parser not yet updated
 
-file_format: "1.0"
+file_format: "1.1"
 
 meter_provider:
   readers:
@@ -11,5 +10,5 @@ meter_provider:
           prometheus/development:
             host: localhost
             port: 9464
-            without_scope_info: false
-            translation_strategy: NoUTF8EscapingWithSuffixes
+            scope_info_enabled: true
+            translation_strategy: no_utf8_escaping_with_suffixes/development

--- a/functional/configuration/shelltests/prometheus_translation_with_suffixes.yaml
+++ b/functional/configuration/shelltests/prometheus_translation_with_suffixes.yaml
@@ -1,8 +1,7 @@
 # Copyright The OpenTelemetry Authors
 # SPDX-License-Identifier: Apache-2.0
-# SKIP_SCHEMA_VALIDATION: translation_strategy 'UnderscoreEscapingWithSuffixes' renamed to 'underscore_escaping_with_suffixes' in schema v1.0; C++ parser not yet updated
 
-file_format: "1.0"
+file_format: "1.1"
 
 meter_provider:
   readers:
@@ -11,5 +10,5 @@ meter_provider:
           prometheus/development:
             host: localhost
             port: 9464
-            without_scope_info: false
-            translation_strategy: UnderscoreEscapingWithSuffixes
+            scope_info_enabled: true
+            translation_strategy: underscore_escaping_with_suffixes

--- a/functional/configuration/shelltests/prometheus_translation_without_suffixes.yaml
+++ b/functional/configuration/shelltests/prometheus_translation_without_suffixes.yaml
@@ -1,8 +1,7 @@
 # Copyright The OpenTelemetry Authors
 # SPDX-License-Identifier: Apache-2.0
-# SKIP_SCHEMA_VALIDATION: translation_strategy 'UnderscoreEscapingWithoutSuffixes' renamed to 'underscore_escaping_without_suffixes/development' in schema v1.0; C++ parser not yet updated
 
-file_format: "1.0"
+file_format: "1.1"
 
 meter_provider:
   readers:
@@ -11,5 +10,5 @@ meter_provider:
           prometheus/development:
             host: localhost
             port: 9464
-            without_scope_info: false
-            translation_strategy: UnderscoreEscapingWithoutSuffixes
+            scope_info_enabled: true
+            translation_strategy: underscore_escaping_without_suffixes/development

--- a/sdk/src/configuration/configuration_parser.cc
+++ b/sdk/src/configuration/configuration_parser.cc
@@ -898,22 +898,23 @@ TranslationStrategy ConfigurationParser::ParseTranslationStrategy(
     const std::unique_ptr<DocumentNode> &node,
     const std::string &name) const
 {
-  if (name == "UnderscoreEscapingWithSuffixes")
+  if (name == "UnderscoreEscapingWithSuffixes" || name == "underscore_escaping_with_suffixes")
   {
     return TranslationStrategy::UnderscoreEscapingWithSuffixes;
   }
 
-  if (name == "UnderscoreEscapingWithoutSuffixes")
+  if (name == "UnderscoreEscapingWithoutSuffixes" ||
+      name == "underscore_escaping_without_suffixes/development")
   {
     return TranslationStrategy::UnderscoreEscapingWithoutSuffixes;
   }
 
-  if (name == "NoUTF8EscapingWithSuffixes")
+  if (name == "NoUTF8EscapingWithSuffixes" || name == "no_utf8_escaping_with_suffixes/development")
   {
     return TranslationStrategy::NoUTF8EscapingWithSuffixes;
   }
 
-  if (name == "NoTranslation")
+  if (name == "NoTranslation" || name == "no_translation/development")
   {
     return TranslationStrategy::NoTranslation;
   }

--- a/sdk/src/configuration/configuration_parser.cc
+++ b/sdk/src/configuration/configuration_parser.cc
@@ -898,23 +898,22 @@ TranslationStrategy ConfigurationParser::ParseTranslationStrategy(
     const std::unique_ptr<DocumentNode> &node,
     const std::string &name) const
 {
-  if (name == "UnderscoreEscapingWithSuffixes" || name == "underscore_escaping_with_suffixes")
+  if (name == "underscore_escaping_with_suffixes")
   {
     return TranslationStrategy::UnderscoreEscapingWithSuffixes;
   }
 
-  if (name == "UnderscoreEscapingWithoutSuffixes" ||
-      name == "underscore_escaping_without_suffixes/development")
+  if (name == "underscore_escaping_without_suffixes/development")
   {
     return TranslationStrategy::UnderscoreEscapingWithoutSuffixes;
   }
 
-  if (name == "NoUTF8EscapingWithSuffixes" || name == "no_utf8_escaping_with_suffixes/development")
+  if (name == "no_utf8_escaping_with_suffixes/development")
   {
     return TranslationStrategy::NoUTF8EscapingWithSuffixes;
   }
 
-  if (name == "NoTranslation" || name == "no_translation/development")
+  if (name == "no_translation/development")
   {
     return TranslationStrategy::NoTranslation;
   }
@@ -966,7 +965,7 @@ ConfigurationParser::ParsePrometheusPullMetricExporterConfiguration(
   }
 
   std::string translation_strategy =
-      node->GetString("translation_strategy", "UnderscoreEscapingWithSuffixes");
+      node->GetString("translation_strategy", "underscore_escaping_with_suffixes");
   model->translation_strategy = ParseTranslationStrategy(node, translation_strategy);
 
   return model;

--- a/sdk/test/configuration/yaml_metrics_test.cc
+++ b/sdk/test/configuration/yaml_metrics_test.cc
@@ -724,7 +724,7 @@ meter_provider:
             port: 1234
             scope_info_enabled: false
             target_info_enabled/development: false
-            translation_strategy: NoUTF8EscapingWithSuffixes
+            translation_strategy: no_utf8_escaping_with_suffixes/development
             resource_constant_labels:
               included:
                 - "foo.in"

--- a/sdk/test/configuration/yaml_metrics_test.cc
+++ b/sdk/test/configuration/yaml_metrics_test.cc
@@ -673,7 +673,7 @@ meter_provider:
             port: 1234
             without_scope_info: true
             without_target_info: true
-            translation_strategy: NoUTF8EscapingWithSuffixes
+            translation_strategy: no_utf8_escaping_with_suffixes/development
             with_resource_constant_labels:
               included:
                 - "foo.in"


### PR DESCRIPTION
Followup to: https://github.com/open-telemetry/opentelemetry-cpp/pull/4340

## Changes

- Update the prometheus exporter yaml keys per schema v1.1.0
- Update the functional test yaml files
- Update the prometheus fields in `kitchen-sink.yaml`

For significant contributions please make sure you have completed the following items:

* [ ] `CHANGELOG.md` updated for non-trivial changes
* [ ] Unit tests have been added
* [ ] Changes in public API reviewed