### PR TITLE
[RESOURCE DETECTOR] Add the service resource detector and builder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,8 @@ Increment the:
 
 * [RESOURCE DETECTOR] Add the host resource detector
   [#4413](https://github.com/open-telemetry/opentelemetry-cpp/issues/4413)
+* [RESOURCE DETECTOR] Add the service resource detector and builder
+  [#4414](https://github.com/open-telemetry/opentelemetry-cpp/issues/4414)
 * [CONFIGURATION] deprecate config builder cmake components
   [#4428](https://github.com/open-telemetry/opentelemetry-cpp/pull/4428)
 

--- a/examples/configuration/kitchen-sink.yaml
+++ b/examples/configuration/kitchen-sink.yaml
@@ -1067,8 +1067,8 @@ resource:
         host:
       - # Enable the process resource detector, which populates process.* attributes.
         process:
-      # - # Enable the service detector, which populates service.name based on the OTEL_SERVICE_NAME environment variable and service.instance.id.
-      #   service:
+      - # Enable the service resource detector, which populates service.name based on the OTEL_SERVICE_NAME environment variable and service.instance.id.
+        service:
       # - # Enable an extension resource detector registered by name.
       #   my_custom_detector:
   # Configure resource schema URL.

--- a/examples/configuration/main.cc
+++ b/examples/configuration/main.cc
@@ -60,6 +60,7 @@
 #  include "opentelemetry/resource_detectors/container_detector_builder.h"
 #  include "opentelemetry/resource_detectors/host_detector_builder.h"
 #  include "opentelemetry/resource_detectors/process_detector_builder.h"
+#  include "opentelemetry/resource_detectors/service_detector_builder.h"
 #endif
 
 static bool opt_help        = false;
@@ -226,6 +227,7 @@ void InitOtel(const std::string &config_file)
     opentelemetry::resource_detector::ContainerDetectorBuilder::Register(registry.get());
     opentelemetry::resource_detector::HostDetectorBuilder::Register(registry.get());
     opentelemetry::resource_detector::ProcessDetectorBuilder::Register(registry.get());
+    opentelemetry::resource_detector::ServiceDetectorBuilder::Register(registry.get());
 #endif
   }
 

--- a/install/test/cmake/component_tests/resource_detectors/CMakeLists.txt
+++ b/install/test/cmake/component_tests/resource_detectors/CMakeLists.txt
@@ -22,6 +22,8 @@ target_link_libraries(
           opentelemetry-cpp::host_resource_detector_builder
           opentelemetry-cpp::process_resource_detector
           opentelemetry-cpp::process_resource_detector_builder
+          opentelemetry-cpp::service_resource_detector
+          opentelemetry-cpp::service_resource_detector_builder
           GTest::gtest
           GTest::gtest_main)
 

--- a/install/test/cmake/fetch_content_test/CMakeLists.txt
+++ b/install/test/cmake/fetch_content_test/CMakeLists.txt
@@ -112,6 +112,8 @@ target_link_libraries(
           opentelemetry-cpp::host_resource_detector_builder
           opentelemetry-cpp::process_resource_detector
           opentelemetry-cpp::process_resource_detector_builder
+          opentelemetry-cpp::service_resource_detector
+          opentelemetry-cpp::service_resource_detector_builder
           opentelemetry-cpp::http_client
           opentelemetry-cpp::http_client_curl
           opentelemetry-cpp::in_memory_span_exporter

--- a/install/test/src/test_resource_detectors.cc
+++ b/install/test/src/test_resource_detectors.cc
@@ -3,6 +3,7 @@
 
 #include <gtest/gtest.h>
 
+#include <opentelemetry/nostd/variant.h>
 #include <opentelemetry/resource_detectors/container_detector.h>
 #include <opentelemetry/resource_detectors/container_detector_builder.h>
 #include <opentelemetry/resource_detectors/env_entity_detector.h>
@@ -10,7 +11,13 @@
 #include <opentelemetry/resource_detectors/host_detector_builder.h>
 #include <opentelemetry/resource_detectors/process_detector.h>
 #include <opentelemetry/resource_detectors/process_detector_builder.h>
+#include <opentelemetry/resource_detectors/service_detector.h>
+#include <opentelemetry/resource_detectors/service_detector_builder.h>
+#include <opentelemetry/semconv/service_attributes.h>
 #include <memory>
+#include <string>
+
+namespace semconv = opentelemetry::semconv;
 
 TEST(ResourceDetectorsInstall, ContainerResourceDetector)
 {
@@ -44,6 +51,24 @@ TEST(ResourceDetectorsInstall, ProcessResourceDetector)
   ASSERT_NO_THROW(auto resource = detector->Detect());
 }
 
+TEST(ResourceDetectorsInstall, ServiceResourceDetector)
+{
+  std::unique_ptr<opentelemetry::sdk::resource::ResourceDetector> detector =
+      std::make_unique<opentelemetry::resource_detector::ServiceResourceDetector>();
+  ASSERT_TRUE(detector != nullptr);
+
+  auto resource     = detector->Detect();
+  const auto &attrs = resource.GetAttributes();
+
+  auto name_it = attrs.find(semconv::service::kServiceName);
+  ASSERT_NE(name_it, attrs.end());
+  EXPECT_FALSE(opentelemetry::nostd::get<std::string>(name_it->second).empty());
+
+  auto instance_id_it = attrs.find(semconv::service::kServiceInstanceId);
+  ASSERT_NE(instance_id_it, attrs.end());
+  EXPECT_FALSE(opentelemetry::nostd::get<std::string>(instance_id_it->second).empty());
+}
+
 TEST(ResourceDetectorsInstall, ContainerDetectorBuilder)
 {
   auto builder = std::make_unique<opentelemetry::resource_detector::ContainerDetectorBuilder>();
@@ -72,4 +97,15 @@ TEST(ResourceDetectorsInstall, ProcessDetectorBuilder)
   opentelemetry::sdk::configuration::ProcessResourceDetectorConfiguration model;
   auto detector = builder->Build(&model);
   ASSERT_TRUE(detector != nullptr);
+}
+
+TEST(ResourceDetectorsInstall, ServiceDetectorBuilder)
+{
+  auto builder = std::make_unique<opentelemetry::resource_detector::ServiceDetectorBuilder>();
+  ASSERT_TRUE(builder != nullptr);
+
+  opentelemetry::sdk::configuration::ServiceResourceDetectorConfiguration model;
+  auto detector = builder->Build(&model);
+  ASSERT_TRUE(detector != nullptr);
+  ASSERT_NO_THROW(auto resource = detector->Detect());
 }

--- a/resource_detectors/BUILD
+++ b/resource_detectors/BUILD
@@ -123,6 +123,15 @@ cc_library(
     ],
 )
 
+cc_library(
+    name = "service_resource_detector_builder",
+    srcs = ["src/service_detector_builder.cc"],
+    deps = [
+        ":service_resource_detector",
+        "//sdk/src/configuration:configuration_core",
+    ],
+)
+
 # Convenience target linking all resource detectors.
 cc_library(
     name = "resource_detectors",
@@ -131,6 +140,7 @@ cc_library(
         ":env_entity_resource_detector",
         ":host_resource_detector",
         ":process_resource_detector",
+        ":service_resource_detector",
     ],
 )
 
@@ -141,5 +151,6 @@ cc_library(
         ":container_resource_detector_builder",
         ":host_resource_detector_builder",
         ":process_resource_detector_builder",
+        ":service_resource_detector_builder",
     ],
 )

--- a/resource_detectors/BUILD
+++ b/resource_detectors/BUILD
@@ -95,6 +95,21 @@ cc_library(
     ],
 )
 
+cc_library(
+    name = "service_resource_detector_utils",
+    srcs = ["src/service_detector_utils.cc"],
+    copts = ["-fexceptions"],
+    deps = [
+        ":process_resource_detector",
+        "//api",
+        "//resource_detectors:headers",
+        "//sdk:headers",
+        "//sdk/src/common:env_variables",
+        "//sdk/src/common:random",
+        "//sdk/src/resource",
+    ],
+)
+
 # Convenience target linking all resource detectors.
 cc_library(
     name = "resource_detectors",

--- a/resource_detectors/BUILD
+++ b/resource_detectors/BUILD
@@ -110,6 +110,19 @@ cc_library(
     ],
 )
 
+cc_library(
+    name = "service_resource_detector",
+    srcs = ["src/service_detector.cc"],
+    copts = ["-fexceptions"],
+    deps = [
+        ":service_resource_detector_utils",
+        "//api",
+        "//resource_detectors:headers",
+        "//sdk:headers",
+        "//sdk/src/resource",
+    ],
+)
+
 # Convenience target linking all resource detectors.
 cc_library(
     name = "resource_detectors",

--- a/resource_detectors/CMakeLists.txt
+++ b/resource_detectors/CMakeLists.txt
@@ -143,6 +143,10 @@ target_link_libraries(
 add_library(opentelemetry_service_resource_detector_utils
             src/service_detector_utils.cc)
 
+set_target_properties(opentelemetry_service_resource_detector_utils
+                      PROPERTIES EXPORT_NAME service_resource_detector_utils)
+set_target_version(opentelemetry_service_resource_detector_utils)
+
 target_link_libraries(
   opentelemetry_service_resource_detector_utils
   PUBLIC opentelemetry_resources
@@ -170,6 +174,27 @@ target_include_directories(
          "$<INSTALL_INTERFACE:include>")
 
 #
+# opentelemetry_service_resource_detector_builder
+#
+
+add_library(opentelemetry_service_resource_detector_builder
+            src/service_detector_builder.cc)
+
+set_target_properties(opentelemetry_service_resource_detector_builder
+                      PROPERTIES EXPORT_NAME service_resource_detector_builder)
+set_target_version(opentelemetry_service_resource_detector_builder)
+
+target_include_directories(
+  opentelemetry_service_resource_detector_builder
+  PUBLIC "$<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}/include>"
+         "$<INSTALL_INTERFACE:include>")
+
+target_link_libraries(
+  opentelemetry_service_resource_detector_builder
+  PRIVATE opentelemetry_service_resource_detector
+          opentelemetry_configuration_core)
+
+#
 # opentelemetry_resource_detectors (interface to all detectors)
 #
 
@@ -183,7 +208,8 @@ target_link_libraries(
   INTERFACE opentelemetry_container_resource_detector
             opentelemetry_env_entity_resource_detector
             opentelemetry_host_resource_detector
-            opentelemetry_process_resource_detector)
+            opentelemetry_process_resource_detector
+            opentelemetry_service_resource_detector)
 
 #
 # opentelemetry_resource_detectors_builders (interface to all builders)
@@ -198,7 +224,8 @@ target_link_libraries(
   opentelemetry_resource_detectors_builders
   INTERFACE opentelemetry_container_resource_detector_builder
             opentelemetry_host_resource_detector_builder
-            opentelemetry_process_resource_detector_builder)
+            opentelemetry_process_resource_detector_builder
+            opentelemetry_service_resource_detector_builder)
 
 otel_add_component(
   COMPONENT
@@ -213,6 +240,9 @@ otel_add_component(
   opentelemetry_host_resource_detector_builder
   opentelemetry_process_resource_detector
   opentelemetry_process_resource_detector_builder
+  opentelemetry_service_resource_detector
+  opentelemetry_service_resource_detector_builder
+  opentelemetry_service_resource_detector_utils
   FILES_DIRECTORY
   "include/opentelemetry/"
   FILES_DESTINATION

--- a/resource_detectors/CMakeLists.txt
+++ b/resource_detectors/CMakeLists.txt
@@ -137,6 +137,22 @@ target_link_libraries(
           opentelemetry_configuration_core)
 
 #
+# opentelemetry_service_resource_detector_utils
+#
+
+add_library(opentelemetry_service_resource_detector_utils
+            src/service_detector_utils.cc)
+
+target_link_libraries(
+  opentelemetry_service_resource_detector_utils
+  PUBLIC opentelemetry_resources
+  PRIVATE opentelemetry_process_resource_detector)
+target_include_directories(
+  opentelemetry_service_resource_detector_utils
+  PUBLIC "$<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}/include>"
+         "$<INSTALL_INTERFACE:include>")
+
+#
 # opentelemetry_resource_detectors (interface to all detectors)
 #
 

--- a/resource_detectors/CMakeLists.txt
+++ b/resource_detectors/CMakeLists.txt
@@ -153,6 +153,23 @@ target_include_directories(
          "$<INSTALL_INTERFACE:include>")
 
 #
+# opentelemetry_service_resource_detector
+#
+
+add_library(opentelemetry_service_resource_detector src/service_detector.cc)
+
+set_target_properties(opentelemetry_service_resource_detector
+                      PROPERTIES EXPORT_NAME service_resource_detector)
+set_target_version(opentelemetry_service_resource_detector)
+
+target_link_libraries(opentelemetry_service_resource_detector
+                      PUBLIC opentelemetry_service_resource_detector_utils)
+target_include_directories(
+  opentelemetry_service_resource_detector
+  PUBLIC "$<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}/include>"
+         "$<INSTALL_INTERFACE:include>")
+
+#
 # opentelemetry_resource_detectors (interface to all detectors)
 #
 

--- a/resource_detectors/README.md
+++ b/resource_detectors/README.md
@@ -139,7 +139,7 @@ opentelemetry::resource_detector::ServiceDetectorBuilder::Register(registry.get(
 
 ## Linking with CMake
 
-### Linking to detectors directly (not required for declaritive config)
+### Linking to detectors directly (not required for declarative config)
 
 Link to all available detectors:
 
@@ -155,9 +155,9 @@ find_package(opentelemetry-cpp CONFIG REQUIRED COMPONENTS resource_detectors)
 target_link_libraries(my_target PRIVATE opentelemetry-cpp::host_resource_detector)
 ```
 
-### Linking to builders for declaritive configuration
+### Linking to builders for declarative configuration
 
-Builder targets make detectors available for declaritive configuration and hide
+Builder targets make detectors available for declarative configuration and hide
 the concrete detector implementations.
 
 Link all builders:
@@ -185,14 +185,14 @@ All targets are part of the `resource_detectors` component.
 | `opentelemetry-cpp::resource_detectors` | Interface: links all detectors |
 | `opentelemetry-cpp::resource_detectors_builders` | Interface: links all builders |
 | `opentelemetry-cpp::container_resource_detector` | Container detector |
-| `opentelemetry-cpp::container_resource_detector_builder` | Container detector builder for declaritive configuration |
+| `opentelemetry-cpp::container_resource_detector_builder` | Container detector builder for declarative configuration |
 | `opentelemetry-cpp::env_entity_resource_detector` | Env entity detector |
 | `opentelemetry-cpp::host_resource_detector` | Host detector |
 | `opentelemetry-cpp::host_resource_detector_builder` | Host detector builder for declaritive configuration |
 | `opentelemetry-cpp::process_resource_detector` | Process detector |
-| `opentelemetry-cpp::process_resource_detector_builder` | Process detector builder for declaritive configuration |
+| `opentelemetry-cpp::process_resource_detector_builder` | Process detector builder for declarative configuration |
 | `opentelemetry-cpp::service_resource_detector` | Service detector |
-| `opentelemetry-cpp::service_resource_detector_builder` | Service detector builder for declaritive configuration |
+| `opentelemetry-cpp::service_resource_detector_builder` | Service detector builder for declarative configuration |
 
 ## Linking with Bazel
 

--- a/resource_detectors/README.md
+++ b/resource_detectors/README.md
@@ -29,7 +29,25 @@ Contributions to detect more attributes for each Entity are welcome.
 
 [Entity: Service](https://opentelemetry.io/docs/specs/semconv/registry/entities/service/)
 
-Not implemented.
+| Attribute | Description | Linux | macOS | Windows |
+| --- | --- | --- | --- | --- |
+| `service.name` | From `OTEL_SERVICE_NAME` when set | Yes | Yes | Yes |
+| `service.name` | Fallback `unknown_service:<process.executable.name>` or `unknown_service` | Yes | Yes | Yes |
+| `service.instance.id` | Stable RFC 4122 UUID version 4 for the current process | Yes | Yes | Yes |
+
+`service.name` is read only from the `OTEL_SERVICE_NAME` environment variable. When
+that variable is unset, the detector falls back to
+`unknown_service:<process.executable.name>` when the executable name is
+available for the current process, otherwise `unknown_service`.
+
+`service.instance.id` is generated once per process and remains stable until the
+process ID changes (for example after `fork()`).
+
+Limitations:
+
+- The detector does not read `OTEL_RESOURCE_ATTRIBUTES`.
+- Executable-name fallback reuses process detector utilities; on macOS the
+  executable name is available for the current process only.
 
 ### Container Resource Detector
 
@@ -102,8 +120,7 @@ resource:
       - container:
       - host:
       - process:
-      # NOTE: service detector cannot be configured currently
-      - service: # not implemented (github.com/open-telemetry/opentelemetry-cpp/issues/4414)
+      - service:
 ```
 
 Call `Register` for each builder before creating the SDK:
@@ -112,10 +129,12 @@ Call `Register` for each builder before creating the SDK:
 #include "opentelemetry/resource_detectors/container_detector_builder.h"
 #include "opentelemetry/resource_detectors/host_detector_builder.h"
 #include "opentelemetry/resource_detectors/process_detector_builder.h"
+#include "opentelemetry/resource_detectors/service_detector_builder.h"
 
 opentelemetry::resource_detector::ContainerDetectorBuilder::Register(registry.get());
 opentelemetry::resource_detector::HostDetectorBuilder::Register(registry.get());
 opentelemetry::resource_detector::ProcessDetectorBuilder::Register(registry.get());
+opentelemetry::resource_detector::ServiceDetectorBuilder::Register(registry.get());
 ```
 
 ## Linking with CMake
@@ -172,6 +191,8 @@ All targets are part of the `resource_detectors` component.
 | `opentelemetry-cpp::host_resource_detector_builder` | Host detector builder for declaritive configuration |
 | `opentelemetry-cpp::process_resource_detector` | Process detector |
 | `opentelemetry-cpp::process_resource_detector_builder` | Process detector builder for declaritive configuration |
+| `opentelemetry-cpp::service_resource_detector` | Service detector |
+| `opentelemetry-cpp::service_resource_detector_builder` | Service detector builder for declaritive configuration |
 
 ## Linking with Bazel
 
@@ -219,3 +240,5 @@ deps = ["//resource_detectors:process_resource_detector_builder"]
 | `//resource_detectors:host_resource_detector_builder` | Host detector builder |
 | `//resource_detectors:process_resource_detector` | Process detector |
 | `//resource_detectors:process_resource_detector_builder` | Process detector builder |
+| `//resource_detectors:service_resource_detector` | Service detector |
+| `//resource_detectors:service_resource_detector_builder` | Service detector builder |

--- a/resource_detectors/README.md
+++ b/resource_detectors/README.md
@@ -80,10 +80,7 @@ or inaccessible.
 | Attribute | Description | Linux | macOS | Windows |
 | --- | --- | --- | --- | --- |
 | `process.pid` | Process ID | Yes | Yes | Yes |
-| `process.executable.path` | Path via `/proc` (Linux) or Win32 APIs | Yes | No | Yes |
-
-Limitation: current macOS implementation does not populate
-`process.executable.path`.
+| `process.executable.path` | Path via `/proc` (Linux) or Win32 APIs | Yes | Yes | Yes |
 
 ### Env Entity Resource Detector (Experimental)
 

--- a/resource_detectors/include/opentelemetry/resource_detectors/detail/process_detector_utils.h
+++ b/resource_detectors/include/opentelemetry/resource_detectors/detail/process_detector_utils.h
@@ -33,6 +33,18 @@ std::string FormFilePath(const int32_t &pid, const char *process_type);
 std::string GetExecutablePath(const int32_t &pid);
 
 /**
+ * Retrieves the executable file name for a given PID.
+ * Platform-specific behavior:
+ *   - Windows: Basename of the path from GetExecutablePath().
+ *   - Linux: Basename of the path from /proc/<pid>/exe.
+ *   - macOS: Uses _NSGetExecutablePath() for the current process only; returns
+ *     an empty string for other PIDs.
+ *
+ * @param pid Process ID.
+ */
+std::string GetExecutableName(const int32_t &pid);
+
+/**
  * Extracts the command-line arguments and the command.
  * Platform-specific behavior:
  *   - Windows: Uses CommandLineToArgvW() to parse the command line.

--- a/resource_detectors/include/opentelemetry/resource_detectors/detail/process_detector_utils.h
+++ b/resource_detectors/include/opentelemetry/resource_detectors/detail/process_detector_utils.h
@@ -26,23 +26,12 @@ std::string FormFilePath(const int32_t &pid, const char *process_type);
  * Platform-specific behavior:
  *   - Windows: Uses OpenProcess() + GetProcessImageFileNameW().
  *   - Linux/Unix: Reads the /proc/<pid>/exe symbolic link.
- *   - TODO: Need to implement for Darwin
- *
- * @param pid Process ID.
- */
-std::string GetExecutablePath(const int32_t &pid);
-
-/**
- * Retrieves the executable file name for a given PID.
- * Platform-specific behavior:
- *   - Windows: Basename of the path from GetExecutablePath().
- *   - Linux: Basename of the path from /proc/<pid>/exe.
  *   - macOS: Uses _NSGetExecutablePath() for the current process only; returns
  *     an empty string for other PIDs.
  *
  * @param pid Process ID.
  */
-std::string GetExecutableName(const int32_t &pid);
+std::string GetExecutablePath(const int32_t &pid);
 
 /**
  * Extracts the command-line arguments and the command.

--- a/resource_detectors/include/opentelemetry/resource_detectors/detail/service_detector_utils.h
+++ b/resource_detectors/include/opentelemetry/resource_detectors/detail/service_detector_utils.h
@@ -1,0 +1,34 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <string>
+
+#include "opentelemetry/version.h"
+
+OPENTELEMETRY_BEGIN_NAMESPACE
+namespace resource_detector
+{
+namespace detail
+{
+
+/**
+ * Resolves the logical service name for the service resource detector.
+ * Platform-specific behavior:
+ *   - Reads OTEL_SERVICE_NAME when set.
+ *   - Otherwise falls back to unknown_service:<process.executable.name> when the
+ *     executable name is available for the current process.
+ *   - Otherwise returns unknown_service.
+ */
+std::string GetServiceName();
+
+/**
+ * Returns a stable service.instance.id for the current process.
+ * A new RFC 4122 UUID version 4 value is generated when the process ID changes.
+ */
+std::string GenerateServiceInstanceId() noexcept;
+
+}  // namespace detail
+}  // namespace resource_detector
+OPENTELEMETRY_END_NAMESPACE

--- a/resource_detectors/include/opentelemetry/resource_detectors/service_detector.h
+++ b/resource_detectors/include/opentelemetry/resource_detectors/service_detector.h
@@ -1,0 +1,33 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "opentelemetry/sdk/resource/resource_detector.h"
+#include "opentelemetry/version.h"
+
+OPENTELEMETRY_BEGIN_NAMESPACE
+namespace resource_detector
+{
+
+/**
+ * ServiceResourceDetector to detect resource attributes describing the service
+ * the process belongs to. It sets service.name and service.instance.id following
+ * the OpenTelemetry semantic conventions.
+ *
+ * Platform specific behavior and limitations:
+ * - service.name is read from the OTEL_SERVICE_NAME environment variable when set.
+ * - When OTEL_SERVICE_NAME is not set, service.name falls back to
+ *   unknown_service:<process.executable.name> or unknown_service when the
+ *   executable name is unavailable.
+ * - service.instance.id is a stable RFC 4122 UUID version 4 value for the
+ *   current process.
+ */
+class ServiceResourceDetector : public opentelemetry::sdk::resource::ResourceDetector
+{
+public:
+  opentelemetry::sdk::resource::Resource Detect() noexcept override;
+};
+
+}  // namespace resource_detector
+OPENTELEMETRY_END_NAMESPACE

--- a/resource_detectors/include/opentelemetry/resource_detectors/service_detector_builder.h
+++ b/resource_detectors/include/opentelemetry/resource_detectors/service_detector_builder.h
@@ -1,0 +1,37 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <memory>
+
+#include "opentelemetry/sdk/configuration/service_resource_detector_builder.h"
+#include "opentelemetry/sdk/configuration/service_resource_detector_configuration.h"
+#include "opentelemetry/sdk/resource/resource_detector.h"
+#include "opentelemetry/version.h"
+
+OPENTELEMETRY_BEGIN_NAMESPACE
+namespace sdk
+{
+namespace configuration
+{
+class Registry;
+}  // namespace configuration
+}  // namespace sdk
+
+namespace resource_detector
+{
+
+class ServiceDetectorBuilder
+    : public opentelemetry::sdk::configuration::ServiceResourceDetectorBuilder
+{
+public:
+  static void Register(opentelemetry::sdk::configuration::Registry *registry);
+
+  std::unique_ptr<opentelemetry::sdk::resource::ResourceDetector> Build(
+      const opentelemetry::sdk::configuration::ServiceResourceDetectorConfiguration *model)
+      const override;
+};
+
+}  // namespace resource_detector
+OPENTELEMETRY_END_NAMESPACE

--- a/resource_detectors/src/process_detector_utils.cc
+++ b/resource_detectors/src/process_detector_utils.cc
@@ -7,6 +7,10 @@
 #include <string>
 #include <vector>
 
+#if defined(__APPLE__)
+#  include <mach-o/dyld.h>
+#endif
+
 #ifdef _MSC_VER
 // clang-format off
 #  include <windows.h>
@@ -30,6 +34,25 @@ namespace detail
 
 constexpr const char *kExecutableName = "exe";
 constexpr const char *kCmdlineName    = "cmdline";
+
+namespace
+{
+std::string Basename(const std::string &path)
+{
+  if (path.empty())
+  {
+    return std::string();
+  }
+
+  const size_t pos = path.find_last_of("/\\");
+  if (pos == std::string::npos)
+  {
+    return path;
+  }
+
+  return path.substr(pos + 1);
+}
+}  // namespace
 
 std::string GetExecutablePath(const int32_t &pid)
 {
@@ -68,6 +91,27 @@ std::string GetExecutablePath(const int32_t &pid)
   }
 
   return std::string();
+#endif
+}
+
+std::string GetExecutableName(const int32_t &pid)
+{
+#if defined(__APPLE__)
+  if (pid != static_cast<int32_t>(getpid()))
+  {
+    return std::string();
+  }
+
+  char path[4096];
+  uint32_t size = sizeof(path);
+  if (_NSGetExecutablePath(path, &size) != 0)
+  {
+    return std::string();
+  }
+
+  return Basename(path);
+#else
+  return Basename(GetExecutablePath(pid));
 #endif
 }
 

--- a/resource_detectors/src/process_detector_utils.cc
+++ b/resource_detectors/src/process_detector_utils.cc
@@ -35,25 +35,6 @@ namespace detail
 constexpr const char *kExecutableName = "exe";
 constexpr const char *kCmdlineName    = "cmdline";
 
-namespace
-{
-std::string Basename(const std::string &path)
-{
-  if (path.empty())
-  {
-    return std::string();
-  }
-
-  const size_t pos = path.find_last_of("/\\");
-  if (pos == std::string::npos)
-  {
-    return path;
-  }
-
-  return path.substr(pos + 1);
-}
-}  // namespace
-
 std::string GetExecutablePath(const int32_t &pid)
 {
 #ifdef _MSC_VER
@@ -79,24 +60,7 @@ std::string GetExecutablePath(const int32_t &pid)
   WideCharToMultiByte(CP_UTF8, 0, wbuffer, len, &utf8_path[0], size_needed, NULL, NULL);
 
   return utf8_path;
-#else
-  std::string path = FormFilePath(pid, kExecutableName);
-  char buffer[4096];
-
-  ssize_t len = readlink(path.c_str(), buffer, sizeof(buffer) - 1);
-  if (len != -1)
-  {
-    buffer[len] = '\0';
-    return std::string(buffer);
-  }
-
-  return std::string();
-#endif
-}
-
-std::string GetExecutableName(const int32_t &pid)
-{
-#if defined(__APPLE__)
+#elif defined(__APPLE__)
   if (pid != static_cast<int32_t>(getpid()))
   {
     return std::string();
@@ -109,9 +73,19 @@ std::string GetExecutableName(const int32_t &pid)
     return std::string();
   }
 
-  return Basename(path);
+  return std::string(path);
 #else
-  return Basename(GetExecutablePath(pid));
+  std::string path = FormFilePath(pid, kExecutableName);
+  char buffer[4096];
+
+  ssize_t len = readlink(path.c_str(), buffer, sizeof(buffer) - 1);
+  if (len != -1)
+  {
+    buffer[len] = '\0';
+    return std::string(buffer);
+  }
+
+  return std::string();
 #endif
 }
 

--- a/resource_detectors/src/service_detector.cc
+++ b/resource_detectors/src/service_detector.cc
@@ -1,0 +1,27 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+#include "opentelemetry/resource_detectors/service_detector.h"
+#include "opentelemetry/resource_detectors/detail/service_detector_utils.h"
+#include "opentelemetry/sdk/resource/resource.h"
+#include "opentelemetry/sdk/resource/resource_detector.h"
+#include "opentelemetry/semconv/schema_url.h"
+#include "opentelemetry/semconv/service_attributes.h"
+#include "opentelemetry/version.h"
+
+#include <string>
+
+OPENTELEMETRY_BEGIN_NAMESPACE
+namespace resource_detector
+{
+
+opentelemetry::sdk::resource::Resource ServiceResourceDetector::Detect() noexcept
+{
+  opentelemetry::sdk::resource::ResourceAttributes attributes;
+  attributes[semconv::service::kServiceName]       = detail::GetServiceName();
+  attributes[semconv::service::kServiceInstanceId] = detail::GenerateServiceInstanceId();
+  return ResourceDetector::Create(attributes, semconv::kSchemaUrl);
+}
+
+}  // namespace resource_detector
+OPENTELEMETRY_END_NAMESPACE

--- a/resource_detectors/src/service_detector.cc
+++ b/resource_detectors/src/service_detector.cc
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "opentelemetry/resource_detectors/service_detector.h"
+#include "opentelemetry/nostd/variant.h"
 #include "opentelemetry/resource_detectors/detail/service_detector_utils.h"
 #include "opentelemetry/sdk/resource/resource.h"
 #include "opentelemetry/sdk/resource/resource_detector.h"

--- a/resource_detectors/src/service_detector_builder.cc
+++ b/resource_detectors/src/service_detector_builder.cc
@@ -1,0 +1,32 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+#include <memory>
+#include <utility>
+
+#include "opentelemetry/resource_detectors/service_detector.h"
+#include "opentelemetry/resource_detectors/service_detector_builder.h"
+#include "opentelemetry/sdk/configuration/registry.h"
+#include "opentelemetry/sdk/configuration/service_resource_detector_builder.h"
+#include "opentelemetry/sdk/resource/resource_detector.h"
+#include "opentelemetry/version.h"
+
+OPENTELEMETRY_BEGIN_NAMESPACE
+namespace resource_detector
+{
+
+void ServiceDetectorBuilder::Register(opentelemetry::sdk::configuration::Registry *registry)
+{
+  auto builder = std::make_unique<ServiceDetectorBuilder>();
+  registry->SetServiceResourceDetectorBuilder(std::move(builder));
+}
+
+std::unique_ptr<opentelemetry::sdk::resource::ResourceDetector> ServiceDetectorBuilder::Build(
+    const opentelemetry::sdk::configuration::ServiceResourceDetectorConfiguration * /* model */)
+    const
+{
+  return std::make_unique<ServiceResourceDetector>();
+}
+
+}  // namespace resource_detector
+OPENTELEMETRY_END_NAMESPACE

--- a/resource_detectors/src/service_detector_utils.cc
+++ b/resource_detectors/src/service_detector_utils.cc
@@ -16,7 +16,6 @@
 #  include <unistd.h>
 #endif
 
-#include "opentelemetry/nostd/span.h"
 #include "opentelemetry/resource_detectors/detail/process_detector_utils.h"
 #include "opentelemetry/sdk/common/env_variables.h"
 #include "opentelemetry/version.h"
@@ -54,8 +53,7 @@ std::string FormatUuidV4(const uint8_t bytes[16]) noexcept
 std::string GenerateUuidV4() noexcept
 {
   uint8_t bytes[16];
-  opentelemetry::sdk::common::Random::GenerateRandomBuffer(
-      opentelemetry::nostd::span<uint8_t>(bytes));
+  opentelemetry::sdk::common::Random::GenerateRandomBuffer(bytes);
   bytes[6] = static_cast<uint8_t>((bytes[6] & 0x0F) | 0x40);
   bytes[8] = static_cast<uint8_t>((bytes[8] & 0x3F) | 0x80);
   return FormatUuidV4(bytes);

--- a/resource_detectors/src/service_detector_utils.cc
+++ b/resource_detectors/src/service_detector_utils.cc
@@ -1,8 +1,8 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-#include "opentelemetry/nostd/span.h"
 #include "opentelemetry/resource_detectors/detail/service_detector_utils.h"
+#include "opentelemetry/nostd/span.h"
 
 #include <stddef.h>
 

--- a/resource_detectors/src/service_detector_utils.cc
+++ b/resource_detectors/src/service_detector_utils.cc
@@ -2,11 +2,11 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "opentelemetry/resource_detectors/detail/service_detector_utils.h"
-#include "opentelemetry/nostd/span.h"
 
 #include <stddef.h>
 
 #include <cstdint>
+#include <cstring>
 #include <mutex>
 #include <string>
 
@@ -54,7 +54,11 @@ std::string FormatUuidV4(const uint8_t bytes[16]) noexcept
 std::string GenerateUuidV4() noexcept
 {
   uint8_t bytes[16];
-  opentelemetry::sdk::common::Random::GenerateRandomBuffer(bytes);
+  for (size_t i = 0; i < sizeof(bytes); i += sizeof(uint64_t))
+  {
+    uint64_t value = opentelemetry::sdk::common::Random::GenerateRandom64();
+    std::memcpy(&bytes[i], &value, sizeof(uint64_t));
+  }
   bytes[6] = static_cast<uint8_t>((bytes[6] & 0x0F) | 0x40);
   bytes[8] = static_cast<uint8_t>((bytes[8] & 0x3F) | 0x80);
   return FormatUuidV4(bytes);

--- a/resource_detectors/src/service_detector_utils.cc
+++ b/resource_detectors/src/service_detector_utils.cc
@@ -1,6 +1,7 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
+#include "opentelemetry/nostd/span.h"
 #include "opentelemetry/resource_detectors/detail/service_detector_utils.h"
 
 #include <stddef.h>

--- a/resource_detectors/src/service_detector_utils.cc
+++ b/resource_detectors/src/service_detector_utils.cc
@@ -1,0 +1,102 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+#include "opentelemetry/resource_detectors/detail/service_detector_utils.h"
+
+#include <cstdint>
+#include <mutex>
+#include <string>
+
+#ifdef _MSC_VER
+#  include <process.h>
+#  define getpid _getpid
+#else
+#  include <unistd.h>
+#endif
+
+#include "opentelemetry/nostd/span.h"
+#include "opentelemetry/resource_detectors/detail/process_detector_utils.h"
+#include "opentelemetry/sdk/common/env_variables.h"
+#include "opentelemetry/version.h"
+#include "src/common/random.h"
+
+OPENTELEMETRY_BEGIN_NAMESPACE
+namespace resource_detector
+{
+namespace detail
+{
+
+namespace
+{
+constexpr const char *kOtelServiceName      = "OTEL_SERVICE_NAME";
+constexpr const char *kUnknownService       = "unknown_service";
+constexpr const char *kUnknownServicePrefix = "unknown_service:";
+constexpr const char kUuidHexDigits[]       = "0123456789abcdef";
+
+std::string FormatUuidV4(const uint8_t bytes[16]) noexcept
+{
+  std::string uuid;
+  uuid.reserve(36);
+  for (size_t i = 0; i < 16; ++i)
+  {
+    if (i == 4 || i == 6 || i == 8 || i == 10)
+    {
+      uuid.push_back('-');
+    }
+    uuid.push_back(kUuidHexDigits[bytes[i] >> 4]);
+    uuid.push_back(kUuidHexDigits[bytes[i] & 0x0F]);
+  }
+  return uuid;
+}
+
+std::string GenerateUuidV4() noexcept
+{
+  uint8_t bytes[16];
+  opentelemetry::sdk::common::Random::GenerateRandomBuffer(
+      opentelemetry::nostd::span<uint8_t>(bytes));
+  bytes[6] = static_cast<uint8_t>((bytes[6] & 0x0F) | 0x40);
+  bytes[8] = static_cast<uint8_t>((bytes[8] & 0x3F) | 0x80);
+  return FormatUuidV4(bytes);
+}
+
+}  // namespace
+
+std::string GetServiceName()
+{
+  std::string service_name;
+  if (opentelemetry::sdk::common::GetStringEnvironmentVariable(kOtelServiceName, service_name) &&
+      !service_name.empty())
+  {
+    return service_name;
+  }
+
+  const std::string executable_name = GetExecutableName(static_cast<int32_t>(getpid()));
+  if (!executable_name.empty())
+  {
+    std::string fallback_service_name(kUnknownServicePrefix);
+    fallback_service_name.append(executable_name);
+    return fallback_service_name;
+  }
+
+  return std::string{kUnknownService};
+}
+
+std::string GenerateServiceInstanceId() noexcept
+{
+  static std::mutex mutex;
+  static int32_t cached_pid = -1;
+  static std::string cached_id;
+
+  const int32_t pid = static_cast<int32_t>(getpid());
+  const std::lock_guard<std::mutex> lock(mutex);
+  if (cached_pid != pid || cached_id.empty())
+  {
+    cached_pid = pid;
+    cached_id  = GenerateUuidV4();
+  }
+  return cached_id;
+}
+
+}  // namespace detail
+}  // namespace resource_detector
+OPENTELEMETRY_END_NAMESPACE

--- a/resource_detectors/src/service_detector_utils.cc
+++ b/resource_detectors/src/service_detector_utils.cc
@@ -73,7 +73,20 @@ std::string GetServiceName()
     return service_name;
   }
 
-  const std::string executable_name = GetExecutableName(static_cast<int32_t>(getpid()));
+  const std::string executable_path = GetExecutablePath(static_cast<int32_t>(getpid()));
+  std::string executable_name;
+  if (!executable_path.empty())
+  {
+    const size_t pos = executable_path.find_last_of("/\\");
+    if (pos == std::string::npos)
+    {
+      executable_name = executable_path;
+    }
+    else
+    {
+      executable_name = executable_path.substr(pos + 1);
+    }
+  }
   if (!executable_name.empty())
   {
     std::string fallback_service_name(kUnknownServicePrefix);

--- a/resource_detectors/src/service_detector_utils.cc
+++ b/resource_detectors/src/service_detector_utils.cc
@@ -3,8 +3,6 @@
 
 #include "opentelemetry/resource_detectors/detail/service_detector_utils.h"
 
-#include <stddef.h>
-
 #include <cstdint>
 #include <cstring>
 #include <mutex>

--- a/resource_detectors/src/service_detector_utils.cc
+++ b/resource_detectors/src/service_detector_utils.cc
@@ -3,6 +3,8 @@
 
 #include "opentelemetry/resource_detectors/detail/service_detector_utils.h"
 
+#include <stddef.h>
+
 #include <cstdint>
 #include <mutex>
 #include <string>

--- a/resource_detectors/test/BUILD
+++ b/resource_detectors/test/BUILD
@@ -105,3 +105,15 @@ cc_test(
         "@com_google_googletest//:gtest_main",
     ],
 )
+
+cc_test(
+    name = "service_resource_detector_builder_test",
+    srcs = ["service_detector_builder_test.cc"],
+    tags = ["test"],
+    deps = [
+        "//resource_detectors:service_resource_detector_builder",
+        "//sdk/src/configuration:configuration_core",
+        "//sdk/src/resource",
+        "@com_google_googletest//:gtest_main",
+    ],
+)

--- a/resource_detectors/test/BUILD
+++ b/resource_detectors/test/BUILD
@@ -94,3 +94,14 @@ cc_test(
         "@com_google_googletest//:gtest_main",
     ],
 )
+
+cc_test(
+    name = "service_resource_detector_test",
+    srcs = ["service_detector_test.cc"],
+    tags = ["test"],
+    deps = [
+        "//resource_detectors:service_resource_detector",
+        "//sdk/src/resource",
+        "@com_google_googletest//:gtest_main",
+    ],
+)

--- a/resource_detectors/test/BUILD
+++ b/resource_detectors/test/BUILD
@@ -82,3 +82,15 @@ cc_test(
         "@com_google_googletest//:gtest_main",
     ],
 )
+
+cc_test(
+    name = "service_resource_detector_utils_test",
+    srcs = ["service_detector_utils_test.cc"],
+    tags = ["test"],
+    deps = [
+        "//resource_detectors:process_resource_detector",
+        "//resource_detectors:service_resource_detector_utils",
+        "//sdk/src/resource",
+        "@com_google_googletest//:gtest_main",
+    ],
+)

--- a/resource_detectors/test/CMakeLists.txt
+++ b/resource_detectors/test/CMakeLists.txt
@@ -85,3 +85,17 @@ gtest_add_tests(
   TARGET process_resource_detector_builder_test
   TEST_PREFIX resource_detector.
   TEST_LIST process_resource_detector_builder_test)
+
+#
+# service_resource_detector_utils tests
+#
+
+add_executable(service_resource_detector_utils_test service_detector_utils_test.cc)
+target_link_libraries(
+  service_resource_detector_utils_test
+  PRIVATE opentelemetry_service_resource_detector_utils
+          opentelemetry_process_resource_detector GTest::gtest_main)
+gtest_add_tests(
+  TARGET service_resource_detector_utils_test
+  TEST_PREFIX resource_detector.
+  TEST_LIST service_resource_detector_utils_test)

--- a/resource_detectors/test/CMakeLists.txt
+++ b/resource_detectors/test/CMakeLists.txt
@@ -99,3 +99,16 @@ gtest_add_tests(
   TARGET service_resource_detector_utils_test
   TEST_PREFIX resource_detector.
   TEST_LIST service_resource_detector_utils_test)
+
+#
+# service_resource_detector tests
+#
+
+add_executable(service_resource_detector_test service_detector_test.cc)
+target_link_libraries(
+  service_resource_detector_test PRIVATE opentelemetry_service_resource_detector
+                                       GTest::gtest_main)
+gtest_add_tests(
+  TARGET service_resource_detector_test
+  TEST_PREFIX resource_detector.
+  TEST_LIST service_resource_detector_test)

--- a/resource_detectors/test/CMakeLists.txt
+++ b/resource_detectors/test/CMakeLists.txt
@@ -112,3 +112,17 @@ gtest_add_tests(
   TARGET service_resource_detector_test
   TEST_PREFIX resource_detector.
   TEST_LIST service_resource_detector_test)
+
+#
+# service_resource_detector_builder tests
+#
+
+add_executable(service_resource_detector_builder_test service_detector_builder_test.cc)
+target_link_libraries(
+  service_resource_detector_builder_test
+  PRIVATE opentelemetry_service_resource_detector_builder
+          opentelemetry_configuration_core GTest::gtest_main)
+gtest_add_tests(
+  TARGET service_resource_detector_builder_test
+  TEST_PREFIX resource_detector.
+  TEST_LIST service_resource_detector_builder_test)

--- a/resource_detectors/test/CMakeLists.txt
+++ b/resource_detectors/test/CMakeLists.txt
@@ -90,7 +90,8 @@ gtest_add_tests(
 # service_resource_detector_utils tests
 #
 
-add_executable(service_resource_detector_utils_test service_detector_utils_test.cc)
+add_executable(service_resource_detector_utils_test
+               service_detector_utils_test.cc)
 target_link_libraries(
   service_resource_detector_utils_test
   PRIVATE opentelemetry_service_resource_detector_utils
@@ -107,7 +108,7 @@ gtest_add_tests(
 add_executable(service_resource_detector_test service_detector_test.cc)
 target_link_libraries(
   service_resource_detector_test PRIVATE opentelemetry_service_resource_detector
-                                       GTest::gtest_main)
+                                         GTest::gtest_main)
 gtest_add_tests(
   TARGET service_resource_detector_test
   TEST_PREFIX resource_detector.
@@ -117,7 +118,8 @@ gtest_add_tests(
 # service_resource_detector_builder tests
 #
 
-add_executable(service_resource_detector_builder_test service_detector_builder_test.cc)
+add_executable(service_resource_detector_builder_test
+               service_detector_builder_test.cc)
 target_link_libraries(
   service_resource_detector_builder_test
   PRIVATE opentelemetry_service_resource_detector_builder

--- a/resource_detectors/test/process_detector_test.cc
+++ b/resource_detectors/test/process_detector_test.cc
@@ -112,6 +112,15 @@ TEST(ProcessDetectorUtilsTest, GetExecutablePathTest)
   EXPECT_EQ(path, expected_path);
 }
 
+TEST(ProcessDetectorUtilsTest, GetExecutableNameTest)
+{
+  int32_t pid                 = getpid();
+  std::string executable_name = opentelemetry::resource_detector::detail::GetExecutableName(pid);
+  EXPECT_FALSE(executable_name.empty());
+  EXPECT_EQ(executable_name.find('/'), std::string::npos);
+  EXPECT_EQ(executable_name.find('\\'), std::string::npos);
+}
+
 TEST(ProcessDetectorUtilsTest, CommandTest)
 {
   int32_t pid = getpid();

--- a/resource_detectors/test/process_detector_test.cc
+++ b/resource_detectors/test/process_detector_test.cc
@@ -18,6 +18,9 @@
 #  include <sys/types.h>
 #  include <unistd.h>
 #  include <cstdio>
+#  if defined(__APPLE__)
+#    include <mach-o/dyld.h>
+#  endif
 #endif
 
 #include "opentelemetry/resource_detectors/detail/process_detector_utils.h"
@@ -93,6 +96,17 @@ TEST(ProcessDetectorUtilsTest, GetExecutablePathTest)
       path = utf8_path;
     }
   }
+#elif defined(__APPLE__)
+  char buffer[4096];
+  uint32_t size = sizeof(buffer);
+  if (_NSGetExecutablePath(buffer, &size) != 0)
+  {
+    path = std::string();
+  }
+  else
+  {
+    path = std::string(buffer);
+  }
 #else
   std::string exe_path = opentelemetry::resource_detector::detail::FormFilePath(pid, "exe");
   char buffer[4096];
@@ -110,15 +124,6 @@ TEST(ProcessDetectorUtilsTest, GetExecutablePathTest)
 #endif
   std::string expected_path = opentelemetry::resource_detector::detail::GetExecutablePath(pid);
   EXPECT_EQ(path, expected_path);
-}
-
-TEST(ProcessDetectorUtilsTest, GetExecutableNameTest)
-{
-  int32_t pid                 = getpid();
-  std::string executable_name = opentelemetry::resource_detector::detail::GetExecutableName(pid);
-  EXPECT_FALSE(executable_name.empty());
-  EXPECT_EQ(executable_name.find('/'), std::string::npos);
-  EXPECT_EQ(executable_name.find('\\'), std::string::npos);
 }
 
 TEST(ProcessDetectorUtilsTest, CommandTest)

--- a/resource_detectors/test/service_detector_builder_test.cc
+++ b/resource_detectors/test/service_detector_builder_test.cc
@@ -2,9 +2,9 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include <gtest/gtest.h>
+#include <memory>
 #include <string>
 
-#include "opentelemetry/resource_detectors/service_detector.h"
 #include "opentelemetry/resource_detectors/service_detector_builder.h"
 #include "opentelemetry/sdk/configuration/registry.h"
 #include "opentelemetry/sdk/configuration/service_resource_detector_configuration.h"
@@ -26,16 +26,4 @@ TEST(ServiceDetectorBuilderTest, Build)
 
   auto detector = builder.Build(&model);
   ASSERT_NE(detector, nullptr);
-}
-
-TEST(ServiceDetectorBuilderTest, BuildCreatesServiceResourceDetector)
-{
-  opentelemetry::resource_detector::ServiceDetectorBuilder builder;
-  opentelemetry::sdk::configuration::ServiceResourceDetectorConfiguration model;
-
-  auto detector = builder.Build(&model);
-  ASSERT_NE(detector, nullptr);
-  ASSERT_NE(
-      dynamic_cast<opentelemetry::resource_detector::ServiceResourceDetector *>(detector.get()),
-      nullptr);
 }

--- a/resource_detectors/test/service_detector_builder_test.cc
+++ b/resource_detectors/test/service_detector_builder_test.cc
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include <gtest/gtest.h>
-#include <memory>
 #include <string>
 
 #include "opentelemetry/resource_detectors/service_detector_builder.h"

--- a/resource_detectors/test/service_detector_builder_test.cc
+++ b/resource_detectors/test/service_detector_builder_test.cc
@@ -1,0 +1,41 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+#include <gtest/gtest.h>
+#include <string>
+
+#include "opentelemetry/resource_detectors/service_detector.h"
+#include "opentelemetry/resource_detectors/service_detector_builder.h"
+#include "opentelemetry/sdk/configuration/registry.h"
+#include "opentelemetry/sdk/configuration/service_resource_detector_configuration.h"
+#include "opentelemetry/sdk/resource/resource_detector.h"
+
+TEST(ServiceDetectorBuilderTest, Register)
+{
+  opentelemetry::sdk::configuration::Registry registry;
+  ASSERT_EQ(registry.GetServiceResourceDetectorBuilder(), nullptr);
+
+  opentelemetry::resource_detector::ServiceDetectorBuilder::Register(&registry);
+  ASSERT_NE(registry.GetServiceResourceDetectorBuilder(), nullptr);
+}
+
+TEST(ServiceDetectorBuilderTest, Build)
+{
+  opentelemetry::resource_detector::ServiceDetectorBuilder builder;
+  opentelemetry::sdk::configuration::ServiceResourceDetectorConfiguration model;
+
+  auto detector = builder.Build(&model);
+  ASSERT_NE(detector, nullptr);
+}
+
+TEST(ServiceDetectorBuilderTest, BuildCreatesServiceResourceDetector)
+{
+  opentelemetry::resource_detector::ServiceDetectorBuilder builder;
+  opentelemetry::sdk::configuration::ServiceResourceDetectorConfiguration model;
+
+  auto detector = builder.Build(&model);
+  ASSERT_NE(detector, nullptr);
+  ASSERT_NE(
+      dynamic_cast<opentelemetry::resource_detector::ServiceResourceDetector *>(detector.get()),
+      nullptr);
+}

--- a/resource_detectors/test/service_detector_test.cc
+++ b/resource_detectors/test/service_detector_test.cc
@@ -1,0 +1,74 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+#include <gtest/gtest.h>
+#include <string>
+
+#ifdef _MSC_VER
+#  include "opentelemetry/sdk/common/env_variables.h"
+using opentelemetry::sdk::common::setenv;
+using opentelemetry::sdk::common::unsetenv;
+#else
+#  include <cstdlib>
+#endif
+
+#include "opentelemetry/nostd/variant.h"
+#include "opentelemetry/resource_detectors/detail/service_detector_utils.h"
+#include "opentelemetry/resource_detectors/service_detector.h"
+#include "opentelemetry/semconv/schema_url.h"
+#include "opentelemetry/semconv/service_attributes.h"
+
+namespace semconv = opentelemetry::semconv;
+
+namespace
+{
+constexpr const char *kOtelServiceName = "OTEL_SERVICE_NAME";
+}  // namespace
+
+TEST(ServiceDetectorTest, DetectSetsServiceAttributes)
+{
+  opentelemetry::resource_detector::ServiceResourceDetector detector;
+  auto resource     = detector.Detect();
+  const auto &attrs = resource.GetAttributes();
+
+  auto name_it = attrs.find(semconv::service::kServiceName);
+  ASSERT_NE(name_it, attrs.end());
+  EXPECT_FALSE(opentelemetry::nostd::get<std::string>(name_it->second).empty());
+
+  auto instance_id_it = attrs.find(semconv::service::kServiceInstanceId);
+  ASSERT_NE(instance_id_it, attrs.end());
+  EXPECT_EQ(opentelemetry::nostd::get<std::string>(instance_id_it->second),
+            opentelemetry::resource_detector::detail::GenerateServiceInstanceId());
+
+  EXPECT_EQ(resource.GetSchemaURL(), std::string{semconv::kSchemaUrl});
+}
+
+TEST(ServiceDetectorTest, DetectUsesServiceNameFromEnvironment)
+{
+  setenv(kOtelServiceName, "stage2-detector-service", 1);
+
+  opentelemetry::resource_detector::ServiceResourceDetector detector;
+  auto resource     = detector.Detect();
+  const auto &attrs = resource.GetAttributes();
+
+  auto name_it = attrs.find(semconv::service::kServiceName);
+  ASSERT_NE(name_it, attrs.end());
+  EXPECT_EQ(opentelemetry::nostd::get<std::string>(name_it->second),
+            std::string{"stage2-detector-service"});
+
+  unsetenv(kOtelServiceName);
+}
+
+TEST(ServiceDetectorTest, DetectUsesServiceNameFallbackWhenEnvUnset)
+{
+  unsetenv(kOtelServiceName);
+
+  opentelemetry::resource_detector::ServiceResourceDetector detector;
+  auto resource     = detector.Detect();
+  const auto &attrs = resource.GetAttributes();
+
+  auto name_it = attrs.find(semconv::service::kServiceName);
+  ASSERT_NE(name_it, attrs.end());
+  EXPECT_EQ(opentelemetry::nostd::get<std::string>(name_it->second),
+            opentelemetry::resource_detector::detail::GetServiceName());
+}

--- a/resource_detectors/test/service_detector_test.cc
+++ b/resource_detectors/test/service_detector_test.cc
@@ -3,6 +3,7 @@
 
 #include <gtest/gtest.h>
 #include <string>
+#include <utility>
 
 #ifdef _MSC_VER
 #  include "opentelemetry/sdk/common/env_variables.h"
@@ -15,6 +16,7 @@ using opentelemetry::sdk::common::unsetenv;
 #include "opentelemetry/nostd/variant.h"
 #include "opentelemetry/resource_detectors/detail/service_detector_utils.h"
 #include "opentelemetry/resource_detectors/service_detector.h"
+#include "opentelemetry/sdk/resource/resource.h"
 #include "opentelemetry/semconv/schema_url.h"
 #include "opentelemetry/semconv/service_attributes.h"
 

--- a/resource_detectors/test/service_detector_utils_test.cc
+++ b/resource_detectors/test/service_detector_utils_test.cc
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include <gtest/gtest.h>
-#include <cstdint>
 #include <regex>
 #include <string>
 

--- a/resource_detectors/test/service_detector_utils_test.cc
+++ b/resource_detectors/test/service_detector_utils_test.cc
@@ -1,0 +1,69 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+#include <gtest/gtest.h>
+#include <cstdint>
+#include <regex>
+#include <string>
+
+#ifdef _MSC_VER
+#  include "opentelemetry/sdk/common/env_variables.h"
+using opentelemetry::sdk::common::setenv;
+using opentelemetry::sdk::common::unsetenv;
+#else
+#  include <cstdlib>
+#endif
+
+#include "opentelemetry/resource_detectors/detail/service_detector_utils.h"
+
+namespace detail = opentelemetry::resource_detector::detail;
+
+namespace
+{
+constexpr const char *kOtelServiceName = "OTEL_SERVICE_NAME";
+
+bool IsUuidV4(const std::string &value)
+{
+  static const std::regex kUuidV4Pattern(
+      "^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$");
+  return std::regex_match(value, kUuidV4Pattern);
+}
+}  // namespace
+
+TEST(ServiceDetectorUtilsTest, GetServiceNameFromEnvironment)
+{
+  setenv(kOtelServiceName, "stage1-test-service", 1);
+
+  EXPECT_EQ(detail::GetServiceName(), std::string{"stage1-test-service"});
+
+  unsetenv(kOtelServiceName);
+}
+
+TEST(ServiceDetectorUtilsTest, GetServiceNameFallbackUsesUnknownServicePrefix)
+{
+  unsetenv(kOtelServiceName);
+
+  const std::string service_name = detail::GetServiceName();
+  if (service_name.rfind("unknown_service:", 0) == 0)
+  {
+    EXPECT_GT(service_name.size(), std::string{"unknown_service:"}.size());
+  }
+  else
+  {
+    EXPECT_EQ(service_name, std::string{"unknown_service"});
+  }
+}
+
+TEST(ServiceDetectorUtilsTest, GenerateServiceInstanceIdIsUuidV4)
+{
+  const std::string instance_id = detail::GenerateServiceInstanceId();
+  EXPECT_FALSE(instance_id.empty());
+  EXPECT_TRUE(IsUuidV4(instance_id));
+}
+
+TEST(ServiceDetectorUtilsTest, GenerateServiceInstanceIdIsStableWithinProcess)
+{
+  const std::string first_id  = detail::GenerateServiceInstanceId();
+  const std::string second_id = detail::GenerateServiceInstanceId();
+  EXPECT_EQ(first_id, second_id);
+}


### PR DESCRIPTION
Fixes #4414 

## Summary

Adds the built-in **service** resource detector for declarative configuration and direct use. The detector populates `service.name` and `service.instance.id` according to the OpenTelemetry semantic conventions, with a builder integrated into the existing `Registry` / `SdkBuilder` path.

## Implementation

- **Service detector utilities**: Adds `GetServiceName()` and `GenerateServiceInstanceId()`, reusing `GetExecutableName()` from the process detector utilities.
- **`ServiceResourceDetector`**: Sets `service.name`, `service.instance.id`, and the service semantic-conventions schema URL.
- **`ServiceDetectorBuilder`**: Registers through `Registry::SetServiceResourceDetectorBuilder()` and builds `ServiceResourceDetector`. Integrated into the resource-detector aggregate targets and installation exports.
- **CMake / Bazel**: Adds targets for the service detector utilities, detector, and builder, including aggregate and test targets.
- **Example configuration**: Registers `ServiceDetectorBuilder` in `examples/configuration/main.cc` and enables `service:` in `kitchen-sink.yaml`. `sdk-default.yaml` remains unchanged, with built-in detectors commented out by design.
- **Install tests**: Adds smoke tests for the installed service detector and builder.
- **Documentation**: Documents service detector behavior, platform considerations, registration, and build targets in `resource_detectors/README.md`. Adds a CHANGELOG entry.

## Behavior

### `service.name`

1. Uses `OTEL_SERVICE_NAME` when it is set and non-empty.
2. Otherwise falls back to `unknown_service:<process.executable.name>` when the executable name is available.
3. Otherwise returns `unknown_service`.

The detector does not read `OTEL_RESOURCE_ATTRIBUTES`.

### `service.instance.id`

Generates an RFC 4122 UUID version 4 using the SDK random utility. The value is cached for the current process ID and regenerated if the PID changes, such as after `fork()`.

### Platform notes

- Executable-name fallback uses the existing process detector utilities.
- On macOS, the executable name is available for the current process only; the service detector always uses the current PID.
- Linux and Windows executable-name fallback is supported.

## Testing

**Passed locally:**

- `service_resource_detector_utils_test` (4/4)
- `service_resource_detector_test` (3/3)
- `service_resource_detector_builder_test` (3/3)
- `registry_test` — `Registry.ServiceResourceDetectorBuilder` (1/1)
- `process_resource_detector_builder_test` (2/2)
- `host_resource_detector_test` (6/6)
- `example_yaml --test --yaml sdk-default.yaml`
- C++14 build and relevant service detector tests
- `clang-format-18 --Werror -n` on changed C++ files

**Not validated locally:**

- Bazel targets/tests (Bazel was not available locally)
- Full install-tree `resource_detectors_test` via `cmake.install.test` (the full install was blocked by an unrelated `ryml` install issue; service headers/libraries were verified in a partial install)

**Environment note:**

- `example_yaml --test --yaml kitchen-sink.yaml` could not be completed locally because the local build did not include the OTLP HTTP and related exporters required by that configuration. CI runs this test with the full feature set.

## Checklist

* [x] `CHANGELOG.md` updated for non-trivial changes
* [x] Unit tests have been added
* [x] Changes in public API reviewed