### PR TITLE
[BUG] Remove a curl easy handle before releasing what it points at

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -128,6 +128,9 @@ Increment the:
   deprecated C headers (`stdint.h`, `stddef.h`, `stdlib.h`, `string.h`,
   `stdio.h`, `ctype.h`, `limits.h`, `assert.h`) with their C++ equivalents
   ([#4349](https://github.com/open-telemetry/opentelemetry-cpp/pull/4349))
+* [BUG] Remove a curl easy handle from the multi handle before freeing that
+  handle and the header list it points at
+  [#4391](https://github.com/open-telemetry/opentelemetry-cpp/issues/4391)
 
 * [CONFIGURATION] Add SDK component builder interfaces to the registry
   [#4358](https://github.com/open-telemetry/opentelemetry-cpp/issues/4358)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -129,7 +129,8 @@ Increment the:
   `stdio.h`, `ctype.h`, `limits.h`, `assert.h`) with their C++ equivalents
   ([#4349](https://github.com/open-telemetry/opentelemetry-cpp/pull/4349))
 * [BUG] Remove a curl easy handle from the multi handle before freeing that
-  handle and the header list it points at
+  handle and the header list it points at, and keep both when libcurl will not
+  take the handle back
   [#4391](https://github.com/open-telemetry/opentelemetry-cpp/issues/4391)
 
 * [CONFIGURATION] Add SDK component builder interfaces to the registry

--- a/ext/include/opentelemetry/ext/http/client/curl/http_client_curl.h
+++ b/ext/include/opentelemetry/ext/http/client/curl/http_client_curl.h
@@ -379,11 +379,13 @@ private:
   std::unordered_map<uint64_t, std::shared_ptr<Session>> sessions_;
   std::unordered_set<uint64_t> pending_to_add_session_ids_;
   std::unordered_map<uint64_t, std::shared_ptr<Session>> pending_to_abort_sessions_;
-  // One easy handle on its way back to libcurl. There is one of these per handle rather than
-  // per session, because a session that starts another request hands over a second handle while
-  // the first is still queued, and one entry per session would drop the first one, leaving its
-  // easy handle and header list with no owner. The session is only filled in when the handle
-  // has to be kept, and names what the handle still points at.
+  // One easy handle on its way back to libcurl, with the session it still names through
+  // CURLOPT_PRIVATE. The session is taken when the record is made, so that nothing has to find
+  // it again later against a sessions_ the calling thread is free to change in between.
+  //
+  // There is one of these per handle rather than per session, because a session that starts
+  // another request hands over a second handle while the first is still queued, and one entry
+  // per session would drop the first one, leaving its easy handle and header list with no owner.
   struct PendingCurlRemoval
   {
     uint64_t session_id;
@@ -392,7 +394,6 @@ private:
   };
 
   std::list<PendingCurlRemoval> pending_to_remove_session_handles_;
-  std::unordered_map<uint64_t, std::shared_ptr<Session>> pending_to_remove_sessions_;
 
   // Which easy handles the multi handle holds, recorded when curl_multi_add_handle accepts one.
   // What curl_multi_remove_handle returns cannot answer that question afterwards: it reports

--- a/ext/include/opentelemetry/ext/http/client/curl/http_client_curl.h
+++ b/ext/include/opentelemetry/ext/http/client/curl/http_client_curl.h
@@ -366,6 +366,9 @@ private:
   bool doRetrySessions(bool report_all);
   void resetMultiHandle();
 
+  bool detachHandle(CURL *easy_handle);
+  void releaseQuarantinedHandles();
+
   std::mutex multi_handle_m_;
   CURLM *multi_handle_;
   std::atomic<uint64_t> next_session_id_{0};
@@ -376,8 +379,32 @@ private:
   std::unordered_map<uint64_t, std::shared_ptr<Session>> sessions_;
   std::unordered_set<uint64_t> pending_to_add_session_ids_;
   std::unordered_map<uint64_t, std::shared_ptr<Session>> pending_to_abort_sessions_;
-  std::unordered_map<uint64_t, HttpCurlEasyResource> pending_to_remove_session_handles_;
-  std::list<std::shared_ptr<Session>> pending_to_remove_sessions_;
+  // One easy handle on its way back to libcurl. There is one of these per handle rather than
+  // per session, because a session that starts another request hands over a second handle while
+  // the first is still queued, and one entry per session would drop the first one, leaving its
+  // easy handle and header list with no owner. The session is only filled in when the handle
+  // has to be kept, and names what the handle still points at.
+  struct PendingCurlRemoval
+  {
+    uint64_t session_id;
+    HttpCurlEasyResource resource;
+    std::shared_ptr<Session> owner;
+  };
+
+  std::list<PendingCurlRemoval> pending_to_remove_session_handles_;
+  std::unordered_map<uint64_t, std::shared_ptr<Session>> pending_to_remove_sessions_;
+
+  // Which easy handles the multi handle holds, recorded when curl_multi_add_handle accepts one.
+  // What curl_multi_remove_handle returns cannot answer that question afterwards: it reports
+  // whether the removal succeeded, and libcurl 8.10 and 8.11 reject a handle the multi handle
+  // does not hold where every other version accepts it. Background thread only.
+  std::unordered_set<CURL *> attached_handles_;
+
+  // Handles libcurl would not give back. A transfer may still be running on one, and its
+  // CURLOPT_PRIVATE names the session, so freeing either would leave libcurl and this client
+  // reading storage that has been released. Both are held until curl_multi_cleanup detaches
+  // the handle, which is where they are freed.
+  std::list<PendingCurlRemoval> quarantined_handles_;
   std::deque<std::shared_ptr<Session>> pending_to_retry_sessions_;
 
   std::mutex background_thread_m_;

--- a/ext/include/opentelemetry/ext/http/client/curl/http_operation_curl.h
+++ b/ext/include/opentelemetry/ext/http/client/curl/http_operation_curl.h
@@ -285,7 +285,12 @@ public:
    *
    * @param code CURLcode
    */
-  void PerformCurlMessage(CURLcode code);
+  /**
+   * Read one completed curl message.
+   * @return true when the operation has been rewound for another attempt, and the caller is to
+   * take it on. False when the message was not this operation's to read, or it is finished.
+   */
+  bool PerformCurlMessage(CURLcode code);
 
   inline CURL *GetCurlEasyHandle() noexcept { return curl_resource_.easy_handle; }
 

--- a/ext/src/http/client/curl/http_client_curl.cc
+++ b/ext/src/http/client/curl/http_client_curl.cc
@@ -765,7 +765,7 @@ bool HttpClient::doAbortSessions()
   }
 
   bool has_data = false;
-  for (const auto &session : pending_to_abort_sessions)
+  for (auto &session : pending_to_abort_sessions)
   {
     if (!session.second)
     {
@@ -776,6 +776,15 @@ bool HttpClient::doAbortSessions()
     {
       session.second->FinishOperation();
       has_data = true;
+    }
+
+    // FinishOperation queued the easy handle for removal, and that handle still holds
+    // CURLOPT_PRIVATE and the callback data pointing into this session and its operation.
+    // doRemoveSessions cannot find the session to hold, because aborting took it out of
+    // sessions_, so hand it the owner directly: it keeps one until the handle is freed.
+    {
+      std::lock_guard<std::recursive_mutex> session_id_lock_guard{session_ids_m_};
+      pending_to_remove_sessions_.emplace_back(std::move(session.second));
     }
   }
   return has_data;

--- a/ext/src/http/client/curl/http_client_curl.cc
+++ b/ext/src/http/client/curl/http_client_curl.cc
@@ -568,9 +568,11 @@ bool HttpClient::MaybeSpawnBackgroundThread()
               {
                 // Session can not be destroyed when calling PerformCurlMessage
                 auto hold_session = session->shared_from_this();
-                operation->PerformCurlMessage(result);
 
-                if (operation->IsRetryable())
+                // Reading the message and taking it on for another attempt are one decision.
+                // Asking again afterwards reads whatever the last message left behind, which for
+                // an operation that has since been cleaned up is a status from before that.
+                if (operation->PerformCurlMessage(result))
                 {
                   self->pending_to_retry_sessions_.push_back(hold_session);
                 }

--- a/ext/src/http/client/curl/http_client_curl.cc
+++ b/ext/src/http/client/curl/http_client_curl.cc
@@ -47,6 +47,26 @@ namespace client
 namespace curl
 {
 
+namespace
+{
+// The easy handle goes first. libcurl does not copy the header list, so it is in use for as long
+// as anything is still transferring on the handle that points at it.
+void ReleaseCurlResource(HttpCurlEasyResource &resource) noexcept
+{
+  if (nullptr != resource.easy_handle)
+  {
+    curl_easy_cleanup(resource.easy_handle);
+    resource.easy_handle = nullptr;
+  }
+
+  if (nullptr != resource.headers_chunk)
+  {
+    curl_slist_free_all(resource.headers_chunk);
+    resource.headers_chunk = nullptr;
+  }
+}
+}  // namespace
+
 HttpCurlGlobalInitializer::HttpCurlGlobalInitializer()
 {
   curl_global_init(CURL_GLOBAL_ALL);
@@ -318,7 +338,31 @@ HttpClient::~HttpClient()
   {
     std::lock_guard<std::mutex> lock_guard{multi_handle_m_};
     curl_multi_cleanup(multi_handle_);
+
+    // Nothing is attached to a multi handle that no longer exists, and clearing the pointer
+    // keeps anything released below from reaching for the one just destroyed.
+    attached_handles_.clear();
+    multi_handle_ = nullptr;
   }
+
+  // The background thread has stopped, so nothing else is coming back for what it left behind.
+  // Sessions go first, because releasing one can hand over one last easy handle, and they are
+  // released outside the lock because that hand over takes it.
+  releaseQuarantinedHandles();
+  {
+    std::unordered_map<uint64_t, std::shared_ptr<Session>> pending_to_remove_sessions;
+    {
+      std::lock_guard<std::recursive_mutex> session_id_lock_guard{session_ids_m_};
+      pending_to_remove_sessions_.swap(pending_to_remove_sessions);
+    }
+  }
+
+  std::lock_guard<std::recursive_mutex> session_id_lock_guard{session_ids_m_};
+  for (auto &pending : pending_to_remove_session_handles_)
+  {
+    ReleaseCurlResource(pending.resource);
+  }
+  pending_to_remove_session_handles_.clear();
 }
 
 std::shared_ptr<opentelemetry::ext::http::client::Session> HttpClient::CreateSession(
@@ -396,10 +440,19 @@ void HttpClient::CleanupSession(uint64_t session_id)
 
     if (session)
     {
-      if (pending_to_remove_session_handles_.end() !=
-          pending_to_remove_session_handles_.find(session_id))
+      bool has_pending_handle = false;
+      for (const auto &pending : pending_to_remove_session_handles_)
       {
-        pending_to_remove_sessions_.emplace_back(std::move(session));
+        if (pending.session_id == session_id)
+        {
+          has_pending_handle = true;
+          break;
+        }
+      }
+
+      if (has_pending_handle)
+      {
+        pending_to_remove_sessions_.emplace(session_id, std::move(session));
       }
       else if (session->IsSessionActive() && session->GetOperation())
       {
@@ -643,7 +696,6 @@ void HttpClient::ScheduleAddSession(uint64_t session_id)
   {
     std::lock_guard<std::recursive_mutex> lock_guard{session_ids_m_};
     pending_to_add_session_ids_.insert(session_id);
-    pending_to_remove_session_handles_.erase(session_id);
     pending_to_abort_sessions_.erase(session_id);
   }
 
@@ -678,7 +730,8 @@ void HttpClient::ScheduleRemoveSession(uint64_t session_id, HttpCurlEasyResource
   {
     std::lock_guard<std::recursive_mutex> lock_guard{session_ids_m_};
     pending_to_add_session_ids_.erase(session_id);
-    pending_to_remove_session_handles_[session_id] = std::move(resource);
+    pending_to_remove_session_handles_.push_back(
+        PendingCurlRemoval{session_id, std::move(resource), nullptr});
   }
 
   wakeupBackgroundThread();
@@ -749,7 +802,18 @@ bool HttpClient::doAddSessions()
       continue;
     }
 
-    curl_multi_add_handle(multi_handle_, easy_handle);
+    const CURLMcode rc = curl_multi_add_handle(multi_handle_, easy_handle);
+    if (CURLM_OK != rc)
+    {
+      // The request never starts. Leaving the handle unrecorded is what stops the release path
+      // from asking the multi handle to give back something it was never given.
+      OTEL_INTERNAL_LOG_ERROR(
+          "[HTTP Client Curl] curl_multi_add_handle failed, this request will not be sent: "
+          << curl_multi_strerror(rc));
+      continue;
+    }
+
+    attached_handles_.insert(easy_handle);
     has_data = true;
   }
 
@@ -781,10 +845,10 @@ bool HttpClient::doAbortSessions()
     // FinishOperation queued the easy handle for removal, and that handle still holds
     // CURLOPT_PRIVATE and the callback data pointing into this session and its operation.
     // doRemoveSessions cannot find the session to hold, because aborting took it out of
-    // sessions_, so hand it the owner directly: it keeps one until the handle is freed.
+    // sessions_, so hand it over under the id it will look the handle up by.
     {
       std::lock_guard<std::recursive_mutex> session_id_lock_guard{session_ids_m_};
-      pending_to_remove_sessions_.emplace_back(std::move(session.second));
+      pending_to_remove_sessions_.emplace(session.first, std::move(session.second));
     }
   }
   return has_data;
@@ -796,8 +860,8 @@ bool HttpClient::doRemoveSessions()
   bool should_continue{false};
   do
   {
-    std::unordered_map<uint64_t, HttpCurlEasyResource> pending_to_remove_session_handles;
-    std::list<std::shared_ptr<Session>> pending_to_remove_sessions;
+    std::list<PendingCurlRemoval> pending_to_remove_session_handles;
+    std::unordered_map<uint64_t, std::shared_ptr<Session>> pending_to_remove_sessions;
     {
       std::lock_guard<std::recursive_mutex> session_id_lock_guard{session_ids_m_};
       pending_to_remove_session_handles_.swap(pending_to_remove_session_handles);
@@ -809,10 +873,10 @@ bool HttpClient::doRemoveSessions()
       std::lock_guard<std::mutex> session_lock_guard{sessions_m_};
       for (auto &removing_handle : pending_to_remove_session_handles)
       {
-        auto session = sessions_.find(removing_handle.first);
+        auto session = sessions_.find(removing_handle.session_id);
         if (session != sessions_.end())
         {
-          pending_to_remove_sessions.emplace_back(std::move(session->second));
+          pending_to_remove_sessions.emplace(session->first, std::move(session->second));
           sessions_.erase(session);
         }
       }
@@ -820,40 +884,35 @@ bool HttpClient::doRemoveSessions()
 
     for (auto &removing_handle : pending_to_remove_session_handles)
     {
-      auto &resource = removing_handle.second;
+      auto &resource = removing_handle.resource;
       if (nullptr == resource.easy_handle)
       {
         continue;
       }
 
-      // Remove before cleanup: libcurl forbids freeing an easy handle, or the header list it
-      // points at, while the multi handle still owns it. A handle never added reports CURLM_OK.
-      const CURLMcode rc = curl_multi_remove_handle(multi_handle_, resource.easy_handle);
-      if (CURLM_OK != rc)
+      // Give the handle back first. libcurl does not copy the header list, so it stays in use
+      // for as long as the multi handle has a transfer running on this handle.
+      if (!detachHandle(resource.easy_handle))
       {
-        // The multi handle may still own it. Leaking one easy handle is the better half of
-        // this trade: freeing it here would corrupt whatever still holds it.
-        OTEL_INTERNAL_LOG_ERROR(
-            "[HTTP Client Curl] curl_multi_remove_handle failed, leaving "
-            "the handle alone: "
-            << curl_multi_strerror(rc));
+        // Still held, so a transfer may still be running on it and its CURLOPT_PRIVATE still
+        // names this session. Keep the whole record instead of losing track of the handle.
+        auto owner = pending_to_remove_sessions.find(removing_handle.session_id);
+        if (owner != pending_to_remove_sessions.end())
+        {
+          removing_handle.owner = owner->second;
+        }
+
+        quarantined_handles_.push_back(std::move(removing_handle));
         continue;
       }
 
-      if (nullptr != resource.headers_chunk)
-      {
-        curl_slist_free_all(resource.headers_chunk);
-        resource.headers_chunk = nullptr;
-      }
-
-      curl_easy_cleanup(resource.easy_handle);
-      resource.easy_handle = nullptr;
+      ReleaseCurlResource(resource);
     }
 
     for (auto &removing_session : pending_to_remove_sessions)
     {
       // This operation may add more pending_to_remove_session_handles
-      removing_session->FinishOperation();
+      removing_session.second->FinishOperation();
     }
 
     should_continue =
@@ -890,8 +949,25 @@ bool HttpClient::doRetrySessions(bool report_all)
     else if (operation->NextRetryTime() < now)
     {
       auto easy_handle = operation->GetCurlEasyHandle();
-      curl_multi_remove_handle(multi_handle_, easy_handle);
-      curl_multi_add_handle(multi_handle_, easy_handle);
+
+      // If the multi handle will not give it back, the add below is answered with
+      // CURLM_ADDED_ALREADY and the transfer carries on where it was.
+      detachHandle(easy_handle);
+
+      const CURLMcode rc = curl_multi_add_handle(multi_handle_, easy_handle);
+      if (CURLM_OK == rc)
+      {
+        attached_handles_.insert(easy_handle);
+      }
+      else
+      {
+        // The session leaves the retry queue either way, so say so rather than let a request
+        // that was never re-armed look like one that was.
+        OTEL_INTERNAL_LOG_ERROR(
+            "[HTTP Client Curl] curl_multi_add_handle failed, this retry will not be sent: "
+            << curl_multi_strerror(rc));
+      }
+
       retry_it = pending_to_retry_sessions_.erase(retry_it);
       has_data = true;
     }
@@ -938,12 +1014,55 @@ void HttpClient::resetMultiHandle()
 
   doRemoveSessions();
 
-  // We will modify the multi_handle_, so we need to lock it
-  std::lock_guard<std::mutex> lock_guard{multi_handle_m_};
-  curl_multi_cleanup(multi_handle_);
+  {
+    // We will modify the multi_handle_, so we need to lock it
+    std::lock_guard<std::mutex> lock_guard{multi_handle_m_};
+    curl_multi_cleanup(multi_handle_);
 
-  // Create a another multi handle to continue pending sessions
-  multi_handle_ = curl_multi_init();
+    // The cleanup detached everything the old handle held, so nothing is attached any more and
+    // nothing may be offered back to the handle created below.
+    attached_handles_.clear();
+
+    // Create a another multi handle to continue pending sessions
+    multi_handle_ = curl_multi_init();
+  }
+
+  releaseQuarantinedHandles();
+}
+
+bool HttpClient::detachHandle(CURL *easy_handle)
+{
+  if (attached_handles_.end() == attached_handles_.find(easy_handle))
+  {
+    // The multi handle was never given this one, so it has nothing to give back. Asking libcurl
+    // is not a way to find that out: 8.10 and 8.11 reject a handle the multi handle does not
+    // hold, and a multi handle that failed to initialize rejects every handle.
+    return true;
+  }
+
+  const CURLMcode rc = curl_multi_remove_handle(multi_handle_, easy_handle);
+  if (CURLM_OK != rc)
+  {
+    OTEL_INTERNAL_LOG_ERROR(
+        "[HTTP Client Curl] curl_multi_remove_handle failed, the handle stays "
+        "with the multi handle: "
+        << curl_multi_strerror(rc));
+    return false;
+  }
+
+  attached_handles_.erase(easy_handle);
+  return true;
+}
+
+void HttpClient::releaseQuarantinedHandles()
+{
+  std::list<PendingCurlRemoval> quarantined_handles;
+  quarantined_handles.swap(quarantined_handles_);
+
+  for (auto &quarantined : quarantined_handles)
+  {
+    ReleaseCurlResource(quarantined.resource);
+  }
 }
 
 }  // namespace curl

--- a/ext/src/http/client/curl/http_client_curl.cc
+++ b/ext/src/http/client/curl/http_client_curl.cc
@@ -11,6 +11,7 @@
 #include <functional>
 #include <list>
 #include <mutex>
+#include <ostream>
 #include <string>
 #include <thread>
 #include <unordered_map>
@@ -23,6 +24,7 @@
 #include "opentelemetry/ext/http/common/url_parser.h"
 #include "opentelemetry/nostd/shared_ptr.h"
 #include "opentelemetry/nostd/string_view.h"
+#include "opentelemetry/sdk/common/global_log_handler.h"
 #include "opentelemetry/sdk/common/thread_instrumentation.h"
 #include "opentelemetry/version.h"
 
@@ -33,8 +35,6 @@
 #  include <array>
 
 #  include "opentelemetry/nostd/type_traits.h"
-#else
-#  include "opentelemetry/sdk/common/global_log_handler.h"
 #endif
 
 OPENTELEMETRY_BEGIN_NAMESPACE
@@ -811,13 +811,36 @@ bool HttpClient::doRemoveSessions()
 
     for (auto &removing_handle : pending_to_remove_session_handles)
     {
-      if (nullptr != removing_handle.second.headers_chunk)
+      auto &resource = removing_handle.second;
+      if (nullptr == resource.easy_handle)
       {
-        curl_slist_free_all(removing_handle.second.headers_chunk);
+        continue;
       }
 
-      curl_multi_remove_handle(multi_handle_, removing_handle.second.easy_handle);
-      curl_easy_cleanup(removing_handle.second.easy_handle);
+      // Take it out of the multi handle first. libcurl does not allow an easy handle to be
+      // cleaned up while a multi handle still owns it, and the header list has to stay alive
+      // until the handle is no longer used for a transfer. A handle that was never added
+      // reports CURLM_OK here, so this does not need to know which is which.
+      const CURLMcode rc = curl_multi_remove_handle(multi_handle_, resource.easy_handle);
+      if (CURLM_OK != rc)
+      {
+        // The multi handle may still own it. Leaking one easy handle is the better half of
+        // this trade: freeing it here would corrupt whatever still holds it.
+        OTEL_INTERNAL_LOG_ERROR(
+            "[HTTP Client Curl] curl_multi_remove_handle failed, leaving "
+            "the handle alone: "
+            << curl_multi_strerror(rc));
+        continue;
+      }
+
+      if (nullptr != resource.headers_chunk)
+      {
+        curl_slist_free_all(resource.headers_chunk);
+        resource.headers_chunk = nullptr;
+      }
+
+      curl_easy_cleanup(resource.easy_handle);
+      resource.easy_handle = nullptr;
     }
 
     for (auto &removing_session : pending_to_remove_sessions)

--- a/ext/src/http/client/curl/http_client_curl.cc
+++ b/ext/src/http/client/curl/http_client_curl.cc
@@ -49,20 +49,29 @@ namespace curl
 
 namespace
 {
-// The easy handle goes first. libcurl does not copy the header list, so it is in use for as long
-// as anything is still transferring on the handle that points at it.
+// Only ever called with the handle detached, either because it has been given back or because
+// the multi handle that held it has been cleaned up.
+//
+// The reset clears the callbacks and the pointers they are given, so that freeing the handle
+// cannot reach the operation or the event handler the caller has let go of by then. The header
+// list goes next, because libcurl does not copy it and the reset is what stops it being read.
 void ReleaseCurlResource(HttpCurlEasyResource &resource) noexcept
 {
   if (nullptr != resource.easy_handle)
   {
-    curl_easy_cleanup(resource.easy_handle);
-    resource.easy_handle = nullptr;
+    curl_easy_reset(resource.easy_handle);
   }
 
   if (nullptr != resource.headers_chunk)
   {
     curl_slist_free_all(resource.headers_chunk);
     resource.headers_chunk = nullptr;
+  }
+
+  if (nullptr != resource.easy_handle)
+  {
+    curl_easy_cleanup(resource.easy_handle);
+    resource.easy_handle = nullptr;
   }
 }
 }  // namespace

--- a/ext/src/http/client/curl/http_client_curl.cc
+++ b/ext/src/http/client/curl/http_client_curl.cc
@@ -346,23 +346,29 @@ HttpClient::~HttpClient()
   }
 
   // The background thread has stopped, so nothing else is coming back for what it left behind.
-  // Sessions go first, because releasing one can hand over one last easy handle, and they are
-  // released outside the lock because that hand over takes it.
+  // A batch at a time and with no lock held: a record owns the session it names, and letting one
+  // go runs a destructor that comes back through ScheduleRemoveSession. That can only queue what
+  // a session still held, and no more sessions are made here, so this ends.
   releaseQuarantinedHandles();
+
+  while (true)
   {
-    std::unordered_map<uint64_t, std::shared_ptr<Session>> pending_to_remove_sessions;
+    std::list<PendingCurlRemoval> pending_to_remove_session_handles;
     {
       std::lock_guard<std::recursive_mutex> session_id_lock_guard{session_ids_m_};
-      pending_to_remove_sessions_.swap(pending_to_remove_sessions);
+      pending_to_remove_session_handles_.swap(pending_to_remove_session_handles);
+    }
+
+    if (pending_to_remove_session_handles.empty())
+    {
+      break;
+    }
+
+    for (auto &pending : pending_to_remove_session_handles)
+    {
+      ReleaseCurlResource(pending.resource);
     }
   }
-
-  std::lock_guard<std::recursive_mutex> session_id_lock_guard{session_ids_m_};
-  for (auto &pending : pending_to_remove_session_handles_)
-  {
-    ReleaseCurlResource(pending.resource);
-  }
-  pending_to_remove_session_handles_.clear();
 }
 
 std::shared_ptr<opentelemetry::ext::http::client::Session> HttpClient::CreateSession(
@@ -438,28 +444,13 @@ void HttpClient::CleanupSession(uint64_t session_id)
     std::lock_guard<std::recursive_mutex> lock_guard{session_ids_m_};
     pending_to_add_session_ids_.erase(session_id);
 
-    if (session)
+    // A handle of this session that is queued for removal already holds the session, so there
+    // is nothing to decide about one here.
+    if (session && session->IsSessionActive() && session->GetOperation())
     {
-      bool has_pending_handle = false;
-      for (const auto &pending : pending_to_remove_session_handles_)
-      {
-        if (pending.session_id == session_id)
-        {
-          has_pending_handle = true;
-          break;
-        }
-      }
-
-      if (has_pending_handle)
-      {
-        pending_to_remove_sessions_.emplace(session_id, std::move(session));
-      }
-      else if (session->IsSessionActive() && session->GetOperation())
-      {
-        // If this session is already running, give it to the background thread for cleanup.
-        pending_to_abort_sessions_[session_id] = std::move(session);
-        need_wakeup_background_thread          = true;
-      }
+      // If this session is already running, give it to the background thread for cleanup.
+      pending_to_abort_sessions_[session_id] = std::move(session);
+      need_wakeup_background_thread          = true;
     }
   }
 
@@ -728,10 +719,23 @@ void HttpClient::ScheduleAbortSession(uint64_t session_id)
 void HttpClient::ScheduleRemoveSession(uint64_t session_id, HttpCurlEasyResource &&resource)
 {
   {
-    std::lock_guard<std::recursive_mutex> lock_guard{session_ids_m_};
+    // The session is taken here, in the same breath as the record. Looking it up when the record
+    // is drained instead leaves a gap the calling thread runs through: it returns from
+    // FinishSession, CleanupSession takes the session out of sessions_, and by then this queue
+    // has been swapped away, so neither side would be holding a session the handle still names.
+    std::lock_guard<std::mutex> session_lock_guard{sessions_m_};
+    std::lock_guard<std::recursive_mutex> session_id_lock_guard{session_ids_m_};
+
+    std::shared_ptr<Session> owner;
+    auto session = sessions_.find(session_id);
+    if (session != sessions_.end())
+    {
+      owner = session->second;
+    }
+
     pending_to_add_session_ids_.erase(session_id);
     pending_to_remove_session_handles_.push_back(
-        PendingCurlRemoval{session_id, std::move(resource), nullptr});
+        PendingCurlRemoval{session_id, std::move(resource), std::move(owner)});
   }
 
   wakeupBackgroundThread();
@@ -842,13 +846,18 @@ bool HttpClient::doAbortSessions()
       has_data = true;
     }
 
-    // FinishOperation queued the easy handle for removal, and that handle still holds
-    // CURLOPT_PRIVATE and the callback data pointing into this session and its operation.
-    // doRemoveSessions cannot find the session to hold, because aborting took it out of
-    // sessions_, so hand it over under the id it will look the handle up by.
+    // Aborting took this session out of sessions_ before FinishOperation queued its easy
+    // handle, so the record could not take the session for itself and is given it here. Nothing
+    // drains the queue in between: both run on this thread, one after the other.
     {
       std::lock_guard<std::recursive_mutex> session_id_lock_guard{session_ids_m_};
-      pending_to_remove_sessions_.emplace(session.first, std::move(session.second));
+      for (auto &pending : pending_to_remove_session_handles_)
+      {
+        if (pending.session_id == session.first && !pending.owner)
+        {
+          pending.owner = session.second;
+        }
+      }
     }
   }
   return has_data;
@@ -865,7 +874,6 @@ bool HttpClient::doRemoveSessions()
     {
       std::lock_guard<std::recursive_mutex> session_id_lock_guard{session_ids_m_};
       pending_to_remove_session_handles_.swap(pending_to_remove_session_handles);
-      pending_to_remove_sessions_.swap(pending_to_remove_sessions);
     }
     {
       // If user callback do not call CancelSession or FinishSession, We still need to remove it
@@ -895,13 +903,8 @@ bool HttpClient::doRemoveSessions()
       if (!detachHandle(resource.easy_handle))
       {
         // Still held, so a transfer may still be running on it and its CURLOPT_PRIVATE still
-        // names this session. Keep the whole record instead of losing track of the handle.
-        auto owner = pending_to_remove_sessions.find(removing_handle.session_id);
-        if (owner != pending_to_remove_sessions.end())
-        {
-          removing_handle.owner = owner->second;
-        }
-
+        // names this session. The record carries that session already, so keeping the record
+        // keeps both.
         quarantined_handles_.push_back(std::move(removing_handle));
         continue;
       }

--- a/ext/src/http/client/curl/http_client_curl.cc
+++ b/ext/src/http/client/curl/http_client_curl.cc
@@ -817,10 +817,8 @@ bool HttpClient::doRemoveSessions()
         continue;
       }
 
-      // Take it out of the multi handle first. libcurl does not allow an easy handle to be
-      // cleaned up while a multi handle still owns it, and the header list has to stay alive
-      // until the handle is no longer used for a transfer. A handle that was never added
-      // reports CURLM_OK here, so this does not need to know which is which.
+      // Remove before cleanup: libcurl forbids freeing an easy handle, or the header list it
+      // points at, while the multi handle still owns it. A handle never added reports CURLM_OK.
       const CURLMcode rc = curl_multi_remove_handle(multi_handle_, resource.easy_handle);
       if (CURLM_OK != rc)
       {

--- a/ext/src/http/client/curl/http_operation_curl.cc
+++ b/ext/src/http/client/curl/http_operation_curl.cc
@@ -542,15 +542,13 @@ void HttpOperation::Cleanup()
   // Only cleanup async once even in recursive calls
   if (async_data_)
   {
-    // Just reset and move easy_handle to owner if in async mode
+    // Move the easy handle to the owner untouched. It may still be attached to the multi handle
+    // and running, and the thread inside curl_multi_perform owns it until the IO thread takes it
+    // out, so writing to it here would be a write to a live transfer. It is pointless as well:
+    // the next thing that happens to the handle is curl_easy_cleanup.
     Session *session = async_data_->session.exchange(nullptr, std::memory_order_acq_rel);
     if (session != nullptr)
     {
-      if (curl_resource_.easy_handle != nullptr)
-      {
-        curl_easy_setopt(curl_resource_.easy_handle, CURLOPT_PRIVATE, NULL);
-        curl_easy_reset(curl_resource_.easy_handle);
-      }
       session->GetHttpClient().ScheduleRemoveSession(session->GetSessionId(),
                                                      std::move(curl_resource_));
     }
@@ -1528,6 +1526,14 @@ void HttpOperation::Abort()
 
 void HttpOperation::PerformCurlMessage(CURLcode code)
 {
+  if (is_cleaned_.load(std::memory_order_acquire))
+  {
+    // Already torn down, and the handle is queued for removal. The multi handle can still hold a
+    // message buffered from before that, and acting on it would dispatch a second round of
+    // terminal events and can put a handle that is waiting to be freed back on the retry queue.
+    return;
+  }
+
   ++retry_attempts_;
   last_attempt_time_      = std::chrono::system_clock::now();
   last_curl_result_       = code;

--- a/ext/src/http/client/curl/http_operation_curl.cc
+++ b/ext/src/http/client/curl/http_operation_curl.cc
@@ -542,10 +542,8 @@ void HttpOperation::Cleanup()
   // Only cleanup async once even in recursive calls
   if (async_data_)
   {
-    // Move the easy handle to the owner untouched. It may still be attached to the multi handle
-    // and running, and the thread inside curl_multi_perform owns it until the IO thread takes it
-    // out, so writing to it here would be a write to a live transfer. It is pointless as well:
-    // the next thing that happens to the handle is curl_easy_cleanup.
+    // Hand the easy handle over untouched. It may still be attached to the multi handle, and the
+    // thread inside curl_multi_perform owns it until the IO thread removes it.
     Session *session = async_data_->session.exchange(nullptr, std::memory_order_acq_rel);
     if (session != nullptr)
     {
@@ -1528,9 +1526,8 @@ void HttpOperation::PerformCurlMessage(CURLcode code)
 {
   if (is_cleaned_.load(std::memory_order_acquire))
   {
-    // Already torn down, and the handle is queued for removal. The multi handle can still hold a
-    // message buffered from before that, and acting on it would dispatch a second round of
-    // terminal events and can put a handle that is waiting to be freed back on the retry queue.
+    // Already torn down and queued for removal. A message buffered before that would dispatch a
+    // second round of terminal events and requeue a handle waiting to be freed.
     return;
   }
 

--- a/ext/src/http/client/curl/http_operation_curl.cc
+++ b/ext/src/http/client/curl/http_operation_curl.cc
@@ -1522,13 +1522,15 @@ void HttpOperation::Abort()
   }
 }
 
-void HttpOperation::PerformCurlMessage(CURLcode code)
+bool HttpOperation::PerformCurlMessage(CURLcode code)
 {
   if (is_cleaned_.load(std::memory_order_acquire))
   {
-    // Already torn down and queued for removal. A message buffered before that would dispatch a
-    // second round of terminal events and requeue a handle waiting to be freed.
-    return;
+    // Some thread has entered Cleanup for this operation, which is as much as the flag says: it
+    // is taken before the terminal event, the hand over of the easy handle and the completion
+    // callback. Either way this message is not this operation's to read, and it is not to be
+    // taken on for another attempt on the strength of what an earlier message left behind.
+    return false;
   }
 
   ++retry_attempts_;
@@ -1635,7 +1637,10 @@ void HttpOperation::PerformCurlMessage(CURLcode code)
   {
     // Cleanup and unbind easy handle from multi handle, and finish callback
     Cleanup();
+    return false;
   }
+
+  return true;
 }
 
 }  // namespace curl

--- a/ext/test/http/curl_http_test.cc
+++ b/ext/test/http/curl_http_test.cc
@@ -527,6 +527,32 @@ TEST_F(BasicCurlHttpTests, RetryPolicyEnabled)
   ASSERT_TRUE(operation.IsRetryable());
 }
 
+// Reading a message and taking the operation on for another attempt are one decision. The status
+// an operation reports does not change when it is cleaned up, so a caller that asks about it
+// separately would put a session whose easy handle is on its way out back in the retry queue.
+TEST_F(BasicCurlHttpTests, ACleanedOperationDoesNotAskToBeRetried)
+{
+  RetryEventHandler handler;
+  http_client::HttpSslOptions no_ssl;
+  http_client::Body body;
+  http_client::Headers headers;
+  http_client::Compression compression  = http_client::Compression::kNone;
+  http_client::RetryPolicy retry_policy = {5, std::chrono::duration<float>{1.0f},
+                                           std::chrono::duration<float>{5.0f}, 1.5f};
+
+  curl::HttpOperation operation(http_client::Method::Post, "http://127.0.0.1:19000/retry/", no_ssl,
+                                &handler, headers, body, compression, false,
+                                curl::kDefaultHttpConnTimeout, false, false, retry_policy);
+
+  ASSERT_EQ(CURLE_OK, operation.Send());
+  ASSERT_TRUE(operation.IsRetryable());
+
+  operation.Cleanup();
+
+  EXPECT_TRUE(operation.IsRetryable());
+  EXPECT_FALSE(operation.PerformCurlMessage(CURLE_OK));
+}
+
 TEST_F(BasicCurlHttpTests, RetryPolicyDisabled)
 {
   RetryEventHandler handler;

--- a/ext/test/http/curl_http_test.cc
+++ b/ext/test/http/curl_http_test.cc
@@ -61,6 +61,8 @@ public:
 
   static bool RemoveSessions(HttpClient &client) { return client.doRemoveSessions(); }
 
+  static bool AbortSessions(HttpClient &client) { return client.doAbortSessions(); }
+
   // What the multi handle holds is recorded when curl_multi_add_handle accepts a handle. The
   // cases below have no transfer to accept, so they say what it holds directly.
   static void NoteAttached(HttpClient &client, CURL *easy_handle)
@@ -76,6 +78,19 @@ public:
   static std::size_t PendingRemovalCount(const HttpClient &client)
   {
     return client.pending_to_remove_session_handles_.size();
+  }
+
+  static std::size_t PendingRemovalOwnerCount(const HttpClient &client)
+  {
+    std::size_t owned = 0;
+    for (const auto &pending : client.pending_to_remove_session_handles_)
+    {
+      if (pending.owner)
+      {
+        ++owned;
+      }
+    }
+    return owned;
   }
 
   static std::size_t QuarantinedCount(const HttpClient &client)
@@ -713,6 +728,72 @@ TEST_F(BasicCurlHttpTests, ARefusedRemovalKeepsTheHandleAndTheSessionItNames)
   EXPECT_FALSE(watch.expired());
 }
 
+// A queued handle still names its session through CURLOPT_PRIVATE, and the message loop reads
+// that back. The session is taken when the record is made rather than found when the record is
+// drained, because between those two the calling thread returns from FinishSession and takes the
+// session out of sessions_, and by then the queue has been swapped away.
+TEST_F(BasicCurlHttpTests, AQueuedHandleTakesTheSessionItNamesWithIt)
+{
+  curl::HttpClient client;
+
+  auto session = client.CreateSession("http://127.0.0.1:19000");
+  ASSERT_TRUE(session != nullptr);
+  const auto session_id = std::static_pointer_cast<curl::Session>(session)->GetSessionId();
+
+  CURL *easy_handle = curl_easy_init();
+  ASSERT_TRUE(easy_handle != nullptr);
+  curl_slist *headers_chunk = curl_slist_append(nullptr, "X-Test: owner");
+  ASSERT_TRUE(headers_chunk != nullptr);
+
+  client.ScheduleRemoveSession(session_id, {easy_handle, headers_chunk});
+
+  EXPECT_EQ(1U, http_client::curl::HttpClientTestPeer::PendingRemovalOwnerCount(client));
+
+  // What the calling thread does next takes nothing away, because there is nothing left for it
+  // to decide.
+  std::weak_ptr<http_client::Session> watch = session;
+  session.reset();
+  client.CleanupSession(session_id);
+
+  EXPECT_FALSE(watch.expired());
+
+  http_client::curl::HttpClientTestPeer::RemoveSessions(client);
+  EXPECT_TRUE(watch.expired());
+}
+
+// Scheduling an abort takes the session out of sessions_, so a handle queued after that finds
+// nothing to take and the abort hands the session over itself. Both steps are the background
+// thread's, one after the other, and no request is sent here so there is no background thread to
+// run them out of order.
+TEST_F(BasicCurlHttpTests, AnAbortedSessionIsGivenToTheHandleItQueued)
+{
+  curl::HttpClient client;
+
+  auto session = client.CreateSession("http://127.0.0.1:19000");
+  ASSERT_TRUE(session != nullptr);
+  const auto session_id = std::static_pointer_cast<curl::Session>(session)->GetSessionId();
+
+  client.ScheduleAbortSession(session_id);
+
+  CURL *easy_handle = curl_easy_init();
+  ASSERT_TRUE(easy_handle != nullptr);
+  curl_slist *headers_chunk = curl_slist_append(nullptr, "X-Test: aborted");
+  ASSERT_TRUE(headers_chunk != nullptr);
+
+  client.ScheduleRemoveSession(session_id, {easy_handle, headers_chunk});
+  EXPECT_EQ(0U, http_client::curl::HttpClientTestPeer::PendingRemovalOwnerCount(client));
+
+  http_client::curl::HttpClientTestPeer::AbortSessions(client);
+  EXPECT_EQ(1U, http_client::curl::HttpClientTestPeer::PendingRemovalOwnerCount(client));
+
+  std::weak_ptr<http_client::Session> watch = session;
+  session.reset();
+  EXPECT_FALSE(watch.expired());
+
+  http_client::curl::HttpClientTestPeer::RemoveSessions(client);
+  EXPECT_TRUE(watch.expired());
+}
+
 // A multi handle that was never given a handle has nothing to give back, and asking it is not a
 // way to find that out: libcurl 8.10 and 8.11 refuse, and a multi handle that failed to
 // initialize refuses on every version. Reading either refusal as ownership strands the handle.
@@ -751,6 +832,36 @@ TEST_F(BasicCurlHttpTests, AHandleQueuedWithNoOneLeftToDrainItIsFreedWithTheClie
   client.ScheduleRemoveSession(4405U, {easy_handle, headers_chunk});
 
   EXPECT_EQ(1U, http_client::curl::HttpClientTestPeer::PendingRemovalCount(client));
+}
+
+// curl_multi_cleanup detaches whatever the old multi handle held, so a handle recorded against
+// it is not attached to anything once it has been replaced, and nothing may be handed back to
+// the replacement. Emptying the ledger in the same step is what says so. The replacement is made
+// to refuse every removal here, so an offer to it would leave the handle kept back instead of
+// freed.
+TEST_F(BasicCurlHttpTests, AHandleFromTheReplacedMultiHandleIsNotOfferedToItsSuccessor)
+{
+  curl::HttpClient client;
+
+  CURL *easy_handle = curl_easy_init();
+  ASSERT_TRUE(easy_handle != nullptr);
+  curl_slist *headers_chunk = curl_slist_append(nullptr, "X-Test: generation");
+  ASSERT_TRUE(headers_chunk != nullptr);
+
+  http_client::curl::HttpClientTestPeer::NoteAttached(client, easy_handle);
+  EXPECT_EQ(1U, http_client::curl::HttpClientTestPeer::AttachedCount(client));
+
+  http_client::curl::HttpClientTestPeer::ResetMultiHandle(client);
+  EXPECT_EQ(0U, http_client::curl::HttpClientTestPeer::AttachedCount(client));
+
+  client.ScheduleRemoveSession(4405U, {easy_handle, headers_chunk});
+
+  CURLM *multi_handle = http_client::curl::HttpClientTestPeer::ExchangeMultiHandle(client, nullptr);
+  http_client::curl::HttpClientTestPeer::RemoveSessions(client);
+  http_client::curl::HttpClientTestPeer::ExchangeMultiHandle(client, multi_handle);
+
+  EXPECT_EQ(0U, http_client::curl::HttpClientTestPeer::QuarantinedCount(client));
+  EXPECT_EQ(0U, http_client::curl::HttpClientTestPeer::PendingRemovalCount(client));
 }
 
 // One record per easy handle. A session that starts another request hands over a second handle

--- a/ext/test/http/curl_http_test.cc
+++ b/ext/test/http/curl_http_test.cc
@@ -143,6 +143,14 @@ public:
 
   void OnEvent(http_client::SessionState state, nostd::string_view reason) noexcept override
   {
+    // Counted on its own, and before the chain below rather than inside it: a case can cancel
+    // from one of these, and two others pin terminal_count_ to an exact value.
+    if (state == http_client::SessionState::ConnectFailed ||
+        state == http_client::SessionState::SendFailed)
+    {
+      failed_count_.fetch_add(1, std::memory_order_release);
+    }
+
     if (state == http_client::SessionState::Cancelled)
     {
       terminal_count_.fetch_add(1, std::memory_order_release);
@@ -175,6 +183,7 @@ public:
   http_client::SessionState cancel_at_ = http_client::SessionState::Response;
   std::thread::id cancelled_from_{};
   std::atomic<int> terminal_count_{0};
+  std::atomic<int> failed_count_{0};
   std::atomic<int> cancelled_from_callback_{0};
 };
 
@@ -829,8 +838,6 @@ TEST_F(BasicCurlHttpTests, ACancelFromTheCallerThreadReportsCancelled)
 // thread sanitizer this reports against the unfixed client on every run.
 TEST_F(BasicCurlHttpTests, RepeatedCallerThreadCancelsAreClean)
 {
-  int terminal_total = 0;
-
   for (int i = 0; i < 20; ++i)
   {
     auto session_manager = std::make_shared<http_client::curl::HttpCurlClientFactory>()->Create();
@@ -847,12 +854,15 @@ TEST_F(BasicCurlHttpTests, RepeatedCallerThreadCancelsAreClean)
     session_manager->FinishAllSessions();
 
     EXPECT_FALSE(handler->got_response_.load(std::memory_order_acquire));
-    terminal_total += handler->terminal_count_.load(std::memory_order_acquire);
-  }
 
-  // A lower bound, not a count: #4360 tracks the same cancel arriving twice, and how many
-  // arrive is not what this case decides.
-  EXPECT_GE(terminal_total, 20);
+    // Whichever side wins, the attempt ends somewhere the handler is told about: the cancel
+    // lands first, or the connection to a closed port fails first and the cancel is then
+    // correctly a no-op. How many cancels arrive is not what this case decides, #4360 tracks
+    // that, and neither is which of the two wins.
+    EXPECT_GT(handler->terminal_count_.load(std::memory_order_acquire) +
+                  handler->failed_count_.load(std::memory_order_acquire),
+              0);
+  }
 }
 
 TEST_F(BasicCurlHttpTests, SendGetRequestSync)

--- a/ext/test/http/curl_http_test.cc
+++ b/ext/test/http/curl_http_test.cc
@@ -508,6 +508,26 @@ TEST_F(BasicCurlHttpTests, CurlHttpOperations)
   delete handler;
 }
 
+// A CA certificate supplied as a string goes to curl as a blob rather than a path. curl copies it
+// and does not read it until a handshake, so a plain request reaches the option and no certificate
+// has to be valid for this.
+TEST_F(BasicCurlHttpTests, ACaCertificateStringIsPassedAsABlob)
+{
+  RetryEventHandler handler;
+  http_client::HttpSslOptions ssl_options;
+  ssl_options.use_ssl = true;
+  ssl_options.ssl_ca_cert_string =
+      "-----BEGIN CERTIFICATE-----\nnot a certificate\n-----END CERTIFICATE-----\n";
+  http_client::Body body;
+  http_client::Headers headers;
+
+  curl::HttpOperation operation(http_client::Method::Get, "http://127.0.0.1:19000/get/",
+                                ssl_options, &handler, headers, body);
+
+  ASSERT_EQ(CURLE_OK, operation.Send());
+  ASSERT_EQ(200, operation.GetResponseCode());
+}
+
 #ifdef ENABLE_OTLP_RETRY_PREVIEW
 TEST_F(BasicCurlHttpTests, RetryPolicyEnabled)
 {

--- a/ext/test/http/curl_http_test.cc
+++ b/ext/test/http/curl_http_test.cc
@@ -1,11 +1,11 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
+#include <curl/curl.h>
 #include <curl/curlver.h>
 #include "gtest/gtest.h"
 
 #ifdef ENABLE_OTLP_RETRY_PREVIEW
-#  include <curl/curl.h>
 #  include "gmock/gmock.h"
 #endif  // ENABLE_OTLP_RETRY_PREVIEW
 
@@ -17,12 +17,14 @@
 #include <chrono>
 #include <condition_variable>
 #include <cstring>
+#include <list>
 #include <map>
 #include <memory>
 #include <mutex>
 #include <sstream>
 #include <string>
 #include <thread>
+#include <unordered_set>
 #include <utility>
 #include <vector>
 
@@ -56,6 +58,39 @@ class HttpClientTestPeer
 {
 public:
   static void ResetMultiHandle(HttpClient &client) { client.resetMultiHandle(); }
+
+  static bool RemoveSessions(HttpClient &client) { return client.doRemoveSessions(); }
+
+  // What the multi handle holds is recorded when curl_multi_add_handle accepts a handle. The
+  // cases below have no transfer to accept, so they say what it holds directly.
+  static void NoteAttached(HttpClient &client, CURL *easy_handle)
+  {
+    client.attached_handles_.insert(easy_handle);
+  }
+
+  static std::size_t AttachedCount(const HttpClient &client)
+  {
+    return client.attached_handles_.size();
+  }
+
+  static std::size_t PendingRemovalCount(const HttpClient &client)
+  {
+    return client.pending_to_remove_session_handles_.size();
+  }
+
+  static std::size_t QuarantinedCount(const HttpClient &client)
+  {
+    return client.quarantined_handles_.size();
+  }
+
+  // A multi handle that failed to initialize refuses every removal, which is how the cases below
+  // reach the path where libcurl will not take a handle back.
+  static CURLM *ExchangeMultiHandle(HttpClient &client, CURLM *replacement)
+  {
+    CURLM *previous      = client.multi_handle_;
+    client.multi_handle_ = replacement;
+    return previous;
+  }
 };
 }  // namespace curl
 }  // namespace client
@@ -634,6 +669,130 @@ TEST_F(BasicCurlHttpTests, ResetMultiHandleWithASessionDoesNotDeadlock)
   http_client::curl::HttpClientTestPeer::ResetMultiHandle(*client);
 
   client->FinishAllSessions();
+}
+
+// The record queued for removal is the only thing naming the easy handle, the header list it
+// points at and the session, so a removal libcurl refuses has to keep all three. The message
+// loop reads that session back out of CURLOPT_PRIVATE, which makes letting go of it as much a
+// live pointer left behind as a handle.
+TEST_F(BasicCurlHttpTests, ARefusedRemovalKeepsTheHandleAndTheSessionItNames)
+{
+  curl::HttpClient client;
+
+  auto session = client.CreateSession("http://127.0.0.1:19000");
+  ASSERT_TRUE(session != nullptr);
+  const auto session_id = std::static_pointer_cast<curl::Session>(session)->GetSessionId();
+
+  CURL *easy_handle = curl_easy_init();
+  ASSERT_TRUE(easy_handle != nullptr);
+  curl_slist *headers_chunk = curl_slist_append(nullptr, "X-Test: keep");
+  ASSERT_TRUE(headers_chunk != nullptr);
+
+  http_client::curl::HttpClientTestPeer::NoteAttached(client, easy_handle);
+  client.ScheduleRemoveSession(session_id, {easy_handle, headers_chunk});
+
+  // From here the client holds the only reference, so what survives the removal is what the
+  // removal chose to keep.
+  std::weak_ptr<http_client::Session> watch = session;
+  session.reset();
+
+  CURLM *multi_handle = http_client::curl::HttpClientTestPeer::ExchangeMultiHandle(client, nullptr);
+  http_client::curl::HttpClientTestPeer::RemoveSessions(client);
+  http_client::curl::HttpClientTestPeer::ExchangeMultiHandle(client, multi_handle);
+
+  EXPECT_EQ(1U, http_client::curl::HttpClientTestPeer::QuarantinedCount(client));
+  EXPECT_FALSE(watch.expired());
+}
+
+// A multi handle that was never given a handle has nothing to give back, and asking it is not a
+// way to find that out: libcurl 8.10 and 8.11 refuse, and a multi handle that failed to
+// initialize refuses on every version. Reading either refusal as ownership strands the handle.
+TEST_F(BasicCurlHttpTests, AHandleTheMultiHandleNeverTookIsFreedNotStranded)
+{
+  curl::HttpClient client;
+
+  CURL *easy_handle = curl_easy_init();
+  ASSERT_TRUE(easy_handle != nullptr);
+  curl_slist *headers_chunk = curl_slist_append(nullptr, "X-Test: free");
+  ASSERT_TRUE(headers_chunk != nullptr);
+
+  client.ScheduleRemoveSession(4405U, {easy_handle, headers_chunk});
+
+  CURLM *multi_handle = http_client::curl::HttpClientTestPeer::ExchangeMultiHandle(client, nullptr);
+  http_client::curl::HttpClientTestPeer::RemoveSessions(client);
+  http_client::curl::HttpClientTestPeer::ExchangeMultiHandle(client, multi_handle);
+
+  EXPECT_EQ(0U, http_client::curl::HttpClientTestPeer::QuarantinedCount(client));
+  EXPECT_EQ(0U, http_client::curl::HttpClientTestPeer::PendingRemovalCount(client));
+}
+
+// A handle handed over after the background thread has stopped, or before it ever started, has
+// nobody left to drain it, so the client frees it on the way out. Nothing here can watch that
+// happen, which leaves this case checking that the record reaches the queue and the sanitizer
+// builds checking what becomes of it.
+TEST_F(BasicCurlHttpTests, AHandleQueuedWithNoOneLeftToDrainItIsFreedWithTheClient)
+{
+  curl::HttpClient client;
+
+  CURL *easy_handle = curl_easy_init();
+  ASSERT_TRUE(easy_handle != nullptr);
+  curl_slist *headers_chunk = curl_slist_append(nullptr, "X-Test: undrained");
+  ASSERT_TRUE(headers_chunk != nullptr);
+
+  client.ScheduleRemoveSession(4405U, {easy_handle, headers_chunk});
+
+  EXPECT_EQ(1U, http_client::curl::HttpClientTestPeer::PendingRemovalCount(client));
+}
+
+// One record per easy handle. A session that starts another request hands over a second handle
+// while the first is still queued, and keying the queue by session would lose the first one.
+TEST_F(BasicCurlHttpTests, ASecondHandleFromTheSameSessionDoesNotDisplaceTheFirst)
+{
+  curl::HttpClient client;
+
+  CURL *first = curl_easy_init();
+  ASSERT_TRUE(first != nullptr);
+  CURL *second = curl_easy_init();
+  ASSERT_TRUE(second != nullptr);
+  curl_slist *first_headers = curl_slist_append(nullptr, "X-Test: first");
+  ASSERT_TRUE(first_headers != nullptr);
+  curl_slist *second_headers = curl_slist_append(nullptr, "X-Test: second");
+  ASSERT_TRUE(second_headers != nullptr);
+
+  client.ScheduleRemoveSession(4405U, {first, first_headers});
+  client.ScheduleAddSession(4405U);
+  client.ScheduleRemoveSession(4405U, {second, second_headers});
+
+  EXPECT_EQ(2U, http_client::curl::HttpClientTestPeer::PendingRemovalCount(client));
+
+  http_client::curl::HttpClientTestPeer::RemoveSessions(client);
+
+  EXPECT_EQ(0U, http_client::curl::HttpClientTestPeer::PendingRemovalCount(client));
+  EXPECT_EQ(0U, http_client::curl::HttpClientTestPeer::QuarantinedCount(client));
+}
+
+// The same ledger after a real request. The background thread is the only one that writes it and
+// it only stops once nothing is running, so what a case can look at is the state it leaves
+// behind: an entry left there would send a later handle allocated at the same address through a
+// removal it never needed, and nothing should still be waiting to be given back.
+TEST_F(BasicCurlHttpTests, TheAttachmentLedgerIsEmptyOnceARequestFinishes)
+{
+  received_requests_.clear();
+  curl::HttpClient client;
+
+  auto session = client.CreateSession("http://127.0.0.1:19000/get/");
+  auto request = session->CreateRequest();
+  request->SetUri("get/");
+  auto handler = std::make_shared<CustomEventHandler>();
+
+  session->SendRequest(handler);
+  ASSERT_TRUE(waitForRequests(30, 1));
+  session->FinishSession();
+  client.WaitBackgroundThreadExit();
+
+  EXPECT_TRUE(handler->got_response_.load(std::memory_order_acquire));
+  EXPECT_EQ(0U, http_client::curl::HttpClientTestPeer::AttachedCount(client));
+  EXPECT_EQ(0U, http_client::curl::HttpClientTestPeer::QuarantinedCount(client));
 }
 
 // The caller-thread side of the same cancel. The server handler takes mtx_requests before it

--- a/ext/test/http/curl_http_test.cc
+++ b/ext/test/http/curl_http_test.cc
@@ -521,8 +521,14 @@ TEST_F(BasicCurlHttpTests, ACaCertificateStringIsPassedAsABlob)
   http_client::Body body;
   http_client::Headers headers;
 
+  http_client::Compression compression = http_client::Compression::kNone;
+  http_client::RetryPolicy retry_policy;
+
+  // Every argument is named. The defaulted ones would be temporaries, and the operation keeps
+  // references to them past the end of this expression.
   curl::HttpOperation operation(http_client::Method::Get, "http://127.0.0.1:19000/get/",
-                                ssl_options, &handler, headers, body);
+                                ssl_options, &handler, headers, body, compression, false,
+                                curl::kDefaultHttpConnTimeout, false, false, retry_policy);
 
   ASSERT_EQ(CURLE_OK, operation.Send());
   ASSERT_EQ(200, operation.GetResponseCode());


### PR DESCRIPTION
Fixes #4391.

## What was wrong, and one thing I had wrong about it

The issue has three parts: `Cleanup()` writes to an easy handle that may still be transferring, `doRemoveSessions()` frees the header list before it takes the handle out of the multi handle, and neither the removal nor the retry path reads the `CURLMcode` it gets back. The first two are ordering and they're fixed by moving two calls.

The third one I got wrong in [my own comment on the issue](https://github.com/open-telemetry/opentelemetry-cpp/issues/4391#issuecomment-5238629759), where I said a handle the multi handle never took reports `CURLM_OK`, so nothing has to remember which handles were added. That's true of the libcurl I tested on and it isn't true in general. The prologue of `curl_multi_remove_handle` picked up a second condition for two minor releases:

| libcurl | prologue | never added, multi handle empty |
| --- | --- | --- |
| 7.81.0, 8.5.0, 8.6.0, 8.7.1, 8.8.0, 8.9.1 | `if(!GOOD_EASY_HANDLE(data))` | `CURLM_OK` |
| **8.10.1, 8.11.1** | `if(!GOOD_EASY_HANDLE(data) \|\| !multi->num_easy)` | **`CURLM_BAD_EASY_HANDLE`** |
| 8.12.0, 8.14.1 | `if(!GOOD_EASY_HANDLE(data))` | `CURLM_OK` |

`find_package(CURL)` here has no lower bound, so both are supported. And the version window isn't even needed to reach the same branch: I measured `curl_multi_remove_handle(NULL, easy)` returning `CURLM_BAD_HANDLE` on 8.14.1, which is what a client whose `curl_multi_init()` failed hands to every removal.

What made that reading dangerous is what the failure branch did with it. `pending_to_remove_session_handles_` is swapped into a local, so a `continue` past a record ends the life of that record at the end of the pass. The easy handle and its header list go with it, and so does the `shared_ptr<Session>` the same pass was releasing, while the handle still carries that session in `CURLOPT_PRIVATE`. The message loop reads it straight back:

```cpp
curl_easy_getinfo(easy_handle, CURLINFO_PRIVATE, &session);
const auto operation = (nullptr != session) ? session->GetOperation().get() : nullptr;
```

## What this does now

* An easy handle is recorded when `curl_multi_add_handle` accepts it, and unrecorded when `curl_multi_remove_handle` gives it back. A handle that was never accepted is freed without asking the multi handle anything, so neither libcurl's answer nor the version it came from decides the path.
* A removal libcurl refuses keeps the whole record: handle, header list and the session it names. Those are freed after `curl_multi_cleanup` has retired the multi they were on, in `resetMultiHandle()` and in the destructor. Cleanup is not what detaches them: `multi.h` is explicit that it does not free or touch any individual easy handle. What makes the order safe is that the multi is gone by the time they are freed. No retry loop, because a refusal here doesn't become acceptance later, and I didn't want a busy path in the IO loop.
* The queue holds one record per easy handle rather than one per session. A session that starts another request hands over a second handle while the first is still queued, and the map keyed by session dropped the first one.
* The destructor releases what the background thread never got to. That path frees nothing today: a handle handed over after the last pass measured 5594 bytes in 7 allocations under LeakSanitizer.
* `doRetrySessions()` goes through the same accounting and reports a re-arm libcurl won't accept, which is the silence the issue asks about.

## Evidence

Fail before, pass after, against `dd2ca474` (this branch before the change) with the same two scenarios written against the members that existed there:

| | before | after |
| --- | --- | --- |
| `ARefusedRemovalKeepsTheHandleAndTheSessionItNames` | fails, the session is released while the handle still names it | passes |
| `ASecondHandleFromTheSameSessionDoesNotDisplaceTheFirst` | fails, 1 record queued where 2 were handed over | passes |
| LeakSanitizer on those two | 11171 bytes in 14 allocations | 0 |

Each case was then checked against the mutation it's meant to catch, on an otherwise clean tree:

| mutation | case that fails |
| --- | --- |
| a refused removal drops the record again | `ARefusedRemovalKeepsTheHandleAndTheSessionItNames` |
| ask libcurl even about a handle it was never given | `AHandleTheMultiHandleNeverTookIsFreedNotStranded` |
| drop this session's queued handles on a new add | `ASecondHandleFromTheSameSessionDoesNotDisplaceTheFirst` |
| forget to unrecord what the removal gave back | `TheAttachmentLedgerIsEmptyOnceARequestFinishes` |
| forget to record what the add accepted | **nothing** |

That last row is honest rather than tidy. With the record never written, every release takes the never-added path and frees a handle the multi handle still holds, and I could not get that to show as anything: `curl_easy_cleanup` detaches the handle itself on the way out, so the state afterwards is identical either way. Measured on 8.14.1 under ASan and UBSan, adding a handle to a multi and performing until `running_handles` is 1, then freeing it while it is still attached:

```
add_handle    = 0
perform       = 0, running=1
easy_cleanup done
perform after = 0, running=0
```

The multi drops it. Freeing in the other order, `curl_multi_cleanup` first and then the attached handle and its header list, is also clean on that build. So the half of the accounting that's covered is the half that skips a removal it doesn't need, and the half that isn't is the documented call order, which I have not found a way to make bite on this libcurl.

## One case fixed that isn't about any of this

The valgrind job went red on `RepeatedCallerThreadCancelsAreClean`, which came in with #4392 and has nothing to do with the accounting here. It sums `Cancelled` and `Response` over twenty attempts against a closed port and asks for at least one each, and there's a third way such an attempt ends: the connection fails before the cancel arrives, and the cancel is then correctly a no-op. Instrumented, the silent attempts run `Created`, `Connecting`, `ConnectFailed` and stop there.

Pinned to one core, fifteen runs each:

| | pinned to one core | unpinned |
| --- | --- | --- |
| main at `3fb1d317` | 15 of 15 fail, 3 to 7 cancels of 20 | 15 of 15 pass |
| #4395 at `66ab56ca` | 15 of 15 fail, 3 to 7 | 12 of 12 pass |
| this branch before the change | 15 of 15 fail, 3 to 7 | 12 of 12 pass |
| this branch after it | 15 of 15 fail, 4 to 7 | 12 of 12 pass |

Same on all four, so it isn't the change, it's a case that pinned one of two legitimate outcomes. It's now asking each attempt to end somewhere the handler is told about rather than to end the same way twenty times, and pinned to one core that goes from 15 of 15 failing to 0 of 15. The connection failure is counted apart from `terminal_count_`, which two other cases pin to an exact value, and outside the existing chain, because `ACancelBeforeTheResponseReportsCancelled` cancels from `ConnectFailed` and needs that branch to keep firing.

It's a separate commit. It rides along because it's the job this PR makes red and it's a case I added, but it splits out cleanly if you'd rather have it on its own.

## Checks

| | result |
| --- | --- |
| `curl_http_test` | 31 of 31 |
| same, `WITH_OTLP_RETRY_PREVIEW=ON` | 31 of 31 |
| same, ASan with `detect_leaks=1` | 31 of 31, no sanitizer output |
| `bazel test //ext/test/http:curl_http_test` | passes |
| clang-tidy 22, CI header filters | 0 warnings before, 0 after, with a positive control that fires |
| include-what-you-use 0.26, `WITH_STL=CXX14` | clean, after taking the include changes it asked for |
| clang-format 18.1.8 | idempotent on all three files |

## Related

Rebased on current main. #4395 also touches `Cleanup()` and is still open, and this revision doesn't go near it: the accounting is all in `http_client_curl.cc` and its header, and the `Cleanup()` hunk is the one the first commit on this branch already had.

## About the line Codecov marks

Codecov reported 5 lines of this change without cover. One of them was the CA
certificate blob, uncovered because nothing in the suite supplied a certificate
as a string, and a case now does: `gcovr` reports one hit afterwards. It sets
`use_ssl`, without which the whole SSL block is skipped and the case would pass
having exercised none of it.

The others are in the ledger's re-attach path and in a log on a branch that was
evaluated 34 and 62 times without being taken. Reaching them needs the removal
and the re-add to interleave in a particular order, which is a timing window
rather than a call, so I have left them uncovered rather than write a case that
would pin a schedule.

For significant contributions please make sure you have completed the following items:

* [x] `CHANGELOG.md` updated for non-trivial changes
* [x] Unit tests have been added
* [x] Changes in public API reviewed


