### PR TITLE
[BUG] Cancel a curl session without writing to the easy handle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,9 @@ Increment the:
 * [BUG] Stop the curl IO thread deadlocking on itself while recovering from a
   multi handle error
   ([#4394](https://github.com/open-telemetry/opentelemetry-cpp/pull/4394))
+* [BUG] Cancel a curl session without writing to the easy handle from the
+  cancelling thread
+  ([#4392](https://github.com/open-telemetry/opentelemetry-cpp/pull/4392))
 * [CODE HEALTH] Enable clang-tidy `modernize-deprecated-headers` and replace
   deprecated C headers (`stdint.h`, `stddef.h`, `stdlib.h`, `string.h`,
   `stdio.h`, `ctype.h`, `limits.h`, `assert.h`) with their C++ equivalents

--- a/ext/include/opentelemetry/ext/http/client/curl/http_operation_curl.h
+++ b/ext/include/opentelemetry/ext/http/client/curl/http_operation_curl.h
@@ -362,7 +362,8 @@ private:
 
   struct AsyncData
   {
-    Session *session{nullptr};  // Owner Session
+    // Read by Abort() on whichever thread cancels, cleared by Cleanup() on the IO thread.
+    std::atomic<Session *> session{nullptr};  // Owner Session
 
     std::thread::id callback_thread;
     std::function<void(HttpOperation &)> callback;

--- a/ext/src/http/client/curl/http_operation_curl.cc
+++ b/ext/src/http/client/curl/http_operation_curl.cc
@@ -375,12 +375,9 @@ int HttpOperation::OnProgressCallback(void *clientp,
     return -1;
   }
 
-  // CURL_PROGRESSFUNC_CONTINUE is added in 7.68.0
-#  if defined(CURL_PROGRESSFUNC_CONTINUE)
-  return CURL_PROGRESSFUNC_CONTINUE;
-#  else
+  // Not CURL_PROGRESSFUNC_CONTINUE, which asks libcurl to also run its built-in progress
+  // meter, and that meter writes to stderr.
   return 0;
-#  endif
 }
 #else
 int HttpOperation::OnProgressCallback(void *clientp,
@@ -546,11 +543,9 @@ void HttpOperation::Cleanup()
   if (async_data_)
   {
     // Just reset and move easy_handle to owner if in async mode
-    if (async_data_->session != nullptr)
+    Session *session = async_data_->session.exchange(nullptr, std::memory_order_acq_rel);
+    if (session != nullptr)
     {
-      auto session         = async_data_->session;
-      async_data_->session = nullptr;
-
       if (curl_resource_.easy_handle != nullptr)
       {
         curl_easy_setopt(curl_resource_.easy_handle, CURLOPT_PRIVATE, NULL);
@@ -1438,7 +1433,7 @@ CURLcode HttpOperation::SendAsync(Session *session, std::function<void(HttpOpera
 
   async_data_.reset(new AsyncData());
   async_data_->is_promise_running.store(false, std::memory_order_release);
-  async_data_->session = nullptr;
+  async_data_->session.store(nullptr, std::memory_order_release);
 
   ReleaseResponse();
 
@@ -1452,12 +1447,17 @@ CURLcode HttpOperation::SendAsync(Session *session, std::function<void(HttpOpera
   }
   curl_easy_setopt(curl_resource_.easy_handle, CURLOPT_PRIVATE, session);
 
+  // Only a session can be cancelled, so only this path needs the progress callback live. Setting
+  // it here, on the thread that owns the handle and before the handle is scheduled, leaves
+  // Abort() with nothing to do but raise the flag.
+  curl_easy_setopt(curl_resource_.easy_handle, CURLOPT_NOPROGRESS, 0L);
+
   DispatchEvent(opentelemetry::ext::http::client::SessionState::Connecting);
   is_finished_.store(false, std::memory_order_release);
   is_aborted_.store(false, std::memory_order_release);
   is_cleaned_.store(false, std::memory_order_release);
 
-  async_data_->session = session;
+  async_data_->session.store(session, std::memory_order_release);
   if (false == async_data_->is_promise_running.exchange(true, std::memory_order_acq_rel))
   {
     async_data_->result_promise = std::promise<CURLcode>();
@@ -1509,15 +1509,16 @@ void HttpOperation::ReleaseResponse()
 
 void HttpOperation::Abort()
 {
+  // The easy handle belongs to the thread inside curl_multi_perform, so nothing here reads or
+  // writes it. Raising the flag is enough: the progress callback polls it, and the scheduled
+  // abort removes the handle on that thread.
   is_aborted_.store(true, std::memory_order_release);
-  if (curl_resource_.easy_handle != nullptr)
+  if (async_data_)
   {
-    // Enable progress callback to abort from polling thread
-    curl_easy_setopt(curl_resource_.easy_handle, CURLOPT_NOPROGRESS, 0L);
-    if (async_data_ && nullptr != async_data_->session)
+    Session *session = async_data_->session.load(std::memory_order_acquire);
+    if (nullptr != session)
     {
-      async_data_->session->GetHttpClient().ScheduleAbortSession(
-          async_data_->session->GetSessionId());
+      session->GetHttpClient().ScheduleAbortSession(session->GetSessionId());
     }
   }
 }

--- a/ext/test/http/curl_http_test.cc
+++ b/ext/test/http/curl_http_test.cc
@@ -127,9 +127,8 @@ public:
     }
   }
 
-  // Cancelling reaches curl_easy_setopt through Abort(), so it has to run on the thread that
-  // owns the handle. Both cases below cancel from an event the IO thread dispatches, and assert
-  // on cancelled_from_ so that a later edit cannot quietly move it back to the caller.
+  // cancel_at_ picks the event to cancel from and cancelled_from_ records the thread it ran
+  // on, so a case can pin which side of the client it covers.
   http_client::Session *cancel_target_ = nullptr;
   http_client::SessionState cancel_at_ = http_client::SessionState::Response;
   std::thread::id cancelled_from_{};
@@ -580,7 +579,7 @@ TEST_F(BasicCurlHttpTests, ACancelBeforeTheResponseReportsCancelled)
   // else reports a cancel.
   EXPECT_EQ(1, handler->cancelled_from_callback_.load(std::memory_order_acquire));
   EXPECT_NE(handler->cancelled_from_, std::this_thread::get_id())
-      << "the cancel has to run on the IO thread, see #4369";
+      << "this case cancels from an event the IO thread dispatches";
 
   session_manager->FinishAllSessions();
 }
@@ -628,6 +627,66 @@ TEST_F(BasicCurlHttpTests, ResetMultiHandleWithASessionDoesNotDeadlock)
   http_client::curl::HttpClientTestPeer::ResetMultiHandle(*client);
 
   client->FinishAllSessions();
+}
+
+// The caller-thread side of the same cancel. The server handler takes mtx_requests before it
+// answers, so holding it keeps a response from racing the cancel and the abort lands while the
+// IO thread is still driving the easy handle. That pairing is what #4369 caught.
+TEST_F(BasicCurlHttpTests, ACancelFromTheCallerThreadReportsCancelled)
+{
+  received_requests_.clear();
+  auto session_manager = std::make_shared<http_client::curl::HttpCurlClientFactory>()->Create();
+  EXPECT_TRUE(session_manager != nullptr);
+
+  auto session = session_manager->CreateSession("http://127.0.0.1:19000");
+  auto request = session->CreateRequest();
+  request->SetUri("get/");
+
+  auto handler = std::make_shared<TerminalCountingHandler>();
+
+  {
+    std::unique_lock<std::mutex> lock_requests(mtx_requests);
+    session->SendRequest(handler);
+    session->CancelSession();
+    session->FinishSession();
+  }
+
+  EXPECT_FALSE(handler->got_response_.load(std::memory_order_acquire));
+  EXPECT_EQ(1, handler->cancelled_from_callback_.load(std::memory_order_acquire));
+
+  session_manager->FinishAllSessions();
+}
+
+// The same cancel again, repeated, because #4369 is a race and one attempt proves little.
+// Nothing listens on 19937, so every attempt fails to connect and the IO thread reaches Cleanup
+// while the caller is still inside CancelSession, which is the overlap the race needs. Under a
+// thread sanitizer this reports against the unfixed client on every run.
+TEST_F(BasicCurlHttpTests, RepeatedCallerThreadCancelsAreClean)
+{
+  int terminal_total = 0;
+
+  for (int i = 0; i < 20; ++i)
+  {
+    auto session_manager = std::make_shared<http_client::curl::HttpCurlClientFactory>()->Create();
+    ASSERT_TRUE(session_manager != nullptr);
+
+    auto session = session_manager->CreateSession("http://127.0.0.1:19937");
+    auto request = session->CreateRequest();
+    request->SetUri("get/");
+
+    auto handler = std::make_shared<TerminalCountingHandler>();
+    session->SendRequest(handler);
+    session->CancelSession();
+    session->FinishSession();
+    session_manager->FinishAllSessions();
+
+    EXPECT_FALSE(handler->got_response_.load(std::memory_order_acquire));
+    terminal_total += handler->terminal_count_.load(std::memory_order_acquire);
+  }
+
+  // A lower bound, not a count: #4360 tracks the same cancel arriving twice, and how many
+  // arrive is not what this case decides.
+  EXPECT_GE(terminal_total, 20);
 }
 
 TEST_F(BasicCurlHttpTests, SendGetRequestSync)


### PR DESCRIPTION
Fixes #4375.

`Abort()` ran `curl_easy_setopt` on whichever thread called `CancelSession()`, while the IO thread was driving the same easy handle through `curl_multi_perform`. That is the pairing TSAN caught in #4369, and libcurl's rule is that one easy handle must not be used by two threads at the same time.

## Where the option is set now

`CURLOPT_NOPROGRESS` was the only option still left at its default, which is the whole reason `Abort()` had to reach for the handle. `SendAsync()` sets it now, right beside `CURLOPT_PRIVATE`, on the thread that owns the handle and before the handle is scheduled. Cancelling is left with the atomic flag the progress callback already reads plus the abort it schedules.

It goes there rather than in `Setup()` because `Setup()` serves the synchronous path too, and nothing on that path can be cancelled: `Abort()` runs only from `Session::CancelSession()`, and `HttpClientSync` never makes a session. Arming the callback there would have bought nothing.

@owent, this keeps the fallback you described. `ScheduleAbortSession()` already calls `wakeupBackgroundThread()`, so on 7.68 and later `curl_multi_wakeup()` gets the IO thread out of `curl_multi_poll` on its own. What the progress callback still buys is the other case, where the IO thread is inside `curl_multi_perform` rather than waiting in the poll, and arming it up front costs one atomic load per progress tick instead of a cross thread write to the handle. The callback fires 376 times across `curl_http_test`, so the option is taking effect, and the cost does not show up: over five runs of the same 22 cases, `main` came in between 17.6 s and 18.6 s and this branch between 16.1 s and 18.6 s, which is the same spread.

## The race that actually reproduces

There is a second one in the same call, and it turned out to be the one I could trigger. `AsyncData::session` is a plain `Session *` that `Abort()` reads at `:1516` while `Cleanup()` writes `nullptr` to it at `:552` on the IO thread. It is `std::atomic<Session *>` now.

There is no lifetime question sitting behind the pointer value here: `Abort()` has exactly one caller, `Session::CancelSession()` at `http_client_curl.cc:249`, so the pointer is always the session whose own method is running, and callers hold that by `shared_ptr`.

Against unmodified `main`, with only the new test case added, TSAN reports on every run:

```text
WARNING: ThreadSanitizer: data race
  Write of size 8 by thread T3:
    #0 HttpOperation::Cleanup() ext/src/http/client/curl/http_operation_curl.cc:552
    #1 HttpOperation::PerformCurlMessage(CURLcode) ext/src/http/client/curl/http_operation_curl.cc:1629
  Previous read of size 8 by main thread:
    #0 HttpOperation::Abort() ext/src/http/client/curl/http_operation_curl.cc:1516
    #1 Session::CancelSession() ext/src/http/client/curl/http_client_curl.cc:249
```

| `curl_http_test --gtest_filter='*RepeatedCallerThreadCancels*'`, 5 runs | TSAN warnings |
| --- | --- |
| `main` at f6e48180 plus the new case | 5 |
| this branch | 0 |

## The return value had to change with it

`OnProgressCallback()` returned `CURL_PROGRESSFUNC_CONTINUE` when the request had not been aborted. That branch was unreachable while `CURLOPT_NOPROGRESS` was only cleared inside `Abort()`, since by then `is_aborted_` is already up and the callback returns early. Arming the option up front makes it the normal path, and it does not mean what the name suggests:

> If your callback function returns CURL_PROGRESSFUNC_CONTINUE it makes libcurl to continue executing the default progress function.

`lib/progress.c` falls straight through to `progress_meter()`, which writes to `data->set.err`, and that is stderr unless `CURLOPT_STDERR` says otherwise:

```c
      if(rc != CURL_PROGRESSFUNC_CONTINUE) {
        if(rc) {
          failf(data, "Callback aborted");
          return CURLE_ABORTED_BY_CALLBACK;
        }
        return CURLE_OK;
      }
    ...
    if(showprogress)
      progress_meter(data);
```

With the option armed and nothing differing but the return value:

| non-aborted return | `curl_http_test` stderr | progress meter headers |
| --- | --- | --- |
| `CURL_PROGRESSFUNC_CONTINUE` | 10,305 bytes | 31 |
| `0` | 114 bytes, one expected log line | 0 |

So without this half, the fix would have printed curl progress bars to stderr for every export that ran longer than a second. A standalone libcurl program built twice from one source, differing only in that return, gives the same answer: 711 bytes of meter against none.

## Tests

`RepeatedCallerThreadCancelsAreClean` cancels from the caller thread while the IO thread owns the handle, twenty times. Nothing listens on 19937, so each attempt fails to connect and the IO thread reaches `Cleanup()` while the caller is still inside `CancelSession()`, which is the overlap the race needs. It passes on `main` too, since a data race is not a functional failure, and it is there for the sanitizer builds.

The two existing cancel cases keep asserting they cancel from the IO thread, but the comment explaining why has to go: it said cancelling reaches `curl_easy_setopt` and therefore has to run on the owning thread, and after this that is no longer true.

## What this does not fix

Three things I ran into on the way and filed rather than folding in here: #4389, where the IO thread deadlocks on `sessions_m_` recovering from a `curl_multi_perform` error, #4390, where cancelling from a `Created` or `Connecting` event loses the cancel and leaves the caller blocked forever, and #4391, where the handle is reset and its header list freed before the removal from the multi handle. All three are on this file or its neighbour and none of them changes what is here.

#4360 is also unaffected: a cancel that the progress callback turns into `CURLE_ABORTED_BY_CALLBACK` still produces `ConnectFailed` or `SendFailed` followed by `Cancelled`. That was already the case before this change, since `Abort()` armed the same callback, so the event sequence is the same as it was.

## Checks

24 of 24 in `curl_http_test`, clean under `OTELCPP_MAINTAINER_MODE=ON`, clean under `clang-format` 18.1.8. The whole suite under TSAN is 24 of 24 with zero warnings.

For significant contributions please make sure you have completed the following items:

* [x] `CHANGELOG.md` updated for non-trivial changes
* [x] Unit tests have been added
* [x] Changes in public API reviewed
