### PR TITLE
[BUGFIX] Complete an OTLP HTTP request on every state its client can end on

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,11 @@ Increment the:
 * [CONFIGURATION] Cleanup build targets and docs
   [#4486](https://github.com/open-telemetry/opentelemetry-cpp/pull/4486)
 
+* [BUGFIX] Complete an OTLP HTTP request that its client ends with
+  `Destroyed`, `ReadError` or `WriteError`, rather than logging the state
+  and leaving the caller waiting
+  [#4425](https://github.com/open-telemetry/opentelemetry-cpp/issues/4425)
+
 * [CONFIGURATION] Build the configured resource detectors in SdkBuilder, apply
   the `detection.attributes` include/exclude filter to the detected attributes,
   and merge the resource per the resource SDK specification.

--- a/exporters/otlp/src/otlp_http_client.cc
+++ b/exporters/otlp/src/otlp_http_client.cc
@@ -187,11 +187,9 @@ public:
   {
     // need to modify stopping_ under lock before calling callback
     //
-    // Every state a request can end on, because a request that ends on one nobody answers leaves
-    // the caller waiting for a callback that is not coming. Destroyed, ReadError and WriteError
-    // are the three the client can finish on that used to be logged and then dropped. Ordering is
-    // decided by the exchange below rather than here, so one of these arriving after a response
-    // has already been reported does not report a second time.
+    // Every state the client can end a request on. A state missing from here leaves the caller
+    // waiting for a callback that never comes. The exchange below decides ordering, so a state
+    // arriving after a response does not report a second time.
     bool need_stop = false;
     switch (state)
     {

--- a/exporters/otlp/src/otlp_http_client.cc
+++ b/exporters/otlp/src/otlp_http_client.cc
@@ -186,6 +186,12 @@ public:
                opentelemetry::nostd::string_view reason) noexcept override
   {
     // need to modify stopping_ under lock before calling callback
+    //
+    // Every state a request can end on, because a request that ends on one nobody answers leaves
+    // the caller waiting for a callback that is not coming. Destroyed, ReadError and WriteError
+    // are the three the client can finish on that used to be logged and then dropped. Ordering is
+    // decided by the exchange below rather than here, so one of these arriving after a response
+    // has already been reported does not report a second time.
     bool need_stop = false;
     switch (state)
     {
@@ -195,6 +201,9 @@ public:
       case http_client::SessionState::SSLHandshakeFailed:
       case http_client::SessionState::TimedOut:
       case http_client::SessionState::NetworkError:
+      case http_client::SessionState::Destroyed:
+      case http_client::SessionState::ReadError:
+      case http_client::SessionState::WriteError:
       case http_client::SessionState::Cancelled: {
         need_stop = true;
       }

--- a/exporters/otlp/test/otlp_http_exporter_custom_client_test.cc
+++ b/exporters/otlp/test/otlp_http_exporter_custom_client_test.cc
@@ -105,9 +105,8 @@ public:
     return {new OtlpHttpClient(MakeOtlpHttpClientOptions(), http_client), http_client};
   }
 
-  // The same, with the outcome recorded. A request that never settles calls this no times, and one
-  // that settles twice calls it twice, so both failures the terminal states can produce are
-  // visible in the count rather than only in a timeout.
+  // Records the outcome. A request that never settles calls back no times and one that settles
+  // twice calls back twice, so both failures show in the count rather than only in a timeout.
   static void ExportOneRequest(OtlpHttpClient &otlp_client,
                                const std::shared_ptr<std::atomic<int>> &calls,
                                const std::shared_ptr<sdk::common::ExportResult> &result)
@@ -275,10 +274,8 @@ TEST_F(OtlpHttpExporterCustomClientTestPeer, ForceFlushReportsSuccessOnceTheSess
   EXPECT_TRUE(otlp_client.ForceFlush(std::chrono::milliseconds{50}));
 }
 
-// Every state the client can finish a request on has to end that request. These three used to be
-// logged and then dropped: the switch that decides whether the request is over did not name them,
-// so a client that ended a transfer this way left the caller waiting for a callback that was not
-// coming, and ForceFlush and Shutdown could only give up on their own deadlines.
+// A client that finishes a transfer on ReadError, WriteError or Destroyed ends the request: the
+// result callback runs once, and ForceFlush returns rather than waiting out its deadline.
 TEST_F(OtlpHttpExporterCustomClientTestPeer, ATerminalClientEventEndsTheRequest)
 {
   for (const auto state :

--- a/exporters/otlp/test/otlp_http_exporter_custom_client_test.cc
+++ b/exporters/otlp/test/otlp_http_exporter_custom_client_test.cc
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include <gtest/gtest.h>
+#include <atomic>
 #include <chrono>
 #include <functional>
 #include <string>
@@ -102,6 +103,32 @@ public:
   {
     auto http_client = http_client::HttpClientTestFactory::Create();
     return {new OtlpHttpClient(MakeOtlpHttpClientOptions(), http_client), http_client};
+  }
+
+  // The same, with the outcome recorded. A request that never settles calls this no times, and one
+  // that settles twice calls it twice, so both failures the terminal states can produce are
+  // visible in the count rather than only in a timeout.
+  static void ExportOneRequest(OtlpHttpClient &otlp_client,
+                               std::shared_ptr<std::atomic<int>> calls,
+                               std::shared_ptr<sdk::common::ExportResult> result)
+  {
+    auto arena = std::make_unique<google::protobuf::Arena>();
+    auto *request =
+        google::protobuf::Arena::Create<proto::collector::trace::v1::ExportTraceServiceRequest>(
+            arena.get());
+    auto *response =
+        google::protobuf::Arena::Create<proto::collector::trace::v1::ExportTraceServiceResponse>(
+            arena.get());
+
+    otlp_client.Export(
+        *request, std::move(arena), response,
+        [calls, result](opentelemetry::sdk::common::ExportResult outcome,
+                        google::protobuf::Message *) {
+          calls->fetch_add(1, std::memory_order_release);
+          *result = outcome;
+          return true;
+        },
+        1);
   }
 
   // A non-zero request budget keeps the export asynchronous, so it returns while the session runs.
@@ -246,6 +273,89 @@ TEST_F(OtlpHttpExporterCustomClientTestPeer, ForceFlushReportsSuccessOnceTheSess
   sent.Finish(*pending);
 
   EXPECT_TRUE(otlp_client.ForceFlush(std::chrono::milliseconds{50}));
+}
+
+// Every state the client can finish a request on has to end that request. These three used to be
+// logged and then dropped: the switch that decides whether the request is over did not name them,
+// so a client that ended a transfer this way left the caller waiting for a callback that was not
+// coming, and ForceFlush and Shutdown could only give up on their own deadlines.
+class OtlpHttpTerminalStateTest : public OtlpHttpExporterCustomClientTestPeer,
+                                  public ::testing::WithParamInterface<http_client::SessionState>
+{};
+
+TEST_P(OtlpHttpTerminalStateTest, ATerminalClientEventEndsTheRequest)
+{
+  auto client         = http_client::HttpClientTestFactory::Create();
+  auto no_send_client = std::static_pointer_cast<http_client::nosend::HttpClient>(client);
+  auto session = std::static_pointer_cast<http_client::nosend::Session>(no_send_client->session_);
+
+  std::shared_ptr<opentelemetry::ext::http::client::EventHandler> pending;
+  EXPECT_CALL(*session, SendRequest)
+      .WillRepeatedly(
+          [&pending](std::shared_ptr<opentelemetry::ext::http::client::EventHandler> callback) {
+            pending = std::move(callback);
+          });
+
+  OtlpHttpClient otlp_client(MakeOtlpHttpClientOptions(std::chrono::seconds{30}), client);
+
+  auto calls  = std::make_shared<std::atomic<int>>(0);
+  auto result = std::make_shared<sdk::common::ExportResult>(sdk::common::ExportResult::kSuccess);
+  ExportOneRequest(otlp_client, calls, result);
+  ASSERT_NE(pending, nullptr);
+
+  pending->OnEvent(GetParam(), "");
+
+  EXPECT_EQ(1, calls->load(std::memory_order_acquire))
+      << "the request was not ended by the state the client finished on";
+  EXPECT_EQ(sdk::common::ExportResult::kFailure, *result);
+
+  // The deadline is short on purpose. Without the request being ended above this waits it out.
+  EXPECT_TRUE(otlp_client.ForceFlush(std::chrono::milliseconds{50}));
+}
+
+INSTANTIATE_TEST_SUITE_P(TerminalStates,
+                         OtlpHttpTerminalStateTest,
+                         ::testing::Values(http_client::SessionState::ReadError,
+                                           http_client::SessionState::WriteError,
+                                           http_client::SessionState::Destroyed));
+
+// The other direction. A client is free to report one of those states after it has already
+// delivered a response, and the outcome the caller was given must not be replaced or repeated.
+TEST_F(OtlpHttpExporterCustomClientTestPeer, ALateTerminalEventDoesNotReportASecondTime)
+{
+  for (const auto state :
+       {http_client::SessionState::ReadError, http_client::SessionState::WriteError,
+        http_client::SessionState::Destroyed})
+  {
+    SCOPED_TRACE(static_cast<int>(state));
+
+    auto client         = http_client::HttpClientTestFactory::Create();
+    auto no_send_client = std::static_pointer_cast<http_client::nosend::HttpClient>(client);
+    auto session = std::static_pointer_cast<http_client::nosend::Session>(no_send_client->session_);
+
+    std::shared_ptr<opentelemetry::ext::http::client::EventHandler> pending;
+    EXPECT_CALL(*session, SendRequest)
+        .WillRepeatedly(
+            [&pending](std::shared_ptr<opentelemetry::ext::http::client::EventHandler> callback) {
+              pending = std::move(callback);
+            });
+
+    OtlpHttpClient otlp_client(MakeOtlpHttpClientOptions(std::chrono::seconds{30}), client);
+
+    auto calls  = std::make_shared<std::atomic<int>>(0);
+    auto result = std::make_shared<sdk::common::ExportResult>(sdk::common::ExportResult::kFailure);
+    ExportOneRequest(otlp_client, calls, result);
+    ASSERT_NE(pending, nullptr);
+
+    http_client::nosend::Response sent;
+    sent.Finish(*pending);
+    ASSERT_EQ(1, calls->load(std::memory_order_acquire));
+
+    pending->OnEvent(state, "");
+
+    EXPECT_EQ(1, calls->load(std::memory_order_acquire))
+        << "a state arriving after the response reported the request a second time";
+  }
 }
 
 }  // namespace otlp

--- a/exporters/otlp/test/otlp_http_exporter_custom_client_test.cc
+++ b/exporters/otlp/test/otlp_http_exporter_custom_client_test.cc
@@ -5,6 +5,7 @@
 #include <atomic>
 #include <chrono>
 #include <functional>
+#include <initializer_list>
 #include <string>
 #include <utility>
 #include "gmock/gmock.h"

--- a/exporters/otlp/test/otlp_http_exporter_custom_client_test.cc
+++ b/exporters/otlp/test/otlp_http_exporter_custom_client_test.cc
@@ -109,8 +109,8 @@ public:
   // that settles twice calls it twice, so both failures the terminal states can produce are
   // visible in the count rather than only in a timeout.
   static void ExportOneRequest(OtlpHttpClient &otlp_client,
-                               std::shared_ptr<std::atomic<int>> calls,
-                               std::shared_ptr<sdk::common::ExportResult> result)
+                               const std::shared_ptr<std::atomic<int>> &calls,
+                               const std::shared_ptr<sdk::common::ExportResult> &result)
   {
     auto arena = std::make_unique<google::protobuf::Arena>();
     auto *request =
@@ -279,45 +279,42 @@ TEST_F(OtlpHttpExporterCustomClientTestPeer, ForceFlushReportsSuccessOnceTheSess
 // logged and then dropped: the switch that decides whether the request is over did not name them,
 // so a client that ended a transfer this way left the caller waiting for a callback that was not
 // coming, and ForceFlush and Shutdown could only give up on their own deadlines.
-class OtlpHttpTerminalStateTest : public OtlpHttpExporterCustomClientTestPeer,
-                                  public ::testing::WithParamInterface<http_client::SessionState>
-{};
-
-TEST_P(OtlpHttpTerminalStateTest, ATerminalClientEventEndsTheRequest)
+TEST_F(OtlpHttpExporterCustomClientTestPeer, ATerminalClientEventEndsTheRequest)
 {
-  auto client         = http_client::HttpClientTestFactory::Create();
-  auto no_send_client = std::static_pointer_cast<http_client::nosend::HttpClient>(client);
-  auto session = std::static_pointer_cast<http_client::nosend::Session>(no_send_client->session_);
+  for (const auto state :
+       {http_client::SessionState::ReadError, http_client::SessionState::WriteError,
+        http_client::SessionState::Destroyed})
+  {
+    SCOPED_TRACE(static_cast<int>(state));
 
-  std::shared_ptr<opentelemetry::ext::http::client::EventHandler> pending;
-  EXPECT_CALL(*session, SendRequest)
-      .WillRepeatedly(
-          [&pending](std::shared_ptr<opentelemetry::ext::http::client::EventHandler> callback) {
-            pending = std::move(callback);
-          });
+    auto client         = http_client::HttpClientTestFactory::Create();
+    auto no_send_client = std::static_pointer_cast<http_client::nosend::HttpClient>(client);
+    auto session = std::static_pointer_cast<http_client::nosend::Session>(no_send_client->session_);
 
-  OtlpHttpClient otlp_client(MakeOtlpHttpClientOptions(std::chrono::seconds{30}), client);
+    std::shared_ptr<opentelemetry::ext::http::client::EventHandler> pending;
+    EXPECT_CALL(*session, SendRequest)
+        .WillRepeatedly(
+            [&pending](std::shared_ptr<opentelemetry::ext::http::client::EventHandler> callback) {
+              pending = std::move(callback);
+            });
 
-  auto calls  = std::make_shared<std::atomic<int>>(0);
-  auto result = std::make_shared<sdk::common::ExportResult>(sdk::common::ExportResult::kSuccess);
-  ExportOneRequest(otlp_client, calls, result);
-  ASSERT_NE(pending, nullptr);
+    OtlpHttpClient otlp_client(MakeOtlpHttpClientOptions(std::chrono::seconds{30}), client);
 
-  pending->OnEvent(GetParam(), "");
+    auto calls  = std::make_shared<std::atomic<int>>(0);
+    auto result = std::make_shared<sdk::common::ExportResult>(sdk::common::ExportResult::kSuccess);
+    ExportOneRequest(otlp_client, calls, result);
+    ASSERT_NE(pending, nullptr);
 
-  EXPECT_EQ(1, calls->load(std::memory_order_acquire))
-      << "the request was not ended by the state the client finished on";
-  EXPECT_EQ(sdk::common::ExportResult::kFailure, *result);
+    pending->OnEvent(state, "");
 
-  // The deadline is short on purpose. Without the request being ended above this waits it out.
-  EXPECT_TRUE(otlp_client.ForceFlush(std::chrono::milliseconds{50}));
+    EXPECT_EQ(1, calls->load(std::memory_order_acquire))
+        << "the request was not ended by the state the client finished on";
+    EXPECT_EQ(sdk::common::ExportResult::kFailure, *result);
+
+    // The deadline is short on purpose. Without the request being ended above this waits it out.
+    EXPECT_TRUE(otlp_client.ForceFlush(std::chrono::milliseconds{50}));
+  }
 }
-
-INSTANTIATE_TEST_SUITE_P(TerminalStates,
-                         OtlpHttpTerminalStateTest,
-                         ::testing::Values(http_client::SessionState::ReadError,
-                                           http_client::SessionState::WriteError,
-                                           http_client::SessionState::Destroyed));
 
 // The other direction. A client is free to report one of those states after it has already
 // delivered a response, and the outcome the caller was given must not be replaced or repeated.


### PR DESCRIPTION
Fixes #4425.

`ResponseHandler::OnEvent` decides a request is over from a switch naming seven states. The client can end a transfer on three more, which the switch below it recognises and logs:

| State | Reported as over | Logged |
| --- | --- | --- |
| `CreateFailed`, `ConnectFailed`, `SendFailed`, `SSLHandshakeFailed`, `TimedOut`, `NetworkError`, `Cancelled` | yes | yes |
| `Destroyed`, `ReadError`, `WriteError` | **no** | yes |

A request that ends on one of those three is described and then dropped. It never reaches `Unbind`, its result callback never runs and its session is never released, so `ForceFlush` and `Shutdown` wait out their own deadlines and the caller waits for a callback that is not coming.

The three states join the same switch. That is the whole change, seven lines in `otlp_http_client.cc`.

The bundled curl client does not produce any of them, so this is reached through the installed `HttpClient` interface by a client the user supplies. `SessionState` is part of that interface, and the header describes these three as a read error, a write error and a destroyed session, so an exporter is not in a position to decide which of them a client may use.

Exactly-once is unchanged. `stopping_` is a compare exchange and the first writer wins, so one of these arriving after a response has already been reported still reports nothing.

Two cases in `otlp_http_exporter_custom_client_test.cc` cover it: each of the three delivered as the only terminal event, and each delivered after a response. Removing the three lines does not turn them red, it hangs the binary on a session that never settles, which is the shape the defect has for a user.

@lalitb noted on #4448 that this can go ahead independently of the transport design. It changes no curl code.

For significant contributions please make sure you have completed the following items:

* [x] `CHANGELOG.md` updated for non-trivial changes
* [x] Unit tests have been added
* [x] Changes in public API reviewed
