### PR TITLE
[CONFIGURATION] Update ViewSelector to comply with schema v1.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,10 @@ Increment the:
   `std::mutex` blocks the waiter instead. Only this one contended lock changes;
   the API `SpinLockMutex` and all other SDK locks are unchanged.
   [#4245](https://github.com/open-telemetry/opentelemetry-cpp/pull/4245)
+
+* [CONFIGURATION] Update ViewSelector to comply with schema v1.1.0
+  [#4384](https://github.com/open-telemetry/opentelemetry-cpp/pull/4384)
+
 * [CONFIGURATION] Add the probability sampler to file configuration
   [#4334](https://github.com/open-telemetry/opentelemetry-cpp/pull/4334)
 

--- a/examples/configuration/kitchen-sink.yaml
+++ b/examples/configuration/kitchen-sink.yaml
@@ -467,9 +467,25 @@ meter_provider:
         exporter:
           # Configure exporter to be console.
           console:
+            # Configure temporality preference.
+            # Values include: cumulative, delta, low_memory.
+            # If omitted or null, cumulative is used.
+            temporality_preference: delta
+            # Configure default histogram aggregation.
+            # Values include: explicit_bucket_histogram, base2_exponential_bucket_histogram.
+            # If omitted or null, explicit_bucket_histogram is used.
+            default_histogram_aggregation: base2_exponential_bucket_histogram
   # Configure views.
   # Each view has a selector which determines the instrument(s) it applies to, and a configuration for the resulting stream(s).
   views:
+    - # Configure a catch-all view. An empty selector matches all instruments from all meters.
+      selector: {}
+      # Configure the resulting stream for every matched instrument.
+      stream:
+        # Retain all attributes except the explicitly excluded sensitive or high-cardinality keys.
+        attribute_keys:
+          excluded:
+            - request.id
     - # Configure view selector.
       # Selection criteria is additive as described in https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/metrics/sdk.md#instrument-selection-criteria.
       selector:
@@ -543,6 +559,104 @@ meter_provider:
           # If omitted, .attribute_keys.included are included.
           excluded:
             - key3
+    - selector:
+        instrument_name: exponential-histogram-instrument
+        instrument_type: histogram
+      stream:
+        # Configure aggregation to be base2 exponential bucket histogram.
+        aggregation:
+          base2_exponential_bucket_histogram:
+            # Configure the max scale factor. Value must be in range [-10, 20].
+            # If omitted or null, 20 is used.
+            max_scale: 20
+            # Configure the maximum number of positive and negative buckets.
+            # If omitted or null, 160 is used.
+            max_size: 160
+            # Configure whether or not to record min and max.
+            # If omitted or null, true is used.
+            record_min_max: true
+    - selector:
+        instrument_name: default-aggregation-instrument
+      stream:
+        # Configure aggregation based on the selected instrument kind.
+        aggregation:
+          default:
+    - selector:
+        instrument_name: dropped-instrument
+      stream:
+        # Configure aggregation to drop all measurements.
+        aggregation:
+          drop:
+    # Gauge instruments are only supported in opentelemetry-cpp ABIv2
+    # - selector:
+    #     instrument_name: last-value-instrument
+    #     instrument_type: gauge
+    #   stream:
+    #     # Configure aggregation to retain the last measurement.
+    #     aggregation:
+    #       last_value:
+    - selector:
+        instrument_name: summed-instrument
+        instrument_type: counter
+      stream:
+        # Configure aggregation to sum measurements.
+        aggregation:
+          sum:
+    - # Configure a view selecting observable counter instruments.
+      selector:
+        # Configure instrument name selection criteria.
+        instrument_name: observable-counter-instrument
+        # Configure instrument type selection criteria.
+        instrument_type: observable_counter
+      # Configure the resulting view stream.
+      stream:
+        # Configure aggregation based on the selected instrument kind.
+        aggregation:
+          default:
+    - # Configure a view selecting observable gauge instruments.
+      selector:
+        # Configure instrument name selection criteria.
+        instrument_name: observable-gauge-instrument
+        # Configure instrument type selection criteria.
+        instrument_type: observable_gauge
+      # Configure the resulting view stream.
+      stream:
+        # Configure aggregation based on the selected instrument kind.
+        aggregation:
+          default:
+    - # Configure a view selecting observable up down counter instruments.
+      selector:
+        # Configure instrument name selection criteria.
+        instrument_name: observable-up-down-counter-instrument
+        # Configure instrument type selection criteria.
+        instrument_type: observable_up_down_counter
+      # Configure the resulting view stream.
+      stream:
+        # Configure aggregation based on the selected instrument kind.
+        aggregation:
+          default:
+    - # Configure a view selecting up down counter instruments.
+      selector:
+        # Configure instrument name selection criteria.
+        instrument_name: up-down-counter-instrument
+        # Configure instrument type selection criteria.
+        instrument_type: up_down_counter
+      # Configure the resulting view stream.
+      stream:
+        # Configure aggregation based on the selected instrument kind.
+        aggregation:
+          default:
+    - # Configure a view selecting a histogram instrument.
+      selector:
+        # Configure instrument name selection criteria.
+        instrument_name: cardinality-limited-instrument
+        # Configure instrument type selection criteria.
+        instrument_type: histogram
+      # Configure the resulting view stream.
+      stream:
+        # Configure the aggregation cardinality limit while retaining the instrument's default aggregation.
+        # If omitted or null, the metric reader's default cardinality limit is used.
+        aggregation_cardinality_limit: 1000
   # Configure the exemplar filter.
   # Values include: trace_based, always_on, always_off. For behavior of values see https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/configuration/sdk-environment-variables.md#metrics-sdk-configuration.
   # If omitted or null, trace_based is used.

--- a/sdk/include/opentelemetry/sdk/configuration/instrument_type.h
+++ b/sdk/include/opentelemetry/sdk/configuration/instrument_type.h
@@ -23,7 +23,8 @@ enum class InstrumentType : std::uint8_t
   observable_counter,
   observable_gauge,
   observable_up_down_counter,
-  up_down_counter
+  up_down_counter,
+  gauge
 };
 
 }  // namespace configuration

--- a/sdk/include/opentelemetry/sdk/configuration/instrument_type.h
+++ b/sdk/include/opentelemetry/sdk/configuration/instrument_type.h
@@ -19,12 +19,12 @@ enum class InstrumentType : std::uint8_t
 {
   none, /* Represents a null entry */
   counter,
+  gauge,
   histogram,
   observable_counter,
   observable_gauge,
   observable_up_down_counter,
-  up_down_counter,
-  gauge
+  up_down_counter
 };
 
 }  // namespace configuration

--- a/sdk/include/opentelemetry/sdk/configuration/view_selector_configuration.h
+++ b/sdk/include/opentelemetry/sdk/configuration/view_selector_configuration.h
@@ -21,7 +21,7 @@ class ViewSelectorConfiguration
 {
 public:
   std::string instrument_name;
-  InstrumentType instrument_type{InstrumentType::counter};
+  InstrumentType instrument_type{InstrumentType::none};
   std::string unit;
   std::string meter_name;
   std::string meter_version;

--- a/sdk/src/configuration/configuration_parser.cc
+++ b/sdk/src/configuration/configuration_parser.cc
@@ -1274,6 +1274,11 @@ InstrumentType ConfigurationParser::ParseInstrumentType(const std::unique_ptr<Do
     return InstrumentType::counter;
   }
 
+  if (name == "gauge")
+  {
+    return InstrumentType::gauge;
+  }
+
   if (name == "histogram")
   {
     return InstrumentType::histogram;

--- a/sdk/src/configuration/sdk_builder.cc
+++ b/sdk/src/configuration/sdk_builder.cc
@@ -1912,94 +1912,124 @@ void SdkBuilder::AddView(
 {
   auto *selector = model->selector.get();
 
-  if (selector->instrument_type == opentelemetry::sdk::configuration::InstrumentType::none)
+  // Synchronous gauge instruments are not supported in ABIv1
+#if OPENTELEMETRY_ABI_VERSION_NO < 2
+  if (selector->instrument_type == opentelemetry::sdk::configuration::InstrumentType::gauge)
   {
-    std::string die("Runtime does not support instrument_type: null");
+    std::string die("Runtime does not support instrument_type: gauge with ABI version 1");
     throw UnsupportedException(die);
   }
+#endif
 
-  auto sdk_instrument_type = ConvertInstrumentType(selector->instrument_type);
+  auto add_view = [&](opentelemetry::sdk::metrics::InstrumentType sdk_instrument_type) {
+    // If the instrument name is empty, use "*" to match all instruments of the given type.
+    const std::string instrument_name =
+        selector->instrument_name.empty() ? "*" : selector->instrument_name;
 
-  auto sdk_instrument_selector = std::make_unique<opentelemetry::sdk::metrics::InstrumentSelector>(
-      sdk_instrument_type, selector->instrument_name, selector->unit);
+    auto sdk_instrument_selector =
+        std::make_unique<opentelemetry::sdk::metrics::InstrumentSelector>(
+            sdk_instrument_type, instrument_name, selector->unit);
 
-  auto sdk_meter_selector = std::make_unique<opentelemetry::sdk::metrics::MeterSelector>(
-      selector->meter_name, selector->meter_version, selector->meter_schema_url);
+    auto sdk_meter_selector = std::make_unique<opentelemetry::sdk::metrics::MeterSelector>(
+        selector->meter_name, selector->meter_version, selector->meter_schema_url);
 
-  auto *stream = model->stream.get();
+    auto *stream = model->stream.get();
 
-  opentelemetry::sdk::metrics::AggregationType sdk_aggregation_type =
-      opentelemetry::sdk::metrics::AggregationType::kDefault;
+    opentelemetry::sdk::metrics::AggregationType sdk_aggregation_type =
+        opentelemetry::sdk::metrics::AggregationType::kDefault;
 
-  std::shared_ptr<opentelemetry::sdk::metrics::AggregationConfig> sdk_aggregation_config;
+    std::shared_ptr<opentelemetry::sdk::metrics::AggregationConfig> sdk_aggregation_config;
 
-  if (stream->aggregation)
-  {
-    sdk_aggregation_config = CreateAggregationConfig(stream->aggregation, sdk_aggregation_type);
-  }
-
-  // Apply aggregation_cardinality_limit from the view stream configuration
-  if (stream->aggregation_cardinality_limit != 0)
-  {
-    if (sdk_aggregation_config)
+    if (stream->aggregation)
     {
-      sdk_aggregation_config->cardinality_limit_ = stream->aggregation_cardinality_limit;
+      sdk_aggregation_config = CreateAggregationConfig(stream->aggregation, sdk_aggregation_type);
     }
-    else
-    {
-      // No explicit `aggregation` block was configured, so the view falls back to the
-      // instrument's default aggregation. ViewRegistry::AddView() rejects a view whose
-      // AggregationConfig type does not match the (possibly instrument-derived) aggregation
-      // type, so the config created here must match that same default rather than always
-      // being a plain AggregationConfig (which only satisfies kSum/kLastValue/kDrop).
-      auto effective_aggregation_type = sdk_aggregation_type;
-      if (effective_aggregation_type == opentelemetry::sdk::metrics::AggregationType::kDefault)
-      {
-        bool is_monotonic{false};
-        effective_aggregation_type =
-            opentelemetry::sdk::metrics::DefaultAggregation::GetDefaultAggregationType(
-                sdk_instrument_type, is_monotonic);
-      }
 
-      switch (effective_aggregation_type)
+    // Apply aggregation_cardinality_limit from the view stream configuration
+    if (stream->aggregation_cardinality_limit != 0)
+    {
+      if (sdk_aggregation_config)
       {
-        case opentelemetry::sdk::metrics::AggregationType::kHistogram: {
-          auto histogram_config =
-              std::make_shared<opentelemetry::sdk::metrics::HistogramAggregationConfig>(
-                  stream->aggregation_cardinality_limit);
-          // A default-constructed HistogramAggregationConfig has empty boundaries_, which
-          // LongHistogramAggregation/DoubleHistogramAggregation interpret as "use these zero
-          // boundaries" rather than "no boundaries configured" (that distinction only exists
-          // when the config pointer itself is null). Since this config is synthesized here
-          // rather than coming from an explicit `aggregation` block, it must carry the SDK's
-          // default boundaries to preserve the instrument's default histogram shape.
-          histogram_config->boundaries_ =
-              opentelemetry::sdk::metrics::HistogramAggregationConfig::DefaultBoundaries();
-          sdk_aggregation_config = histogram_config;
-          break;
+        sdk_aggregation_config->cardinality_limit_ = stream->aggregation_cardinality_limit;
+      }
+      else
+      {
+        // No explicit `aggregation` block was configured, so the view falls back to the
+        // instrument's default aggregation. ViewRegistry::AddView() rejects a view whose
+        // AggregationConfig type does not match the (possibly instrument-derived) aggregation
+        // type, so the config created here must match that same default rather than always
+        // being a plain AggregationConfig (which only satisfies kSum/kLastValue/kDrop).
+        auto effective_aggregation_type = sdk_aggregation_type;
+        if (effective_aggregation_type == opentelemetry::sdk::metrics::AggregationType::kDefault)
+        {
+          bool is_monotonic{false};
+          effective_aggregation_type =
+              opentelemetry::sdk::metrics::DefaultAggregation::GetDefaultAggregationType(
+                  sdk_instrument_type, is_monotonic);
         }
 
-        default:
-          sdk_aggregation_config = std::make_shared<opentelemetry::sdk::metrics::AggregationConfig>(
-              stream->aggregation_cardinality_limit);
-          break;
+        switch (effective_aggregation_type)
+        {
+          case opentelemetry::sdk::metrics::AggregationType::kHistogram: {
+            auto histogram_config =
+                std::make_shared<opentelemetry::sdk::metrics::HistogramAggregationConfig>(
+                    stream->aggregation_cardinality_limit);
+            // A default-constructed HistogramAggregationConfig has empty boundaries_, which
+            // LongHistogramAggregation/DoubleHistogramAggregation interpret as "use these zero
+            // boundaries" rather than "no boundaries configured" (that distinction only exists
+            // when the config pointer itself is null). Since this config is synthesized here
+            // rather than coming from an explicit `aggregation` block, it must carry the SDK's
+            // default boundaries to preserve the instrument's default histogram shape.
+            histogram_config->boundaries_ =
+                opentelemetry::sdk::metrics::HistogramAggregationConfig::DefaultBoundaries();
+            sdk_aggregation_config = histogram_config;
+            break;
+          }
+
+          default:
+            sdk_aggregation_config =
+                std::make_shared<opentelemetry::sdk::metrics::AggregationConfig>(
+                    stream->aggregation_cardinality_limit);
+            break;
+        }
       }
     }
-  }
 
-  std::unique_ptr<opentelemetry::sdk::metrics::AttributesProcessor> sdk_attribute_processor;
+    std::unique_ptr<opentelemetry::sdk::metrics::AttributesProcessor> sdk_attribute_processor;
 
-  if (stream->attribute_keys != nullptr)
+    // FIXME-SDK: The CreateAttributesProcessor method is not implemented yet.
+    if (stream->attribute_keys != nullptr)
+    {
+      sdk_attribute_processor = CreateAttributesProcessor(stream->attribute_keys);
+    }
+
+    auto sdk_view = std::make_unique<opentelemetry::sdk::metrics::View>(
+        stream->name, stream->description, sdk_aggregation_type, sdk_aggregation_config,
+        std::move(sdk_attribute_processor));
+
+    view_registry->AddView(std::move(sdk_instrument_selector), std::move(sdk_meter_selector),
+                           std::move(sdk_view));
+  };  // add_view
+
+  // If the instrument type is "none", add views to select all instrument types.
+  // FIXME-SDK: register a single view instead. InstrumentSelector must support an optional
+  // instrument type (a "match all types" value honored by ViewRegistry::MatchInstrument).
+  if (selector->instrument_type == opentelemetry::sdk::configuration::InstrumentType::none)
   {
-    sdk_attribute_processor = CreateAttributesProcessor(stream->attribute_keys);
+    add_view(opentelemetry::sdk::metrics::InstrumentType::kCounter);
+    add_view(opentelemetry::sdk::metrics::InstrumentType::kHistogram);
+    add_view(opentelemetry::sdk::metrics::InstrumentType::kUpDownCounter);
+    add_view(opentelemetry::sdk::metrics::InstrumentType::kObservableCounter);
+    add_view(opentelemetry::sdk::metrics::InstrumentType::kObservableGauge);
+    add_view(opentelemetry::sdk::metrics::InstrumentType::kObservableUpDownCounter);
+#if OPENTELEMETRY_ABI_VERSION_NO >= 2
+    add_view(opentelemetry::sdk::metrics::InstrumentType::kGauge);
+#endif
   }
-
-  auto sdk_view = std::make_unique<opentelemetry::sdk::metrics::View>(
-      stream->name, stream->description, sdk_aggregation_type, sdk_aggregation_config,
-      std::move(sdk_attribute_processor));
-
-  view_registry->AddView(std::move(sdk_instrument_selector), std::move(sdk_meter_selector),
-                         std::move(sdk_view));
+  else
+  {
+    add_view(ConvertInstrumentType(selector->instrument_type));
+  }
 }
 
 std::unique_ptr<opentelemetry::sdk::instrumentationscope::ScopeConfigurator<

--- a/sdk/src/configuration/sdk_builder.cc
+++ b/sdk/src/configuration/sdk_builder.cc
@@ -1563,6 +1563,9 @@ static opentelemetry::sdk::metrics::InstrumentType ConvertInstrumentType(
     case opentelemetry::sdk::configuration::InstrumentType::counter:
       sdk = opentelemetry::sdk::metrics::InstrumentType::kCounter;
       break;
+    case opentelemetry::sdk::configuration::InstrumentType::gauge:
+      sdk = opentelemetry::sdk::metrics::InstrumentType::kGauge;
+      break;
     case opentelemetry::sdk::configuration::InstrumentType::histogram:
       sdk = opentelemetry::sdk::metrics::InstrumentType::kHistogram;
       break;

--- a/sdk/test/configuration/programmatic_configuration_test.cc
+++ b/sdk/test/configuration/programmatic_configuration_test.cc
@@ -474,7 +474,195 @@ TEST_F(ProgrammaticConfigTest, MeterProviderWithMeterConfigurator)
   }
 }
 
-TEST_F(ProgrammaticConfigTest, MeterProviderWithViews)
+TEST_F(ProgrammaticConfigTest, MeterProviderWithDefaultViewSelector)
+{
+  // Create a view with a default selector (no instrument name or type, no meter name).
+  // This view must match all instruments from all meters.
+
+  auto view                 = std::make_unique<config_sdk::ViewConfiguration>();
+  view->selector            = std::make_unique<config_sdk::ViewSelectorConfiguration>();
+  view->stream              = std::make_unique<config_sdk::ViewStreamConfiguration>();
+  view->stream->description = "selected-by-default-view";
+
+  auto meter_provider_config = MakeMeterProviderConfig();
+  meter_provider_config->views.emplace_back(std::move(view));
+
+  auto model            = std::make_unique<config_sdk::Configuration>();
+  model->meter_provider = std::move(meter_provider_config);
+
+  CreateAndInstallSdk(model);
+  ASSERT_NE(sdk_->meter_provider, nullptr);
+
+  auto first_meter = metrics::Provider::GetMeterProvider()->GetMeter(
+      "first-meter", "1.0", "https://opentelemetry.io/schemas/1.0.0");
+  first_meter->CreateUInt64Counter("first-counter", "original", "requests")->Add(1);
+
+  auto second_meter = metrics::Provider::GetMeterProvider()->GetMeter(
+      "second-meter", "2.0", "https://opentelemetry.io/schemas/1.1.0");
+  second_meter->CreateInt64UpDownCounter("second-up-down-counter", "original", "connections")
+      ->Add(1);
+  auto active_context = context::Context{};
+  second_meter->CreateDoubleHistogram("third-histogram", "original", "milliseconds")
+      ->Record(1.0, active_context);
+
+  ASSERT_TRUE(sdk_->meter_provider->ForceFlush(std::chrono::milliseconds(kProcessTimeout)));
+  ASSERT_TRUE(sdk_->meter_provider->Shutdown(std::chrono::milliseconds(kProcessTimeout)));
+
+  ASSERT_EQ(metric_buffer_->size(), 3);
+  for (const auto &metric : *metric_buffer_)
+  {
+    EXPECT_EQ(metric.instrument_descriptor.description_, "selected-by-default-view");
+  }
+}
+
+TEST_F(ProgrammaticConfigTest, MeterProviderWithDefaultInstrumentNameViewSelector)
+{
+  // Create a selector with a specific instrument type, but default (empty) instrument name.
+  // This must match all instruments of the specified type.
+  auto selector             = std::make_unique<config_sdk::ViewSelectorConfiguration>();
+  selector->instrument_type = config_sdk::InstrumentType::histogram;
+
+  auto stream         = std::make_unique<config_sdk::ViewStreamConfiguration>();
+  stream->description = "selected-histogram";
+
+  auto view      = std::make_unique<config_sdk::ViewConfiguration>();
+  view->selector = std::move(selector);
+  view->stream   = std::move(stream);
+
+  auto meter_provider_config = MakeMeterProviderConfig();
+  meter_provider_config->views.emplace_back(std::move(view));
+
+  auto model            = std::make_unique<config_sdk::Configuration>();
+  model->meter_provider = std::move(meter_provider_config);
+
+  CreateAndInstallSdk(model);
+  ASSERT_NE(sdk_->meter_provider, nullptr);
+
+  auto active_context = context::Context{};
+  auto meter          = metrics::Provider::GetMeterProvider()->GetMeter("test");
+  meter->CreateDoubleHistogram("first-histogram", "original")->Record(1.0, active_context);
+  meter->CreateDoubleHistogram("second-histogram", "original")->Record(1.0, active_context);
+  meter->CreateUInt64Counter("counter", "original")->Add(1);
+
+  ASSERT_TRUE(sdk_->meter_provider->ForceFlush(std::chrono::milliseconds(kProcessTimeout)));
+  ASSERT_TRUE(sdk_->meter_provider->Shutdown(std::chrono::milliseconds(kProcessTimeout)));
+
+  ASSERT_EQ(metric_buffer_->size(), 3);
+  std::size_t matched = 0;
+  for (const auto &metric : *metric_buffer_)
+  {
+    if (metric.instrument_descriptor.description_ == "selected-histogram")
+    {
+      EXPECT_EQ(metric.instrument_descriptor.type_, metrics_sdk::InstrumentType::kHistogram);
+      ++matched;
+    }
+  }
+  EXPECT_EQ(matched, 2);
+}
+
+TEST_F(ProgrammaticConfigTest, MeterProviderWithDefaultInstrumentTypeViewSelector)
+{
+  // Create a selector with a specific instrument name, but default (none) instrument type.
+  // This must match all instruments of the specified name, regardless of type.
+  // Different meters may each have an instrument of the same name and type.
+  auto selector             = std::make_unique<config_sdk::ViewSelectorConfiguration>();
+  selector->instrument_name = "selected-instrument";
+
+  auto stream         = std::make_unique<config_sdk::ViewStreamConfiguration>();
+  stream->description = "selected-instrument";
+
+  auto view      = std::make_unique<config_sdk::ViewConfiguration>();
+  view->selector = std::move(selector);
+  view->stream   = std::move(stream);
+
+  auto meter_provider_config = MakeMeterProviderConfig();
+  meter_provider_config->views.emplace_back(std::move(view));
+
+  auto model            = std::make_unique<config_sdk::Configuration>();
+  model->meter_provider = std::move(meter_provider_config);
+
+  CreateAndInstallSdk(model);
+  ASSERT_NE(sdk_->meter_provider, nullptr);
+
+  auto active_context  = context::Context{};
+  auto histogram_meter = metrics::Provider::GetMeterProvider()->GetMeter("histogram-meter");
+  histogram_meter->CreateDoubleHistogram("selected-instrument", "original")
+      ->Record(1.0, active_context);
+
+  auto counter_meter = metrics::Provider::GetMeterProvider()->GetMeter("counter-meter");
+  counter_meter->CreateUInt64Counter("selected-instrument", "original")->Add(1);
+  counter_meter->CreateUInt64Counter("unmatched-counter", "original")->Add(1);
+
+  ASSERT_TRUE(sdk_->meter_provider->ForceFlush(std::chrono::milliseconds(kProcessTimeout)));
+  ASSERT_TRUE(sdk_->meter_provider->Shutdown(std::chrono::milliseconds(kProcessTimeout)));
+
+  ASSERT_EQ(metric_buffer_->size(), 3);
+  std::size_t matched = 0;
+  for (const auto &metric : *metric_buffer_)
+  {
+    if (metric.instrument_descriptor.description_ == "selected-instrument")
+    {
+      ++matched;
+    }
+  }
+  EXPECT_EQ(matched, 2);
+}
+
+TEST_F(ProgrammaticConfigTest, MeterProviderWithMeterScopeViewSelector)
+{
+  auto selector              = std::make_unique<config_sdk::ViewSelectorConfiguration>();
+  selector->instrument_name  = "test-counter";
+  selector->instrument_type  = config_sdk::InstrumentType::counter;
+  selector->meter_name       = "selected-meter";
+  selector->meter_version    = "1.0";
+  selector->meter_schema_url = "https://opentelemetry.io/schemas/1.0.0";
+
+  auto stream         = std::make_unique<config_sdk::ViewStreamConfiguration>();
+  stream->description = "selected-by-meter";
+
+  auto view      = std::make_unique<config_sdk::ViewConfiguration>();
+  view->selector = std::move(selector);
+  view->stream   = std::move(stream);
+
+  auto meter_provider_config = MakeMeterProviderConfig();
+  meter_provider_config->views.emplace_back(std::move(view));
+
+  auto model            = std::make_unique<config_sdk::Configuration>();
+  model->meter_provider = std::move(meter_provider_config);
+
+  CreateAndInstallSdk(model);
+  ASSERT_NE(sdk_->meter_provider, nullptr);
+
+  auto meter_provider = metrics::Provider::GetMeterProvider();
+  meter_provider->GetMeter("selected-meter", "1.0", "https://opentelemetry.io/schemas/1.0.0")
+      ->CreateUInt64Counter("test-counter", "original")
+      ->Add(1);
+  meter_provider->GetMeter("other-meter", "1.0", "https://opentelemetry.io/schemas/1.0.0")
+      ->CreateUInt64Counter("test-counter", "original")
+      ->Add(1);
+  meter_provider->GetMeter("selected-meter", "2.0", "https://opentelemetry.io/schemas/1.0.0")
+      ->CreateUInt64Counter("test-counter", "original")
+      ->Add(1);
+  meter_provider->GetMeter("selected-meter", "1.0", "https://opentelemetry.io/schemas/1.1.0")
+      ->CreateUInt64Counter("test-counter", "original")
+      ->Add(1);
+
+  ASSERT_TRUE(sdk_->meter_provider->ForceFlush(std::chrono::milliseconds(kProcessTimeout)));
+  ASSERT_TRUE(sdk_->meter_provider->Shutdown(std::chrono::milliseconds(kProcessTimeout)));
+
+  ASSERT_EQ(metric_buffer_->size(), 4);
+  std::size_t matched = 0;
+  for (const auto &metric : *metric_buffer_)
+  {
+    if (metric.instrument_descriptor.description_ == "selected-by-meter")
+    {
+      ++matched;
+    }
+  }
+  EXPECT_EQ(matched, 1);
+}
+
+TEST_F(ProgrammaticConfigTest, MeterProviderWithHistogramAggregationViews)
 {
   // View 1: Base2 exponential aggregation
   const std::size_t max_scale   = 10;

--- a/sdk/test/configuration/sdk_builder_test.cc
+++ b/sdk/test/configuration/sdk_builder_test.cc
@@ -19,8 +19,10 @@
 #include "opentelemetry/nostd/string_view.h"
 #include "opentelemetry/nostd/utility.h"
 
+#include "opentelemetry/sdk/configuration/aggregation_configuration.h"
 #include "opentelemetry/sdk/configuration/always_off_sampler_configuration.h"
 #include "opentelemetry/sdk/configuration/always_on_sampler_configuration.h"
+#include "opentelemetry/sdk/configuration/cardinality_limits_configuration.h"
 #include "opentelemetry/sdk/configuration/composable_always_off_sampler_configuration.h"
 #include "opentelemetry/sdk/configuration/composable_always_on_sampler_configuration.h"
 #include "opentelemetry/sdk/configuration/composable_parent_threshold_sampler_configuration.h"
@@ -30,6 +32,7 @@
 #include "opentelemetry/sdk/configuration/composable_rule_based_sampler_rule_attribute_values_configuration.h"
 #include "opentelemetry/sdk/configuration/composable_rule_based_sampler_rule_configuration.h"
 #include "opentelemetry/sdk/configuration/composable_sampler_configuration.h"
+#include "opentelemetry/sdk/configuration/explicit_bucket_histogram_aggregation_configuration.h"
 #include "opentelemetry/sdk/configuration/extension_push_metric_exporter_builder.h"
 #include "opentelemetry/sdk/configuration/extension_push_metric_exporter_configuration.h"
 #include "opentelemetry/sdk/configuration/instrument_type.h"
@@ -48,6 +51,7 @@
 #include "opentelemetry/sdk/configuration/span_limits_configuration.h"
 #include "opentelemetry/sdk/configuration/trace_id_ratio_based_sampler_configuration.h"
 #include "opentelemetry/sdk/configuration/tracer_provider_configuration.h"
+#include "opentelemetry/sdk/configuration/unsupported_exception.h"
 #include "opentelemetry/sdk/configuration/view_configuration.h"
 #include "opentelemetry/sdk/configuration/view_selector_configuration.h"
 #include "opentelemetry/sdk/configuration/view_stream_configuration.h"
@@ -701,9 +705,18 @@ TEST(SdkBuilder, CreatePeriodicMetricReader)
   exporter->name = "noop";
 
   config_sdk::PeriodicMetricReaderConfiguration model;
-  model.exporter = std::move(exporter);
-  model.interval = 12345;
-  model.timeout  = 678;
+  model.exporter           = std::move(exporter);
+  model.interval           = 12345;
+  model.timeout            = 678;
+  model.cardinality_limits = std::make_unique<config_sdk::CardinalityLimitsConfiguration>();
+  model.cardinality_limits->default_limit              = 100;
+  model.cardinality_limits->counter                    = 200;
+  model.cardinality_limits->gauge                      = 300;
+  model.cardinality_limits->histogram                  = 400;
+  model.cardinality_limits->observable_counter         = 500;
+  model.cardinality_limits->observable_gauge           = 600;
+  model.cardinality_limits->observable_up_down_counter = 700;
+  model.cardinality_limits->up_down_counter            = 800;
 
   auto captured = std::make_shared<config_test::CapturedPeriodicReaderArgs>();
 
@@ -721,6 +734,23 @@ TEST(SdkBuilder, CreatePeriodicMetricReader)
   EXPECT_EQ(captured->interval, model.interval);
   EXPECT_EQ(captured->timeout, model.timeout);
   EXPECT_TRUE(captured->exporter != nullptr);
+  EXPECT_EQ(reader->GetCardinalityLimit(opentelemetry::sdk::metrics::InstrumentType::kCounter),
+            200u);
+  EXPECT_EQ(reader->GetCardinalityLimit(opentelemetry::sdk::metrics::InstrumentType::kGauge), 300u);
+  EXPECT_EQ(reader->GetCardinalityLimit(opentelemetry::sdk::metrics::InstrumentType::kHistogram),
+            400u);
+  EXPECT_EQ(
+      reader->GetCardinalityLimit(opentelemetry::sdk::metrics::InstrumentType::kObservableCounter),
+      500u);
+  EXPECT_EQ(
+      reader->GetCardinalityLimit(opentelemetry::sdk::metrics::InstrumentType::kObservableGauge),
+      600u);
+  EXPECT_EQ(reader->GetCardinalityLimit(
+                opentelemetry::sdk::metrics::InstrumentType::kObservableUpDownCounter),
+            700u);
+  EXPECT_EQ(
+      reader->GetCardinalityLimit(opentelemetry::sdk::metrics::InstrumentType::kUpDownCounter),
+      800u);
 }
 
 namespace
@@ -744,6 +774,63 @@ std::unique_ptr<config_sdk::ViewConfiguration> MakeCardinalityOnlyViewConfig(
 
 }  // namespace
 
+#if OPENTELEMETRY_ABI_VERSION_NO < 2
+TEST(SdkBuilder, AddViewGaugeUnsupportedWithABIv1)
+{
+  auto model = MakeCardinalityOnlyViewConfig(config_sdk::InstrumentType::gauge, 42);
+
+  auto registry = std::make_shared<config_sdk::Registry>();
+  config_sdk::SdkBuilder builder(registry);
+  opentelemetry::sdk::metrics::ViewRegistry view_registry;
+
+  EXPECT_THROW(builder.AddView(&view_registry, model), config_sdk::UnsupportedException);
+}
+#endif
+
+TEST(SdkBuilder, AddViewEmptySelectorMatchesAllSupportedInstrumentTypes)
+{
+  namespace metrics_sdk = opentelemetry::sdk::metrics;
+
+  auto model = MakeCardinalityOnlyViewConfig(config_sdk::InstrumentType::none, 42);
+
+  auto registry = std::make_shared<config_sdk::Registry>();
+  config_sdk::SdkBuilder builder(registry);
+  metrics_sdk::ViewRegistry view_registry;
+  builder.AddView(&view_registry, model);
+
+  auto instrumentation_scope = scope_sdk::InstrumentationScope::Create("");
+  std::vector<metrics_sdk::InstrumentType> supported_instrument_types{
+      metrics_sdk::InstrumentType::kCounter,
+      metrics_sdk::InstrumentType::kHistogram,
+      metrics_sdk::InstrumentType::kUpDownCounter,
+      metrics_sdk::InstrumentType::kObservableCounter,
+      metrics_sdk::InstrumentType::kObservableGauge,
+      metrics_sdk::InstrumentType::kObservableUpDownCounter};
+#if OPENTELEMETRY_ABI_VERSION_NO >= 2
+  supported_instrument_types.push_back(metrics_sdk::InstrumentType::kGauge);
+#endif
+
+  for (auto instrument_type : supported_instrument_types)
+  {
+    metrics_sdk::InstrumentDescriptor instrument_descriptor{
+        "test.instrument", "test description", "units", instrument_type,
+        metrics_sdk::InstrumentValueType::kLong};
+    int matched = 0;
+    view_registry.FindViews(instrument_descriptor, *instrumentation_scope,
+                            [&](const metrics_sdk::View &view) {
+                              auto *config = view.GetAggregationConfig();
+                              EXPECT_NE(config, nullptr);
+                              if (config != nullptr)
+                              {
+                                EXPECT_EQ(config->cardinality_limit_, 42u);
+                                matched++;
+                              }
+                              return true;
+                            });
+    EXPECT_EQ(matched, 1);
+  }
+}
+
 TEST(SdkBuilder, AddViewHistogramCardinalityLimitOnly)
 {
   namespace metrics_sdk = opentelemetry::sdk::metrics;
@@ -757,7 +844,8 @@ TEST(SdkBuilder, AddViewHistogramCardinalityLimitOnly)
   builder.AddView(&view_registry, model);
 
   metrics_sdk::InstrumentDescriptor instrument_descriptor{
-      "", "", "", metrics_sdk::InstrumentType::kHistogram, metrics_sdk::InstrumentValueType::kLong};
+      "test.instrument", "test description", "units", metrics_sdk::InstrumentType::kHistogram,
+      metrics_sdk::InstrumentValueType::kLong};
   auto instrumentation_scope = scope_sdk::InstrumentationScope::Create("");
 
   int matched = 0;
@@ -810,7 +898,8 @@ TEST(SdkBuilder, AddViewCounterCardinalityLimitOnly)
   builder.AddView(&view_registry, model);
 
   metrics_sdk::InstrumentDescriptor instrument_descriptor{
-      "", "", "", metrics_sdk::InstrumentType::kCounter, metrics_sdk::InstrumentValueType::kLong};
+      "test.instrument", "test description", "units", metrics_sdk::InstrumentType::kCounter,
+      metrics_sdk::InstrumentValueType::kLong};
   auto instrumentation_scope = scope_sdk::InstrumentationScope::Create("");
 
   int matched = 0;
@@ -823,6 +912,47 @@ TEST(SdkBuilder, AddViewCounterCardinalityLimitOnly)
         {
           EXPECT_EQ(aggregation_config->GetType(), metrics_sdk::AggregationType::kDefault);
           EXPECT_EQ(aggregation_config->cardinality_limit_, 7u);
+        }
+        return true;
+      });
+
+  EXPECT_EQ(matched, 1);
+}
+
+TEST(SdkBuilder, AddViewWithCardinalityLimitPreservesExplicitAggregation)
+{
+  namespace metrics_sdk = opentelemetry::sdk::metrics;
+
+  auto model = MakeCardinalityOnlyViewConfig(config_sdk::InstrumentType::histogram, 42);
+  auto aggregation =
+      std::make_unique<config_sdk::ExplicitBucketHistogramAggregationConfiguration>();
+  aggregation->boundaries    = {1.0, 2.0};
+  model->stream->aggregation = std::move(aggregation);
+
+  auto registry = std::make_shared<config_sdk::Registry>();
+  config_sdk::SdkBuilder builder(registry);
+
+  metrics_sdk::ViewRegistry view_registry;
+  builder.AddView(&view_registry, model);
+
+  metrics_sdk::InstrumentDescriptor instrument_descriptor{
+      "test.instrument", "test description", "units", metrics_sdk::InstrumentType::kHistogram,
+      metrics_sdk::InstrumentValueType::kLong};
+  auto instrumentation_scope = scope_sdk::InstrumentationScope::Create("");
+
+  int matched = 0;
+  view_registry.FindViews(
+      instrument_descriptor, *instrumentation_scope, [&](const metrics_sdk::View &view) {
+        ++matched;
+        auto *aggregation_config = view.GetAggregationConfig();
+        EXPECT_NE(aggregation_config, nullptr);
+        if (aggregation_config)
+        {
+          EXPECT_EQ(aggregation_config->GetType(), metrics_sdk::AggregationType::kHistogram);
+          EXPECT_EQ(aggregation_config->cardinality_limit_, 42u);
+          auto *histogram_config =
+              static_cast<const metrics_sdk::HistogramAggregationConfig *>(aggregation_config);
+          EXPECT_EQ(histogram_config->boundaries_, (std::vector<double>{1.0, 2.0}));
         }
         return true;
       });

--- a/sdk/test/configuration/sdk_builder_test.cc
+++ b/sdk/test/configuration/sdk_builder_test.cc
@@ -51,7 +51,6 @@
 #include "opentelemetry/sdk/configuration/span_limits_configuration.h"
 #include "opentelemetry/sdk/configuration/trace_id_ratio_based_sampler_configuration.h"
 #include "opentelemetry/sdk/configuration/tracer_provider_configuration.h"
-#include "opentelemetry/sdk/configuration/unsupported_exception.h"
 #include "opentelemetry/sdk/configuration/view_configuration.h"
 #include "opentelemetry/sdk/configuration/view_selector_configuration.h"
 #include "opentelemetry/sdk/configuration/view_stream_configuration.h"
@@ -79,6 +78,10 @@
 #include "opentelemetry/trace/span_metadata.h"
 #include "opentelemetry/trace/trace_flags.h"
 #include "opentelemetry/trace/trace_id.h"
+
+#if OPENTELEMETRY_ABI_VERSION_NO < 2
+#  include "opentelemetry/sdk/configuration/unsupported_exception.h"
+#endif
 
 using opentelemetry::sdk::configuration::Registry;
 using opentelemetry::sdk::configuration::SdkBuilder;

--- a/sdk/test/configuration/yaml_metrics_test.cc
+++ b/sdk/test/configuration/yaml_metrics_test.cc
@@ -816,7 +816,7 @@ meter_provider:
   ASSERT_EQ(view->stream->attribute_keys, nullptr);
 }
 
-TEST(YamlMetrics, selector)
+TEST(YamlMetrics, selector_counter)
 {
   std::string yaml = R"(
 file_format: "1.0-metrics"
@@ -856,6 +856,181 @@ meter_provider:
   ASSERT_EQ(view->stream->aggregation_cardinality_limit, 0);
   ASSERT_EQ(view->stream->aggregation, nullptr);
   ASSERT_EQ(view->stream->attribute_keys, nullptr);
+}
+
+TEST(YamlMetrics, selector_gauge)
+{
+  std::string yaml = R"(
+file_format: "1.1"
+meter_provider:
+  readers:
+    - periodic:
+        exporter:
+          console:
+  views:
+    - selector:
+        instrument_type: gauge
+      stream:
+)";
+
+  auto config = DoParse(yaml);
+  ASSERT_NE(config, nullptr);
+  ASSERT_NE(config->meter_provider, nullptr);
+  ASSERT_EQ(config->meter_provider->views.size(), 1);
+  auto *view = config->meter_provider->views[0].get();
+  ASSERT_NE(view, nullptr);
+  ASSERT_NE(view->selector, nullptr);
+  ASSERT_EQ(view->selector->instrument_type,
+            opentelemetry::sdk::configuration::InstrumentType::gauge);
+}
+
+TEST(YamlMetrics, selector_histogram)
+{
+  std::string yaml = R"(
+file_format: "1.1"
+meter_provider:
+  readers:
+    - periodic:
+        exporter:
+          console:
+  views:
+    - selector:
+        instrument_type: histogram
+      stream:
+)";
+
+  auto config = DoParse(yaml);
+  ASSERT_NE(config, nullptr);
+  ASSERT_NE(config->meter_provider, nullptr);
+  ASSERT_EQ(config->meter_provider->views.size(), 1);
+  auto *view = config->meter_provider->views[0].get();
+  ASSERT_NE(view, nullptr);
+  ASSERT_NE(view->selector, nullptr);
+  ASSERT_EQ(view->selector->instrument_type,
+            opentelemetry::sdk::configuration::InstrumentType::histogram);
+}
+
+TEST(YamlMetrics, selector_observable_counter)
+{
+  std::string yaml = R"(
+file_format: "1.1"
+meter_provider:
+  readers:
+    - periodic:
+        exporter:
+          console:
+  views:
+    - selector:
+        instrument_type: observable_counter
+      stream:
+)";
+
+  auto config = DoParse(yaml);
+  ASSERT_NE(config, nullptr);
+  ASSERT_NE(config->meter_provider, nullptr);
+  ASSERT_EQ(config->meter_provider->views.size(), 1);
+  auto *view = config->meter_provider->views[0].get();
+  ASSERT_NE(view, nullptr);
+  ASSERT_NE(view->selector, nullptr);
+  ASSERT_EQ(view->selector->instrument_type,
+            opentelemetry::sdk::configuration::InstrumentType::observable_counter);
+}
+
+TEST(YamlMetrics, selector_observable_gauge)
+{
+  std::string yaml = R"(
+file_format: "1.1"
+meter_provider:
+  readers:
+    - periodic:
+        exporter:
+          console:
+  views:
+    - selector:
+        instrument_type: observable_gauge
+      stream:
+)";
+
+  auto config = DoParse(yaml);
+  ASSERT_NE(config, nullptr);
+  ASSERT_NE(config->meter_provider, nullptr);
+  ASSERT_EQ(config->meter_provider->views.size(), 1);
+  auto *view = config->meter_provider->views[0].get();
+  ASSERT_NE(view, nullptr);
+  ASSERT_NE(view->selector, nullptr);
+  ASSERT_EQ(view->selector->instrument_type,
+            opentelemetry::sdk::configuration::InstrumentType::observable_gauge);
+}
+
+TEST(YamlMetrics, selector_observable_up_down_counter)
+{
+  std::string yaml = R"(
+file_format: "1.1"
+meter_provider:
+  readers:
+    - periodic:
+        exporter:
+          console:
+  views:
+    - selector:
+        instrument_type: observable_up_down_counter
+      stream:
+)";
+
+  auto config = DoParse(yaml);
+  ASSERT_NE(config, nullptr);
+  ASSERT_NE(config->meter_provider, nullptr);
+  ASSERT_EQ(config->meter_provider->views.size(), 1);
+  auto *view = config->meter_provider->views[0].get();
+  ASSERT_NE(view, nullptr);
+  ASSERT_NE(view->selector, nullptr);
+  ASSERT_EQ(view->selector->instrument_type,
+            opentelemetry::sdk::configuration::InstrumentType::observable_up_down_counter);
+}
+
+TEST(YamlMetrics, selector_up_down_counter)
+{
+  std::string yaml = R"(
+file_format: "1.1"
+meter_provider:
+  readers:
+    - periodic:
+        exporter:
+          console:
+  views:
+    - selector:
+        instrument_type: up_down_counter
+      stream:
+)";
+
+  auto config = DoParse(yaml);
+  ASSERT_NE(config, nullptr);
+  ASSERT_NE(config->meter_provider, nullptr);
+  ASSERT_EQ(config->meter_provider->views.size(), 1);
+  auto *view = config->meter_provider->views[0].get();
+  ASSERT_NE(view, nullptr);
+  ASSERT_NE(view->selector, nullptr);
+  ASSERT_EQ(view->selector->instrument_type,
+            opentelemetry::sdk::configuration::InstrumentType::up_down_counter);
+}
+
+TEST(YamlMetrics, selector_invalid_instrument_type)
+{
+  std::string yaml = R"(
+file_format: "1.1"
+meter_provider:
+  readers:
+    - periodic:
+        exporter:
+          console:
+  views:
+    - selector:
+        instrument_type: invalid
+      stream:
+)";
+
+  auto config = DoParse(yaml);
+  ASSERT_EQ(config, nullptr);
 }
 
 TEST(YamlMetrics, stream)


### PR DESCRIPTION
Followup to: https://github.com/open-telemetry/opentelemetry-cpp/pull/4340

The schema includes synchronous `gauge` in the supported instrument types for view selection and defines a match all default behavior for unspecified instrument names and types. The current behavior is to throw an exception if the instrument type is not specified and select no instruments if the name is empty. 

This PR adds support for `gauge` and fixes the default behavior of the selector to match the schema. 

```yaml
  ViewSelector:
    type: object
    additionalProperties: false
    properties:
      instrument_name:
        type:
          - string
          - "null"
        description: |
          Configure instrument name selection criteria.
        defaultBehavior: all instrument names match
      instrument_type:
        $ref: "#/$defs/InstrumentType"
        description: |
          Configure instrument type selection criteria.
        defaultBehavior: all instrument types match
```

## Changes

- Added synchronous gauge view-selector support with ABI v2
- Fixed empty instrument name to match all instrument names
- Fixed `none` instrument type to match all supported instrument types
- Added SdkBuilder and programmatic config tests covering views and selection
- Updates the `kitchen-sink.yaml` to cover supported view configurations 

For significant contributions please make sure you have completed the following items:

* [x] `CHANGELOG.md` updated for non-trivial changes
* [x] Unit tests have been added
* [ ] Changes in public API reviewed