### PR TITLE
[BUG] Complete a curl operation that is never scheduled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -123,6 +123,10 @@ Increment the:
   including the ones the IO thread delivers, instead of waiting on a completion
   only that thread goes on to publish
   ([#4395](https://github.com/open-telemetry/opentelemetry-cpp/pull/4395))
+* [BUG] Decide whether a curl thread is inside a callback without an
+  unsynchronized member, which was read and written from two threads behind a
+  sanitizer suppression
+  ([#4395](https://github.com/open-telemetry/opentelemetry-cpp/pull/4395))
 * [CODE HEALTH] Enable clang-tidy `modernize-deprecated-headers` and replace
   deprecated C headers (`stdint.h`, `stddef.h`, `stdlib.h`, `string.h`,
   `stdio.h`, `ctype.h`, `limits.h`, `assert.h`) with their C++ equivalents

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -119,6 +119,10 @@ Increment the:
 * [BUG] Store the curl session state before the event that reports it, so a
   cancel dispatched by the IO thread is not overwritten or raced
   ([#4395](https://github.com/open-telemetry/opentelemetry-cpp/pull/4395))
+* [BUG] Let a handler finish the request it is being told about from any event,
+  including the ones the IO thread delivers, instead of waiting on a completion
+  only that thread goes on to publish
+  ([#4395](https://github.com/open-telemetry/opentelemetry-cpp/pull/4395))
 * [CODE HEALTH] Enable clang-tidy `modernize-deprecated-headers` and replace
   deprecated C headers (`stdint.h`, `stddef.h`, `stdlib.h`, `string.h`,
   `stdio.h`, `ctype.h`, `limits.h`, `assert.h`) with their C++ equivalents

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -113,6 +113,9 @@ Increment the:
 * [BUG] Finish a curl operation that never gets scheduled, instead of leaving
   FinishSession blocked forever
   ([#4395](https://github.com/open-telemetry/opentelemetry-cpp/pull/4395))
+* [BUG] Report a curl request the multi handle refused as a failed create,
+  rather than as a cancel nobody asked for
+  ([#4395](https://github.com/open-telemetry/opentelemetry-cpp/pull/4395))
 * [BUG] Store the curl session state before the event that reports it, so a
   cancel dispatched by the IO thread is not overwritten or raced
   ([#4395](https://github.com/open-telemetry/opentelemetry-cpp/pull/4395))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -113,6 +113,9 @@ Increment the:
 * [BUG] Finish a curl operation that never gets scheduled, instead of leaving
   FinishSession blocked forever
   ([#4395](https://github.com/open-telemetry/opentelemetry-cpp/pull/4395))
+* [BUG] Store the curl session state before the event that reports it, so a
+  cancel dispatched by the IO thread is not overwritten or raced
+  ([#4395](https://github.com/open-telemetry/opentelemetry-cpp/pull/4395))
 * [CODE HEALTH] Enable clang-tidy `modernize-deprecated-headers` and replace
   deprecated C headers (`stdint.h`, `stddef.h`, `stdlib.h`, `string.h`,
   `stdio.h`, `ctype.h`, `limits.h`, `assert.h`) with their C++ equivalents

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -110,6 +110,9 @@ Increment the:
 * [BUG] Cancel a curl session without writing to the easy handle from the
   cancelling thread
   ([#4392](https://github.com/open-telemetry/opentelemetry-cpp/pull/4392))
+* [BUG] Finish a curl operation that never gets scheduled, instead of leaving
+  FinishSession blocked forever
+  ([#4395](https://github.com/open-telemetry/opentelemetry-cpp/pull/4395))
 * [CODE HEALTH] Enable clang-tidy `modernize-deprecated-headers` and replace
   deprecated C headers (`stdint.h`, `stddef.h`, `stdlib.h`, `string.h`,
   `stdio.h`, `ctype.h`, `limits.h`, `assert.h`) with their C++ equivalents

--- a/ext/include/opentelemetry/ext/http/client/curl/http_client_curl.h
+++ b/ext/include/opentelemetry/ext/http/client/curl/http_client_curl.h
@@ -348,7 +348,7 @@ public:
   // return true if create background thread, false is already exist background thread
   bool MaybeSpawnBackgroundThread();
 
-  void ScheduleAddSession(uint64_t session_id);
+  bool ScheduleAddSession(uint64_t session_id);
   void ScheduleAbortSession(uint64_t session_id);
   void ScheduleRemoveSession(uint64_t session_id, HttpCurlEasyResource &&resource);
 

--- a/ext/include/opentelemetry/ext/http/client/curl/http_client_curl.h
+++ b/ext/include/opentelemetry/ext/http/client/curl/http_client_curl.h
@@ -368,6 +368,12 @@ private:
 
   std::mutex multi_handle_m_;
   CURLM *multi_handle_;
+
+  // How a session is handed to the multi handle. Only a test replaces it, so that a case about
+  // what happens to a refused session can name the code libcurl returns instead of arranging a
+  // multi handle libcurl documents as unusable and relying on what it does with one.
+  CURLMcode (*add_handle_)(CURLM *, CURL *) = &curl_multi_add_handle;
+
   std::atomic<uint64_t> next_session_id_{0};
   uint64_t max_sessions_per_connection_;
 

--- a/ext/include/opentelemetry/ext/http/client/curl/http_operation_curl.h
+++ b/ext/include/opentelemetry/ext/http/client/curl/http_operation_curl.h
@@ -13,6 +13,7 @@
 #  include <future>
 #endif
 
+#include <atomic>
 #include <cstdint>
 #include <functional>
 #include <map>
@@ -246,7 +247,7 @@ public:
    */
   opentelemetry::ext::http::client::SessionState GetSessionState() const noexcept
   {
-    return session_state_;
+    return session_state_.load(std::memory_order_acquire);
   }
 
   /**
@@ -338,7 +339,9 @@ private:
   const Headers &request_headers_;
   const opentelemetry::ext::http::client::Body &request_body_;
   size_t request_nwrite_{0};
-  opentelemetry::ext::http::client::SessionState session_state_{
+  // Written by whichever thread dispatches an event. A handler that cancels from one event
+  // lets the background thread dispatch another, so the two dispatches can overlap.
+  std::atomic<opentelemetry::ext::http::client::SessionState> session_state_{
       opentelemetry::ext::http::client::SessionState::Created};
 
   const opentelemetry::ext::http::client::Compression &compression_;

--- a/ext/include/opentelemetry/ext/http/client/curl/http_operation_curl.h
+++ b/ext/include/opentelemetry/ext/http/client/curl/http_operation_curl.h
@@ -20,7 +20,6 @@
 #include <regex>
 #include <sstream>
 #include <string>
-#include <thread>
 #include <vector>
 #ifdef _WIN32
 #  include <io.h>
@@ -230,17 +229,6 @@ public:
    */
   CURLcode SendAsync(Session *session, std::function<void(HttpOperation &)> callback = nullptr);
 
-  /**
-   * Finish an operation that nothing is going to run, and say why.
-   *
-   * The event goes in ahead of the cleanup, because the only strong reference to the caller's
-   * handler is the one the completion callback holds and the cleanup is what lets that go. The
-   * event carries the terminal state with it, so the cleanup still does not report a cancel
-   * nobody asked for, and cleaning up last is what makes a Finish() on another thread wait for
-   * the event rather than for the promise alone.
-   */
-  void FinishUnscheduled(const char *reason);
-
   inline void SendSync() { Send(); }
 
   /**
@@ -302,6 +290,22 @@ public:
   inline CURL *GetCurlEasyHandle() noexcept { return curl_resource_.easy_handle; }
 
 private:
+  // The client is what discovers that nothing will run a request, so it is what gets to say so.
+  friend class HttpClient;
+
+  /**
+   * Finish an operation that nothing is going to run, and say why. Not for callers: it forces a
+   * terminal state, cleans up, dispatches the terminal event, fulfils the promise and hands the
+   * easy resource back, none of which is safe to ask for from outside the client.
+   *
+   * The event goes in ahead of the cleanup, because the only strong reference to the caller's
+   * handler is the one the completion callback holds and the cleanup is what lets that go. The
+   * event carries the terminal state with it, so the cleanup still does not report a cancel
+   * nobody asked for, and cleaning up last is what makes a Finish() on another thread wait for
+   * the event rather than for the promise alone.
+   */
+  void FinishUnscheduled(const char *reason);
+
   CURLcode SetCurlPtrOption(CURLoption option, void *value);
 
   CURLcode SetCurlStrOption(CURLoption option, const char *str)
@@ -378,13 +382,11 @@ private:
     // Read by Abort() on whichever thread cancels, cleared by Cleanup() on the IO thread.
     std::atomic<Session *> session{nullptr};  // Owner Session
 
-    std::thread::id callback_thread;
     std::function<void(HttpOperation &)> callback;
     std::atomic<bool> is_promise_running{false};
     std::promise<CURLcode> result_promise;
     std::future<CURLcode> result_future;
   };
-  friend class HttpOperationAccessor;
   std::unique_ptr<AsyncData> async_data_;
 };
 }  // namespace curl

--- a/ext/include/opentelemetry/ext/http/client/curl/http_operation_curl.h
+++ b/ext/include/opentelemetry/ext/http/client/curl/http_operation_curl.h
@@ -339,8 +339,7 @@ private:
   const Headers &request_headers_;
   const opentelemetry::ext::http::client::Body &request_body_;
   size_t request_nwrite_{0};
-  // Written by whichever thread dispatches an event. A handler that cancels from one event
-  // lets the background thread dispatch another, so the two dispatches can overlap.
+  // Atomic because a handler that cancels from one event can overlap the next dispatch.
   std::atomic<opentelemetry::ext::http::client::SessionState> session_state_{
       opentelemetry::ext::http::client::SessionState::Created};
 

--- a/ext/include/opentelemetry/ext/http/client/curl/http_operation_curl.h
+++ b/ext/include/opentelemetry/ext/http/client/curl/http_operation_curl.h
@@ -233,9 +233,11 @@ public:
   /**
    * Finish an operation that nothing is going to run, and say why.
    *
-   * The state goes in ahead of the cleanup, which would otherwise report a cancel nobody asked
-   * for, and the cleanup goes in ahead of the event, so a handler that calls FinishSession()
-   * from it is not waiting on the promise that this cleanup is the only thing able to fulfil.
+   * The event goes in ahead of the cleanup, because the only strong reference to the caller's
+   * handler is the one the completion callback holds and the cleanup is what lets that go. The
+   * event carries the terminal state with it, so the cleanup still does not report a cancel
+   * nobody asked for, and cleaning up last is what makes a Finish() on another thread wait for
+   * the event rather than for the promise alone.
    */
   void FinishUnscheduled(const char *reason);
 

--- a/ext/include/opentelemetry/ext/http/client/curl/http_operation_curl.h
+++ b/ext/include/opentelemetry/ext/http/client/curl/http_operation_curl.h
@@ -230,6 +230,15 @@ public:
    */
   CURLcode SendAsync(Session *session, std::function<void(HttpOperation &)> callback = nullptr);
 
+  /**
+   * Finish an operation that nothing is going to run, and say why.
+   *
+   * The state goes in ahead of the cleanup, which would otherwise report a cancel nobody asked
+   * for, and the cleanup goes in ahead of the event, so a handler that calls FinishSession()
+   * from it is not waiting on the promise that this cleanup is the only thing able to fulfil.
+   */
+  void FinishUnscheduled(const char *reason);
+
   inline void SendSync() { Send(); }
 
   /**

--- a/ext/src/http/client/curl/http_client_curl.cc
+++ b/ext/src/http/client/curl/http_client_curl.cc
@@ -644,10 +644,8 @@ bool HttpClient::ScheduleAddSession(uint64_t session_id)
     std::lock_guard<std::mutex> sessions_lock{sessions_m_};
     if (sessions_.end() == sessions_.find(session_id))
     {
-      // Either the URL never parsed, so CreateSession handed the caller a session it did not
-      // register, or a handler took this one out while the first events were dispatched.
-      // Whatever removed it owns the teardown; adding it back would run an operation nobody
-      // is waiting on and leave the caller waiting on one nobody runs.
+      // Whatever removed the session owns its teardown. Adding it back would run an operation
+      // nobody waits on, and leave the caller waiting on one nobody runs.
       return false;
     }
 

--- a/ext/src/http/client/curl/http_client_curl.cc
+++ b/ext/src/http/client/curl/http_client_curl.cc
@@ -765,7 +765,7 @@ bool HttpClient::doAddSessions()
         continue;
       }
 
-      const CURLMcode rc = curl_multi_add_handle(multi_handle_, easy_handle);
+      const CURLMcode rc = add_handle_(multi_handle_, easy_handle);
       if (CURLM_OK != rc)
       {
         // Nothing will drive this transfer. Leaving it here is what makes a caller wait on a

--- a/ext/src/http/client/curl/http_client_curl.cc
+++ b/ext/src/http/client/curl/http_client_curl.cc
@@ -784,7 +784,6 @@ bool HttpClient::doAddSessions()
   for (auto &rejected : rejected_by_multi)
   {
     const char *reason = curl_multi_strerror(rejected.second);
-    OTEL_INTERNAL_LOG_ERROR("[HTTP Client Curl] curl_multi_add_handle failed: " << reason);
 
     // Told the same way as a session this client never registered, because it is the same thing
     // from the handler's side: nothing is going to run this request.
@@ -793,6 +792,11 @@ bool HttpClient::doAddSessions()
     {
       operation->FinishUnscheduled(reason);
     }
+
+    // Settled first. A log handler is replaceable application code, and one that calls
+    // FinishSession() from here would otherwise wait on a promise only the line above fulfils,
+    // on this thread.
+    OTEL_INTERNAL_LOG_ERROR("[HTTP Client Curl] curl_multi_add_handle failed: " << reason);
   }
 
   // Finishing a rejected session queues its removal, and the loop's idle check has already run

--- a/ext/src/http/client/curl/http_client_curl.cc
+++ b/ext/src/http/client/curl/http_client_curl.cc
@@ -783,9 +783,16 @@ bool HttpClient::doAddSessions()
   // that cancels from it takes that lock again. See #4389.
   for (auto &rejected : rejected_by_multi)
   {
-    OTEL_INTERNAL_LOG_ERROR("[HTTP Client Curl] curl_multi_add_handle failed: "
-                            << curl_multi_strerror(rejected.second));
-    rejected.first->FinishOperation();
+    const char *reason = curl_multi_strerror(rejected.second);
+    OTEL_INTERNAL_LOG_ERROR("[HTTP Client Curl] curl_multi_add_handle failed: " << reason);
+
+    // Told the same way as a session this client never registered, because it is the same thing
+    // from the handler's side: nothing is going to run this request.
+    auto &operation = rejected.first->GetOperation();
+    if (operation)
+    {
+      operation->FinishUnscheduled(reason);
+    }
   }
 
   // Finishing a rejected session queues its removal, and the loop's idle check has already run

--- a/ext/src/http/client/curl/http_client_curl.cc
+++ b/ext/src/http/client/curl/http_client_curl.cc
@@ -327,7 +327,12 @@ std::shared_ptr<opentelemetry::ext::http::client::Session> HttpClient::CreateSes
   const auto parsedUrl = common::UrlParser(std::string(url));
   if (!parsedUrl.success_)
   {
-    return std::make_shared<Session>(*this);
+    // Unregistered, but given an id all the same. Pending removals are keyed by session id, so
+    // two sessions sharing one displace each other's easy handle and header list, which nothing
+    // then frees.
+    auto unregistered = std::make_shared<Session>(*this);
+    unregistered->SetId(++next_session_id_);
+    return unregistered;
   }
   auto session =
       std::make_shared<Session>(*this, parsedUrl.scheme_, parsedUrl.host_, parsedUrl.port_);
@@ -737,7 +742,7 @@ bool HttpClient::doAddSessions()
   }
 
   bool has_data = false;
-  std::list<std::shared_ptr<Session>> rejected_by_multi;
+  std::list<std::pair<std::shared_ptr<Session>, CURLMcode>> rejected_by_multi;
 
   {
     std::lock_guard<std::mutex> lock_guard{sessions_m_};
@@ -764,10 +769,9 @@ bool HttpClient::doAddSessions()
       if (CURLM_OK != rc)
       {
         // Nothing will drive this transfer. Leaving it here is what makes a caller wait on a
-        // future nobody can complete, so hand it to the loop below to be finished.
-        OTEL_INTERNAL_LOG_ERROR(
-            "[HTTP Client Curl] curl_multi_add_handle failed: " << curl_multi_strerror(rc));
-        rejected_by_multi.push_back(session->second);
+        // future nobody can complete, so hand it to the loop below to be finished. Reported
+        // there too: the log handler is application code that can re-enter this client.
+        rejected_by_multi.emplace_back(session->second, rc);
         continue;
       }
 
@@ -777,12 +781,17 @@ bool HttpClient::doAddSessions()
 
   // Outside sessions_m_ on purpose. FinishOperation runs the caller's handler, and a handler
   // that cancels from it takes that lock again. See #4389.
-  for (auto &session : rejected_by_multi)
+  for (auto &rejected : rejected_by_multi)
   {
-    session->FinishOperation();
+    OTEL_INTERNAL_LOG_ERROR("[HTTP Client Curl] curl_multi_add_handle failed: "
+                            << curl_multi_strerror(rejected.second));
+    rejected.first->FinishOperation();
   }
 
-  return has_data;
+  // Finishing a rejected session queues its removal, and the loop's idle check has already run
+  // doRemoveSessions by the time it calls this. Answering false here lets the worker exit with
+  // that removal still queued.
+  return has_data || !rejected_by_multi.empty();
 }
 
 bool HttpClient::doAbortSessions()

--- a/ext/src/http/client/curl/http_client_curl.cc
+++ b/ext/src/http/client/curl/http_client_curl.cc
@@ -11,6 +11,7 @@
 #include <functional>
 #include <list>
 #include <mutex>
+#include <ostream>
 #include <string>
 #include <thread>
 #include <unordered_map>
@@ -23,6 +24,7 @@
 #include "opentelemetry/ext/http/common/url_parser.h"
 #include "opentelemetry/nostd/shared_ptr.h"
 #include "opentelemetry/nostd/string_view.h"
+#include "opentelemetry/sdk/common/global_log_handler.h"
 #include "opentelemetry/sdk/common/thread_instrumentation.h"
 #include "opentelemetry/version.h"
 
@@ -33,8 +35,6 @@
 #  include <array>
 
 #  include "opentelemetry/nostd/type_traits.h"
-#else
-#  include "opentelemetry/sdk/common/global_log_handler.h"
 #endif
 
 OPENTELEMETRY_BEGIN_NAMESPACE
@@ -638,9 +638,19 @@ bool HttpClient::MaybeSpawnBackgroundThread()
   return true;
 }
 
-void HttpClient::ScheduleAddSession(uint64_t session_id)
+bool HttpClient::ScheduleAddSession(uint64_t session_id)
 {
   {
+    std::lock_guard<std::mutex> sessions_lock{sessions_m_};
+    if (sessions_.end() == sessions_.find(session_id))
+    {
+      // Either the URL never parsed, so CreateSession handed the caller a session it did not
+      // register, or a handler took this one out while the first events were dispatched.
+      // Whatever removed it owns the teardown; adding it back would run an operation nobody
+      // is waiting on and leave the caller waiting on one nobody runs.
+      return false;
+    }
+
     std::lock_guard<std::recursive_mutex> lock_guard{session_ids_m_};
     pending_to_add_session_ids_.insert(session_id);
     pending_to_remove_session_handles_.erase(session_id);
@@ -648,6 +658,7 @@ void HttpClient::ScheduleAddSession(uint64_t session_id)
   }
 
   wakeupBackgroundThread();
+  return true;
 }
 
 void HttpClient::ScheduleAbortSession(uint64_t session_id)
@@ -728,29 +739,49 @@ bool HttpClient::doAddSessions()
   }
 
   bool has_data = false;
+  std::list<std::shared_ptr<Session>> rejected_by_multi;
 
-  std::lock_guard<std::mutex> lock_guard{sessions_m_};
-  for (auto &session_id : pending_to_add_session_ids)
   {
-    auto session = sessions_.find(session_id);
-    if (session == sessions_.end())
+    std::lock_guard<std::mutex> lock_guard{sessions_m_};
+    for (auto &session_id : pending_to_add_session_ids)
     {
-      continue;
-    }
+      auto session = sessions_.find(session_id);
+      if (session == sessions_.end())
+      {
+        continue;
+      }
 
-    if (!session->second->GetOperation())
-    {
-      continue;
-    }
+      if (!session->second->GetOperation())
+      {
+        continue;
+      }
 
-    CURL *easy_handle = session->second->GetOperation()->GetCurlEasyHandle();
-    if (nullptr == easy_handle)
-    {
-      continue;
-    }
+      CURL *easy_handle = session->second->GetOperation()->GetCurlEasyHandle();
+      if (nullptr == easy_handle)
+      {
+        continue;
+      }
 
-    curl_multi_add_handle(multi_handle_, easy_handle);
-    has_data = true;
+      const CURLMcode rc = curl_multi_add_handle(multi_handle_, easy_handle);
+      if (CURLM_OK != rc)
+      {
+        // Nothing will drive this transfer. Leaving it here is what makes a caller wait on a
+        // future nobody can complete, so hand it to the loop below to be finished.
+        OTEL_INTERNAL_LOG_ERROR(
+            "[HTTP Client Curl] curl_multi_add_handle failed: " << curl_multi_strerror(rc));
+        rejected_by_multi.push_back(session->second);
+        continue;
+      }
+
+      has_data = true;
+    }
+  }
+
+  // Outside sessions_m_ on purpose. FinishOperation runs the caller's handler, and a handler
+  // that cancels from it takes that lock again. See #4389.
+  for (auto &session : rejected_by_multi)
+  {
+    session->FinishOperation();
   }
 
   return has_data;

--- a/ext/src/http/client/curl/http_operation_curl.cc
+++ b/ext/src/http/client/curl/http_operation_curl.cc
@@ -20,7 +20,6 @@
 #include <random>
 #include <sstream>
 #include <string>
-#include <thread>
 #include <utility>
 #include <vector>
 
@@ -97,28 +96,6 @@ namespace client
 {
 namespace curl
 {
-
-class HttpOperationAccessor
-{
-public:
-  OPENTELEMETRY_SANITIZER_NO_THREAD static std::thread::id GetThreadId(
-      const HttpOperation::AsyncData &async_data)
-  {
-#if !(defined(OPENTELEMETRY_HAVE_THREAD_SANITIZER) && OPENTELEMETRY_HAVE_THREAD_SANITIZER)
-    std::atomic_thread_fence(std::memory_order_acquire);
-#endif
-    return async_data.callback_thread;
-  }
-
-  OPENTELEMETRY_SANITIZER_NO_THREAD static void SetThreadId(HttpOperation::AsyncData &async_data,
-                                                            std::thread::id thread_id)
-  {
-    async_data.callback_thread = thread_id;
-#if !(defined(OPENTELEMETRY_HAVE_THREAD_SANITIZER) && OPENTELEMETRY_HAVE_THREAD_SANITIZER)
-    std::atomic_thread_fence(std::memory_order_release);
-#endif
-  }
-};
 
 size_t HttpOperation::WriteMemoryCallback(void *contents, size_t size, size_t nmemb, void *userp)
 {
@@ -542,13 +519,14 @@ HttpOperation::~HttpOperation()
     case opentelemetry::ext::http::client::SessionState::Connecting:
     case opentelemetry::ext::http::client::SessionState::Connected:
     case opentelemetry::ext::http::client::SessionState::Sending: {
-      if (async_data_ && async_data_->result_future.valid())
+      // Not while inside a callback this operation dispatched: a handler that destroys the
+      // operation it is being told about would be waiting for a completion that only the thread
+      // running the handler can publish.
+      if (async_data_ && async_data_->result_future.valid() &&
+          !CallbackScope::InsideCallbackFor(this))
       {
-        if (HttpOperationAccessor::GetThreadId(*async_data_) != std::this_thread::get_id())
-        {
-          async_data_->result_future.wait();
-          last_curl_result_ = async_data_->result_future.get();
-        }
+        async_data_->result_future.wait();
+        last_curl_result_ = async_data_->result_future.get();
       }
       break;
     }
@@ -576,12 +554,8 @@ void HttpOperation::Finish()
 
   if (async_data_ && async_data_->result_future.valid())
   {
-    // We should not wait in callback from Cleanup()
-    if (HttpOperationAccessor::GetThreadId(*async_data_) != std::this_thread::get_id())
-    {
-      async_data_->result_future.wait();
-      last_curl_result_ = async_data_->result_future.get();
-    }
+    async_data_->result_future.wait();
+    last_curl_result_ = async_data_->result_future.get();
   }
 }
 
@@ -628,9 +602,7 @@ void HttpOperation::Cleanup()
     if (callback)
     {
       const CallbackScope scope{this};
-      HttpOperationAccessor::SetThreadId(*async_data_, std::this_thread::get_id());
       callback(*this);
-      HttpOperationAccessor::SetThreadId(*async_data_, std::thread::id());
     }
 
     // Set value to promise to continue Finish()

--- a/ext/src/http/client/curl/http_operation_curl.cc
+++ b/ext/src/http/client/curl/http_operation_curl.cc
@@ -413,6 +413,39 @@ static_assert(
         alignof(opentelemetry::ext::http::client::SessionState),
     "std::atomic<SessionState> is more aligned, which changes the layout of HttpOperation");
 
+namespace
+{
+// Which operations the calling thread is currently inside a callback for. A handler is allowed to
+// call FinishSession() on the request it is being told about, and that call must not wait for a
+// completion only the thread it is running on can publish.
+thread_local std::vector<const HttpOperation *> callbacks_in_progress;
+
+class CallbackScope
+{
+public:
+  explicit CallbackScope(const HttpOperation *operation) noexcept
+  {
+    callbacks_in_progress.push_back(operation);
+  }
+  ~CallbackScope() { callbacks_in_progress.pop_back(); }
+
+  CallbackScope(const CallbackScope &)            = delete;
+  CallbackScope &operator=(const CallbackScope &) = delete;
+
+  static bool InsideCallbackFor(const HttpOperation *operation) noexcept
+  {
+    for (const auto *entry : callbacks_in_progress)
+    {
+      if (entry == operation)
+      {
+        return true;
+      }
+    }
+    return false;
+  }
+};
+}  // namespace
+
 void HttpOperation::DispatchEvent(opentelemetry::ext::http::client::SessionState type,
                                   const std::string &reason)
 {
@@ -422,6 +455,7 @@ void HttpOperation::DispatchEvent(opentelemetry::ext::http::client::SessionState
 
   if (event_handle_ != nullptr)
   {
+    const CallbackScope scope{this};
     event_handle_->OnEvent(type, reason);
   }
 }
@@ -514,6 +548,14 @@ HttpOperation::~HttpOperation()
 
 void HttpOperation::Finish()
 {
+  // Called from inside a callback this operation dispatched, so the completion being waited for is
+  // the one this thread has not published yet. Returning before the flag below leaves the wait
+  // available to a caller that is not inside a callback.
+  if (CallbackScope::InsideCallbackFor(this))
+  {
+    return;
+  }
+
   if (is_finished_.exchange(true, std::memory_order_acq_rel))
   {
     return;
@@ -572,6 +614,7 @@ void HttpOperation::Cleanup()
     callback.swap(async_data_->callback);
     if (callback)
     {
+      const CallbackScope scope{this};
       HttpOperationAccessor::SetThreadId(*async_data_, std::this_thread::get_id());
       callback(*this);
       HttpOperationAccessor::SetThreadId(*async_data_, std::thread::id());
@@ -1472,26 +1515,18 @@ CURLcode HttpOperation::SendAsync(Session *session, std::function<void(HttpOpera
   is_finished_.store(false, std::memory_order_release);
   is_aborted_.store(false, std::memory_order_release);
   is_cleaned_.store(false, std::memory_order_release);
-  async_data_->session.store(session, std::memory_order_release);
-  async_data_->callback = std::move(callback);
-
-  DispatchEvent(opentelemetry::ext::http::client::SessionState::Connecting);
-
-  // The future alone stays unpublished until after the event, so a handler calling
-  // FinishSession() from it returns instead of waiting on an unscheduled transfer.
+  async_data_->callback       = std::move(callback);
   async_data_->result_promise = std::promise<CURLcode>();
   async_data_->result_future  = async_data_->result_promise.get_future();
   async_data_->is_promise_running.store(true, std::memory_order_release);
 
-  // A cancel from the event may have torn the operation down before the future existed.
-  if (is_cleaned_.load(std::memory_order_acquire))
-  {
-    if (async_data_->is_promise_running.exchange(false, std::memory_order_acq_rel))
-    {
-      async_data_->result_promise.set_value(last_curl_result_);
-    }
-    return CURLE_OK;
-  }
+  // Last, and the only thing that makes this operation reachable from the IO thread: an abort is
+  // queued through this route, so nothing can bring the operation there before the callback and
+  // the completion above exist. Cleanup is therefore the only thing that ever fulfils the promise,
+  // at its tail, once the terminal event and the completion callback have run.
+  async_data_->session.store(session, std::memory_order_release);
+
+  DispatchEvent(opentelemetry::ext::http::client::SessionState::Connecting);
 
   if (WasAborted())
   {

--- a/ext/src/http/client/curl/http_operation_curl.cc
+++ b/ext/src/http/client/curl/http_operation_curl.cc
@@ -418,32 +418,45 @@ namespace
 // Which operations the calling thread is currently inside a callback for. A handler is allowed to
 // call FinishSession() on the request it is being told about, and that call must not wait for a
 // completion only the thread it is running on can publish.
-thread_local std::vector<const HttpOperation *> callbacks_in_progress;
-
+// A stack of scopes linked through the scopes themselves, so entering one allocates nothing. Each
+// lives on the stack frame that dispatches the callback, which is exactly as long as the entry
+// needs to be there. A container here would put a heap allocation on every event, and would put
+// it inside a noexcept constructor, where running out of memory calls std::terminate rather than
+// reaching whoever asked for the request.
 class CallbackScope
 {
 public:
   explicit CallbackScope(const HttpOperation *operation) noexcept
+      : operation_{operation}, previous_{current_}
   {
-    callbacks_in_progress.push_back(operation);
+    current_ = this;
   }
-  ~CallbackScope() { callbacks_in_progress.pop_back(); }
+
+  ~CallbackScope() { current_ = previous_; }
 
   CallbackScope(const CallbackScope &)            = delete;
   CallbackScope &operator=(const CallbackScope &) = delete;
 
   static bool InsideCallbackFor(const HttpOperation *operation) noexcept
   {
-    for (const auto *entry : callbacks_in_progress)
+    for (const CallbackScope *scope = current_; nullptr != scope; scope = scope->previous_)
     {
-      if (entry == operation)
+      if (scope->operation_ == operation)
       {
         return true;
       }
     }
     return false;
   }
+
+private:
+  const HttpOperation *operation_;
+  const CallbackScope *previous_;
+
+  static thread_local const CallbackScope *current_;
 };
+
+thread_local const CallbackScope *CallbackScope::current_ = nullptr;
 }  // namespace
 
 void HttpOperation::DispatchEvent(opentelemetry::ext::http::client::SessionState type,

--- a/ext/src/http/client/curl/http_operation_curl.cc
+++ b/ext/src/http/client/curl/http_operation_curl.cc
@@ -404,9 +404,8 @@ int HttpOperation::OnProgressCallback(void *clientp,
 void HttpOperation::DispatchEvent(opentelemetry::ext::http::client::SessionState type,
                                   const std::string &reason)
 {
-  // Published before the handler runs. A handler can cancel from here, which lets the background
-  // thread finish the operation and publish a state of its own, and a store left until after the
-  // handler returned would overwrite that one.
+  // Store before dispatching: a handler may cancel, and a later store would overwrite the state
+  // the background thread publishes.
   session_state_.store(type, std::memory_order_release);
 
   if (event_handle_ != nullptr)
@@ -1455,11 +1454,9 @@ CURLcode HttpOperation::SendAsync(Session *session, std::function<void(HttpOpera
   // Abort() with nothing to do but raise the flag.
   curl_easy_setopt(curl_resource_.easy_handle, CURLOPT_NOPROGRESS, 0L);
 
-  // A handler can cancel from this event, so everything Cleanup() needs has to be published
-  // before it runs. The callback most of all: Cleanup() takes is_cleaned_ at its start and
-  // swaps the callback much later, so a cleanup racing an assignment placed after the event
-  // would swap an empty one, never run the completion, and leave the session marked active
-  // for good.
+  // Publish everything Cleanup() needs before dispatching, the callback most of all: Cleanup()
+  // reads is_cleaned_ first and swaps the callback last, so one assigned after the event would be
+  // swapped out empty and the completion would never run.
   is_finished_.store(false, std::memory_order_release);
   is_aborted_.store(false, std::memory_order_release);
   is_cleaned_.store(false, std::memory_order_release);
@@ -1468,15 +1465,13 @@ CURLcode HttpOperation::SendAsync(Session *session, std::function<void(HttpOpera
 
   DispatchEvent(opentelemetry::ext::http::client::SessionState::Connecting);
 
-  // The future is the one thing that stays unpublished until after the event, so a handler that
-  // calls FinishSession() from it returns instead of waiting on a transfer that has not been
-  // scheduled yet.
+  // The future alone stays unpublished until after the event, so a handler calling
+  // FinishSession() from it returns instead of waiting on an unscheduled transfer.
   async_data_->result_promise = std::promise<CURLcode>();
   async_data_->result_future  = async_data_->result_promise.get_future();
   async_data_->is_promise_running.store(true, std::memory_order_release);
 
-  // Cancelling from the event hands the session to the IO thread, which may already have torn
-  // the operation down and found no future to complete. Settle it here if so.
+  // A cancel from the event may have torn the operation down before the future existed.
   if (is_cleaned_.load(std::memory_order_acquire))
   {
     if (async_data_->is_promise_running.exchange(false, std::memory_order_acq_rel))
@@ -1488,9 +1483,8 @@ CURLcode HttpOperation::SendAsync(Session *session, std::function<void(HttpOpera
 
   if (WasAborted() || !session->GetHttpClient().ScheduleAddSession(session->GetSessionId()))
   {
-    // Nothing is going to run this operation. It was cancelled while the event was dispatched,
-    // or its session was never registered because the URL did not parse. Finish it here rather
-    // than leave a future nobody can complete.
+    // Nothing will run this operation, so finish it here rather than leave an unfulfillable
+    // future.
     Cleanup();
   }
 

--- a/ext/src/http/client/curl/http_operation_curl.cc
+++ b/ext/src/http/client/curl/http_operation_curl.cc
@@ -401,6 +401,18 @@ int HttpOperation::OnProgressCallback(void *clientp,
 }
 #endif
 
+// The atomic member is only free of layout cost while it stays the size and alignment of the
+// enum it replaced. The standard does not promise that, so it is checked here rather than
+// asserted in prose: a toolchain where it does not hold changes an installed type and should say
+// so at build time.
+static_assert(sizeof(std::atomic<opentelemetry::ext::http::client::SessionState>) ==
+                  sizeof(opentelemetry::ext::http::client::SessionState),
+              "std::atomic<SessionState> grew, which changes the layout of HttpOperation");
+static_assert(
+    alignof(std::atomic<opentelemetry::ext::http::client::SessionState>) ==
+        alignof(opentelemetry::ext::http::client::SessionState),
+    "std::atomic<SessionState> is more aligned, which changes the layout of HttpOperation");
+
 void HttpOperation::DispatchEvent(opentelemetry::ext::http::client::SessionState type,
                                   const std::string &reason)
 {

--- a/ext/src/http/client/curl/http_operation_curl.cc
+++ b/ext/src/http/client/curl/http_operation_curl.cc
@@ -1599,18 +1599,21 @@ void HttpOperation::Abort()
 
 void HttpOperation::FinishUnscheduled(const char *reason)
 {
-  // Ahead of the cleanup: Cleanup() reports a manual cancel for any state short of a terminal
-  // one, with a reason read from a curl result that is still CURLE_OK, and nobody cancelled
-  // this. The enum documents Cancelled as manually cancelled and both exporters print that word.
-  session_state_.store(opentelemetry::ext::http::client::SessionState::CreateFailed,
-                       std::memory_order_release);
-
-  // Ahead of the event, so a handler calling FinishSession() from it is not waiting on the
-  // promise that this cleanup is the only thing able to fulfil.
-  Cleanup();
-
+  // The event first, because the operation holds the handler as a bare pointer and the only
+  // strong reference to it is the one the completion callback captured. Cleanup() takes that
+  // callback and lets it go, so an event dispatched afterwards can be talking to a handler
+  // nothing owns any more. A handler calling FinishSession() from here is inside a callback for
+  // this operation, so Finish() returns rather than waiting on a promise this thread has not
+  // published yet, which is what used to make the other order necessary.
+  //
+  // DispatchEvent stores the state before it calls the handler, so the cleanup below sees a
+  // terminal state and does not report a manual cancel for something nobody cancelled.
   DispatchEvent(opentelemetry::ext::http::client::SessionState::CreateFailed,
                 nullptr != reason ? reason : "");
+
+  // Last, so that a Finish() on another thread waits for the terminal event and the completion
+  // callback rather than for the promise alone.
+  Cleanup();
 }
 
 void HttpOperation::PerformCurlMessage(CURLcode code)

--- a/ext/src/http/client/curl/http_operation_curl.cc
+++ b/ext/src/http/client/curl/http_operation_curl.cc
@@ -403,8 +403,7 @@ namespace
 class CallbackScope
 {
 public:
-  explicit CallbackScope(const HttpOperation *operation) noexcept
-      : operation_{operation}, previous_{current_}
+  explicit CallbackScope(const HttpOperation *operation) noexcept : operation_{operation}
   {
     current_ = this;
   }
@@ -412,7 +411,9 @@ public:
   ~CallbackScope() { current_ = previous_; }
 
   CallbackScope(const CallbackScope &)            = delete;
+  CallbackScope(CallbackScope &&)                 = delete;
   CallbackScope &operator=(const CallbackScope &) = delete;
+  CallbackScope &operator=(CallbackScope &&)      = delete;
 
   static bool InsideCallbackFor(const HttpOperation *operation) noexcept
   {
@@ -427,10 +428,11 @@ public:
   }
 
 private:
-  const HttpOperation *operation_;
-  const CallbackScope *previous_;
-
   static thread_local const CallbackScope *current_;
+
+  const HttpOperation *operation_;
+  // Read before the constructor body replaces it, which is what makes the stack a stack.
+  const CallbackScope *previous_ = current_;
 };
 
 thread_local const CallbackScope *CallbackScope::current_ = nullptr;

--- a/ext/src/http/client/curl/http_operation_curl.cc
+++ b/ext/src/http/client/curl/http_operation_curl.cc
@@ -1452,20 +1452,45 @@ CURLcode HttpOperation::SendAsync(Session *session, std::function<void(HttpOpera
   // Abort() with nothing to do but raise the flag.
   curl_easy_setopt(curl_resource_.easy_handle, CURLOPT_NOPROGRESS, 0L);
 
-  DispatchEvent(opentelemetry::ext::http::client::SessionState::Connecting);
+  // A handler can cancel from this event, so everything Cleanup() needs has to be published
+  // before it runs. The callback most of all: Cleanup() takes is_cleaned_ at its start and
+  // swaps the callback much later, so a cleanup racing an assignment placed after the event
+  // would swap an empty one, never run the completion, and leave the session marked active
+  // for good.
   is_finished_.store(false, std::memory_order_release);
   is_aborted_.store(false, std::memory_order_release);
   is_cleaned_.store(false, std::memory_order_release);
-
   async_data_->session.store(session, std::memory_order_release);
-  if (false == async_data_->is_promise_running.exchange(true, std::memory_order_acq_rel))
-  {
-    async_data_->result_promise = std::promise<CURLcode>();
-    async_data_->result_future  = async_data_->result_promise.get_future();
-  }
   async_data_->callback = std::move(callback);
 
-  session->GetHttpClient().ScheduleAddSession(session->GetSessionId());
+  DispatchEvent(opentelemetry::ext::http::client::SessionState::Connecting);
+
+  // The future is the one thing that stays unpublished until after the event, so a handler that
+  // calls FinishSession() from it returns instead of waiting on a transfer that has not been
+  // scheduled yet.
+  async_data_->result_promise = std::promise<CURLcode>();
+  async_data_->result_future  = async_data_->result_promise.get_future();
+  async_data_->is_promise_running.store(true, std::memory_order_release);
+
+  // Cancelling from the event hands the session to the IO thread, which may already have torn
+  // the operation down and found no future to complete. Settle it here if so.
+  if (is_cleaned_.load(std::memory_order_acquire))
+  {
+    if (async_data_->is_promise_running.exchange(false, std::memory_order_acq_rel))
+    {
+      async_data_->result_promise.set_value(last_curl_result_);
+    }
+    return CURLE_OK;
+  }
+
+  if (WasAborted() || !session->GetHttpClient().ScheduleAddSession(session->GetSessionId()))
+  {
+    // Nothing is going to run this operation. It was cancelled while the event was dispatched,
+    // or its session was never registered because the URL did not parse. Finish it here rather
+    // than leave a future nobody can complete.
+    Cleanup();
+  }
+
   return CURLE_OK;
 }
 

--- a/ext/src/http/client/curl/http_operation_curl.cc
+++ b/ext/src/http/client/curl/http_operation_curl.cc
@@ -1536,16 +1536,8 @@ CURLcode HttpOperation::SendAsync(Session *session, std::function<void(HttpOpera
   }
   else if (!session->GetHttpClient().ScheduleAddSession(session->GetSessionId()))
   {
-    // The same, except nobody cancelled anything. The terminal state goes in first so Cleanup()
-    // does not report a manual cancel, with a reason read from a curl result that is still
-    // CURLE_OK, and the operation is finished before the handler hears about it: a handler that
-    // calls FinishSession() from this event would otherwise wait on the promise that the
-    // Cleanup() below it is the only thing able to fulfil.
-    session_state_.store(opentelemetry::ext::http::client::SessionState::CreateFailed,
-                         std::memory_order_release);
-    Cleanup();
-    DispatchEvent(opentelemetry::ext::http::client::SessionState::CreateFailed,
-                  "the session is not registered with this client");
+    // The same, except nobody cancelled anything.
+    FinishUnscheduled("the session is not registered with this client");
   }
 
   return CURLE_OK;
@@ -1603,6 +1595,22 @@ void HttpOperation::Abort()
       session->GetHttpClient().ScheduleAbortSession(session->GetSessionId());
     }
   }
+}
+
+void HttpOperation::FinishUnscheduled(const char *reason)
+{
+  // Ahead of the cleanup: Cleanup() reports a manual cancel for any state short of a terminal
+  // one, with a reason read from a curl result that is still CURLE_OK, and nobody cancelled
+  // this. The enum documents Cancelled as manually cancelled and both exporters print that word.
+  session_state_.store(opentelemetry::ext::http::client::SessionState::CreateFailed,
+                       std::memory_order_release);
+
+  // Ahead of the event, so a handler calling FinishSession() from it is not waiting on the
+  // promise that this cleanup is the only thing able to fulfil.
+  Cleanup();
+
+  DispatchEvent(opentelemetry::ext::http::client::SessionState::CreateFailed,
+                nullptr != reason ? reason : "");
 }
 
 void HttpOperation::PerformCurlMessage(CURLcode code)

--- a/ext/src/http/client/curl/http_operation_curl.cc
+++ b/ext/src/http/client/curl/http_operation_curl.cc
@@ -404,12 +404,15 @@ int HttpOperation::OnProgressCallback(void *clientp,
 void HttpOperation::DispatchEvent(opentelemetry::ext::http::client::SessionState type,
                                   const std::string &reason)
 {
+  // Published before the handler runs. A handler can cancel from here, which lets the background
+  // thread finish the operation and publish a state of its own, and a store left until after the
+  // handler returned would overwrite that one.
+  session_state_.store(type, std::memory_order_release);
+
   if (event_handle_ != nullptr)
   {
     event_handle_->OnEvent(type, reason);
   }
-
-  session_state_ = type;
 }
 
 HttpOperation::HttpOperation(opentelemetry::ext::http::client::Method method,

--- a/ext/src/http/client/curl/http_operation_curl.cc
+++ b/ext/src/http/client/curl/http_operation_curl.cc
@@ -1489,11 +1489,16 @@ CURLcode HttpOperation::SendAsync(Session *session, std::function<void(HttpOpera
   }
   else if (!session->GetHttpClient().ScheduleAddSession(session->GetSessionId()))
   {
-    // The same, except nobody cancelled anything. Name the failure first: Cleanup() would report
-    // a manual cancel, with a reason read from a curl result that is still CURLE_OK.
+    // The same, except nobody cancelled anything. The terminal state goes in first so Cleanup()
+    // does not report a manual cancel, with a reason read from a curl result that is still
+    // CURLE_OK, and the operation is finished before the handler hears about it: a handler that
+    // calls FinishSession() from this event would otherwise wait on the promise that the
+    // Cleanup() below it is the only thing able to fulfil.
+    session_state_.store(opentelemetry::ext::http::client::SessionState::CreateFailed,
+                         std::memory_order_release);
+    Cleanup();
     DispatchEvent(opentelemetry::ext::http::client::SessionState::CreateFailed,
                   "the session is not registered with this client");
-    Cleanup();
   }
 
   return CURLE_OK;

--- a/ext/src/http/client/curl/http_operation_curl.cc
+++ b/ext/src/http/client/curl/http_operation_curl.cc
@@ -1481,10 +1481,18 @@ CURLcode HttpOperation::SendAsync(Session *session, std::function<void(HttpOpera
     return CURLE_OK;
   }
 
-  if (WasAborted() || !session->GetHttpClient().ScheduleAddSession(session->GetSessionId()))
+  if (WasAborted())
   {
     // Nothing will run this operation, so finish it here rather than leave an unfulfillable
-    // future.
+    // future. Cleanup() reports the cancel, which is what happened.
+    Cleanup();
+  }
+  else if (!session->GetHttpClient().ScheduleAddSession(session->GetSessionId()))
+  {
+    // The same, except nobody cancelled anything. Name the failure first: Cleanup() would report
+    // a manual cancel, with a reason read from a curl result that is still CURLE_OK.
+    DispatchEvent(opentelemetry::ext::http::client::SessionState::CreateFailed,
+                  "the session is not registered with this client");
     Cleanup();
   }
 

--- a/ext/test/http/CMakeLists.txt
+++ b/ext/test/http/CMakeLists.txt
@@ -15,6 +15,11 @@ if(OTELCPP_WITH_HTTP_CLIENT_CURL)
     TARGET ${FILENAME}
     TEST_PREFIX ext.http.curl.
     TEST_LIST ${FILENAME})
+  # These cover waits that are meant to end. When one stops ending it hangs
+  # rather than fails, and without a bound it takes the whole job with it
+  # instead of reporting. The slowest case that legitimately waits takes thirty
+  # seconds.
+  set_tests_properties(${${FILENAME}} PROPERTIES TIMEOUT 120)
 endif()
 
 set(SOCKET_TOOLS_FILENAME socket_tools_test)

--- a/ext/test/http/curl_http_test.cc
+++ b/ext/test/http/curl_http_test.cc
@@ -108,7 +108,13 @@ public:
 
   void OnEvent(http_client::SessionState state, nostd::string_view reason) noexcept override
   {
-    if (state == http_client::SessionState::Cancelled)
+    if (state == http_client::SessionState::CreateFailed)
+    {
+      terminal_count_.fetch_add(1, std::memory_order_release);
+      create_failed_.fetch_add(1, std::memory_order_release);
+      last_reason_empty_.store(reason.empty(), std::memory_order_release);
+    }
+    else if (state == http_client::SessionState::Cancelled)
     {
       terminal_count_.fetch_add(1, std::memory_order_release);
       // Cleanup dispatches its own Cancelled carrying a curl message, and GetCurlErrorMessage
@@ -134,6 +140,8 @@ public:
   std::thread::id cancelled_from_{};
   std::atomic<int> terminal_count_{0};
   std::atomic<int> cancelled_from_callback_{0};
+  std::atomic<int> create_failed_{0};
+  std::atomic<bool> last_reason_empty_{true};
 };
 
 class GetEventHandler : public CustomEventHandler
@@ -711,7 +719,7 @@ TEST_F(BasicCurlHttpTests, CancelFromCreatedCompletes)
   session_manager->FinishAllSessions();
 
   EXPECT_FALSE(handler->got_response_.load(std::memory_order_acquire));
-  EXPECT_GE(handler->terminal_count_.load(std::memory_order_acquire), 1);
+  EXPECT_EQ(1, handler->terminal_count_.load(std::memory_order_acquire));
 }
 
 TEST_F(BasicCurlHttpTests, CancelFromConnectingCompletes)
@@ -732,12 +740,49 @@ TEST_F(BasicCurlHttpTests, CancelFromConnectingCompletes)
   session_manager->FinishAllSessions();
 
   EXPECT_FALSE(handler->got_response_.load(std::memory_order_acquire));
-  EXPECT_GE(handler->terminal_count_.load(std::memory_order_acquire), 1);
+  // Two, and one is the goal rather than the behaviour: cancelling once the transfer has been
+  // handed to the IO thread produces a terminal event from Cleanup and another from the
+  // completion callback. That is #4360, and pinning the number here makes any change to it
+  // visible instead of letting an at-least-one assertion absorb it.
+  EXPECT_EQ(2, handler->terminal_count_.load(std::memory_order_acquire));
 }
 
 // CreateSession hands back an unregistered session when the URL does not parse, and
 // CURLOPT_URL is not checked when it is set, so nothing on this path stops the operation
 // reaching the same dead end with no handler involved at all. See #4393.
+// Pending removals are keyed by session id. Two sessions whose URL never parsed must not share
+// one: the map's move assignment swaps the displaced easy handle and header list into a
+// temporary whose destructor frees neither.
+TEST_F(BasicCurlHttpTests, UnparsableUrlsReleaseTheirOwnResources)
+{
+  auto session_manager = std::make_shared<http_client::curl::HttpCurlClientFactory>()->Create();
+  ASSERT_TRUE(session_manager != nullptr);
+
+  auto first  = session_manager->CreateSession("http://127.0.0.1:not-a-port");
+  auto second = session_manager->CreateSession("http://127.0.0.1:also-not-a-port");
+
+  const auto first_id  = static_cast<http_client::curl::Session *>(first.get())->GetSessionId();
+  const auto second_id = static_cast<http_client::curl::Session *>(second.get())->GetSessionId();
+  EXPECT_NE(0U, first_id) << "an unregistered session kept the default id";
+  EXPECT_NE(first_id, second_id) << "two unregistered sessions share a pending removal key";
+
+  auto first_request = first->CreateRequest();
+  first_request->SetUri("get/");
+  auto second_request = second->CreateRequest();
+  second_request->SetUri("get/");
+
+  auto first_handler  = std::make_shared<TerminalCountingHandler>();
+  auto second_handler = std::make_shared<TerminalCountingHandler>();
+  first->SendRequest(first_handler);
+  second->SendRequest(second_handler);
+  first->FinishSession();
+  second->FinishSession();
+  session_manager->FinishAllSessions();
+
+  EXPECT_EQ(1, first_handler->terminal_count_.load(std::memory_order_acquire));
+  EXPECT_EQ(1, second_handler->terminal_count_.load(std::memory_order_acquire));
+}
+
 TEST_F(BasicCurlHttpTests, InvalidUrlCompletes)
 {
   auto session_manager = std::make_shared<http_client::curl::HttpCurlClientFactory>()->Create();
@@ -754,7 +799,13 @@ TEST_F(BasicCurlHttpTests, InvalidUrlCompletes)
   session_manager->FinishAllSessions();
 
   EXPECT_FALSE(handler->got_response_.load(std::memory_order_acquire));
-  EXPECT_GE(handler->terminal_count_.load(std::memory_order_acquire), 1);
+  // Exact, so a duplicate notification or a failure dressed as a manual cancel fails here
+  // rather than passing as at least one of something.
+  EXPECT_EQ(1, handler->terminal_count_.load(std::memory_order_acquire));
+  EXPECT_EQ(1, handler->create_failed_.load(std::memory_order_acquire))
+      << "an unregistered session was not reported as a failed create";
+  EXPECT_FALSE(handler->last_reason_empty_.load(std::memory_order_acquire))
+      << "the failure was reported without saying what failed";
 }
 
 // The counters say whether the IO thread reached this handler while the caller was still

--- a/ext/test/http/curl_http_test.cc
+++ b/ext/test/http/curl_http_test.cc
@@ -1,6 +1,7 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
+#include <curl/curl.h>
 #include <curl/curlver.h>
 #include "gtest/gtest.h"
 

--- a/ext/test/http/curl_http_test.cc
+++ b/ext/test/http/curl_http_test.cc
@@ -16,6 +16,7 @@
 #include <atomic>
 #include <chrono>
 #include <condition_variable>
+#include <cstdio>
 #include <cstring>
 #include <map>
 #include <memory>
@@ -56,6 +57,19 @@ class HttpClientTestPeer
 {
 public:
   static void ResetMultiHandle(HttpClient &client) { client.resetMultiHandle(); }
+
+  static bool AddSessions(HttpClient &client) { return client.doAddSessions(); }
+
+  static bool RemoveSessions(HttpClient &client) { return client.doRemoveSessions(); }
+
+  // A multi handle that failed to initialize refuses every add, which is the state the case
+  // below needs and the one thing no transfer can be arranged into.
+  static CURLM *ExchangeMultiHandle(HttpClient &client, CURLM *replacement)
+  {
+    CURLM *previous      = client.multi_handle_;
+    client.multi_handle_ = replacement;
+    return previous;
+  }
 };
 }  // namespace curl
 }  // namespace client
@@ -637,6 +651,85 @@ TEST_F(BasicCurlHttpTests, ResetMultiHandleWithASessionDoesNotDeadlock)
   http_client::curl::HttpClientTestPeer::ResetMultiHandle(*client);
 
   client->FinishAllSessions();
+}
+
+class RecordingHandler : public CustomEventHandler
+{
+public:
+  void OnResponse(http_client::Response & /* response */) noexcept override
+  {
+    got_response_.store(true, std::memory_order_release);
+  }
+
+  void OnEvent(http_client::SessionState state, nostd::string_view /* reason */) noexcept override
+  {
+    std::lock_guard<std::mutex> lock_guard{states_m_};
+    states_.push_back(state);
+  }
+
+  std::vector<http_client::SessionState> States()
+  {
+    std::lock_guard<std::mutex> lock_guard{states_m_};
+    return states_;
+  }
+
+private:
+  std::mutex states_m_;
+  std::vector<http_client::SessionState> states_;
+};
+
+// The third way an operation ends up with nothing to run it. SendAsync does the whole async
+// setup and Session::SendRequest is what spawns the worker, so the add runs here on one thread
+// against a multi handle that refuses it, which is what a multi handle that failed to initialize
+// does to every add.
+TEST_F(BasicCurlHttpTests, ASessionTheMultiHandleRefusesIsFinished)
+{
+  curl::HttpClient client;
+
+  auto session = client.CreateSession("http://127.0.0.1:19000");
+  ASSERT_TRUE(session != nullptr);
+  auto curl_session = std::static_pointer_cast<curl::Session>(session);
+
+  auto handler = std::make_shared<RecordingHandler>();
+  http_client::HttpSslOptions no_ssl;
+  http_client::Body body;
+  http_client::Headers headers;
+  http_client::RetryPolicy no_retry{};
+
+  // Named, and outliving the operation: it keeps a reference to the ssl options, the headers,
+  // the body and this rather than a copy of any of them.
+  http_client::Compression compression = http_client::Compression::kNone;
+
+  curl_session->GetOperation().reset(new curl::HttpOperation(
+      http_client::Method::Get, "http://127.0.0.1:19000/get/", no_ssl, handler.get(), headers, body,
+      compression, false, curl::kDefaultHttpConnTimeout, false, false, no_retry));
+
+  std::atomic<int> completed{0};
+  ASSERT_EQ(CURLE_OK, curl_session->GetOperation()->SendAsync(
+                          curl_session.get(), [&completed](curl::HttpOperation & /* operation */) {
+                            completed.fetch_add(1, std::memory_order_release);
+                          }));
+
+  CURLM *multi_handle = http_client::curl::HttpClientTestPeer::ExchangeMultiHandle(client, nullptr);
+  const bool has_data = http_client::curl::HttpClientTestPeer::AddSessions(client);
+  http_client::curl::HttpClientTestPeer::ExchangeMultiHandle(client, multi_handle);
+
+  // The removal the finish queues is the reason this has to answer true: the worker checks it
+  // after it has already run doRemoveSessions for this round, and nothing else would drain it.
+  EXPECT_TRUE(has_data);
+  EXPECT_EQ(1, completed.load(std::memory_order_acquire));
+
+  // Told the same way as a session this client never registered. Not Cancelled: the enum calls
+  // that one manually cancelled and both exporters print that word, and nobody cancelled this.
+  const auto states = handler->States();
+  ASSERT_FALSE(states.empty());
+  EXPECT_EQ(http_client::SessionState::CreateFailed, states.back());
+  for (const auto state : states)
+  {
+    EXPECT_NE(http_client::SessionState::Cancelled, state);
+  }
+
+  http_client::curl::HttpClientTestPeer::RemoveSessions(client);
 }
 
 // The caller-thread side of the same cancel. The server handler takes mtx_requests before it

--- a/ext/test/http/curl_http_test.cc
+++ b/ext/test/http/curl_http_test.cc
@@ -13,13 +13,13 @@
 #  include <numeric>
 #endif  // ENABLE_OTLP_COMPRESSION_PREVIEW
 
+#include <algorithm>
 #include <atomic>
 #include <chrono>
 #include <condition_variable>
 #include <cstring>
 #include <functional>
 #include <map>
-#include <memory>
 #include <mutex>
 #include <sstream>
 #include <string>
@@ -33,13 +33,16 @@
 #include "opentelemetry/ext/http/client/http_client.h"
 #include "opentelemetry/ext/http/server/http_server.h"
 #include "opentelemetry/nostd/function_ref.h"
+#include "opentelemetry/nostd/shared_ptr.h"
 #include "opentelemetry/nostd/string_view.h"
+#include "opentelemetry/sdk/common/global_log_handler.h"
 #include "opentelemetry/version.h"
 
 constexpr int HTTP_PORT{19000};
 
 namespace curl        = opentelemetry::ext::http::client::curl;
 namespace http_client = opentelemetry::ext::http::client;
+namespace sdk_common  = opentelemetry::sdk::common;
 namespace nostd       = opentelemetry::nostd;
 
 OPENTELEMETRY_BEGIN_NAMESPACE
@@ -779,6 +782,115 @@ TEST_F(BasicCurlHttpTests, AnUnscheduledSessionTellsAHandlerNothingElseHolds)
                              << "the ownership it says it is";
   EXPECT_LT(event_at, destroyed_at)
       << "the terminal event reached the handler after the last reference to it had gone";
+
+  http_client::curl::HttpClientTestPeer::RemoveSessions(client);
+}
+
+// Restores the global log handler and level whatever the case does, since both are process wide
+// and gtest runs one process per case only under CTest.
+class ScopedLogHandler
+{
+public:
+  explicit ScopedLogHandler(const nostd::shared_ptr<sdk_common::internal_log::LogHandler> &handler)
+      : previous_handler_(sdk_common::internal_log::GlobalLogHandler::GetLogHandler()),
+        previous_level_(sdk_common::internal_log::GlobalLogHandler::GetLogLevel())
+  {
+    sdk_common::internal_log::GlobalLogHandler::SetLogHandler(handler);
+
+    // Error rather than Debug: it is the level the refusal is written at, and anything wider
+    // hands this observer unrelated lines from the same path.
+    sdk_common::internal_log::GlobalLogHandler::SetLogLevel(
+        sdk_common::internal_log::LogLevel::Error);
+  }
+
+  ~ScopedLogHandler()
+  {
+    sdk_common::internal_log::GlobalLogHandler::SetLogHandler(previous_handler_);
+    sdk_common::internal_log::GlobalLogHandler::SetLogLevel(previous_level_);
+  }
+
+  ScopedLogHandler(const ScopedLogHandler &)            = delete;
+  ScopedLogHandler(ScopedLogHandler &&)                 = delete;
+  ScopedLogHandler &operator=(const ScopedLogHandler &) = delete;
+  ScopedLogHandler &operator=(ScopedLogHandler &&)      = delete;
+
+private:
+  nostd::shared_ptr<sdk_common::internal_log::LogHandler> previous_handler_;
+  sdk_common::internal_log::LogLevel previous_level_;
+};
+
+// Runs whatever the case gives it, on the thread that wrote the log line.
+class ObservingLogHandler : public sdk_common::internal_log::LogHandler
+{
+public:
+  explicit ObservingLogHandler(std::function<void()> observe) : observe_(std::move(observe)) {}
+
+  void Handle(sdk_common::internal_log::LogLevel /* level */,
+              const char * /* file */,
+              int /* line */,
+              const char * /* msg */,
+              const sdk_common::AttributeMap & /* attributes */) noexcept override
+  {
+    observe_();
+  }
+
+private:
+  std::function<void()> observe_;
+};
+
+// The refusal is reported through the global log handler, which is application code that can call
+// back into this client. Reporting before the operation is settled leaves a handler that answers
+// with FinishSession() waiting on a promise only this thread can fulfil.
+TEST_F(BasicCurlHttpTests, ARejectedSessionIsSettledBeforeItIsReported)
+{
+  curl::HttpClient client;
+
+  auto session = client.CreateSession("http://127.0.0.1:19000");
+  ASSERT_TRUE(session != nullptr);
+  auto curl_session = std::static_pointer_cast<curl::Session>(session);
+
+  auto handler = std::make_shared<RecordingHandler>();
+  http_client::HttpSslOptions no_ssl;
+  http_client::Body body;
+  http_client::Headers headers;
+  http_client::RetryPolicy no_retry{};
+  http_client::Compression compression = http_client::Compression::kNone;
+
+  curl_session->GetOperation().reset(new curl::HttpOperation(
+      http_client::Method::Get, "http://127.0.0.1:19000/get/", no_ssl, handler.get(), headers, body,
+      compression, false, curl::kDefaultHttpConnTimeout, false, false, no_retry));
+
+  ASSERT_EQ(CURLE_OK, curl_session->GetOperation()->SendAsync(
+                          curl_session.get(), [](curl::HttpOperation & /* operation */) {}));
+
+  std::atomic<int> log_calls{0};
+  std::atomic<int> settled_when_logged{0};
+  auto observer = nostd::shared_ptr<sdk_common::internal_log::LogHandler>(
+      new ObservingLogHandler([&handler, &log_calls, &settled_when_logged]() {
+        log_calls.fetch_add(1, std::memory_order_release);
+
+        // The terminal event specifically. Created arrives during setup, so "the handler has
+        // seen something" is true in either order.
+        const std::vector<http_client::SessionState> states = handler->States();
+        if (std::find(states.begin(), states.end(), http_client::SessionState::CreateFailed) !=
+            states.end())
+        {
+          settled_when_logged.fetch_add(1, std::memory_order_release);
+        }
+      }));
+
+  {
+    ScopedLogHandler scoped{observer};
+    http_client::curl::HttpClientTestPeer::RefuseAdds(client);
+    http_client::curl::HttpClientTestPeer::AddSessions(client);
+    http_client::curl::HttpClientTestPeer::AllowAdds(client);
+  }
+
+  ASSERT_EQ(1, log_calls.load(std::memory_order_acquire))
+      << "the refusal was not reported once, so this case is not observing what it says it is";
+  EXPECT_EQ(1, settled_when_logged.load(std::memory_order_acquire))
+      << "the refusal was reported while the operation was still unsettled, so a log handler "
+      << "calling FinishSession() from here would wait on a promise only this thread fulfils";
 
   http_client::curl::HttpClientTestPeer::RemoveSessions(client);
 }

--- a/ext/test/http/curl_http_test.cc
+++ b/ext/test/http/curl_http_test.cc
@@ -6,7 +6,6 @@
 #include "gtest/gtest.h"
 
 #ifdef ENABLE_OTLP_RETRY_PREVIEW
-#  include <curl/curl.h>
 #  include "gmock/gmock.h"
 #endif  // ENABLE_OTLP_RETRY_PREVIEW
 

--- a/ext/test/http/curl_http_test.cc
+++ b/ext/test/http/curl_http_test.cc
@@ -993,7 +993,7 @@ public:
   void OnEvent(http_client::SessionState state, nostd::string_view reason) noexcept override
   {
     TerminalCountingHandler::OnEvent(state, reason);
-    if (state == http_client::SessionState::CreateFailed && finish_target_ != nullptr)
+    if (state == finish_at_ && finish_target_ != nullptr)
     {
       auto *target   = finish_target_;
       finish_target_ = nullptr;
@@ -1004,6 +1004,7 @@ public:
   }
 
   http_client::Session *finish_target_ = nullptr;
+  http_client::SessionState finish_at_ = http_client::SessionState::CreateFailed;
   std::atomic<bool> entered_{false};
   std::atomic<bool> returned_{false};
 };
@@ -1188,6 +1189,151 @@ TEST_F(BasicCurlHttpTests, FinishDoesNotReturnWhileAHandlerIsRunning)
                              << " ms with a handler still running";
   EXPECT_GE(handler->entries_.load(std::memory_order_relaxed), 1)
       << "the terminal event never arrived, so nothing was tested";
+}
+
+namespace
+{
+// Stays inside the terminal event until the case lets it out, so another thread's FinishSession()
+// has something to be held up by.
+class HeldTerminalHandler : public CustomEventHandler
+{
+public:
+  std::atomic<bool> inside_{false};
+  std::atomic<bool> release_{false};
+
+  void OnResponse(http_client::Response & /* response */) noexcept override {}
+
+  void OnEvent(http_client::SessionState state, nostd::string_view /* reason */) noexcept override
+  {
+    if (http_client::SessionState::CreateFailed != state)
+    {
+      return;
+    }
+    inside_.store(true, std::memory_order_release);
+    while (!release_.load(std::memory_order_acquire))
+    {
+      std::this_thread::yield();
+    }
+    inside_.store(false, std::memory_order_release);
+  }
+};
+
+// Polls a condition to a deadline rather than sleeping for a fixed time, so a pass costs only as
+// long as the thing being waited for takes and a failure is a bounded wait rather than a hang.
+template <typename Predicate>
+bool WaitFor(Predicate ready, std::chrono::milliseconds budget)
+{
+  const auto deadline = std::chrono::steady_clock::now() + budget;
+  while (std::chrono::steady_clock::now() < deadline)
+  {
+    if (ready())
+    {
+      return true;
+    }
+    std::this_thread::yield();
+  }
+  return ready();
+}
+}  // namespace
+
+// A handler is allowed to finish the request it is being told about. On the IO thread's events
+// that used to be a deadlock, because Finish() waited on a promise only the thread running the
+// handler goes on to fulfil. Fixes #4402.
+TEST_F(BasicCurlHttpTests, FinishSessionFromAnEventTheIoThreadDelivers)
+{
+  auto session_manager = std::make_shared<http_client::curl::HttpCurlClientFactory>()->Create();
+  ASSERT_TRUE(session_manager != nullptr);
+
+  auto session = session_manager->CreateSession("http://127.0.0.1:19937");
+  auto request = session->CreateRequest();
+  request->SetUri("get/");
+
+  auto handler            = std::make_shared<FinishFromEventHandler>();
+  handler->finish_target_ = session.get();
+  handler->finish_at_     = http_client::SessionState::ConnectFailed;
+
+  // The handler has to be the first caller: a FinishSession() from here would take is_finished_
+  // and every later one would return without ever reaching the wait.
+  session->SendRequest(handler);
+
+  const bool entered =
+      WaitFor([&handler]() { return handler->entered_.load(std::memory_order_acquire); },
+              std::chrono::seconds(30));
+  ASSERT_TRUE(entered) << "the connect never failed, so no handler ran and nothing was tested";
+
+  const bool returned =
+      WaitFor([&handler]() { return handler->returned_.load(std::memory_order_acquire); },
+              std::chrono::seconds(30));
+  EXPECT_TRUE(returned) << "FinishSession() called from the event did not return";
+
+  session_manager->FinishAllSessions();
+}
+
+// The other half of the same ordering: an outside Finish() has to wait for the terminal event and
+// the completion callback, not just for the promise. The handler holds the event open and the
+// case watches the other thread stay inside FinishSession() until it lets go.
+TEST_F(BasicCurlHttpTests, FinishFromAnotherThreadWaitsForTheTerminalEvent)
+{
+  curl::HttpClient client;
+
+  auto session = client.CreateSession("http://127.0.0.1:19000");
+  ASSERT_TRUE(session != nullptr);
+  auto curl_session = std::static_pointer_cast<curl::Session>(session);
+
+  auto handler = std::make_shared<HeldTerminalHandler>();
+  http_client::HttpSslOptions no_ssl;
+  http_client::Body body;
+  http_client::Headers headers;
+  http_client::RetryPolicy no_retry{};
+  http_client::Compression compression = http_client::Compression::kNone;
+
+  curl_session->GetOperation().reset(new curl::HttpOperation(
+      http_client::Method::Get, "http://127.0.0.1:19000/get/", no_ssl, handler.get(), headers, body,
+      compression, false, curl::kDefaultHttpConnTimeout, false, false, no_retry));
+
+  ASSERT_EQ(CURLE_OK, curl_session->GetOperation()->SendAsync(
+                          curl_session.get(), [](curl::HttpOperation & /* operation */) {}));
+
+  CURLM *multi_handle = http_client::curl::HttpClientTestPeer::ExchangeMultiHandle(client, nullptr);
+
+  std::atomic<bool> finish_returned{false};
+  std::thread finisher([&curl_session, &finish_returned]() {
+    curl_session->FinishSession();
+    finish_returned.store(true, std::memory_order_release);
+  });
+
+  // This thread is the one that dispatches the terminal event, so it is the one that parks inside
+  // the handler. Whoever lets it out has to be somebody else, and that somebody is also the only
+  // one placed to watch the finisher while the event is still running.
+  std::atomic<bool> observed_held{false};
+  std::atomic<bool> returned_early{false};
+  std::thread watcher([&handler, &finish_returned, &observed_held, &returned_early]() {
+    if (WaitFor([&handler]() { return handler->inside_.load(std::memory_order_acquire); },
+                std::chrono::seconds(30)))
+    {
+      observed_held.store(true, std::memory_order_release);
+      returned_early.store(
+          WaitFor([&finish_returned]() { return finish_returned.load(std::memory_order_acquire); },
+                  std::chrono::milliseconds(200)),
+          std::memory_order_release);
+    }
+    handler->release_.store(true, std::memory_order_release);
+  });
+
+  http_client::curl::HttpClientTestPeer::AddSessions(client);
+  http_client::curl::HttpClientTestPeer::ExchangeMultiHandle(client, multi_handle);
+
+  watcher.join();
+  finisher.join();
+
+  ASSERT_TRUE(observed_held.load(std::memory_order_acquire))
+      << "the terminal event never reached the handler, so nothing was tested";
+  EXPECT_FALSE(returned_early.load(std::memory_order_acquire))
+      << "FinishSession() on another thread returned while the handler was still inside the "
+      << "terminal event";
+  EXPECT_TRUE(finish_returned.load(std::memory_order_acquire));
+
+  http_client::curl::HttpClientTestPeer::RemoveSessions(client);
 }
 
 TEST_F(BasicCurlHttpTests, CancelFromConnectingWhilePollingCompletes)

--- a/ext/test/http/curl_http_test.cc
+++ b/ext/test/http/curl_http_test.cc
@@ -757,6 +757,85 @@ TEST_F(BasicCurlHttpTests, InvalidUrlCompletes)
   EXPECT_GE(handler->terminal_count_.load(std::memory_order_acquire), 1);
 }
 
+// The counters say whether the IO thread reached this handler while the caller was still
+// inside an event of its own. They are relaxed on purpose. An acquire or a release on them
+// would give the two threads an ordering the code under test does not have, and a state store
+// racing another would stop being reported.
+class OverlappingCancelHandler : public TerminalCountingHandler
+{
+public:
+  void OnEvent(http_client::SessionState state, nostd::string_view reason) noexcept override
+  {
+    const int depth = inside_events_.fetch_add(1, std::memory_order_relaxed) + 1;
+    int highest     = max_concurrent_events_.load(std::memory_order_relaxed);
+    while (depth > highest &&
+           !max_concurrent_events_.compare_exchange_weak(highest, depth, std::memory_order_relaxed,
+                                                         std::memory_order_relaxed))
+    {
+    }
+
+    TerminalCountingHandler::OnEvent(state, reason);
+
+    if (state == cancel_at_)
+    {
+      // Cancelling wakes the IO thread, which finishes the operation and dispatches a Cancelled
+      // of its own. Stay in this event until that one arrives so the two really do overlap, and
+      // give up rather than hang if it never does.
+      const auto deadline = std::chrono::steady_clock::now() + std::chrono::seconds(30);
+      while (inside_events_.load(std::memory_order_relaxed) < 2 &&
+             std::chrono::steady_clock::now() < deadline)
+      {
+        std::this_thread::sleep_for(std::chrono::milliseconds(1));
+      }
+    }
+
+    inside_events_.fetch_sub(1, std::memory_order_relaxed);
+  }
+
+  std::atomic<int> inside_events_{0};
+  std::atomic<int> max_concurrent_events_{0};
+};
+
+// A client spawns its IO thread only after a request has been scheduled, so cancelling from
+// the first event of the first request has nothing to overlap. On a client that is already
+// polling, the IO thread finishes the operation while the handler is still inside that event,
+// and the caller reaches the end of SendAsync with the operation already cleaned up.
+TEST_F(BasicCurlHttpTests, CancelFromConnectingWhilePollingCompletes)
+{
+  received_requests_.clear();
+  auto session_manager = std::make_shared<http_client::curl::HttpCurlClientFactory>()->Create();
+  ASSERT_TRUE(session_manager != nullptr);
+
+  {
+    auto warm         = session_manager->CreateSession("http://127.0.0.1:19000");
+    auto warm_request = warm->CreateRequest();
+    warm_request->SetUri("get/");
+    auto warm_handler = std::make_shared<TerminalCountingHandler>();
+    warm->SendRequest(warm_handler);
+    ASSERT_TRUE(waitForRequests(30, 1));
+    warm->FinishSession();
+    ASSERT_TRUE(warm_handler->got_response_.load(std::memory_order_acquire));
+  }
+
+  // Nothing listens on 19937, so this operation cannot answer on its own.
+  auto session = session_manager->CreateSession("http://127.0.0.1:19937");
+  auto request = session->CreateRequest();
+  request->SetUri("get/");
+
+  auto handler            = std::make_shared<OverlappingCancelHandler>();
+  handler->cancel_target_ = session.get();
+  handler->cancel_at_     = http_client::SessionState::Connecting;
+
+  session->SendRequest(handler);
+  session->FinishSession();
+  session_manager->FinishAllSessions();
+
+  EXPECT_EQ(2, handler->max_concurrent_events_.load(std::memory_order_acquire));
+  EXPECT_FALSE(handler->got_response_.load(std::memory_order_acquire));
+  EXPECT_EQ(1, handler->cancelled_from_callback_.load(std::memory_order_acquire));
+  EXPECT_FALSE(session->IsSessionActive());
+}
+
 TEST_F(BasicCurlHttpTests, SendGetRequestSync)
 {
   received_requests_.clear();

--- a/ext/test/http/curl_http_test.cc
+++ b/ext/test/http/curl_http_test.cc
@@ -689,6 +689,74 @@ TEST_F(BasicCurlHttpTests, RepeatedCallerThreadCancelsAreClean)
   EXPECT_GE(terminal_total, 20);
 }
 
+// A handler is allowed to cancel from the events SendRequest dispatches, so the flags and the
+// cancel route have to be published before the dispatch. Publish them after it and the cancel
+// is thrown away, the request is neither sent nor completed, and FinishSession() waits on a
+// promise nobody can fulfil. See #4390.
+TEST_F(BasicCurlHttpTests, CancelFromCreatedCompletes)
+{
+  auto session_manager = std::make_shared<http_client::curl::HttpCurlClientFactory>()->Create();
+  ASSERT_TRUE(session_manager != nullptr);
+
+  auto session = session_manager->CreateSession("http://127.0.0.1:19000");
+  auto request = session->CreateRequest();
+  request->SetUri("get/");
+
+  auto handler            = std::make_shared<TerminalCountingHandler>();
+  handler->cancel_target_ = session.get();
+  handler->cancel_at_     = http_client::SessionState::Created;
+
+  session->SendRequest(handler);
+  session->FinishSession();
+  session_manager->FinishAllSessions();
+
+  EXPECT_FALSE(handler->got_response_.load(std::memory_order_acquire));
+  EXPECT_GE(handler->terminal_count_.load(std::memory_order_acquire), 1);
+}
+
+TEST_F(BasicCurlHttpTests, CancelFromConnectingCompletes)
+{
+  auto session_manager = std::make_shared<http_client::curl::HttpCurlClientFactory>()->Create();
+  ASSERT_TRUE(session_manager != nullptr);
+
+  auto session = session_manager->CreateSession("http://127.0.0.1:19000");
+  auto request = session->CreateRequest();
+  request->SetUri("get/");
+
+  auto handler            = std::make_shared<TerminalCountingHandler>();
+  handler->cancel_target_ = session.get();
+  handler->cancel_at_     = http_client::SessionState::Connecting;
+
+  session->SendRequest(handler);
+  session->FinishSession();
+  session_manager->FinishAllSessions();
+
+  EXPECT_FALSE(handler->got_response_.load(std::memory_order_acquire));
+  EXPECT_GE(handler->terminal_count_.load(std::memory_order_acquire), 1);
+}
+
+// CreateSession hands back an unregistered session when the URL does not parse, and
+// CURLOPT_URL is not checked when it is set, so nothing on this path stops the operation
+// reaching the same dead end with no handler involved at all. See #4393.
+TEST_F(BasicCurlHttpTests, InvalidUrlCompletes)
+{
+  auto session_manager = std::make_shared<http_client::curl::HttpCurlClientFactory>()->Create();
+  ASSERT_TRUE(session_manager != nullptr);
+
+  auto session = session_manager->CreateSession("http://127.0.0.1:not-a-port");
+  auto request = session->CreateRequest();
+  request->SetUri("get/");
+
+  auto handler = std::make_shared<TerminalCountingHandler>();
+
+  session->SendRequest(handler);
+  session->FinishSession();
+  session_manager->FinishAllSessions();
+
+  EXPECT_FALSE(handler->got_response_.load(std::memory_order_acquire));
+  EXPECT_GE(handler->terminal_count_.load(std::memory_order_acquire), 1);
+}
+
 TEST_F(BasicCurlHttpTests, SendGetRequestSync)
 {
   received_requests_.clear();

--- a/ext/test/http/curl_http_test.cc
+++ b/ext/test/http/curl_http_test.cc
@@ -783,6 +783,56 @@ TEST_F(BasicCurlHttpTests, UnparsableUrlsReleaseTheirOwnResources)
   EXPECT_EQ(1, second_handler->terminal_count_.load(std::memory_order_acquire));
 }
 
+namespace
+{
+// The event is dispatched after the operation is finished, so a handler is free to call
+// FinishSession() from it. Reporting first instead leaves this waiting on a promise that only the
+// Cleanup() below the dispatch can fulfil, which hangs rather than fails, so this case has to run.
+class FinishFromEventHandler : public TerminalCountingHandler
+{
+public:
+  void OnEvent(http_client::SessionState state, nostd::string_view reason) noexcept override
+  {
+    TerminalCountingHandler::OnEvent(state, reason);
+    if (state == http_client::SessionState::CreateFailed && finish_target_ != nullptr)
+    {
+      auto *target   = finish_target_;
+      finish_target_ = nullptr;
+      entered_.store(true, std::memory_order_release);
+      target->FinishSession();
+      returned_.store(true, std::memory_order_release);
+    }
+  }
+
+  http_client::Session *finish_target_ = nullptr;
+  std::atomic<bool> entered_{false};
+  std::atomic<bool> returned_{false};
+};
+}  // namespace
+
+TEST_F(BasicCurlHttpTests, FinishFromTheCreateFailedEventReturns)
+{
+  auto session_manager = std::make_shared<http_client::curl::HttpCurlClientFactory>()->Create();
+  ASSERT_TRUE(session_manager != nullptr);
+
+  auto session = session_manager->CreateSession("http://127.0.0.1:not-a-port");
+  auto request = session->CreateRequest();
+  request->SetUri("get/");
+
+  auto handler            = std::make_shared<FinishFromEventHandler>();
+  handler->finish_target_ = session.get();
+
+  session->SendRequest(handler);
+
+  ASSERT_TRUE(handler->entered_.load(std::memory_order_acquire))
+      << "the failure never reached the handler, so nothing was tested";
+  EXPECT_TRUE(handler->returned_.load(std::memory_order_acquire))
+      << "FinishSession from this event waited on a promise only its own caller can set";
+
+  session->FinishSession();
+  session_manager->FinishAllSessions();
+}
+
 TEST_F(BasicCurlHttpTests, InvalidUrlCompletes)
 {
   auto session_manager = std::make_shared<http_client::curl::HttpCurlClientFactory>()->Create();

--- a/ext/test/http/curl_http_test.cc
+++ b/ext/test/http/curl_http_test.cc
@@ -678,6 +678,101 @@ private:
   std::vector<http_client::SessionState> states_;
 };
 
+// Owned by the case rather than by the handler, so the order survives the handler being
+// destroyed. That is what lets the case below tell "the event ran while the handler was alive"
+// from "the event ran on memory nothing owned any more" without depending on a sanitizer,
+// though AddressSanitizer reports the second one outright.
+struct LifetimeProbe
+{
+  std::atomic<int> next{0};
+  std::atomic<int> event_at{-1};
+  std::atomic<int> destroyed_at{-1};
+};
+
+class ProbedHandler : public CustomEventHandler
+{
+public:
+  explicit ProbedHandler(std::shared_ptr<LifetimeProbe> probe) : probe_{std::move(probe)} {}
+
+  ~ProbedHandler() override
+  {
+    probe_->destroyed_at.store(probe_->next.fetch_add(1, std::memory_order_acq_rel),
+                               std::memory_order_release);
+  }
+
+  ProbedHandler(const ProbedHandler &)            = delete;
+  ProbedHandler(ProbedHandler &&)                 = delete;
+  ProbedHandler &operator=(const ProbedHandler &) = delete;
+  ProbedHandler &operator=(ProbedHandler &&)      = delete;
+
+  void OnResponse(http_client::Response & /* response */) noexcept override {}
+
+  void OnEvent(http_client::SessionState /* state */,
+               nostd::string_view /* reason */) noexcept override
+  {
+    probe_->event_at.store(probe_->next.fetch_add(1, std::memory_order_acq_rel),
+                           std::memory_order_release);
+  }
+
+private:
+  std::shared_ptr<LifetimeProbe> probe_;
+};
+
+// The operation holds the handler as a bare pointer, and what keeps the caller's handler alive
+// past SendRequest is the shared_ptr the completion callback captured. Cleanup() takes that
+// callback and lets it go, so anything dispatched after Cleanup() is talking to whatever is left
+// of the handler. This case is the only one in the file that leaves the completion callback as
+// the sole owner, which is exactly what Session::SendRequest arranges for every real caller.
+TEST_F(BasicCurlHttpTests, AnUnscheduledSessionTellsAHandlerNothingElseHolds)
+{
+  curl::HttpClient client;
+
+  auto session = client.CreateSession("http://127.0.0.1:19000");
+  ASSERT_TRUE(session != nullptr);
+  auto curl_session = std::static_pointer_cast<curl::Session>(session);
+
+  auto probe   = std::make_shared<LifetimeProbe>();
+  auto handler = std::make_shared<ProbedHandler>(probe);
+
+  http_client::HttpSslOptions no_ssl;
+  http_client::Body body;
+  http_client::Headers headers;
+  http_client::RetryPolicy no_retry{};
+  http_client::Compression compression = http_client::Compression::kNone;
+
+  curl_session->GetOperation().reset(new curl::HttpOperation(
+      http_client::Method::Get, "http://127.0.0.1:19000/get/", no_ssl, handler.get(), headers, body,
+      compression, false, curl::kDefaultHttpConnTimeout, false, false, no_retry));
+
+  std::atomic<int> completed{0};
+  ASSERT_EQ(CURLE_OK,
+            curl_session->GetOperation()->SendAsync(
+                curl_session.get(), [handler, &completed](curl::HttpOperation & /* operation */) {
+                  completed.fetch_add(1, std::memory_order_release);
+                }));
+
+  // Deliberately the last reference the case holds, the same as a caller that hands its handler
+  // to SendRequest and keeps nothing of its own.
+  handler.reset();
+
+  CURLM *multi_handle = http_client::curl::HttpClientTestPeer::ExchangeMultiHandle(client, nullptr);
+  const bool has_data = http_client::curl::HttpClientTestPeer::AddSessions(client);
+  http_client::curl::HttpClientTestPeer::ExchangeMultiHandle(client, multi_handle);
+
+  EXPECT_TRUE(has_data);
+  EXPECT_EQ(1, completed.load(std::memory_order_acquire));
+
+  const int event_at     = probe->event_at.load(std::memory_order_acquire);
+  const int destroyed_at = probe->destroyed_at.load(std::memory_order_acquire);
+  ASSERT_GE(event_at, 0) << "the handler was never told that nothing would run its request";
+  ASSERT_GE(destroyed_at, 0) << "the handler outlived the operation, so this case is not holding "
+                             << "the ownership it says it is";
+  EXPECT_LT(event_at, destroyed_at)
+      << "the terminal event reached the handler after the last reference to it had gone";
+
+  http_client::curl::HttpClientTestPeer::RemoveSessions(client);
+}
+
 // The third way an operation ends up with nothing to run it. SendAsync does the whole async
 // setup and Session::SendRequest is what spawns the worker, so the add runs here on one thread
 // against a multi handle that refuses it, which is what a multi handle that failed to initialize

--- a/ext/test/http/curl_http_test.cc
+++ b/ext/test/http/curl_http_test.cc
@@ -986,11 +986,23 @@ public:
       // Cancelling wakes the IO thread, which finishes the operation and dispatches a Cancelled
       // of its own. Stay in this event until that one arrives so the two really do overlap, and
       // give up rather than hang if it never does.
+      //
+      // On the count that only goes up. inside_events_ is lowered again on the way out of that
+      // event, which is a few atomics long, so sampling it every millisecond almost never catches
+      // it and the bound below is spent in full even though the overlap did happen.
       const auto deadline = std::chrono::steady_clock::now() + std::chrono::seconds(30);
-      while (inside_events_.load(std::memory_order_relaxed) < 2 &&
+      while (max_concurrent_events_.load(std::memory_order_relaxed) < 2 &&
              std::chrono::steady_clock::now() < deadline)
       {
         std::this_thread::sleep_for(std::chrono::milliseconds(1));
+      }
+
+      if (max_concurrent_events_.load(std::memory_order_relaxed) < 2)
+      {
+        // Only a run where the overlap never happened reaches this, and it is worth saying so:
+        // the count checked at the end would otherwise read as the client dispatching one event
+        // rather than as the other thread never turning up.
+        overlap_timed_out_.store(true, std::memory_order_release);
       }
     }
 
@@ -999,6 +1011,7 @@ public:
 
   std::atomic<int> inside_events_{0};
   std::atomic<int> max_concurrent_events_{0};
+  std::atomic<bool> overlap_timed_out_{false};
 };
 
 // A client spawns its IO thread only after a request has been scheduled, so cancelling from
@@ -1118,6 +1131,7 @@ TEST_F(BasicCurlHttpTests, CancelFromConnectingWhilePollingCompletes)
   // number is pinned because this case exists to reach that overlap, and a client that started
   // serialising callbacks per operation would be an improvement worth noticing rather than a
   // silent change. Read it as a record of the shape, not as a contract to preserve.
+  EXPECT_FALSE(handler->overlap_timed_out_.load(std::memory_order_acquire));
   EXPECT_EQ(2, handler->max_concurrent_events_.load(std::memory_order_acquire));
   EXPECT_FALSE(handler->got_response_.load(std::memory_order_acquire));
   EXPECT_EQ(1, handler->cancelled_from_callback_.load(std::memory_order_acquire));

--- a/ext/test/http/curl_http_test.cc
+++ b/ext/test/http/curl_http_test.cc
@@ -95,7 +95,7 @@ public:
 
 // Counts the terminal notifications one request produces. Set cancel_at_response_ to cancel from
 // inside the Response event, which is the one moment both arms of the completion callback are
-// eligible: DispatchEvent notifies the handler before it stores the new state, and the callback
+// eligible: DispatchEvent stores the new state before it notifies the handler, and the callback
 // runs after both, so it sees an aborted operation that also has a response.
 class TerminalCountingHandler : public CustomEventHandler
 {
@@ -117,6 +117,7 @@ public:
     else if (state == http_client::SessionState::Cancelled)
     {
       terminal_count_.fetch_add(1, std::memory_order_release);
+      cancelled_.fetch_add(1, std::memory_order_release);
       // Cleanup dispatches its own Cancelled carrying a curl message, and GetCurlErrorMessage
       // never yields an empty one, so an empty reason is the completion callback and only it.
       if (reason.empty())
@@ -141,6 +142,7 @@ public:
   std::atomic<int> terminal_count_{0};
   std::atomic<int> cancelled_from_callback_{0};
   std::atomic<int> create_failed_{0};
+  std::atomic<int> cancelled_{0};
   std::atomic<bool> last_reason_empty_{true};
 };
 
@@ -719,7 +721,16 @@ TEST_F(BasicCurlHttpTests, CancelFromCreatedCompletes)
   session_manager->FinishAllSessions();
 
   EXPECT_FALSE(handler->got_response_.load(std::memory_order_acquire));
+  // Exact, and the classification with it, because a count alone cannot tell an honoured cancel
+  // from a request that was never registered. What it reports today is the second one: Created is
+  // dispatched from the constructor, before curl_operation_ holds this operation, so the cancel
+  // reaches the Session but not the operation, and scheduling then finds no registration. The
+  // caller asked to cancel and is told the create failed. Moving the first events out of the
+  // constructor is what would make this a cancel, and that is the startup ordering #4390 is
+  // about rather than something to bolt on here. Pinned so the day it changes is visible.
   EXPECT_EQ(1, handler->terminal_count_.load(std::memory_order_acquire));
+  EXPECT_EQ(0, handler->cancelled_.load(std::memory_order_acquire));
+  EXPECT_EQ(1, handler->create_failed_.load(std::memory_order_acquire));
 }
 
 TEST_F(BasicCurlHttpTests, CancelFromConnectingCompletes)

--- a/ext/test/http/curl_http_test.cc
+++ b/ext/test/http/curl_http_test.cc
@@ -16,8 +16,8 @@
 #include <atomic>
 #include <chrono>
 #include <condition_variable>
-#include <cstdio>
 #include <cstring>
+#include <functional>
 #include <map>
 #include <memory>
 #include <mutex>

--- a/ext/test/http/curl_http_test.cc
+++ b/ext/test/http/curl_http_test.cc
@@ -62,6 +62,16 @@ public:
 
   static bool RemoveSessions(HttpClient &client) { return client.doRemoveSessions(); }
 
+  // Refuses every add with a code the case chooses. A case about what happens to a refused
+  // session then says which refusal it means, instead of arranging a multi handle libcurl
+  // documents as unusable and depending on what libcurl does with one.
+  static void RefuseAdds(HttpClient &client)
+  {
+    client.add_handle_ = [](CURLM *, CURL *) { return CURLM_BAD_EASY_HANDLE; };
+  }
+
+  static void AllowAdds(HttpClient &client) { client.add_handle_ = &curl_multi_add_handle; }
+
   // A multi handle that failed to initialize refuses every add, which is the state the case
   // below needs and the one thing no transfer can be arranged into.
   static CURLM *ExchangeMultiHandle(HttpClient &client, CURLM *replacement)
@@ -755,9 +765,9 @@ TEST_F(BasicCurlHttpTests, AnUnscheduledSessionTellsAHandlerNothingElseHolds)
   // to SendRequest and keeps nothing of its own.
   handler.reset();
 
-  CURLM *multi_handle = http_client::curl::HttpClientTestPeer::ExchangeMultiHandle(client, nullptr);
+  http_client::curl::HttpClientTestPeer::RefuseAdds(client);
   const bool has_data = http_client::curl::HttpClientTestPeer::AddSessions(client);
-  http_client::curl::HttpClientTestPeer::ExchangeMultiHandle(client, multi_handle);
+  http_client::curl::HttpClientTestPeer::AllowAdds(client);
 
   EXPECT_TRUE(has_data);
   EXPECT_EQ(1, completed.load(std::memory_order_acquire));
@@ -805,9 +815,9 @@ TEST_F(BasicCurlHttpTests, ASessionTheMultiHandleRefusesIsFinished)
                             completed.fetch_add(1, std::memory_order_release);
                           }));
 
-  CURLM *multi_handle = http_client::curl::HttpClientTestPeer::ExchangeMultiHandle(client, nullptr);
+  http_client::curl::HttpClientTestPeer::RefuseAdds(client);
   const bool has_data = http_client::curl::HttpClientTestPeer::AddSessions(client);
-  http_client::curl::HttpClientTestPeer::ExchangeMultiHandle(client, multi_handle);
+  http_client::curl::HttpClientTestPeer::AllowAdds(client);
 
   // The removal the finish queues is the reason this has to answer true: the worker checks it
   // after it has already run doRemoveSessions for this round, and nothing else would drain it.
@@ -1294,7 +1304,7 @@ TEST_F(BasicCurlHttpTests, FinishFromAnotherThreadWaitsForTheTerminalEvent)
   ASSERT_EQ(CURLE_OK, curl_session->GetOperation()->SendAsync(
                           curl_session.get(), [](curl::HttpOperation & /* operation */) {}));
 
-  CURLM *multi_handle = http_client::curl::HttpClientTestPeer::ExchangeMultiHandle(client, nullptr);
+  http_client::curl::HttpClientTestPeer::RefuseAdds(client);
 
   std::atomic<bool> finish_returned{false};
   std::thread finisher([&curl_session, &finish_returned]() {
@@ -1321,7 +1331,7 @@ TEST_F(BasicCurlHttpTests, FinishFromAnotherThreadWaitsForTheTerminalEvent)
   });
 
   http_client::curl::HttpClientTestPeer::AddSessions(client);
-  http_client::curl::HttpClientTestPeer::ExchangeMultiHandle(client, multi_handle);
+  http_client::curl::HttpClientTestPeer::AllowAdds(client);
 
   watcher.join();
   finisher.join();

--- a/ext/test/http/curl_http_test.cc
+++ b/ext/test/http/curl_http_test.cc
@@ -1368,6 +1368,40 @@ TEST_F(BasicCurlHttpTests, FinishInAsyncCallback)
   }
 }
 
+TEST_F(BasicCurlHttpTests, ASessionResetTookBeforeItWasQueuedIsFinished)
+{
+  auto client = std::make_shared<http_client::curl::HttpCurlClientFactory>()->Create();
+  ASSERT_TRUE(client != nullptr);
+  auto *concrete = static_cast<http_client::curl::HttpClient *>(client.get());
+
+  auto session = client->CreateSession("http://127.0.0.1:19000");
+  auto request = session->CreateRequest();
+  request->SetUri("get/");
+
+  // The interleaving, in program order, which is what makes it a case rather than a window.
+  // A reset keeps the sessions whose ids are already in pending_to_add_session_ids_ and takes
+  // the rest, and a request that has not reached ScheduleAddSession yet is one of the rest:
+  // the caller is between CreateSession, which registered it, and SendAsync, which is what
+  // queues the id. Nothing here is sent, so the IO thread does not exist and this thread is
+  // standing exactly where it would be standing.
+  http_client::curl::HttpClientTestPeer::ResetMultiHandle(*concrete);
+
+  auto handler = std::make_shared<RecordingHandler>();
+  session->SendRequest(handler);
+
+  // Nothing is going to run this operation: the session it names is not registered any more,
+  // and adding the id back would leave the caller waiting on a transfer nobody arranged. So
+  // what has to happen is that it is finished. Returning from here is the assertion, and
+  // without it this hangs rather than fails.
+  session->FinishSession();
+
+  const auto states = handler->States();
+  ASSERT_FALSE(states.empty());
+  EXPECT_EQ(http_client::SessionState::CreateFailed, states.back());
+
+  client->FinishAllSessions();
+}
+
 TEST_F(BasicCurlHttpTests, ElegantQuitQuick)
 {
   auto http_client = std::make_shared<http_client::curl::HttpCurlClientFactory>()->Create();

--- a/ext/test/http/curl_http_test.cc
+++ b/ext/test/http/curl_http_test.cc
@@ -942,6 +942,12 @@ TEST_F(BasicCurlHttpTests, CancelFromConnectingWhilePollingCompletes)
   session->FinishSession();
   session_manager->FinishAllSessions();
 
+  // Two callbacks are in the handler at once here. That is what this client does today, not
+  // something EventHandler promises: the interface says nothing about whether one request's
+  // callbacks can overlap, so a handler written against it is not obliged to be re-entrant. The
+  // number is pinned because this case exists to reach that overlap, and a client that started
+  // serialising callbacks per operation would be an improvement worth noticing rather than a
+  // silent change. Read it as a record of the shape, not as a contract to preserve.
   EXPECT_EQ(2, handler->max_concurrent_events_.load(std::memory_order_acquire));
   EXPECT_FALSE(handler->got_response_.load(std::memory_order_acquire));
   EXPECT_EQ(1, handler->cancelled_from_callback_.load(std::memory_order_acquire));

--- a/ext/test/http/curl_http_test.cc
+++ b/ext/test/http/curl_http_test.cc
@@ -912,6 +912,83 @@ public:
 // the first event of the first request has nothing to overlap. On a client that is already
 // polling, the IO thread finishes the operation while the handler is still inside that event,
 // and the caller reaches the end of SendAsync with the operation already cleaned up.
+namespace
+{
+// Cancels from Connecting, then holds inside the terminal event for a bounded 200 ms. The bound is
+// its own, so this can never block for good and a case built on it can only fail, not hang.
+class LatchedCancelHandler : public TerminalCountingHandler
+{
+public:
+  void OnEvent(http_client::SessionState state, nostd::string_view reason) noexcept override
+  {
+    TerminalCountingHandler::OnEvent(state, reason);
+    if (state == http_client::SessionState::Cancelled)
+    {
+      entries_.fetch_add(1, std::memory_order_relaxed);
+      if (std::this_thread::get_id() == owner_)
+      {
+        on_owner_thread_.fetch_add(1, std::memory_order_relaxed);
+      }
+      inside_.fetch_add(1, std::memory_order_release);
+      std::this_thread::sleep_for(std::chrono::milliseconds(200));
+      inside_.fetch_sub(1, std::memory_order_release);
+    }
+  }
+
+  std::thread::id owner_{};
+  std::atomic<int> entries_{0};
+  std::atomic<int> on_owner_thread_{0};
+  std::atomic<int> inside_{0};
+};
+}  // namespace
+
+// Holds that Finish does not return while a handler is still running. Which thread delivers the
+// terminal event is not something this case can choose: when the caller thread delivers it there
+// is nothing for Finish to wait for and the case only confirms that. Measured across separate
+// runs, the IO thread takes it roughly one time in three, and that is the run that matters. So
+// this asserts a true invariant on either schedule but does not on its own discriminate the
+// ordering change it came from; the evidence for that is in the commit that made it.
+TEST_F(BasicCurlHttpTests, FinishDoesNotReturnWhileAHandlerIsRunning)
+{
+  received_requests_.clear();
+  auto session_manager = std::make_shared<http_client::curl::HttpCurlClientFactory>()->Create();
+  ASSERT_TRUE(session_manager != nullptr);
+
+  {
+    auto warm         = session_manager->CreateSession("http://127.0.0.1:19000");
+    auto warm_request = warm->CreateRequest();
+    warm_request->SetUri("get/");
+    auto warm_handler = std::make_shared<TerminalCountingHandler>();
+    warm->SendRequest(warm_handler);
+    ASSERT_TRUE(waitForRequests(30, 1));
+    warm->FinishSession();
+  }
+
+  auto session = session_manager->CreateSession("http://127.0.0.1:19937");
+  auto request = session->CreateRequest();
+  request->SetUri("get/");
+
+  auto handler            = std::make_shared<LatchedCancelHandler>();
+  handler->owner_         = std::this_thread::get_id();
+  handler->cancel_target_ = session.get();
+  handler->cancel_at_     = http_client::SessionState::Connecting;
+
+  session->SendRequest(handler);
+
+  const auto start = std::chrono::steady_clock::now();
+  session->FinishSession();
+  const auto finished = std::chrono::duration_cast<std::chrono::milliseconds>(
+                            std::chrono::steady_clock::now() - start)
+                            .count();
+  const int still_inside = handler->inside_.load(std::memory_order_acquire);
+  session_manager->FinishAllSessions();
+
+  EXPECT_EQ(0, still_inside) << "Finish returned after " << finished
+                             << " ms with a handler still running";
+  EXPECT_GE(handler->entries_.load(std::memory_order_relaxed), 1)
+      << "the terminal event never arrived, so nothing was tested";
+}
+
 TEST_F(BasicCurlHttpTests, CancelFromConnectingWhilePollingCompletes)
 {
   received_requests_.clear();


### PR DESCRIPTION
Fixes #4390.
Fixes #4393.
Fixes #4408.
Fixes #4402.

An operation could be given a promise and then never handed to the IO thread, and then nobody was in a position to complete it. `FinishSession()` blocked forever.

Three ways in, and each one hangs on `main` today:

| | |
| --- | --- |
| A handler cancels from the `Created` or `Connecting` event | `SendAsync` dispatched the event and only then reset `is_aborted_`, so the cancel was thrown away, while `CleanupSession()` had already taken the session out of the client. `ScheduleAddSession` then erased the pending abort for good measure |
| The URL does not parse | `CreateSession` hands back a session it never registered and never gave an id. `CURLOPT_URL` is not checked when it is set, so `Setup()` succeeds and the request reaches `ScheduleAddSession(0)`, which nothing can find |
| `curl_multi_add_handle` rejects the handle | The result was dropped, so the operation sat there with nothing to run it |

They are one invariant with three holes in it: **an operation that never gets scheduled still has to finish.**

## What changed

The flags and the cancel route are published before the first event, so a handler cancelling from it is not overwritten by the rest of `SendAsync`. The future is published *after* the event, deliberately: a handler calling `FinishSession()` from `Connecting` would otherwise wait on a transfer that has not been scheduled yet, with `SendAsync` unable to schedule it because it is inside that handler.

`ScheduleAddSession` now reports whether the session was still registered, and `SendAsync` finishes the operation itself when it was not, or when the event cancelled it. `doAddSessions` does the same for the ones libcurl rejects, outside `sessions_m_`, since finishing one reaches the caller's handler and a handler that cancels takes that lock again.

All three say the same thing to the handler, a failed create carrying the reason, through one method rather than the same three lines in two places. The one libcurl refuses used to arrive as `Cancelled`, which the enum calls "(manually) cancelled" and which both exporters print in those words, for a request nobody cancelled and without the reason libcurl gave. Nothing behaves differently for the change: `CreateFailed` and `Cancelled` both set `need_stop` in the OTLP HTTP handler and both end the wait in the Elasticsearch one, so what moves is the message.

There is one ordering subtlety worth pointing at. Between publishing the future and scheduling the add, the IO thread can already have torn the operation down and found no future to complete, so `SendAsync` rechecks `is_cleaned_` and settles it with an `exchange`. Whichever side gets there first, the value is set exactly once.

That same window had a second defect in it, raised by @lalitb in review. `DispatchEvent` stored `session_state_` after the handler returned, so a handler cancelling from the first event on a client that is already polling had the IO thread storing a `Cancelled` of its own at the same time, and the store after the handler returned overwrote it. ThreadSanitizer reports it on this branch before the change, five runs out of five. The store now happens before the handler runs, which orders it ahead of the cancel through `sessions_m_` and `session_ids_m_`, and the member is a `std::atomic` for the paths where a third thread cancels instead of the handler. `SessionState` is a `std::uint8_t` enum, and on the toolchains this was built with `std::atomic` of it stays one byte with alignment one, so the layout does not move. The standard promises neither, so both are `static_assert`s in `http_operation_curl.cc` rather than a claim here: a toolchain where they do not hold fails the build instead of changing the layout quietly. Worth being exact about whose layout, since I was not. `ext/CMakeLists.txt` installs four headers from `ext/http/client` and `http_operation_curl.h` is not one of them, so a CMake consumer never sees this type. `//ext` takes `hdrs = glob(["include/**/*.h"])`, so a Bazel consumer does, which is why the guard is worth keeping rather than dropping. Lock freedom is a separate property and nothing here checks it, since `is_always_lock_free` is C++17 and this still builds at C++14.

## What a second review round found

Three things, all in the code this branch adds rather than in what it inherited, and each one
is held by a case that fails without the fix.

`FinishUnscheduled` cleaned up and then dispatched the terminal event. The operation holds the
caller's handler as a bare pointer and the only strong reference to it is the one
`Session::SendRequest` captured in the completion callback, so the cleanup that releases that
callback is what frees the handler, and the event that followed read it. AddressSanitizer
reports a heap-use-after-free at the `OnEvent` call reached from `FinishUnscheduled`. Nothing in
the suite caught it, because every case that reaches this path either keeps its own reference to
the handler or hands `SendAsync` a completion capturing none, so the ownership that breaks was
never assembled. The event goes first now. `AnUnscheduledSessionTellsAHandlerNothingElseHolds` is
the only case in the file that leaves the completion callback as the sole owner, which is what
every real caller of `SendRequest` arranges, and it records its own event against its own
destruction into state the case owns, so it fails without a sanitizer as well as with one.

`AsyncData::callback_thread` was a plain `std::thread::id` written on the thread running a
callback and read by `Finish()` and by the destructor on whichever thread called them. Its
accessors put a standalone `atomic_thread_fence` either side of a plain load and store, which
orders nothing: fences synchronize through atomic operations on a common object and there was
none. ThreadSanitizer stayed quiet because both accessors carried
`OPENTELEMETRY_SANITIZER_NO_THREAD`, and the fences were compiled out under that same sanitizer,
so what it was told to ignore was a bare unsynchronized access. The callback scope already
answers the question the member existed to answer and answers it without shared state, so the
member, its accessors and the friend declaration are gone. `Finish()` consulted the scope before
it ever reached the member, which made the second check unreachable as anything but true.

`FinishUnscheduled` is private now, with the client as a friend. It forces a terminal state,
cleans up, dispatches, fulfils the promise and hands the easy resource back, and the client is
the only thing that ever discovers a request nothing will run. `ext/CMakeLists.txt` does not
install this header, but `//ext` globs it, so a public method here is source API for a Bazel
consumer.

## The refusal was reported before the operation it describes was settled

A third reading of `doAddSessions` found the loop in the wrong order. It logged the refusal, then read `GetOperation()`, then finished it.

The log goes through the global handler, which is replaceable application code and, unlike everything else on this path, is not inside a callback scope for that operation. A handler answering with `Session::FinishSession()` reaches `HttpOperation::Finish()`, which is not `InsideCallbackFor(this)` and so waits on a promise only the `FinishUnscheduled` below it can fulfil, on the same thread. Reading the operation after the log is the other half: a handler calling `SendRequest()` from there swaps the operation, and the loop then finishes the new one and leaves the refused one unsettled.

`FinishUnscheduled` already dispatches its event before it cleans up, and its comment says why that matters: a handler calling `FinishSession()` from that event is inside a callback for the operation, so `Finish()` returns rather than waiting. Reporting after it is what brings the log handler under the same protection. Nothing else moved.

`ARejectedSessionIsSettledBeforeItIsReported` installs a global log handler that records whether the terminal event has arrived by the time the refusal is logged, and puts the previous handler and level back through a scope guard. With the report moved back above the settlement it fails at the ordering assertion; with the change it passes. Forty cases in the binary, all passing.

Worth naming because it nearly went in wrong: the first version of that assertion asked only whether the handler had seen any event. `SendAsync` dispatches `Created` during setup, so that is true in both orders, and the case passed with the defect deliberately put back. It asks for `CreateFailed` now.

## What this path shares with the rest of the client, and does not fix

Telling a refused session that nothing will run its request means dispatching a terminal event, and a handler is free to answer it by starting another request on the same session. `Session::curl_operation_` is a `std::unique_ptr<HttpOperation>` and `Session::SendRequest` assigns into it with `reset`, so that answer frees the operation whose member function is dispatching the event. AddressSanitizer reports a heap use after free, single threaded and on the first attempt.

This is not introduced here. The same two stacks reproduce on `main` at `58ed80d9` through `Connecting`, which is dispatched from inside `SendAsync` and has nothing to do with this change. I have put the measurement on #4448, where the question of what a callback may call is one of the open contract items, rather than opening an issue for it.

I looked at fixing it inside this pull request and decided not to. Taking ownership of the operation before finishing it removes the use after free, and it also makes `FinishSession()` on another thread return without waiting, because that wait is keyed on the session still holding an operation rather than on there being outstanding work. `FinishFromAnotherThreadWaitsForTheTerminalEvent` fails on that change, and it is right to. Both behaviours follow from the same ownership model, so choosing between them is the contract decision rather than something this change should settle on its own.

## The part I looked hardest at

This makes the completion callback run on the calling thread in those paths, where it always ran on the IO thread before. I went through every in-tree caller rather than assume:

- `OtlpHttpClient::addSession` closes its `session_manager_lock_` scope before `SendRequest`, which the comment there says is deliberate, and the lock is recursive anyway. The handler's `Cancelled` reaches `Unbind` and `ReleaseSession`, and `ReleaseSession` moves the session to `gc_sessions_` rather than calling `FinishSession`, so nothing waits.
- The Elasticsearch exporter holds no lock across either of its `SendRequest` calls, and the synchronous `waitForResponse()` waits on a predicate, which is exactly the case where the completion is recorded before the waiter arrives.
- A handler calling `FinishSession()` from inside a callback this operation dispatched is covered by a callback scope. Entering one records the operation on the calling thread, and `Finish()` returns rather than waiting on a completion that thread has not published yet. That covers the completion callback and every event, which is what closes #4402.
- This is not a new shape either way. `Session::SendRequest` already calls `callback->OnEvent(CreateFailed, "")` inline on the calling thread when `SendAsync` fails.

The behaviour change a user could notice is that a cancel from `Connecting` is now honoured. It used to be dropped and the request went out regardless.

## Tests

`CancelFromCreatedCompletes`, `CancelFromConnectingCompletes` and `InvalidUrlCompletes`. All three hang rather than fail without the change: `timeout 25` gives exit 124 and zero cases finished, and they pass in about 500 ms with it. Worth knowing for a bisect, since a regression here looks like a CI timeout rather than a red assertion.

`CancelFromConnectingWhilePollingCompletes` is the fourth, and the only one that puts an IO thread there before the event runs. A client spawns one only after `SendAsync` returns, so it warms the client with a completed request first, then cancels from `Connecting` and stays in the handler until the IO thread has entered it too. Two things follow from that. It reports the state store race without the change and none with it, five runs out of five each way. And instrumenting both tail branches of `SendAsync` and running the whole binary shows it is the only thing that reaches the `is_cleaned_` recheck, which the three cases above never touch.

What it stays in the handler *on* took a second look. It waited on `inside_events_`, which is raised on the way into an event and lowered on the way out, and the event the IO thread dispatches there is a few atomics long, so sampling it every millisecond almost never caught it at two: four runs measured 30005, 30509, 30006 and 30015 ms and all passed, because the count the assertion reads is written by the thread that creates the overlap and never goes down. Waiting on that one instead leaves as soon as the overlap has happened, and the case goes from 30006 ms to 511 ms, ten runs out of ten, with the binary down from about 53 seconds to 23.5. The shorter wait is also the one that works: against a faithful revert of what this branch changed about `session_state_`, a plain member again and the store back after the handler, ThreadSanitizer reports the race five runs out of five with it and none at all with the thirty second version, which spends that long and a great many reads of the same address between the two writes. A bound that does expire now means the overlap really did not happen, so it is recorded and checked rather than left to read as one dispatched event.

`ASessionTheMultiHandleRefusesIsFinished` is the third root cause, and nothing reached it before. `SendAsync` does the whole async setup and `Session::SendRequest` is what starts the worker, so the case builds the operation, sends it, and drives `doAddSessions` itself on one thread. What refuses the add is a seam: the client reaches `curl_multi_add_handle` through a member, and a case replaces it with one that returns the code it wants. It used to swap the client's multi handle for a null one, which works, but it works by handing libcurl a handle its own documentation says not to use after `curl_multi_init` returns null, so what was under test was libcurl's defence against invalid input rather than a refusal it promises. The manual only promises that a non-zero return means the add failed. Reverting that finish to the plain one it had fails the case twice over, on the state it reports and on the absence of a cancel.

Its overlap counters are `relaxed` on purpose. With `acq_rel` the two threads synchronize through the counter itself, which orders the very stores the case exists to keep unordered, and ThreadSanitizer goes quiet. A deliberate unsynchronized counter used as a control confirms it: the `acq_rel` build reports neither, the `relaxed` build reports both.

## Checks

All 38 cases in `curl_http_test` pass in each of eight configurations, built and run one at a time from a committed tree: the default one, AddressSanitizer, ThreadSanitizer, UndefinedBehaviorSanitizer with `-fno-sanitize-recover`, C++20, `WITH_OTLP_HTTP_COMPRESSION=ON`, `WITH_THREAD_INSTRUMENTATION_PREVIEW=ON` and `WITH_OTLP_RETRY_PREVIEW=OFF`. Each run reports its own counts rather than going through CTest, because a case an `#ifdef` compiles out still gets a CTest entry and passes as zero tests run. Nothing skipped in any of them, the three sanitizers reported nothing, and the two configurations whose counts move are the ones with gated cases: compression adds two and retry-off drops three. Each of them now carries a CTest timeout of 120 seconds, read back from `ctest --show-only=json-v1`, because what these cases catch fails by hanging: without a bound a regression stops the job rather than reporting, which happened three times while this was being written. The whole binary takes 23.5 seconds, and the two slowest cases are the ones that wait out a request timeout on purpose, at 5007 ms each.

One number in here is pinned as it is rather than as it should be. Cancelling once the transfer belongs to the IO thread delivers two terminal events, one from `Cleanup` and one from the completion callback, and `CancelFromConnectingCompletes` requires exactly two so that a change to it is visible. One is the goal, and that is #4360, which this change does not close. A cancel from `Created` is reported as a failed create for the same reason: the event is dispatched from the constructor, before the `Session` holds the operation, so the cancel never reaches it. Moving the first events out of the constructor is the startup ordering work, not something to add here, and both are pinned rather than smoothed over. Under ThreadSanitizer the whole binary reports zero races with the change, and the new case reports the state store race five times out of five without it. Clean under `OTELCPP_MAINTAINER_MODE=ON` and `clang-format` 18.1.8, clang-tidy one warning below `main` under the CI filters, since deleting the accessor class took one with it and the scope guard's own two were fixed rather than accepted, and IWYU reports correct includes for both changed translation units on all three of its presets.

## Related

#4392 fixed the cross thread write to the easy handle on the same file and has landed, and this is rebased on it: the resolution keeps its CURLOPT_NOPROGRESS placement and its atomic AsyncData::session alongside the ordering here. #4402 is closed here. That is a correction to what this description said before: I had scoped the claim to the terminal event this client generates itself, but the mechanism is not specific to it. A callback scope wraps every dispatch and `Finish()` consults it, so a handler is covered on the events the IO thread delivers during a transfer as well, which is exactly the case the issue describes. `FinishSessionFromAnEventTheIoThreadDelivers` is that case, taken from the issue and made deterministic by waiting on a condition rather than sleeping; take the check out of `Finish()` and it hangs. The alternative was to narrow the mechanism back to the unscheduled path, and that only puts the deadlock back for everyone else, so I would rather claim what the code does. `FinishFromAnotherThreadWaitsForTheTerminalEvent` holds the other direction, that an outside `Finish()` waits for the terminal event and the completion callback rather than for the promise alone.

#4405 changes teardown after `Cleanup()` has handed the easy resource back to the client, so the two are independent, but whichever lands second needs a real rebase rather than a metadata one because both touch the same removal path. I stacked all of #4405 on top of this branch to find out what that costs rather than leave you to work it out. Four of its eight commits conflict. `doAddSessions` is one thing wanted from two ends, since this branch finishes a session `curl_multi_add_handle` rejected and #4405 keeps that same handle off its attachment ledger, and it resolves as the union. `PerformCurlMessage` is another, where this branch adds a function immediately above it and #4405 changes what it returns. The rest is the test file, and that part wants judgement rather than a merge tool: both branches add cases at the same anchor whose first four lines are identical, so a mechanical union folds them into one function with two `TEST_F` headers stacked and a variable declared twice, and it does not compile. Taken apart again and resolved, the combined tree passes the curl suite 43 of 43 under AddressSanitizer with `detect_leaks=1`, the same with `WITH_OTLP_RETRY_PREVIEW=ON`, and under bazel.

## About the lines Codecov marks

Codecov reports 5 lines of this change without cover. Two are the guards in
`doAddSessions()` for a session whose operation or easy handle has gone before
the queue drains; they were evaluated 39 times each and never taken, and
reaching them needs a cancel to land inside that window.

The other three are the wait in `~HttpOperation()` for a transfer that is still
in flight. Those are worth naming rather than covering. The only route to them
is a second `SendRequest()` on a session whose first is still running, since the
client holds a strong reference to every registered session and nothing else
destroys an operation in `Connecting`, `Connected` or `Sending`. #4431 refuses
that second call, so a case written here would pin behaviour that PR removes.
Once it lands those three lines become unreachable and should go, rather than
gain a test now.

Measured rather than read: `527` is hit twice and `528` not at all, so the
condition short circuits before the callback scope test is even evaluated.

For significant contributions please make sure you have completed the following items:

* [x] `CHANGELOG.md` updated for non-trivial changes
* [x] Unit tests have been added
* [x] Changes in public API reviewed














