### PR TITLE
[CONFIGURATION] Set schema default values for all parameters (#4432)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -243,6 +243,22 @@ Important changes:
 
 Breaking changes:
 
+* [CONFIGURATION] Align declarative configuration schema defaults with
+  OpenTelemetry Configuration Schema v1.1.0
+  [#4432](https://github.com/open-telemetry/opentelemetry-cpp/issues/4432)
+  * When a YAML field is omitted, the parsed configuration model now uses
+    these schema defaults instead of the previous legacy values:
+    * `attribute_limits.attribute_value_length_limit`,
+      `logger_provider.limits.attribute_value_length_limit`, and
+      `tracer_provider.limits.attribute_value_length_limit` default to no limit
+      (unlimited attribute value length) instead of 4096 bytes.
+    * `batch` log record processor `schedule_delay` defaults to 1000 ms instead
+      of 5000 ms (more frequent batch exports when the field is omitted).
+    * `periodic` metric reader `interval` defaults to 60000 ms instead of 5000 ms
+      (less frequent metric exports when the field is omitted).
+    * `trace_id_ratio_based` sampler `ratio` defaults to 1.0 instead of 0.0
+      (sample all traces instead of dropping all when the field is omitted).
+
 * [CONFIGURATION] SDK default component builder libraries and example
   [#4367](https://github.com/open-telemetry/opentelemetry-cpp/pull/4367)
   * The declaritive configuration registry is now empty on construction and

--- a/sdk/include/opentelemetry/sdk/configuration/attribute_limits_configuration.h
+++ b/sdk/include/opentelemetry/sdk/configuration/attribute_limits_configuration.h
@@ -4,6 +4,7 @@
 #pragma once
 
 #include <cstddef>
+#include <limits>
 
 #include "opentelemetry/version.h"
 
@@ -18,9 +19,9 @@ namespace configuration
 class AttributeLimitsConfiguration
 {
 public:
-  // TODO: spec default is no limit, using 4096 to preserve original behavior
-  static constexpr std::size_t kDefaultAttributeValueLengthLimit = 4096;
-  static constexpr std::size_t kDefaultAttributeCountLimit       = 128;
+  static constexpr std::size_t kDefaultAttributeValueLengthLimit =
+      (std::numeric_limits<std::size_t>::max)();
+  static constexpr std::size_t kDefaultAttributeCountLimit = 128;
 
   std::size_t attribute_value_length_limit{kDefaultAttributeValueLengthLimit};
   std::size_t attribute_count_limit{kDefaultAttributeCountLimit};

--- a/sdk/include/opentelemetry/sdk/configuration/batch_log_record_processor_configuration.h
+++ b/sdk/include/opentelemetry/sdk/configuration/batch_log_record_processor_configuration.h
@@ -22,8 +22,7 @@ namespace configuration
 class BatchLogRecordProcessorConfiguration : public LogRecordProcessorConfiguration
 {
 public:
-  // TODO: spec default is 1000ms for schedule_delay, using 5000ms to preserve original behavior
-  static constexpr std::size_t kDefaultScheduleDelayMs    = 5000;
+  static constexpr std::size_t kDefaultScheduleDelayMs    = 1000;
   static constexpr std::size_t kDefaultExportTimeoutMs    = 30000;
   static constexpr std::size_t kDefaultMaxQueueSize       = 2048;
   static constexpr std::size_t kDefaultMaxExportBatchSize = 512;

--- a/sdk/include/opentelemetry/sdk/configuration/log_record_limits_configuration.h
+++ b/sdk/include/opentelemetry/sdk/configuration/log_record_limits_configuration.h
@@ -4,6 +4,7 @@
 #pragma once
 
 #include <cstddef>
+#include <limits>
 
 #include "opentelemetry/version.h"
 
@@ -18,9 +19,9 @@ namespace configuration
 class LogRecordLimitsConfiguration
 {
 public:
-  // TODO: spec default is no limit, using 4096 to preserve original behavior
-  static constexpr std::size_t kDefaultAttributeValueLengthLimit = 4096;
-  static constexpr std::size_t kDefaultAttributeCountLimit       = 128;
+  static constexpr std::size_t kDefaultAttributeValueLengthLimit =
+      (std::numeric_limits<std::size_t>::max)();
+  static constexpr std::size_t kDefaultAttributeCountLimit = 128;
 
   std::size_t attribute_value_length_limit{kDefaultAttributeValueLengthLimit};
   std::size_t attribute_count_limit{kDefaultAttributeCountLimit};

--- a/sdk/include/opentelemetry/sdk/configuration/periodic_metric_reader_configuration.h
+++ b/sdk/include/opentelemetry/sdk/configuration/periodic_metric_reader_configuration.h
@@ -25,8 +25,7 @@ namespace configuration
 class PeriodicMetricReaderConfiguration : public MetricReaderConfiguration
 {
 public:
-  // TODO: spec default is 60000ms for interval, using 5000ms to preserve original behavior
-  static constexpr std::size_t kDefaultIntervalMs = 5000;
+  static constexpr std::size_t kDefaultIntervalMs = 60000;
   static constexpr std::size_t kDefaultTimeoutMs  = 30000;
 
   void Accept(MetricReaderConfigurationVisitor *visitor) const override

--- a/sdk/include/opentelemetry/sdk/configuration/span_limits_configuration.h
+++ b/sdk/include/opentelemetry/sdk/configuration/span_limits_configuration.h
@@ -4,6 +4,7 @@
 #pragma once
 
 #include <cstddef>
+#include <limits>
 
 #include "opentelemetry/version.h"
 
@@ -18,8 +19,8 @@ namespace configuration
 class SpanLimitsConfiguration
 {
 public:
-  // TODO: spec default is no limit, using 4096 to preserve original behavior
-  static constexpr std::size_t kDefaultAttributeValueLengthLimit  = 4096;
+  static constexpr std::size_t kDefaultAttributeValueLengthLimit =
+      (std::numeric_limits<std::size_t>::max)();
   static constexpr std::uint32_t kDefaultAttributeCountLimit      = 128;
   static constexpr std::uint32_t kDefaultEventCountLimit          = 128;
   static constexpr std::uint32_t kDefaultLinkCountLimit           = 128;

--- a/sdk/include/opentelemetry/sdk/configuration/trace_id_ratio_based_sampler_configuration.h
+++ b/sdk/include/opentelemetry/sdk/configuration/trace_id_ratio_based_sampler_configuration.h
@@ -18,8 +18,7 @@ namespace configuration
 class TraceIdRatioBasedSamplerConfiguration : public SamplerConfiguration
 {
 public:
-  // TODO: spec default is 1.0, using 0.0 to preserve original behavior
-  static constexpr double kDefaultRatio = 0.0;
+  static constexpr double kDefaultRatio = 1.0;
 
   void Accept(SamplerConfigurationVisitor *visitor) const override
   {

--- a/sdk/test/configuration/yaml_logs_test.cc
+++ b/sdk/test/configuration/yaml_logs_test.cc
@@ -120,9 +120,8 @@ logger_provider:
   auto *batch =
       reinterpret_cast<opentelemetry::sdk::configuration::BatchLogRecordProcessorConfiguration *>(
           processor);
-  ASSERT_EQ(batch->schedule_delay,
-            opentelemetry::sdk::configuration::BatchLogRecordProcessorConfiguration::
-                kDefaultScheduleDelayMs);
+  const auto defaults = opentelemetry::sdk::configuration::BatchLogRecordProcessorConfiguration{};
+  ASSERT_EQ(batch->schedule_delay, defaults.schedule_delay);
   ASSERT_EQ(batch->export_timeout, 30000);
   ASSERT_EQ(batch->max_queue_size, 2048);
   ASSERT_EQ(batch->max_export_batch_size, 512);
@@ -462,9 +461,9 @@ logger_provider:
   ASSERT_NE(config, nullptr);
   ASSERT_NE(config->logger_provider, nullptr);
   ASSERT_NE(config->logger_provider->limits, nullptr);
+  const auto defaults = opentelemetry::sdk::configuration::LogRecordLimitsConfiguration{};
   ASSERT_EQ(config->logger_provider->limits->attribute_value_length_limit,
-            opentelemetry::sdk::configuration::LogRecordLimitsConfiguration::
-                kDefaultAttributeValueLengthLimit);
+            defaults.attribute_value_length_limit);
   ASSERT_EQ(config->logger_provider->limits->attribute_count_limit, 128);
 }
 

--- a/sdk/test/configuration/yaml_logs_test.cc
+++ b/sdk/test/configuration/yaml_logs_test.cc
@@ -120,7 +120,9 @@ logger_provider:
   auto *batch =
       reinterpret_cast<opentelemetry::sdk::configuration::BatchLogRecordProcessorConfiguration *>(
           processor);
-  ASSERT_EQ(batch->schedule_delay, 5000);
+  ASSERT_EQ(batch->schedule_delay,
+            opentelemetry::sdk::configuration::BatchLogRecordProcessorConfiguration::
+                kDefaultScheduleDelayMs);
   ASSERT_EQ(batch->export_timeout, 30000);
   ASSERT_EQ(batch->max_queue_size, 2048);
   ASSERT_EQ(batch->max_export_batch_size, 512);
@@ -460,7 +462,9 @@ logger_provider:
   ASSERT_NE(config, nullptr);
   ASSERT_NE(config->logger_provider, nullptr);
   ASSERT_NE(config->logger_provider->limits, nullptr);
-  ASSERT_EQ(config->logger_provider->limits->attribute_value_length_limit, 4096);
+  ASSERT_EQ(config->logger_provider->limits->attribute_value_length_limit,
+            opentelemetry::sdk::configuration::LogRecordLimitsConfiguration::
+                kDefaultAttributeValueLengthLimit);
   ASSERT_EQ(config->logger_provider->limits->attribute_count_limit, 128);
 }
 

--- a/sdk/test/configuration/yaml_metrics_test.cc
+++ b/sdk/test/configuration/yaml_metrics_test.cc
@@ -114,7 +114,9 @@ meter_provider:
   auto *periodic =
       reinterpret_cast<opentelemetry::sdk::configuration::PeriodicMetricReaderConfiguration *>(
           reader);
-  ASSERT_EQ(periodic->interval, 5000);
+  ASSERT_EQ(
+      periodic->interval,
+      opentelemetry::sdk::configuration::PeriodicMetricReaderConfiguration::kDefaultIntervalMs);
   ASSERT_EQ(periodic->timeout, 30000);
   ASSERT_NE(periodic->exporter, nullptr);
   auto *exporter = periodic->exporter.get();

--- a/sdk/test/configuration/yaml_metrics_test.cc
+++ b/sdk/test/configuration/yaml_metrics_test.cc
@@ -114,9 +114,8 @@ meter_provider:
   auto *periodic =
       reinterpret_cast<opentelemetry::sdk::configuration::PeriodicMetricReaderConfiguration *>(
           reader);
-  ASSERT_EQ(
-      periodic->interval,
-      opentelemetry::sdk::configuration::PeriodicMetricReaderConfiguration::kDefaultIntervalMs);
+  const auto defaults = opentelemetry::sdk::configuration::PeriodicMetricReaderConfiguration{};
+  ASSERT_EQ(periodic->interval, defaults.interval);
   ASSERT_EQ(periodic->timeout, 30000);
   ASSERT_NE(periodic->exporter, nullptr);
   auto *exporter = periodic->exporter.get();

--- a/sdk/test/configuration/yaml_test.cc
+++ b/sdk/test/configuration/yaml_test.cc
@@ -176,9 +176,9 @@ attribute_limits:
   ASSERT_NE(config, nullptr);
   ASSERT_EQ(config->file_format, "1.0");
   ASSERT_NE(config->attribute_limits, nullptr);
+  const auto defaults = opentelemetry::sdk::configuration::AttributeLimitsConfiguration{};
   ASSERT_EQ(config->attribute_limits->attribute_value_length_limit,
-            opentelemetry::sdk::configuration::AttributeLimitsConfiguration::
-                kDefaultAttributeValueLengthLimit);
+            defaults.attribute_value_length_limit);
   ASSERT_EQ(config->attribute_limits->attribute_count_limit, 128);
 }
 
@@ -610,9 +610,8 @@ tracer_provider:
   auto ratio_sampler =
       static_cast<opentelemetry::sdk::configuration::TraceIdRatioBasedSamplerConfiguration *>(
           sampler);
-  ASSERT_EQ(
-      ratio_sampler->ratio,
-      opentelemetry::sdk::configuration::TraceIdRatioBasedSamplerConfiguration::kDefaultRatio);
+  const auto defaults = opentelemetry::sdk::configuration::TraceIdRatioBasedSamplerConfiguration{};
+  ASSERT_EQ(ratio_sampler->ratio, defaults.ratio);
 }
 
 TEST(Yaml, illegal_double)
@@ -657,9 +656,8 @@ tracer_provider:
   auto ratio_sampler =
       static_cast<opentelemetry::sdk::configuration::TraceIdRatioBasedSamplerConfiguration *>(
           sampler);
-  ASSERT_EQ(
-      ratio_sampler->ratio,
-      opentelemetry::sdk::configuration::TraceIdRatioBasedSamplerConfiguration::kDefaultRatio);
+  const auto defaults = opentelemetry::sdk::configuration::TraceIdRatioBasedSamplerConfiguration{};
+  ASSERT_EQ(ratio_sampler->ratio, defaults.ratio);
 }
 
 TEST(Yaml, empty_double_substitution)
@@ -686,9 +684,8 @@ tracer_provider:
   auto ratio_sampler =
       static_cast<opentelemetry::sdk::configuration::TraceIdRatioBasedSamplerConfiguration *>(
           sampler);
-  ASSERT_EQ(
-      ratio_sampler->ratio,
-      opentelemetry::sdk::configuration::TraceIdRatioBasedSamplerConfiguration::kDefaultRatio);
+  const auto defaults = opentelemetry::sdk::configuration::TraceIdRatioBasedSamplerConfiguration{};
+  ASSERT_EQ(ratio_sampler->ratio, defaults.ratio);
 }
 
 TEST(Yaml, with_double_substitution)

--- a/sdk/test/configuration/yaml_test.cc
+++ b/sdk/test/configuration/yaml_test.cc
@@ -176,7 +176,9 @@ attribute_limits:
   ASSERT_NE(config, nullptr);
   ASSERT_EQ(config->file_format, "1.0");
   ASSERT_NE(config->attribute_limits, nullptr);
-  ASSERT_EQ(config->attribute_limits->attribute_value_length_limit, 4096);
+  ASSERT_EQ(config->attribute_limits->attribute_value_length_limit,
+            opentelemetry::sdk::configuration::AttributeLimitsConfiguration::
+                kDefaultAttributeValueLengthLimit);
   ASSERT_EQ(config->attribute_limits->attribute_count_limit, 128);
 }
 
@@ -608,7 +610,9 @@ tracer_provider:
   auto ratio_sampler =
       static_cast<opentelemetry::sdk::configuration::TraceIdRatioBasedSamplerConfiguration *>(
           sampler);
-  ASSERT_EQ(ratio_sampler->ratio, 0.0);
+  ASSERT_EQ(
+      ratio_sampler->ratio,
+      opentelemetry::sdk::configuration::TraceIdRatioBasedSamplerConfiguration::kDefaultRatio);
 }
 
 TEST(Yaml, illegal_double)
@@ -653,7 +657,9 @@ tracer_provider:
   auto ratio_sampler =
       static_cast<opentelemetry::sdk::configuration::TraceIdRatioBasedSamplerConfiguration *>(
           sampler);
-  ASSERT_EQ(ratio_sampler->ratio, 0.0);
+  ASSERT_EQ(
+      ratio_sampler->ratio,
+      opentelemetry::sdk::configuration::TraceIdRatioBasedSamplerConfiguration::kDefaultRatio);
 }
 
 TEST(Yaml, empty_double_substitution)
@@ -680,7 +686,9 @@ tracer_provider:
   auto ratio_sampler =
       static_cast<opentelemetry::sdk::configuration::TraceIdRatioBasedSamplerConfiguration *>(
           sampler);
-  ASSERT_EQ(ratio_sampler->ratio, 0.0);
+  ASSERT_EQ(
+      ratio_sampler->ratio,
+      opentelemetry::sdk::configuration::TraceIdRatioBasedSamplerConfiguration::kDefaultRatio);
 }
 
 TEST(Yaml, with_double_substitution)

--- a/sdk/test/configuration/yaml_trace_test.cc
+++ b/sdk/test/configuration/yaml_trace_test.cc
@@ -605,9 +605,9 @@ tracer_provider:
   ASSERT_NE(config, nullptr);
   ASSERT_NE(config->tracer_provider, nullptr);
   ASSERT_NE(config->tracer_provider->limits, nullptr);
+  const auto defaults = opentelemetry::sdk::configuration::SpanLimitsConfiguration{};
   ASSERT_EQ(config->tracer_provider->limits->attribute_value_length_limit,
-            opentelemetry::sdk::configuration::SpanLimitsConfiguration::
-                kDefaultAttributeValueLengthLimit);
+            defaults.attribute_value_length_limit);
   ASSERT_EQ(config->tracer_provider->limits->attribute_count_limit, 128);
   ASSERT_EQ(config->tracer_provider->limits->event_count_limit, 128);
   ASSERT_EQ(config->tracer_provider->limits->link_count_limit, 128);
@@ -951,9 +951,8 @@ tracer_provider:
   auto *ratio =
       reinterpret_cast<opentelemetry::sdk::configuration::TraceIdRatioBasedSamplerConfiguration *>(
           sampler);
-  ASSERT_EQ(
-      ratio->ratio,
-      opentelemetry::sdk::configuration::TraceIdRatioBasedSamplerConfiguration::kDefaultRatio);
+  const auto defaults = opentelemetry::sdk::configuration::TraceIdRatioBasedSamplerConfiguration{};
+  ASSERT_EQ(ratio->ratio, defaults.ratio);
 }
 
 TEST(YamlTrace, trace_id_ratio_based_sampler)

--- a/sdk/test/configuration/yaml_trace_test.cc
+++ b/sdk/test/configuration/yaml_trace_test.cc
@@ -605,7 +605,9 @@ tracer_provider:
   ASSERT_NE(config, nullptr);
   ASSERT_NE(config->tracer_provider, nullptr);
   ASSERT_NE(config->tracer_provider->limits, nullptr);
-  ASSERT_EQ(config->tracer_provider->limits->attribute_value_length_limit, 4096);
+  ASSERT_EQ(config->tracer_provider->limits->attribute_value_length_limit,
+            opentelemetry::sdk::configuration::SpanLimitsConfiguration::
+                kDefaultAttributeValueLengthLimit);
   ASSERT_EQ(config->tracer_provider->limits->attribute_count_limit, 128);
   ASSERT_EQ(config->tracer_provider->limits->event_count_limit, 128);
   ASSERT_EQ(config->tracer_provider->limits->link_count_limit, 128);
@@ -949,7 +951,9 @@ tracer_provider:
   auto *ratio =
       reinterpret_cast<opentelemetry::sdk::configuration::TraceIdRatioBasedSamplerConfiguration *>(
           sampler);
-  ASSERT_EQ(ratio->ratio, 0.0);
+  ASSERT_EQ(
+      ratio->ratio,
+      opentelemetry::sdk::configuration::TraceIdRatioBasedSamplerConfiguration::kDefaultRatio);
 }
 
 TEST(YamlTrace, trace_id_ratio_based_sampler)


### PR DESCRIPTION
Fixes #4432 

## Changes

Align declarative configuration `kDefault*` constants with [OpenTelemetry Configuration Schema v1.1.0](https://github.com/open-telemetry/opentelemetry-configuration/tree/v1.1.0) when the corresponding configuration fields are omitted.

### Default updates

| Parameter | Previous default | New default (schema) |
|-----------|------------------|----------------------|
| `attribute_limits.attribute_value_length_limit` | 4096 | no limit |
| `logger_provider.limits.attribute_value_length_limit` | 4096 | no limit |
| `tracer_provider.limits.attribute_value_length_limit` | 4096 | no limit |
| `batch` log processor `schedule_delay` | 5000 ms | 1000 ms |
| `periodic` metric reader `interval` | 5000 ms | 60000 ms |
| `trace_id_ratio_based` sampler `ratio` | 0.0 | 1.0 |

The three attribute value length limits use `(std::numeric_limits<std::size_t>::max)()`, matching the existing SDK "no limit" representation in `span_limits.h` and `log_record_limits.h`.

### Breaking behavior

When the corresponding configuration field is **omitted**, parsed configuration now reflects the schema defaults above instead of the previous legacy values. This affects attribute truncation, batch log export timing, metric export interval, and trace sampling ratio.

Explicit configuration values are unchanged.

The breaking changes are documented under `[Unreleased]` in `CHANGELOG.md`.

### Why no parser/builder changes

`configuration_parser.cc` already assigns omitted fields from the corresponding `Config::kDefault*` constants. Updating these constants is therefore sufficient for the parsed configuration model to use the new defaults.

### Tests

Local build with `-DWITH_CONFIGURATION=ON` and `-DOTELCPP_MAINTAINER_MODE=ON`:

| Test | Result |
|------|--------|
| `yaml_test` | 51 passed |
| `yaml_trace_test` | 48 passed |
| `yaml_logs_test` | 23 passed |
| `yaml_metrics_test` | 47 passed |
| `sdk_builder_test` | 34 passed |

Default-expectation assertions in the YAML configuration tests were updated to reference the `kDefault*` constants. Explicit-value tests (e.g. `1111`, `5555`, `3.14`) were not changed.

### Formatting / lint

- **clang-format 18.1.8:** `--Werror -n` passed on all 10 modified C++ files.
- **markdownlint-cli 0.46.0:** `CHANGELOG.md` passed.

The full Docker `do_ci.sh format` workflow was not run locally because the Docker environment ran out of memory during third-party dependency builds. Targeted formatting validation with clang-format 18 completed successfully on all changed C++ files.

## Out of scope / follow-ups

- **YAML explicit `null`:** The parser does not currently treat explicit YAML `null` the same as an omitted field. This is not addressed by #4432 and may be handled separately.
- **Root `attribute_limits`:** The configuration is parsed but not applied by `SdkBuilder`; this is tracked separately in #3303.
- **`kitchen-sink.yaml`:** Retains explicit legacy values such as 4096 and 5000 and is intentionally unchanged because those are explicit example configuration values.

For significant contributions please make sure you have completed the following items:

* [x] `CHANGELOG.md` updated for non-trivial changes
* [x] Unit tests have been added
* [x] Changes in public API reviewed