### PR TITLE
[BUG] Send one request per curl session

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,10 @@ Increment the:
   in the value as-is rather than dropping the attribute.
   [#1536](https://github.com/open-telemetry/opentelemetry-cpp/issues/1536)
 
+* [BUG] Send one request per curl session, rather than replacing the operation
+  a running request still belongs to
+  [#4396](https://github.com/open-telemetry/opentelemetry-cpp/issues/4396)
+
 * [BUG] Report one outcome per request when a curl session is cancelled after
   the response arrives
   ([#4363](https://github.com/open-telemetry/opentelemetry-cpp/pull/4363))

--- a/ext/include/opentelemetry/ext/http/client/curl/http_client_curl.h
+++ b/ext/include/opentelemetry/ext/http/client/curl/http_client_curl.h
@@ -186,10 +186,25 @@ public:
 
   std::shared_ptr<opentelemetry::ext::http::client::Request> CreateRequest() noexcept override
   {
+    if (send_started_.load(std::memory_order_acquire))
+    {
+      // The request that has been sent stays where it is. libcurl does not copy the body or the
+      // header list, so the transfer reads them for as long as it runs.
+      return http_request_;
+    }
+
     http_request_.reset(new Request());
     return http_request_;
   }
 
+  /**
+   * Send the request this session carries.
+   *
+   * A session carries one request. A second call reports CreateFailed to its own handler and
+   * sends nothing: the easy handle of the first request holds this session and the operation
+   * that owns it, and replacing that operation takes away what libcurl and the client are still
+   * reading.
+   */
   void SendRequest(
       std::shared_ptr<opentelemetry::ext::http::client::EventHandler> callback) noexcept override;
 
@@ -235,6 +250,9 @@ private:
   uint64_t session_id_ = 0UL;
   HttpClient &http_client_;
   std::atomic<bool> is_session_active_{false};
+
+  // Raised by the first SendRequest and never lowered. A session carries one request.
+  std::atomic<bool> send_started_{false};
 };
 
 class HttpClientSync : public opentelemetry::ext::http::client::HttpClientSync

--- a/ext/src/http/client/curl/http_client_curl.cc
+++ b/ext/src/http/client/curl/http_client_curl.cc
@@ -141,6 +141,21 @@ static int deflateInPlace(z_stream *strm, unsigned char *buf, uint32_t len, uint
 void Session::SendRequest(
     std::shared_ptr<opentelemetry::ext::http::client::EventHandler> callback) noexcept
 {
+  if (send_started_.exchange(true, std::memory_order_acq_rel))
+  {
+    // The first request is not finished with this session. Its easy handle names the session in
+    // CURLOPT_PRIVATE and names its operation in every callback it was given, and the message
+    // loop resolves that name to whichever operation the session owns, so a second operation
+    // would be handed the first one's completion. Worse from a handler that sends again from
+    // OnResponse, where the operation being replaced is the one running that handler.
+    if (callback)
+    {
+      callback->OnEvent(opentelemetry::ext::http::client::SessionState::CreateFailed,
+                        "a session carries one request");
+    }
+    return;
+  }
+
   is_session_active_.store(true, std::memory_order_release);
   const auto &url       = host_ + http_request_->uri_;
   auto callback_ptr     = callback.get();

--- a/ext/test/http/curl_http_test.cc
+++ b/ext/test/http/curl_http_test.cc
@@ -97,6 +97,37 @@ public:
 // inside the Response event, which is the one moment both arms of the completion callback are
 // eligible: DispatchEvent notifies the handler before it stores the new state, and the callback
 // runs after both, so it sees an aborted operation that also has a response.
+class ReentrantSendHandler : public CustomEventHandler
+{
+public:
+  void OnResponse(http_client::Response & /* response */) noexcept override
+  {
+    got_response_.store(true, std::memory_order_release);
+
+    if (session_ != nullptr && !resent_.exchange(true, std::memory_order_acq_rel))
+    {
+      auto again = session_->CreateRequest();
+      again->SetUri("get/");
+      session_->SendRequest(self_.lock());
+    }
+  }
+
+  void OnEvent(http_client::SessionState state, nostd::string_view /* reason */) noexcept override
+  {
+    if (state == http_client::SessionState::CreateFailed)
+    {
+      create_failed_.fetch_add(1, std::memory_order_release);
+    }
+  }
+
+  http_client::Session *session_ = nullptr;
+  std::weak_ptr<ReentrantSendHandler> self_;
+  std::atomic<int> create_failed_{0};
+
+private:
+  std::atomic<bool> resent_{false};
+};
+
 class TerminalCountingHandler : public CustomEventHandler
 {
 public:
@@ -627,6 +658,63 @@ TEST_F(BasicCurlHttpTests, ResetMultiHandleWithASessionDoesNotDeadlock)
   http_client::curl::HttpClientTestPeer::ResetMultiHandle(*client);
 
   client->FinishAllSessions();
+}
+
+// The reproduction from #4396. A handler that sends again from OnResponse replaces the operation
+// whose Cleanup is running that handler, and Cleanup reads that operation again on the way out.
+TEST_F(BasicCurlHttpTests, ASecondRequestFromInsideTheResponseIsRefused)
+{
+  received_requests_.clear();
+  auto session_manager = std::make_shared<http_client::curl::HttpCurlClientFactory>()->Create();
+  ASSERT_TRUE(session_manager != nullptr);
+
+  auto session = session_manager->CreateSession("http://127.0.0.1:19000");
+  auto request = session->CreateRequest();
+  request->SetUri("get/");
+
+  auto handler      = std::make_shared<ReentrantSendHandler>();
+  handler->session_ = session.get();
+  handler->self_    = handler;
+
+  session->SendRequest(handler);
+  ASSERT_TRUE(waitForRequests(30, 1));
+  session->FinishSession();
+
+  EXPECT_TRUE(handler->got_response_.load(std::memory_order_acquire));
+  EXPECT_EQ(1, handler->create_failed_.load(std::memory_order_acquire));
+
+  session_manager->FinishAllSessions();
+}
+
+// The same thing without the re-entrancy, and the request the first send is reading from is not
+// replaced under it either.
+TEST_F(BasicCurlHttpTests, ASessionSendsOneRequest)
+{
+  received_requests_.clear();
+  auto session_manager = std::make_shared<http_client::curl::HttpCurlClientFactory>()->Create();
+  ASSERT_TRUE(session_manager != nullptr);
+
+  auto session = session_manager->CreateSession("http://127.0.0.1:19000");
+  auto request = session->CreateRequest();
+  request->SetUri("get/");
+
+  auto first = std::make_shared<ReentrantSendHandler>();
+  session->SendRequest(first);
+  ASSERT_TRUE(waitForRequests(30, 1));
+  session->FinishSession();
+
+  EXPECT_TRUE(first->got_response_.load(std::memory_order_acquire));
+  EXPECT_EQ(0, first->create_failed_.load(std::memory_order_acquire));
+
+  auto again = session->CreateRequest();
+  EXPECT_EQ(request.get(), again.get());
+
+  auto second = std::make_shared<ReentrantSendHandler>();
+  session->SendRequest(second);
+  EXPECT_EQ(1, second->create_failed_.load(std::memory_order_acquire));
+  EXPECT_FALSE(second->got_response_.load(std::memory_order_acquire));
+
+  session_manager->FinishAllSessions();
 }
 
 // The caller-thread side of the same cancel. The server handler takes mtx_requests before it


### PR DESCRIPTION
Fixes #4396.

## What happens today

`Session::SendRequest()` replaces the operation the session owns. The easy handle of the first request holds that operation in every pointer libcurl calls back through, and holds the session in `CURLOPT_PRIVATE`. The message loop reads that back and resolves it to whichever operation the session owns by then:

```cpp
curl_easy_getinfo(easy_handle, CURLINFO_PRIVATE, &session);
const auto operation = (nullptr != session) ? session->GetOperation().get() : nullptr;
```

So a second request takes delivery of the first one's completion, and the first one's handle keeps calling back into an operation nobody owns.

From a handler that sends again out of `OnResponse` it is worse than a mix up. `Cleanup()` takes the completion callback and runs it while the operation it belongs to is still on the stack, so the `unique_ptr::reset` destroys the object whose `Cleanup()` is two frames up, and `Cleanup()` reads it again on the way out.

## What this does

A session carries one request:

* the first `SendRequest` consumes it, and a second reports `CreateFailed` to its own handler and sends nothing, which is what a send that cannot be made already reports on this class;
* `CreateRequest()` after that leaves the request the send is reading from where it is, because libcurl does not copy the body or the header list.

## Evidence

The case is the reproduction from the issue, a handler that sends again from `OnResponse`. Same binary, same command, either side of the change:

| | before | after |
| --- | --- | --- |
| `ASecondRequestFromInsideTheResponseIsRefused` | exit 1, `heap-use-after-free` in `unique_ptr<AsyncData>::_M_ptr()` | passes |
| AddressSanitizer reports | 1 | 0 |
| whole `curl_http_test` under ASan | | 28 of 28, no sanitizer output |

The second case, `ASessionSendsOneRequest`, is the same rule without the re-entrancy: send, wait, send again, and check that the second is refused and the backing request was not replaced under the first.

## Is anything relying on reuse

Not here. Both callers make a session, send once and let it go:

* `exporters/otlp/src/otlp_http_client.cc:1029` creates the session, `:1098` is the only send;
* `exporters/elasticsearch/src/es_log_record_exporter.cc:405` creates it, `:462` and `:467` are the two arms of one `#ifdef`.

No case in `curl_http_test` sends twice on one session either, and the three OTLP HTTP exporter test binaries pass under ASan unchanged: 55, 16 and 22.

## What I did not do

I have not put the rule in the `ext/http/client/http_client.h` interface, only on the curl `Session` that implements it. Saying it in the interface would bind every implementation, including the one in `examples/custom_http_client`, and that reads like your call rather than mine. Say the word and I will move it.

The alternative is to keep reuse and give each operation an identity of its own: `CURLOPT_PRIVATE` would carry the operation rather than the session, the pending records would own the exact operation, its request and its handler, and the message loop would resolve the operation that owns the handle rather than the one the session owns now. That is a rewrite of how this client owns things, it conflicts with every open change to the same file, and nothing in this repository asks for reuse. If you want it, it wants its own issue.

## Checks

| | result |
| --- | --- |
| `curl_http_test` under ASan with `detect_leaks=1` | 28 of 28, no sanitizer output |
| same, `WITH_OTLP_RETRY_PREVIEW=ON` | 28 of 28 |
| `bazel test //ext/test/http:curl_http_test` | passes |
| `otlp_http_exporter_test`, log record, metric, all under ASan | 55, 16, 22, all pass |
| clang-format 18.1.8 | clean |

For significant contributions please make sure you have completed the following items:

* [x] `CHANGELOG.md` updated for non-trivial changes
* [x] Unit tests have been added
* [x] Changes in public API reviewed
