### PR TITLE
[CONFIGURATION] Add a builder for the host resource detector

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ Increment the:
 
 ## [Unreleased]
 
+* [CONFIGURATION] Add a configuration builder for the host resource detector
+  [#4451](https://github.com/open-telemetry/opentelemetry-cpp/issues/4451)
 * [CONFIGURATION] Build the configured resource detectors in SdkBuilder, apply
   the `detection.attributes` include/exclude filter to the detected attributes,
   and merge the resource per the resource SDK specification.

--- a/examples/configuration/kitchen-sink.yaml
+++ b/examples/configuration/kitchen-sink.yaml
@@ -1063,8 +1063,8 @@ resource:
     detectors:
       - # Enable the container resource detector, which populates container.* attributes.
         container:
-      # - # Enable the host resource detector, which populates host.* and os.* attributes.
-      #   host:
+      - # Enable the host resource detector, which populates host.* attributes.
+        host:
       - # Enable the process resource detector, which populates process.* attributes.
         process:
       # - # Enable the service detector, which populates service.name based on the OTEL_SERVICE_NAME environment variable and service.instance.id.

--- a/examples/configuration/main.cc
+++ b/examples/configuration/main.cc
@@ -58,6 +58,7 @@
 
 #ifdef OTEL_HAVE_RESOURCE_DETECTORS
 #  include "opentelemetry/resource_detectors/container_detector_builder.h"
+#  include "opentelemetry/resource_detectors/host_detector_builder.h"
 #  include "opentelemetry/resource_detectors/process_detector_builder.h"
 #endif
 
@@ -223,6 +224,7 @@ void InitOtel(const std::string &config_file)
 
 #ifdef OTEL_HAVE_RESOURCE_DETECTORS
     opentelemetry::resource_detector::ContainerDetectorBuilder::Register(registry.get());
+    opentelemetry::resource_detector::HostDetectorBuilder::Register(registry.get());
     opentelemetry::resource_detector::ProcessDetectorBuilder::Register(registry.get());
 #endif
   }

--- a/install/test/cmake/component_tests/resource_detectors/CMakeLists.txt
+++ b/install/test/cmake/component_tests/resource_detectors/CMakeLists.txt
@@ -19,6 +19,7 @@ target_link_libraries(
           opentelemetry-cpp::container_resource_detector_builder
           opentelemetry-cpp::env_entity_resource_detector
           opentelemetry-cpp::host_resource_detector
+          opentelemetry-cpp::host_resource_detector_builder
           opentelemetry-cpp::process_resource_detector
           opentelemetry-cpp::process_resource_detector_builder
           GTest::gtest

--- a/install/test/cmake/fetch_content_test/CMakeLists.txt
+++ b/install/test/cmake/fetch_content_test/CMakeLists.txt
@@ -90,6 +90,7 @@ target_link_libraries(
           opentelemetry-cpp::container_resource_detector_builder
           opentelemetry-cpp::env_entity_resource_detector
           opentelemetry-cpp::host_resource_detector
+          opentelemetry-cpp::host_resource_detector_builder
           opentelemetry-cpp::process_resource_detector
           opentelemetry-cpp::process_resource_detector_builder
           opentelemetry-cpp::http_client

--- a/install/test/src/test_resource_detectors.cc
+++ b/install/test/src/test_resource_detectors.cc
@@ -7,6 +7,7 @@
 #include <opentelemetry/resource_detectors/container_detector_builder.h>
 #include <opentelemetry/resource_detectors/env_entity_detector.h>
 #include <opentelemetry/resource_detectors/host_detector.h>
+#include <opentelemetry/resource_detectors/host_detector_builder.h>
 #include <opentelemetry/resource_detectors/process_detector.h>
 #include <opentelemetry/resource_detectors/process_detector_builder.h>
 #include <memory>
@@ -49,6 +50,16 @@ TEST(ResourceDetectorsInstall, ContainerDetectorBuilder)
   ASSERT_TRUE(builder != nullptr);
 
   opentelemetry::sdk::configuration::ContainerResourceDetectorConfiguration model;
+  auto detector = builder->Build(&model);
+  ASSERT_TRUE(detector != nullptr);
+}
+
+TEST(ResourceDetectorsInstall, HostDetectorBuilder)
+{
+  auto builder = std::make_unique<opentelemetry::resource_detector::HostDetectorBuilder>();
+  ASSERT_TRUE(builder != nullptr);
+
+  opentelemetry::sdk::configuration::HostResourceDetectorConfiguration model;
   auto detector = builder->Build(&model);
   ASSERT_TRUE(detector != nullptr);
 }

--- a/resource_detectors/BUILD
+++ b/resource_detectors/BUILD
@@ -63,6 +63,15 @@ cc_library(
 )
 
 cc_library(
+    name = "host_resource_detector_builder",
+    srcs = ["src/host_detector_builder.cc"],
+    deps = [
+        ":host_resource_detector",
+        "//sdk/src/configuration:configuration_core",
+    ],
+)
+
+cc_library(
     name = "process_resource_detector",
     srcs = [
         "src/process_detector.cc",
@@ -102,6 +111,7 @@ cc_library(
     name = "resource_detectors_builders",
     deps = [
         ":container_resource_detector_builder",
+        ":host_resource_detector_builder",
         ":process_resource_detector_builder",
     ],
 )

--- a/resource_detectors/CMakeLists.txt
+++ b/resource_detectors/CMakeLists.txt
@@ -78,6 +78,26 @@ target_include_directories(
          "$<INSTALL_INTERFACE:include>")
 
 #
+# opentelemetry_host_resource_detector_builder
+#
+
+add_library(opentelemetry_host_resource_detector_builder
+            src/host_detector_builder.cc)
+
+set_target_properties(opentelemetry_host_resource_detector_builder
+                      PROPERTIES EXPORT_NAME host_resource_detector_builder)
+set_target_version(opentelemetry_host_resource_detector_builder)
+
+target_include_directories(
+  opentelemetry_host_resource_detector_builder
+  PUBLIC "$<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}/include>"
+         "$<INSTALL_INTERFACE:include>")
+
+target_link_libraries(
+  opentelemetry_host_resource_detector_builder
+  PRIVATE opentelemetry_host_resource_detector opentelemetry_configuration_core)
+
+#
 # opentelemetry_process_resource_detector
 #
 
@@ -144,6 +164,7 @@ set_target_properties(opentelemetry_resource_detectors_builders
 target_link_libraries(
   opentelemetry_resource_detectors_builders
   INTERFACE opentelemetry_container_resource_detector_builder
+            opentelemetry_host_resource_detector_builder
             opentelemetry_process_resource_detector_builder)
 
 otel_add_component(
@@ -156,6 +177,7 @@ otel_add_component(
   opentelemetry_container_resource_detector_builder
   opentelemetry_env_entity_resource_detector
   opentelemetry_host_resource_detector
+  opentelemetry_host_resource_detector_builder
   opentelemetry_process_resource_detector
   opentelemetry_process_resource_detector_builder
   FILES_DIRECTORY

--- a/resource_detectors/README.md
+++ b/resource_detectors/README.md
@@ -100,9 +100,9 @@ resource:
   detection/development:
     detectors:
       - container:
+      - host:
       - process:
-      # NOTE: host and service detectors cannot be configured currently
-      - host:    # needs a builder (`Registry::SetHostResourceDetectorBuilder`)
+      # NOTE: service detector cannot be configured currently
       - service: # not implemented (github.com/open-telemetry/opentelemetry-cpp/issues/4414)
 ```
 
@@ -110,9 +110,11 @@ Call `Register` for each builder before creating the SDK:
 
 ```cpp
 #include "opentelemetry/resource_detectors/container_detector_builder.h"
+#include "opentelemetry/resource_detectors/host_detector_builder.h"
 #include "opentelemetry/resource_detectors/process_detector_builder.h"
 
 opentelemetry::resource_detector::ContainerDetectorBuilder::Register(registry.get());
+opentelemetry::resource_detector::HostDetectorBuilder::Register(registry.get());
 opentelemetry::resource_detector::ProcessDetectorBuilder::Register(registry.get());
 ```
 
@@ -167,6 +169,7 @@ All targets are part of the `resource_detectors` component.
 | `opentelemetry-cpp::container_resource_detector_builder` | Container detector builder for declaritive configuration |
 | `opentelemetry-cpp::env_entity_resource_detector` | Env entity detector |
 | `opentelemetry-cpp::host_resource_detector` | Host detector |
+| `opentelemetry-cpp::host_resource_detector_builder` | Host detector builder for declaritive configuration |
 | `opentelemetry-cpp::process_resource_detector` | Process detector |
 | `opentelemetry-cpp::process_resource_detector_builder` | Process detector builder for declaritive configuration |
 
@@ -213,5 +216,6 @@ deps = ["//resource_detectors:process_resource_detector_builder"]
 | `//resource_detectors:container_resource_detector_builder` | Container detector builder |
 | `//resource_detectors:env_entity_resource_detector` | Env entity detector |
 | `//resource_detectors:host_resource_detector` | Host detector |
+| `//resource_detectors:host_resource_detector_builder` | Host detector builder |
 | `//resource_detectors:process_resource_detector` | Process detector |
 | `//resource_detectors:process_resource_detector_builder` | Process detector builder |

--- a/resource_detectors/include/opentelemetry/resource_detectors/host_detector_builder.h
+++ b/resource_detectors/include/opentelemetry/resource_detectors/host_detector_builder.h
@@ -1,0 +1,36 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <memory>
+
+#include "opentelemetry/sdk/configuration/host_resource_detector_builder.h"
+#include "opentelemetry/sdk/configuration/host_resource_detector_configuration.h"
+#include "opentelemetry/sdk/resource/resource_detector.h"
+#include "opentelemetry/version.h"
+
+OPENTELEMETRY_BEGIN_NAMESPACE
+namespace sdk
+{
+namespace configuration
+{
+class Registry;
+}  // namespace configuration
+}  // namespace sdk
+
+namespace resource_detector
+{
+
+class HostDetectorBuilder : public opentelemetry::sdk::configuration::HostResourceDetectorBuilder
+{
+public:
+  static void Register(opentelemetry::sdk::configuration::Registry *registry);
+
+  std::unique_ptr<opentelemetry::sdk::resource::ResourceDetector> Build(
+      const opentelemetry::sdk::configuration::HostResourceDetectorConfiguration *model)
+      const override;
+};
+
+}  // namespace resource_detector
+OPENTELEMETRY_END_NAMESPACE

--- a/resource_detectors/src/host_detector_builder.cc
+++ b/resource_detectors/src/host_detector_builder.cc
@@ -1,0 +1,31 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+#include <memory>
+#include <utility>
+
+#include "opentelemetry/resource_detectors/host_detector.h"
+#include "opentelemetry/resource_detectors/host_detector_builder.h"
+#include "opentelemetry/sdk/configuration/host_resource_detector_builder.h"
+#include "opentelemetry/sdk/configuration/registry.h"
+#include "opentelemetry/sdk/resource/resource_detector.h"
+#include "opentelemetry/version.h"
+
+OPENTELEMETRY_BEGIN_NAMESPACE
+namespace resource_detector
+{
+
+void HostDetectorBuilder::Register(opentelemetry::sdk::configuration::Registry *registry)
+{
+  auto builder = std::make_unique<HostDetectorBuilder>();
+  registry->SetHostResourceDetectorBuilder(std::move(builder));
+}
+
+std::unique_ptr<opentelemetry::sdk::resource::ResourceDetector> HostDetectorBuilder::Build(
+    const opentelemetry::sdk::configuration::HostResourceDetectorConfiguration * /* model */) const
+{
+  return std::make_unique<HostResourceDetector>();
+}
+
+}  // namespace resource_detector
+OPENTELEMETRY_END_NAMESPACE

--- a/resource_detectors/test/BUILD
+++ b/resource_detectors/test/BUILD
@@ -60,6 +60,18 @@ cc_test(
 )
 
 cc_test(
+    name = "host_resource_detector_builder_test",
+    srcs = ["host_detector_builder_test.cc"],
+    tags = ["test"],
+    deps = [
+        "//resource_detectors:host_resource_detector_builder",
+        "//sdk/src/configuration:configuration_core",
+        "//sdk/src/resource",
+        "@com_google_googletest//:gtest_main",
+    ],
+)
+
+cc_test(
     name = "process_resource_detector_builder_test",
     srcs = ["process_detector_builder_test.cc"],
     tags = ["test"],

--- a/resource_detectors/test/CMakeLists.txt
+++ b/resource_detectors/test/CMakeLists.txt
@@ -51,6 +51,17 @@ gtest_add_tests(
   TEST_PREFIX resource_detector.
   TEST_LIST host_resource_detector_test)
 
+add_executable(host_resource_detector_builder_test
+               host_detector_builder_test.cc)
+target_link_libraries(
+  host_resource_detector_builder_test
+  PRIVATE opentelemetry_host_resource_detector_builder
+          opentelemetry_configuration_core GTest::gtest_main)
+gtest_add_tests(
+  TARGET host_resource_detector_builder_test
+  TEST_PREFIX resource_detector.
+  TEST_LIST host_resource_detector_builder_test)
+
 #
 # process_resource_detector tests
 #

--- a/resource_detectors/test/host_detector_builder_test.cc
+++ b/resource_detectors/test/host_detector_builder_test.cc
@@ -1,0 +1,28 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+#include <gtest/gtest.h>
+#include <string>
+
+#include "opentelemetry/resource_detectors/host_detector_builder.h"
+#include "opentelemetry/sdk/configuration/host_resource_detector_configuration.h"
+#include "opentelemetry/sdk/configuration/registry.h"
+#include "opentelemetry/sdk/resource/resource_detector.h"
+
+TEST(HostDetectorBuilderTest, Register)
+{
+  opentelemetry::sdk::configuration::Registry registry;
+  ASSERT_EQ(registry.GetHostResourceDetectorBuilder(), nullptr);
+
+  opentelemetry::resource_detector::HostDetectorBuilder::Register(&registry);
+  ASSERT_NE(registry.GetHostResourceDetectorBuilder(), nullptr);
+}
+
+TEST(HostDetectorBuilderTest, Build)
+{
+  opentelemetry::resource_detector::HostDetectorBuilder builder;
+  opentelemetry::sdk::configuration::HostResourceDetectorConfiguration model;
+
+  auto detector = builder.Build(&model);
+  ASSERT_NE(detector, nullptr);
+}


### PR DESCRIPTION
Fixes #4451

## Changes

Adds a configuration builder for the host resource detector, `HostDetectorBuilder`, in `resource_detectors/`, following the `ContainerDetectorBuilder` / `ProcessDetectorBuilder` pattern. `Build` returns a `HostResourceDetector`. The builder is registered in `examples/configuration/main.cc` behind `OTEL_HAVE_RESOURCE_DETECTORS`.

The builder is exported as `opentelemetry_host_resource_detector_builder` / `//resource_detectors:host_resource_detector_builder` and is included in `resource_detectors_builders`. Unit tests, install tests, README, CHANGELOG, and the kitchen-sink example YAML are updated so `- host:` can be configured via declarative configuration.

For significant contributions please make sure you have completed the following items:

* [x] `CHANGELOG.md` updated for non-trivial changes
* [x] Unit tests have been added
* [x] Changes in public API reviewed