### PR TITLE
[BUG] Check what curl_slist_append and curl_multi_init return

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -131,7 +131,7 @@ Increment the:
 * [BUG] Check what curl_slist_append and curl_multi_init return instead of
   treating a failed allocation as success
   [#4404](https://github.com/open-telemetry/opentelemetry-cpp/issues/4404)
-* [BUG] Stop the curl IO thread spinning, and the client refusing to be
+* [BUG] Stop the curl IO thread spinning, flooding the log, and refusing to be
   destroyed, when the multi handle cannot be created
   [#4404](https://github.com/open-telemetry/opentelemetry-cpp/issues/4404)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -128,6 +128,9 @@ Increment the:
   deprecated C headers (`stdint.h`, `stddef.h`, `stdlib.h`, `string.h`,
   `stdio.h`, `ctype.h`, `limits.h`, `assert.h`) with their C++ equivalents
   ([#4349](https://github.com/open-telemetry/opentelemetry-cpp/pull/4349))
+* [BUG] Check what curl_slist_append and curl_multi_init return instead of
+  treating a failed allocation as success
+  [#4404](https://github.com/open-telemetry/opentelemetry-cpp/issues/4404)
 
 * [CONFIGURATION] Add SDK component builder interfaces to the registry
   [#4358](https://github.com/open-telemetry/opentelemetry-cpp/issues/4358)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -134,6 +134,14 @@ Increment the:
 * [BUG] Stop the curl IO thread spinning, flooding the log, and refusing to be
   destroyed, when the multi handle cannot be created
   [#4404](https://github.com/open-telemetry/opentelemetry-cpp/issues/4404)
+* [BUG] Keep the curl IO thread from retiring while a request it accepted is
+  still waiting to be scheduled, and release the easy handles and header lists
+  left queued when the client is destroyed
+  [#4404](https://github.com/open-telemetry/opentelemetry-cpp/issues/4404)
+* [BUG] Take an operation that was cancelled or torn down out of the curl retry
+  queue, and check what curl_multi_remove_handle and curl_multi_add_handle
+  return when a retry is scheduled
+  [#4404](https://github.com/open-telemetry/opentelemetry-cpp/issues/4404)
 
 * [CONFIGURATION] Add SDK component builder interfaces to the registry
   [#4358](https://github.com/open-telemetry/opentelemetry-cpp/issues/4358)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -128,8 +128,8 @@ Increment the:
   deprecated C headers (`stdint.h`, `stddef.h`, `stdlib.h`, `string.h`,
   `stdio.h`, `ctype.h`, `limits.h`, `assert.h`) with their C++ equivalents
   ([#4349](https://github.com/open-telemetry/opentelemetry-cpp/pull/4349))
-* [BUG] Check what curl_slist_append and curl_multi_init return instead of
-  treating a failed allocation as success
+* [BUG] Check what curl_easy_init, curl_slist_append and curl_multi_init return
+  instead of treating a failed allocation as success
   [#4404](https://github.com/open-telemetry/opentelemetry-cpp/issues/4404)
 * [BUG] Stop the curl IO thread spinning, flooding the log, and refusing to be
   destroyed, when the multi handle cannot be created

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -131,6 +131,9 @@ Increment the:
 * [BUG] Check what curl_slist_append and curl_multi_init return instead of
   treating a failed allocation as success
   [#4404](https://github.com/open-telemetry/opentelemetry-cpp/issues/4404)
+* [BUG] Stop the curl IO thread spinning, and the client refusing to be
+  destroyed, when the multi handle cannot be created
+  [#4404](https://github.com/open-telemetry/opentelemetry-cpp/issues/4404)
 
 * [CONFIGURATION] Add SDK component builder interfaces to the registry
   [#4358](https://github.com/open-telemetry/opentelemetry-cpp/issues/4358)

--- a/ext/include/opentelemetry/ext/http/client/curl/http_client_curl.h
+++ b/ext/include/opentelemetry/ext/http/client/curl/http_client_curl.h
@@ -364,8 +364,7 @@ private:
   bool doAbortSessions();
   bool doRemoveSessions();
   bool doRetrySessions(bool report_all);
-  // Returns whether the client has a multi handle afterwards. The IO loop has nothing to
-  // run while it does not, and needs to know rather than call into libcurl regardless.
+  // Returns true if the client has a multi handle afterwards.
   bool resetMultiHandle();
 
   std::mutex multi_handle_m_;

--- a/ext/include/opentelemetry/ext/http/client/curl/http_client_curl.h
+++ b/ext/include/opentelemetry/ext/http/client/curl/http_client_curl.h
@@ -364,7 +364,9 @@ private:
   bool doAbortSessions();
   bool doRemoveSessions();
   bool doRetrySessions(bool report_all);
-  void resetMultiHandle();
+  // Returns whether the client has a multi handle afterwards. The IO loop has nothing to
+  // run while it does not, and needs to know rather than call into libcurl regardless.
+  bool resetMultiHandle();
 
   std::mutex multi_handle_m_;
   CURLM *multi_handle_;

--- a/ext/include/opentelemetry/ext/http/client/curl/http_client_curl.h
+++ b/ext/include/opentelemetry/ext/http/client/curl/http_client_curl.h
@@ -369,6 +369,9 @@ private:
   // work. Call it on the background thread only: it prunes pending_to_retry_sessions_, which
   // has no lock because that thread is the only one that touches it.
   bool hasActionableWork();
+  // Cleans up the multi handle if there is one, and leaves none behind either way. Call it
+  // holding multi_handle_m_.
+  void ReleaseMultiHandle();
   // Returns true if the client has a multi handle afterwards.
   bool resetMultiHandle();
 

--- a/ext/include/opentelemetry/ext/http/client/curl/http_client_curl.h
+++ b/ext/include/opentelemetry/ext/http/client/curl/http_client_curl.h
@@ -367,10 +367,6 @@ private:
   // Returns true if the client has a multi handle afterwards.
   bool resetMultiHandle();
 
-  // Returns true if any queue still holds work. The IO loop cannot read that from
-  // still_running, which only the phases that need a multi handle ever set.
-  bool hasPendingWork();
-
   std::mutex multi_handle_m_;
   CURLM *multi_handle_;
   std::atomic<uint64_t> next_session_id_{0};

--- a/ext/include/opentelemetry/ext/http/client/curl/http_client_curl.h
+++ b/ext/include/opentelemetry/ext/http/client/curl/http_client_curl.h
@@ -370,8 +370,10 @@ private:
   // has no lock because that thread is the only one that touches it.
   bool hasActionableWork();
   // Cleans up the multi handle if there is one, and leaves none behind either way. Call it
-  // holding multi_handle_m_.
-  void ReleaseMultiHandle();
+  // holding multi_handle_m_. It answers with what curl_multi_cleanup said rather than reporting
+  // it, because reporting reaches a log handler the application supplies, and one that comes back
+  // into this client would do it while the caller still holds that mutex.
+  CURLMcode ReleaseMultiHandle();
   // Returns true if the client has a multi handle afterwards.
   bool resetMultiHandle();
 

--- a/ext/include/opentelemetry/ext/http/client/curl/http_client_curl.h
+++ b/ext/include/opentelemetry/ext/http/client/curl/http_client_curl.h
@@ -367,6 +367,10 @@ private:
   // Returns true if the client has a multi handle afterwards.
   bool resetMultiHandle();
 
+  // Returns true if any queue still holds work. The IO loop cannot read that from
+  // still_running, which only the phases that need a multi handle ever set.
+  bool hasPendingWork();
+
   std::mutex multi_handle_m_;
   CURLM *multi_handle_;
   std::atomic<uint64_t> next_session_id_{0};

--- a/ext/include/opentelemetry/ext/http/client/curl/http_client_curl.h
+++ b/ext/include/opentelemetry/ext/http/client/curl/http_client_curl.h
@@ -364,6 +364,11 @@ private:
   bool doAbortSessions();
   bool doRemoveSessions();
   bool doRetrySessions(bool report_all);
+  // Returns true if the background thread still owes somebody an answer. Drops what it finds
+  // that nothing can be owed for, so that a queue which is merely not empty does not read as
+  // work. Call it on the background thread only: it prunes pending_to_retry_sessions_, which
+  // has no lock because that thread is the only one that touches it.
+  bool hasActionableWork();
   // Returns true if the client has a multi handle afterwards.
   bool resetMultiHandle();
 
@@ -388,6 +393,10 @@ private:
 
   std::chrono::milliseconds background_thread_wait_for_;
   std::atomic<bool> is_shutdown_{false};
+  // Raised by every producer. curl_multi_wakeup is how the background thread is woken out of
+  // curl_multi_poll and it needs a multi handle, so the wait taken when there is none watches
+  // this instead.
+  std::atomic<uint64_t> wakeup_generation_{0};
 
   nostd::shared_ptr<HttpCurlGlobalInitializer> curl_global_initializer_;
 };

--- a/ext/include/opentelemetry/ext/http/client/curl/http_client_curl.h
+++ b/ext/include/opentelemetry/ext/http/client/curl/http_client_curl.h
@@ -377,6 +377,10 @@ private:
   // Returns true if the client has a multi handle afterwards.
   bool resetMultiHandle();
 
+  // Declared before multi_handle_ on purpose: members are initialised in declaration
+  // order, and curl_multi_init() may not run before curl_global_init().
+  nostd::shared_ptr<HttpCurlGlobalInitializer> curl_global_initializer_;
+
   std::mutex multi_handle_m_;
   CURLM *multi_handle_;
   std::atomic<uint64_t> next_session_id_{0};
@@ -402,8 +406,6 @@ private:
   // curl_multi_poll and it needs a multi handle, so the wait taken when there is none watches
   // this instead.
   std::atomic<uint64_t> wakeup_generation_{0};
-
-  nostd::shared_ptr<HttpCurlGlobalInitializer> curl_global_initializer_;
 };
 
 }  // namespace curl

--- a/ext/include/opentelemetry/ext/http/client/curl/http_operation_curl.h
+++ b/ext/include/opentelemetry/ext/http/client/curl/http_operation_curl.h
@@ -325,6 +325,9 @@ private:
   char curl_error_message_[CURL_ERROR_SIZE]{};
   HttpCurlEasyResource curl_resource_;
   CURLcode last_curl_result_{CURLE_OK};  // Curl result OR HTTP status code if successful
+  // Set when the constructor could not finish. Send() and SendAsync() refuse on it, so a
+  // request whose setup never completed is not put on the wire.
+  CURLcode construction_result_{CURLE_OK};
 
   opentelemetry::ext::http::client::EventHandler *event_handle_{nullptr};
 

--- a/ext/include/opentelemetry/ext/http/client/curl/http_operation_curl.h
+++ b/ext/include/opentelemetry/ext/http/client/curl/http_operation_curl.h
@@ -324,10 +324,8 @@ private:
 
   char curl_error_message_[CURL_ERROR_SIZE]{};
   HttpCurlEasyResource curl_resource_;
-  CURLcode last_curl_result_{CURLE_OK};  // Curl result OR HTTP status code if successful
-  // Set when the constructor could not finish. Send() and SendAsync() refuse on it, so a
-  // request whose setup never completed is not put on the wire.
-  CURLcode construction_result_{CURLE_OK};
+  CURLcode last_curl_result_{CURLE_OK};     // Curl result OR HTTP status code if successful
+  CURLcode construction_result_{CURLE_OK};  // Non-OK if setup failed; Send() refuses on it
 
   opentelemetry::ext::http::client::EventHandler *event_handle_{nullptr};
 

--- a/ext/src/http/client/curl/http_client_curl.cc
+++ b/ext/src/http/client/curl/http_client_curl.cc
@@ -979,22 +979,44 @@ bool HttpClient::doRetrySessions(bool report_all)
     const auto session   = *retry_it;
     const auto operation = session ? session->GetOperation().get() : nullptr;
 
-    if (!operation)
+    // An operation that was cancelled, or torn down, is not going to be retried. Its easy
+    // handle has gone back to the client already, so what waiting for its turn would buy is a
+    // null handle offered to libcurl and an entry that keeps the background thread alive until
+    // a time that means nothing. At shutdown that time is time the join spends waiting.
+    if (nullptr == operation || operation->WasAborted() ||
+        nullptr == operation->GetCurlEasyHandle())
     {
       retry_it = pending_to_retry_sessions_.erase(retry_it);
+      continue;
     }
-    else if (operation->NextRetryTime() < now)
+
+    if (operation->NextRetryTime() >= now)
     {
-      auto easy_handle = operation->GetCurlEasyHandle();
-      curl_multi_remove_handle(multi_handle_, easy_handle);
-      curl_multi_add_handle(multi_handle_, easy_handle);
-      retry_it = pending_to_retry_sessions_.erase(retry_it);
-      has_data = true;
-    }
-    else
-    {
+      // Pushed at the back, so nothing behind this one is due either.
       break;
     }
+
+    CURL *const easy_handle = operation->GetCurlEasyHandle();
+
+    // The handle is still with the multi handle from the attempt that just failed, so it has
+    // to come back before it can go again, and it only goes again if it came back.
+    const CURLMcode detached = curl_multi_remove_handle(multi_handle_, easy_handle);
+    const CURLMcode attached =
+        (CURLM_OK == detached) ? curl_multi_add_handle(multi_handle_, easy_handle) : detached;
+
+    retry_it = pending_to_retry_sessions_.erase(retry_it);
+
+    if (CURLM_OK != attached)
+    {
+      // Nobody is going to run this transfer, so it is finished here rather than left with a
+      // promise nothing will fulfil, and it is not reported as work that was arranged.
+      OTEL_INTERNAL_LOG_ERROR(
+          "[HTTP Client Curl] a retry could not be scheduled: " << curl_multi_strerror(attached));
+      session->FinishOperation();
+      continue;
+    }
+
+    has_data = true;
   }
 
   report_all = report_all && !pending_to_retry_sessions_.empty();

--- a/ext/src/http/client/curl/http_client_curl.cc
+++ b/ext/src/http/client/curl/http_client_curl.cc
@@ -521,7 +521,17 @@ bool HttpClient::MaybeSpawnBackgroundThread()
                     "curl_multi_init succeeds");
                 missing_multi_handle_reported = true;
               }
-              std::this_thread::sleep_for(self->scheduled_delay_milliseconds_);
+              // In slices, because this thread cannot be woken: wakeupBackgroundThread reaches it
+              // through the multi handle, and there is not one. A whole delay here would be a
+              // whole delay added to destroying the client.
+              constexpr std::chrono::milliseconds kMissingHandleWaitSlice{16};
+              for (std::chrono::milliseconds waited = std::chrono::milliseconds::zero();
+                   waited < self->scheduled_delay_milliseconds_ &&
+                   !self->is_shutdown_.load(std::memory_order_acquire);
+                   waited += kMissingHandleWaitSlice)
+              {
+                std::this_thread::sleep_for(kMissingHandleWaitSlice);
+              }
             }
           }
           else if (still_running || need_wait_more)
@@ -556,7 +566,9 @@ bool HttpClient::MaybeSpawnBackgroundThread()
 
           do
           {
-            msg = curl_multi_info_read(self->multi_handle_, &queued);
+            msg = (nullptr == self->multi_handle_)
+                      ? nullptr
+                      : curl_multi_info_read(self->multi_handle_, &queued);
             if (msg == nullptr)
             {
               break;

--- a/ext/src/http/client/curl/http_client_curl.cc
+++ b/ext/src/http/client/curl/http_client_curl.cc
@@ -285,25 +285,35 @@ static CURLM *initMultiHandle()
 }
 
 HttpClient::HttpClient()
-    : multi_handle_(initMultiHandle()),
+    : multi_handle_(nullptr),
       next_session_id_{0},
       max_sessions_per_connection_{8},
       background_thread_instrumentation_(nullptr),
       scheduled_delay_milliseconds_{std::chrono::milliseconds(256)},
       background_thread_wait_for_{std::chrono::minutes{1}},
       curl_global_initializer_(HttpCurlGlobalInitializer::GetInstance())
-{}
+{
+  // Members are initialised in declaration order, and multi_handle_ is declared first, so this
+  // cannot go in the list: curl_global_init has to have run before any other libcurl call, and
+  // it runs from curl_global_initializer_ above.
+  multi_handle_ = initMultiHandle();
+}
 
 HttpClient::HttpClient(
     const std::shared_ptr<sdk::common::ThreadInstrumentation> &thread_instrumentation)
-    : multi_handle_(initMultiHandle()),
+    : multi_handle_(nullptr),
       next_session_id_{0},
       max_sessions_per_connection_{8},
       background_thread_instrumentation_(thread_instrumentation),
       scheduled_delay_milliseconds_{std::chrono::milliseconds(256)},
       background_thread_wait_for_{std::chrono::minutes{1}},
       curl_global_initializer_(HttpCurlGlobalInitializer::GetInstance())
-{}
+{
+  // Members are initialised in declaration order, and multi_handle_ is declared first, so this
+  // cannot go in the list: curl_global_init has to have run before any other libcurl call, and
+  // it runs from curl_global_initializer_ above.
+  multi_handle_ = initMultiHandle();
+}
 
 HttpClient::~HttpClient()
 {

--- a/ext/src/http/client/curl/http_client_curl.cc
+++ b/ext/src/http/client/curl/http_client_curl.cc
@@ -293,9 +293,7 @@ HttpClient::HttpClient()
       background_thread_wait_for_{std::chrono::minutes{1}},
       curl_global_initializer_(HttpCurlGlobalInitializer::GetInstance())
 {
-  // Members are initialised in declaration order, and multi_handle_ is declared first, so this
-  // cannot go in the list: curl_global_init has to have run before any other libcurl call, and
-  // it runs from curl_global_initializer_ above.
+  // Not in the initialiser list: curl_global_initializer_ is declared later and has to run first.
   multi_handle_ = initMultiHandle();
 }
 
@@ -309,9 +307,7 @@ HttpClient::HttpClient(
       background_thread_wait_for_{std::chrono::minutes{1}},
       curl_global_initializer_(HttpCurlGlobalInitializer::GetInstance())
 {
-  // Members are initialised in declaration order, and multi_handle_ is declared first, so this
-  // cannot go in the list: curl_global_init has to have run before any other libcurl call, and
-  // it runs from curl_global_initializer_ above.
+  // Not in the initialiser list: curl_global_initializer_ is declared later and has to run first.
   multi_handle_ = initMultiHandle();
 }
 
@@ -612,17 +608,14 @@ bool HttpClient::MaybeSpawnBackgroundThread()
             }
           } while (true);
 
-          // Abort all pending easy handles. This one calls nothing from the multi interface, so
-          // it runs whether or not there is a handle and teardown keeps working without one.
+          // Abort all pending easy handles. Calls no multi function, so it runs without a handle.
           if (self->doAbortSessions())
           {
             still_running = 1;
           }
 
-          // The three below every call curl_multi_add_handle or curl_multi_remove_handle. Running
-          // them without a handle would take the pending sessions out of the queue that keeps
-          // them safe from the next reset, hand them to a multi function that cannot accept
-          // them, and report the transfer as running.
+          // The three below each call curl_multi_add_handle or curl_multi_remove_handle. Without
+          // a handle they would drain the pending queue into a function that cannot accept it.
           const bool multi_available = (nullptr != self->multi_handle_);
 
           // Remove all pending easy handles

--- a/ext/src/http/client/curl/http_client_curl.cc
+++ b/ext/src/http/client/curl/http_client_curl.cc
@@ -11,6 +11,7 @@
 #include <functional>
 #include <list>
 #include <mutex>
+#include <ostream>
 #include <string>
 #include <thread>
 #include <unordered_map>

--- a/ext/src/http/client/curl/http_client_curl.cc
+++ b/ext/src/http/client/curl/http_client_curl.cc
@@ -482,6 +482,10 @@ bool HttpClient::MaybeSpawnBackgroundThread()
           // can not curl_multi_perform it again
           if (mc != CURLM_OK)
           {
+            // curl_multi_perform leaves still_running alone when it rejects the handle, and it
+            // starts at one, so without this the loop keeps reporting work it does not have,
+            // never reaches the shutdown check below, and the thread cannot be joined.
+            still_running = 0;
             self->resetMultiHandle();
           }
           else if (still_running || need_wait_more)

--- a/ext/src/http/client/curl/http_client_curl.cc
+++ b/ext/src/http/client/curl/http_client_curl.cc
@@ -346,9 +346,19 @@ HttpClient::~HttpClient()
   doAbortSessions();
   doRemoveSessions();
 
+  CURLMcode cleanup_result = CURLM_OK;
   {
     std::lock_guard<std::mutex> lock_guard{multi_handle_m_};
-    ReleaseMultiHandle();
+    cleanup_result = ReleaseMultiHandle();
+  }
+
+  // Outside the lock: the log handler is replaceable application code, and one that comes back
+  // into this client reaches wakeupBackgroundThread(), which takes the mutex this thread would
+  // still be holding.
+  if (CURLM_OK != cleanup_result)
+  {
+    OTEL_INTERNAL_LOG_ERROR("[HTTP Client Curl] curl_multi_cleanup failed with message: "
+                            << curl_multi_strerror(cleanup_result));
   }
 }
 
@@ -1060,7 +1070,7 @@ bool HttpClient::doRetrySessions(bool /* report_all */)
 }
 #endif  // ENABLE_OTLP_RETRY_PREVIEW
 
-void HttpClient::ReleaseMultiHandle()
+CURLMcode HttpClient::ReleaseMultiHandle()
 {
   if (nullptr == multi_handle_)
   {
@@ -1068,16 +1078,12 @@ void HttpClient::ReleaseMultiHandle()
     // and curl_multi_cleanup is one of them. Reaching here with none is ordinary: the
     // constructor may have started without one, and a reset that could not build a replacement
     // leaves none behind.
-    return;
+    return CURLM_OK;
   }
 
   const CURLMcode cleanup_result = curl_multi_cleanup(multi_handle_);
   multi_handle_                  = nullptr;
-  if (CURLM_OK != cleanup_result)
-  {
-    OTEL_INTERNAL_LOG_ERROR("[HTTP Client Curl] curl_multi_cleanup failed with message: "
-                            << curl_multi_strerror(cleanup_result));
-  }
+  return cleanup_result;
 }
 
 bool HttpClient::hasActionableWork()
@@ -1147,14 +1153,28 @@ bool HttpClient::resetMultiHandle()
 
   doRemoveSessions();
 
-  // We will modify the multi_handle_, so we need to lock it
-  std::lock_guard<std::mutex> lock_guard{multi_handle_m_};
-  ReleaseMultiHandle();
+  CURLMcode cleanup_result = CURLM_OK;
+  bool have_handle         = false;
+  {
+    // We will modify the multi_handle_, so we need to lock it
+    std::lock_guard<std::mutex> lock_guard{multi_handle_m_};
+    cleanup_result = ReleaseMultiHandle();
 
-  // Create a another multi handle to continue pending sessions. Silent on failure: the caller
-  // decides how often a run of failures is worth reporting.
-  multi_handle_ = curl_multi_init();
-  return nullptr != multi_handle_;
+    // Create a another multi handle to continue pending sessions. Silent on failure: the caller
+    // decides how often a run of failures is worth reporting.
+    multi_handle_ = curl_multi_init();
+    have_handle   = (nullptr != multi_handle_);
+  }
+
+  // Outside the lock, for the same reason as the other caller: a log handler that comes back into
+  // this client takes this mutex.
+  if (CURLM_OK != cleanup_result)
+  {
+    OTEL_INTERNAL_LOG_ERROR("[HTTP Client Curl] curl_multi_cleanup failed with message: "
+                            << curl_multi_strerror(cleanup_result));
+  }
+
+  return have_handle;
 }
 
 }  // namespace curl

--- a/ext/src/http/client/curl/http_client_curl.cc
+++ b/ext/src/http/client/curl/http_client_curl.cc
@@ -1054,10 +1054,9 @@ bool HttpClient::hasActionableWork()
   std::lock_guard<std::mutex> session_lock_guard{sessions_m_};
   std::lock_guard<std::recursive_mutex> session_id_lock_guard{session_ids_m_};
 
-  // An id whose session has gone is what doAddSessions would drop on its next pass, so it is
-  // dropped here too rather than counted. The difference matters: the first version of this
-  // check took every queue at its size, and an entry nothing could be done about held the
-  // thread open against the join in the destructor.
+  // An id whose session has gone is what doAddSessions drops on its next pass, so it is
+  // dropped here too rather than counted. Counting an entry that can never drain would keep
+  // this thread alive against the join in the destructor.
   for (auto id = pending_to_add_session_ids_.begin(); id != pending_to_add_session_ids_.end();)
   {
     const auto session = sessions_.find(*id);

--- a/ext/src/http/client/curl/http_client_curl.cc
+++ b/ext/src/http/client/curl/http_client_curl.cc
@@ -521,6 +521,13 @@ bool HttpClient::MaybeSpawnBackgroundThread()
                     "curl_multi_init succeeds");
                 missing_multi_handle_reported = true;
               }
+#ifdef ENABLE_THREAD_INSTRUMENTATION_PREVIEW
+              if (self->background_thread_instrumentation_ != nullptr)
+              {
+                self->background_thread_instrumentation_->BeforeWait();
+              }
+#endif /* ENABLE_THREAD_INSTRUMENTATION_PREVIEW */
+
               // In slices, because this thread cannot be woken: wakeupBackgroundThread reaches it
               // through the multi handle, and there is not one. A whole delay here would be a
               // whole delay added to destroying the client.
@@ -532,6 +539,13 @@ bool HttpClient::MaybeSpawnBackgroundThread()
               {
                 std::this_thread::sleep_for(kMissingHandleWaitSlice);
               }
+
+#ifdef ENABLE_THREAD_INSTRUMENTATION_PREVIEW
+              if (self->background_thread_instrumentation_ != nullptr)
+              {
+                self->background_thread_instrumentation_->AfterWait();
+              }
+#endif /* ENABLE_THREAD_INSTRUMENTATION_PREVIEW */
             }
           }
           else if (still_running || need_wait_more)

--- a/ext/src/http/client/curl/http_client_curl.cc
+++ b/ext/src/http/client/curl/http_client_curl.cc
@@ -500,7 +500,8 @@ bool HttpClient::MaybeSpawnBackgroundThread()
             // curl_multi_perform leaves still_running alone when it rejects the handle, and it
             // starts at one, so without this the loop keeps reporting work it does not have,
             // never reaches the shutdown check below, and the thread cannot be joined.
-            still_running = 0;
+            still_running           = 0;
+            const uint64_t woken_at = self->wakeup_generation_.load(std::memory_order_acquire);
             if (self->resetMultiHandle())
             {
               missing_multi_handle_reported = false;
@@ -524,13 +525,16 @@ bool HttpClient::MaybeSpawnBackgroundThread()
               }
 #endif /* ENABLE_THREAD_INSTRUMENTATION_PREVIEW */
 
-              // In slices, because this thread cannot be woken: wakeupBackgroundThread reaches it
-              // through the multi handle, and there is not one. A whole delay here would be a
-              // whole delay added to destroying the client.
+              // In slices, because curl_multi_wakeup cannot reach this thread: it goes through
+              // the multi handle, and there is not one. What ends the wait early instead is the
+              // counter every producer raises, or shutdown. A whole delay spent either way would
+              // be a whole delay added to answering the next request, and to destroying the
+              // client.
               constexpr std::chrono::milliseconds kMissingHandleWaitSlice{16};
               for (std::chrono::milliseconds waited = std::chrono::milliseconds::zero();
                    waited < self->scheduled_delay_milliseconds_ &&
-                   !self->is_shutdown_.load(std::memory_order_acquire);
+                   !self->is_shutdown_.load(std::memory_order_acquire) &&
+                   woken_at == self->wakeup_generation_.load(std::memory_order_acquire);
                    waited += kMissingHandleWaitSlice)
               {
                 std::this_thread::sleep_for(kMissingHandleWaitSlice);
@@ -694,6 +698,17 @@ bool HttpClient::MaybeSpawnBackgroundThread()
               still_running = 1;
             }
 
+            // Skipping those three reports nothing, which is not the same as having nothing to
+            // do. A request the client has accepted has to be either handed to libcurl or
+            // finished, and this thread is the only one that does either, so it stays while it
+            // owes one. Shutdown is exempt: there the queues that need a handle cannot drain
+            // without one, and staying for them is staying under the join that is waiting here.
+            if (!multi_available_now && !self->is_shutdown_.load(std::memory_order_acquire) &&
+                self->hasActionableWork())
+            {
+              still_running = 1;
+            }
+
             // If there is no pending jobs, we can stop the background thread.
             if (still_running == 0)
             {
@@ -788,6 +803,10 @@ void HttpClient::WaitBackgroundThreadExit()
 
 void HttpClient::wakeupBackgroundThread()
 {
+  // First, and whatever libcurl is: the call below needs a multi handle and there is not always
+  // one, so this is what the background thread watches when it is waiting without a handle.
+  wakeup_generation_.fetch_add(1, std::memory_order_release);
+
 // Before libcurl 7.68.0, we can only wait for timeout and do the rest jobs
 // See https://curl.se/libcurl/c/curl_multi_wakeup.html
 #if LIBCURL_VERSION_NUM >= 0x074400
@@ -960,6 +979,46 @@ bool HttpClient::doRetrySessions(bool /* report_all */)
   return false;
 }
 #endif  // ENABLE_OTLP_RETRY_PREVIEW
+
+bool HttpClient::hasActionableWork()
+{
+  std::lock_guard<std::mutex> session_lock_guard{sessions_m_};
+  std::lock_guard<std::recursive_mutex> session_id_lock_guard{session_ids_m_};
+
+  // An id whose session has gone is what doAddSessions would drop on its next pass, so it is
+  // dropped here too rather than counted. The difference matters: the first version of this
+  // check took every queue at its size, and an entry nothing could be done about held the
+  // thread open against the join in the destructor.
+  for (auto id = pending_to_add_session_ids_.begin(); id != pending_to_add_session_ids_.end();)
+  {
+    const auto session = sessions_.find(*id);
+    if (session == sessions_.end() || !session->second || !session->second->GetOperation())
+    {
+      id = pending_to_add_session_ids_.erase(id);
+    }
+    else
+    {
+      ++id;
+    }
+  }
+
+  // Same rule doRetrySessions applies to the same container.
+  for (auto retry = pending_to_retry_sessions_.begin(); retry != pending_to_retry_sessions_.end();)
+  {
+    if (!*retry || !(*retry)->GetOperation())
+    {
+      retry = pending_to_retry_sessions_.erase(retry);
+    }
+    else
+    {
+      ++retry;
+    }
+  }
+
+  return !pending_to_add_session_ids_.empty() || !pending_to_abort_sessions_.empty() ||
+         !pending_to_remove_session_handles_.empty() || !pending_to_remove_sessions_.empty() ||
+         !pending_to_retry_sessions_.empty();
+}
 
 bool HttpClient::resetMultiHandle()
 {

--- a/ext/src/http/client/curl/http_client_curl.cc
+++ b/ext/src/http/client/curl/http_client_curl.cc
@@ -335,6 +335,16 @@ HttpClient::~HttpClient()
       background_thread->join();
     }
   }
+
+  // The background thread has gone and no more sessions are made here, so nothing else is
+  // coming back for what it left behind. Aborting first, because finishing an operation hands
+  // its easy handle and header list to the removal queue, and that queue holds two raw
+  // pointers whose container frees neither. Ordinarily both are already empty: this is for the
+  // case where the thread had retired before the sessions were cancelled, and it runs before
+  // the multi handle goes so a handle that is still attached can be given back.
+  doAbortSessions();
+  doRemoveSessions();
+
   {
     std::lock_guard<std::mutex> lock_guard{multi_handle_m_};
     ReleaseMultiHandle();

--- a/ext/src/http/client/curl/http_client_curl.cc
+++ b/ext/src/http/client/curl/http_client_curl.cc
@@ -23,6 +23,7 @@
 #include "opentelemetry/ext/http/common/url_parser.h"
 #include "opentelemetry/nostd/shared_ptr.h"
 #include "opentelemetry/nostd/string_view.h"
+#include "opentelemetry/sdk/common/global_log_handler.h"
 #include "opentelemetry/sdk/common/thread_instrumentation.h"
 #include "opentelemetry/version.h"
 
@@ -33,8 +34,6 @@
 #  include <array>
 
 #  include "opentelemetry/nostd/type_traits.h"
-#else
-#  include "opentelemetry/sdk/common/global_log_handler.h"
 #endif
 
 OPENTELEMETRY_BEGIN_NAMESPACE
@@ -236,7 +235,8 @@ void Session::SendRequest(
   {
     if (callback)
     {
-      callback->OnEvent(opentelemetry::ext::http::client::SessionState::CreateFailed, "");
+      callback->OnEvent(opentelemetry::ext::http::client::SessionState::CreateFailed,
+                        curl_easy_strerror(curl_operation_->GetLastResultCode()));
     }
     is_session_active_.store(false, std::memory_order_release);
   }
@@ -270,8 +270,20 @@ void Session::FinishOperation()
   }
 }
 
+// A null multi handle makes every curl_multi_add_handle report CURLM_BAD_HANDLE, so a client
+// built on one accepts sessions and never sends any of them. Say so rather than fail quietly.
+static CURLM *initMultiHandle()
+{
+  CURLM *handle = curl_multi_init();
+  if (nullptr == handle)
+  {
+    OTEL_INTERNAL_LOG_ERROR("[HTTP Client Curl] curl_multi_init failed, this client cannot send");
+  }
+  return handle;
+}
+
 HttpClient::HttpClient()
-    : multi_handle_(curl_multi_init()),
+    : multi_handle_(initMultiHandle()),
       next_session_id_{0},
       max_sessions_per_connection_{8},
       background_thread_instrumentation_(nullptr),
@@ -282,7 +294,7 @@ HttpClient::HttpClient()
 
 HttpClient::HttpClient(
     const std::shared_ptr<sdk::common::ThreadInstrumentation> &thread_instrumentation)
-    : multi_handle_(curl_multi_init()),
+    : multi_handle_(initMultiHandle()),
       next_session_id_{0},
       max_sessions_per_connection_{8},
       background_thread_instrumentation_(thread_instrumentation),
@@ -913,7 +925,7 @@ void HttpClient::resetMultiHandle()
   curl_multi_cleanup(multi_handle_);
 
   // Create a another multi handle to continue pending sessions
-  multi_handle_ = curl_multi_init();
+  multi_handle_ = initMultiHandle();
 }
 
 }  // namespace curl

--- a/ext/src/http/client/curl/http_client_curl.cc
+++ b/ext/src/http/client/curl/http_client_curl.cc
@@ -683,6 +683,13 @@ bool HttpClient::MaybeSpawnBackgroundThread()
             // Double check, make sure no more pending sessions after locking background thread
             // management
 
+            // Read before the drains below, compared after them. Everything that queues work for
+            // this thread bumps it, and the producers of the abort and removal queues only wake
+            // this thread rather than starting one, so anything queued after a drain has already
+            // reported empty would sit there until the next request or the destructor.
+            const uint64_t generation_before =
+                self->wakeup_generation_.load(std::memory_order_acquire);
+
             // Abort all pending easy handles
             if (self->doAbortSessions())
             {
@@ -714,6 +721,14 @@ bool HttpClient::MaybeSpawnBackgroundThread()
             // without one, and staying for them is staying under the join that is waiting here.
             if (nullptr == self->multi_handle_ &&
                 !self->is_shutdown_.load(std::memory_order_acquire) && self->hasActionableWork())
+            {
+              still_running = 1;
+            }
+
+            // Queued while the drains above were running, so this thread still owes somebody
+            // the work rather than being finished with it.
+            if (still_running == 0 &&
+                generation_before != self->wakeup_generation_.load(std::memory_order_acquire))
             {
               still_running = 1;
             }

--- a/ext/src/http/client/curl/http_client_curl.cc
+++ b/ext/src/http/client/curl/http_client_curl.cc
@@ -959,6 +959,21 @@ bool HttpClient::doRemoveSessions()
   return has_data;
 }
 
+namespace
+{
+// One rule for the retry queue, shared by the pass that drains it and by the scan that decides
+// whether this thread still owes anybody an answer. They walk the same container, so a predicate
+// that disagreed would either keep the thread alive for an entry the retry pass is about to drop,
+// or drop one the retry pass still wants. Outside the retry guard because the scan runs in both
+// builds and the queue is empty rather than absent when the preview is off.
+bool RetryEntryIsLive(const std::shared_ptr<Session> &session)
+{
+  const auto operation = session ? session->GetOperation().get() : nullptr;
+  return nullptr != operation && !operation->WasAborted() &&
+         nullptr != operation->GetCurlEasyHandle();
+}
+}  // namespace
+
 #ifdef ENABLE_OTLP_RETRY_PREVIEW
 bool HttpClient::doRetrySessions(bool report_all)
 {
@@ -977,19 +992,19 @@ bool HttpClient::doRetrySessions(bool report_all)
   for (auto retry_it = pending_to_retry_sessions_.cbegin();
        retry_it != pending_to_retry_sessions_.cend();)
   {
-    const auto session   = *retry_it;
-    const auto operation = session ? session->GetOperation().get() : nullptr;
+    const auto session = *retry_it;
 
     // An operation that was cancelled, or torn down, is not going to be retried. Its easy
     // handle has gone back to the client already, so what waiting for its turn would buy is a
     // null handle offered to libcurl and an entry that keeps the background thread alive until
     // a time that means nothing. At shutdown that time is time the join spends waiting.
-    if (nullptr == operation || operation->WasAborted() ||
-        nullptr == operation->GetCurlEasyHandle())
+    if (!RetryEntryIsLive(session))
     {
       retry_it = pending_to_retry_sessions_.erase(retry_it);
       continue;
     }
+
+    const auto operation = session->GetOperation().get();
 
     if (operation->NextRetryTime() >= now)
     {
@@ -1071,10 +1086,11 @@ bool HttpClient::hasActionableWork()
     }
   }
 
-  // Same rule doRetrySessions applies to the same container.
+  // The same rule doRetrySessions applies to the same container, from the same function, so the
+  // two cannot drift apart again.
   for (auto retry = pending_to_retry_sessions_.begin(); retry != pending_to_retry_sessions_.end();)
   {
-    if (!*retry || !(*retry)->GetOperation())
+    if (!RetryEntryIsLive(*retry))
     {
       retry = pending_to_retry_sessions_.erase(retry);
     }

--- a/ext/src/http/client/curl/http_client_curl.cc
+++ b/ext/src/http/client/curl/http_client_curl.cc
@@ -337,7 +337,7 @@ HttpClient::~HttpClient()
   }
   {
     std::lock_guard<std::mutex> lock_guard{multi_handle_m_};
-    curl_multi_cleanup(multi_handle_);
+    ReleaseMultiHandle();
   }
 }
 
@@ -618,24 +618,24 @@ bool HttpClient::MaybeSpawnBackgroundThread()
             still_running = 1;
           }
 
-          // The three below each call curl_multi_add_handle or curl_multi_remove_handle. Without
-          // a handle they would drain the pending queue into a function that cannot accept it.
-          const bool multi_available = (nullptr != self->multi_handle_);
-
-          // Remove all pending easy handles
-          if (multi_available && self->doRemoveSessions())
+          // Remove all pending easy handles. Detaching is the only thing here that wants a
+          // multi handle, and without one there is nothing to detach from, so this releases
+          // rather than waits: holding the resources back would hold them for the whole
+          // outage.
+          if (self->doRemoveSessions())
           {
             still_running = 1;
           }
 
-          // Add all pending easy handles
-          if (multi_available && self->doAddSessions())
+          // Add all pending easy handles. Answers for itself when there is no handle, as does
+          // the retry below: neither can hand libcurl a transfer without one.
+          if (self->doAddSessions())
           {
             still_running = 1;
           }
 
           // Check if pending easy handles can be retried
-          if (multi_available && self->doRetrySessions(false))
+          if (self->doRetrySessions(false))
           {
             still_running = 1;
           }
@@ -678,22 +678,20 @@ bool HttpClient::MaybeSpawnBackgroundThread()
               still_running = 1;
             }
 
-            const bool multi_available_now = (nullptr != self->multi_handle_);
-
             // Remove all pending easy handles
-            if (multi_available_now && self->doRemoveSessions())
+            if (self->doRemoveSessions())
             {
               still_running = 1;
             }
 
             // Add all pending easy handles
-            if (multi_available_now && self->doAddSessions())
+            if (self->doAddSessions())
             {
               still_running = 1;
             }
 
             // Check if pending easy handles can be retried
-            if (multi_available_now && self->doRetrySessions(true))
+            if (self->doRetrySessions(true))
             {
               still_running = 1;
             }
@@ -703,8 +701,8 @@ bool HttpClient::MaybeSpawnBackgroundThread()
             // finished, and this thread is the only one that does either, so it stays while it
             // owes one. Shutdown is exempt: there the queues that need a handle cannot drain
             // without one, and staying for them is staying under the join that is waiting here.
-            if (!multi_available_now && !self->is_shutdown_.load(std::memory_order_acquire) &&
-                self->hasActionableWork())
+            if (nullptr == self->multi_handle_ &&
+                !self->is_shutdown_.load(std::memory_order_acquire) && self->hasActionableWork())
             {
               still_running = 1;
             }
@@ -820,6 +818,12 @@ void HttpClient::wakeupBackgroundThread()
 
 bool HttpClient::doAddSessions()
 {
+  if (nullptr == multi_handle_)
+  {
+    // Before the swap below, which would drop the ids it took.
+    return false;
+  }
+
   std::unordered_set<uint64_t> pending_to_add_session_ids;
   {
     std::lock_guard<std::recursive_mutex> session_id_lock_guard{session_ids_m_};
@@ -915,7 +919,15 @@ bool HttpClient::doRemoveSessions()
         curl_slist_free_all(removing_handle.second.headers_chunk);
       }
 
-      curl_multi_remove_handle(multi_handle_, removing_handle.second.easy_handle);
+      // Detaching needs something to detach from. Without a multi handle there is nothing
+      // this could name: the one it would have named was destroyed by curl_multi_cleanup,
+      // which detaches what it still holds, and nothing has been attached since. So the
+      // resource is released rather than kept, which is what resetMultiHandle asks for when
+      // curl_multi_init has just failed on it.
+      if (nullptr != multi_handle_)
+      {
+        curl_multi_remove_handle(multi_handle_, removing_handle.second.easy_handle);
+      }
       curl_easy_cleanup(removing_handle.second.easy_handle);
     }
 
@@ -939,6 +951,11 @@ bool HttpClient::doRemoveSessions()
 #ifdef ENABLE_OTLP_RETRY_PREVIEW
 bool HttpClient::doRetrySessions(bool report_all)
 {
+  if (nullptr == multi_handle_)
+  {
+    return false;
+  }
+
   const auto now = std::chrono::system_clock::now();
   auto has_data  = false;
 
@@ -979,6 +996,26 @@ bool HttpClient::doRetrySessions(bool /* report_all */)
   return false;
 }
 #endif  // ENABLE_OTLP_RETRY_PREVIEW
+
+void HttpClient::ReleaseMultiHandle()
+{
+  if (nullptr == multi_handle_)
+  {
+    // curl_multi_init says the other multi functions cannot be used once it has returned null,
+    // and curl_multi_cleanup is one of them. Reaching here with none is ordinary: the
+    // constructor may have started without one, and a reset that could not build a replacement
+    // leaves none behind.
+    return;
+  }
+
+  const CURLMcode cleanup_result = curl_multi_cleanup(multi_handle_);
+  multi_handle_                  = nullptr;
+  if (CURLM_OK != cleanup_result)
+  {
+    OTEL_INTERNAL_LOG_ERROR("[HTTP Client Curl] curl_multi_cleanup failed with message: "
+                            << curl_multi_strerror(cleanup_result));
+  }
+}
 
 bool HttpClient::hasActionableWork()
 {
@@ -1049,7 +1086,7 @@ bool HttpClient::resetMultiHandle()
 
   // We will modify the multi_handle_, so we need to lock it
   std::lock_guard<std::mutex> lock_guard{multi_handle_m_};
-  curl_multi_cleanup(multi_handle_);
+  ReleaseMultiHandle();
 
   // Create a another multi handle to continue pending sessions. Silent on failure: the caller
   // decides how often a run of failures is worth reporting.

--- a/ext/src/http/client/curl/http_client_curl.cc
+++ b/ext/src/http/client/curl/http_client_curl.cc
@@ -598,26 +598,33 @@ bool HttpClient::MaybeSpawnBackgroundThread()
             }
           } while (true);
 
-          // Abort all pending easy handles
+          // Abort all pending easy handles. This one calls nothing from the multi interface, so
+          // it runs whether or not there is a handle and teardown keeps working without one.
           if (self->doAbortSessions())
           {
             still_running = 1;
           }
 
+          // The three below every call curl_multi_add_handle or curl_multi_remove_handle. Running
+          // them without a handle would take the pending sessions out of the queue that keeps
+          // them safe from the next reset, hand them to a multi function that cannot accept
+          // them, and report the transfer as running.
+          const bool multi_available = (nullptr != self->multi_handle_);
+
           // Remove all pending easy handles
-          if (self->doRemoveSessions())
+          if (multi_available && self->doRemoveSessions())
           {
             still_running = 1;
           }
 
           // Add all pending easy handles
-          if (self->doAddSessions())
+          if (multi_available && self->doAddSessions())
           {
             still_running = 1;
           }
 
           // Check if pending easy handles can be retried
-          if (self->doRetrySessions(false))
+          if (multi_available && self->doRetrySessions(false))
           {
             still_running = 1;
           }
@@ -660,20 +667,22 @@ bool HttpClient::MaybeSpawnBackgroundThread()
               still_running = 1;
             }
 
+            const bool multi_available_now = (nullptr != self->multi_handle_);
+
             // Remove all pending easy handles
-            if (self->doRemoveSessions())
+            if (multi_available_now && self->doRemoveSessions())
             {
               still_running = 1;
             }
 
             // Add all pending easy handles
-            if (self->doAddSessions())
+            if (multi_available_now && self->doAddSessions())
             {
               still_running = 1;
             }
 
             // Check if pending easy handles can be retried
-            if (self->doRetrySessions(true))
+            if (multi_available_now && self->doRetrySessions(true))
             {
               still_running = 1;
             }

--- a/ext/src/http/client/curl/http_client_curl.cc
+++ b/ext/src/http/client/curl/http_client_curl.cc
@@ -286,31 +286,25 @@ static CURLM *initMultiHandle()
 }
 
 HttpClient::HttpClient()
-    : multi_handle_(nullptr),
+    : curl_global_initializer_(HttpCurlGlobalInitializer::GetInstance()),
+      multi_handle_(initMultiHandle()),
       next_session_id_{0},
       max_sessions_per_connection_{8},
       background_thread_instrumentation_(nullptr),
       scheduled_delay_milliseconds_{std::chrono::milliseconds(256)},
-      background_thread_wait_for_{std::chrono::minutes{1}},
-      curl_global_initializer_(HttpCurlGlobalInitializer::GetInstance())
-{
-  // Not in the initialiser list: curl_global_initializer_ is declared later and has to run first.
-  multi_handle_ = initMultiHandle();
-}
+      background_thread_wait_for_{std::chrono::minutes{1}}
+{}
 
 HttpClient::HttpClient(
     const std::shared_ptr<sdk::common::ThreadInstrumentation> &thread_instrumentation)
-    : multi_handle_(nullptr),
+    : curl_global_initializer_(HttpCurlGlobalInitializer::GetInstance()),
+      multi_handle_(initMultiHandle()),
       next_session_id_{0},
       max_sessions_per_connection_{8},
       background_thread_instrumentation_(thread_instrumentation),
       scheduled_delay_milliseconds_{std::chrono::milliseconds(256)},
-      background_thread_wait_for_{std::chrono::minutes{1}},
-      curl_global_initializer_(HttpCurlGlobalInitializer::GetInstance())
-{
-  // Not in the initialiser list: curl_global_initializer_ is declared later and has to run first.
-  multi_handle_ = initMultiHandle();
-}
+      background_thread_wait_for_{std::chrono::minutes{1}}
+{}
 
 HttpClient::~HttpClient()
 {

--- a/ext/src/http/client/curl/http_client_curl.cc
+++ b/ext/src/http/client/curl/http_client_curl.cc
@@ -676,14 +676,6 @@ bool HttpClient::MaybeSpawnBackgroundThread()
 
             const bool multi_available_now = (nullptr != self->multi_handle_);
 
-            // Without a handle the three phases below are skipped, and they are the only thing
-            // that sets still_running, so retiring here would strand whatever they did not get
-            // to. Nothing starts this thread again until another request arrives.
-            if (!multi_available_now && self->hasPendingWork())
-            {
-              still_running = 1;
-            }
-
             // Remove all pending easy handles
             if (multi_available_now && self->doRemoveSessions())
             {
@@ -805,14 +797,6 @@ void HttpClient::wakeupBackgroundThread()
     curl_multi_wakeup(multi_handle_);
   }
 #endif
-}
-
-bool HttpClient::hasPendingWork()
-{
-  std::lock_guard<std::recursive_mutex> session_id_lock_guard{session_ids_m_};
-  return !pending_to_add_session_ids_.empty() || !pending_to_abort_sessions_.empty() ||
-         !pending_to_remove_session_handles_.empty() || !pending_to_remove_sessions_.empty() ||
-         !pending_to_retry_sessions_.empty();
 }
 
 bool HttpClient::doAddSessions()

--- a/ext/src/http/client/curl/http_client_curl.cc
+++ b/ext/src/http/client/curl/http_client_curl.cc
@@ -270,14 +270,16 @@ void Session::FinishOperation()
   }
 }
 
-// A null multi handle makes every curl_multi_add_handle report CURLM_BAD_HANDLE, so a client
-// built on one accepts sessions and never sends any of them. Say so rather than fail quietly.
+// Reported once, where it happens. The IO loop does its own reporting, because sharing this one
+// would repeat the same line on every pass for as long as the handle stays missing.
 static CURLM *initMultiHandle()
 {
   CURLM *handle = curl_multi_init();
   if (nullptr == handle)
   {
-    OTEL_INTERNAL_LOG_ERROR("[HTTP Client Curl] curl_multi_init failed, this client cannot send");
+    OTEL_INTERNAL_LOG_ERROR(
+        "[HTTP Client Curl] curl_multi_init failed, requests cannot be processed until it "
+        "succeeds");
   }
   return handle;
 }
@@ -470,14 +472,21 @@ bool HttpClient::MaybeSpawnBackgroundThread()
         }
 #endif /* ENABLE_THREAD_INSTRUMENTATION_PREVIEW */
 
-        auto still_running           = 1;
-        auto last_free_job_timepoint = std::chrono::system_clock::now();
-        auto need_wait_more          = false;
+        auto still_running                 = 1;
+        auto last_free_job_timepoint       = std::chrono::system_clock::now();
+        auto need_wait_more                = false;
+        bool missing_multi_handle_reported = false;
         while (true)
         {
           CURLMsg *msg = nullptr;
           int queued   = 0;
-          CURLMcode mc = curl_multi_perform(self->multi_handle_, &still_running);
+          // curl_multi_init says the other multi functions cannot be used once it has returned
+          // null, so a missing handle is answered here rather than passed to libcurl.
+          CURLMcode mc = CURLM_BAD_HANDLE;
+          if (nullptr != self->multi_handle_)
+          {
+            mc = curl_multi_perform(self->multi_handle_, &still_running);
+          }
           // According to https://curl.se/libcurl/c/curl_multi_perform.html, when mc is not OK, we
           // can not curl_multi_perform it again
           if (mc != CURLM_OK)
@@ -486,7 +495,24 @@ bool HttpClient::MaybeSpawnBackgroundThread()
             // starts at one, so without this the loop keeps reporting work it does not have,
             // never reaches the shutdown check below, and the thread cannot be joined.
             still_running = 0;
-            self->resetMultiHandle();
+            if (self->resetMultiHandle())
+            {
+              missing_multi_handle_reported = false;
+            }
+            else if (!self->is_shutdown_.load(std::memory_order_acquire))
+            {
+              // Nothing can run without a handle. Retrying at once pegs a core and repeats one
+              // error for the whole idle window, so report the run of failures once and wait as
+              // long as a poll would have. Shutdown skips the wait so teardown stays prompt.
+              if (!missing_multi_handle_reported)
+              {
+                OTEL_INTERNAL_LOG_ERROR(
+                    "[HTTP Client Curl] no multi handle, requests cannot be processed until "
+                    "curl_multi_init succeeds");
+                missing_multi_handle_reported = true;
+              }
+              std::this_thread::sleep_for(self->scheduled_delay_milliseconds_);
+            }
           }
           else if (still_running || need_wait_more)
           {
@@ -897,7 +923,7 @@ bool HttpClient::doRetrySessions(bool /* report_all */)
 }
 #endif  // ENABLE_OTLP_RETRY_PREVIEW
 
-void HttpClient::resetMultiHandle()
+bool HttpClient::resetMultiHandle()
 {
   std::list<std::shared_ptr<Session>> sessions;
   {
@@ -928,8 +954,10 @@ void HttpClient::resetMultiHandle()
   std::lock_guard<std::mutex> lock_guard{multi_handle_m_};
   curl_multi_cleanup(multi_handle_);
 
-  // Create a another multi handle to continue pending sessions
-  multi_handle_ = initMultiHandle();
+  // Create a another multi handle to continue pending sessions. Silent on failure: the caller
+  // decides how often a run of failures is worth reporting.
+  multi_handle_ = curl_multi_init();
+  return nullptr != multi_handle_;
 }
 
 }  // namespace curl

--- a/ext/src/http/client/curl/http_client_curl.cc
+++ b/ext/src/http/client/curl/http_client_curl.cc
@@ -676,6 +676,14 @@ bool HttpClient::MaybeSpawnBackgroundThread()
 
             const bool multi_available_now = (nullptr != self->multi_handle_);
 
+            // Without a handle the three phases below are skipped, and they are the only thing
+            // that sets still_running, so retiring here would strand whatever they did not get
+            // to. Nothing starts this thread again until another request arrives.
+            if (!multi_available_now && self->hasPendingWork())
+            {
+              still_running = 1;
+            }
+
             // Remove all pending easy handles
             if (multi_available_now && self->doRemoveSessions())
             {
@@ -797,6 +805,14 @@ void HttpClient::wakeupBackgroundThread()
     curl_multi_wakeup(multi_handle_);
   }
 #endif
+}
+
+bool HttpClient::hasPendingWork()
+{
+  std::lock_guard<std::recursive_mutex> session_id_lock_guard{session_ids_m_};
+  return !pending_to_add_session_ids_.empty() || !pending_to_abort_sessions_.empty() ||
+         !pending_to_remove_session_handles_.empty() || !pending_to_remove_sessions_.empty() ||
+         !pending_to_retry_sessions_.empty();
 }
 
 bool HttpClient::doAddSessions()

--- a/ext/src/http/client/curl/http_operation_curl.cc
+++ b/ext/src/http/client/curl/http_operation_curl.cc
@@ -455,8 +455,8 @@ HttpOperation::HttpOperation(opentelemetry::ext::http::client::Method method,
     last_curl_result_ = CURLE_FAILED_INIT;
     // Refuses Send() and SendAsync(), which would otherwise drive a null handle into libcurl.
     construction_result_ = CURLE_FAILED_INIT;
-    // Terminal already, and reported by the caller that sees SendAsync refuse, the same way the
-    // header list failure below is. Dispatching here as well told the handler twice.
+    // Terminal already, and reported once by the caller that sees SendAsync refuse, the same
+    // way the header list failure below is. Nothing is dispatched from here.
     session_state_ = opentelemetry::ext::http::client::SessionState::CreateFailed;
     return;
   }

--- a/ext/src/http/client/curl/http_operation_curl.cc
+++ b/ext/src/http/client/curl/http_operation_curl.cc
@@ -453,11 +453,11 @@ HttpOperation::HttpOperation(opentelemetry::ext::http::client::Method method,
   if (!curl_resource_.easy_handle)
   {
     last_curl_result_ = CURLE_FAILED_INIT;
-    // Refuses Send() and SendAsync(), which would otherwise drive a null handle into libcurl and
-    // add a connect failure to the create failure this already reports.
+    // Refuses Send() and SendAsync(), which would otherwise drive a null handle into libcurl.
     construction_result_ = CURLE_FAILED_INIT;
-    DispatchEvent(opentelemetry::ext::http::client::SessionState::CreateFailed,
-                  curl_easy_strerror(last_curl_result_));
+    // Terminal already, and reported by the caller that sees SendAsync refuse, the same way the
+    // header list failure below is. Dispatching here as well told the handler twice.
+    session_state_ = opentelemetry::ext::http::client::SessionState::CreateFailed;
     return;
   }
 

--- a/ext/src/http/client/curl/http_operation_curl.cc
+++ b/ext/src/http/client/curl/http_operation_curl.cc
@@ -453,6 +453,9 @@ HttpOperation::HttpOperation(opentelemetry::ext::http::client::Method method,
   if (!curl_resource_.easy_handle)
   {
     last_curl_result_ = CURLE_FAILED_INIT;
+    // Refuses Send() and SendAsync(), which would otherwise drive a null handle into libcurl and
+    // add a connect failure to the create failure this already reports.
+    construction_result_ = CURLE_FAILED_INIT;
     DispatchEvent(opentelemetry::ext::http::client::SessionState::CreateFailed,
                   curl_easy_strerror(last_curl_result_));
     return;

--- a/ext/src/http/client/curl/http_operation_curl.cc
+++ b/ext/src/http/client/curl/http_operation_curl.cc
@@ -464,8 +464,25 @@ HttpOperation::HttpOperation(opentelemetry::ext::http::client::Method method,
     for (auto &kv : this->request_headers_)
     {
       const auto header = std::string(kv.first).append(": ").append(kv.second);
-      curl_resource_.headers_chunk =
-          curl_slist_append(curl_resource_.headers_chunk, header.c_str());
+
+      // Into a temporary first. curl_slist_append returns null without freeing the list it was
+      // given, so assigning the result straight back would drop the only pointer to everything
+      // appended so far, and Setup() would then send the request with none of these headers
+      // rather than not send it.
+      curl_slist *appended = curl_slist_append(curl_resource_.headers_chunk, header.c_str());
+      if (nullptr == appended)
+      {
+        curl_slist_free_all(curl_resource_.headers_chunk);
+        curl_resource_.headers_chunk = nullptr;
+        last_curl_result_            = CURLE_OUT_OF_MEMORY;
+        construction_result_         = CURLE_OUT_OF_MEMORY;
+        // Terminal already, so Cleanup() does not later announce a cancel for an operation that
+        // never started, to a handler the caller may no longer be holding.
+        session_state_ = opentelemetry::ext::http::client::SessionState::CreateFailed;
+        return;
+      }
+
+      curl_resource_.headers_chunk = appended;
     }
   }
 
@@ -1394,6 +1411,12 @@ CURLcode HttpOperation::Setup()
 
 CURLcode HttpOperation::Send()
 {
+  if (construction_result_ != CURLE_OK)
+  {
+    last_curl_result_ = construction_result_;
+    return construction_result_;
+  }
+
   // If it is async sending, just return error
   if (async_data_ && async_data_->is_promise_running.load(std::memory_order_acquire))
   {
@@ -1424,6 +1447,12 @@ CURLcode HttpOperation::Send()
 
 CURLcode HttpOperation::SendAsync(Session *session, std::function<void(HttpOperation &)> callback)
 {
+  if (construction_result_ != CURLE_OK)
+  {
+    last_curl_result_ = construction_result_;
+    return construction_result_;
+  }
+
   if (nullptr == session)
   {
     return CURLE_FAILED_INIT;

--- a/ext/test/http/curl_http_test.cc
+++ b/ext/test/http/curl_http_test.cc
@@ -16,11 +16,9 @@
 #include <atomic>
 #include <chrono>
 #include <condition_variable>
-#include <cstdio>
 #include <cstdlib>
 #include <cstring>
 #include <map>
-#include <memory>
 #include <mutex>
 #include <sstream>
 #include <string>

--- a/ext/test/http/curl_http_test.cc
+++ b/ext/test/http/curl_http_test.cc
@@ -23,6 +23,7 @@
 #include <sstream>
 #include <string>
 #include <thread>
+#include <unordered_map>
 #include <utility>
 #include <vector>
 

--- a/ext/test/http/curl_http_test.cc
+++ b/ext/test/http/curl_http_test.cc
@@ -62,6 +62,13 @@ public:
 
   static bool RemoveSessions(HttpClient &client) { return client.doRemoveSessions(); }
 
+#ifdef ENABLE_OTLP_RETRY_PREVIEW
+  static std::size_t RetryQueueSize(const HttpClient &client)
+  {
+    return client.pending_to_retry_sessions_.size();
+  }
+#endif  // ENABLE_OTLP_RETRY_PREVIEW
+
   static CURLM *ExchangeMultiHandle(HttpClient &client, CURLM *replacement)
   {
     CURLM *previous      = client.multi_handle_;
@@ -1596,6 +1603,54 @@ TEST_F(BasicCurlHttpTests, GzipIncompressibleData)
 // queued while the handle is missing leaves the pending queue for a multi function that cannot
 // take it, and the next reset cancels it, so the caller is told a request was cancelled that
 // nothing cancelled.
+#ifdef ENABLE_OTLP_RETRY_PREVIEW
+TEST_F(BasicCurlHttpTests, ACancelledRetryDoesNotHoldTheClientOpen)
+{
+  received_requests_.clear();
+
+  const auto started = std::chrono::steady_clock::now();
+  {
+    auto client = std::make_shared<http_client::curl::HttpCurlClientFactory>()->Create();
+    ASSERT_TRUE(client != nullptr);
+    auto *concrete = static_cast<http_client::curl::HttpClient *>(client.get());
+
+    auto session = client->CreateSession("http://127.0.0.1:19000");
+    auto request = session->CreateRequest();
+    request->SetUri("retry/");
+    request->SetMethod(http_client::Method::Post);
+
+    // Long enough that waiting for it would be unmistakable, and long enough that it cannot
+    // come round on its own inside the bound below.
+    request->SetRetryPolicy(
+        {4, std::chrono::duration<float>{8.0f}, std::chrono::duration<float>{16.0f}, 2.0f});
+
+    auto handler = std::make_shared<MultiHandleOutcomeHandler>();
+    session->SendRequest(handler);
+
+    // The server answers this route with something retryable, so the session goes into the
+    // retry queue with a time on it that has not come.
+    for (int i = 0;
+         i < 300 && 0 == http_client::curl::HttpClientTestPeer::RetryQueueSize(*concrete); ++i)
+    {
+      std::this_thread::sleep_for(std::chrono::milliseconds(10));
+    }
+    ASSERT_GE(http_client::curl::HttpClientTestPeer::RetryQueueSize(*concrete), 1u)
+        << "the request was never queued for retry, so nothing was tested";
+
+    // Cancelling takes the operation apart and hands its easy handle back, and the entry left
+    // behind names an operation that is not going to be retried by anybody.
+    session->CancelSession();
+    session->FinishSession();
+  }
+  const auto elapsed = std::chrono::duration_cast<std::chrono::milliseconds>(
+      std::chrono::steady_clock::now() - started);
+
+  EXPECT_LT(elapsed.count(), 4000)
+      << "destroying the client took " << elapsed.count()
+      << " ms, which is it waiting out a retry for an operation that had already finished";
+}
+#endif  // ENABLE_OTLP_RETRY_PREVIEW
+
 TEST_F(BasicCurlHttpTests, AQueuedHandleIsReleasedWithTheClientThatQueuedIt)
 {
   auto client = std::make_shared<http_client::curl::HttpClient>();

--- a/ext/test/http/curl_http_test.cc
+++ b/ext/test/http/curl_http_test.cc
@@ -327,24 +327,96 @@ struct FailCurlCalloc
   FailCurlCalloc &operator=(FailCurlCalloc &&)      = delete;
 };
 
+// The failure that reaches every thread, and the exemption for the one that armed it, since
+// they are armed together and have to be put away together. A guard because these two are
+// process wide and there are fatal assertions between arming and disarming: one of those
+// returning early would otherwise leave every later case in the binary allocating through a
+// calloc that refuses, on every thread, which turns one mismatched injection into a matrix of
+// timeouts rather than one red case. The cases below disarm on their way through, and this is
+// what happens when they do not get that far.
+struct FailCurlCallocEverywhere
+{
+  FailCurlCallocEverywhere()
+  {
+    g_curl_calloc_failures.store(0, std::memory_order_relaxed);
+    g_fail_curl_calloc_everywhere.store(true, std::memory_order_relaxed);
+  }
+
+  ~FailCurlCallocEverywhere() { Disarm(); }
+
+  // curl_easy_init allocates the same way, so a case that has to build a request exempts the
+  // thread it builds it on. The IO thread is not exempt, which is the point.
+  void ExemptThisThread() { g_curl_calloc_exempt = true; }
+
+  void Disarm()
+  {
+    g_fail_curl_calloc_everywhere.store(false, std::memory_order_relaxed);
+    g_curl_calloc_exempt = false;
+  }
+
+  FailCurlCallocEverywhere(const FailCurlCallocEverywhere &)            = delete;
+  FailCurlCallocEverywhere(FailCurlCallocEverywhere &&)                 = delete;
+  FailCurlCallocEverywhere &operator=(const FailCurlCallocEverywhere &) = delete;
+  FailCurlCallocEverywhere &operator=(FailCurlCallocEverywhere &&)      = delete;
+};
+
 // Counts terminal outcomes without caring which one, since a client whose multi handle could
 // not be created may still recover and answer, and the case below is about the caller being
 // told either way rather than about which answer it gets.
-// Counts internal log lines, so a case can hold that a run of failures is reported a bounded
-// number of times rather than once per pass of the IO loop.
+// Counts the internal log lines that say a particular thing, so a case can hold that a run of
+// failures is reported a bounded number of times rather than once per pass of the IO loop. Only
+// the ones it asked for: anything else the binary writes while this is installed would move the
+// bound without meaning anything.
 class CountingLogHandler : public opentelemetry::sdk::common::internal_log::LogHandler
 {
 public:
+  explicit CountingLogHandler(std::string wanted) : wanted_{std::move(wanted)} {}
+
   void Handle(opentelemetry::sdk::common::internal_log::LogLevel /* level */,
               const char * /* file */,
               int /* line */,
-              const char * /* msg */,
+              const char *msg,
               const opentelemetry::sdk::common::AttributeMap & /* attributes */) noexcept override
   {
-    count_.fetch_add(1, std::memory_order_relaxed);
+    if (nullptr != msg && std::string::npos != std::string{msg}.find(wanted_))
+    {
+      count_.fetch_add(1, std::memory_order_relaxed);
+    }
   }
 
   std::atomic<int> count_{0};
+
+private:
+  const std::string wanted_;
+};
+
+// GlobalLogHandler reads and writes the handler through a plain shared pointer with nothing
+// synchronizing it, and the documentation asks for it to be set once at startup for that
+// reason. So a case that captures installs it before anything that logs exists and puts it back
+// after all of it has gone. A guard rather than two calls: declared before the client, it is
+// destroyed after it, and an assertion that returns early still puts it back.
+class ScopedLogHandler
+{
+public:
+  explicit ScopedLogHandler(
+      const nostd::shared_ptr<opentelemetry::sdk::common::internal_log::LogHandler> &handler)
+      : previous_{opentelemetry::sdk::common::internal_log::GlobalLogHandler::GetLogHandler()}
+  {
+    opentelemetry::sdk::common::internal_log::GlobalLogHandler::SetLogHandler(handler);
+  }
+
+  ~ScopedLogHandler()
+  {
+    opentelemetry::sdk::common::internal_log::GlobalLogHandler::SetLogHandler(previous_);
+  }
+
+  ScopedLogHandler(const ScopedLogHandler &)            = delete;
+  ScopedLogHandler(ScopedLogHandler &&)                 = delete;
+  ScopedLogHandler &operator=(const ScopedLogHandler &) = delete;
+  ScopedLogHandler &operator=(ScopedLogHandler &&)      = delete;
+
+private:
+  const nostd::shared_ptr<opentelemetry::sdk::common::internal_log::LogHandler> previous_;
 };
 
 class MultiHandleOutcomeHandler : public http_client::EventHandler
@@ -490,6 +562,18 @@ public:
     g_curl_hooks_installed =
         (CURLE_OK == curl_global_init_mem(CURL_GLOBAL_ALL, CurlTestMalloc, CurlTestFree,
                                           CurlTestRealloc, CurlTestStrdup, CurlTestCalloc));
+  }
+
+  // libcurl counts initializations and asks for a cleanup for each one. The line above is this
+  // suite's, and every client takes one of its own through HttpCurlGlobalInitializer, so
+  // without this the count never reaches zero: the allocator callbacks stay installed into
+  // static teardown, and what libcurl still holds is reported as leaked.
+  static void TearDownTestSuite()
+  {
+    if (g_curl_hooks_installed)
+    {
+      curl_global_cleanup();
+    }
   }
 
 protected:
@@ -1049,9 +1133,8 @@ TEST_F(BasicCurlHttpTests, AFailedMultiHandleAllocationIsReported)
   }
 
   auto *capture = new CapturingLogHandler();
-  auto previous = opentelemetry::sdk::common::internal_log::GlobalLogHandler::GetLogHandler();
-  opentelemetry::sdk::common::internal_log::GlobalLogHandler::SetLogHandler(
-      nostd::shared_ptr<opentelemetry::sdk::common::internal_log::LogHandler>(capture));
+  ScopedLogHandler installed{
+      nostd::shared_ptr<opentelemetry::sdk::common::internal_log::LogHandler>(capture)};
 
   {
     FailCurlCalloc fail;
@@ -1061,7 +1144,6 @@ TEST_F(BasicCurlHttpTests, AFailedMultiHandleAllocationIsReported)
   }
 
   const std::string text = capture->Text();
-  opentelemetry::sdk::common::internal_log::GlobalLogHandler::SetLogHandler(previous);
 
   EXPECT_NE(std::string::npos, text.find("curl_multi_init failed"))
       << "a multi handle that could not be created was not reported, captured: " << text;
@@ -1121,9 +1203,8 @@ TEST_F(BasicCurlHttpTests, AFailedMultiHandleIsReportedForAnInstrumentedClient)
   }
 
   auto *capture = new CapturingLogHandler();
-  auto previous = opentelemetry::sdk::common::internal_log::GlobalLogHandler::GetLogHandler();
-  opentelemetry::sdk::common::internal_log::GlobalLogHandler::SetLogHandler(
-      nostd::shared_ptr<opentelemetry::sdk::common::internal_log::LogHandler>(capture));
+  ScopedLogHandler installed{
+      nostd::shared_ptr<opentelemetry::sdk::common::internal_log::LogHandler>(capture)};
 
   {
     FailCurlCalloc fail;
@@ -1134,7 +1215,6 @@ TEST_F(BasicCurlHttpTests, AFailedMultiHandleIsReportedForAnInstrumentedClient)
   }
 
   const std::string text = capture->Text();
-  opentelemetry::sdk::common::internal_log::GlobalLogHandler::SetLogHandler(previous);
 
   EXPECT_NE(std::string::npos, text.find("curl_multi_init failed"))
       << "the instrumented constructor did not report a multi handle it could not create, "
@@ -1701,15 +1781,14 @@ TEST_F(BasicCurlHttpTests, AQueuedRequestSurvivesAMissingMultiHandle)
   // Built without a handle, for the reason given above: a case that took one away would be
   // using it from two threads at once, and could not then say whether what it saw was the
   // client's behaviour or its own.
-  g_curl_calloc_failures.store(0, std::memory_order_relaxed);
-  g_fail_curl_calloc_everywhere.store(true, std::memory_order_relaxed);
+  FailCurlCallocEverywhere failing;
   auto client = std::make_shared<http_client::curl::HttpCurlClientFactory>()->Create();
   ASSERT_TRUE(client != nullptr);
   auto *concrete = static_cast<http_client::curl::HttpClient *>(client.get());
   ASSERT_GE(g_curl_calloc_failures.load(std::memory_order_relaxed), 1)
       << "the client was built with a multi handle, so nothing was tested";
 
-  g_curl_calloc_exempt = true;
+  failing.ExemptThisThread();
 
   // The idle grace is a minute by default, but only from libcurl 7.68: the line that gives it
   // that value is behind a version check, and older libcurl leaves it at zero, where the IO
@@ -1722,6 +1801,10 @@ TEST_F(BasicCurlHttpTests, AQueuedRequestSurvivesAMissingMultiHandle)
   auto request = session->CreateRequest();
   request->SetUri("get/");
   auto handler = std::make_shared<MultiHandleOutcomeHandler>();
+
+  // Back to zero after the constructor's own attempt and before there is an IO thread to make
+  // one, and this thread is exempt from here on, so what is counted below was refused to that
+  // thread and to nothing else. Without this the wait would be satisfied by the constructor.
   g_curl_calloc_failures.store(0, std::memory_order_relaxed);
   session->SendRequest(handler);
 
@@ -1735,8 +1818,7 @@ TEST_F(BasicCurlHttpTests, AQueuedRequestSurvivesAMissingMultiHandle)
   ASSERT_GE(g_curl_calloc_failures.load(std::memory_order_relaxed), 1)
       << "the IO thread never ran without a handle, so nothing was tested";
 
-  g_fail_curl_calloc_everywhere.store(false, std::memory_order_relaxed);
-  g_curl_calloc_exempt = false;
+  failing.Disarm();
 
   for (int i = 0; i < 300 && 0 == handler->terminal_.load(std::memory_order_acquire); ++i)
   {
@@ -1769,10 +1851,11 @@ TEST_F(BasicCurlHttpTests, AFailedEasyHandleIsReportedOnce)
   request->SetUri("get/");
   auto handler = std::make_shared<MultiHandleOutcomeHandler>();
 
-  // Armed here so it reaches the curl_easy_init inside SendRequest and nothing before it.
-  g_fail_curl_calloc_everywhere.store(true, std::memory_order_relaxed);
-  session->SendRequest(handler);
-  g_fail_curl_calloc_everywhere.store(false, std::memory_order_relaxed);
+  {
+    // Armed here so it reaches the curl_easy_init inside SendRequest and nothing before it.
+    FailCurlCallocEverywhere failing;
+    session->SendRequest(handler);
+  }
 
   EXPECT_EQ(1, handler->create_failed_.load(std::memory_order_acquire))
       << "one failed handle was not described exactly once";
@@ -1793,49 +1876,54 @@ TEST_F(BasicCurlHttpTests, APersistentMultiHandleFailureDoesNotSpin)
   ASSERT_TRUE(g_curl_hooks_installed);
   received_requests_.clear();
 
-  // The client is built without a multi handle rather than having one taken away. Nothing here
-  // touches a handle another thread is using, which libcurl does not allow and which would
-  // leave any result this case reported open to being an artefact of the injection. What fails
-  // is curl_multi_init, on whichever thread calls it, and after the constructor that is the IO
-  // thread every time.
-  g_curl_calloc_failures.store(0, std::memory_order_relaxed);
-  g_fail_curl_calloc_everywhere.store(true, std::memory_order_relaxed);
-  auto client = std::make_shared<http_client::curl::HttpCurlClientFactory>()->Create();
-  ASSERT_TRUE(client != nullptr);
-  ASSERT_GE(g_curl_calloc_failures.load(std::memory_order_relaxed), 1)
-      << "the client was built with a multi handle, so nothing was tested";
-
-  // curl_easy_init allocates with calloc too, and the request below needs one. The IO thread is
-  // not exempt, so its curl_multi_init goes on failing.
-  g_curl_calloc_exempt = true;
-
-  // After the constructor, so the report it makes is not counted as one of the loop's.
-  auto *capture = new CountingLogHandler();
-  auto previous = opentelemetry::sdk::common::internal_log::GlobalLogHandler::GetLogHandler();
-  opentelemetry::sdk::common::internal_log::GlobalLogHandler::SetLogHandler(
-      nostd::shared_ptr<opentelemetry::sdk::common::internal_log::LogHandler>(capture));
+  // First, and outside everything below, so that it is in place before anything that logs
+  // exists and goes back only once all of it has been destroyed. Counting the line the loop
+  // writes rather than every line, which also leaves out the one the constructor writes about
+  // the same failure.
+  auto *capture = new CountingLogHandler("no multi handle");
+  ScopedLogHandler installed{
+      nostd::shared_ptr<opentelemetry::sdk::common::internal_log::LogHandler>(capture)};
 
   int attempts = 0;
   {
+    // The client is built without a multi handle rather than having one taken away. Nothing
+    // here touches a handle another thread is using, which libcurl does not allow and which
+    // would leave any result this case reported open to being an artefact of the injection.
+    // What fails is curl_multi_init, on whichever thread calls it, and after the constructor
+    // that is the IO thread every time.
+    FailCurlCallocEverywhere failing;
+    auto client = std::make_shared<http_client::curl::HttpCurlClientFactory>()->Create();
+    ASSERT_TRUE(client != nullptr);
+    ASSERT_GE(g_curl_calloc_failures.load(std::memory_order_relaxed), 1)
+        << "the client was built with a multi handle, so nothing was tested";
+
+    failing.ExemptThisThread();
+
     // A request is what keeps the IO thread there. With nothing owed to anybody it retires,
     // which is the other half of this and is held by the case below.
     auto session = client->CreateSession("http://127.0.0.1:19000");
     auto request = session->CreateRequest();
     request->SetUri("get/");
     auto handler = std::make_shared<MultiHandleOutcomeHandler>();
+
+    // Back to zero after the constructor's own attempt and before there is an IO thread to
+    // make one, and this thread is exempt from here on, so what is counted below was refused
+    // to that thread and to nothing else. Without this the count would be the constructor's
+    // and would say nothing about whether the loop ever tried.
     g_curl_calloc_failures.store(0, std::memory_order_relaxed);
     session->SendRequest(handler);
 
     std::this_thread::sleep_for(std::chrono::seconds(1));
     attempts = g_curl_calloc_failures.load(std::memory_order_relaxed);
 
-    g_fail_curl_calloc_everywhere.store(false, std::memory_order_relaxed);
-    g_curl_calloc_exempt = false;
+    failing.Disarm();
     session->CancelSession();
     session->FinishSession();
+    client->FinishAllSessions();
   }
+
+  // Read once the client, and the thread that was writing those lines, have gone.
   const int log_lines = capture->count_.load(std::memory_order_relaxed);
-  opentelemetry::sdk::common::internal_log::GlobalLogHandler::SetLogHandler(previous);
 
   // Counting what the allocator refused says how often the IO thread tried, which is what a spin
   // is, and says it the same way on every platform. The lower bounds matter as much as the upper
@@ -1845,8 +1933,6 @@ TEST_F(BasicCurlHttpTests, APersistentMultiHandleFailureDoesNotSpin)
                           << " times in a second, which is a spin rather than a wait";
   EXPECT_GE(log_lines, 1) << "the failure was never reported";
   EXPECT_LE(log_lines, 8) << "the same failure was reported " << log_lines << " times";
-
-  client->FinishAllSessions();
 }
 
 }  // namespace

--- a/ext/test/http/curl_http_test.cc
+++ b/ext/test/http/curl_http_test.cc
@@ -1800,6 +1800,56 @@ TEST_F(BasicCurlHttpTests, GzipIncompressibleData)
 // take it, and the next reset cancels it, so the caller is told a request was cancelled that
 // nothing cancelled.
 #ifdef ENABLE_OTLP_RETRY_PREVIEW
+// The other half of the case above, and the one an exporter actually does: nothing cancels the
+// request, the client is simply destroyed. The entry left in the retry queue names an operation
+// that still holds a promise and an easy handle, so somebody has to be the one to finish it and
+// release them, and after the client has gone there is nobody.
+TEST_F(BasicCurlHttpTests, AClientDestroyedWithAPendingRetryDoesNotWaitForIt)
+{
+  received_requests_.clear();
+
+  // Outside the block on purpose. The terminal event for this one is dispatched from the
+  // client's destructor, so the handler has to outlive the client rather than the other way
+  // round.
+  auto handler = std::make_shared<MultiHandleOutcomeHandler>();
+
+  const auto started = std::chrono::steady_clock::now();
+  {
+    auto client = std::make_shared<http_client::curl::HttpCurlClientFactory>()->Create();
+    ASSERT_TRUE(client != nullptr);
+    auto *concrete = static_cast<http_client::curl::HttpClient *>(client.get());
+
+    auto session = client->CreateSession("http://127.0.0.1:19000");
+    auto request = session->CreateRequest();
+    request->SetUri("retry/");
+    request->SetMethod(http_client::Method::Post);
+
+    // Long enough that waiting for it would be unmistakable inside the bound below.
+    request->SetRetryPolicy(
+        {4, std::chrono::duration<float>{8.0f}, std::chrono::duration<float>{16.0f}, 2.0f});
+
+    session->SendRequest(handler);
+
+    for (int i = 0;
+         i < 300 && 0 == http_client::curl::HttpClientTestPeer::RetryQueueSize(*concrete); ++i)
+    {
+      std::this_thread::sleep_for(std::chrono::milliseconds(10));
+    }
+    ASSERT_GE(http_client::curl::HttpClientTestPeer::RetryQueueSize(*concrete), 1u)
+        << "the request was never queued for retry, so nothing was tested";
+  }
+  const auto elapsed = std::chrono::duration_cast<std::chrono::milliseconds>(
+      std::chrono::steady_clock::now() - started);
+
+  EXPECT_LT(elapsed.count(), 4000) << "destroying the client took " << elapsed.count()
+                                   << " ms, which is it waiting out a retry nobody is going to run";
+  EXPECT_GE(handler->terminal_.load(std::memory_order_acquire), 1)
+      << "the request was neither retried nor finished";
+  // LeakSanitizer is what says the easy handle and the header list went with it.
+}
+#endif  // ENABLE_OTLP_RETRY_PREVIEW
+
+#ifdef ENABLE_OTLP_RETRY_PREVIEW
 TEST_F(BasicCurlHttpTests, ACancelledRetryDoesNotHoldTheClientOpen)
 {
   received_requests_.clear();

--- a/ext/test/http/curl_http_test.cc
+++ b/ext/test/http/curl_http_test.cc
@@ -1671,8 +1671,10 @@ TEST_F(BasicCurlHttpTests, AFailedEasyHandleIsReportedOnce)
   session->SendRequest(handler);
   g_fail_curl_calloc_everywhere.store(false, std::memory_order_relaxed);
 
-  EXPECT_GE(handler->create_failed_.load(std::memory_order_acquire), 1)
-      << "the caller was never told the handle could not be created";
+  EXPECT_EQ(1, handler->create_failed_.load(std::memory_order_acquire))
+      << "one failed handle was not described exactly once";
+  EXPECT_EQ(1, handler->terminal_.load(std::memory_order_acquire))
+      << "one request produced more than one terminal outcome";
   EXPECT_EQ(0, handler->connect_failed_.load(std::memory_order_acquire))
       << "a request with no easy handle still reported a connect failure";
   EXPECT_EQ(0, handler->responses_.load(std::memory_order_acquire));

--- a/ext/test/http/curl_http_test.cc
+++ b/ext/test/http/curl_http_test.cc
@@ -1559,10 +1559,9 @@ TEST_F(BasicCurlHttpTests, GzipIncompressibleData)
 }
 #endif  // ENABLE_OTLP_COMPRESSION_PREVIEW
 
-// A client whose multi handle can never be created has nothing to run, and used to say so as
-// fast as the CPU allowed: measured at a full core and 1,168,126 error lines over three seconds
-// with the client alive. The IO loop reports a run of failures once and waits between attempts
-// now, and this holds both.
+// A client whose multi handle can never be created has nothing to run. The IO loop reports a run
+// of failures once and waits between attempts, so a client left alive in that state costs neither
+// a core nor a log line per pass, and this holds both.
 TEST_F(BasicCurlHttpTests, APersistentMultiHandleFailureDoesNotSpin)
 {
   ASSERT_TRUE(g_curl_hooks_installed);

--- a/ext/test/http/curl_http_test.cc
+++ b/ext/test/http/curl_http_test.cc
@@ -1,11 +1,11 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
+#include <curl/curl.h>
 #include <curl/curlver.h>
 #include "gtest/gtest.h"
 
 #ifdef ENABLE_OTLP_RETRY_PREVIEW
-#  include <curl/curl.h>
 #  include "gmock/gmock.h"
 #endif  // ENABLE_OTLP_RETRY_PREVIEW
 
@@ -221,10 +221,19 @@ static thread_local bool g_fail_curl_calloc = false;
 
 // NOLINTBEGIN(cppcoreguidelines-no-malloc,hicpp-no-malloc): these are the allocator libcurl
 // is given, so reaching for the C allocation functions is the point of them.
+// A curl_slist node is two pointers, and a curl easy handle is thousands of bytes on every
+// libcurl, so the bound aims the failure at the list append. Which call consumes the first
+// failing allocation is otherwise a property of the libcurl in use rather than of this test.
+static const size_t kCurlSmallAllocation = 64;
+
 static void *CurlTestMalloc(size_t size)
 {
   g_curl_hooks_ran.store(true, std::memory_order_relaxed);
-  return g_fail_curl_malloc ? nullptr : std::malloc(size);
+  if (g_fail_curl_malloc && size <= kCurlSmallAllocation)
+  {
+    return nullptr;
+  }
+  return std::malloc(size);
 }
 
 static void CurlTestFree(void *ptr)
@@ -237,9 +246,8 @@ static void *CurlTestRealloc(void *ptr, size_t size)
   return std::realloc(ptr, size);
 }
 
-// Not routed through CurlTestMalloc on purpose. curl_easy_init allocates with strdup and calloc
-// and never with malloc, while curl_slist_append uses one malloc and one strdup, so failing
-// malloc alone selects the list append and leaves the easy handle alone.
+// Not routed through CurlTestMalloc on purpose, so that a failing malloc cannot reach the
+// copies libcurl makes of the caller's strings and land somewhere other than the list node.
 static char *CurlTestStrdup(const char *str)
 {
   const size_t length = std::strlen(str) + 1;
@@ -916,12 +924,19 @@ TEST_F(BasicCurlHttpTests, AFailedHeaderAllocationIsReported)
   // out anyway, carrying none of the caller's headers.
   EXPECT_EQ(static_cast<size_t>(0), requests_seen)
       << "the request reached the server after the failure was reported";
+
+  // Everything past here is specific to the header list having been the allocation that failed.
+  // A libcurl that took the failure somewhere else reports its own message, and says so rather
+  // than asserting against a path it did not take.
+  const std::string reason = handler->Reason();
+  if (std::string::npos == reason.find("Out of memory"))
+  {
+    GTEST_SKIP() << "this libcurl consumed the failing allocation before the header list, "
+                 << "reported as: " << reason;
+  }
+
   EXPECT_EQ(1, handler->terminal_count_.load(std::memory_order_acquire))
       << "expected exactly one terminal outcome";
-  // A failed curl_easy_init would report "Failed initialization" instead, so this holds the
-  // case to the header list rather than to whichever allocation happened to fail.
-  const std::string reason = handler->Reason();
-  EXPECT_NE(std::string::npos, reason.find("Out of memory")) << "reported as: " << reason;
 }
 
 // A client whose multi handle is null accepts sessions, adds none of them, and completes none

--- a/ext/test/http/curl_http_test.cc
+++ b/ext/test/http/curl_http_test.cc
@@ -18,7 +18,6 @@
 #include <condition_variable>
 #include <cstdlib>
 #include <cstring>
-#include <ctime>
 #include <map>
 #include <mutex>
 #include <sstream>
@@ -265,13 +264,22 @@ static char *CurlTestStrdup(const char *str)
 // against. Which internal allocation a given libcurl uses is not part of its contract, so
 // the cases that rely on this check what actually failed rather than assume.
 // Not thread_local, unlike the switches above. The case that keeps a client alive while the
-// multi handle cannot be created needs the failure to reach the IO thread as well.
+// multi handle cannot be created needs the failure to reach the IO thread.
 static std::atomic<bool> g_fail_curl_calloc_everywhere{false};
+
+// Counts what the process wide switch refused, which is one per curl_multi_init the IO thread
+// tried while it had no handle. That is the retry rate, measured the same way everywhere.
+static std::atomic<int> g_curl_calloc_failures{0};
 
 static void *CurlTestCalloc(size_t count, size_t size)
 {
   g_curl_hooks_ran.store(true, std::memory_order_relaxed);
-  if (g_fail_curl_calloc || g_fail_curl_calloc_everywhere.load(std::memory_order_relaxed))
+  if (g_fail_curl_calloc_everywhere.load(std::memory_order_relaxed))
+  {
+    g_curl_calloc_failures.fetch_add(1, std::memory_order_relaxed);
+    return nullptr;
+  }
+  if (g_fail_curl_calloc)
   {
     return nullptr;
   }
@@ -1144,7 +1152,7 @@ TEST_F(BasicCurlHttpTests, AClientWithoutAMultiHandleReachesATerminalOutcome)
   EXPECT_FALSE(session->IsSessionActive()) << "the session stayed active with nothing running it";
 
   // Cancel before finishing. If either assertion above failed then nothing is going to complete
-  // this operation, and FinishSession would wait for it for good, so the case would hang rather
+  // this operation, so the case would hang rather
   // than fail. Cancelling a session that already answered does nothing.
   session->CancelSession();
   session->FinishSession();
@@ -1587,41 +1595,33 @@ TEST_F(BasicCurlHttpTests, APersistentMultiHandleFailureDoesNotSpin)
   opentelemetry::sdk::common::internal_log::GlobalLogHandler::SetLogHandler(
       nostd::shared_ptr<opentelemetry::sdk::common::internal_log::LogHandler>(capture));
 
-  const std::clock_t cpu_before = std::clock();
+  int attempts = 0;
   {
     // The hooks serve libcurl only, so this fails curl_multi_init on the IO thread without
     // touching the allocations the rest of the binary makes.
+    g_curl_calloc_failures.store(0, std::memory_order_relaxed);
     g_fail_curl_calloc_everywhere.store(true, std::memory_order_relaxed);
     auto *concrete = static_cast<http_client::curl::HttpClient *>(client.get());
     http_client::curl::HttpClientTestPeer::ResetMultiHandle(*concrete);
     std::this_thread::sleep_for(std::chrono::seconds(1));
+    attempts = g_curl_calloc_failures.load(std::memory_order_relaxed);
     g_fail_curl_calloc_everywhere.store(false, std::memory_order_relaxed);
   }
-  const double cpu_seconds = static_cast<double>(std::clock() - cpu_before) / CLOCKS_PER_SEC;
-  const int log_lines      = capture->count_.load(std::memory_order_relaxed);
-
+  const int log_lines = capture->count_.load(std::memory_order_relaxed);
   opentelemetry::sdk::common::internal_log::GlobalLogHandler::SetLogHandler(previous);
 
-  EXPECT_LT(cpu_seconds, 0.5) << "the IO thread spun while it had no multi handle, " << cpu_seconds
-                              << " seconds of CPU over a one second window";
+  // Counting what the allocator refused says how often the IO thread tried, which is what a spin
+  // is, and says it the same way on every platform. The lower bounds matter as much as the upper
+  // ones: without them an injection that stopped working reads as a pass.
+  EXPECT_GE(attempts, 1) << "the IO thread never tried to create a handle, so nothing was tested";
+  EXPECT_LE(attempts, 64) << "the IO thread tried " << attempts
+                          << " times in a second, which is a spin rather than a wait";
+  EXPECT_GE(log_lines, 1) << "the failure was never reported";
   EXPECT_LE(log_lines, 8) << "the same failure was reported " << log_lines << " times";
 
-  // And it recovers once allocation works again, so the wait is a wait rather than a stop.
-  received_requests_.clear();
-  auto session = client->CreateSession("http://127.0.0.1:19000");
-  auto request = session->CreateRequest();
-  request->SetUri("get/");
-  auto handler = std::make_shared<MultiHandleOutcomeHandler>();
-  session->SendRequest(handler);
-  for (int i = 0; i < 300 && 0 == handler->terminal_.load(std::memory_order_acquire); ++i)
-  {
-    std::this_thread::sleep_for(std::chrono::milliseconds(100));
-  }
-  EXPECT_GE(handler->terminal_.load(std::memory_order_acquire), 1)
-      << "the client did not come back once curl_multi_init could succeed again";
-
-  session->CancelSession();
-  session->FinishSession();
+  // Recovery from a handle that could not be created is held by
+  // AClientWithoutAMultiHandleReachesATerminalOutcome. What this case is for is the state in
+  // between, which nothing else reaches.
   client->FinishAllSessions();
 }
 

--- a/ext/test/http/curl_http_test.cc
+++ b/ext/test/http/curl_http_test.cc
@@ -242,36 +242,21 @@ static thread_local bool g_fail_curl_calloc = false;
 // failing allocation is otherwise a property of the libcurl in use rather than of this test.
 static const size_t kCurlSmallAllocation = 64;
 
-// Measured rather than assumed. libcurl does not say which allocator a list append uses, how
-// large a node is, or how many allocations anything else makes first, so a case that wants the
-// failure to land on a particular append asks this file to watch one happen and then aims at
-// blocks of exactly that size. Which append is the one that fails is a count, so a case can
-// have the first go through and the second not.
-static thread_local size_t g_watch_malloc_size    = 0;
-static thread_local size_t g_watched_malloc_size  = 0;
-static thread_local size_t g_fail_malloc_of_size  = 0;
-static thread_local int g_let_through_before_fail = 0;
+// Named rather than measured. A case that wants one particular append to fail says which header
+// it is, and the refusal happens when libcurl copies that exact string. Sizes and counts cannot
+// do this: a node's size is not part of libcurl's contract, and anything allocated before the
+// append can match the same size and consume the refusal, which leaves the list built and the
+// case asserting against a path it never took.
+static thread_local const char *g_refuse_strdup_of = nullptr;
+static thread_local const char *g_watch_strdup_of  = nullptr;
+static thread_local int g_strdup_calls             = 0;
+static thread_local int g_strdup_refusals          = 0;
+static thread_local int g_watched_at               = 0;
+static thread_local int g_refused_at               = 0;
 
 static void *CurlTestMalloc(size_t size)
 {
   g_curl_hooks_ran.store(true, std::memory_order_relaxed);
-
-  if (0 != g_watch_malloc_size && 0 == g_watched_malloc_size)
-  {
-    g_watched_malloc_size = size;
-  }
-
-  if (0 != g_fail_malloc_of_size && size == g_fail_malloc_of_size)
-  {
-    if (g_let_through_before_fail > 0)
-    {
-      --g_let_through_before_fail;
-    }
-    else
-    {
-      return nullptr;
-    }
-  }
 
   if (g_fail_curl_malloc && size <= kCurlSmallAllocation)
   {
@@ -292,8 +277,29 @@ static void *CurlTestRealloc(void *ptr, size_t size)
 
 // Not routed through CurlTestMalloc on purpose, so that a failing malloc cannot reach the
 // copies libcurl makes of the caller's strings and land somewhere other than the list node.
+// The one refusal it does make is aimed by content: curl_slist_append copies the string it is
+// given before it has a list to return, so refusing that copy is what makes that append, and no
+// other, return null.
 static char *CurlTestStrdup(const char *str)
 {
+  if (nullptr != str && (nullptr != g_watch_strdup_of || nullptr != g_refuse_strdup_of))
+  {
+    ++g_strdup_calls;
+
+    if (nullptr != g_watch_strdup_of && 0 == g_watched_at &&
+        0 == std::strcmp(str, g_watch_strdup_of))
+    {
+      g_watched_at = g_strdup_calls;
+    }
+
+    if (nullptr != g_refuse_strdup_of && 0 == std::strcmp(str, g_refuse_strdup_of))
+    {
+      ++g_strdup_refusals;
+      g_refused_at = g_strdup_calls;
+      return nullptr;
+    }
+  }
+
   const size_t length = std::strlen(str) + 1;
   char *copy          = static_cast<char *>(std::malloc(length));
   if (copy != nullptr)
@@ -357,42 +363,32 @@ struct FailCurlCalloc
   FailCurlCalloc &operator=(FailCurlCalloc &&)      = delete;
 };
 
-// How big a list node is on the libcurl this binary is linked against, or zero if an append
-// does not reach the malloc callback at all. Taken by watching one, since libcurl promises
-// none of it. The string is copied through the strdup callback, which is deliberately not the
-// one being watched, so the only block this sees is the node.
-inline size_t MeasureSlistNode()
+// Watches one header go on and refuses the next, both by name, and records the order the two
+// were copied in. A case reads those back to say three different things apart: a libcurl that
+// never routed an appended string here at all, an append that was refused as asked, and a
+// refusal that landed on the first header rather than part way through a list.
+struct RefuseSlistAppendOf
 {
-  g_watched_malloc_size = 0;
-  g_watch_malloc_size   = 1;
-  curl_slist *measured  = curl_slist_append(nullptr, "X-Measure: 1");
-  g_watch_malloc_size   = 0;
-
-  const size_t size = (nullptr != measured) ? g_watched_malloc_size : 0;
-  curl_slist_free_all(measured);
-  return size;
-}
-
-// Lets a number of nodes through and refuses the next one, so a case can say which append
-// fails rather than hoping it is the first thing libcurl asks for.
-struct FailSlistNodeAfter
-{
-  FailSlistNodeAfter(int let_through, size_t node_size)
+  RefuseSlistAppendOf(const char *let_through, const char *refuse)
   {
-    g_let_through_before_fail = let_through;
-    g_fail_malloc_of_size     = node_size;
+    g_strdup_calls     = 0;
+    g_strdup_refusals  = 0;
+    g_watched_at       = 0;
+    g_refused_at       = 0;
+    g_watch_strdup_of  = let_through;
+    g_refuse_strdup_of = refuse;
   }
 
-  ~FailSlistNodeAfter()
+  ~RefuseSlistAppendOf()
   {
-    g_fail_malloc_of_size     = 0;
-    g_let_through_before_fail = 0;
+    g_watch_strdup_of  = nullptr;
+    g_refuse_strdup_of = nullptr;
   }
 
-  FailSlistNodeAfter(const FailSlistNodeAfter &)            = delete;
-  FailSlistNodeAfter(FailSlistNodeAfter &&)                 = delete;
-  FailSlistNodeAfter &operator=(const FailSlistNodeAfter &) = delete;
-  FailSlistNodeAfter &operator=(FailSlistNodeAfter &&)      = delete;
+  RefuseSlistAppendOf(const RefuseSlistAppendOf &)            = delete;
+  RefuseSlistAppendOf(RefuseSlistAppendOf &&)                 = delete;
+  RefuseSlistAppendOf &operator=(const RefuseSlistAppendOf &) = delete;
+  RefuseSlistAppendOf &operator=(RefuseSlistAppendOf &&)      = delete;
 };
 
 // The failure that reaches every thread, and the exemption for the one that armed it, since
@@ -1195,13 +1191,6 @@ TEST_F(BasicCurlHttpTests, AHeaderListThatFailsPartWayThroughIsNotLost)
   ASSERT_TRUE(g_curl_hooks_installed);
   received_requests_.clear();
 
-  const size_t node = MeasureSlistNode();
-  if (0 == node)
-  {
-    GTEST_SKIP() << "list appends on this libcurl do not reach the malloc callback, so the "
-                 << "failure cannot be aimed at one";
-  }
-
   auto session_manager = std::make_shared<http_client::curl::HttpCurlClientFactory>()->Create();
   auto session         = session_manager->CreateSession("http://127.0.0.1:19000");
   auto request         = session->CreateRequest();
@@ -1209,12 +1198,19 @@ TEST_F(BasicCurlHttpTests, AHeaderListThatFailsPartWayThroughIsNotLost)
   request->AddHeader("X-First", "1");
   request->AddHeader("X-Second", "2");
 
-  auto handler = std::make_shared<ReportedStateHandler>();
+  auto handler       = std::make_shared<ReportedStateHandler>();
+  int refusals       = 0;
+  int let_through_at = 0;
+  int refused_at     = 0;
   {
-    // One node through, the next refused. Whichever append that turns out to be, the list is
-    // not empty when it happens, which is the whole point.
-    FailSlistNodeAfter failing{1, node};
+    // Named, not counted. Which append fails is then a property of this case rather than of how
+    // the libcurl in use sizes a node, or of what it happened to allocate before reaching the
+    // header list.
+    RefuseSlistAppendOf failing{"X-First: 1", "X-Second: 2"};
     session->SendRequest(handler);
+    refusals       = g_strdup_refusals;
+    let_through_at = g_watched_at;
+    refused_at     = g_refused_at;
   }
 
   session->FinishSession();
@@ -1225,6 +1221,19 @@ TEST_F(BasicCurlHttpTests, AHeaderListThatFailsPartWayThroughIsNotLost)
     std::unique_lock<std::mutex> lock_requests(mtx_requests);
     requests_seen = received_requests_.size();
   }
+
+  if (0 == refusals && 0 == let_through_at)
+  {
+    GTEST_SKIP() << "this libcurl does not copy appended header strings through the allocator "
+                 << "callbacks, so an append cannot be refused by name";
+  }
+  ASSERT_EQ(1, refusals) << "this libcurl reached the allocator callbacks with the first header "
+                         << "but never with the second, so nothing below is a statement about "
+                         << "what happens when an append fails";
+  ASSERT_GT(let_through_at, 0) << "the first header was never copied, so the refusal landed on "
+                               << "an empty list and this case is not the one it says it is";
+  ASSERT_LT(let_through_at, refused_at) << "the refusal came before the first header went on, so "
+                                        << "the list it landed on was still empty";
 
   EXPECT_TRUE(handler->create_failed_.load(std::memory_order_acquire))
       << "a header list that could not be finished was not reported";

--- a/ext/test/http/curl_http_test.cc
+++ b/ext/test/http/curl_http_test.cc
@@ -16,9 +16,9 @@
 #include <atomic>
 #include <chrono>
 #include <condition_variable>
+#include <cstdlib>
 #include <cstring>
 #include <map>
-#include <memory>
 #include <mutex>
 #include <sstream>
 #include <string>
@@ -32,7 +32,9 @@
 #include "opentelemetry/ext/http/client/http_client.h"
 #include "opentelemetry/ext/http/server/http_server.h"
 #include "opentelemetry/nostd/function_ref.h"
+#include "opentelemetry/nostd/shared_ptr.h"
 #include "opentelemetry/nostd/string_view.h"
+#include "opentelemetry/sdk/common/global_log_handler.h"
 #include "opentelemetry/version.h"
 
 constexpr int HTTP_PORT{19000};
@@ -205,6 +207,162 @@ public:
   }
 };
 
+// libcurl routes every internal allocation through the callbacks given to
+// curl_global_init_mem, which is the only way to reach the failure returns of
+// curl_slist_append and curl_multi_init. They have to be installed before libcurl is
+// initialised: called afterwards the function returns CURLE_OK and quietly changes nothing.
+//
+// The failure switches are thread local, so arming one cannot disturb a client's background
+// thread. These callbacks serve the whole binary once installed.
+extern "C" {
+static std::atomic<bool> g_curl_hooks_ran{false};
+static thread_local bool g_fail_curl_malloc = false;
+static thread_local bool g_fail_curl_calloc = false;
+
+// NOLINTBEGIN(cppcoreguidelines-no-malloc,hicpp-no-malloc): these are the allocator libcurl
+// is given, so reaching for the C allocation functions is the point of them.
+static void *CurlTestMalloc(size_t size)
+{
+  g_curl_hooks_ran.store(true, std::memory_order_relaxed);
+  return g_fail_curl_malloc ? nullptr : std::malloc(size);
+}
+
+static void CurlTestFree(void *ptr)
+{
+  std::free(ptr);
+}
+
+static void *CurlTestRealloc(void *ptr, size_t size)
+{
+  return std::realloc(ptr, size);
+}
+
+// Not routed through CurlTestMalloc on purpose. curl_easy_init allocates with strdup and calloc
+// and never with malloc, while curl_slist_append uses one malloc and one strdup, so failing
+// malloc alone selects the list append and leaves the easy handle alone.
+static char *CurlTestStrdup(const char *str)
+{
+  const size_t length = std::strlen(str) + 1;
+  char *copy          = static_cast<char *>(std::malloc(length));
+  if (copy != nullptr)
+  {
+    std::memcpy(copy, str, length);
+  }
+  return copy;
+}
+
+// curl_multi_init allocates with calloc and never with malloc, so this one selects it.
+static void *CurlTestCalloc(size_t count, size_t size)
+{
+  g_curl_hooks_ran.store(true, std::memory_order_relaxed);
+  return g_fail_curl_calloc ? nullptr : std::calloc(count, size);
+}
+// NOLINTEND(cppcoreguidelines-no-malloc,hicpp-no-malloc)
+}  // extern "C"
+
+namespace
+{
+bool g_curl_hooks_installed = false;
+
+struct FailCurlMalloc
+{
+  FailCurlMalloc() { g_fail_curl_malloc = true; }
+  ~FailCurlMalloc() { g_fail_curl_malloc = false; }
+  FailCurlMalloc(const FailCurlMalloc &)            = delete;
+  FailCurlMalloc(FailCurlMalloc &&)                 = delete;
+  FailCurlMalloc &operator=(const FailCurlMalloc &) = delete;
+  FailCurlMalloc &operator=(FailCurlMalloc &&)      = delete;
+};
+
+struct FailCurlCalloc
+{
+  FailCurlCalloc() { g_fail_curl_calloc = true; }
+  ~FailCurlCalloc() { g_fail_curl_calloc = false; }
+  FailCurlCalloc(const FailCurlCalloc &)            = delete;
+  FailCurlCalloc(FailCurlCalloc &&)                 = delete;
+  FailCurlCalloc &operator=(const FailCurlCalloc &) = delete;
+  FailCurlCalloc &operator=(FailCurlCalloc &&)      = delete;
+};
+
+class CapturingLogHandler : public opentelemetry::sdk::common::internal_log::LogHandler
+{
+public:
+  void Handle(opentelemetry::sdk::common::internal_log::LogLevel,
+              const char *,
+              int,
+              const char *msg,
+              const opentelemetry::sdk::common::AttributeMap &) noexcept override
+  {
+    if (msg == nullptr)
+    {
+      return;
+    }
+    std::lock_guard<std::mutex> lock(messages_m_);
+    messages_.append(msg).append("\n");
+  }
+
+  std::string Text()
+  {
+    std::lock_guard<std::mutex> lock(messages_m_);
+    return messages_;
+  }
+
+private:
+  std::mutex messages_m_;
+  std::string messages_;
+};
+
+class ReportedStateHandler : public CustomEventHandler
+{
+public:
+  std::atomic<bool> create_failed_{false};
+  std::atomic<int> terminal_count_{0};
+
+  void OnResponse(http_client::Response &) noexcept override
+  {
+    terminal_count_.fetch_add(1, std::memory_order_acq_rel);
+  }
+
+  void OnEvent(http_client::SessionState state, nostd::string_view reason) noexcept override
+  {
+    switch (state)
+    {
+      case http_client::SessionState::CreateFailed:
+      case http_client::SessionState::ConnectFailed:
+      case http_client::SessionState::SendFailed:
+      case http_client::SessionState::SSLHandshakeFailed:
+      case http_client::SessionState::TimedOut:
+      case http_client::SessionState::NetworkError:
+      case http_client::SessionState::Cancelled:
+        terminal_count_.fetch_add(1, std::memory_order_acq_rel);
+        break;
+      default:
+        break;
+    }
+
+    if (state != http_client::SessionState::CreateFailed)
+    {
+      return;
+    }
+    {
+      std::lock_guard<std::mutex> lock(reason_m_);
+      reason_.assign(reason.data(), reason.size());
+    }
+    create_failed_.store(true, std::memory_order_release);
+  }
+
+  std::string Reason()
+  {
+    std::lock_guard<std::mutex> lock(reason_m_);
+    return reason_;
+  }
+
+private:
+  std::mutex reason_m_;
+  std::string reason_;
+};
+}  // namespace
+
 class BasicCurlHttpTests : public ::testing::Test, public HTTP_SERVER_NS::HttpRequestCallback
 {
 protected:
@@ -221,6 +379,15 @@ protected:
 
 public:
   BasicCurlHttpTests() : is_setup_(false), is_running_(false) {}
+
+  // Runs once before the first case, which is the only point still ahead of the first
+  // HttpClient and therefore ahead of curl_global_init.
+  static void SetUpTestSuite()
+  {
+    g_curl_hooks_installed =
+        (CURLE_OK == curl_global_init_mem(CURL_GLOBAL_ALL, CurlTestMalloc, CurlTestFree,
+                                          CurlTestRealloc, CurlTestStrdup, CurlTestCalloc));
+  }
 
 protected:
   void SetUp() override
@@ -694,6 +861,100 @@ TEST_F(BasicCurlHttpTests, RepeatedCallerThreadCancelsAreClean)
   // A lower bound, not a count: #4360 tracks the same cancel arriving twice, and how many
   // arrive is not what this case decides.
   EXPECT_GE(terminal_total, 20);
+}
+
+// Without this the two cases below would fail for the wrong reason if the hooks ever stopped
+// being installed early enough, and the message would not say so.
+TEST_F(BasicCurlHttpTests, CurlAllocationHooksAreInstalled)
+{
+  EXPECT_TRUE(g_curl_hooks_installed) << "curl_global_init_mem did not return CURLE_OK";
+
+  auto session_manager = std::make_shared<http_client::curl::HttpCurlClientFactory>()->Create();
+  ASSERT_TRUE(session_manager != nullptr);
+  session_manager->FinishAllSessions();
+
+  EXPECT_TRUE(g_curl_hooks_ran.load(std::memory_order_relaxed))
+      << "libcurl allocated without calling the hooks, so they were installed too late";
+}
+
+// A header list that cannot be built has to end the operation. Reporting it is what stops the
+// request going out with none of the caller's headers, which for an OTLP export means no
+// Content-Type and a receiver that rejects it.
+TEST_F(BasicCurlHttpTests, AFailedHeaderAllocationIsReported)
+{
+  ASSERT_TRUE(g_curl_hooks_installed);
+
+  received_requests_.clear();
+
+  auto session_manager = std::make_shared<http_client::curl::HttpCurlClientFactory>()->Create();
+  auto session         = session_manager->CreateSession("http://127.0.0.1:19000");
+  auto request         = session->CreateRequest();
+  request->SetUri("get/");
+  request->AddHeader("X-Test", "1");
+
+  auto handler = std::make_shared<ReportedStateHandler>();
+  {
+    // The operation is constructed on this thread inside SendRequest, so the switch reaches
+    // only its allocations.
+    FailCurlMalloc fail;
+    session->SendRequest(handler);
+  }
+
+  session->FinishSession();
+  session_manager->FinishAllSessions();
+
+  size_t requests_seen = 0;
+  {
+    std::unique_lock<std::mutex> lock_requests(mtx_requests);
+    requests_seen = received_requests_.size();
+  }
+
+  EXPECT_TRUE(handler->create_failed_.load(std::memory_order_acquire))
+      << "a header list that could not be built was not reported";
+  // Reporting it is only half. The easy handle is still valid here and Setup() skips
+  // CURLOPT_HTTPHEADER when the list is null, so without a construction result the request goes
+  // out anyway, carrying none of the caller's headers.
+  EXPECT_EQ(static_cast<size_t>(0), requests_seen)
+      << "the request reached the server after the failure was reported";
+  EXPECT_EQ(1, handler->terminal_count_.load(std::memory_order_acquire))
+      << "expected exactly one terminal outcome";
+  // A failed curl_easy_init would report "Failed initialization" instead, so this holds the
+  // case to the header list rather than to whichever allocation happened to fail.
+  const std::string reason = handler->Reason();
+  EXPECT_NE(std::string::npos, reason.find("Out of memory")) << "reported as: " << reason;
+}
+
+// A client whose multi handle is null accepts sessions, adds none of them, and completes none
+// of them, so the failure has to be visible somewhere.
+TEST_F(BasicCurlHttpTests, AFailedMultiHandleAllocationIsReported)
+{
+  ASSERT_TRUE(g_curl_hooks_installed);
+
+  // One ordinary client first, so the global curl initializer already exists and the switch
+  // below can only reach curl_multi_init.
+  {
+    auto warmup = std::make_shared<http_client::curl::HttpCurlClientFactory>()->Create();
+    ASSERT_TRUE(warmup != nullptr);
+    warmup->FinishAllSessions();
+  }
+
+  auto *capture = new CapturingLogHandler();
+  auto previous = opentelemetry::sdk::common::internal_log::GlobalLogHandler::GetLogHandler();
+  opentelemetry::sdk::common::internal_log::GlobalLogHandler::SetLogHandler(
+      nostd::shared_ptr<opentelemetry::sdk::common::internal_log::LogHandler>(capture));
+
+  {
+    FailCurlCalloc fail;
+    auto client = std::make_shared<http_client::curl::HttpCurlClientFactory>()->Create();
+    ASSERT_TRUE(client != nullptr);
+    client->FinishAllSessions();
+  }
+
+  const std::string text = capture->Text();
+  opentelemetry::sdk::common::internal_log::GlobalLogHandler::SetLogHandler(previous);
+
+  EXPECT_NE(std::string::npos, text.find("curl_multi_init failed"))
+      << "a multi handle that could not be created was not reported, captured: " << text;
 }
 
 TEST_F(BasicCurlHttpTests, SendGetRequestSync)

--- a/ext/test/http/curl_http_test.cc
+++ b/ext/test/http/curl_http_test.cc
@@ -1626,50 +1626,36 @@ TEST_F(BasicCurlHttpTests, AQueuedRequestSurvivesAMissingMultiHandle)
   ASSERT_TRUE(g_curl_hooks_installed);
   received_requests_.clear();
 
+  // Built without a handle, for the reason given above: a case that took one away would be
+  // using it from two threads at once, and could not then say whether what it saw was the
+  // client's behaviour or its own.
+  g_curl_calloc_failures.store(0, std::memory_order_relaxed);
+  g_fail_curl_calloc_everywhere.store(true, std::memory_order_relaxed);
   auto client = std::make_shared<http_client::curl::HttpCurlClientFactory>()->Create();
   ASSERT_TRUE(client != nullptr);
   auto *concrete = static_cast<http_client::curl::HttpClient *>(client.get());
+  ASSERT_GE(g_curl_calloc_failures.load(std::memory_order_relaxed), 1)
+      << "the client was built with a multi handle, so nothing was tested";
 
-  // The idle grace is a minute by default, but only from libcurl 7.68: the assignment that
-  // gives it that value is behind a version check, and older libcurl leaves it at zero, where
-  // the IO thread reaches the retirement check on its first idle pass. CMake asks for no
-  // minimum libcurl, so both are supported and this asks for the shorter one, to run the same
+  g_curl_calloc_exempt = true;
+
+  // The idle grace is a minute by default, but only from libcurl 7.68: the line that gives it
+  // that value is behind a version check, and older libcurl leaves it at zero, where the IO
+  // thread reaches the retirement check on its first idle pass. CMake asks for no minimum
+  // libcurl, so both are supported, and this asks for the shorter one so the case runs the same
   // way everywhere rather than the way whichever libcurl the job has happens to allow.
   concrete->SetBackgroundWaitFor(std::chrono::milliseconds::zero());
-
-  // One completed request, so the IO thread exists and is running the loop under test.
-  {
-    auto warm         = client->CreateSession("http://127.0.0.1:19000");
-    auto warm_request = warm->CreateRequest();
-    warm_request->SetUri("get/");
-    auto warm_handler = std::make_shared<MultiHandleOutcomeHandler>();
-    warm->SendRequest(warm_handler);
-    ASSERT_TRUE(waitForRequests(30, 1));
-    warm->FinishSession();
-    ASSERT_GE(warm_handler->responses_.load(std::memory_order_acquire), 1);
-  }
-  received_requests_.clear();
-
-  // Join the IO thread before taking its multi handle away. resetMultiHandle destroys the one
-  // it finds, and a handle another thread is inside is not one to destroy.
-  concrete->WaitBackgroundThreadExit();
-
-  g_curl_calloc_failures.store(0, std::memory_order_relaxed);
-  g_fail_curl_calloc_everywhere.store(true, std::memory_order_relaxed);
-  http_client::curl::HttpClientTestPeer::ResetMultiHandle(*concrete);
-
-  // curl_easy_init allocates with calloc too, so without this the request below could not be
-  // built and the case would test the refusal rather than the queue.
-  g_curl_calloc_exempt = true;
 
   auto session = client->CreateSession("http://127.0.0.1:19000");
   auto request = session->CreateRequest();
   request->SetUri("get/");
   auto handler = std::make_shared<MultiHandleOutcomeHandler>();
+  g_curl_calloc_failures.store(0, std::memory_order_relaxed);
   session->SendRequest(handler);
 
-  // Wait for the IO thread to go round several times with no handle, so the gated phases have
-  // had every chance to consume the queued session.
+  // Wait for the IO thread to go round several times with no handle, so the phases that need
+  // one have had every chance to consume the queued session and the retirement check has been
+  // reached more than once.
   for (int i = 0; i < 200 && g_curl_calloc_failures.load(std::memory_order_relaxed) < 5; ++i)
   {
     std::this_thread::sleep_for(std::chrono::milliseconds(10));
@@ -1735,21 +1721,23 @@ TEST_F(BasicCurlHttpTests, APersistentMultiHandleFailureDoesNotSpin)
   ASSERT_TRUE(g_curl_hooks_installed);
   received_requests_.clear();
 
+  // The client is built without a multi handle rather than having one taken away. Nothing here
+  // touches a handle another thread is using, which libcurl does not allow and which would
+  // leave any result this case reported open to being an artefact of the injection. What fails
+  // is curl_multi_init, on whichever thread calls it, and after the constructor that is the IO
+  // thread every time.
+  g_curl_calloc_failures.store(0, std::memory_order_relaxed);
+  g_fail_curl_calloc_everywhere.store(true, std::memory_order_relaxed);
   auto client = std::make_shared<http_client::curl::HttpCurlClientFactory>()->Create();
   ASSERT_TRUE(client != nullptr);
+  ASSERT_GE(g_curl_calloc_failures.load(std::memory_order_relaxed), 1)
+      << "the client was built with a multi handle, so nothing was tested";
 
-  // One completed request, so the IO thread exists and the loop below is the one under test.
-  {
-    auto warm         = client->CreateSession("http://127.0.0.1:19000");
-    auto warm_request = warm->CreateRequest();
-    warm_request->SetUri("get/");
-    auto warm_handler = std::make_shared<MultiHandleOutcomeHandler>();
-    warm->SendRequest(warm_handler);
-    ASSERT_TRUE(waitForRequests(30, 1));
-    warm->FinishSession();
-    ASSERT_GE(warm_handler->terminal_.load(std::memory_order_acquire), 1);
-  }
+  // curl_easy_init allocates with calloc too, and the request below needs one. The IO thread is
+  // not exempt, so its curl_multi_init goes on failing.
+  g_curl_calloc_exempt = true;
 
+  // After the constructor, so the report it makes is not counted as one of the loop's.
   auto *capture = new CountingLogHandler();
   auto previous = opentelemetry::sdk::common::internal_log::GlobalLogHandler::GetLogHandler();
   opentelemetry::sdk::common::internal_log::GlobalLogHandler::SetLogHandler(
@@ -1757,15 +1745,22 @@ TEST_F(BasicCurlHttpTests, APersistentMultiHandleFailureDoesNotSpin)
 
   int attempts = 0;
   {
-    // The hooks serve libcurl only, so this fails curl_multi_init on the IO thread without
-    // touching the allocations the rest of the binary makes.
+    // A request is what keeps the IO thread there. With nothing owed to anybody it retires,
+    // which is the other half of this and is held by the case below.
+    auto session = client->CreateSession("http://127.0.0.1:19000");
+    auto request = session->CreateRequest();
+    request->SetUri("get/");
+    auto handler = std::make_shared<MultiHandleOutcomeHandler>();
     g_curl_calloc_failures.store(0, std::memory_order_relaxed);
-    g_fail_curl_calloc_everywhere.store(true, std::memory_order_relaxed);
-    auto *concrete = static_cast<http_client::curl::HttpClient *>(client.get());
-    http_client::curl::HttpClientTestPeer::ResetMultiHandle(*concrete);
+    session->SendRequest(handler);
+
     std::this_thread::sleep_for(std::chrono::seconds(1));
     attempts = g_curl_calloc_failures.load(std::memory_order_relaxed);
+
     g_fail_curl_calloc_everywhere.store(false, std::memory_order_relaxed);
+    g_curl_calloc_exempt = false;
+    session->CancelSession();
+    session->FinishSession();
   }
   const int log_lines = capture->count_.load(std::memory_order_relaxed);
   opentelemetry::sdk::common::internal_log::GlobalLogHandler::SetLogHandler(previous);
@@ -1779,9 +1774,6 @@ TEST_F(BasicCurlHttpTests, APersistentMultiHandleFailureDoesNotSpin)
   EXPECT_GE(log_lines, 1) << "the failure was never reported";
   EXPECT_LE(log_lines, 8) << "the same failure was reported " << log_lines << " times";
 
-  // Recovery from a handle that could not be created is held by
-  // AClientWithoutAMultiHandleReachesATerminalOutcome. What this case is for is the state in
-  // between, which nothing else reaches.
   client->FinishAllSessions();
 }
 

--- a/ext/test/http/curl_http_test.cc
+++ b/ext/test/http/curl_http_test.cc
@@ -240,9 +240,37 @@ static thread_local bool g_fail_curl_calloc = false;
 // failing allocation is otherwise a property of the libcurl in use rather than of this test.
 static const size_t kCurlSmallAllocation = 64;
 
+// Measured rather than assumed. libcurl does not say which allocator a list append uses, how
+// large a node is, or how many allocations anything else makes first, so a case that wants the
+// failure to land on a particular append asks this file to watch one happen and then aims at
+// blocks of exactly that size. Which append is the one that fails is a count, so a case can
+// have the first go through and the second not.
+static thread_local size_t g_watch_malloc_size    = 0;
+static thread_local size_t g_watched_malloc_size  = 0;
+static thread_local size_t g_fail_malloc_of_size  = 0;
+static thread_local int g_let_through_before_fail = 0;
+
 static void *CurlTestMalloc(size_t size)
 {
   g_curl_hooks_ran.store(true, std::memory_order_relaxed);
+
+  if (0 != g_watch_malloc_size && 0 == g_watched_malloc_size)
+  {
+    g_watched_malloc_size = size;
+  }
+
+  if (0 != g_fail_malloc_of_size && size == g_fail_malloc_of_size)
+  {
+    if (g_let_through_before_fail > 0)
+    {
+      --g_let_through_before_fail;
+    }
+    else
+    {
+      return nullptr;
+    }
+  }
+
   if (g_fail_curl_malloc && size <= kCurlSmallAllocation)
   {
     return nullptr;
@@ -325,6 +353,44 @@ struct FailCurlCalloc
   FailCurlCalloc(FailCurlCalloc &&)                 = delete;
   FailCurlCalloc &operator=(const FailCurlCalloc &) = delete;
   FailCurlCalloc &operator=(FailCurlCalloc &&)      = delete;
+};
+
+// How big a list node is on the libcurl this binary is linked against, or zero if an append
+// does not reach the malloc callback at all. Taken by watching one, since libcurl promises
+// none of it. The string is copied through the strdup callback, which is deliberately not the
+// one being watched, so the only block this sees is the node.
+inline size_t MeasureSlistNode()
+{
+  g_watched_malloc_size = 0;
+  g_watch_malloc_size   = 1;
+  curl_slist *measured  = curl_slist_append(nullptr, "X-Measure: 1");
+  g_watch_malloc_size   = 0;
+
+  const size_t size = (nullptr != measured) ? g_watched_malloc_size : 0;
+  curl_slist_free_all(measured);
+  return size;
+}
+
+// Lets a number of nodes through and refuses the next one, so a case can say which append
+// fails rather than hoping it is the first thing libcurl asks for.
+struct FailSlistNodeAfter
+{
+  FailSlistNodeAfter(int let_through, size_t node_size)
+  {
+    g_let_through_before_fail = let_through;
+    g_fail_malloc_of_size     = node_size;
+  }
+
+  ~FailSlistNodeAfter()
+  {
+    g_fail_malloc_of_size     = 0;
+    g_let_through_before_fail = 0;
+  }
+
+  FailSlistNodeAfter(const FailSlistNodeAfter &)            = delete;
+  FailSlistNodeAfter(FailSlistNodeAfter &&)                 = delete;
+  FailSlistNodeAfter &operator=(const FailSlistNodeAfter &) = delete;
+  FailSlistNodeAfter &operator=(FailSlistNodeAfter &&)      = delete;
 };
 
 // The failure that reaches every thread, and the exemption for the one that armed it, since
@@ -1116,6 +1182,56 @@ TEST_F(BasicCurlHttpTests, AFailedHeaderAllocationIsReported)
 
   EXPECT_EQ(1, handler->terminal_count_.load(std::memory_order_acquire))
       << "expected exactly one terminal outcome";
+}
+
+// The first header goes on and the second does not. That is the case the temporary pointer is
+// there for: curl_slist_append returns null on failure and leaves the list it was given, so
+// assigning its result straight back over the member loses everything appended so far. With one
+// header there is nothing to lose, which is why the case above cannot tell the difference.
+TEST_F(BasicCurlHttpTests, AHeaderListThatFailsPartWayThroughIsNotLost)
+{
+  ASSERT_TRUE(g_curl_hooks_installed);
+  received_requests_.clear();
+
+  const size_t node = MeasureSlistNode();
+  if (0 == node)
+  {
+    GTEST_SKIP() << "list appends on this libcurl do not reach the malloc callback, so the "
+                 << "failure cannot be aimed at one";
+  }
+
+  auto session_manager = std::make_shared<http_client::curl::HttpCurlClientFactory>()->Create();
+  auto session         = session_manager->CreateSession("http://127.0.0.1:19000");
+  auto request         = session->CreateRequest();
+  request->SetUri("get/");
+  request->AddHeader("X-First", "1");
+  request->AddHeader("X-Second", "2");
+
+  auto handler = std::make_shared<ReportedStateHandler>();
+  {
+    // One node through, the next refused. Whichever append that turns out to be, the list is
+    // not empty when it happens, which is the whole point.
+    FailSlistNodeAfter failing{1, node};
+    session->SendRequest(handler);
+  }
+
+  session->FinishSession();
+  session_manager->FinishAllSessions();
+
+  size_t requests_seen = 0;
+  {
+    std::unique_lock<std::mutex> lock_requests(mtx_requests);
+    requests_seen = received_requests_.size();
+  }
+
+  EXPECT_TRUE(handler->create_failed_.load(std::memory_order_acquire))
+      << "a header list that could not be finished was not reported";
+  EXPECT_EQ(static_cast<size_t>(0), requests_seen)
+      << "the request reached the server carrying a header list that was never finished";
+  EXPECT_EQ(1, handler->terminal_count_.load(std::memory_order_acquire))
+      << "expected exactly one terminal outcome";
+  // LeakSanitizer is what says the nodes that were appended before the failure were freed
+  // rather than dropped.
 }
 
 // A client whose multi handle is null accepts sessions, adds none of them, and completes none

--- a/ext/test/http/curl_http_test.cc
+++ b/ext/test/http/curl_http_test.cc
@@ -54,13 +54,21 @@ namespace client
 namespace curl
 {
 // resetMultiHandle only runs when curl_multi_perform fails, which a test cannot provoke, so
-// the case below reaches it directly. See #4389.
+// ResetMultiHandleWithASessionDoesNotDeadlock reaches it directly. See #4389.
 class HttpClientTestPeer
 {
 public:
   static void ResetMultiHandle(HttpClient &client) { client.resetMultiHandle(); }
 
   static bool RemoveSessions(HttpClient &client) { return client.doRemoveSessions(); }
+
+  // Guarded by session_ids_m_, which is what every producer of this queue takes, so a case may
+  // read it whatever else is running.
+  static std::size_t PendingRemovalCount(HttpClient &client)
+  {
+    std::lock_guard<std::recursive_mutex> lock_guard{client.session_ids_m_};
+    return client.pending_to_remove_session_handles_.size();
+  }
 
   static CURLM *ExchangeMultiHandle(HttpClient &client, CURLM *replacement)
   {
@@ -419,9 +427,6 @@ struct FailCurlCallocEverywhere
   FailCurlCallocEverywhere &operator=(FailCurlCallocEverywhere &&)      = delete;
 };
 
-// Counts terminal outcomes without caring which one, since a client whose multi handle could
-// not be created may still recover and answer, and the case below is about the caller being
-// told either way rather than about which answer it gets.
 // Counts the internal log lines that say a particular thing, so a case can hold that a run of
 // failures is reported a bounded number of times rather than once per pass of the IO loop. Only
 // the ones it asked for: anything else the binary writes while this is installed would move the
@@ -478,6 +483,9 @@ private:
   const nostd::shared_ptr<opentelemetry::sdk::common::internal_log::LogHandler> previous_;
 };
 
+// Counts terminal outcomes without caring which one, since a client whose multi handle could
+// not be created may still recover and answer, and what the cases using this ask is whether the
+// caller was told either way rather than which answer it got.
 class MultiHandleOutcomeHandler : public http_client::EventHandler
 {
 public:
@@ -1865,13 +1873,12 @@ TEST_F(BasicCurlHttpTests, ACancelledRetryDoesNotHoldTheClientOpen)
 
     session->SendRequest(handler);
 
-    // Watched from outside the client. The retry queue has no lock, because only the
-    // background thread is supposed to touch it, and a peer that read it from here would make
-    // that untrue: ThreadSanitizer reports exactly that, twice, against a version of this case
-    // that did. So it waits on what the server saw, which is behind a mutex, and then for long
-    // enough that the answer has been read and the session put back with its wait on it. A
-    // second in, that wait still has seven to run, so anything outstanding here is outstanding
-    // because it is queued.
+    // Watched from outside the client, because the retry queue has no lock: only the
+    // background thread is meant to touch it, and reading it from here would make that untrue.
+    // So this waits on what the server saw, which is behind a mutex, and then long enough for
+    // the answer to have been read and the session put back with its wait on it. A second in,
+    // that wait still has seven to run, so anything outstanding here is outstanding because it
+    // is queued.
     ASSERT_TRUE(waitForRequests(30, 1)) << "the request never reached the server";
     std::this_thread::sleep_for(std::chrono::seconds(1));
     ASSERT_EQ(0, handler->terminal_.load(std::memory_order_acquire))
@@ -1903,6 +1910,9 @@ TEST_F(BasicCurlHttpTests, AQueuedHandleIsReleasedWithTheClientThatQueuedIt)
   resource.headers_chunk = curl_slist_append(nullptr, "X-Test: 1");
   ASSERT_TRUE(resource.headers_chunk != nullptr);
   client->ScheduleRemoveSession(4404, std::move(resource));
+  ASSERT_EQ(static_cast<std::size_t>(1),
+            http_client::curl::HttpClientTestPeer::PendingRemovalCount(*client))
+      << "the handle was never queued, so nothing was tested";
 
   // Nothing was sent, so there is no IO thread and nobody else is coming for that queue. The
   // record is two raw pointers and the container that holds it frees neither, so what is still
@@ -1925,6 +1935,9 @@ TEST_F(BasicCurlHttpTests, AHandleQueuedWithoutAMultiHandleIsReleased)
 
   CURLM *previous = http_client::curl::HttpClientTestPeer::ExchangeMultiHandle(*concrete, nullptr);
   concrete->ScheduleRemoveSession(4404, std::move(resource));
+  ASSERT_EQ(static_cast<std::size_t>(1),
+            http_client::curl::HttpClientTestPeer::PendingRemovalCount(*concrete))
+      << "the handle was never queued, so nothing was tested";
 
   // What resetMultiHandle does when curl_multi_init has just failed on it. The easy handle and
   // its header list are released rather than held until a multi handle comes back, and neither
@@ -1943,6 +1956,9 @@ TEST_F(BasicCurlHttpTests, AQueuedRequestSurvivesAMissingMultiHandle)
   // Built without a handle, for the reason given above: a case that took one away would be
   // using it from two threads at once, and could not then say whether what it saw was the
   // client's behaviour or its own.
+  // Before the client, so that it outlives it. The client dispatches terminal events from its
+  // destructor, and a handler declared after it would be gone by then.
+  auto handler = std::make_shared<MultiHandleOutcomeHandler>();
   FailCurlCallocEverywhere failing;
   auto client = std::make_shared<http_client::curl::HttpCurlClientFactory>()->Create();
   ASSERT_TRUE(client != nullptr);
@@ -1962,7 +1978,6 @@ TEST_F(BasicCurlHttpTests, AQueuedRequestSurvivesAMissingMultiHandle)
   auto session = client->CreateSession("http://127.0.0.1:19000");
   auto request = session->CreateRequest();
   request->SetUri("get/");
-  auto handler = std::make_shared<MultiHandleOutcomeHandler>();
 
   // Back to zero after the constructor's own attempt and before there is an IO thread to make
   // one, and this thread is exempt from here on, so what is counted below was refused to that
@@ -2005,13 +2020,15 @@ TEST_F(BasicCurlHttpTests, AFailedEasyHandleIsReportedOnce)
   ASSERT_TRUE(g_curl_hooks_installed);
   received_requests_.clear();
 
-  auto client = std::make_shared<http_client::curl::HttpCurlClientFactory>()->Create();
+  // Before the client, so that it outlives it. The client dispatches terminal events from its
+  // destructor, and a handler declared after it would be gone by then.
+  auto handler = std::make_shared<MultiHandleOutcomeHandler>();
+  auto client  = std::make_shared<http_client::curl::HttpCurlClientFactory>()->Create();
   ASSERT_TRUE(client != nullptr);
 
   auto session = client->CreateSession("http://127.0.0.1:19000");
   auto request = session->CreateRequest();
   request->SetUri("get/");
-  auto handler = std::make_shared<MultiHandleOutcomeHandler>();
 
   {
     // Armed here so it reaches the curl_easy_init inside SendRequest and nothing before it.
@@ -2053,6 +2070,9 @@ TEST_F(BasicCurlHttpTests, APersistentMultiHandleFailureDoesNotSpin)
     // would leave any result this case reported open to being an artefact of the injection.
     // What fails is curl_multi_init, on whichever thread calls it, and after the constructor
     // that is the IO thread every time.
+    // Before the client, so that it outlives it. The client dispatches terminal events from its
+    // destructor, and a handler declared after it would be gone by then.
+    auto handler = std::make_shared<MultiHandleOutcomeHandler>();
     FailCurlCallocEverywhere failing;
     auto client = std::make_shared<http_client::curl::HttpCurlClientFactory>()->Create();
     ASSERT_TRUE(client != nullptr);
@@ -2066,7 +2086,6 @@ TEST_F(BasicCurlHttpTests, APersistentMultiHandleFailureDoesNotSpin)
     auto session = client->CreateSession("http://127.0.0.1:19000");
     auto request = session->CreateRequest();
     request->SetUri("get/");
-    auto handler = std::make_shared<MultiHandleOutcomeHandler>();
 
     // Back to zero after the constructor's own attempt and before there is an IO thread to
     // make one, and this thread is exempt from here on, so what is counted below was refused

--- a/ext/test/http/curl_http_test.cc
+++ b/ext/test/http/curl_http_test.cc
@@ -349,7 +349,13 @@ public:
         terminal_.fetch_add(1, std::memory_order_release);
         break;
       case http_client::SessionState::CreateFailed:
+        create_failed_.fetch_add(1, std::memory_order_release);
+        terminal_.fetch_add(1, std::memory_order_release);
+        break;
       case http_client::SessionState::ConnectFailed:
+        connect_failed_.fetch_add(1, std::memory_order_release);
+        terminal_.fetch_add(1, std::memory_order_release);
+        break;
       case http_client::SessionState::SendFailed:
         terminal_.fetch_add(1, std::memory_order_release);
         break;
@@ -361,6 +367,8 @@ public:
   std::atomic<int> terminal_{0};
   std::atomic<int> responses_{0};
   std::atomic<int> cancels_{0};
+  std::atomic<int> create_failed_{0};
+  std::atomic<int> connect_failed_{0};
 };
 
 class CapturingLogHandler : public opentelemetry::sdk::common::internal_log::LogHandler
@@ -1638,6 +1646,39 @@ TEST_F(BasicCurlHttpTests, AQueuedRequestSurvivesAMissingMultiHandle)
       << "the request queued while the handle was missing never reached the wire";
 
   session->CancelSession();
+  session->FinishSession();
+  client->FinishAllSessions();
+}
+
+// curl_easy_init can fail as well, and the operation then holds no handle. It has to be refused
+// like a failed header list, so one request produces one kind of failure rather than a create
+// failure from the constructor followed by a connect failure from the null handle.
+TEST_F(BasicCurlHttpTests, AFailedEasyHandleIsReportedOnce)
+{
+  ASSERT_TRUE(g_curl_hooks_installed);
+  received_requests_.clear();
+
+  auto client = std::make_shared<http_client::curl::HttpCurlClientFactory>()->Create();
+  ASSERT_TRUE(client != nullptr);
+
+  auto session = client->CreateSession("http://127.0.0.1:19000");
+  auto request = session->CreateRequest();
+  request->SetUri("get/");
+  auto handler = std::make_shared<MultiHandleOutcomeHandler>();
+
+  // Armed here so it reaches the curl_easy_init inside SendRequest and nothing before it.
+  g_fail_curl_calloc_everywhere.store(true, std::memory_order_relaxed);
+  session->SendRequest(handler);
+  g_fail_curl_calloc_everywhere.store(false, std::memory_order_relaxed);
+
+  EXPECT_GE(handler->create_failed_.load(std::memory_order_acquire), 1)
+      << "the caller was never told the handle could not be created";
+  EXPECT_EQ(0, handler->connect_failed_.load(std::memory_order_acquire))
+      << "a request with no easy handle still reported a connect failure";
+  EXPECT_EQ(0, handler->responses_.load(std::memory_order_acquire));
+  EXPECT_FALSE(session->IsSessionActive()) << "the session stayed active with nothing running it";
+  EXPECT_EQ(0U, received_requests_.size()) << "a request with no easy handle reached the server";
+
   session->FinishSession();
   client->FinishAllSessions();
 }

--- a/ext/test/http/curl_http_test.cc
+++ b/ext/test/http/curl_http_test.cc
@@ -292,6 +292,35 @@ struct FailCurlCalloc
   FailCurlCalloc &operator=(FailCurlCalloc &&)      = delete;
 };
 
+// Counts terminal outcomes without caring which one, since a client whose multi handle could
+// not be created may still recover and answer, and the case below is about the caller being
+// told either way rather than about which answer it gets.
+class MultiHandleOutcomeHandler : public http_client::EventHandler
+{
+public:
+  void OnResponse(http_client::Response & /* response */) noexcept override
+  {
+    terminal_.fetch_add(1, std::memory_order_release);
+  }
+
+  void OnEvent(http_client::SessionState state, nostd::string_view /* reason */) noexcept override
+  {
+    switch (state)
+    {
+      case http_client::SessionState::CreateFailed:
+      case http_client::SessionState::ConnectFailed:
+      case http_client::SessionState::SendFailed:
+      case http_client::SessionState::Cancelled:
+        terminal_.fetch_add(1, std::memory_order_release);
+        break;
+      default:
+        break;
+    }
+  }
+
+  std::atomic<int> terminal_{0};
+};
+
 class CapturingLogHandler : public opentelemetry::sdk::common::internal_log::LogHandler
 {
 public:
@@ -970,6 +999,48 @@ TEST_F(BasicCurlHttpTests, AFailedMultiHandleAllocationIsReported)
 
   EXPECT_NE(std::string::npos, text.find("curl_multi_init failed"))
       << "a multi handle that could not be created was not reported, captured: " << text;
+}
+
+// Reporting the failure does not by itself stop the client taking requests, so this holds what
+// taking one leads to. The IO loop resets the multi handle whenever curl_multi_perform rejects
+// it, so a client built on a null handle repairs itself and answers; if the allocation is still
+// failing by then it reports a failure instead. What must not happen is neither.
+TEST_F(BasicCurlHttpTests, AClientWithoutAMultiHandleStillAnswers)
+{
+  ASSERT_TRUE(g_curl_hooks_installed);
+  received_requests_.clear();
+
+  {
+    auto warmup = std::make_shared<http_client::curl::HttpCurlClientFactory>()->Create();
+    ASSERT_TRUE(warmup != nullptr);
+    warmup->FinishAllSessions();
+  }
+
+  std::shared_ptr<http_client::HttpClient> client;
+  {
+    FailCurlCalloc fail;
+    client = std::make_shared<http_client::curl::HttpCurlClientFactory>()->Create();
+  }
+  ASSERT_TRUE(client != nullptr);
+
+  auto session = client->CreateSession("http://127.0.0.1:19000");
+  auto request = session->CreateRequest();
+  request->SetUri("get/");
+
+  auto handler = std::make_shared<MultiHandleOutcomeHandler>();
+  session->SendRequest(handler);
+
+  for (int i = 0; i < 300 && 0 == handler->terminal_.load(std::memory_order_acquire); ++i)
+  {
+    std::this_thread::sleep_for(std::chrono::milliseconds(100));
+  }
+
+  EXPECT_GE(handler->terminal_.load(std::memory_order_acquire), 1)
+      << "the request was accepted and never reached an outcome";
+  EXPECT_FALSE(session->IsSessionActive()) << "the session stayed active with nothing running it";
+
+  session->FinishSession();
+  client->FinishAllSessions();
 }
 
 TEST_F(BasicCurlHttpTests, SendGetRequestSync)

--- a/ext/test/http/curl_http_test.cc
+++ b/ext/test/http/curl_http_test.cc
@@ -18,6 +18,7 @@
 #include <condition_variable>
 #include <cstdlib>
 #include <cstring>
+#include <ctime>
 #include <map>
 #include <mutex>
 #include <sstream>
@@ -260,11 +261,21 @@ static char *CurlTestStrdup(const char *str)
   return copy;
 }
 
-// curl_multi_init allocates with calloc and never with malloc, so this one selects it.
+// Aimed at curl_multi_init, which allocates with calloc on the libcurl this was measured
+// against. Which internal allocation a given libcurl uses is not part of its contract, so
+// the cases that rely on this check what actually failed rather than assume.
+// Not thread_local, unlike the switches above. The case that keeps a client alive while the
+// multi handle cannot be created needs the failure to reach the IO thread as well.
+static std::atomic<bool> g_fail_curl_calloc_everywhere{false};
+
 static void *CurlTestCalloc(size_t count, size_t size)
 {
   g_curl_hooks_ran.store(true, std::memory_order_relaxed);
-  return g_fail_curl_calloc ? nullptr : std::calloc(count, size);
+  if (g_fail_curl_calloc || g_fail_curl_calloc_everywhere.load(std::memory_order_relaxed))
+  {
+    return nullptr;
+  }
+  return std::calloc(count, size);
 }
 // NOLINTEND(cppcoreguidelines-no-malloc,hicpp-no-malloc)
 }  // extern "C"
@@ -296,6 +307,23 @@ struct FailCurlCalloc
 // Counts terminal outcomes without caring which one, since a client whose multi handle could
 // not be created may still recover and answer, and the case below is about the caller being
 // told either way rather than about which answer it gets.
+// Counts internal log lines, so a case can hold that a run of failures is reported a bounded
+// number of times rather than once per pass of the IO loop.
+class CountingLogHandler : public opentelemetry::sdk::common::internal_log::LogHandler
+{
+public:
+  void Handle(opentelemetry::sdk::common::internal_log::LogLevel /* level */,
+              const char * /* file */,
+              int /* line */,
+              const char * /* msg */,
+              const opentelemetry::sdk::common::AttributeMap & /* attributes */) noexcept override
+  {
+    count_.fetch_add(1, std::memory_order_relaxed);
+  }
+
+  std::atomic<int> count_{0};
+};
+
 class MultiHandleOutcomeHandler : public http_client::EventHandler
 {
 public:
@@ -1077,10 +1105,11 @@ TEST_F(BasicCurlHttpTests, AFailedMultiHandleIsReportedForAnInstrumentedClient)
 }
 
 // Reporting the failure does not by itself stop the client taking requests, so this holds what
-// taking one leads to. The IO loop resets the multi handle whenever curl_multi_perform rejects
-// it, so a client built on a null handle repairs itself and answers; if the allocation is still
-// failing by then it reports a failure instead. What must not happen is neither.
-TEST_F(BasicCurlHttpTests, AClientWithoutAMultiHandleStillAnswers)
+// taking one leads to. The IO loop creates a new multi handle when curl_multi_perform rejects
+// the one it has, so a client built on a null handle usually recovers and answers, and reports a
+// failure instead when the allocation is still failing by then. Either is fine. Neither is not,
+// and that is what this checks, so it does not assert which one arrives.
+TEST_F(BasicCurlHttpTests, AClientWithoutAMultiHandleReachesATerminalOutcome)
 {
   ASSERT_TRUE(g_curl_hooks_installed);
   received_requests_.clear();
@@ -1529,5 +1558,72 @@ TEST_F(BasicCurlHttpTests, GzipIncompressibleData)
   session_manager->FinishAllSessions();
 }
 #endif  // ENABLE_OTLP_COMPRESSION_PREVIEW
+
+// A client whose multi handle can never be created has nothing to run, and used to say so as
+// fast as the CPU allowed: measured at a full core and 1,168,126 error lines over three seconds
+// with the client alive. The IO loop reports a run of failures once and waits between attempts
+// now, and this holds both.
+TEST_F(BasicCurlHttpTests, APersistentMultiHandleFailureDoesNotSpin)
+{
+  ASSERT_TRUE(g_curl_hooks_installed);
+  received_requests_.clear();
+
+  auto client = std::make_shared<http_client::curl::HttpCurlClientFactory>()->Create();
+  ASSERT_TRUE(client != nullptr);
+
+  // One completed request, so the IO thread exists and the loop below is the one under test.
+  {
+    auto warm         = client->CreateSession("http://127.0.0.1:19000");
+    auto warm_request = warm->CreateRequest();
+    warm_request->SetUri("get/");
+    auto warm_handler = std::make_shared<MultiHandleOutcomeHandler>();
+    warm->SendRequest(warm_handler);
+    ASSERT_TRUE(waitForRequests(30, 1));
+    warm->FinishSession();
+    ASSERT_GE(warm_handler->terminal_.load(std::memory_order_acquire), 1);
+  }
+
+  auto *capture = new CountingLogHandler();
+  auto previous = opentelemetry::sdk::common::internal_log::GlobalLogHandler::GetLogHandler();
+  opentelemetry::sdk::common::internal_log::GlobalLogHandler::SetLogHandler(
+      nostd::shared_ptr<opentelemetry::sdk::common::internal_log::LogHandler>(capture));
+
+  const std::clock_t cpu_before = std::clock();
+  {
+    // The hooks serve libcurl only, so this fails curl_multi_init on the IO thread without
+    // touching the allocations the rest of the binary makes.
+    g_fail_curl_calloc_everywhere.store(true, std::memory_order_relaxed);
+    auto *concrete = static_cast<http_client::curl::HttpClient *>(client.get());
+    http_client::curl::HttpClientTestPeer::ResetMultiHandle(*concrete);
+    std::this_thread::sleep_for(std::chrono::seconds(1));
+    g_fail_curl_calloc_everywhere.store(false, std::memory_order_relaxed);
+  }
+  const double cpu_seconds = static_cast<double>(std::clock() - cpu_before) / CLOCKS_PER_SEC;
+  const int log_lines      = capture->count_.load(std::memory_order_relaxed);
+
+  opentelemetry::sdk::common::internal_log::GlobalLogHandler::SetLogHandler(previous);
+
+  EXPECT_LT(cpu_seconds, 0.5) << "the IO thread spun while it had no multi handle, " << cpu_seconds
+                              << " seconds of CPU over a one second window";
+  EXPECT_LE(log_lines, 8) << "the same failure was reported " << log_lines << " times";
+
+  // And it recovers once allocation works again, so the wait is a wait rather than a stop.
+  received_requests_.clear();
+  auto session = client->CreateSession("http://127.0.0.1:19000");
+  auto request = session->CreateRequest();
+  request->SetUri("get/");
+  auto handler = std::make_shared<MultiHandleOutcomeHandler>();
+  session->SendRequest(handler);
+  for (int i = 0; i < 300 && 0 == handler->terminal_.load(std::memory_order_acquire); ++i)
+  {
+    std::this_thread::sleep_for(std::chrono::milliseconds(100));
+  }
+  EXPECT_GE(handler->terminal_.load(std::memory_order_acquire), 1)
+      << "the client did not come back once curl_multi_init could succeed again";
+
+  session->CancelSession();
+  session->FinishSession();
+  client->FinishAllSessions();
+}
 
 }  // namespace

--- a/ext/test/http/curl_http_test.cc
+++ b/ext/test/http/curl_http_test.cc
@@ -881,8 +881,14 @@ TEST_F(BasicCurlHttpTests, TlsVersionRangeAndCipherListAreAccepted)
   http_client::Body body;
   http_client::Headers headers;
 
+  http_client::Compression compression = http_client::Compression::kNone;
+  http_client::RetryPolicy retry_policy;
+
+  // Every argument is named. The defaulted ones would be temporaries, and the operation keeps
+  // references to them past the end of this expression.
   curl::HttpOperation operation(http_client::Method::Get, "http://127.0.0.1:19000/get/",
-                                ssl_options, &handler, headers, body);
+                                ssl_options, &handler, headers, body, compression, false,
+                                curl::kDefaultHttpConnTimeout, false, false, retry_policy);
 
   ASSERT_EQ(CURLE_OK, operation.Send());
   ASSERT_EQ(200, operation.GetResponseCode());
@@ -899,8 +905,14 @@ TEST_F(BasicCurlHttpTests, AnUnknownTlsVersionIsRefused)
   http_client::Body body;
   http_client::Headers headers;
 
+  http_client::Compression compression = http_client::Compression::kNone;
+  http_client::RetryPolicy retry_policy;
+
+  // Every argument is named. The defaulted ones would be temporaries, and the operation keeps
+  // references to them past the end of this expression.
   curl::HttpOperation operation(http_client::Method::Get, "http://127.0.0.1:19000/get/",
-                                ssl_options, &handler, headers, body);
+                                ssl_options, &handler, headers, body, compression, false,
+                                curl::kDefaultHttpConnTimeout, false, false, retry_policy);
 
   ASSERT_EQ(CURLE_UNKNOWN_OPTION, operation.Send());
 }

--- a/ext/test/http/curl_http_test.cc
+++ b/ext/test/http/curl_http_test.cc
@@ -867,6 +867,44 @@ TEST_F(BasicCurlHttpTests, CurlHttpOperations)
   delete handler;
 }
 
+// Setup() applies the TLS version range and the cipher list to the easy handle, and returns early
+// on either if curl rejects it. A plain http request reaches both, so the outcome says the options
+// were accepted rather than that a handshake succeeded.
+TEST_F(BasicCurlHttpTests, TlsVersionRangeAndCipherListAreAccepted)
+{
+  RetryEventHandler handler;
+  http_client::HttpSslOptions ssl_options;
+  ssl_options.use_ssl     = true;
+  ssl_options.ssl_min_tls = "1.2";
+  ssl_options.ssl_max_tls = "1.3";
+  ssl_options.ssl_cipher  = "ECDHE-RSA-AES128-GCM-SHA256";
+  http_client::Body body;
+  http_client::Headers headers;
+
+  curl::HttpOperation operation(http_client::Method::Get, "http://127.0.0.1:19000/get/",
+                                ssl_options, &handler, headers, body);
+
+  ASSERT_EQ(CURLE_OK, operation.Send());
+  ASSERT_EQ(200, operation.GetResponseCode());
+}
+
+// An unknown version is refused rather than passed to curl, which is the branch above returning
+// before CURLOPT_SSLVERSION is set at all.
+TEST_F(BasicCurlHttpTests, AnUnknownTlsVersionIsRefused)
+{
+  RetryEventHandler handler;
+  http_client::HttpSslOptions ssl_options;
+  ssl_options.use_ssl     = true;
+  ssl_options.ssl_min_tls = "1.1";
+  http_client::Body body;
+  http_client::Headers headers;
+
+  curl::HttpOperation operation(http_client::Method::Get, "http://127.0.0.1:19000/get/",
+                                ssl_options, &handler, headers, body);
+
+  ASSERT_EQ(CURLE_UNKNOWN_OPTION, operation.Send());
+}
+
 #ifdef ENABLE_OTLP_RETRY_PREVIEW
 TEST_F(BasicCurlHttpTests, RetryPolicyEnabled)
 {

--- a/ext/test/http/curl_http_test.cc
+++ b/ext/test/http/curl_http_test.cc
@@ -59,6 +59,15 @@ class HttpClientTestPeer
 {
 public:
   static void ResetMultiHandle(HttpClient &client) { client.resetMultiHandle(); }
+
+  static bool RemoveSessions(HttpClient &client) { return client.doRemoveSessions(); }
+
+  static CURLM *ExchangeMultiHandle(HttpClient &client, CURLM *replacement)
+  {
+    CURLM *previous      = client.multi_handle_;
+    client.multi_handle_ = replacement;
+    return previous;
+  }
 };
 }  // namespace curl
 }  // namespace client
@@ -1587,6 +1596,31 @@ TEST_F(BasicCurlHttpTests, GzipIncompressibleData)
 // queued while the handle is missing leaves the pending queue for a multi function that cannot
 // take it, and the next reset cancels it, so the caller is told a request was cancelled that
 // nothing cancelled.
+TEST_F(BasicCurlHttpTests, AHandleQueuedWithoutAMultiHandleIsReleased)
+{
+  auto client = std::make_shared<http_client::curl::HttpCurlClientFactory>()->Create();
+  ASSERT_TRUE(client != nullptr);
+  auto *concrete = static_cast<http_client::curl::HttpClient *>(client.get());
+
+  // Nothing has been sent, so this is the only thread here and the queue is the client's own.
+  http_client::curl::HttpCurlEasyResource resource;
+  resource.easy_handle = curl_easy_init();
+  ASSERT_TRUE(resource.easy_handle != nullptr);
+  resource.headers_chunk = curl_slist_append(nullptr, "X-Test: 1");
+  ASSERT_TRUE(resource.headers_chunk != nullptr);
+
+  CURLM *previous = http_client::curl::HttpClientTestPeer::ExchangeMultiHandle(*concrete, nullptr);
+  concrete->ScheduleRemoveSession(4404, std::move(resource));
+
+  // What resetMultiHandle does when curl_multi_init has just failed on it. The easy handle and
+  // its header list are released rather than held until a multi handle comes back, and neither
+  // is handed to a multi function that has none to work with. LeakSanitizer is what says the
+  // release happened.
+  EXPECT_TRUE(http_client::curl::HttpClientTestPeer::RemoveSessions(*concrete));
+
+  http_client::curl::HttpClientTestPeer::ExchangeMultiHandle(*concrete, previous);
+}
+
 TEST_F(BasicCurlHttpTests, AQueuedRequestSurvivesAMissingMultiHandle)
 {
   ASSERT_TRUE(g_curl_hooks_installed);

--- a/ext/test/http/curl_http_test.cc
+++ b/ext/test/http/curl_http_test.cc
@@ -62,13 +62,6 @@ public:
 
   static bool RemoveSessions(HttpClient &client) { return client.doRemoveSessions(); }
 
-#ifdef ENABLE_OTLP_RETRY_PREVIEW
-  static std::size_t RetryQueueSize(const HttpClient &client)
-  {
-    return client.pending_to_retry_sessions_.size();
-  }
-#endif  // ENABLE_OTLP_RETRY_PREVIEW
-
   static CURLM *ExchangeMultiHandle(HttpClient &client, CURLM *replacement)
   {
     CURLM *previous      = client.multi_handle_;
@@ -1813,30 +1806,30 @@ TEST_F(BasicCurlHttpTests, AClientDestroyedWithAPendingRetryDoesNotWaitForIt)
   // round.
   auto handler = std::make_shared<MultiHandleOutcomeHandler>();
 
-  const auto started = std::chrono::steady_clock::now();
+  std::chrono::steady_clock::time_point started{};
   {
     auto client = std::make_shared<http_client::curl::HttpCurlClientFactory>()->Create();
     ASSERT_TRUE(client != nullptr);
-    auto *concrete = static_cast<http_client::curl::HttpClient *>(client.get());
 
     auto session = client->CreateSession("http://127.0.0.1:19000");
     auto request = session->CreateRequest();
     request->SetUri("retry/");
     request->SetMethod(http_client::Method::Post);
-
-    // Long enough that waiting for it would be unmistakable inside the bound below.
     request->SetRetryPolicy(
         {4, std::chrono::duration<float>{8.0f}, std::chrono::duration<float>{16.0f}, 2.0f});
 
     session->SendRequest(handler);
 
-    for (int i = 0;
-         i < 300 && 0 == http_client::curl::HttpClientTestPeer::RetryQueueSize(*concrete); ++i)
-    {
-      std::this_thread::sleep_for(std::chrono::milliseconds(10));
-    }
-    ASSERT_GE(http_client::curl::HttpClientTestPeer::RetryQueueSize(*concrete), 1u)
-        << "the request was never queued for retry, so nothing was tested";
+    ASSERT_TRUE(waitForRequests(30, 1)) << "the request never reached the server";
+    std::this_thread::sleep_for(std::chrono::seconds(1));
+    ASSERT_EQ(0, handler->terminal_.load(std::memory_order_acquire))
+        << "the request had already finished, so nothing was pending";
+
+    started = std::chrono::steady_clock::now();
+
+    // Nothing cancels it. The client simply goes, which is what an exporter shutting down
+    // does, and the entry it leaves behind names an operation holding a promise and an easy
+    // handle.
   }
   const auto elapsed = std::chrono::duration_cast<std::chrono::milliseconds>(
       std::chrono::steady_clock::now() - started);
@@ -1854,34 +1847,37 @@ TEST_F(BasicCurlHttpTests, ACancelledRetryDoesNotHoldTheClientOpen)
 {
   received_requests_.clear();
 
-  const auto started = std::chrono::steady_clock::now();
+  auto handler = std::make_shared<MultiHandleOutcomeHandler>();
+  std::chrono::steady_clock::time_point started{};
   {
     auto client = std::make_shared<http_client::curl::HttpCurlClientFactory>()->Create();
     ASSERT_TRUE(client != nullptr);
-    auto *concrete = static_cast<http_client::curl::HttpClient *>(client.get());
 
     auto session = client->CreateSession("http://127.0.0.1:19000");
     auto request = session->CreateRequest();
     request->SetUri("retry/");
     request->SetMethod(http_client::Method::Post);
 
-    // Long enough that waiting for it would be unmistakable, and long enough that it cannot
-    // come round on its own inside the bound below.
+    // Long enough that waiting it out would be unmistakable, and long enough that it cannot
+    // come round on its own while the case is still setting up.
     request->SetRetryPolicy(
         {4, std::chrono::duration<float>{8.0f}, std::chrono::duration<float>{16.0f}, 2.0f});
 
-    auto handler = std::make_shared<MultiHandleOutcomeHandler>();
     session->SendRequest(handler);
 
-    // The server answers this route with something retryable, so the session goes into the
-    // retry queue with a time on it that has not come.
-    for (int i = 0;
-         i < 300 && 0 == http_client::curl::HttpClientTestPeer::RetryQueueSize(*concrete); ++i)
-    {
-      std::this_thread::sleep_for(std::chrono::milliseconds(10));
-    }
-    ASSERT_GE(http_client::curl::HttpClientTestPeer::RetryQueueSize(*concrete), 1u)
-        << "the request was never queued for retry, so nothing was tested";
+    // Watched from outside the client. The retry queue has no lock, because only the
+    // background thread is supposed to touch it, and a peer that read it from here would make
+    // that untrue: ThreadSanitizer reports exactly that, twice, against a version of this case
+    // that did. So it waits on what the server saw, which is behind a mutex, and then for long
+    // enough that the answer has been read and the session put back with its wait on it. A
+    // second in, that wait still has seven to run, so anything outstanding here is outstanding
+    // because it is queued.
+    ASSERT_TRUE(waitForRequests(30, 1)) << "the request never reached the server";
+    std::this_thread::sleep_for(std::chrono::seconds(1));
+    ASSERT_EQ(0, handler->terminal_.load(std::memory_order_acquire))
+        << "the request had already finished, so nothing was pending";
+
+    started = std::chrono::steady_clock::now();
 
     // Cancelling takes the operation apart and hands its easy handle back, and the entry left
     // behind names an operation that is not going to be retried by anybody.
@@ -1892,7 +1888,7 @@ TEST_F(BasicCurlHttpTests, ACancelledRetryDoesNotHoldTheClientOpen)
       std::chrono::steady_clock::now() - started);
 
   EXPECT_LT(elapsed.count(), 4000)
-      << "destroying the client took " << elapsed.count()
+      << "tearing the client down took " << elapsed.count()
       << " ms, which is it waiting out a retry for an operation that had already finished";
 }
 #endif  // ENABLE_OTLP_RETRY_PREVIEW

--- a/ext/test/http/curl_http_test.cc
+++ b/ext/test/http/curl_http_test.cc
@@ -1116,6 +1116,10 @@ TEST_F(BasicCurlHttpTests, AClientWithoutAMultiHandleStillAnswers)
       << "the request was accepted and never reached an outcome";
   EXPECT_FALSE(session->IsSessionActive()) << "the session stayed active with nothing running it";
 
+  // Cancel before finishing. If either assertion above failed then nothing is going to complete
+  // this operation, and FinishSession would wait for it for good, so the case would hang rather
+  // than fail. Cancelling a session that already answered does nothing.
+  session->CancelSession();
   session->FinishSession();
   client->FinishAllSessions();
 }

--- a/ext/test/http/curl_http_test.cc
+++ b/ext/test/http/curl_http_test.cc
@@ -208,13 +208,10 @@ public:
   }
 };
 
-// libcurl routes every internal allocation through the callbacks given to
-// curl_global_init_mem, which is the only way to reach the failure returns of
-// curl_slist_append and curl_multi_init. They have to be installed before libcurl is
-// initialised: called afterwards the function returns CURLE_OK and quietly changes nothing.
-//
-// The failure switches are thread local, so arming one cannot disturb a client's background
-// thread. These callbacks serve the whole binary once installed.
+// curl_global_init_mem is the only way to reach the failure returns of curl_slist_append and
+// curl_multi_init. It must be called before libcurl is initialised: afterwards it returns
+// CURLE_OK and changes nothing. The switches are thread local, so arming one from a test cannot
+// disturb a client's background thread.
 extern "C" {
 static std::atomic<bool> g_curl_hooks_ran{false};
 static thread_local bool g_fail_curl_malloc = false;
@@ -261,10 +258,8 @@ static char *CurlTestStrdup(const char *str)
 }
 
 // Aimed at curl_multi_init, which allocates with calloc on the libcurl this was measured
-// against. Which internal allocation a given libcurl uses is not part of its contract, so
-// the cases that rely on this check what actually failed rather than assume.
-// Not thread_local, unlike the switches above. The case that keeps a client alive while the
-// multi handle cannot be created needs the failure to reach the IO thread.
+// against. That is not part of libcurl's contract, so the cases assert on what actually failed.
+// Not thread local, unlike the switches above: the failure has to reach the IO thread.
 static std::atomic<bool> g_fail_curl_calloc_everywhere{false};
 
 // Counts what the process wide switch refused, which is one per curl_multi_init the IO thread

--- a/ext/test/http/curl_http_test.cc
+++ b/ext/test/http/curl_http_test.cc
@@ -266,10 +266,14 @@ static std::atomic<bool> g_fail_curl_calloc_everywhere{false};
 // tried while it had no handle. That is the retry rate, measured the same way everywhere.
 static std::atomic<int> g_curl_calloc_failures{0};
 
+// Exempts one thread from the process wide switch. A test that has to build a request while the
+// IO thread cannot create a handle needs its own allocations to keep working.
+static thread_local bool g_curl_calloc_exempt = false;
+
 static void *CurlTestCalloc(size_t count, size_t size)
 {
   g_curl_hooks_ran.store(true, std::memory_order_relaxed);
-  if (g_fail_curl_calloc_everywhere.load(std::memory_order_relaxed))
+  if (g_fail_curl_calloc_everywhere.load(std::memory_order_relaxed) && !g_curl_calloc_exempt)
   {
     g_curl_calloc_failures.fetch_add(1, std::memory_order_relaxed);
     return nullptr;
@@ -332,6 +336,7 @@ class MultiHandleOutcomeHandler : public http_client::EventHandler
 public:
   void OnResponse(http_client::Response & /* response */) noexcept override
   {
+    responses_.fetch_add(1, std::memory_order_release);
     terminal_.fetch_add(1, std::memory_order_release);
   }
 
@@ -339,10 +344,13 @@ public:
   {
     switch (state)
     {
+      case http_client::SessionState::Cancelled:
+        cancels_.fetch_add(1, std::memory_order_release);
+        terminal_.fetch_add(1, std::memory_order_release);
+        break;
       case http_client::SessionState::CreateFailed:
       case http_client::SessionState::ConnectFailed:
       case http_client::SessionState::SendFailed:
-      case http_client::SessionState::Cancelled:
         terminal_.fetch_add(1, std::memory_order_release);
         break;
       default:
@@ -351,6 +359,8 @@ public:
   }
 
   std::atomic<int> terminal_{0};
+  std::atomic<int> responses_{0};
+  std::atomic<int> cancels_{0};
 };
 
 class CapturingLogHandler : public opentelemetry::sdk::common::internal_log::LogHandler
@@ -1565,6 +1575,73 @@ TEST_F(BasicCurlHttpTests, GzipIncompressibleData)
 // A client whose multi handle can never be created has nothing to run. The IO loop reports a run
 // of failures once and waits between attempts, so a client left alive in that state costs neither
 // a core nor a log line per pass, and this holds both.
+// The phases the loop gates on a multi handle move sessions between queues. Ungated, a session
+// queued while the handle is missing leaves the pending queue for a multi function that cannot
+// take it, and the next reset cancels it, so the caller is told a request was cancelled that
+// nothing cancelled.
+TEST_F(BasicCurlHttpTests, AQueuedRequestSurvivesAMissingMultiHandle)
+{
+  ASSERT_TRUE(g_curl_hooks_installed);
+  received_requests_.clear();
+
+  auto client = std::make_shared<http_client::curl::HttpCurlClientFactory>()->Create();
+  ASSERT_TRUE(client != nullptr);
+
+  // One completed request, so the IO thread exists and is running the loop under test.
+  {
+    auto warm         = client->CreateSession("http://127.0.0.1:19000");
+    auto warm_request = warm->CreateRequest();
+    warm_request->SetUri("get/");
+    auto warm_handler = std::make_shared<MultiHandleOutcomeHandler>();
+    warm->SendRequest(warm_handler);
+    ASSERT_TRUE(waitForRequests(30, 1));
+    warm->FinishSession();
+    ASSERT_GE(warm_handler->responses_.load(std::memory_order_acquire), 1);
+  }
+  received_requests_.clear();
+
+  g_curl_calloc_failures.store(0, std::memory_order_relaxed);
+  g_fail_curl_calloc_everywhere.store(true, std::memory_order_relaxed);
+  auto *concrete = static_cast<http_client::curl::HttpClient *>(client.get());
+  http_client::curl::HttpClientTestPeer::ResetMultiHandle(*concrete);
+
+  // curl_easy_init allocates with calloc too, so without this the request below could not be
+  // built and the case would test the refusal rather than the queue.
+  g_curl_calloc_exempt = true;
+
+  auto session = client->CreateSession("http://127.0.0.1:19000");
+  auto request = session->CreateRequest();
+  request->SetUri("get/");
+  auto handler = std::make_shared<MultiHandleOutcomeHandler>();
+  session->SendRequest(handler);
+
+  // Wait for the IO thread to go round several times with no handle, so the gated phases have
+  // had every chance to consume the queued session.
+  for (int i = 0; i < 200 && g_curl_calloc_failures.load(std::memory_order_relaxed) < 5; ++i)
+  {
+    std::this_thread::sleep_for(std::chrono::milliseconds(10));
+  }
+  ASSERT_GE(g_curl_calloc_failures.load(std::memory_order_relaxed), 1)
+      << "the IO thread never ran without a handle, so nothing was tested";
+
+  g_fail_curl_calloc_everywhere.store(false, std::memory_order_relaxed);
+  g_curl_calloc_exempt = false;
+
+  for (int i = 0; i < 300 && 0 == handler->terminal_.load(std::memory_order_acquire); ++i)
+  {
+    std::this_thread::sleep_for(std::chrono::milliseconds(100));
+  }
+
+  EXPECT_EQ(0, handler->cancels_.load(std::memory_order_acquire))
+      << "the queued request was cancelled although nothing cancelled it";
+  EXPECT_GE(handler->responses_.load(std::memory_order_acquire), 1)
+      << "the request queued while the handle was missing never reached the wire";
+
+  session->CancelSession();
+  session->FinishSession();
+  client->FinishAllSessions();
+}
+
 TEST_F(BasicCurlHttpTests, APersistentMultiHandleFailureDoesNotSpin)
 {
   ASSERT_TRUE(g_curl_hooks_installed);

--- a/ext/test/http/curl_http_test.cc
+++ b/ext/test/http/curl_http_test.cc
@@ -1596,6 +1596,23 @@ TEST_F(BasicCurlHttpTests, GzipIncompressibleData)
 // queued while the handle is missing leaves the pending queue for a multi function that cannot
 // take it, and the next reset cancels it, so the caller is told a request was cancelled that
 // nothing cancelled.
+TEST_F(BasicCurlHttpTests, AQueuedHandleIsReleasedWithTheClientThatQueuedIt)
+{
+  auto client = std::make_shared<http_client::curl::HttpClient>();
+
+  http_client::curl::HttpCurlEasyResource resource;
+  resource.easy_handle = curl_easy_init();
+  ASSERT_TRUE(resource.easy_handle != nullptr);
+  resource.headers_chunk = curl_slist_append(nullptr, "X-Test: 1");
+  ASSERT_TRUE(resource.headers_chunk != nullptr);
+  client->ScheduleRemoveSession(4404, std::move(resource));
+
+  // Nothing was sent, so there is no IO thread and nobody else is coming for that queue. The
+  // record is two raw pointers and the container that holds it frees neither, so what is still
+  // queued when the client goes is the client's to release. LeakSanitizer is the assertion.
+  client.reset();
+}
+
 TEST_F(BasicCurlHttpTests, AHandleQueuedWithoutAMultiHandleIsReleased)
 {
   auto client = std::make_shared<http_client::curl::HttpCurlClientFactory>()->Create();

--- a/ext/test/http/curl_http_test.cc
+++ b/ext/test/http/curl_http_test.cc
@@ -16,9 +16,11 @@
 #include <atomic>
 #include <chrono>
 #include <condition_variable>
+#include <cstdio>
 #include <cstdlib>
 #include <cstring>
 #include <map>
+#include <memory>
 #include <mutex>
 #include <sstream>
 #include <string>
@@ -35,6 +37,7 @@
 #include "opentelemetry/nostd/shared_ptr.h"
 #include "opentelemetry/nostd/string_view.h"
 #include "opentelemetry/sdk/common/global_log_handler.h"
+#include "opentelemetry/sdk/common/thread_instrumentation.h"
 #include "opentelemetry/version.h"
 
 constexpr int HTTP_PORT{19000};
@@ -999,6 +1002,80 @@ TEST_F(BasicCurlHttpTests, AFailedMultiHandleAllocationIsReported)
 
   EXPECT_NE(std::string::npos, text.find("curl_multi_init failed"))
       << "a multi handle that could not be created was not reported, captured: " << text;
+}
+
+// SendAsync refuses a request whose header list could not be built, and Send has to refuse it
+// the same way, or a synchronous caller puts one on the wire carrying none of its headers.
+TEST_F(BasicCurlHttpTests, ASynchronousSendRefusesAFailedHeaderAllocation)
+{
+  ASSERT_TRUE(g_curl_hooks_installed);
+  received_requests_.clear();
+
+  // The operation keeps references to these, so they outlive it.
+  const http_client::HttpSslOptions no_ssl;
+  const http_client::Body body;
+  const http_client::Headers headers         = {{"X-Test", "1"}};
+  const http_client::Compression compression = http_client::Compression::kNone;
+
+  std::unique_ptr<curl::HttpOperation> operation;
+  {
+    // Only the constructor allocates under the switch. Send needs its own allocations to work.
+    FailCurlMalloc fail;
+    operation.reset(new curl::HttpOperation(http_client::Method::Get, "http://127.0.0.1:19000/get/",
+                                            no_ssl, nullptr, headers, body, compression));
+  }
+
+  const CURLcode result = operation->Send();
+
+  size_t requests_seen = 0;
+  {
+    std::unique_lock<std::mutex> lock_requests(mtx_requests);
+    requests_seen = received_requests_.size();
+  }
+
+  EXPECT_EQ(static_cast<size_t>(0), requests_seen)
+      << "a synchronous request went out after its setup had failed";
+
+  if (CURLE_OUT_OF_MEMORY != result)
+  {
+    GTEST_SKIP() << "this libcurl consumed the failing allocation before the header list, "
+                 << "reported as: " << curl_easy_strerror(result);
+  }
+  EXPECT_EQ(CURLE_OUT_OF_MEMORY, operation->GetLastResultCode())
+      << "the refusal was not recorded as the last result";
+}
+
+// Both constructors reach the multi handle through the same helper, so the overload that takes
+// thread instrumentation reports a failed one too. A null instrumentation is enough to pick it.
+TEST_F(BasicCurlHttpTests, AFailedMultiHandleIsReportedForAnInstrumentedClient)
+{
+  ASSERT_TRUE(g_curl_hooks_installed);
+
+  {
+    auto warmup = std::make_shared<http_client::curl::HttpCurlClientFactory>()->Create();
+    ASSERT_TRUE(warmup != nullptr);
+    warmup->FinishAllSessions();
+  }
+
+  auto *capture = new CapturingLogHandler();
+  auto previous = opentelemetry::sdk::common::internal_log::GlobalLogHandler::GetLogHandler();
+  opentelemetry::sdk::common::internal_log::GlobalLogHandler::SetLogHandler(
+      nostd::shared_ptr<opentelemetry::sdk::common::internal_log::LogHandler>(capture));
+
+  {
+    FailCurlCalloc fail;
+    auto client = std::make_shared<http_client::curl::HttpCurlClientFactory>()->Create(
+        std::shared_ptr<opentelemetry::sdk::common::ThreadInstrumentation>{});
+    ASSERT_TRUE(client != nullptr);
+    client->FinishAllSessions();
+  }
+
+  const std::string text = capture->Text();
+  opentelemetry::sdk::common::internal_log::GlobalLogHandler::SetLogHandler(previous);
+
+  EXPECT_NE(std::string::npos, text.find("curl_multi_init failed"))
+      << "the instrumented constructor did not report a multi handle it could not create, "
+      << "captured: " << text;
 }
 
 // Reporting the failure does not by itself stop the client taking requests, so this holds what

--- a/ext/test/http/curl_http_test.cc
+++ b/ext/test/http/curl_http_test.cc
@@ -1594,6 +1594,14 @@ TEST_F(BasicCurlHttpTests, AQueuedRequestSurvivesAMissingMultiHandle)
 
   auto client = std::make_shared<http_client::curl::HttpCurlClientFactory>()->Create();
   ASSERT_TRUE(client != nullptr);
+  auto *concrete = static_cast<http_client::curl::HttpClient *>(client.get());
+
+  // The idle grace is a minute by default, but only from libcurl 7.68: the assignment that
+  // gives it that value is behind a version check, and older libcurl leaves it at zero, where
+  // the IO thread reaches the retirement check on its first idle pass. CMake asks for no
+  // minimum libcurl, so both are supported and this asks for the shorter one, to run the same
+  // way everywhere rather than the way whichever libcurl the job has happens to allow.
+  concrete->SetBackgroundWaitFor(std::chrono::milliseconds::zero());
 
   // One completed request, so the IO thread exists and is running the loop under test.
   {
@@ -1608,9 +1616,12 @@ TEST_F(BasicCurlHttpTests, AQueuedRequestSurvivesAMissingMultiHandle)
   }
   received_requests_.clear();
 
+  // Join the IO thread before taking its multi handle away. resetMultiHandle destroys the one
+  // it finds, and a handle another thread is inside is not one to destroy.
+  concrete->WaitBackgroundThreadExit();
+
   g_curl_calloc_failures.store(0, std::memory_order_relaxed);
   g_fail_curl_calloc_everywhere.store(true, std::memory_order_relaxed);
-  auto *concrete = static_cast<http_client::curl::HttpClient *>(client.get());
   http_client::curl::HttpClientTestPeer::ResetMultiHandle(*concrete);
 
   // curl_easy_init allocates with calloc too, so without this the request below could not be


### PR DESCRIPTION
Fixes #4404

## Changes

Two allocation points whose failure was read as success. Each sits next to a check the same file already makes, which is what makes them look like oversights rather than a decision.

### `curl_slist_append`

[The docs](https://curl.se/libcurl/c/curl_slist_append.html) name this pattern: "A null pointer is returned if anything went wrong, otherwise the new list pointer is returned. To avoid overwriting an existing non-empty list on failure, the new list should be returned to a temporary variable which can be tested for NULL before updating the original list pointer."

Assigning straight back over `headers_chunk` is the opposite of that. The pointer to everything appended so far goes with it, so the two places that free the list, `Cleanup()` and `doRemoveSessions()`, both see null and neither runs. Then the constructor carries on and dispatches `Created`, and `Setup()` only sets `CURLOPT_HTTPHEADER` when `headers_chunk` is non-null, so the request goes out with none of the caller's headers rather than not going out at all. For an OTLP export that is no `Content-Type: application/x-protobuf` and a receiver rejecting a request the exporter believes it sent correctly.

It appends into a temporary now, and on failure the partial list is released.

Reporting it is not the whole fix, which is the part I had wrong when I first opened this. Returning from the constructor does not stop `Session::SendRequest`: it calls `SendAsync` unconditionally, the easy handle is still valid, and `Setup()` only skips `CURLOPT_HTTPHEADER` rather than failing. So the first version of this announced `CreateFailed` and then sent the request anyway, without the caller's headers, which is the behaviour this PR exists to stop. Measured three runs out of three before the fix, one request reaching the test server each time.

The construction result is now held on the operation, `Send()` and `SendAsync()` both refuse on it before `Setup()`, and `Session::SendRequest` reports it once with the reason curl gave rather than the empty string that branch used to pass. The constructor also marks the operation terminal, or `Cleanup()` from `~HttpOperation` announces a cancel for something that never started, to a handler the caller may already have dropped. That one aborts with `pure virtual method called`, and it only showed up once the send was actually stopped.

### `curl_multi_init`

Same shape, three sites: both `HttpClient` constructors and `resetMultiHandle()`. [The docs](https://curl.se/libcurl/c/curl_multi_init.html): "If this function returns NULL, something went wrong and you cannot use the other curl functions."

What a null one does, measured rather than assumed, against libcurl 8.14.1:

```
multi_add_handle(NULL, easy)    = 1  (Invalid multi handle)
multi_remove_handle(NULL, easy) = 1  (Invalid multi handle)
  CURLM_BAD_HANDLE              = 1
```

`doAddSessions()` drops that return, so such a client would accept every session, add none of them to a multi handle, and complete none of them. `resetMultiHandle()` is the one I would worry about most: it runs while recovering from a multi error, so a failure there turns a working client into a black hole for the rest of its life with nothing logged. All three now go through one small helper that logs.

`HttpClient::wakeupBackgroundThread()` already guards the same member for null before `curl_multi_wakeup`, so a null handle is something this file half expects. This makes it visible rather than silent.

### The IO thread, once the handle is null

@lalitb asked whether logging the failure changes anything, since the client still takes requests. Following that down found two things it does not change.

A client built on a null multi handle does answer. `curl_multi_perform` rejects the handle, the loop creates a new one, the pending session moves to it, and the request completes. Measured three runs out of three, with the internal log captured in the same run so the numbers are not describing a healthy client. So refusing at `SendRequest` would trade a transient failure that repairs itself for a client that is permanently dead.

What does not recover is a handle that can never be created, and that used to be much worse than a missing feature. `curl_multi_perform` leaves `still_running` alone when it rejects the handle, and the loop initializes it to one, so the client kept reporting work it did not have: every pass took the `still_running > 0` branch, which is above the `is_shutdown_` check and above the wait. With the client alive, that cost **3.00 seconds of CPU and 1,168,126 error lines over a three second window**, three runs out of three, and `~HttpClient` could never join the thread.

Three changes close it. `curl_multi_perform` and `curl_multi_info_read` are not called with a handle libcurl refused to give, which is what `curl_multi_init` asks for. `resetMultiHandle()` reports whether the client has a handle afterwards. And a run of failures is reported once and waited on for as long as a poll would have taken. The same window now costs 0.00 seconds of CPU and two log lines.

Two things that reviewing the change turned up, rather than review. The wait cannot be interrupted, because `wakeupBackgroundThread` reaches the worker through the multi handle and the branch exists precisely because there is not one, so destroying a client whose worker was inside it measured 168 ms. It is taken in 16 ms slices with `is_shutdown_` rechecked now, which measures 10 ms, five runs out of five. And `curl_multi_poll` and `curl_multi_wait` need no guard, since they sit inside the branch that only runs when perform succeeded. `curl_multi_add_handle` and `curl_multi_remove_handle` do get a null handle, and the section below is what became of that.

### The handle was also created before libcurl was initialized

Members are initialized in declaration order, and `multi_handle_` is declared before `curl_global_initializer_`, so both constructors called `curl_multi_init` before `HttpCurlGlobalInitializer` had called `curl_global_init`. libcurl asks for the opposite. No CI job could see it: the allocation cases install their allocators from `SetUpTestSuite` with `curl_global_init_mem`, which initializes libcurl before any client exists. The handle is created in the constructor body now, after every member including that one.

## Tests

Both failures are covered now, and the first thing to say is that I was wrong above. I wrote that neither could be forced without an allocator hook. The hook is [`curl_global_init_mem`](https://curl.se/libcurl/c/curl_global_init_mem.html), a documented part of libcurl, so that was a reason not to go looking rather than a reason it could not be done.

libcurl routes its internal allocations through the callbacks that function is given, so the suite installs a set of them and arms a thread local switch around the call under test. Thread local matters: once installed these callbacks serve the whole binary, and a client's background thread has to keep allocating normally while one test is arming a failure.

The switch is per allocation function rather than per call count, which is what keeps it independent of how many allocations a particular libcurl happens to make. Measured against 8.14.1:

| | malloc | calloc | strdup |
| --- | ---: | ---: | ---: |
| `curl_easy_init` | 0 | 1 | 4 |
| `curl_slist_append` | 1 | 0 | 1 |
| `curl_multi_init` | 0 | 8 | 4 |

Failing malloc alone therefore selects the list append and leaves the easy handle intact, and failing calloc selects the multi handle. The header case also holds the reported reason to "Out of memory" rather than "Failed initialization", so it cannot pass on a `curl_easy_init` failure by accident, and it asserts what the fix is actually for: the server receives no request, and exactly one terminal outcome reaches the handler.

The flag those hooks set is `std::atomic<bool>`. It was a plain `bool` in the first version and the Bazel TSAN job reported the race, since libcurl calls the callbacks from whichever thread is allocating, including a client's background thread.

`curl_global_init_mem` returns `CURLE_OK` and quietly changes nothing once libcurl has been initialised, so the hooks go in from `SetUpTestSuite`. A third case asserts they were installed in time, since otherwise the other two would fail with a confusing message rather than a clear one.

Fail before and pass after, reverting one production file at a time:

| reverted | result |
| --- | --- |
| the `curl_slist_append` change only | `AFailedHeaderAllocationIsReported` fails |
| the `curl_multi_init` change only | `AFailedMultiHandleAllocationIsReported` fails |
| nothing | 26 of 26 pass |

## Checks

| | result |
| --- | --- |
| `curl_http_test`, `OTELCPP_MAINTAINER_MODE=ON` | 27 of 27, 0 warnings, rebased over #4394 |
| the same suite without `WITH_STL` | 26 of 26, so dropping `<memory>` costs nothing off the `CXX14` path |
| `clang-format` 18.1.8 | clean on all three changed files |
| `clang-tidy` 22 with the CI filters | 0 on the test file and on `http_client_curl.cc`, and 4 on `http_operation_curl.cc` which is exactly what `main` reports for it |
| `include-what-you-use` 0.26 with `--mapping_file=.iwyu.imp`, `CXX14` | 0 diagnostics on all three, having first reported and then cleared two |

## Installed surface

Correcting myself on where these classes live, because I had it wrong here. `ext/CMakeLists.txt` installs four headers from `ext/http/client`, and `http_client_curl.h` and `http_operation_curl.h` are not among them: they are the implementation behind `http_client_factory_curl.h`. So a CMake consumer does not see either layout. Bazel is the other way round, since `//ext` takes `hdrs = glob(["include/**/*.h"])`, so a Bazel consumer can include both. That difference is its own question and not this one.

With that said, two layouts move. `HttpOperation` gains `construction_result_`, and `HttpClient` gains `wakeup_generation_`, an atomic the producers raise so the background thread can be woken without a multi handle. Both are private, and `HttpClient::resetMultiHandle()` becoming `bool` is private too. If the project holds these two to a layout guarantee anyway, say so: the construction result can be carried in the existing `last_curl_result_` and `session_state_`, and the wakeup counter can go behind the existing `multi_handle_m_` instead of being its own member.

## What review turned up after that, and what came of it

Six things in the change itself, each measured before it was accepted and each with a case that fails without the fix, and five in the cases.

**The worker could retire holding a request.** Without a multi handle the add, remove and retry phases are skipped, and the retirement check read that as having nothing to do, so a request the client had already accepted could be sitting in `pending_to_add_session_ids_` while the thread that was going to schedule it detached and left. Nothing brought it back, and `FinishSession` waited on a promise nobody was left to fulfil. How long that took depended on the libcurl the job was built against: the idle grace is a minute, but the line that sets it is behind a version check and older libcurl leaves it at zero, where the thread reaches the retirement check on its first idle pass. CMake asks for no minimum libcurl, so both are supported, and that is why the case was red on some jobs and green here. The thread now stays while it has work of its own left, with shutdown exempt, which is the whole difference from an earlier version of this gate that took every queue at its size and held the thread against the join in the destructor. Actionable is not the same as present, so an id whose session has gone is dropped rather than counted.

**`wakeupBackgroundThread` did nothing without a handle.** It goes through `curl_multi_wakeup`, and on libcurl older than 7.68.0 it compiled to nothing at all. Every producer now raises a counter first, and the wait taken when there is no handle watches that, so a queued request is picked up within a slice rather than at the end of the delay.

**Three multi calls were still made with no multi handle.** `curl_multi_cleanup` twice, in the destructor and in `resetMultiHandle`, and `curl_multi_remove_handle` through `doRemoveSessions`, which `resetMultiHandle` calls whether or not there is a handle. That is the contract the rest of this branch guards, so it should not have been the branch breaking it. Cleanup now goes through one function that answers whether there is a handle, reports a result that is not `CURLM_OK`, and leaves none behind. Detaching needs something to detach from, and there is nothing a null handle could name: the one it would have named was destroyed by `curl_multi_cleanup`, which detaches what it still holds, and nothing has been attached since, so the resource is released. Removing therefore no longer waits for a handle, since waiting held easy handles and header lists for the whole outage, which is the wrong way round.

**The recovery cases were unsound.** Both sent a request first, so the IO thread existed, and then called `resetMultiHandle` from the test thread, which destroys the multi handle and builds another while the IO thread may be inside `curl_multi_perform`, `curl_multi_poll` or `curl_multi_info_read` on the same one. libcurl leaves handles unsynchronized, and the IO thread does not hold `multi_handle_m_` around those calls, so the lock the reset takes does not stand for it. Neither case needs to take a handle away: `curl_multi_init` is what fails in #4404, and it is called first by the constructor, so a client built while the allocator is refusing has no multi handle from the start and every attempt after that is the IO thread's own. Both are built that way now.

**Resources could be left with no owner.** An operation hands its easy handle and header list to `pending_to_remove_session_handles_` on its way out, and that record is two raw pointers whose container frees neither. Everything that drains it runs on the background thread. Anything queued after that thread retired, or by the cancel the destructor itself does, had nobody left to release it, and the caller may already have had its terminal outcome: what is left over is the libcurl resources behind it. The destructor does that last pass itself now, before the multi handle goes so a handle still attached can be given back.

**A retry queue entry outlived what it named.** Under `ENABLE_OTLP_RETRY_PREVIEW` a retryable response puts the session in the retry queue with a time on it, and a cancel or a reset before that time left the entry there, since the session was still a session and still had an operation. When the time came the easy handle had gone back to the client, so libcurl was handed a null one and the result was never read, and until it came the idle check reported the queue as work. At shutdown that is the join waiting for an operation that finished long before: 6.4 seconds, three runs out of three. Entries are dropped when the operation is gone, was cancelled, or no longer holds an easy handle, and the remove and the add are read now, with the add only attempted if the remove worked and the operation finished rather than forgotten if it did not.

## What the cases were getting wrong

**Global state a failing case could leave behind.** The allocator switches were armed with three fatal assertions between the arming and the disarming, so one of those returning would have left every later case in the binary allocating through a calloc that refuses, on every thread. The internal log handler is a process global that `GlobalLogHandler` reads and writes through a plain shared pointer with nothing synchronizing it, and one case put it back while the client, and the thread writing to it, were still there. Both are guards now, the log one declared before the client so it is destroyed after it. And `curl_global_init_mem` in `SetUpTestSuite` had no matching cleanup, so with every client taking one of its own through `HttpCurlGlobalInitializer` the count never reached zero and the allocator callbacks stayed installed into static teardown.

**A count that did not say what it claimed.** The log capture counted every line rather than the one the case is about, so anything else the binary wrote moved a bound that is meant to say how often one failure was reported. It takes the text it wants now. The allocation count had the same problem from the other end: the constructor's own attempt is one, so the assertion saying the IO thread had tried could be satisfied without the IO thread existing. Both cases put it back to zero after the constructor and before there is a thread to make one, and the thread that armed it is exempt from that point, so what is counted afterwards was refused to the IO thread and to nothing else.

**A fix with no case that could fail without it.** The header cases sent one header, so the append that failed was the first one and the list it was given was empty, which is the one shape the temporary pointer cannot be told apart from assigning the result straight back. Aiming at the second append needs the failure to land on a particular allocation, and the injection asked for any block of 64 bytes or less, which is a guess about a libcurl that promises none of it. It is measured now: the file watches one append happen and takes the size of the block it asked for, then refuses blocks of exactly that size after letting a stated number through. That also narrows what has to be skipped, from anything else having consumed the failure to an append not reaching the malloc callback at all. Against the assignment `main` has, LeakSanitizer reports 27 bytes in 2 allocations, three runs out of three.

## The policy this picks, and the one it does not

A client with no multi handle can be answered two ways, and until now it was answered both, badly. This branch is recovery: work that has been accepted is kept, the IO thread stays while it owes somebody an answer, and the request goes out as soon as `curl_multi_init` succeeds, which the case measures at 1081 ms. Shutdown is the bound. There everything unscheduled is finished and the native resources are released, by the IO thread while it is still there and by the destructor when it is not. There is deliberately no retry budget: while the client is alive, a request it accepted keeps being tried.

Fail fast is the other coherent answer, a budget and then every pending operation finished exactly once, and it is a bound plus one condition on the same gate. @lalitb has already looked at this and said preserving the transient recovery is preferable to failing the client permanently, so recovery is what this does rather than an open question, and the fail fast shape is written down here only so that the choice is visible.

What was there before was neither. Recovery sometimes, a `Cancelled` nobody asked for sometimes, a request stranded until some later request happened to spawn a thread sometimes. Each of those is a commit here, and each has a mutation check: reverting the retirement gate hangs the queued case three runs out of three at the 240 second bound, reverting the destructor drain leaks 5582 bytes in 7 allocations, reverting the retry purge makes the destructor take 6.4 seconds, and reverting the temporary pointer in the header loop leaks 27 bytes in 2. The null handle guards are the one exception and are marked as such below: measured libcurl answers a null multi handle with `CURLM_BAD_HANDLE` rather than crashing, so what changes there is the contract rather than the behaviour.

## What this does not close

Four things sit next to this and are not fixed by it. Saying so here rather than letting the branch read as if the whole client were now exactly-once.

**`curl_global_init`'s return is still ignored.** This branch fixed the ordering, since `multi_handle_` is declared before `curl_global_initializer_` and member initialisation order meant `curl_multi_init` ran before `curl_global_init` had. Ordering is not success, and libcurl says a non-zero return means the other functions cannot be used. #4434 has the detail, including why there is no patch: the suite installs its allocator callbacks with `curl_global_init_mem`, which **is** the global initialisation, so by the time any client exists libcurl is initialised and the singleton's `curl_global_init` is a reference count bump that returns `CURLE_OK` whatever the allocator does. Reaching that failure needs a seam, and that is a conversation rather than something to slip in here.

**Exactly-once is claimed for construction failure only.** A `Setup()` failure still dispatches `ConnectFailed` from `SendAsync` and then `CreateFailed` from `Session::SendRequest`, which is #4360 item 3 and is untouched. What this branch does is give the constructor a result and make `SendAsync` refuse on it before `Setup()` runs, so a failed `curl_easy_init` or header list produces one terminal event. `AFailedEasyHandleIsReportedOnce` counts that and nothing wider.

**The gzip branch still reports and sends.** `CreateFailed` goes to the caller and then control falls through to `SendAsync`, carrying a body `deflateInPlace` may have written into, at its original length and with no `Content-Encoding`. #4360 item 1, untouched.

**A direct `HttpOperation` caller is told by the return code, not by its handler.** The constructor records a failure and does not dispatch it, so a failed `curl_easy_init` or header list reaches an `EventHandler` only through `Session::SendRequest`, once, as `CreateFailed`. That is coherent if `Session` is the only supported owner of asynchronous notification, and it is what keeps the count at one. The asymmetry is that the constructor does dispatch `Created` on its way out when it succeeds. Making it symmetric means the constructor reports and `Session::SendRequest` then must not, which is more machinery for the same single event, so I have left it as it is and would rather be told. How much that matters depends on which build you take. `ext/CMakeLists.txt` does not install `http_operation_curl.h`, so a CMake consumer cannot construct one directly at all, while `//ext` takes `hdrs = glob(["include/**/*.h"])` and a Bazel consumer can. So the question is narrower than an installed API and wider than an internal detail, and it is still yours to answer rather than mine.

## What the cases cover, and what they do not

Against the failure schedules worth having, since a list of green cases says less than a list of the ones that are missing.

Covered here: a multi handle that cannot be created and then can; one that never can, through to shutdown; a removal queued with no multi handle, and one still queued when the client goes; a retry entry whose session was cancelled before its time; the first header append succeeding and the second failing; a failed `curl_easy_init` on both the synchronous and asynchronous paths. Covered on #4395: a session a reset took before its id was queued, and one `curl_multi_add_handle` rejects.

Also covered, and added because the list of failure schedules worth having asked for it: a client destroyed with a retry still pending and nobody cancelling it, which is what an exporter shutting down actually does. Both retry cases fail against a queue check that only drops entries with no operation, three runs out of three, at 5.40 seconds against a bound of four.

Not covered, and each for a reason rather than an oversight: a working multi handle failing mid-transfer, because `curl_multi_perform` cannot be made to fail from a test without a seam; a retryable response already queued when a reset happens; a `curl_easy_setopt` failing inside `Setup()`, which is the #4360 path above; and the gzip failure, likewise. The libcurl version split is covered rather than skipped, because the queued case pins the zero idle grace that older libcurl uses, so both branches of that version check run on every platform.

Configurations, because one build saying yes is not the same as the matrix saying yes, and the first pass here was one build. All on Linux with gcc 14 and libcurl 8.14.1, and all from one commit, which is named because three commits have landed since: a review pass over the cases, and the two includes include-what-you-use asked for. The table is being re-measured on the head rather than carried forward, and this line will say which commit once it is.

| | cases | |
| --- | ---: | --- |
| default, retry preview on | 40 | pass |
| retry preview off | 35 | pass, the four retry cases compile out |
| thread instrumentation preview on | 40 | pass |
| compression preview on | 42 | pass, and the two gzip cases only exist here |
| AddressSanitizer with `detect_leaks=1` | 40 | pass, no report |
| ThreadSanitizer | 40 | pass, no warning |
| UndefinedBehaviorSanitizer | 40 | pass, no report |
| C++20 | 40 | pass |

LeakSanitizer was checked with a deliberate leak first, so that a clean run means it was looking. Two things that came out of running the rest rather than assuming them: with compression on there are two more cases that had never been compiled in anything I ran, and ThreadSanitizer found two data races, both of them in a test peer of mine that read the retry queue from the test thread while the background thread pushed to it. That queue has no lock because only the background thread is meant to touch it, so the peer made its own premise false. It is gone, and the cases wait on what the server received instead.

Not run, and worth saying: Valgrind, a no-exceptions build, static against shared libcurl, Windows and macOS, and libcurl older than 7.68. The last one is the only one that worries me and it is the one the cases work around, by pinning the zero idle grace that older libcurl uses so both sides of that version check run everywhere.

## Related

#4395 is a dependency rather than an overlap, and this section used to say the opposite. `resetMultiHandle` keeps the sessions whose ids are already in `pending_to_add_session_ids_` and takes the rest, and a request between `CreateSession` and `SendAsync` is one of the rest: the reset cancels it, and on `main` the id then goes into the queue whatever became of the session, where `doAddSessions` finds nothing to add and moves on, leaving a promise nobody fulfils. #4395 refuses that id and finishes the operation itself, and `ASessionResetTookBeforeItWasQueuedIsFinished` on that branch is the case for it: it hangs three runs out of three against a revert, and passes in 503 ms. So this branch can recover a multi handle and still leave that one request unanswered without it, and the order that works is #4395 first with this rebased on it.

#4405 answers the ownership question this one raises, and the two do not combine mechanically. The ledger there records whether the multi handle was ever given a particular easy handle, which is the question a missing handle makes unanswerable from `multi_handle_` alone, and a refused removal is kept in a member queue rather than dropped. The resolution that works puts `attached_handles_.clear()` inside the single function that releases the multi handle, so a ledger naming a handle that has gone is not a state either branch can reach. I built the two together to find out rather than assume: `AResetThatCannotBuildAReplacementLeavesNothingAttached` is the combined case, and without that one line it reports the handle still attached and the record quarantined for a multi handle that is never coming. The combined tree passes 46 of 46 under AddressSanitizer with `detect_leaks=1`.

Small overlaps with two open PRs, both one line, and I will take the rebase rather than ask anyone else to:

* #4405 makes the same include change, because it also logs from outside the compression guard: one unconditional `global_log_handler.h` in place of the conditional copy.
* #4394 has landed, and the rebase keeps its change rather than the old body: `sessions_m_` is still scoped to the snapshot inside `resetMultiHandle()`, and `friend class HttpClientTestPeer` is still on the client.

#4392 has landed and this branch is rebased on it, and its rule is kept: nothing here writes to an easy handle from the calling thread. The one conflict was in the test file, where both add cases at the same place, and both sets are present. #4394 is in the base too, and the `sessions_m_` scope inside `resetMultiHandle` is still the snapshot only.

#4391 asked for the unchecked `curl_multi_remove_handle` and `curl_multi_add_handle`, and the retry path is one of the places it named. That pair is read now, and the add only happens if the remove worked, so that part of it is answered here. The rest of #4391 is the teardown ownership #4405 carries, and the issue should stay open for it.

## About the lines Codecov marks

Codecov reported 11 lines of this change without cover. I read them rather than
adding a test per line, and they are not one thing.

Three of them were the TLS version range and the cipher list in `Setup()`, and
they were uncovered because nothing in the suite passed either option. Two cases
now do, and `gcovr` reports one hit each afterwards. The first draft of those
cases passed while covering none of it, because the whole SSL block sits behind
`ssl_options_.use_ssl` and I had set the TLS fields without it; the measurement
is what caught that, not the green.

The rest are in the recovery path this change adds for a null multi handle, and
in the two `curl_multi_cleanup` failure logs. Reaching the first needs a client
whose multi handle failed to initialise, and there is no seam for that here:
`curl_multi_init` is called directly. Reaching the second needs
`curl_multi_cleanup` to fail, which it did not in 104 and 13 evaluations
respectively. I have left both uncovered rather than build injection machinery
for them, and I would rather say so than have the number read as an oversight.

For significant contributions please make sure you have completed the following items:

* [x] `CHANGELOG.md` updated for non-trivial changes
* [x] Unit tests have been added
* [x] Changes in public API reviewed











