### PR TITLE
[CONFIGURATION] Add a resource detector extension example

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,9 @@ Increment the:
 
 ## [Unreleased]
 
+* [CONFIGURATION] Add a resource detector extension example
+  [#4419](https://github.com/open-telemetry/opentelemetry-cpp/issues/4419)
+
 * [RESOURCE DETECTOR] Add the host resource detector
   [#4413](https://github.com/open-telemetry/opentelemetry-cpp/issues/4413)
 * [CONFIGURATION] Add configuration builders for the container and process

--- a/examples/configuration/CMakeLists.txt
+++ b/examples/configuration/CMakeLists.txt
@@ -17,7 +17,9 @@ add_executable(
   custom_log_record_exporter.cc
   custom_log_record_exporter_builder.cc
   custom_log_record_processor.cc
-  custom_log_record_processor_builder.cc)
+  custom_log_record_processor_builder.cc
+  custom_resource_detector.cc
+  custom_resource_detector_builder.cc)
 
 target_link_libraries(
   example_yaml

--- a/examples/configuration/custom_resource_detector.cc
+++ b/examples/configuration/custom_resource_detector.cc
@@ -10,5 +10,5 @@
 opentelemetry::sdk::resource::Resource CustomResourceDetector::Detect() noexcept
 {
   OTEL_INTERNAL_LOG_ERROR("CustomResourceDetector::Detect(): YOUR CODE HERE");
-  return ResourceDetector::Create({});
+  return ResourceDetector::Create({{"custom.comment", comment_}});
 }

--- a/examples/configuration/custom_resource_detector.cc
+++ b/examples/configuration/custom_resource_detector.cc
@@ -1,0 +1,14 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+#include "opentelemetry/sdk/common/global_log_handler.h"
+#include "opentelemetry/sdk/resource/resource.h"
+#include "opentelemetry/sdk/resource/resource_detector.h"
+
+#include "custom_resource_detector.h"
+
+opentelemetry::sdk::resource::Resource CustomResourceDetector::Detect() noexcept
+{
+  OTEL_INTERNAL_LOG_ERROR("CustomResourceDetector::Detect(): YOUR CODE HERE");
+  return ResourceDetector::Create({});
+}

--- a/examples/configuration/custom_resource_detector.cc
+++ b/examples/configuration/custom_resource_detector.cc
@@ -1,6 +1,8 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
+#include <utility>
+
 #include "opentelemetry/sdk/common/global_log_handler.h"
 #include "opentelemetry/sdk/resource/resource.h"
 #include "opentelemetry/sdk/resource/resource_detector.h"

--- a/examples/configuration/custom_resource_detector.h
+++ b/examples/configuration/custom_resource_detector.h
@@ -5,7 +5,6 @@
 
 #include <string>
 
-#include "opentelemetry/sdk/resource/resource.h"
 #include "opentelemetry/sdk/resource/resource_detector.h"
 
 class CustomResourceDetector : public opentelemetry::sdk::resource::ResourceDetector

--- a/examples/configuration/custom_resource_detector.h
+++ b/examples/configuration/custom_resource_detector.h
@@ -1,0 +1,25 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <string>
+
+#include "opentelemetry/sdk/resource/resource.h"
+#include "opentelemetry/sdk/resource/resource_detector.h"
+
+class CustomResourceDetector : public opentelemetry::sdk::resource::ResourceDetector
+{
+public:
+  CustomResourceDetector(const std::string &comment) : comment_(comment) {}
+  CustomResourceDetector(CustomResourceDetector &&)                      = delete;
+  CustomResourceDetector(const CustomResourceDetector &)                 = delete;
+  CustomResourceDetector &operator=(CustomResourceDetector &&)           = delete;
+  CustomResourceDetector &operator=(const CustomResourceDetector &other) = delete;
+  ~CustomResourceDetector() override                                     = default;
+
+  opentelemetry::sdk::resource::Resource Detect() noexcept override;
+
+private:
+  std::string comment_;
+};

--- a/examples/configuration/custom_resource_detector_builder.cc
+++ b/examples/configuration/custom_resource_detector_builder.cc
@@ -1,0 +1,31 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+#include <memory>
+#include <string>
+#include <utility>
+
+#include "opentelemetry/sdk/configuration/document_node.h"
+#include "opentelemetry/sdk/configuration/extension_resource_detector_configuration.h"
+#include "opentelemetry/sdk/configuration/registry.h"
+
+#include "custom_resource_detector.h"
+#include "custom_resource_detector_builder.h"
+
+std::unique_ptr<opentelemetry::sdk::resource::ResourceDetector>
+CustomResourceDetectorBuilder::Build(
+    const opentelemetry::sdk::configuration::ExtensionResourceDetectorConfiguration *model) const
+{
+  // Read yaml attributes
+  std::string comment = model->node->GetRequiredString("comment");
+
+  auto sdk = std::make_unique<CustomResourceDetector>(comment);
+
+  return sdk;
+}
+
+void CustomResourceDetectorBuilder::Register(opentelemetry::sdk::configuration::Registry *registry)
+{
+  auto builder = std::make_unique<CustomResourceDetectorBuilder>();
+  registry->SetExtensionResourceDetectorBuilder("my_custom_detector", std::move(builder));
+}

--- a/examples/configuration/custom_resource_detector_builder.h
+++ b/examples/configuration/custom_resource_detector_builder.h
@@ -1,0 +1,18 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "opentelemetry/sdk/configuration/extension_resource_detector_builder.h"
+#include "opentelemetry/sdk/configuration/registry.h"
+
+class CustomResourceDetectorBuilder
+    : public opentelemetry::sdk::configuration::ExtensionResourceDetectorBuilder
+{
+public:
+  static void Register(opentelemetry::sdk::configuration::Registry *registry);
+
+  std::unique_ptr<opentelemetry::sdk::resource::ResourceDetector> Build(
+      const opentelemetry::sdk::configuration::ExtensionResourceDetectorConfiguration *model)
+      const override;
+};

--- a/examples/configuration/extensions.yaml
+++ b/examples/configuration/extensions.yaml
@@ -74,6 +74,6 @@ logger_provider:
 resource:
   detection/development:
     detectors:
-      # Registry::SetExtensionResourceDetectorBuilder. No example implementation in this directory.
+      # Registry::SetExtensionResourceDetectorBuilder, see custom_resource_detector.cc.
       - my_custom_detector:
           comment: "This is a resource detector extension point, with properties."

--- a/examples/configuration/main.cc
+++ b/examples/configuration/main.cc
@@ -21,6 +21,7 @@
 #include "custom_log_record_processor_builder.h"
 #include "custom_pull_metric_exporter_builder.h"
 #include "custom_push_metric_exporter_builder.h"
+#include "custom_resource_detector_builder.h"
 #include "custom_sampler_builder.h"
 #include "custom_span_exporter_builder.h"
 #include "custom_span_processor_builder.h"
@@ -235,6 +236,7 @@ void InitOtel(const std::string &config_file)
   CustomPullMetricExporterBuilder::Register(registry.get());
   CustomLogRecordExporterBuilder::Register(registry.get());
   CustomLogRecordProcessorBuilder::Register(registry.get());
+  CustomResourceDetectorBuilder::Register(registry.get());
 
   /* 4 - Parse a config.yaml */
 


### PR DESCRIPTION
Fixes #4419

## Changes

Adds `CustomResourceDetector` and `CustomResourceDetectorBuilder` to `examples/configuration`, mirroring the other Custom* extension skeletons (comment property read from yaml, YOUR CODE HERE placeholder in `Detect()`). The builder registers under `my_custom_detector` via `Registry::SetExtensionResourceDetectorBuilder`, matching the entry that already exists in `extensions.yaml`, whose placeholder comment now points at the implementation.

As noted on the issue, the configured SDK will not build the detector until #4411 lands; this only provides the extension point wiring.

For significant contributions please make sure you have completed the following items:

* [x] `CHANGELOG.md` updated for non-trivial changes
* [ ] Unit tests have been added
* [x] Changes in public API reviewed
