### PR TITLE
[CONFIGURATION/BUILD] Resource detector targets and README

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,10 @@ Increment the:
 * [CONFIGURATION] Add support for the composite sampler configuration
   (programmatic and from yaml)
   ([#4366](https://github.com/open-telemetry/opentelemetry-cpp/pull/4366))
+
+* [CONFIGURATION/BUILD] Add resource detector targets and README
+  [#4430](https://github.com/open-telemetry/opentelemetry-cpp/pull/4430)
+
 * [SDK] `OTELResourceDetector` now percent-decodes values parsed from the
   `OTEL_RESOURCE_ATTRIBUTES` environment variable, per the W3C Baggage value
   grammar the resource spec defers to. A malformed escape sequence is left

--- a/ci/do_ci.sh
+++ b/ci/do_ci.sh
@@ -623,8 +623,8 @@ elif [[ "$1" == "bazel.noexcept" ]]; then
   # that make this test always fail. Ignore these packages in the noexcept test here.
   # Set the api:with_cxx_stdlib=none because C++17 std::variant::get<> throws
 
-  bazel $BAZEL_STARTUP_OPTIONS build --copt=-fno-exceptions --//api:with_cxx_stdlib=none $BAZEL_OPTIONS_ASYNC -- //... -//exporters/prometheus/... -//examples/prometheus/... -//opentracing-shim/... -//examples/configuration/... -//sdk/src/configuration/... -//sdk/test/configuration/... -//resource_detectors/test:resource_detector_builder_test
-  bazel $BAZEL_STARTUP_OPTIONS test --copt=-fno-exceptions --//api:with_cxx_stdlib=none $BAZEL_TEST_OPTIONS_ASYNC -- //... -//exporters/prometheus/... -//examples/prometheus/... -//opentracing-shim/... -//examples/configuration/... -//sdk/src/configuration/... -//sdk/test/configuration/... -//resource_detectors/test:resource_detector_builder_test
+  bazel $BAZEL_STARTUP_OPTIONS build --copt=-fno-exceptions --//api:with_cxx_stdlib=none $BAZEL_OPTIONS_ASYNC -- //... -//exporters/prometheus/... -//examples/prometheus/... -//opentracing-shim/... -//examples/configuration/... -//sdk/src/configuration/... -//sdk/test/configuration/... -//resource_detectors/...
+  bazel $BAZEL_STARTUP_OPTIONS test --copt=-fno-exceptions --//api:with_cxx_stdlib=none $BAZEL_TEST_OPTIONS_ASYNC -- //... -//exporters/prometheus/... -//examples/prometheus/... -//opentracing-shim/... -//examples/configuration/... -//sdk/src/configuration/... -//sdk/test/configuration/... -//resource_detectors/...
   exit 0
 elif [[ "$1" == "bazel.nortti" ]]; then
   # there are some exceptions and error handling code from the Prometheus Client

--- a/install/test/cmake/component_tests/resource_detectors/CMakeLists.txt
+++ b/install/test/cmake/component_tests/resource_detectors/CMakeLists.txt
@@ -14,7 +14,14 @@ add_executable(resource_detectors_test
 target_link_libraries(
   resource_detectors_test
   PRIVATE opentelemetry-cpp::resource_detectors
-          opentelemetry-cpp::resource_detectors_builders GTest::gtest
+          opentelemetry-cpp::resource_detectors_builders
+          opentelemetry-cpp::container_resource_detector
+          opentelemetry-cpp::container_resource_detector_builder
+          opentelemetry-cpp::env_entity_resource_detector
+          opentelemetry-cpp::host_resource_detector
+          opentelemetry-cpp::process_resource_detector
+          opentelemetry-cpp::process_resource_detector_builder
+          GTest::gtest
           GTest::gtest_main)
 
 gtest_discover_tests(resource_detectors_test)

--- a/install/test/cmake/fetch_content_test/CMakeLists.txt
+++ b/install/test/cmake/fetch_content_test/CMakeLists.txt
@@ -86,6 +86,12 @@ target_link_libraries(
           opentelemetry-cpp::configuration
           opentelemetry-cpp::resource_detectors
           opentelemetry-cpp::resource_detectors_builders
+          opentelemetry-cpp::container_resource_detector
+          opentelemetry-cpp::container_resource_detector_builder
+          opentelemetry-cpp::env_entity_resource_detector
+          opentelemetry-cpp::host_resource_detector
+          opentelemetry-cpp::process_resource_detector
+          opentelemetry-cpp::process_resource_detector_builder
           opentelemetry-cpp::http_client
           opentelemetry-cpp::http_client_curl
           opentelemetry-cpp::in_memory_span_exporter

--- a/resource_detectors/BUILD
+++ b/resource_detectors/BUILD
@@ -12,13 +12,59 @@ cc_library(
 )
 
 cc_library(
-    name = "resource_detectors",
+    name = "container_resource_detector",
     srcs = [
         "src/container_detector.cc",
         "src/container_detector_utils.cc",
-        "src/env_entity_detector.cc",
+    ],
+    copts = ["-fexceptions"],
+    deps = [
+        "//api",
+        "//resource_detectors:headers",
+        "//sdk:headers",
+        "//sdk/src/resource",
+    ],
+)
+
+cc_library(
+    name = "container_resource_detector_builder",
+    srcs = ["src/container_detector_builder.cc"],
+    deps = [
+        ":container_resource_detector",
+        "//sdk/src/configuration:configuration_core",
+    ],
+)
+
+cc_library(
+    name = "env_entity_resource_detector",
+    srcs = ["src/env_entity_detector.cc"],
+    copts = ["-fexceptions"],
+    deps = [
+        "//api",
+        "//resource_detectors:headers",
+        "//sdk:headers",
+        "//sdk/src/resource",
+    ],
+)
+
+cc_library(
+    name = "host_resource_detector",
+    srcs = [
         "src/host_detector.cc",
         "src/host_detector_utils.cc",
+    ],
+    copts = ["-fexceptions"],
+    deps = [
+        "//api",
+        "//resource_detectors:headers",
+        "//sdk:headers",
+        "//sdk/src/resource",
+    ],
+)
+
+cc_library(
+    name = "process_resource_detector",
+    srcs = [
         "src/process_detector.cc",
         "src/process_detector_utils.cc",
     ],
@@ -32,12 +78,30 @@ cc_library(
 )
 
 cc_library(
-    name = "resource_detectors_builders",
-    srcs = [
-        "src/container_detector_builder.cc",
-        "src/process_detector_builder.cc",
-    ],
+    name = "process_resource_detector_builder",
+    srcs = ["src/process_detector_builder.cc"],
     deps = [
-        ":resource_detectors",
+        ":process_resource_detector",
+        "//sdk/src/configuration:configuration_core",
+    ],
+)
+
+# Convenience target linking all individual detectors.
+cc_library(
+    name = "resource_detectors",
+    deps = [
+        ":container_resource_detector",
+        ":env_entity_resource_detector",
+        ":host_resource_detector",
+        ":process_resource_detector",
+    ],
+)
+
+# Convenience target linking all individual builders.
+cc_library(
+    name = "resource_detectors_builders",
+    deps = [
+        ":container_resource_detector_builder",
+        ":process_resource_detector_builder",
     ],
 )

--- a/resource_detectors/BUILD
+++ b/resource_detectors/BUILD
@@ -86,7 +86,7 @@ cc_library(
     ],
 )
 
-# Convenience target linking all individual detectors.
+# Convenience target linking all resource detectors.
 cc_library(
     name = "resource_detectors",
     deps = [
@@ -97,7 +97,7 @@ cc_library(
     ],
 )
 
-# Convenience target linking all individual builders.
+# Convenience target linking all resource detector builders.
 cc_library(
     name = "resource_detectors_builders",
     deps = [

--- a/resource_detectors/CMakeLists.txt
+++ b/resource_detectors/CMakeLists.txt
@@ -1,47 +1,152 @@
 # Copyright The OpenTelemetry Authors
 # SPDX-License-Identifier: Apache-2.0
 
-add_library(
-  opentelemetry_resource_detectors
-  src/container_detector_utils.cc
-  src/container_detector.cc
-  src/env_entity_detector.cc
-  src/host_detector.cc
-  src/host_detector_utils.cc
-  src/process_detector.cc
-  src/process_detector_utils.cc)
+#
+# opentelemetry_container_resource_detector
+#
 
-set_target_properties(opentelemetry_resource_detectors
-                      PROPERTIES EXPORT_NAME resource_detectors)
-set_target_version(opentelemetry_resource_detectors)
+add_library(opentelemetry_container_resource_detector
+            src/container_detector.cc src/container_detector_utils.cc)
 
-target_link_libraries(opentelemetry_resource_detectors
+set_target_properties(opentelemetry_container_resource_detector
+                      PROPERTIES EXPORT_NAME container_resource_detector)
+set_target_version(opentelemetry_container_resource_detector)
+
+target_link_libraries(opentelemetry_container_resource_detector
                       PUBLIC opentelemetry_resources)
 target_include_directories(
-  opentelemetry_resource_detectors
+  opentelemetry_container_resource_detector
   PUBLIC "$<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}/include>"
          "$<INSTALL_INTERFACE:include>")
 
 #
-# opentelemetry_resource_detectors_builders
+# opentelemetry_container_resource_detector_builder
 #
 
-add_library(opentelemetry_resource_detectors_builders
-            src/container_detector_builder.cc src/process_detector_builder.cc)
+add_library(opentelemetry_container_resource_detector_builder
+            src/container_detector_builder.cc)
 
-set_target_properties(opentelemetry_resource_detectors_builders
-                      PROPERTIES EXPORT_NAME resource_detectors_builders)
-set_target_version(opentelemetry_resource_detectors_builders)
+set_target_properties(
+  opentelemetry_container_resource_detector_builder
+  PROPERTIES EXPORT_NAME container_resource_detector_builder)
+set_target_version(opentelemetry_container_resource_detector_builder)
 
 target_include_directories(
-  opentelemetry_resource_detectors_builders
+  opentelemetry_container_resource_detector_builder
   PUBLIC "$<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}/include>"
          "$<INSTALL_INTERFACE:include>")
 
 target_link_libraries(
+  opentelemetry_container_resource_detector_builder
+  PRIVATE opentelemetry_container_resource_detector
+          opentelemetry_configuration_core)
+
+#
+# opentelemetry_env_entity_resource_detector
+#
+
+add_library(opentelemetry_env_entity_resource_detector
+            src/env_entity_detector.cc)
+
+set_target_properties(opentelemetry_env_entity_resource_detector
+                      PROPERTIES EXPORT_NAME env_entity_resource_detector)
+set_target_version(opentelemetry_env_entity_resource_detector)
+
+target_link_libraries(opentelemetry_env_entity_resource_detector
+                      PUBLIC opentelemetry_resources)
+target_include_directories(
+  opentelemetry_env_entity_resource_detector
+  PUBLIC "$<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}/include>"
+         "$<INSTALL_INTERFACE:include>")
+
+#
+# opentelemetry_host_resource_detector
+#
+
+add_library(opentelemetry_host_resource_detector src/host_detector.cc
+                                                 src/host_detector_utils.cc)
+
+set_target_properties(opentelemetry_host_resource_detector
+                      PROPERTIES EXPORT_NAME host_resource_detector)
+set_target_version(opentelemetry_host_resource_detector)
+
+target_link_libraries(opentelemetry_host_resource_detector
+                      PUBLIC opentelemetry_resources)
+target_include_directories(
+  opentelemetry_host_resource_detector
+  PUBLIC "$<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}/include>"
+         "$<INSTALL_INTERFACE:include>")
+
+#
+# opentelemetry_process_resource_detector
+#
+
+add_library(opentelemetry_process_resource_detector
+            src/process_detector.cc src/process_detector_utils.cc)
+
+set_target_properties(opentelemetry_process_resource_detector
+                      PROPERTIES EXPORT_NAME process_resource_detector)
+set_target_version(opentelemetry_process_resource_detector)
+
+target_link_libraries(opentelemetry_process_resource_detector
+                      PUBLIC opentelemetry_resources)
+target_include_directories(
+  opentelemetry_process_resource_detector
+  PUBLIC "$<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}/include>"
+         "$<INSTALL_INTERFACE:include>")
+
+#
+# opentelemetry_process_resource_detector_builder
+#
+
+add_library(opentelemetry_process_resource_detector_builder
+            src/process_detector_builder.cc)
+
+set_target_properties(opentelemetry_process_resource_detector_builder
+                      PROPERTIES EXPORT_NAME process_resource_detector_builder)
+set_target_version(opentelemetry_process_resource_detector_builder)
+
+target_include_directories(
+  opentelemetry_process_resource_detector_builder
+  PUBLIC "$<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}/include>"
+         "$<INSTALL_INTERFACE:include>")
+
+target_link_libraries(
+  opentelemetry_process_resource_detector_builder
+  PRIVATE opentelemetry_process_resource_detector
+          opentelemetry_configuration_core)
+
+#
+# opentelemetry_resource_detectors (interface - links all individual detectors
+# and builders)
+#
+
+add_library(opentelemetry_resource_detectors INTERFACE)
+
+set_target_properties(opentelemetry_resource_detectors
+                      PROPERTIES EXPORT_NAME resource_detectors)
+
+target_link_libraries(
+  opentelemetry_resource_detectors
+  INTERFACE opentelemetry_container_resource_detector
+            opentelemetry_env_entity_resource_detector
+            opentelemetry_host_resource_detector
+            opentelemetry_process_resource_detector)
+
+#
+# opentelemetry_resource_detectors_builders (interface - links all individual
+# builders)
+#
+
+add_library(opentelemetry_resource_detectors_builders INTERFACE)
+
+set_target_properties(opentelemetry_resource_detectors_builders
+                      PROPERTIES EXPORT_NAME resource_detectors_builders)
+
+target_link_libraries(
   opentelemetry_resource_detectors_builders
-  PUBLIC opentelemetry_resource_detectors
-  PRIVATE opentelemetry_configuration_core)
+  INTERFACE opentelemetry_container_resource_detector_builder
+            opentelemetry_process_resource_detector_builder)
 
 otel_add_component(
   COMPONENT
@@ -49,6 +154,12 @@ otel_add_component(
   TARGETS
   opentelemetry_resource_detectors
   opentelemetry_resource_detectors_builders
+  opentelemetry_container_resource_detector
+  opentelemetry_container_resource_detector_builder
+  opentelemetry_env_entity_resource_detector
+  opentelemetry_host_resource_detector
+  opentelemetry_process_resource_detector
+  opentelemetry_process_resource_detector_builder
   FILES_DIRECTORY
   "include/opentelemetry/"
   FILES_DESTINATION

--- a/resource_detectors/CMakeLists.txt
+++ b/resource_detectors/CMakeLists.txt
@@ -117,8 +117,7 @@ target_link_libraries(
           opentelemetry_configuration_core)
 
 #
-# opentelemetry_resource_detectors (interface - links all individual detectors
-# and builders)
+# opentelemetry_resource_detectors (interface to all detectors)
 #
 
 add_library(opentelemetry_resource_detectors INTERFACE)
@@ -134,8 +133,7 @@ target_link_libraries(
             opentelemetry_process_resource_detector)
 
 #
-# opentelemetry_resource_detectors_builders (interface - links all individual
-# builders)
+# opentelemetry_resource_detectors_builders (interface to all builders)
 #
 
 add_library(opentelemetry_resource_detectors_builders INTERFACE)

--- a/resource_detectors/README.md
+++ b/resource_detectors/README.md
@@ -15,7 +15,7 @@ and its attributes.
 Reads the container ID from the cgroup file (e.g. Docker, Kubernetes).
 
 | Attribute | Description |
-|---|---|
+| --- | --- |
 | `container.id` | Container ID (e.g. `a3bf90e006b2`) |
 
 ### Host Resource Detector
@@ -25,7 +25,7 @@ Reads the container ID from the cgroup file (e.g. Docker, Kubernetes).
 Reads host information from the operating system.
 
 | Attribute | Description |
-|---|---|
+| --- | --- |
 | `host.name` | Hostname (from `gethostname` / `uname`) |
 | `host.arch` | CPU architecture (e.g. `amd64`, `arm64`) |
 | `host.id` | Machine ID (from `/etc/machine-id` on Linux, registry on Windows) |
@@ -37,7 +37,7 @@ Reads host information from the operating system.
 Reads process information from the operating system.
 
 | Attribute | Description |
-|---|---|
+| --- | --- |
 | `process.pid` | Process ID |
 | `process.executable.path` | Full path to the process executable |
 
@@ -111,7 +111,7 @@ target_link_libraries(my_target PRIVATE opentelemetry-cpp::host_resource_detecto
 
 ### Builder targets: Link to builders for declaritive configuration
 
-Builder targets make detectors availble for declaritive configuration and hide
+Builder targets make detectors available for declaritive configuration and hide
 the concrete detector implementations.
 
 Link all builders:
@@ -135,7 +135,7 @@ target_link_libraries(my_target PRIVATE
 All targets are part of the `resource_detectors` component.
 
 | Target | Description |
-|---|---|
+| --- | --- |
 | `opentelemetry-cpp::resource_detectors` | Interface: links all detectors |
 | `opentelemetry-cpp::resource_detectors_builders` | Interface: links all builders |
 | `opentelemetry-cpp::container_resource_detector` | Container detector |
@@ -181,7 +181,7 @@ deps = ["//resource_detectors:process_resource_detector_builder"]
 ### Available targets (Bazel)
 
 | Target | Description |
-|---|---|
+| --- | --- |
 | `//resource_detectors` | Interface: links all detectors |
 | `//resource_detectors:resource_detectors_builders` | Interface: links all builders |
 | `//resource_detectors:container_resource_detector` | Container detector |

--- a/resource_detectors/README.md
+++ b/resource_detectors/README.md
@@ -5,14 +5,16 @@ describing the environment where the application is running.
 
 Detectors in this project will be limited to those defined as `built-in` by the
 OTel [Resource SDK Spec](https://opentelemetry.io/docs/specs/otel/resource/sdk/#resource-detector-name)
-and [declaritive configuration resource schema](https://github.com/open-telemetry/opentelemetry-configuration/blob/main/schema/resource.yaml).
-Currently this set includes:
+and [configuration schema](https://github.com/open-telemetry/opentelemetry-configuration/blob/main/schema/resource.yaml)
+along with the experimental
+[EnvEntity Detector](https://opentelemetry.io/docs/specs/otel/entities/entity-propagation/#enventitydetector).
+
+Currently the `built-in` detectors include:
 
 - `service`
 - `container`
 - `host`
 - `process`
-- `env entities (experimental and not defined in the yaml configuration schema)`
 
 The detectors should support all tested platforms (Linux, macOS, and Windows)
 and must follow the semantic conventions for
@@ -85,9 +87,8 @@ OTEL_ENTITIES=service{service.name=my-app,service.instance.id=i-1}[service.versi
 
 Each builder registers its detector with the SDK
 [declarative configuration](https://opentelemetry.io/docs/specs/otel/configuration/)
-`Registry`, making it available when the SDK is initialised from a config file.
-The detector is a private dependency of the builder and is not exposed
-transitively — link only the builder targets you need.
+`Registry`, making it available when the SDK is initialized using programmatic
+configuration or from a yaml file.
 
 Detectors can be declared under the `resource.detection/development` entry in
 the configuration YAML file.
@@ -117,7 +118,7 @@ opentelemetry::resource_detector::ProcessDetectorBuilder::Register(registry.get(
 
 ## Linking with CMake
 
-### Detector targets: Link to the detector for direct use in an application
+### Linking to detectors directly (not required for declaritive config)
 
 Link to all available detectors:
 
@@ -133,7 +134,7 @@ find_package(opentelemetry-cpp CONFIG REQUIRED COMPONENTS resource_detectors)
 target_link_libraries(my_target PRIVATE opentelemetry-cpp::host_resource_detector)
 ```
 
-### Builder targets: Link to builders for declaritive configuration
+### Linking to builders for declaritive configuration
 
 Builder targets make detectors available for declaritive configuration and hide
 the concrete detector implementations.
@@ -171,7 +172,7 @@ All targets are part of the `resource_detectors` component.
 
 ## Linking with Bazel
 
-### Detector targets: Link detector for direct use in an application
+### Linking to detectors directly
 
 Link to all available detectors:
 
@@ -185,7 +186,7 @@ Link to only the detectors you use:
 deps = ["//resource_detectors:host_resource_detector"]
 ```
 
-### Builder targets: Link builders for declaritive configuration
+### Linking to builders only
 
 Builder targets make detectors available for declarative configuration and hide
 the concrete detector implementations.

--- a/resource_detectors/README.md
+++ b/resource_detectors/README.md
@@ -1,0 +1,192 @@
+# Resource Detectors
+
+Resource detectors populate the OpenTelemetry `Resource` with attributes
+describing the environment where the application is running.
+
+Refer to the linked semconv pages for the stability status of each detector
+and its attributes.
+
+## Available detectors
+
+### Container Resource Detector
+
+[Semconv: Container](https://opentelemetry.io/docs/specs/semconv/resource/container/)
+
+Reads the container ID from the cgroup file (e.g. Docker, Kubernetes).
+
+| Attribute | Description |
+|---|---|
+| `container.id` | Container ID (e.g. `a3bf90e006b2`) |
+
+### Host Resource Detector
+
+[Semconv: Host](https://opentelemetry.io/docs/specs/semconv/resource/host/)
+
+Reads host information from the operating system.
+
+| Attribute | Description |
+|---|---|
+| `host.name` | Hostname (from `gethostname` / `uname`) |
+| `host.arch` | CPU architecture (e.g. `amd64`, `arm64`) |
+| `host.id` | Machine ID (from `/etc/machine-id` on Linux, registry on Windows) |
+
+### Process Resource Detector
+
+[Semconv: Process](https://opentelemetry.io/docs/specs/semconv/resource/process/)
+
+Reads process information from the operating system.
+
+| Attribute | Description |
+|---|---|
+| `process.pid` | Process ID |
+| `process.executable.path` | Full path to the process executable |
+
+### Env Entity Resource Detector (Experimental)
+
+[Spec: Entity Propagation — `OTEL_ENTITIES`](https://opentelemetry.io/docs/specs/otel/entities/entity-propagation/)
+(experimental)
+
+Reads entity definitions from the `OTEL_ENTITIES` environment variable. Each
+entity specifies a type, identifying attributes, and optional descriptive
+attributes. The resulting resource attributes depend entirely on what is set in
+the environment variable.
+
+Example value:
+
+```bash
+OTEL_ENTITIES=service{service.name=my-app,service.instance.id=i-1}[service.version=1.0.0]
+```
+
+## Declarative configuration
+
+Each builder registers its detector with the SDK
+[declarative configuration](https://opentelemetry.io/docs/specs/otel/configuration/)
+`Registry`, making it available when the SDK is initialised from a config file.
+The detector is a private dependency of the builder and is not exposed
+transitively — link only the builder targets you need.
+
+Detectors can be declared under the `resource.detection/development` entry in
+the configuration YAML file.
+
+Example configuration:
+
+```yaml
+resource:
+  detection/development:
+    detectors:
+      - container:
+      - process:
+      # NOTE: host and service detectors cannot be configured currently
+      - host:    # needs a builder (`Registry::SetHostResourceDetectorBuilder`)
+      - service: # not implemented (github.com/open-telemetry/opentelemetry-cpp/issues/4414)
+```
+
+Call `Register` for each builder before creating the SDK:
+
+```cpp
+#include "opentelemetry/resource_detectors/container_detector_builder.h"
+#include "opentelemetry/resource_detectors/process_detector_builder.h"
+
+opentelemetry::resource_detector::ContainerDetectorBuilder::Register(registry.get());
+opentelemetry::resource_detector::ProcessDetectorBuilder::Register(registry.get());
+```
+
+## Linking with CMake
+
+### Detector targets: Link to the detector for direct use in an application
+
+Link to all available detectors:
+
+```cmake
+find_package(opentelemetry-cpp CONFIG REQUIRED COMPONENTS resource_detectors)
+target_link_libraries(my_target PRIVATE opentelemetry-cpp::resource_detectors)
+```
+
+Link to only the detectors you use:
+
+```cmake
+find_package(opentelemetry-cpp CONFIG REQUIRED COMPONENTS resource_detectors)
+target_link_libraries(my_target PRIVATE opentelemetry-cpp::host_resource_detector)
+```
+
+### Builder targets: Link to builders for declaritive configuration
+
+Builder targets make detectors availble for declaritive configuration and hide
+the concrete detector implementations.
+
+Link all builders:
+
+```cmake
+find_package(opentelemetry-cpp CONFIG REQUIRED COMPONENTS resource_detectors)
+target_link_libraries(my_target PRIVATE
+  opentelemetry-cpp::resource_detectors_builders)
+```
+
+Link to only the builders you use:
+
+```cmake
+find_package(opentelemetry-cpp CONFIG REQUIRED COMPONENTS resource_detectors)
+target_link_libraries(my_target PRIVATE
+  opentelemetry-cpp::process_resource_detector_builder)
+```
+
+### Available targets
+
+All targets are part of the `resource_detectors` component.
+
+| Target | Description |
+|---|---|
+| `opentelemetry-cpp::resource_detectors` | Interface: links all detectors |
+| `opentelemetry-cpp::resource_detectors_builders` | Interface: links all builders |
+| `opentelemetry-cpp::container_resource_detector` | Container detector |
+| `opentelemetry-cpp::container_resource_detector_builder` | Container detector builder for declaritive configuration |
+| `opentelemetry-cpp::env_entity_resource_detector` | Env entity detector |
+| `opentelemetry-cpp::host_resource_detector` | Host detector |
+| `opentelemetry-cpp::process_resource_detector` | Process detector |
+| `opentelemetry-cpp::process_resource_detector_builder` | Process detector builder for declaritive configuration |
+
+## Linking with Bazel
+
+### Detector targets: Link detector for direct use in an application
+
+Link to all available detectors:
+
+```python
+deps = ["//resource_detectors"]
+```
+
+Link to only the detectors you use:
+
+```python
+deps = ["//resource_detectors:host_resource_detector"]
+```
+
+### Builder targets: Link builders for declaritive configuration
+
+Builder targets make detectors available for declarative configuration and hide
+the concrete detector implementations.
+
+Link all builders:
+
+```python
+deps = ["//resource_detectors:resource_detectors_builders"]
+```
+
+Link to only the builders you use:
+
+```python
+deps = ["//resource_detectors:process_resource_detector_builder"]
+```
+
+### Available targets (Bazel)
+
+| Target | Description |
+|---|---|
+| `//resource_detectors` | Interface: links all detectors |
+| `//resource_detectors:resource_detectors_builders` | Interface: links all builders |
+| `//resource_detectors:container_resource_detector` | Container detector |
+| `//resource_detectors:container_resource_detector_builder` | Container detector builder |
+| `//resource_detectors:env_entity_resource_detector` | Env entity detector |
+| `//resource_detectors:host_resource_detector` | Host detector |
+| `//resource_detectors:process_resource_detector` | Process detector |
+| `//resource_detectors:process_resource_detector_builder` | Process detector builder |

--- a/resource_detectors/README.md
+++ b/resource_detectors/README.md
@@ -1,45 +1,69 @@
 # Resource Detectors
 
-Resource detectors populate the OpenTelemetry `Resource` with attributes
+Resource detectors populate `Resource Entity` attributes
 describing the environment where the application is running.
 
-Refer to the linked semconv pages for the stability status of each detector
-and its attributes.
+Detectors in this project will be limited to those defined as `built-in` by the
+OTel [Resource SDK Spec](https://opentelemetry.io/docs/specs/otel/resource/sdk/#resource-detector-name)
+and [declaritive configuration resource schema](https://github.com/open-telemetry/opentelemetry-configuration/blob/main/schema/resource.yaml).
+Currently this set includes:
 
-## Available detectors
+- `service`
+- `container`
+- `host`
+- `process`
+- `env entities (experimental and not defined in the yaml configuration schema)`
+
+The detectors should support all tested platforms (Linux, macOS, and Windows)
+and must follow the semantic conventions for
+[Entities](https://opentelemetry.io/docs/specs/semconv/registry/entities/).
+
+## Built-in detectors
+
+Each detector section lists currently supported Entity attributes by platform.
+Contributions to detect more attributes for each Entity are welcome.
+
+### Service Resource Detector
+
+[Entity: Service](https://opentelemetry.io/docs/specs/semconv/registry/entities/service/)
+
+Not implemented.
 
 ### Container Resource Detector
 
-[Semconv: Container](https://opentelemetry.io/docs/specs/semconv/resource/container/)
+[Entity: Container](https://opentelemetry.io/docs/specs/semconv/registry/entities/container/)
 
-Reads the container ID from the cgroup file (e.g. Docker, Kubernetes).
+| Attribute | Description | Linux | macOS | Windows |
+| --- | --- | --- | --- | --- |
+| `container.id` | Container ID from `/proc/self/cgroup` | Yes | No | No |
 
-| Attribute | Description |
-| --- | --- |
-| `container.id` | Container ID (e.g. `a3bf90e006b2`) |
+Limitation: this detector depends on Linux cgroup data and may return no value
+outside containers or when cgroup data is unavailable.
 
 ### Host Resource Detector
 
-[Semconv: Host](https://opentelemetry.io/docs/specs/semconv/resource/host/)
+[Entity: Host](https://opentelemetry.io/docs/specs/semconv/registry/entities/host/)
 
-Reads host information from the operating system.
+| Attribute | Description | Linux | macOS | Windows |
+| --- | --- | --- | --- | --- |
+| `host.name` | Hostname from OS APIs | Yes | Yes | Yes |
+| `host.arch` | Architecture mapped at build time | Yes | Yes | Yes |
+| `host.id` | Host ID from OS-specific sources | Yes | Yes | Yes |
 
-| Attribute | Description |
-| --- | --- |
-| `host.name` | Hostname (from `gethostname` / `uname`) |
-| `host.arch` | CPU architecture (e.g. `amd64`, `arm64`) |
-| `host.id` | Machine ID (from `/etc/machine-id` on Linux, registry on Windows) |
+Limitation: `host.id` is omitted when the platform-specific source is missing
+or inaccessible.
 
 ### Process Resource Detector
 
-[Semconv: Process](https://opentelemetry.io/docs/specs/semconv/resource/process/)
+[Entity: Process](https://opentelemetry.io/docs/specs/semconv/registry/entities/process/)
 
-Reads process information from the operating system.
+| Attribute | Description | Linux | macOS | Windows |
+| --- | --- | --- | --- | --- |
+| `process.pid` | Process ID | Yes | Yes | Yes |
+| `process.executable.path` | Path via `/proc` (Linux) or Win32 APIs | Yes | No | Yes |
 
-| Attribute | Description |
-| --- | --- |
-| `process.pid` | Process ID |
-| `process.executable.path` | Full path to the process executable |
+Limitation: current macOS implementation does not populate
+`process.executable.path`.
 
 ### Env Entity Resource Detector (Experimental)
 

--- a/resource_detectors/test/BUILD
+++ b/resource_detectors/test/BUILD
@@ -4,36 +4,70 @@
 load("@rules_cc//cc:cc_test.bzl", "cc_test")
 
 cc_test(
-    name = "resource_detector_test",
-    srcs = [
-        "container_detector_test.cc",
-        "env_entity_detector_test.cc",
-        "host_detector_test.cc",
-        "process_detector_test.cc",
-    ],
+    name = "container_resource_detector_test",
+    srcs = ["container_detector_test.cc"],
     tags = ["test"],
     deps = [
-        "//api",
-        "//resource_detectors",
+        "//resource_detectors:container_resource_detector",
         "//sdk/src/resource",
         "@com_google_googletest//:gtest_main",
     ],
 )
 
-# Kept separate from resource_detector_test: linking configuration_core pulls in
-# sdk_builder.cc, which requires exception support, so this target is excluded
-# from the bazel.noexcept build in ci/do_ci.sh.
 cc_test(
-    name = "resource_detector_builder_test",
-    srcs = [
-        "container_detector_builder_test.cc",
-        "process_detector_builder_test.cc",
-    ],
+    name = "env_entity_resource_detector_test",
+    srcs = ["env_entity_detector_test.cc"],
     tags = ["test"],
     deps = [
-        "//api",
-        "//resource_detectors",
-        "//resource_detectors:resource_detectors_builders",
+        "//resource_detectors:env_entity_resource_detector",
+        "//sdk/src/resource",
+        "@com_google_googletest//:gtest_main",
+    ],
+)
+
+cc_test(
+    name = "host_resource_detector_test",
+    srcs = ["host_detector_test.cc"],
+    tags = ["test"],
+    deps = [
+        "//resource_detectors:host_resource_detector",
+        "//sdk/src/resource",
+        "@com_google_googletest//:gtest_main",
+    ],
+)
+
+cc_test(
+    name = "process_resource_detector_test",
+    srcs = ["process_detector_test.cc"],
+    tags = ["test"],
+    deps = [
+        "//resource_detectors:process_resource_detector",
+        "//sdk/src/resource",
+        "@com_google_googletest//:gtest_main",
+    ],
+)
+
+# Kept separate from detector tests: linking configuration_core pulls in
+# sdk_builder.cc, which requires exception support, so these targets are excluded
+# from the bazel.noexcept build in ci/do_ci.sh.
+cc_test(
+    name = "container_resource_detector_builder_test",
+    srcs = ["container_detector_builder_test.cc"],
+    tags = ["test"],
+    deps = [
+        "//resource_detectors:container_resource_detector_builder",
+        "//sdk/src/configuration:configuration_core",
+        "//sdk/src/resource",
+        "@com_google_googletest//:gtest_main",
+    ],
+)
+
+cc_test(
+    name = "process_resource_detector_builder_test",
+    srcs = ["process_detector_builder_test.cc"],
+    tags = ["test"],
+    deps = [
+        "//resource_detectors:process_resource_detector_builder",
         "//sdk/src/configuration:configuration_core",
         "//sdk/src/resource",
         "@com_google_googletest//:gtest_main",

--- a/resource_detectors/test/BUILD
+++ b/resource_detectors/test/BUILD
@@ -47,9 +47,6 @@ cc_test(
     ],
 )
 
-# Kept separate from detector tests: linking configuration_core pulls in
-# sdk_builder.cc, which requires exception support, so these targets are excluded
-# from the bazel.noexcept build in ci/do_ci.sh.
 cc_test(
     name = "container_resource_detector_builder_test",
     srcs = ["container_detector_builder_test.cc"],

--- a/resource_detectors/test/CMakeLists.txt
+++ b/resource_detectors/test/CMakeLists.txt
@@ -1,34 +1,76 @@
 # Copyright The OpenTelemetry Authors
 # SPDX-License-Identifier: Apache-2.0
 
-add_executable(
-  resource_detector_test container_detector_test.cc host_detector_test.cc
-                         process_detector_test.cc env_entity_detector_test.cc)
+#
+# container_resource_detector tests
+#
 
-# Link the required dependencies
+add_executable(container_resource_detector_test container_detector_test.cc)
 target_link_libraries(
-  resource_detector_test
-  PRIVATE opentelemetry_resource_detectors opentelemetry_api
-          opentelemetry_resources GTest::gtest_main)
-
+  container_resource_detector_test
+  PRIVATE opentelemetry_container_resource_detector GTest::gtest_main)
 gtest_add_tests(
-  TARGET resource_detector_test
+  TARGET container_resource_detector_test
   TEST_PREFIX resource_detector.
-  TEST_LIST resource_detector_test)
+  TEST_LIST container_resource_detector_test)
 
-add_executable(resource_detector_builder_test container_detector_builder_test.cc
-                                              process_detector_builder_test.cc)
-
+add_executable(container_resource_detector_builder_test
+               container_detector_builder_test.cc)
 target_link_libraries(
-  resource_detector_builder_test
-  PRIVATE opentelemetry_resource_detectors
-          opentelemetry_resource_detectors_builders
-          opentelemetry_api
-          opentelemetry_resources
-          opentelemetry_configuration_core
-          GTest::gtest_main)
-
+  container_resource_detector_builder_test
+  PRIVATE opentelemetry_container_resource_detector_builder
+          opentelemetry_configuration_core GTest::gtest_main)
 gtest_add_tests(
-  TARGET resource_detector_builder_test
+  TARGET container_resource_detector_builder_test
   TEST_PREFIX resource_detector.
-  TEST_LIST resource_detector_builder_test)
+  TEST_LIST container_resource_detector_builder_test)
+
+#
+# env_entity_resource_detector tests
+#
+
+add_executable(env_entity_resource_detector_test env_entity_detector_test.cc)
+target_link_libraries(
+  env_entity_resource_detector_test
+  PRIVATE opentelemetry_env_entity_resource_detector GTest::gtest_main)
+gtest_add_tests(
+  TARGET env_entity_resource_detector_test
+  TEST_PREFIX resource_detector.
+  TEST_LIST env_entity_resource_detector_test)
+
+#
+# host_resource_detector tests
+#
+
+add_executable(host_resource_detector_test host_detector_test.cc)
+target_link_libraries(
+  host_resource_detector_test PRIVATE opentelemetry_host_resource_detector
+                                      GTest::gtest_main)
+gtest_add_tests(
+  TARGET host_resource_detector_test
+  TEST_PREFIX resource_detector.
+  TEST_LIST host_resource_detector_test)
+
+#
+# process_resource_detector tests
+#
+
+add_executable(process_resource_detector_test process_detector_test.cc)
+target_link_libraries(
+  process_resource_detector_test PRIVATE opentelemetry_process_resource_detector
+                                         GTest::gtest_main)
+gtest_add_tests(
+  TARGET process_resource_detector_test
+  TEST_PREFIX resource_detector.
+  TEST_LIST process_resource_detector_test)
+
+add_executable(process_resource_detector_builder_test
+               process_detector_builder_test.cc)
+target_link_libraries(
+  process_resource_detector_builder_test
+  PRIVATE opentelemetry_process_resource_detector_builder
+          opentelemetry_configuration_core GTest::gtest_main)
+gtest_add_tests(
+  TARGET process_resource_detector_builder_test
+  TEST_PREFIX resource_detector.
+  TEST_LIST process_resource_detector_builder_test)


### PR DESCRIPTION
Contributes to: https://github.com/open-telemetry/opentelemetry-cpp/issues/3548
Follow up to https://github.com/open-telemetry/opentelemetry-cpp/pull/4417#discussion_r3766765631

The spec defines `built-in` resource detectors as `host`, `service`, `process`, and `container` along with an experimental EnvEntity detector.

The detectors should follow the Entity semantic conventions for attributes: 
  - [Entity: Host](https://opentelemetry.io/docs/specs/semconv/registry/entities/host/)
  - [Entity: Process](https://opentelemetry.io/docs/specs/semconv/registry/entities/process/)
  - [Entity: Service](https://opentelemetry.io/docs/specs/semconv/registry/entities/service/)
  - [Entity: Container](https://opentelemetry.io/docs/specs/semconv/registry/entities/container/)

The implemented resource detectors support a small subset of these attributes and are currently built into a single target (and single test executable). 

This PR sets up the documentation and creates individual targets for each detector that will make it easier for contributors to add support for attributes. Individual detector targets will allow users to link only what they use. 

## Changes

- Create individual targets (CMake and Bazel) for each detector and builder
- Create two interface targets to group all detector and builders respectively
- Update builders to link detector targets privately
- Break up the one unit test exe into per detector/builder tests
- Update install tests to use the new targets
- Add README for the detectors directory

Please provide a brief description of the changes here.

For significant contributions please make sure you have completed the following items:

* [x] `CHANGELOG.md` updated for non-trivial changes
* [ ] Unit tests have been added
* [ ] Changes in public API reviewed