### PR TITLE
[API] Never set a null global provider or propagator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -196,6 +196,24 @@ Increment the:
   `AlwaysOff`/`TraceBased`)
   [#4267](https://github.com/open-telemetry/opentelemetry-cpp/pull/4267)
 
+Important changes:
+
+* [API] Never set a null global provider or propagator
+  [#4420](https://github.com/open-telemetry/opentelemetry-cpp/pull/4420)
+
+  * `trace::Provider::SetTracerProvider()`,
+    `metrics::Provider::SetMeterProvider()`,
+    `logs::Provider::SetLoggerProvider()`,
+    `logs::Provider::SetEventLoggerProvider()` and
+    `context::propagation::GlobalTextMapPropagator::SetGlobalPropagator()`
+    now install the corresponding no-op implementation when passed a null
+    pointer, instead of storing the null. The matching getters therefore never
+    return `nullptr`, as already documented, and code that resets a global
+    during cleanup no longer risks a nullptr de-ref on a later use.
+    **Note**: this is a correctness fix to an inline API header; the observable
+    behavior of these methods changes towards the already documented contract
+    (see `docs/abi-policy.md`).
+
 Breaking changes:
 
 * [CONFIGURATION] SDK default component builder libraries and example

--- a/api/include/opentelemetry/context/propagation/global_propagator.h
+++ b/api/include/opentelemetry/context/propagation/global_propagator.h
@@ -26,16 +26,35 @@ class TextMapPropagator;
 class OPENTELEMETRY_EXPORT GlobalTextMapPropagator
 {
 public:
+  /**
+   * Returns the singleton TextMapPropagator.
+   *
+   * By default, a no-op TextMapPropagator is returned. This will never return a
+   * nullptr TextMapPropagator.
+   */
   static nostd::shared_ptr<TextMapPropagator> GetGlobalPropagator() noexcept
   {
     std::lock_guard<common::SpinLockMutex> guard(GetLock());
     return nostd::shared_ptr<TextMapPropagator>(GetPropagator());
   }
 
+  /**
+   * Changes the singleton TextMapPropagator.
+   *
+   * Passing a nullptr TextMapPropagator installs a no-op TextMapPropagator, so
+   * that GetGlobalPropagator() never returns a nullptr TextMapPropagator.
+   */
   static void SetGlobalPropagator(const nostd::shared_ptr<TextMapPropagator> &prop) noexcept
   {
     std::lock_guard<common::SpinLockMutex> guard(GetLock());
-    GetPropagator() = prop;
+    if (prop)
+    {
+      GetPropagator() = prop;
+    }
+    else
+    {
+      GetPropagator() = nostd::shared_ptr<TextMapPropagator>(new NoOpPropagator());
+    }
   }
 
 private:

--- a/api/include/opentelemetry/logs/provider.h
+++ b/api/include/opentelemetry/logs/provider.h
@@ -40,11 +40,21 @@ public:
 
   /**
    * Changes the singleton LoggerProvider.
+   *
+   * Passing a nullptr LoggerProvider installs a no-op LoggerProvider, so that
+   * GetLoggerProvider() never returns a nullptr LoggerProvider.
    */
   static void SetLoggerProvider(const nostd::shared_ptr<LoggerProvider> &tp) noexcept
   {
     std::lock_guard<common::SpinLockMutex> guard(GetLock());
-    GetProvider() = tp;
+    if (tp)
+    {
+      GetProvider() = tp;
+    }
+    else
+    {
+      GetProvider() = nostd::shared_ptr<LoggerProvider>(new NoopLoggerProvider);
+    }
   }
 
 #if OPENTELEMETRY_ABI_VERSION_NO < 2
@@ -64,13 +74,23 @@ public:
 
   /**
    * Changes the singleton EventLoggerProvider.
+   *
+   * Passing a nullptr EventLoggerProvider installs a no-op EventLoggerProvider,
+   * so that GetEventLoggerProvider() never returns a nullptr EventLoggerProvider.
    * @deprecated
    */
   OPENTELEMETRY_DEPRECATED static void SetEventLoggerProvider(
       const nostd::shared_ptr<EventLoggerProvider> &tp) noexcept
   {
     std::lock_guard<common::SpinLockMutex> guard(GetLock());
-    GetEventProvider() = tp;
+    if (tp)
+    {
+      GetEventProvider() = tp;
+    }
+    else
+    {
+      GetEventProvider() = nostd::shared_ptr<EventLoggerProvider>(new NoopEventLoggerProvider);
+    }
   }
 #endif
 

--- a/api/include/opentelemetry/metrics/provider.h
+++ b/api/include/opentelemetry/metrics/provider.h
@@ -35,11 +35,21 @@ public:
 
   /**
    * Changes the singleton MeterProvider.
+   *
+   * Passing a nullptr MeterProvider installs a no-op MeterProvider, so that
+   * GetMeterProvider() never returns a nullptr MeterProvider.
    */
   static void SetMeterProvider(const nostd::shared_ptr<MeterProvider> &tp) noexcept
   {
     std::lock_guard<common::SpinLockMutex> guard(GetLock());
-    GetProvider() = tp;
+    if (tp)
+    {
+      GetProvider() = tp;
+    }
+    else
+    {
+      GetProvider() = nostd::shared_ptr<MeterProvider>(new NoopMeterProvider);
+    }
   }
 
 private:

--- a/api/include/opentelemetry/trace/provider.h
+++ b/api/include/opentelemetry/trace/provider.h
@@ -35,11 +35,21 @@ public:
 
   /**
    * Changes the singleton TracerProvider.
+   *
+   * Passing a nullptr TracerProvider installs a no-op TracerProvider, so that
+   * GetTracerProvider() never returns a nullptr TracerProvider.
    */
   static void SetTracerProvider(const nostd::shared_ptr<TracerProvider> &tp) noexcept
   {
     std::lock_guard<common::SpinLockMutex> guard(GetLock());
-    GetProvider() = tp;
+    if (tp)
+    {
+      GetProvider() = tp;
+    }
+    else
+    {
+      GetProvider() = nostd::shared_ptr<TracerProvider>(new NoopTracerProvider);
+    }
   }
 
 private:

--- a/api/test/context/propagation/BUILD
+++ b/api/test/context/propagation/BUILD
@@ -17,3 +17,18 @@ cc_test(
         "@com_google_googletest//:gtest_main",
     ],
 )
+
+cc_test(
+    name = "global_propagator_test",
+    srcs = [
+        "global_propagator_test.cc",
+    ],
+    tags = [
+        "api",
+        "test",
+    ],
+    deps = [
+        "//api",
+        "@com_google_googletest//:gtest_main",
+    ],
+)

--- a/api/test/context/propagation/CMakeLists.txt
+++ b/api/test/context/propagation/CMakeLists.txt
@@ -1,7 +1,8 @@
 # Copyright The OpenTelemetry Authors
 # SPDX-License-Identifier: Apache-2.0
 
-foreach(testname composite_propagator_test environment_carrier_test)
+foreach(testname composite_propagator_test environment_carrier_test
+                 global_propagator_test)
   add_executable(${testname} "${testname}.cc")
   target_link_libraries(${testname} ${GTEST_BOTH_LIBRARIES}
                         ${CMAKE_THREAD_LIBS_INIT} opentelemetry_api)

--- a/api/test/context/propagation/global_propagator_test.cc
+++ b/api/test/context/propagation/global_propagator_test.cc
@@ -1,0 +1,107 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+#include <gtest/gtest.h>
+#include <cstdint>
+#include <map>
+#include <string>
+
+#include "opentelemetry/context/context.h"
+#include "opentelemetry/context/propagation/global_propagator.h"
+#include "opentelemetry/context/propagation/text_map_propagator.h"
+#include "opentelemetry/nostd/function_ref.h"
+#include "opentelemetry/nostd/shared_ptr.h"
+#include "opentelemetry/nostd/string_view.h"
+#include "opentelemetry/nostd/variant.h"
+
+using opentelemetry::context::propagation::GlobalTextMapPropagator;
+using opentelemetry::context::propagation::TextMapCarrier;
+using opentelemetry::context::propagation::TextMapPropagator;
+
+namespace context = opentelemetry::context;
+namespace nostd   = opentelemetry::nostd;
+
+namespace
+{
+
+class TextMapCarrierTest : public TextMapCarrier
+{
+public:
+  nostd::string_view Get(nostd::string_view key) const noexcept override
+  {
+    auto it = headers_.find(std::string(key));
+    if (it != headers_.end())
+    {
+      return nostd::string_view(it->second);
+    }
+    return "";
+  }
+
+  void Set(nostd::string_view key, nostd::string_view value) noexcept override
+  {
+    headers_[std::string(key)] = std::string(value);
+  }
+
+  std::map<std::string, std::string> headers_;
+};
+
+class TestPropagator : public TextMapPropagator
+{
+public:
+  context::Context Extract(const TextMapCarrier & /* carrier */,
+                           context::Context &context) noexcept override
+  {
+    return context;
+  }
+
+  void Inject(TextMapCarrier &carrier, const context::Context & /* context */) noexcept override
+  {
+    carrier.Set("test", "value");
+  }
+
+  bool Fields(nostd::function_ref<bool(nostd::string_view)> /* callback */) const noexcept override
+  {
+    return true;
+  }
+};
+
+TEST(GlobalPropagator, GetGlobalPropagatorDefault)
+{
+  auto propagator = GlobalTextMapPropagator::GetGlobalPropagator();
+  EXPECT_NE(nullptr, propagator);
+}
+
+TEST(GlobalPropagator, SetGlobalPropagator)
+{
+  auto propagator = nostd::shared_ptr<TextMapPropagator>(new TestPropagator());
+  GlobalTextMapPropagator::SetGlobalPropagator(propagator);
+  ASSERT_EQ(propagator, GlobalTextMapPropagator::GetGlobalPropagator());
+}
+
+TEST(GlobalPropagator, SetNullGlobalPropagator)
+{
+  auto propagator = nostd::shared_ptr<TextMapPropagator>(new TestPropagator());
+  GlobalTextMapPropagator::SetGlobalPropagator(propagator);
+  ASSERT_EQ(propagator, GlobalTextMapPropagator::GetGlobalPropagator());
+
+  // Setting a null TextMapPropagator installs a no-op TextMapPropagator.
+  GlobalTextMapPropagator::SetGlobalPropagator(nostd::shared_ptr<TextMapPropagator>());
+
+  auto noop = GlobalTextMapPropagator::GetGlobalPropagator();
+  ASSERT_NE(nullptr, noop);
+  ASSERT_NE(propagator, noop);
+
+  // The no-op TextMapPropagator is usable, it does not crash on use.
+  TextMapCarrierTest carrier;
+  context::Context context = context::Context{"key", static_cast<int64_t>(42)};
+
+  // The no-op inject writes nothing to the carrier.
+  noop->Inject(carrier, context);
+  EXPECT_TRUE(carrier.headers_.empty());
+
+  // The no-op extract returns the input context.
+  context::Context extracted = noop->Extract(carrier, context);
+  EXPECT_EQ(42, nostd::get<int64_t>(extracted.GetValue("key")));
+}
+
+}  // namespace

--- a/api/test/context/propagation/global_propagator_test.cc
+++ b/api/test/context/propagation/global_propagator_test.cc
@@ -5,6 +5,7 @@
 #include <cstdint>
 #include <map>
 #include <string>
+#include <utility>
 
 #include "opentelemetry/context/context.h"
 #include "opentelemetry/context/propagation/global_propagator.h"

--- a/api/test/logs/provider_test.cc
+++ b/api/test/logs/provider_test.cc
@@ -68,6 +68,23 @@ TEST(Provider, MultipleLoggerProviders)
   ASSERT_NE(Provider::GetLoggerProvider(), tf);
 }
 
+TEST(Provider, SetNullLoggerProvider)
+{
+  auto tf = shared_ptr<LoggerProvider>(new TestProvider());
+  Provider::SetLoggerProvider(tf);
+  ASSERT_EQ(tf, Provider::GetLoggerProvider());
+
+  // Setting a null LoggerProvider installs a no-op LoggerProvider.
+  Provider::SetLoggerProvider(shared_ptr<LoggerProvider>());
+
+  auto noop = Provider::GetLoggerProvider();
+  ASSERT_NE(nullptr, noop);
+  ASSERT_NE(tf, noop);
+
+  // The no-op LoggerProvider is usable, it does not crash on use.
+  EXPECT_NE(nullptr, noop->GetLogger("test"));
+}
+
 TEST(Provider, GetLogger)
 {
   auto tf = shared_ptr<LoggerProvider>(new TestProvider());
@@ -143,6 +160,23 @@ TEST(Provider, MultipleEventLoggerProviders)
   Provider::SetEventLoggerProvider(tf2);
 
   ASSERT_NE(Provider::GetEventLoggerProvider(), tf);
+}
+
+TEST(Provider, SetNullEventLoggerProvider)
+{
+  auto tf = nostd::shared_ptr<EventLoggerProvider>(new TestEventLoggerProvider());
+  Provider::SetEventLoggerProvider(tf);
+  ASSERT_EQ(tf, Provider::GetEventLoggerProvider());
+
+  // Setting a null EventLoggerProvider installs a no-op EventLoggerProvider.
+  Provider::SetEventLoggerProvider(nostd::shared_ptr<EventLoggerProvider>());
+
+  auto noop = Provider::GetEventLoggerProvider();
+  ASSERT_NE(nullptr, noop);
+  ASSERT_NE(tf, noop);
+
+  // The no-op EventLoggerProvider is usable, it does not crash on use.
+  EXPECT_NE(nullptr, noop->CreateEventLogger(nostd::shared_ptr<Logger>(nullptr), "domain"));
 }
 
 TEST(Provider, CreateEventLogger)

--- a/api/test/metrics/meter_provider_test.cc
+++ b/api/test/metrics/meter_provider_test.cc
@@ -35,3 +35,20 @@ TEST(Provider, MultipleMeterProviders)
 
   ASSERT_NE(Provider::GetMeterProvider(), tf);
 }
+
+TEST(Provider, SetNullMeterProvider)
+{
+  auto tf = opentelemetry::nostd::shared_ptr<MeterProvider>(new NoopMeterProvider());
+  Provider::SetMeterProvider(tf);
+  ASSERT_EQ(tf, Provider::GetMeterProvider());
+
+  // Setting a null MeterProvider installs a no-op MeterProvider.
+  Provider::SetMeterProvider(opentelemetry::nostd::shared_ptr<MeterProvider>());
+
+  auto noop = Provider::GetMeterProvider();
+  ASSERT_NE(nullptr, noop);
+  ASSERT_NE(tf, noop);
+
+  // The no-op MeterProvider is usable, it does not crash on use.
+  EXPECT_NE(nullptr, noop->GetMeter("test"));
+}

--- a/api/test/trace/provider_test.cc
+++ b/api/test/trace/provider_test.cc
@@ -53,4 +53,21 @@ TEST(Provider, SetTracerProvider)
   ASSERT_EQ(tf, Provider::GetTracerProvider());
 }
 
+TEST(Provider, SetNullTracerProvider)
+{
+  auto tf = nostd::shared_ptr<TracerProvider>(new TestProvider());
+  Provider::SetTracerProvider(tf);
+  ASSERT_EQ(tf, Provider::GetTracerProvider());
+
+  // Setting a null TracerProvider installs a no-op TracerProvider.
+  Provider::SetTracerProvider(nostd::shared_ptr<TracerProvider>());
+
+  auto noop = Provider::GetTracerProvider();
+  ASSERT_NE(nullptr, noop);
+  ASSERT_NE(tf, noop);
+
+  // The no-op TracerProvider is usable, it does not crash on use.
+  EXPECT_NE(nullptr, noop->GetTracer("test"));
+}
+
 }  // namespace

--- a/sdk/test/configuration/configured_sdk_test.cc
+++ b/sdk/test/configuration/configured_sdk_test.cc
@@ -68,7 +68,7 @@ protected:
   void SetUp() override
   {
     MakeRegistry();
-    SetNullProviders();
+    SetNoopProviders();
   }
 
   void TearDown() override
@@ -87,10 +87,11 @@ protected:
     logs::Provider::SetLoggerProvider({});
     metrics::Provider::SetMeterProvider({});
 
-    ASSERT_EQ(propagation::GlobalTextMapPropagator::GetGlobalPropagator(), nullptr);
-    ASSERT_EQ(trace::Provider::GetTracerProvider(), nullptr);
-    ASSERT_EQ(logs::Provider::GetLoggerProvider(), nullptr);
-    ASSERT_EQ(metrics::Provider::GetMeterProvider(), nullptr);
+    // Installing null providers falls back to the no-op providers.
+    ASSERT_NE(propagation::GlobalTextMapPropagator::GetGlobalPropagator(), nullptr);
+    ASSERT_NE(trace::Provider::GetTracerProvider(), nullptr);
+    ASSERT_NE(logs::Provider::GetLoggerProvider(), nullptr);
+    ASSERT_NE(metrics::Provider::GetMeterProvider(), nullptr);
   }
 
   void SetNoopProviders()
@@ -213,14 +214,26 @@ TEST_F(ConfiguredSdkTest, ConfiguredSdkInstallUninstall)
 
   CreateSdk(model);
   sdk_->Install();
+  auto sdk_tracer_provider = trace::Provider::GetTracerProvider();
+  auto sdk_logger_provider = logs::Provider::GetLoggerProvider();
+  auto sdk_meter_provider  = metrics::Provider::GetMeterProvider();
+  auto sdk_propagator      = propagation::GlobalTextMapPropagator::GetGlobalPropagator();
+
+  EXPECT_NE(sdk_tracer_provider, nullptr);
+  EXPECT_NE(sdk_logger_provider, nullptr);
+  EXPECT_NE(sdk_meter_provider, nullptr);
+  EXPECT_NE(sdk_propagator, nullptr);
+
+  sdk_->UnInstall();
+  // UnInstall() releases the SDK providers, and the globals fall back to no-op
+  // providers instead of becoming null.
   EXPECT_NE(trace::Provider::GetTracerProvider(), nullptr);
   EXPECT_NE(logs::Provider::GetLoggerProvider(), nullptr);
   EXPECT_NE(metrics::Provider::GetMeterProvider(), nullptr);
   EXPECT_NE(propagation::GlobalTextMapPropagator::GetGlobalPropagator(), nullptr);
 
-  sdk_->UnInstall();
-  EXPECT_EQ(trace::Provider::GetTracerProvider(), nullptr);
-  EXPECT_EQ(logs::Provider::GetLoggerProvider(), nullptr);
-  EXPECT_EQ(metrics::Provider::GetMeterProvider(), nullptr);
-  EXPECT_EQ(propagation::GlobalTextMapPropagator::GetGlobalPropagator(), nullptr);
+  EXPECT_NE(trace::Provider::GetTracerProvider(), sdk_tracer_provider);
+  EXPECT_NE(logs::Provider::GetLoggerProvider(), sdk_logger_provider);
+  EXPECT_NE(metrics::Provider::GetMeterProvider(), sdk_meter_provider);
+  EXPECT_NE(propagation::GlobalTextMapPropagator::GetGlobalPropagator(), sdk_propagator);
 }


### PR DESCRIPTION
Fixes #3694 and a bit more

## Changes

- Installs the corresponding noop provider/propagator when given a null to prevent unintended nullptr de-ref via getters that promise to never return a null.
- While this does change the observable behaviour of stable public API, given it is the expected behaviour as documented already and is a correctness fix I believe it fits in the carve out in the ABI policy to be delivered without ABI level guard.
- This explicitly calls `new` in a `noexcept` function which could lead to program termination on bad alloc etc. This is left for the overall cleanup as part of #4361 

* [x] `CHANGELOG.md` updated for non-trivial changes
* [x] Unit tests have been added
* [ ] Changes in public API reviewed