### PR TITLE
[BUG] Draw the retry jitter from a per thread generator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,9 @@ Increment the:
 * [BUG] Report one outcome per request when a curl session is cancelled after
   the response arrives
   ([#4363](https://github.com/open-telemetry/opentelemetry-cpp/pull/4363))
+* [BUG] Draw the curl retry jitter from a per thread generator instead of one
+  shared across HTTP client threads
+  ([#4399](https://github.com/open-telemetry/opentelemetry-cpp/pull/4399))
 * [CODE HEALTH] Enable clang-tidy `modernize-deprecated-headers` and replace
   deprecated C headers (`stdint.h`, `stddef.h`, `stdlib.h`, `string.h`,
   `stdio.h`, `ctype.h`, `limits.h`, `assert.h`) with their C++ equivalents

--- a/ext/src/http/client/curl/http_operation_curl.cc
+++ b/ext/src/http/client/curl/http_operation_curl.cc
@@ -618,9 +618,10 @@ std::chrono::system_clock::time_point HttpOperation::NextRetryTime()
     return retry_after_time_point_;
   }
 
-  static std::random_device rd;
-  static std::mt19937 gen(rd());
-  static std::uniform_real_distribution<float> dis(0.8f, 1.2f);
+  // One engine per thread. Every HttpClient drives its own background thread, and drawing from
+  // the engine advances its state, so a shared one is written by all of them at once.
+  static thread_local std::mt19937 gen{std::random_device{}()};
+  std::uniform_real_distribution<float> dis(0.8f, 1.2f);
 
   // The initial retry attempt will occur after initialBackoff * random(0.8, 1.2)
   auto backoff = retry_policy_.initial_backoff;

--- a/ext/test/http/curl_http_test.cc
+++ b/ext/test/http/curl_http_test.cc
@@ -562,6 +562,37 @@ TEST_F(BasicCurlHttpTests, ACancelBeforeTheResponseReportsCancelled)
   session_manager->FinishAllSessions();
 }
 
+// NextRetryTime draws the backoff jitter from an engine that used to be a shared static, so
+// two clients retrying at the same time wrote the same std::mt19937. The case passes either
+// way, since a data race is not a functional failure. It is here for the sanitizer builds.
+TEST_F(BasicCurlHttpTests, RetryJitterIsNotSharedAcrossThreads)
+{
+  opentelemetry::ext::http::client::HttpSslOptions ssl_options;
+  opentelemetry::ext::http::client::Headers request_headers;
+  opentelemetry::ext::http::client::Body request_body;
+
+  http_client::curl::HttpOperation first(http_client::Method::Get, "http://127.0.0.1:19000/",
+                                         ssl_options, nullptr, request_headers, request_body);
+  http_client::curl::HttpOperation second(http_client::Method::Get, "http://127.0.0.1:19000/",
+                                          ssl_options, nullptr, request_headers, request_body);
+
+  std::thread drawing_first([&first] {
+    for (int i = 0; i < 200; ++i)
+    {
+      (void)first.NextRetryTime();
+    }
+  });
+  std::thread drawing_second([&second] {
+    for (int i = 0; i < 200; ++i)
+    {
+      (void)second.NextRetryTime();
+    }
+  });
+
+  drawing_first.join();
+  drawing_second.join();
+}
+
 TEST_F(BasicCurlHttpTests, SendGetRequestSync)
 {
   received_requests_.clear();


### PR DESCRIPTION
Fixes #4398, the first of the three things on it.

`NextRetryTime()` multiplies the backoff by a sample from a static engine:

```cpp
  static std::random_device rd;
  static std::mt19937 gen(rd());
  static std::uniform_real_distribution<float> dis(0.8f, 1.2f);
  ...
  backoff *= dis(gen);
```

Drawing from an engine advances its state, so `dis(gen)` is a write. Every `HttpClient` runs its own background thread and each one calls this from its own retry loop, so two clients retrying at the same time write the same `std::mt19937`. C++ guarantees the initialisation of a function local static is thread safe; it says nothing about using one afterwards.

The engine becomes `thread_local`, seeded per thread from a temporary `random_device`. The distribution becomes an ordinary local, since it was only static out of habit and sharing it bought nothing.

## Evidence

`NextRetryTime()` is public and, unlike `IsRetryable()`, its body is not behind `ENABLE_OTLP_RETRY_PREVIEW`, so the static compiles into every build and a test can reach it without a retrying server. Two operations, two threads, 200 draws each:

| `RetryJitterIsNotSharedAcrossThreads` under TSAN | warnings per run |
| --- | ---: |
| `main` at f6e48180 with this test added | 3, 3, 3 |
| this branch | 0, 0, 0 |

```text
WARNING: ThreadSanitizer: data race
  Read of size 8 by thread T3:
    #0 std::mersenne_twister_engine<...>::operator()() /usr/include/c++/14/bits/random.tcc:458
    #5 HttpOperation::NextRetryTime() ext/src/http/client/curl/http_operation_curl.cc:641
```

The case passes on `main` too, because a data race is not a functional failure. It is here so the sanitizer builds keep it fixed.

## What this does not touch

#4398 has two more items and neither is here. The retry deadline is redrawn every time `doRetrySessions()` asks for it, so it is not a stable point in time, and `IsRetryable()` does not consider whether the request was cancelled. Both are tangled with the retry queue and with the teardown ordering in #4391, and both are worth deciding rather than guessing.

## Checks

23 of 23 in `curl_http_test`. Clean under `OTELCPP_MAINTAINER_MODE=ON` and `clang-format` 18.1.8. clang-tidy at zero delta against `main` under the CI filters. IWYU clean on all three variants, `all-options-abiv1`, `all-options-abiv1-preview` and `all-options-abiv2-preview`, each checked against a deliberately unused include first so the zero means something.

## Related

#4392, #4394 and #4395 are open against the same two files. This one only touches `NextRetryTime`, which none of them go near, so the production sides do not overlap. The test file is shared, and I will rebase whichever of them lands second.

For significant contributions please make sure you have completed the following items:

* [x] `CHANGELOG.md` updated for non-trivial changes
* [x] Unit tests have been added
* [x] Changes in public API reviewed
