### PR TITLE
[BENCHMARK] sync instrument recording benchmarks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,10 @@ Increment the:
   [#4413](https://github.com/open-telemetry/opentelemetry-cpp/issues/4413)
 * [RESOURCE DETECTOR] Add the service resource detector and builder
   [#4414](https://github.com/open-telemetry/opentelemetry-cpp/issues/4414)
+
+* [BENCHMARK] Sync instrument recording benchmarks
+  [#4470](https://github.com/open-telemetry/opentelemetry-cpp/pull/4470)
+
 * [CONFIGURATION] deprecate config builder cmake components
   [#4428](https://github.com/open-telemetry/opentelemetry-cpp/pull/4428)
 

--- a/sdk/test/metrics/BUILD
+++ b/sdk/test/metrics/BUILD
@@ -179,3 +179,19 @@ otel_cc_benchmark(
         "//sdk/src/resource",
     ],
 )
+
+otel_cc_benchmark(
+    name = "sync_instruments_benchmark",
+    srcs = [
+        "sync_instruments_benchmark.cc",
+    ],
+    tags = [
+        "benchmark",
+        "metrics",
+        "test",
+    ],
+    deps = [
+        "//sdk/src/metrics",
+        "//sdk/src/resource",
+    ],
+)

--- a/sdk/test/metrics/CMakeLists.txt
+++ b/sdk/test/metrics/CMakeLists.txt
@@ -111,6 +111,10 @@ if(OTELCPP_WITH_BENCHMARK)
   target_link_libraries(
     measurements_benchmark benchmark::benchmark opentelemetry_metrics
     opentelemetry_resources ${CMAKE_THREAD_LIBS_INIT} opentelemetry_common)
+  add_executable(sync_instruments_benchmark sync_instruments_benchmark.cc)
+  target_link_libraries(
+    sync_instruments_benchmark benchmark::benchmark opentelemetry_metrics
+    opentelemetry_resources ${CMAKE_THREAD_LIBS_INIT} opentelemetry_common)
   add_executable(sum_aggregation_benchmark sum_aggregation_benchmark.cc)
   target_link_libraries(
     sum_aggregation_benchmark benchmark::benchmark ${CMAKE_THREAD_LIBS_INIT}

--- a/sdk/test/metrics/sync_instruments_benchmark.cc
+++ b/sdk/test/metrics/sync_instruments_benchmark.cc
@@ -26,7 +26,7 @@
 //    OPENTELEMETRY_HAVE_METRICS_BOUND_INSTRUMENTS_PREVIEW = OFF
 // -------------------------------------------------------------------------------------------------------
 //  ~/build/sdk/test/metrics/sync_instruments_benchmark
-// 2026-08-22T18:29:21+00:00
+// 2026-08-22T20:05:18+00:00
 // Running /home/devuser/build/sdk/test/metrics/sync_instruments_benchmark
 // Run on (32 X 5700 MHz CPU s)
 // CPU Caches:
@@ -34,63 +34,63 @@
 //   L1 Instruction 32 KiB (x16)
 //   L2 Unified 2048 KiB (x16)
 //   L3 Unified 36864 KiB (x1)
-// Load Average: 0.31, 1.59, 6.96
+// Load Average: 2.11, 4.01, 3.82
 // ***WARNING*** ASLR is enabled, the results may have unreproducible noise in them.
 // -----------------------------------------------------------------------------------------------------
 // Benchmark                                                           Time             CPU   Iterations
 // -----------------------------------------------------------------------------------------------------
-// BM_Record_Counter_Disabled_ByThreads/threads:1                  0.240 ns        0.240 ns   2810278222
-// BM_Record_Counter_Disabled_ByThreads/threads:2                  0.251 ns        0.251 ns   2657675522
-// BM_Record_Counter_Disabled_ByThreads/threads:4                  0.249 ns        0.249 ns   2217318376
-// BM_Record_Counter_Drop_ByThreads/threads:1                        172 ns          172 ns      4061768
-// BM_Record_Counter_Drop_ByThreads/threads:2                        199 ns          199 ns      3502520
-// BM_Record_Counter_Drop_ByThreads/threads:4                        480 ns          451 ns      1460396
-// BM_Record_Counter_Sum_ByAttributes/0                             21.3 ns         21.3 ns     32952539
-// BM_Record_Counter_Sum_ByAttributes/1                             58.9 ns         58.9 ns     11783391
-// BM_Record_Counter_Sum_ByAttributes/10                             622 ns          621 ns      1147270
-// BM_Record_Counter_Sum_ByAttributes/128                          10463 ns        10461 ns        61934
-// BM_Record_Counter_Sum_ByCardinality/10                            167 ns          167 ns      4229155
-// BM_Record_Counter_Sum_ByCardinality/500                           182 ns          182 ns      3887130
-// BM_Record_Counter_Sum_ByCardinality/2000                          184 ns          184 ns      3895325
-// BM_Record_Counter_Sum_ByCardinality/4000                          188 ns          188 ns      3684246
-// BM_Record_Counter_Sum_ByThreads/threads:1                         165 ns          165 ns      4253673
-// BM_Record_Counter_Sum_ByThreads/threads:2                         306 ns          306 ns      2191990
-// BM_Record_Counter_Sum_ByThreads/threads:4                         776 ns          695 ns      1046688
-// BM_Record_Histogram_Disabled_ByThreads/threads:1                0.211 ns        0.211 ns   3317925441
-// BM_Record_Histogram_Disabled_ByThreads/threads:2                0.220 ns        0.220 ns   2448391836
-// BM_Record_Histogram_Disabled_ByThreads/threads:4                0.215 ns        0.215 ns   2565877976
-// BM_Record_Histogram_Drop_ByThreads/threads:1                      168 ns          168 ns      4025374
-// BM_Record_Histogram_Drop_ByThreads/threads:2                      183 ns          183 ns      3715406
-// BM_Record_Histogram_Drop_ByThreads/threads:4                      386 ns          374 ns      1466744
-// BM_Record_Histogram_Explicit_ByAttributes/0                      24.7 ns         24.7 ns     27963357
-// BM_Record_Histogram_Explicit_ByAttributes/1                      68.2 ns         68.2 ns      9980062
-// BM_Record_Histogram_Explicit_ByAttributes/10                      615 ns          615 ns      1116173
-// BM_Record_Histogram_Explicit_ByAttributes/128                   10998 ns        10996 ns        60390
-// BM_Record_Histogram_Explicit_ByCardinality/10                     172 ns          172 ns      3897194
-// BM_Record_Histogram_Explicit_ByCardinality/500                    186 ns          186 ns      3635122
-// BM_Record_Histogram_Explicit_ByCardinality/2000                   189 ns          189 ns      3714421
-// BM_Record_Histogram_Explicit_ByThreads/threads:1                  171 ns          171 ns      4044930
-// BM_Record_Histogram_Explicit_ByThreads/threads:2                  386 ns          384 ns      1623758
-// BM_Record_Histogram_Explicit_ByThreads/threads:4                  895 ns          791 ns       877804
-// BM_Record_Histogram_Base2Expo_ByAttributes/0                     30.4 ns         30.4 ns     25880391
-// BM_Record_Histogram_Base2Expo_ByAttributes/1                     70.5 ns         70.4 ns      9238204
-// BM_Record_Histogram_Base2Expo_ByAttributes/10                     634 ns          634 ns      1091161
-// BM_Record_Histogram_Base2Expo_ByAttributes/128                  11322 ns        11321 ns        59828
-// BM_Record_Histogram_Base2Expo_ByCardinality/10                    188 ns          188 ns      3823091
-// BM_Record_Histogram_Base2Expo_ByCardinality/500                   197 ns          197 ns      3442858
-// BM_Record_Histogram_Base2Expo_ByCardinality/2000                  198 ns          198 ns      3510467
-// BM_Record_Histogram_Base2Expo_ByThreads/threads:1                 187 ns          187 ns      3738470
-// BM_Record_Histogram_Base2Expo_ByThreads/threads:2                 372 ns          372 ns      1751874
-// BM_Record_Histogram_Base2Expo_ByThreads/threads:4                 846 ns          756 ns       900708
-// BM_Record_Counter_Sum_Exemplar_AlwaysOff                          172 ns          172 ns      4053919
-// BM_Record_Counter_Sum_Exemplar_AlwaysOn                           311 ns          311 ns      2222684
-// BM_Record_Counter_Sum_Exemplar_TraceBased_EmptyContext            178 ns          178 ns      3918620
-// BM_Record_Counter_Sum_Exemplar_TraceBased_UnsampledContext        181 ns          181 ns      3802845
-// BM_Record_Counter_Sum_Exemplar_TraceBased_SampledContext          323 ns          323 ns      2180391
-// BM_Record_Histogram_Explicit_Exemplar_AlwaysOff                   182 ns          182 ns      3842404
-// BM_Record_Histogram_Explicit_Exemplar_AlwaysOn                    322 ns          322 ns      2148460
-// BM_Record_Histogram_Base2Expo_Exemplar_AlwaysOff                  191 ns          191 ns      3660302
-// BM_Record_Histogram_Base2Expo_Exemplar_AlwaysOn                   326 ns          326 ns      2160708
+// BM_Record_Counter_Disabled_ByThreads/threads:1                  0.223 ns        0.223 ns   3149132264
+// BM_Record_Counter_Disabled_ByThreads/threads:2                  0.334 ns        0.334 ns   2424266898
+// BM_Record_Counter_Disabled_ByThreads/threads:4                  0.335 ns        0.335 ns   1860780336
+// BM_Record_Counter_Drop_ByThreads/threads:1                        181 ns          181 ns      3883111
+// BM_Record_Counter_Drop_ByThreads/threads:2                        336 ns          336 ns      3412070
+// BM_Record_Counter_Drop_ByThreads/threads:4                        548 ns          519 ns      1265888
+// BM_Record_Counter_Sum_ByThreads/threads:1                         183 ns          183 ns      3725731
+// BM_Record_Counter_Sum_ByThreads/threads:2                         313 ns          313 ns      1731700
+// BM_Record_Counter_Sum_ByThreads/threads:4                         658 ns          605 ns      1074776
+// BM_Record_Counter_Sum_ByAttributes/0                             21.7 ns         21.7 ns     32259034
+// BM_Record_Counter_Sum_ByAttributes/1                             63.7 ns         63.7 ns     11103173
+// BM_Record_Counter_Sum_ByAttributes/10                             665 ns          665 ns      1067127
+// BM_Record_Counter_Sum_ByAttributes/128                          11495 ns        11495 ns        58949
+// BM_Record_Counter_Sum_ByCardinality/10                            189 ns          189 ns      3620079
+// BM_Record_Counter_Sum_ByCardinality/500                           187 ns          187 ns      3732425
+// BM_Record_Counter_Sum_ByCardinality/2000                          185 ns          185 ns      3746437
+// BM_Record_Counter_Sum_ByCardinality/4000                          195 ns          195 ns      3587680
+// BM_Record_Histogram_Disabled_ByThreads/threads:1                0.215 ns        0.215 ns   3245684429
+// BM_Record_Histogram_Disabled_ByThreads/threads:2                0.215 ns        0.215 ns   3219420938
+// BM_Record_Histogram_Disabled_ByThreads/threads:4                0.227 ns        0.227 ns   2728839212
+// BM_Record_Histogram_Drop_ByThreads/threads:1                      180 ns          180 ns      3891143
+// BM_Record_Histogram_Drop_ByThreads/threads:2                      198 ns          198 ns      3255264
+// BM_Record_Histogram_Drop_ByThreads/threads:4                      556 ns          515 ns      1294128
+// BM_Record_Histogram_Explicit_ByThreads/threads:1                  192 ns          192 ns      3652980
+// BM_Record_Histogram_Explicit_ByThreads/threads:2                  473 ns          471 ns      1458558
+// BM_Record_Histogram_Explicit_ByThreads/threads:4                  910 ns          806 ns       840420
+// BM_Record_Histogram_Explicit_ByAttributes/0                      25.4 ns         25.4 ns     27240860
+// BM_Record_Histogram_Explicit_ByAttributes/1                      73.7 ns         73.7 ns      9490681
+// BM_Record_Histogram_Explicit_ByAttributes/10                      662 ns          662 ns      1069361
+// BM_Record_Histogram_Explicit_ByAttributes/128                   10666 ns        10665 ns        65408
+// BM_Record_Histogram_Explicit_ByCardinality/10                     202 ns          202 ns      3515610
+// BM_Record_Histogram_Explicit_ByCardinality/500                    202 ns          202 ns      3499771
+// BM_Record_Histogram_Explicit_ByCardinality/2000                   205 ns          205 ns      3499176
+// BM_Record_Histogram_Base2Expo_ByThreads/threads:1                 209 ns          209 ns      3356693
+// BM_Record_Histogram_Base2Expo_ByThreads/threads:2                 378 ns          378 ns      1566898
+// BM_Record_Histogram_Base2Expo_ByThreads/threads:4                 884 ns          786 ns       881608
+// BM_Record_Histogram_Base2Expo_ByAttributes/0                     27.4 ns         27.4 ns     23210481
+// BM_Record_Histogram_Base2Expo_ByAttributes/1                     72.1 ns         72.1 ns      9380658
+// BM_Record_Histogram_Base2Expo_ByAttributes/10                     662 ns          662 ns      1060240
+// BM_Record_Histogram_Base2Expo_ByAttributes/128                  10619 ns        10618 ns        57887
+// BM_Record_Histogram_Base2Expo_ByCardinality/10                    207 ns          207 ns      3466383
+// BM_Record_Histogram_Base2Expo_ByCardinality/500                   203 ns          203 ns      3436550
+// BM_Record_Histogram_Base2Expo_ByCardinality/2000                  206 ns          206 ns      3400210
+// BM_Record_Counter_Sum_Exemplar_AlwaysOff                          181 ns          181 ns      3876313
+// BM_Record_Counter_Sum_Exemplar_AlwaysOn                           331 ns          331 ns      2119737
+// BM_Record_Counter_Sum_Exemplar_TraceBased_EmptyContext            188 ns          188 ns      3748573
+// BM_Record_Counter_Sum_Exemplar_TraceBased_UnsampledContext        191 ns          191 ns      3628388
+// BM_Record_Counter_Sum_Exemplar_TraceBased_SampledContext          341 ns          341 ns      2064088
+// BM_Record_Histogram_Explicit_Exemplar_AlwaysOff                   191 ns          191 ns      3657244
+// BM_Record_Histogram_Explicit_Exemplar_AlwaysOn                    339 ns          339 ns      2063476
+// BM_Record_Histogram_Base2Expo_Exemplar_AlwaysOff                  190 ns          190 ns      3650174
+// BM_Record_Histogram_Base2Expo_Exemplar_AlwaysOn                   343 ns          343 ns      2076733
 //
 // *******************************************************************************************************
 // ABIv2 with preview options
@@ -98,7 +98,7 @@
 //    OPENTELEMETRY_HAVE_METRICS_BOUND_INSTRUMENTS_PREVIEW = ON
 // -------------------------------------------------------------------------------------------------------
 // ~/build/sdk/test/metrics/sync_instruments_benchmark
-// 2026-08-22T18:35:28+00:00
+// 2026-08-22T19:58:12+00:00
 // Running /home/devuser/build/sdk/test/metrics/sync_instruments_benchmark
 // Run on (32 X 5700 MHz CPU s)
 // CPU Caches:
@@ -106,100 +106,100 @@
 //   L1 Instruction 32 KiB (x16)
 //   L2 Unified 2048 KiB (x16)
 //   L3 Unified 36864 KiB (x1)
-// Load Average: 1.26, 3.33, 6.24
+// Load Average: 1.76, 4.54, 3.46
 // ***WARNING*** ASLR is enabled, the results may have unreproducible noise in them.
 // -----------------------------------------------------------------------------------------------------
 // Benchmark                                                           Time             CPU   Iterations
 // -----------------------------------------------------------------------------------------------------
-// BM_Record_Counter_Disabled_ByThreads/threads:1                  0.244 ns        0.244 ns   2854410569
-// BM_Record_Counter_Disabled_ByThreads/threads:2                  0.246 ns        0.246 ns   2283314028
-// BM_Record_Counter_Disabled_ByThreads/threads:4                  0.259 ns        0.259 ns   2767156460
-// BM_Record_Counter_Drop_ByThreads/threads:1                        280 ns          280 ns      2500556
-// BM_Record_Counter_Drop_ByThreads/threads:2                        504 ns          502 ns      1230074
-// BM_Record_Counter_Drop_ByThreads/threads:4                       1188 ns         1005 ns       693584
-// BM_Record_Counter_Sum_ByAttributes/0                             25.9 ns         25.9 ns     26993356
-// BM_Record_Counter_Sum_ByAttributes/1                              102 ns          102 ns      6857076
-// BM_Record_Counter_Sum_ByAttributes/10                            1047 ns         1047 ns       673706
-// BM_Record_Counter_Sum_ByAttributes/128                          18473 ns        18472 ns        40446
-// BM_Record_Counter_Sum_ByCardinality/10                            264 ns          264 ns      2605094
-// BM_Record_Counter_Sum_ByCardinality/500                           283 ns          282 ns      2415468
-// BM_Record_Counter_Sum_ByCardinality/2000                          288 ns          288 ns      2405574
-// BM_Record_Counter_Sum_ByCardinality/4000                          284 ns          284 ns      2464235
-// BM_Record_Counter_Sum_ByThreads/threads:1                         267 ns          267 ns      2619454
-// BM_Record_Counter_Sum_ByThreads/threads:2                         545 ns          540 ns      1119670
-// BM_Record_Counter_Sum_ByThreads/threads:4                        1382 ns         1143 ns       600404
-// BM_Record_Histogram_Disabled_ByThreads/threads:1                0.230 ns        0.230 ns   3061468421
-// BM_Record_Histogram_Disabled_ByThreads/threads:2                0.226 ns        0.226 ns   2510237466
-// BM_Record_Histogram_Disabled_ByThreads/threads:4                0.227 ns        0.227 ns   2325233576
-// BM_Record_Histogram_Drop_ByThreads/threads:1                      282 ns          282 ns      2483406
-// BM_Record_Histogram_Drop_ByThreads/threads:2                      518 ns          513 ns      1299874
-// BM_Record_Histogram_Drop_ByThreads/threads:4                     1163 ns          986 ns       722172
-// BM_Record_Histogram_Explicit_ByAttributes/0                      34.0 ns         34.0 ns     20597805
-// BM_Record_Histogram_Explicit_ByAttributes/1                       114 ns          114 ns      6252720
-// BM_Record_Histogram_Explicit_ByAttributes/10                     1049 ns         1049 ns       678527
-// BM_Record_Histogram_Explicit_ByAttributes/128                   15747 ns        15744 ns        43593
-// BM_Record_Histogram_Explicit_ByCardinality/10                     278 ns          278 ns      2514763
-// BM_Record_Histogram_Explicit_ByCardinality/500                    309 ns          309 ns      2329567
-// BM_Record_Histogram_Explicit_ByCardinality/2000                   318 ns          318 ns      2247860
-// BM_Record_Histogram_Explicit_ByThreads/threads:1                  280 ns          280 ns      2502514
-// BM_Record_Histogram_Explicit_ByThreads/threads:2                  796 ns          701 ns       993288
-// BM_Record_Histogram_Explicit_ByThreads/threads:4                 1710 ns         1327 ns       419468
-// BM_Record_Histogram_Base2Expo_ByAttributes/0                     36.6 ns         36.6 ns     19063681
-// BM_Record_Histogram_Base2Expo_ByAttributes/1                      115 ns          115 ns      5972985
-// BM_Record_Histogram_Base2Expo_ByAttributes/10                    1040 ns         1040 ns       670899
-// BM_Record_Histogram_Base2Expo_ByAttributes/128                  16436 ns        16435 ns        39525
-// BM_Record_Histogram_Base2Expo_ByCardinality/10                    280 ns          280 ns      2450117
-// BM_Record_Histogram_Base2Expo_ByCardinality/500                   301 ns          301 ns      2191454
-// BM_Record_Histogram_Base2Expo_ByCardinality/2000                  313 ns          312 ns      2204814
-// BM_Record_Histogram_Base2Expo_ByThreads/threads:1                 282 ns          282 ns      2481630
-// BM_Record_Histogram_Base2Expo_ByThreads/threads:2                 645 ns          611 ns       887212
-// BM_Record_Histogram_Base2Expo_ByThreads/threads:4                1651 ns         1314 ns       511640
-// BM_Record_Gauge_Disabled_ByThreads/threads:1                    0.216 ns        0.216 ns   3232809477
-// BM_Record_Gauge_Disabled_ByThreads/threads:2                    0.216 ns        0.216 ns   3244371026
-// BM_Record_Gauge_Disabled_ByThreads/threads:4                    0.223 ns        0.223 ns   2298688384
-// BM_Record_Gauge_Drop_ByThreads/threads:1                          278 ns          278 ns      2532793
-// BM_Record_Gauge_Drop_ByThreads/threads:2                          517 ns          513 ns      1321788
-// BM_Record_Gauge_Drop_ByThreads/threads:4                         1245 ns         1037 ns       696352
-// BM_Record_Gauge_LastValue_ByAttributes/0                         34.9 ns         34.9 ns     19978376
-// BM_Record_Gauge_LastValue_ByAttributes/1                          108 ns          108 ns      6470010
-// BM_Record_Gauge_LastValue_ByAttributes/10                        1039 ns         1039 ns       676449
-// BM_Record_Gauge_LastValue_ByAttributes/128                      17818 ns        17815 ns        37888
-// BM_Record_Gauge_LastValue_ByCardinality/10                        271 ns          271 ns      2582416
-// BM_Record_Gauge_LastValue_ByCardinality/500                       302 ns          302 ns      2359183
-// BM_Record_Gauge_LastValue_ByCardinality/2000                      318 ns          318 ns      2295226
-// BM_Record_Gauge_LastValue_ByThreads/threads:1                     270 ns          270 ns      2573195
-// BM_Record_Gauge_LastValue_ByThreads/threads:2                     784 ns          686 ns       994984
-// BM_Record_Gauge_LastValue_ByThreads/threads:4                    1620 ns         1270 ns       413504
-// BM_Record_Counter_Sum_Exemplar_AlwaysOff                          286 ns          286 ns      2470999
-// BM_Record_Counter_Sum_Exemplar_AlwaysOn                           420 ns          420 ns      1669949
-// BM_Record_Counter_Sum_Exemplar_TraceBased_EmptyContext            290 ns          290 ns      2436719
-// BM_Record_Counter_Sum_Exemplar_TraceBased_UnsampledContext        289 ns          289 ns      2414961
-// BM_Record_Counter_Sum_Exemplar_TraceBased_SampledContext          432 ns          431 ns      1615447
-// BM_Record_Histogram_Explicit_Exemplar_AlwaysOff                   292 ns          292 ns      2407769
-// BM_Record_Histogram_Explicit_Exemplar_AlwaysOn                    435 ns          435 ns      1616356
-// BM_Record_Histogram_Base2Expo_Exemplar_AlwaysOff                  295 ns          295 ns      2347904
-// BM_Record_Histogram_Base2Expo_Exemplar_AlwaysOn                   436 ns          436 ns      1623613
-// BM_Record_BoundCounter_Disabled_ByThreads/threads:1             0.336 ns        0.336 ns   2095049975
-// BM_Record_BoundCounter_Disabled_ByThreads/threads:2             0.292 ns        0.292 ns   2104157288
-// BM_Record_BoundCounter_Disabled_ByThreads/threads:4             0.285 ns        0.285 ns   1865496864
-// BM_Record_BoundCounter_Drop_ByThreads/threads:1                  5.86 ns         5.86 ns    120410059
-// BM_Record_BoundCounter_Drop_ByThreads/threads:2                  10.5 ns         7.56 ns     69726378
-// BM_Record_BoundCounter_Drop_ByThreads/threads:4                   141 ns          131 ns      8562596
-// BM_Record_BoundCounter_Sum_ByThreads/threads:1                   10.2 ns         10.2 ns     68523190
-// BM_Record_BoundCounter_Sum_ByThreads/threads:2                   15.5 ns         10.3 ns     67745558
-// BM_Record_BoundCounter_Sum_ByThreads/threads:4                   31.3 ns         12.4 ns     45178704
-// BM_Record_BoundHistogram_Disabled_ByThreads/threads:1           0.214 ns        0.214 ns   3254335214
-// BM_Record_BoundHistogram_Disabled_ByThreads/threads:2           0.215 ns        0.215 ns   3209349632
-// BM_Record_BoundHistogram_Disabled_ByThreads/threads:4           0.228 ns        0.227 ns   2214249064
-// BM_Record_BoundHistogram_Drop_ByThreads/threads:1                6.17 ns         6.17 ns    113446830
-// BM_Record_BoundHistogram_Drop_ByThreads/threads:2                37.1 ns         35.7 ns     20000000
-// BM_Record_BoundHistogram_Drop_ByThreads/threads:4                 151 ns          149 ns     40000000
-// BM_Record_BoundHistogram_Explicit_ByThreads/threads:1            11.6 ns         11.6 ns     60184742
-// BM_Record_BoundHistogram_Explicit_ByThreads/threads:2            18.9 ns         12.8 ns     48591882
-// BM_Record_BoundHistogram_Explicit_ByThreads/threads:4             106 ns         63.9 ns     36674124
-// BM_Record_BoundHistogram_Base2Expo_ByThreads/threads:1           19.0 ns         19.0 ns     36771009
-// BM_Record_BoundHistogram_Base2Expo_ByThreads/threads:2           83.2 ns         74.1 ns     18307054
-// BM_Record_BoundHistogram_Base2Expo_ByThreads/threads:4           82.0 ns         33.1 ns     31623316
+// BM_Record_Counter_Disabled_ByThreads/threads:1                  0.225 ns        0.225 ns   3106874136
+// BM_Record_Counter_Disabled_ByThreads/threads:2                  0.235 ns        0.235 ns   2399463178
+// BM_Record_Counter_Disabled_ByThreads/threads:4                  0.235 ns        0.235 ns   3078807728
+// BM_Record_Counter_Drop_ByThreads/threads:1                        291 ns          291 ns      2434016
+// BM_Record_Counter_Drop_ByThreads/threads:2                        545 ns          536 ns      1124740
+// BM_Record_Counter_Drop_ByThreads/threads:4                       1222 ns         1021 ns       646440
+// BM_Record_Counter_Sum_ByThreads/threads:1                         293 ns          293 ns      2380047
+// BM_Record_Counter_Sum_ByThreads/threads:2                         546 ns          541 ns      1106950
+// BM_Record_Counter_Sum_ByThreads/threads:4                        1372 ns         1130 ns       480448
+// BM_Record_Counter_Sum_ByAttributes/0                             26.3 ns         26.3 ns     26542376
+// BM_Record_Counter_Sum_ByAttributes/1                              102 ns          102 ns      6829105
+// BM_Record_Counter_Sum_ByAttributes/10                            1086 ns         1086 ns       638378
+// BM_Record_Counter_Sum_ByAttributes/128                          17152 ns        17151 ns        41400
+// BM_Record_Counter_Sum_ByCardinality/10                            296 ns          296 ns      2372167
+// BM_Record_Counter_Sum_ByCardinality/500                           293 ns          293 ns      2327678
+// BM_Record_Counter_Sum_ByCardinality/2000                          308 ns          308 ns      2324245
+// BM_Record_Counter_Sum_ByCardinality/4000                          285 ns          285 ns      2494418
+// BM_Record_Histogram_Disabled_ByThreads/threads:1                0.219 ns        0.219 ns   3091515656
+// BM_Record_Histogram_Disabled_ByThreads/threads:2                0.220 ns        0.220 ns   3112553734
+// BM_Record_Histogram_Disabled_ByThreads/threads:4                0.228 ns        0.228 ns   3084546480
+// BM_Record_Histogram_Drop_ByThreads/threads:1                      288 ns          288 ns      2422775
+// BM_Record_Histogram_Drop_ByThreads/threads:2                      540 ns          535 ns      1184022
+// BM_Record_Histogram_Drop_ByThreads/threads:4                     1423 ns         1175 ns       453324
+// BM_Record_Histogram_Explicit_ByThreads/threads:1                  297 ns          297 ns      2348315
+// BM_Record_Histogram_Explicit_ByThreads/threads:2                  746 ns          683 ns       960462
+// BM_Record_Histogram_Explicit_ByThreads/threads:4                 1759 ns         1392 ns       396388
+// BM_Record_Histogram_Explicit_ByAttributes/0                      34.0 ns         34.0 ns     20428456
+// BM_Record_Histogram_Explicit_ByAttributes/1                       113 ns          113 ns      6214071
+// BM_Record_Histogram_Explicit_ByAttributes/10                     1078 ns         1077 ns       650557
+// BM_Record_Histogram_Explicit_ByAttributes/128                   17187 ns        17185 ns        41086
+// BM_Record_Histogram_Explicit_ByCardinality/10                     305 ns          305 ns      2279601
+// BM_Record_Histogram_Explicit_ByCardinality/500                    313 ns          313 ns      2186641
+// BM_Record_Histogram_Explicit_ByCardinality/2000                   332 ns          332 ns      2170545
+// BM_Record_Histogram_Base2Expo_ByThreads/threads:1                 300 ns          300 ns      2344747
+// BM_Record_Histogram_Base2Expo_ByThreads/threads:2                 588 ns          582 ns      1194796
+// BM_Record_Histogram_Base2Expo_ByThreads/threads:4                1500 ns         1196 ns       518668
+// BM_Record_Histogram_Base2Expo_ByAttributes/0                     39.3 ns         39.3 ns     19087472
+// BM_Record_Histogram_Base2Expo_ByAttributes/1                      115 ns          115 ns      5936592
+// BM_Record_Histogram_Base2Expo_ByAttributes/10                    1067 ns         1067 ns       656089
+// BM_Record_Histogram_Base2Expo_ByAttributes/128                  18242 ns        18241 ns        38268
+// BM_Record_Histogram_Base2Expo_ByCardinality/10                    313 ns          313 ns      2235656
+// BM_Record_Histogram_Base2Expo_ByCardinality/500                   317 ns          317 ns      2232139
+// BM_Record_Histogram_Base2Expo_ByCardinality/2000                  331 ns          331 ns      2086932
+// BM_Record_Gauge_Disabled_ByThreads/threads:1                    0.219 ns        0.219 ns   3205741054
+// BM_Record_Gauge_Disabled_ByThreads/threads:2                    0.223 ns        0.223 ns   2690301556
+// BM_Record_Gauge_Disabled_ByThreads/threads:4                    0.229 ns        0.229 ns   2606758588
+// BM_Record_Gauge_Drop_ByThreads/threads:1                          286 ns          286 ns      2439706
+// BM_Record_Gauge_Drop_ByThreads/threads:2                          546 ns          539 ns      1177080
+// BM_Record_Gauge_Drop_ByThreads/threads:4                         1200 ns         1012 ns       497924
+// BM_Record_Gauge_LastValue_ByThreads/threads:1                     293 ns          293 ns      2371945
+// BM_Record_Gauge_LastValue_ByThreads/threads:2                     564 ns          559 ns      1232712
+// BM_Record_Gauge_LastValue_ByThreads/threads:4                    1513 ns         1214 ns       520464
+// BM_Record_Gauge_LastValue_ByAttributes/0                         37.1 ns         37.1 ns     18902040
+// BM_Record_Gauge_LastValue_ByAttributes/1                          108 ns          108 ns      6302008
+// BM_Record_Gauge_LastValue_ByAttributes/10                        1092 ns         1092 ns       647118
+// BM_Record_Gauge_LastValue_ByAttributes/128                      16605 ns        16604 ns        41995
+// BM_Record_Gauge_LastValue_ByCardinality/10                        298 ns          298 ns      2289380
+// BM_Record_Gauge_LastValue_ByCardinality/500                       309 ns          309 ns      2298937
+// BM_Record_Gauge_LastValue_ByCardinality/2000                      318 ns          318 ns      2242299
+// BM_Record_Counter_Sum_Exemplar_AlwaysOff                          296 ns          295 ns      2395056
+// BM_Record_Counter_Sum_Exemplar_AlwaysOn                           437 ns          437 ns      1585966
+// BM_Record_Counter_Sum_Exemplar_TraceBased_EmptyContext            302 ns          302 ns      2365598
+// BM_Record_Counter_Sum_Exemplar_TraceBased_UnsampledContext        303 ns          303 ns      2348573
+// BM_Record_Counter_Sum_Exemplar_TraceBased_SampledContext          450 ns          450 ns      1557082
+// BM_Record_Histogram_Explicit_Exemplar_AlwaysOff                   301 ns          301 ns      2266520
+// BM_Record_Histogram_Explicit_Exemplar_AlwaysOn                    453 ns          453 ns      1573692
+// BM_Record_Histogram_Base2Expo_Exemplar_AlwaysOff                  303 ns          303 ns      2274437
+// BM_Record_Histogram_Base2Expo_Exemplar_AlwaysOn                   453 ns          453 ns      1550092
+// BM_Record_BoundCounter_Disabled_ByThreads/threads:1             0.221 ns        0.221 ns   3142560276
+// BM_Record_BoundCounter_Disabled_ByThreads/threads:2             0.222 ns        0.222 ns   2660334766
+// BM_Record_BoundCounter_Disabled_ByThreads/threads:4             0.226 ns        0.226 ns   2861051432
+// BM_Record_BoundCounter_Drop_ByThreads/threads:1                  5.81 ns         5.81 ns    120342496
+// BM_Record_BoundCounter_Drop_ByThreads/threads:2                  34.8 ns         33.5 ns     20000000
+// BM_Record_BoundCounter_Drop_ByThreads/threads:4                   123 ns          112 ns      6062044
+// BM_Record_BoundCounter_Sum_ByThreads/threads:1                   10.7 ns         10.7 ns     65164652
+// BM_Record_BoundCounter_Sum_ByThreads/threads:2                   19.6 ns         13.2 ns     48429404
+// BM_Record_BoundCounter_Sum_ByThreads/threads:4                   73.4 ns         41.7 ns     32971620
+// BM_Record_BoundHistogram_Disabled_ByThreads/threads:1           0.214 ns        0.214 ns   3277171217
+// BM_Record_BoundHistogram_Disabled_ByThreads/threads:2           0.214 ns        0.214 ns   2444610710
+// BM_Record_BoundHistogram_Disabled_ByThreads/threads:4           0.224 ns        0.224 ns   2556315680
+// BM_Record_BoundHistogram_Drop_ByThreads/threads:1                6.19 ns         6.19 ns    113761230
+// BM_Record_BoundHistogram_Drop_ByThreads/threads:2                32.6 ns         29.9 ns     61564776
+// BM_Record_BoundHistogram_Drop_ByThreads/threads:4                 155 ns          145 ns     42223756
+// BM_Record_BoundHistogram_Explicit_ByThreads/threads:1            11.8 ns         11.8 ns     59006925
+// BM_Record_BoundHistogram_Explicit_ByThreads/threads:2            23.6 ns         13.5 ns     44770066
+// BM_Record_BoundHistogram_Explicit_ByThreads/threads:4             196 ns          133 ns      9838224
+// BM_Record_BoundHistogram_Base2Expo_ByThreads/threads:1           19.3 ns         19.3 ns     37052293
+// BM_Record_BoundHistogram_Base2Expo_ByThreads/threads:2           32.8 ns         21.5 ns     35315540
+// BM_Record_BoundHistogram_Base2Expo_ByThreads/threads:4           67.1 ns         25.8 ns     31687100
 //
 // clang-format on
 

--- a/sdk/test/metrics/sync_instruments_benchmark.cc
+++ b/sdk/test/metrics/sync_instruments_benchmark.cc
@@ -1,13 +1,30 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
+// Benchmarks for the synchronous instrument recording path including:
+// Counter, Histogram, and Gauge (ABI v2) and supported Bound variants.
+//
+// Each instrument type is measured across the following scenarios:
+//   - Record values with 1-4 threads contending on the same instrument with nominal attributes and
+//   the following variations:
+//        - Meter disabled
+//        - Drop aggregation
+//        - Value Aggregation (Sum for Counter, LastValue for Gauge, Explicit Buckets and Base2
+//        Exponential for Histogram)
+//   - Record values with a range of attributes from 0 to 128
+//   - Record values with a range of a nominal attribute count that creates cardinality from 10 to
+//   4000 (default limit is 2000)
+//   - Record values with ExemplarFilter set to AlwaysOff, AlwaysOn, and TraceBased.
+//   - Record values with bound instrument variants (ABI v2 preview)
+//
 // clang-format off
 //
+// Results:
 // *******************************************************************************************************
 // ABIv1 with preview options
 //    ENABLE_METRICS_EXEMPLAR_PREVIEW = ON
 //    OPENTELEMETRY_HAVE_METRICS_BOUND_INSTRUMENTS_PREVIEW = OFF
-// *******************************************************************************************************
+// -------------------------------------------------------------------------------------------------------
 //  ~/build/sdk/test/metrics/sync_instruments_benchmark
 // 2026-08-22T18:29:21+00:00
 // Running /home/devuser/build/sdk/test/metrics/sync_instruments_benchmark
@@ -79,7 +96,7 @@
 // ABIv2 with preview options
 //    ENABLE_METRICS_EXEMPLAR_PREVIEW = ON
 //    OPENTELEMETRY_HAVE_METRICS_BOUND_INSTRUMENTS_PREVIEW = ON
-// *******************************************************************************************************
+// -------------------------------------------------------------------------------------------------------
 // ~/build/sdk/test/metrics/sync_instruments_benchmark
 // 2026-08-22T18:35:28+00:00
 // Running /home/devuser/build/sdk/test/metrics/sync_instruments_benchmark
@@ -274,13 +291,30 @@ std::size_t GetBenchmarkThreads()
   return 4;
 }
 
+// Create a set of random values for recording into histograms
+static std::vector<double> MakeRecordingValues()
+{
+  constexpr std::size_t kNumValues = 1024;
+  constexpr double kMinValue       = 1.0;
+  constexpr double kMaxValue       = 10000.0;
+
+  thread_local std::mt19937 rng(std::random_device{}());
+  thread_local std::uniform_real_distribution<double> dist(kMinValue, kMaxValue);
+  std::vector<double> values(kNumValues);
+  for (auto &val : values)
+  {
+    val = dist(rng);
+  }
+  return values;
+}
+
 // Create a set of attributes with a given count
-static AttributeMap MakeAttributes(std::size_t count)
+static AttributeMap MakeAttributes(std::size_t count, std::string value = {})
 {
   AttributeMap attributes;
   for (std::size_t i = 0; i < count; i++)
   {
-    attributes["attr_" + std::to_string(i)] = "value_" + std::to_string(i);
+    attributes["attr_" + std::to_string(i)] = value.empty() ? "value_" + std::to_string(i) : value;
   }
   return attributes;
 }
@@ -292,12 +326,7 @@ static std::vector<AttributeMap> MakeAttributeSets(std::size_t cardinality)
   sets.reserve(cardinality);
   for (std::size_t i = 0; i < cardinality; i++)
   {
-    AttributeMap attrs;
-    for (std::size_t k = 0; k < kNominalAttributeCount; k++)
-    {
-      attrs["key_" + std::to_string(k)] = std::to_string(i);
-    }
-    sets.push_back(std::move(attrs));
+    sets.push_back(MakeAttributes(kNominalAttributeCount, "value_" + std::to_string(i)));
   }
   return sets;
 }
@@ -361,28 +390,15 @@ struct BenchmarkProvider
 
 void BM_Record_Counter_Disabled_ByThreads(benchmark::State &state)
 {
-  // Create a meter provider that disabled meters by default
-  bool meter_enabled = false;
-  static BenchmarkProvider provider(meter_enabled);
-  static auto counter = provider.meter->CreateDoubleCounter("benchmark_counter");
-  auto attribute_sets = MakeAttributeSets(kNominalCardinality);
-  std::vector<AttributesView> attribute_views;
-  attribute_views.reserve(attribute_sets.size());
-  for (auto &kv_set : attribute_sets)
-  {
-    attribute_views.emplace_back(kv_set);
-  }
-  opentelemetry::context::Context context{};
-  for (auto &kv_view : attribute_views)
-  {
-    counter->Add(1.0, kv_view, context);
-  }
-  std::size_t index = 0;
-
+  static BenchmarkProvider provider(false);
+  static auto counter   = provider.meter->CreateDoubleCounter("benchmark_counter");
+  const auto attributes = MakeAttributes(kNominalAttributeCount);
+  const AttributesView attributes_view(attributes);
+  const opentelemetry::context::Context context{};
   for (auto _ : state)
   {
     benchmark::DoNotOptimize(counter);
-    counter->Add(1.0, attribute_views[index++ % attribute_views.size()], context);
+    counter->Add(1.0, attributes_view, context);
   }
 }
 BENCHMARK(BM_Record_Counter_Disabled_ByThreads)
@@ -390,13 +406,16 @@ BENCHMARK(BM_Record_Counter_Disabled_ByThreads)
 
 void BM_Record_Counter_Drop_ByThreads(benchmark::State &state)
 {
-  BenchmarkProvider provider;
-  provider.AddView(metrics_sdk::InstrumentType::kCounter, "benchmark_counter",
-                   metrics_sdk::AggregationType::kDrop);
-  static auto counter    = provider.meter->CreateDoubleCounter("benchmark_counter");
-  static auto attributes = MakeAttributes(kNominalAttributeCount);
-  AttributesView attributes_view(attributes);
-  opentelemetry::context::Context context{};
+  static BenchmarkProvider provider = [] {
+    BenchmarkProvider p;
+    p.AddView(metrics_sdk::InstrumentType::kCounter, "benchmark_counter",
+              metrics_sdk::AggregationType::kDrop);
+    return p;
+  }();
+  static auto counter   = provider.meter->CreateDoubleCounter("benchmark_counter");
+  const auto attributes = MakeAttributes(kNominalAttributeCount);
+  const AttributesView attributes_view(attributes);
+  const opentelemetry::context::Context context{};
   for (auto _ : state)
   {
     benchmark::DoNotOptimize(counter);
@@ -406,13 +425,28 @@ void BM_Record_Counter_Drop_ByThreads(benchmark::State &state)
 BENCHMARK(BM_Record_Counter_Drop_ByThreads)
     ->ThreadRange(1, static_cast<int>(GetBenchmarkThreads()));
 
+void BM_Record_Counter_Sum_ByThreads(benchmark::State &state)
+{
+  static BenchmarkProvider provider;
+  static auto counter   = provider.meter->CreateDoubleCounter("benchmark_counter");
+  const auto attributes = MakeAttributes(kNominalAttributeCount);
+  const AttributesView attributes_view(attributes);
+  const opentelemetry::context::Context context{};
+  for (auto _ : state)
+  {
+    benchmark::DoNotOptimize(counter);
+    counter->Add(1.0, attributes_view, context);
+  }
+}
+BENCHMARK(BM_Record_Counter_Sum_ByThreads)->ThreadRange(1, static_cast<int>(GetBenchmarkThreads()));
+
 void BM_Record_Counter_Sum_ByAttributes(benchmark::State &state)
 {
   BenchmarkProvider provider;
-  auto counter    = provider.meter->CreateDoubleCounter("benchmark_counter");
-  auto attributes = MakeAttributes(state.range(0));
-  AttributesView attributes_view(attributes);
-  opentelemetry::context::Context context{};
+  auto counter          = provider.meter->CreateDoubleCounter("benchmark_counter");
+  const auto attributes = MakeAttributes(state.range(0));
+  const AttributesView attributes_view(attributes);
+  const opentelemetry::context::Context context{};
   for (auto _ : state)
   {
     benchmark::DoNotOptimize(counter);
@@ -424,15 +458,10 @@ BENCHMARK(BM_Record_Counter_Sum_ByAttributes)->Arg(0)->Arg(1)->Arg(10)->Arg(128)
 void BM_Record_Counter_Sum_ByCardinality(benchmark::State &state)
 {
   BenchmarkProvider provider;
-  auto counter        = provider.meter->CreateDoubleCounter("benchmark_counter");
-  auto attribute_sets = MakeAttributeSets(state.range(0));
-  std::vector<AttributesView> attribute_views;
-  attribute_views.reserve(attribute_sets.size());
-  for (auto &kv_set : attribute_sets)
-  {
-    attribute_views.emplace_back(kv_set);
-  }
-  opentelemetry::context::Context context{};
+  auto counter              = provider.meter->CreateDoubleCounter("benchmark_counter");
+  const auto attribute_sets = MakeAttributeSets(state.range(0));
+  const std::vector<AttributesView> attribute_views(attribute_sets.begin(), attribute_sets.end());
+  const opentelemetry::context::Context context{};
   std::size_t index = 0;
   for (auto _ : state)
   {
@@ -446,62 +475,22 @@ BENCHMARK(BM_Record_Counter_Sum_ByCardinality)
     ->Arg(2000)
     ->Arg(4000);  //< Overflow cardinality limits (default limit is 2000)
 
-void BM_Record_Counter_Sum_ByThreads(benchmark::State &state)
-{
-  static BenchmarkProvider provider;
-  static auto counter = provider.meter->CreateDoubleCounter("benchmark_counter");
-  auto attribute_sets = MakeAttributeSets(kNominalCardinality);
-  std::vector<AttributesView> attribute_views;
-  attribute_views.reserve(attribute_sets.size());
-  for (auto &kv_set : attribute_sets)
-  {
-    attribute_views.emplace_back(kv_set);
-  }
-  opentelemetry::context::Context context{};
-  std::size_t index = 0;
-  for (auto _ : state)
-  {
-    benchmark::DoNotOptimize(counter);
-    counter->Add(1.0, attribute_views[index++ % attribute_views.size()], context);
-  }
-}
-BENCHMARK(BM_Record_Counter_Sum_ByThreads)->ThreadRange(1, static_cast<int>(GetBenchmarkThreads()));
-
 // ---------------------------------------------------------------------------
 // Histogram (Explicit Buckets) benchmarks
-
-static std::vector<double> MakeRecordingValues()
-{
-  thread_local std::mt19937 rng(std::random_device{}());
-  thread_local std::uniform_real_distribution<double> dist(1.0, 10000.0);
-  std::vector<double> values(1024);
-  for (auto &kv_view : values)
-  {
-    kv_view = dist(rng);
-  }
-  return values;
-}
 
 void BM_Record_Histogram_Disabled_ByThreads(benchmark::State &state)
 {
   static BenchmarkProvider provider(false);
   static auto histogram = provider.meter->CreateDoubleHistogram("benchmark_histogram");
-  auto attribute_sets   = MakeAttributeSets(kNominalCardinality);
-  std::vector<AttributesView> attribute_views;
-  attribute_views.reserve(attribute_sets.size());
-  for (auto &kv_set : attribute_sets)
-  {
-    attribute_views.emplace_back(kv_set);
-  }
-  opentelemetry::context::Context context{};
+  const auto attributes = MakeAttributes(kNominalAttributeCount);
+  const AttributesView attributes_view(attributes);
+  const opentelemetry::context::Context context{};
   const auto values = MakeRecordingValues();
   std::size_t index = 0;
   for (auto _ : state)
   {
     benchmark::DoNotOptimize(histogram);
-    const std::size_t i = index++;
-    histogram->Record(values[i % values.size()], attribute_views[i % attribute_views.size()],
-                      context);
+    histogram->Record(values[index++ % values.size()], attributes_view, context);
   }
 }
 BENCHMARK(BM_Record_Histogram_Disabled_ByThreads)
@@ -509,13 +498,16 @@ BENCHMARK(BM_Record_Histogram_Disabled_ByThreads)
 
 void BM_Record_Histogram_Drop_ByThreads(benchmark::State &state)
 {
-  BenchmarkProvider provider;
-  provider.AddView(metrics_sdk::InstrumentType::kHistogram, "benchmark_histogram",
-                   metrics_sdk::AggregationType::kDrop);
-  static auto histogram  = provider.meter->CreateDoubleHistogram("benchmark_histogram");
-  static auto attributes = MakeAttributes(kNominalAttributeCount);
-  AttributesView attributes_view(attributes);
-  opentelemetry::context::Context context{};
+  static BenchmarkProvider provider = [] {
+    BenchmarkProvider p;
+    p.AddView(metrics_sdk::InstrumentType::kHistogram, "benchmark_histogram",
+              metrics_sdk::AggregationType::kDrop);
+    return p;
+  }();
+  static auto histogram = provider.meter->CreateDoubleHistogram("benchmark_histogram");
+  const auto attributes = MakeAttributes(kNominalAttributeCount);
+  const AttributesView attributes_view(attributes);
+  const opentelemetry::context::Context context{};
   const auto values = MakeRecordingValues();
   std::size_t index = 0;
   for (auto _ : state)
@@ -527,13 +519,31 @@ void BM_Record_Histogram_Drop_ByThreads(benchmark::State &state)
 BENCHMARK(BM_Record_Histogram_Drop_ByThreads)
     ->ThreadRange(1, static_cast<int>(GetBenchmarkThreads()));
 
+void BM_Record_Histogram_Explicit_ByThreads(benchmark::State &state)
+{
+  static BenchmarkProvider provider;
+  static auto histogram = provider.meter->CreateDoubleHistogram("benchmark_histogram");
+  const auto attributes = MakeAttributes(kNominalAttributeCount);
+  const AttributesView attributes_view(attributes);
+  const opentelemetry::context::Context context{};
+  const auto values = MakeRecordingValues();
+  std::size_t index = 0;
+  for (auto _ : state)
+  {
+    benchmark::DoNotOptimize(histogram);
+    histogram->Record(values[index++ % values.size()], attributes_view, context);
+  }
+}
+BENCHMARK(BM_Record_Histogram_Explicit_ByThreads)
+    ->ThreadRange(1, static_cast<int>(GetBenchmarkThreads()));
+
 void BM_Record_Histogram_Explicit_ByAttributes(benchmark::State &state)
 {
   BenchmarkProvider provider;
-  auto histogram  = provider.meter->CreateDoubleHistogram("benchmark_histogram");
-  auto attributes = MakeAttributes(state.range(0));
-  AttributesView attributes_view(attributes);
-  opentelemetry::context::Context context{};
+  auto histogram        = provider.meter->CreateDoubleHistogram("benchmark_histogram");
+  const auto attributes = MakeAttributes(state.range(0));
+  const AttributesView attributes_view(attributes);
+  const opentelemetry::context::Context context{};
   const auto values = MakeRecordingValues();
   std::size_t index = 0;
   for (auto _ : state)
@@ -547,15 +557,10 @@ BENCHMARK(BM_Record_Histogram_Explicit_ByAttributes)->Arg(0)->Arg(1)->Arg(10)->A
 void BM_Record_Histogram_Explicit_ByCardinality(benchmark::State &state)
 {
   BenchmarkProvider provider;
-  auto histogram      = provider.meter->CreateDoubleHistogram("benchmark_histogram");
-  auto attribute_sets = MakeAttributeSets(state.range(0));
-  std::vector<AttributesView> attribute_views;
-  attribute_views.reserve(attribute_sets.size());
-  for (auto &kv_set : attribute_sets)
-  {
-    attribute_views.emplace_back(kv_set);
-  }
-  opentelemetry::context::Context context{};
+  auto histogram            = provider.meter->CreateDoubleHistogram("benchmark_histogram");
+  const auto attribute_sets = MakeAttributeSets(state.range(0));
+  const std::vector<AttributesView> attribute_views(attribute_sets.begin(), attribute_sets.end());
+  const opentelemetry::context::Context context{};
   const auto values = MakeRecordingValues();
   std::size_t index = 0;
   for (auto _ : state)
@@ -568,33 +573,31 @@ void BM_Record_Histogram_Explicit_ByCardinality(benchmark::State &state)
 }
 BENCHMARK(BM_Record_Histogram_Explicit_ByCardinality)->Arg(10)->Arg(500)->Arg(2000);
 
-void BM_Record_Histogram_Explicit_ByThreads(benchmark::State &state)
+// ---------------------------------------------------------------------------
+// Histogram (Base2ExponentialHistogram) benchmarks
+
+void BM_Record_Histogram_Base2Expo_ByThreads(benchmark::State &state)
 {
-  static BenchmarkProvider provider;
+  static auto provider = []() -> BenchmarkProvider {
+    BenchmarkProvider p;
+    p.AddView(metrics_sdk::InstrumentType::kHistogram, "benchmark_histogram",
+              metrics_sdk::AggregationType::kBase2ExponentialHistogram);
+    return p;
+  }();
   static auto histogram = provider.meter->CreateDoubleHistogram("benchmark_histogram");
-  auto attribute_sets   = MakeAttributeSets(kNominalCardinality);
-  std::vector<AttributesView> attribute_views;
-  attribute_views.reserve(attribute_sets.size());
-  for (auto &kv_set : attribute_sets)
-  {
-    attribute_views.emplace_back(kv_set);
-  }
-  opentelemetry::context::Context context{};
+  const auto attributes = MakeAttributes(kNominalAttributeCount);
+  const AttributesView attributes_view(attributes);
+  const opentelemetry::context::Context context{};
   const auto values = MakeRecordingValues();
   std::size_t index = 0;
   for (auto _ : state)
   {
     benchmark::DoNotOptimize(histogram);
-    const std::size_t i = index++;
-    histogram->Record(values[i % values.size()], attribute_views[i % attribute_views.size()],
-                      context);
+    histogram->Record(values[index++ % values.size()], attributes_view, context);
   }
 }
-BENCHMARK(BM_Record_Histogram_Explicit_ByThreads)
+BENCHMARK(BM_Record_Histogram_Base2Expo_ByThreads)
     ->ThreadRange(1, static_cast<int>(GetBenchmarkThreads()));
-
-// ---------------------------------------------------------------------------
-// Histogram (Base2ExponentialHistogram) benchmarks
 
 void BM_Record_Histogram_Base2Expo_ByAttributes(benchmark::State &state)
 {
@@ -603,8 +606,8 @@ void BM_Record_Histogram_Base2Expo_ByAttributes(benchmark::State &state)
                    metrics_sdk::AggregationType::kBase2ExponentialHistogram);
   auto histogram  = provider.meter->CreateDoubleHistogram("benchmark_histogram");
   auto attributes = MakeAttributes(state.range(0));
-  AttributesView attributes_view(attributes);
-  opentelemetry::context::Context context{};
+  const AttributesView attributes_view(attributes);
+  const opentelemetry::context::Context context{};
   const auto values = MakeRecordingValues();
   std::size_t index = 0;
   for (auto _ : state)
@@ -622,13 +625,8 @@ void BM_Record_Histogram_Base2Expo_ByCardinality(benchmark::State &state)
                    metrics_sdk::AggregationType::kBase2ExponentialHistogram);
   auto histogram      = provider.meter->CreateDoubleHistogram("benchmark_histogram");
   auto attribute_sets = MakeAttributeSets(state.range(0));
-  std::vector<AttributesView> attribute_views;
-  attribute_views.reserve(attribute_sets.size());
-  for (auto &kv_set : attribute_sets)
-  {
-    attribute_views.emplace_back(kv_set);
-  }
-  opentelemetry::context::Context context{};
+  const std::vector<AttributesView> attribute_views(attribute_sets.begin(), attribute_sets.end());
+  const opentelemetry::context::Context context{};
   const auto values = MakeRecordingValues();
   std::size_t index = 0;
   for (auto _ : state)
@@ -641,36 +639,6 @@ void BM_Record_Histogram_Base2Expo_ByCardinality(benchmark::State &state)
 }
 BENCHMARK(BM_Record_Histogram_Base2Expo_ByCardinality)->Arg(10)->Arg(500)->Arg(2000);
 
-void BM_Record_Histogram_Base2Expo_ByThreads(benchmark::State &state)
-{
-  static auto provider = []() -> BenchmarkProvider {
-    BenchmarkProvider p;
-    p.AddView(metrics_sdk::InstrumentType::kHistogram, "benchmark_histogram",
-              metrics_sdk::AggregationType::kBase2ExponentialHistogram);
-    return p;
-  }();
-  static auto histogram = provider.meter->CreateDoubleHistogram("benchmark_histogram");
-  auto attribute_sets   = MakeAttributeSets(kNominalCardinality);
-  std::vector<AttributesView> attribute_views;
-  attribute_views.reserve(attribute_sets.size());
-  for (auto &kv_set : attribute_sets)
-  {
-    attribute_views.emplace_back(kv_set);
-  }
-  opentelemetry::context::Context context{};
-  const auto values = MakeRecordingValues();
-  std::size_t index = 0;
-  for (auto _ : state)
-  {
-    benchmark::DoNotOptimize(histogram);
-    const std::size_t i = index++;
-    histogram->Record(values[i % values.size()], attribute_views[i % attribute_views.size()],
-                      context);
-  }
-}
-BENCHMARK(BM_Record_Histogram_Base2Expo_ByThreads)
-    ->ThreadRange(1, static_cast<int>(GetBenchmarkThreads()));
-
 // ---------------------------------------------------------------------------
 // Gauge (LastValue) benchmarks
 
@@ -679,20 +647,16 @@ BENCHMARK(BM_Record_Histogram_Base2Expo_ByThreads)
 void BM_Record_Gauge_Disabled_ByThreads(benchmark::State &state)
 {
   static BenchmarkProvider provider(false);
-  static auto gauge   = provider.meter->CreateDoubleGauge("benchmark_gauge");
-  auto attribute_sets = MakeAttributeSets(kNominalCardinality);
-  std::vector<AttributesView> attribute_views;
-  attribute_views.reserve(attribute_sets.size());
-  for (auto &kv_set : attribute_sets)
-  {
-    attribute_views.emplace_back(kv_set);
-  }
-  opentelemetry::context::Context context{};
+  static auto gauge = provider.meter->CreateDoubleGauge("benchmark_gauge");
+  auto attributes   = MakeAttributes(kNominalAttributeCount);
+  const AttributesView attributes_view(attributes);
+  const auto values = MakeRecordingValues();
+  const opentelemetry::context::Context context{};
   std::size_t index = 0;
   for (auto _ : state)
   {
     benchmark::DoNotOptimize(gauge);
-    gauge->Record(1.0, attribute_views[index++ % attribute_views.size()], context);
+    gauge->Record(values[index++ % values.size()], attributes_view, context);
   }
 }
 BENCHMARK(BM_Record_Gauge_Disabled_ByThreads)
@@ -708,27 +672,49 @@ void BM_Record_Gauge_Drop_ByThreads(benchmark::State &state)
   }();
   static auto gauge = provider.meter->CreateDoubleGauge("benchmark_gauge");
   auto attributes   = MakeAttributes(kNominalAttributeCount);
-  AttributesView attributes_view(attributes);
-  opentelemetry::context::Context context{};
+  const AttributesView attributes_view(attributes);
+  const auto values = MakeRecordingValues();
+  const opentelemetry::context::Context context{};
+  std::size_t index = 0;
   for (auto _ : state)
   {
     benchmark::DoNotOptimize(gauge);
-    gauge->Record(1.0, attributes_view, context);
+    gauge->Record(values[index++ % values.size()], attributes_view, context);
   }
 }
 BENCHMARK(BM_Record_Gauge_Drop_ByThreads)->ThreadRange(1, static_cast<int>(GetBenchmarkThreads()));
+
+void BM_Record_Gauge_LastValue_ByThreads(benchmark::State &state)
+{
+  static BenchmarkProvider provider;
+  static auto gauge = provider.meter->CreateDoubleGauge("benchmark_gauge");
+  auto attributes   = MakeAttributes(kNominalAttributeCount);
+  const AttributesView attributes_view(attributes);
+  const auto values = MakeRecordingValues();
+  const opentelemetry::context::Context context{};
+  std::size_t index = 0;
+  for (auto _ : state)
+  {
+    benchmark::DoNotOptimize(gauge);
+    gauge->Record(values[index++ % values.size()], attributes_view, context);
+  }
+}
+BENCHMARK(BM_Record_Gauge_LastValue_ByThreads)
+    ->ThreadRange(1, static_cast<int>(GetBenchmarkThreads()));
 
 void BM_Record_Gauge_LastValue_ByAttributes(benchmark::State &state)
 {
   BenchmarkProvider provider;
   auto gauge      = provider.meter->CreateDoubleGauge("benchmark_gauge");
   auto attributes = MakeAttributes(state.range(0));
-  AttributesView attributes_view(attributes);
-  opentelemetry::context::Context context{};
+  const AttributesView attributes_view(attributes);
+  const opentelemetry::context::Context context{};
+  const auto values = MakeRecordingValues();
+  std::size_t index = 0;
   for (auto _ : state)
   {
     benchmark::DoNotOptimize(gauge);
-    gauge->Record(1.0, attributes_view, context);
+    gauge->Record(values[index++ % values.size()], attributes_view, context);
   }
 }
 BENCHMARK(BM_Record_Gauge_LastValue_ByAttributes)->Arg(0)->Arg(1)->Arg(10)->Arg(128);
@@ -736,45 +722,20 @@ BENCHMARK(BM_Record_Gauge_LastValue_ByAttributes)->Arg(0)->Arg(1)->Arg(10)->Arg(
 void BM_Record_Gauge_LastValue_ByCardinality(benchmark::State &state)
 {
   BenchmarkProvider provider;
-  auto gauge          = provider.meter->CreateDoubleGauge("benchmark_gauge");
-  auto attribute_sets = MakeAttributeSets(state.range(0));
-  std::vector<AttributesView> attribute_views;
-  attribute_views.reserve(attribute_sets.size());
-  for (auto &kv_set : attribute_sets)
-  {
-    attribute_views.emplace_back(kv_set);
-  }
-  opentelemetry::context::Context context{};
+  auto gauge                = provider.meter->CreateDoubleGauge("benchmark_gauge");
+  const auto attribute_sets = MakeAttributeSets(state.range(0));
+  const std::vector<AttributesView> attribute_views(attribute_sets.begin(), attribute_sets.end());
+  const auto values = MakeRecordingValues();
+  const opentelemetry::context::Context context{};
   std::size_t index = 0;
   for (auto _ : state)
   {
     benchmark::DoNotOptimize(gauge);
-    gauge->Record(1.0, attribute_views[index++ % attribute_views.size()], context);
+    const std::size_t i = index++;
+    gauge->Record(values[i % values.size()], attribute_views[i % attribute_views.size()], context);
   }
 }
 BENCHMARK(BM_Record_Gauge_LastValue_ByCardinality)->Arg(10)->Arg(500)->Arg(2000);
-
-void BM_Record_Gauge_LastValue_ByThreads(benchmark::State &state)
-{
-  static BenchmarkProvider provider;
-  static auto gauge   = provider.meter->CreateDoubleGauge("benchmark_gauge");
-  auto attribute_sets = MakeAttributeSets(kNominalCardinality);
-  std::vector<AttributesView> attribute_views;
-  attribute_views.reserve(attribute_sets.size());
-  for (auto &kv_set : attribute_sets)
-  {
-    attribute_views.emplace_back(kv_set);
-  }
-  opentelemetry::context::Context context{};
-  std::size_t index = 0;
-  for (auto _ : state)
-  {
-    benchmark::DoNotOptimize(gauge);
-    gauge->Record(1.0, attribute_views[index++ % attribute_views.size()], context);
-  }
-}
-BENCHMARK(BM_Record_Gauge_LastValue_ByThreads)
-    ->ThreadRange(1, static_cast<int>(GetBenchmarkThreads()));
 
 #endif  // OPENTELEMETRY_ABI_VERSION_NO > 1
 
@@ -816,7 +777,7 @@ void BM_Record_Counter_Sum_Exemplar_AlwaysOff(benchmark::State &state)
   auto counter                  = provider.meter->CreateDoubleCounter("benchmark_counter");
   const AttributeMap attributes = MakeAttributes(kNominalAttributeCount);
   const AttributesView attributes_view(attributes);
-  auto context =
+  const auto context =
       MakeContext(opentelemetry::trace::TraceFlags{opentelemetry::trace::TraceFlags::kIsSampled});
   for (auto _ : state)
   {
@@ -833,7 +794,7 @@ void BM_Record_Counter_Sum_Exemplar_AlwaysOn(benchmark::State &state)
   auto counter                  = provider.meter->CreateDoubleCounter("benchmark_counter");
   const AttributeMap attributes = MakeAttributes(kNominalAttributeCount);
   const AttributesView attributes_view(attributes);
-  auto context =
+  const auto context =
       MakeContext(opentelemetry::trace::TraceFlags{opentelemetry::trace::TraceFlags::kIsSampled});
   for (auto _ : state)
   {
@@ -850,7 +811,7 @@ void BM_Record_Counter_Sum_Exemplar_TraceBased_EmptyContext(benchmark::State &st
   auto counter                  = provider.meter->CreateDoubleCounter("benchmark_counter");
   const AttributeMap attributes = MakeAttributes(kNominalAttributeCount);
   const AttributesView attributes_view(attributes);
-  opentelemetry::context::Context context{};
+  const opentelemetry::context::Context context{};
   for (auto _ : state)
   {
     benchmark::DoNotOptimize(counter);
@@ -866,7 +827,7 @@ void BM_Record_Counter_Sum_Exemplar_TraceBased_UnsampledContext(benchmark::State
   auto counter                  = provider.meter->CreateDoubleCounter("benchmark_counter");
   const AttributeMap attributes = MakeAttributes(kNominalAttributeCount);
   const AttributesView attributes_view(attributes);
-  auto context = MakeContext(opentelemetry::trace::TraceFlags{});
+  const auto context = MakeContext(opentelemetry::trace::TraceFlags{});
   for (auto _ : state)
   {
     benchmark::DoNotOptimize(counter);
@@ -882,7 +843,7 @@ void BM_Record_Counter_Sum_Exemplar_TraceBased_SampledContext(benchmark::State &
   auto counter                  = provider.meter->CreateDoubleCounter("benchmark_counter");
   const AttributeMap attributes = MakeAttributes(kNominalAttributeCount);
   const AttributesView attributes_view(attributes);
-  auto context =
+  const auto context =
       MakeContext(opentelemetry::trace::TraceFlags{opentelemetry::trace::TraceFlags::kIsSampled});
   for (auto _ : state)
   {
@@ -899,7 +860,7 @@ void BM_Record_Histogram_Explicit_Exemplar_AlwaysOff(benchmark::State &state)
   auto histogram                = provider.meter->CreateDoubleHistogram("benchmark_histogram");
   const AttributeMap attributes = MakeAttributes(kNominalAttributeCount);
   const AttributesView attributes_view(attributes);
-  auto context =
+  const auto context =
       MakeContext(opentelemetry::trace::TraceFlags{opentelemetry::trace::TraceFlags::kIsSampled});
   const auto values = MakeRecordingValues();
   std::size_t index = 0;
@@ -918,7 +879,7 @@ void BM_Record_Histogram_Explicit_Exemplar_AlwaysOn(benchmark::State &state)
   auto histogram                = provider.meter->CreateDoubleHistogram("benchmark_histogram");
   const AttributeMap attributes = MakeAttributes(kNominalAttributeCount);
   const AttributesView attributes_view(attributes);
-  auto context =
+  const auto context =
       MakeContext(opentelemetry::trace::TraceFlags{opentelemetry::trace::TraceFlags::kIsSampled});
   const auto values = MakeRecordingValues();
   std::size_t index = 0;
@@ -939,7 +900,7 @@ void BM_Record_Histogram_Base2Expo_Exemplar_AlwaysOff(benchmark::State &state)
   auto histogram                = provider.meter->CreateDoubleHistogram("benchmark_histogram");
   const AttributeMap attributes = MakeAttributes(kNominalAttributeCount);
   const AttributesView attributes_view(attributes);
-  auto context =
+  const auto context =
       MakeContext(opentelemetry::trace::TraceFlags{opentelemetry::trace::TraceFlags::kIsSampled});
   const auto values = MakeRecordingValues();
   std::size_t index = 0;
@@ -960,7 +921,7 @@ void BM_Record_Histogram_Base2Expo_Exemplar_AlwaysOn(benchmark::State &state)
   auto histogram                = provider.meter->CreateDoubleHistogram("benchmark_histogram");
   const AttributeMap attributes = MakeAttributes(kNominalAttributeCount);
   const AttributesView attributes_view(attributes);
-  auto context =
+  const auto context =
       MakeContext(opentelemetry::trace::TraceFlags{opentelemetry::trace::TraceFlags::kIsSampled});
   const auto values = MakeRecordingValues();
   std::size_t index = 0;

--- a/sdk/test/metrics/sync_instruments_benchmark.cc
+++ b/sdk/test/metrics/sync_instruments_benchmark.cc
@@ -174,13 +174,17 @@
 #include "opentelemetry/nostd/span.h"
 #include "opentelemetry/nostd/string_view.h"
 #include "opentelemetry/nostd/utility.h"
+#include "opentelemetry/sdk/instrumentationscope/scope_configurator.h"
 #include "opentelemetry/sdk/metrics/aggregation/aggregation_config.h"
 #include "opentelemetry/sdk/metrics/instruments.h"
+#include "opentelemetry/sdk/metrics/meter_config.h"
 #include "opentelemetry/sdk/metrics/meter_provider.h"
 #include "opentelemetry/sdk/metrics/metric_reader.h"
 #include "opentelemetry/sdk/metrics/view/instrument_selector.h"
 #include "opentelemetry/sdk/metrics/view/meter_selector.h"
 #include "opentelemetry/sdk/metrics/view/view.h"
+#include "opentelemetry/sdk/metrics/view/view_registry.h"
+#include "opentelemetry/sdk/resource/resource.h"
 #include "opentelemetry/trace/span_id.h"
 #include "opentelemetry/trace/trace_flags.h"
 #include "opentelemetry/trace/trace_id.h"
@@ -192,7 +196,9 @@
 #  include "opentelemetry/trace/span_context.h"
 #endif
 
-namespace metrics_sdk = opentelemetry::sdk::metrics;
+namespace metrics_sdk  = opentelemetry::sdk::metrics;
+namespace resource_sdk = opentelemetry::sdk::resource;
+namespace scope_sdk    = opentelemetry::sdk::instrumentationscope;
 
 namespace
 {
@@ -268,9 +274,21 @@ struct BenchmarkProvider
   std::shared_ptr<metrics_sdk::MeterProvider> sdk_meter_provider;
   opentelemetry::nostd::shared_ptr<opentelemetry::metrics::Meter> meter;
 
-  BenchmarkProvider()
+  BenchmarkProvider(bool meter_enabled = true)
   {
-    sdk_meter_provider = std::make_shared<metrics_sdk::MeterProvider>();
+    auto view_registry = std::make_unique<metrics_sdk::ViewRegistry>();
+    auto resource      = resource_sdk::Resource::Create({});
+
+    auto default_config =
+        meter_enabled ? metrics_sdk::MeterConfig::Default() : metrics_sdk::MeterConfig::Disabled();
+
+    auto meter_configurator =
+        std::make_unique<scope_sdk::ScopeConfigurator<metrics_sdk::MeterConfig>>(
+            scope_sdk::ScopeConfigurator<metrics_sdk::MeterConfig>::Builder(default_config)
+                .Build());
+
+    sdk_meter_provider = std::make_shared<metrics_sdk::MeterProvider>(
+        std::move(view_registry), resource, std::move(meter_configurator));
     sdk_meter_provider->AddMetricReader(std::make_shared<MockMetricExporter>());
 #ifdef ENABLE_METRICS_EXEMPLAR_PREVIEW
     sdk_meter_provider->SetExemplarFilter(metrics_sdk::ExemplarFilterType::kAlwaysOff);
@@ -308,21 +326,52 @@ struct BenchmarkProvider
 // ---------------------------------------------------------------------------
 // Counter benchmarks
 
-void BM_Record_Counter_Drop(benchmark::State &state)
+void BM_Record_Counter_Disabled_ByThreads(benchmark::State &state)
+{
+  // Create a meter provider that disabled meters by default
+  bool meter_enabled = false;
+  static BenchmarkProvider provider(meter_enabled);
+  static auto counter = provider.meter->CreateDoubleCounter("benchmark_counter");
+  auto attribute_sets = MakeAttributeSets(kNominalCardinality);
+  std::vector<AttributesView> attribute_views;
+  attribute_views.reserve(attribute_sets.size());
+  for (auto &kv_set : attribute_sets)
+  {
+    attribute_views.emplace_back(kv_set);
+  }
+  opentelemetry::context::Context context{};
+  for (auto &kv_view : attribute_views)
+  {
+    counter->Add(1.0, kv_view, context);
+  }
+  std::size_t index = 0;
+
+  for (auto _ : state)
+  {
+    benchmark::DoNotOptimize(counter);
+    counter->Add(1.0, attribute_views[index++ % attribute_views.size()], context);
+  }
+}
+BENCHMARK(BM_Record_Counter_Disabled_ByThreads)
+    ->ThreadRange(1, static_cast<int>(GetBenchmarkThreads()));
+
+void BM_Record_Counter_Drop_ByThreads(benchmark::State &state)
 {
   BenchmarkProvider provider;
   provider.AddView(metrics_sdk::InstrumentType::kCounter, "benchmark_counter",
                    metrics_sdk::AggregationType::kDrop);
-  auto counter    = provider.meter->CreateDoubleCounter("benchmark_counter");
-  auto attributes = MakeAttributes(kNominalAttributeCount);
+  static auto counter    = provider.meter->CreateDoubleCounter("benchmark_counter");
+  static auto attributes = MakeAttributes(kNominalAttributeCount);
   AttributesView attributes_view(attributes);
   opentelemetry::context::Context context{};
   for (auto _ : state)
   {
+    benchmark::DoNotOptimize(counter);
     counter->Add(1.0, attributes_view, context);
   }
 }
-BENCHMARK(BM_Record_Counter_Drop);
+BENCHMARK(BM_Record_Counter_Drop_ByThreads)
+    ->ThreadRange(1, static_cast<int>(GetBenchmarkThreads()));
 
 void BM_Record_Counter_Sum_ByAttributes(benchmark::State &state)
 {
@@ -333,6 +382,7 @@ void BM_Record_Counter_Sum_ByAttributes(benchmark::State &state)
   opentelemetry::context::Context context{};
   for (auto _ : state)
   {
+    benchmark::DoNotOptimize(counter);
     counter->Add(1.0, attributes_view, context);
   }
 }
@@ -350,13 +400,10 @@ void BM_Record_Counter_Sum_ByCardinality(benchmark::State &state)
     attribute_views.emplace_back(kv_set);
   }
   opentelemetry::context::Context context{};
-  for (auto &kv_view : attribute_views)
-  {
-    counter->Add(1.0, kv_view, context);
-  }
   std::size_t index = 0;
   for (auto _ : state)
   {
+    benchmark::DoNotOptimize(counter);
     counter->Add(1.0, attribute_views[index++ % attribute_views.size()], context);
   }
 }
@@ -378,13 +425,10 @@ void BM_Record_Counter_Sum_ByThreads(benchmark::State &state)
     attribute_views.emplace_back(kv_set);
   }
   opentelemetry::context::Context context{};
-  for (auto &kv_view : attribute_views)
-  {
-    counter->Add(1.0, kv_view, context);
-  }
   std::size_t index = 0;
   for (auto _ : state)
   {
+    benchmark::DoNotOptimize(counter);
     counter->Add(1.0, attribute_views[index++ % attribute_views.size()], context);
   }
 }
@@ -395,8 +439,8 @@ BENCHMARK(BM_Record_Counter_Sum_ByThreads)->ThreadRange(1, static_cast<int>(GetB
 
 static std::vector<double> MakeRecordingValues()
 {
-  static std::mt19937 rng(std::random_device{}());
-  static std::uniform_real_distribution<double> dist(1.0, 10000.0);
+  thread_local std::mt19937 rng(std::random_device{}());
+  thread_local std::uniform_real_distribution<double> dist(1.0, 10000.0);
   std::vector<double> values(1024);
   for (auto &kv_view : values)
   {
@@ -405,25 +449,52 @@ static std::vector<double> MakeRecordingValues()
   return values;
 }
 
-void BM_Record_Histogram_Drop(benchmark::State &state)
+void BM_Record_Histogram_Disabled_ByThreads(benchmark::State &state)
+{
+  static BenchmarkProvider provider(false);
+  static auto histogram = provider.meter->CreateDoubleHistogram("benchmark_histogram");
+  auto attribute_sets   = MakeAttributeSets(kNominalCardinality);
+  std::vector<AttributesView> attribute_views;
+  attribute_views.reserve(attribute_sets.size());
+  for (auto &kv_set : attribute_sets)
+  {
+    attribute_views.emplace_back(kv_set);
+  }
+  opentelemetry::context::Context context{};
+  const auto values = MakeRecordingValues();
+  std::size_t index = 0;
+  for (auto _ : state)
+  {
+    benchmark::DoNotOptimize(histogram);
+    const std::size_t i = index++;
+    histogram->Record(values[i % values.size()], attribute_views[i % attribute_views.size()],
+                      context);
+  }
+}
+BENCHMARK(BM_Record_Histogram_Disabled_ByThreads)
+    ->ThreadRange(1, static_cast<int>(GetBenchmarkThreads()));
+
+void BM_Record_Histogram_Drop_ByThreads(benchmark::State &state)
 {
   BenchmarkProvider provider;
   provider.AddView(metrics_sdk::InstrumentType::kHistogram, "benchmark_histogram",
                    metrics_sdk::AggregationType::kDrop);
-  auto histogram  = provider.meter->CreateDoubleHistogram("benchmark_histogram");
-  auto attributes = MakeAttributes(kNominalAttributeCount);
+  static auto histogram  = provider.meter->CreateDoubleHistogram("benchmark_histogram");
+  static auto attributes = MakeAttributes(kNominalAttributeCount);
   AttributesView attributes_view(attributes);
   opentelemetry::context::Context context{};
   const auto values = MakeRecordingValues();
   std::size_t index = 0;
   for (auto _ : state)
   {
+    benchmark::DoNotOptimize(histogram);
     histogram->Record(values[index++ % values.size()], attributes_view, context);
   }
 }
-BENCHMARK(BM_Record_Histogram_Drop);
+BENCHMARK(BM_Record_Histogram_Drop_ByThreads)
+    ->ThreadRange(1, static_cast<int>(GetBenchmarkThreads()));
 
-void BM_Record_Histogram_ByAttributes(benchmark::State &state)
+void BM_Record_Histogram_Explicit_ByAttributes(benchmark::State &state)
 {
   BenchmarkProvider provider;
   auto histogram  = provider.meter->CreateDoubleHistogram("benchmark_histogram");
@@ -434,12 +505,13 @@ void BM_Record_Histogram_ByAttributes(benchmark::State &state)
   std::size_t index = 0;
   for (auto _ : state)
   {
+    benchmark::DoNotOptimize(histogram);
     histogram->Record(values[index++ % values.size()], attributes_view, context);
   }
 }
-BENCHMARK(BM_Record_Histogram_ByAttributes)->Arg(0)->Arg(1)->Arg(10)->Arg(128);
+BENCHMARK(BM_Record_Histogram_Explicit_ByAttributes)->Arg(0)->Arg(1)->Arg(10)->Arg(128);
 
-void BM_Record_Histogram_ByCardinality(benchmark::State &state)
+void BM_Record_Histogram_Explicit_ByCardinality(benchmark::State &state)
 {
   BenchmarkProvider provider;
   auto histogram      = provider.meter->CreateDoubleHistogram("benchmark_histogram");
@@ -452,22 +524,18 @@ void BM_Record_Histogram_ByCardinality(benchmark::State &state)
   }
   opentelemetry::context::Context context{};
   const auto values = MakeRecordingValues();
-  std::size_t vidx  = 0;
-  for (auto &kv_view : attribute_views)
-  {
-    histogram->Record(values[vidx++ % values.size()], kv_view, context);
-  }
   std::size_t index = 0;
   for (auto _ : state)
   {
+    benchmark::DoNotOptimize(histogram);
     const std::size_t i = index++;
     histogram->Record(values[i % values.size()], attribute_views[i % attribute_views.size()],
                       context);
   }
 }
-BENCHMARK(BM_Record_Histogram_ByCardinality)->Arg(10)->Arg(500)->Arg(2000);
+BENCHMARK(BM_Record_Histogram_Explicit_ByCardinality)->Arg(10)->Arg(500)->Arg(2000);
 
-void BM_Record_Histogram_ByThreads(benchmark::State &state)
+void BM_Record_Histogram_Explicit_ByThreads(benchmark::State &state)
 {
   static BenchmarkProvider provider;
   static auto histogram = provider.meter->CreateDoubleHistogram("benchmark_histogram");
@@ -480,41 +548,20 @@ void BM_Record_Histogram_ByThreads(benchmark::State &state)
   }
   opentelemetry::context::Context context{};
   const auto values = MakeRecordingValues();
-  std::size_t vidx  = 0;
-  for (auto &kv_view : attribute_views)
-  {
-    histogram->Record(values[vidx++ % values.size()], kv_view, context);
-  }
   std::size_t index = 0;
   for (auto _ : state)
   {
+    benchmark::DoNotOptimize(histogram);
     const std::size_t i = index++;
     histogram->Record(values[i % values.size()], attribute_views[i % attribute_views.size()],
                       context);
   }
 }
-BENCHMARK(BM_Record_Histogram_ByThreads)->ThreadRange(1, static_cast<int>(GetBenchmarkThreads()));
+BENCHMARK(BM_Record_Histogram_Explicit_ByThreads)
+    ->ThreadRange(1, static_cast<int>(GetBenchmarkThreads()));
 
 // ---------------------------------------------------------------------------
 // Histogram (Base2ExponentialHistogram) benchmarks
-
-void BM_Record_Histogram_Base2Expo_Drop(benchmark::State &state)
-{
-  BenchmarkProvider provider;
-  provider.AddView(metrics_sdk::InstrumentType::kHistogram, "benchmark_histogram",
-                   metrics_sdk::AggregationType::kDrop);
-  auto histogram  = provider.meter->CreateDoubleHistogram("benchmark_histogram");
-  auto attributes = MakeAttributes(kNominalAttributeCount);
-  AttributesView attributes_view(attributes);
-  opentelemetry::context::Context context{};
-  const auto values = MakeRecordingValues();
-  std::size_t index = 0;
-  for (auto _ : state)
-  {
-    histogram->Record(values[index++ % values.size()], attributes_view, context);
-  }
-}
-BENCHMARK(BM_Record_Histogram_Base2Expo_Drop);
 
 void BM_Record_Histogram_Base2Expo_ByAttributes(benchmark::State &state)
 {
@@ -529,6 +576,7 @@ void BM_Record_Histogram_Base2Expo_ByAttributes(benchmark::State &state)
   std::size_t index = 0;
   for (auto _ : state)
   {
+    benchmark::DoNotOptimize(histogram);
     histogram->Record(values[index++ % values.size()], attributes_view, context);
   }
 }
@@ -549,14 +597,10 @@ void BM_Record_Histogram_Base2Expo_ByCardinality(benchmark::State &state)
   }
   opentelemetry::context::Context context{};
   const auto values = MakeRecordingValues();
-  std::size_t vidx  = 0;
-  for (auto &kv_view : attribute_views)
-  {
-    histogram->Record(values[vidx++ % values.size()], kv_view, context);
-  }
   std::size_t index = 0;
   for (auto _ : state)
   {
+    benchmark::DoNotOptimize(histogram);
     const std::size_t i = index++;
     histogram->Record(values[i % values.size()], attribute_views[i % attribute_views.size()],
                       context);
@@ -567,10 +611,10 @@ BENCHMARK(BM_Record_Histogram_Base2Expo_ByCardinality)->Arg(10)->Arg(500)->Arg(2
 void BM_Record_Histogram_Base2Expo_ByThreads(benchmark::State &state)
 {
   static auto provider = []() -> BenchmarkProvider {
-    BenchmarkProvider provider;
-    provider.AddView(metrics_sdk::InstrumentType::kHistogram, "benchmark_histogram",
-                     metrics_sdk::AggregationType::kBase2ExponentialHistogram);
-    return provider;
+    BenchmarkProvider p;
+    p.AddView(metrics_sdk::InstrumentType::kHistogram, "benchmark_histogram",
+              metrics_sdk::AggregationType::kBase2ExponentialHistogram);
+    return p;
   }();
   static auto histogram = provider.meter->CreateDoubleHistogram("benchmark_histogram");
   auto attribute_sets   = MakeAttributeSets(kNominalCardinality);
@@ -582,14 +626,10 @@ void BM_Record_Histogram_Base2Expo_ByThreads(benchmark::State &state)
   }
   opentelemetry::context::Context context{};
   const auto values = MakeRecordingValues();
-  std::size_t vidx  = 0;
-  for (auto &kv_view : attribute_views)
-  {
-    histogram->Record(values[vidx++ % values.size()], kv_view, context);
-  }
   std::size_t index = 0;
   for (auto _ : state)
   {
+    benchmark::DoNotOptimize(histogram);
     const std::size_t i = index++;
     histogram->Record(values[i % values.size()], attribute_views[i % attribute_views.size()],
                       context);
@@ -603,21 +643,47 @@ BENCHMARK(BM_Record_Histogram_Base2Expo_ByThreads)
 
 #if OPENTELEMETRY_ABI_VERSION_NO > 1
 
-void BM_Record_Gauge_Drop(benchmark::State &state)
+void BM_Record_Gauge_Disabled_ByThreads(benchmark::State &state)
 {
-  BenchmarkProvider provider;
-  provider.AddView(metrics_sdk::InstrumentType::kGauge, "benchmark_gauge",
-                   metrics_sdk::AggregationType::kDrop);
-  auto gauge      = provider.meter->CreateDoubleGauge("benchmark_gauge");
-  auto attributes = MakeAttributes(kNominalAttributeCount);
+  static BenchmarkProvider provider(false);
+  static auto gauge   = provider.meter->CreateDoubleGauge("benchmark_gauge");
+  auto attribute_sets = MakeAttributeSets(kNominalCardinality);
+  std::vector<AttributesView> attribute_views;
+  attribute_views.reserve(attribute_sets.size());
+  for (auto &kv_set : attribute_sets)
+  {
+    attribute_views.emplace_back(kv_set);
+  }
+  opentelemetry::context::Context context{};
+  std::size_t index = 0;
+  for (auto _ : state)
+  {
+    benchmark::DoNotOptimize(gauge);
+    gauge->Record(1.0, attribute_views[index++ % attribute_views.size()], context);
+  }
+}
+BENCHMARK(BM_Record_Gauge_Disabled_ByThreads)
+    ->ThreadRange(1, static_cast<int>(GetBenchmarkThreads()));
+
+void BM_Record_Gauge_Drop_ByThreads(benchmark::State &state)
+{
+  static BenchmarkProvider provider = []() -> BenchmarkProvider {
+    BenchmarkProvider p;
+    p.AddView(metrics_sdk::InstrumentType::kGauge, "benchmark_gauge",
+              metrics_sdk::AggregationType::kDrop);
+    return p;
+  }();
+  static auto gauge = provider.meter->CreateDoubleGauge("benchmark_gauge");
+  auto attributes   = MakeAttributes(kNominalAttributeCount);
   AttributesView attributes_view(attributes);
   opentelemetry::context::Context context{};
   for (auto _ : state)
   {
+    benchmark::DoNotOptimize(gauge);
     gauge->Record(1.0, attributes_view, context);
   }
 }
-BENCHMARK(BM_Record_Gauge_Drop);
+BENCHMARK(BM_Record_Gauge_Drop_ByThreads)->ThreadRange(1, static_cast<int>(GetBenchmarkThreads()));
 
 void BM_Record_Gauge_LastValue_ByAttributes(benchmark::State &state)
 {
@@ -628,6 +694,7 @@ void BM_Record_Gauge_LastValue_ByAttributes(benchmark::State &state)
   opentelemetry::context::Context context{};
   for (auto _ : state)
   {
+    benchmark::DoNotOptimize(gauge);
     gauge->Record(1.0, attributes_view, context);
   }
 }
@@ -645,13 +712,10 @@ void BM_Record_Gauge_LastValue_ByCardinality(benchmark::State &state)
     attribute_views.emplace_back(kv_set);
   }
   opentelemetry::context::Context context{};
-  for (auto &kv_view : attribute_views)
-  {
-    gauge->Record(1.0, kv_view, context);
-  }
   std::size_t index = 0;
   for (auto _ : state)
   {
+    benchmark::DoNotOptimize(gauge);
     gauge->Record(1.0, attribute_views[index++ % attribute_views.size()], context);
   }
 }
@@ -669,13 +733,10 @@ void BM_Record_Gauge_LastValue_ByThreads(benchmark::State &state)
     attribute_views.emplace_back(kv_set);
   }
   opentelemetry::context::Context context{};
-  for (auto &kv_view : attribute_views)
-  {
-    gauge->Record(1.0, kv_view, context);
-  }
   std::size_t index = 0;
   for (auto _ : state)
   {
+    benchmark::DoNotOptimize(gauge);
     gauge->Record(1.0, attribute_views[index++ % attribute_views.size()], context);
   }
 }
@@ -715,83 +776,7 @@ static opentelemetry::context::Context MakeContext(opentelemetry::trace::TraceFl
   return opentelemetry::trace::SetSpan(context, {span});
 }
 
-void BM_Record_Histogram_ExemplarFilter_AlwaysOff(benchmark::State &state)
-{
-  BenchmarkProvider provider;
-  provider.sdk_meter_provider->SetExemplarFilter(metrics_sdk::ExemplarFilterType::kAlwaysOff);
-  auto histogram                = provider.meter->CreateDoubleHistogram("benchmark_histogram");
-  const AttributeMap attributes = MakeAttributes(kNominalAttributeCount);
-  const AttributesView attributes_view(attributes);
-  auto context =
-      MakeContext(opentelemetry::trace::TraceFlags{opentelemetry::trace::TraceFlags::kIsSampled});
-  const auto values = MakeRecordingValues();
-  std::size_t index = 0;
-  for (auto _ : state)
-  {
-    histogram->Record(values[index++ % values.size()], attributes_view, context);
-  }
-}
-BENCHMARK(BM_Record_Histogram_ExemplarFilter_AlwaysOff);
-
-void BM_Record_Histogram_ExemplarFilter_AlwaysOn(benchmark::State &state)
-{
-  BenchmarkProvider provider;
-  provider.sdk_meter_provider->SetExemplarFilter(metrics_sdk::ExemplarFilterType::kAlwaysOn);
-  auto histogram                = provider.meter->CreateDoubleHistogram("benchmark_histogram");
-  const AttributeMap attributes = MakeAttributes(kNominalAttributeCount);
-  const AttributesView attributes_view(attributes);
-  auto context =
-      MakeContext(opentelemetry::trace::TraceFlags{opentelemetry::trace::TraceFlags::kIsSampled});
-  const auto values = MakeRecordingValues();
-  std::size_t index = 0;
-  for (auto _ : state)
-  {
-    histogram->Record(values[index++ % values.size()], attributes_view, context);
-  }
-}
-BENCHMARK(BM_Record_Histogram_ExemplarFilter_AlwaysOn);
-
-void BM_Record_Histogram_Base2Expo_ExemplarFilter_AlwaysOff(benchmark::State &state)
-{
-  BenchmarkProvider provider;
-  provider.AddView(metrics_sdk::InstrumentType::kHistogram, "benchmark_histogram",
-                   metrics_sdk::AggregationType::kBase2ExponentialHistogram);
-  provider.sdk_meter_provider->SetExemplarFilter(metrics_sdk::ExemplarFilterType::kAlwaysOff);
-  auto histogram                = provider.meter->CreateDoubleHistogram("benchmark_histogram");
-  const AttributeMap attributes = MakeAttributes(kNominalAttributeCount);
-  const AttributesView attributes_view(attributes);
-  auto context =
-      MakeContext(opentelemetry::trace::TraceFlags{opentelemetry::trace::TraceFlags::kIsSampled});
-  const auto values = MakeRecordingValues();
-  std::size_t index = 0;
-  for (auto _ : state)
-  {
-    histogram->Record(values[index++ % values.size()], attributes_view, context);
-  }
-}
-BENCHMARK(BM_Record_Histogram_Base2Expo_ExemplarFilter_AlwaysOff);
-
-void BM_Record_Histogram_Base2Expo_ExemplarFilter_AlwaysOn(benchmark::State &state)
-{
-  BenchmarkProvider provider;
-  provider.AddView(metrics_sdk::InstrumentType::kHistogram, "benchmark_histogram",
-                   metrics_sdk::AggregationType::kBase2ExponentialHistogram);
-  provider.sdk_meter_provider->SetExemplarFilter(metrics_sdk::ExemplarFilterType::kAlwaysOn);
-  auto histogram                = provider.meter->CreateDoubleHistogram("benchmark_histogram");
-  const AttributeMap attributes = MakeAttributes(kNominalAttributeCount);
-  const AttributesView attributes_view(attributes);
-  auto context =
-      MakeContext(opentelemetry::trace::TraceFlags{opentelemetry::trace::TraceFlags::kIsSampled});
-  const auto values = MakeRecordingValues();
-  std::size_t index = 0;
-  for (auto _ : state)
-  {
-    histogram->Record(values[index++ % values.size()], attributes_view, context);
-  }
-}
-BENCHMARK(BM_Record_Histogram_Base2Expo_ExemplarFilter_AlwaysOn);
-
-void BM_Record_Counter_ExemplarFilter_AlwaysOff(benchmark::State &state)
+void BM_Record_Counter_Sum_Exemplar_AlwaysOff(benchmark::State &state)
 {
   BenchmarkProvider provider;
   provider.sdk_meter_provider->SetExemplarFilter(metrics_sdk::ExemplarFilterType::kAlwaysOff);
@@ -802,12 +787,13 @@ void BM_Record_Counter_ExemplarFilter_AlwaysOff(benchmark::State &state)
       MakeContext(opentelemetry::trace::TraceFlags{opentelemetry::trace::TraceFlags::kIsSampled});
   for (auto _ : state)
   {
+    benchmark::DoNotOptimize(counter);
     counter->Add(1.0, attributes_view, context);
   }
 }
-BENCHMARK(BM_Record_Counter_ExemplarFilter_AlwaysOff);
+BENCHMARK(BM_Record_Counter_Sum_Exemplar_AlwaysOff);
 
-void BM_Record_Counter_ExemplarFilter_AlwaysOn(benchmark::State &state)
+void BM_Record_Counter_Sum_Exemplar_AlwaysOn(benchmark::State &state)
 {
   BenchmarkProvider provider;
   provider.sdk_meter_provider->SetExemplarFilter(metrics_sdk::ExemplarFilterType::kAlwaysOn);
@@ -818,12 +804,13 @@ void BM_Record_Counter_ExemplarFilter_AlwaysOn(benchmark::State &state)
       MakeContext(opentelemetry::trace::TraceFlags{opentelemetry::trace::TraceFlags::kIsSampled});
   for (auto _ : state)
   {
+    benchmark::DoNotOptimize(counter);
     counter->Add(1.0, attributes_view, context);
   }
 }
-BENCHMARK(BM_Record_Counter_ExemplarFilter_AlwaysOn);
+BENCHMARK(BM_Record_Counter_Sum_Exemplar_AlwaysOn);
 
-void BM_Record_Counter_ExemplarFilter_TraceBased_EmptyContext(benchmark::State &state)
+void BM_Record_Counter_Sum_Exemplar_TraceBased_EmptyContext(benchmark::State &state)
 {
   BenchmarkProvider provider;
   provider.sdk_meter_provider->SetExemplarFilter(metrics_sdk::ExemplarFilterType::kTraceBased);
@@ -833,12 +820,13 @@ void BM_Record_Counter_ExemplarFilter_TraceBased_EmptyContext(benchmark::State &
   opentelemetry::context::Context context{};
   for (auto _ : state)
   {
+    benchmark::DoNotOptimize(counter);
     counter->Add(1.0, attributes_view, context);
   }
 }
-BENCHMARK(BM_Record_Counter_ExemplarFilter_TraceBased_EmptyContext);
+BENCHMARK(BM_Record_Counter_Sum_Exemplar_TraceBased_EmptyContext);
 
-void BM_Record_Counter_ExemplarFilter_TraceBased_UnsampledContext(benchmark::State &state)
+void BM_Record_Counter_Sum_Exemplar_TraceBased_UnsampledContext(benchmark::State &state)
 {
   BenchmarkProvider provider;
   provider.sdk_meter_provider->SetExemplarFilter(metrics_sdk::ExemplarFilterType::kTraceBased);
@@ -848,12 +836,13 @@ void BM_Record_Counter_ExemplarFilter_TraceBased_UnsampledContext(benchmark::Sta
   auto context = MakeContext(opentelemetry::trace::TraceFlags{});
   for (auto _ : state)
   {
+    benchmark::DoNotOptimize(counter);
     counter->Add(1.0, attributes_view, context);
   }
 }
-BENCHMARK(BM_Record_Counter_ExemplarFilter_TraceBased_UnsampledContext);
+BENCHMARK(BM_Record_Counter_Sum_Exemplar_TraceBased_UnsampledContext);
 
-void BM_Record_Counter_ExemplarFilter_TraceBased_SampledContext(benchmark::State &state)
+void BM_Record_Counter_Sum_Exemplar_TraceBased_SampledContext(benchmark::State &state)
 {
   BenchmarkProvider provider;
   provider.sdk_meter_provider->SetExemplarFilter(metrics_sdk::ExemplarFilterType::kTraceBased);
@@ -864,10 +853,91 @@ void BM_Record_Counter_ExemplarFilter_TraceBased_SampledContext(benchmark::State
       MakeContext(opentelemetry::trace::TraceFlags{opentelemetry::trace::TraceFlags::kIsSampled});
   for (auto _ : state)
   {
+    benchmark::DoNotOptimize(counter);
     counter->Add(1.0, attributes_view, context);
   }
 }
-BENCHMARK(BM_Record_Counter_ExemplarFilter_TraceBased_SampledContext);
+BENCHMARK(BM_Record_Counter_Sum_Exemplar_TraceBased_SampledContext);
+
+void BM_Record_Histogram_Explicit_Exemplar_AlwaysOff(benchmark::State &state)
+{
+  BenchmarkProvider provider;
+  provider.sdk_meter_provider->SetExemplarFilter(metrics_sdk::ExemplarFilterType::kAlwaysOff);
+  auto histogram                = provider.meter->CreateDoubleHistogram("benchmark_histogram");
+  const AttributeMap attributes = MakeAttributes(kNominalAttributeCount);
+  const AttributesView attributes_view(attributes);
+  auto context =
+      MakeContext(opentelemetry::trace::TraceFlags{opentelemetry::trace::TraceFlags::kIsSampled});
+  const auto values = MakeRecordingValues();
+  std::size_t index = 0;
+  for (auto _ : state)
+  {
+    benchmark::DoNotOptimize(histogram);
+    histogram->Record(values[index++ % values.size()], attributes_view, context);
+  }
+}
+BENCHMARK(BM_Record_Histogram_Explicit_Exemplar_AlwaysOff);
+
+void BM_Record_Histogram_Explicit_Exemplar_AlwaysOn(benchmark::State &state)
+{
+  BenchmarkProvider provider;
+  provider.sdk_meter_provider->SetExemplarFilter(metrics_sdk::ExemplarFilterType::kAlwaysOn);
+  auto histogram                = provider.meter->CreateDoubleHistogram("benchmark_histogram");
+  const AttributeMap attributes = MakeAttributes(kNominalAttributeCount);
+  const AttributesView attributes_view(attributes);
+  auto context =
+      MakeContext(opentelemetry::trace::TraceFlags{opentelemetry::trace::TraceFlags::kIsSampled});
+  const auto values = MakeRecordingValues();
+  std::size_t index = 0;
+  for (auto _ : state)
+  {
+    benchmark::DoNotOptimize(histogram);
+    histogram->Record(values[index++ % values.size()], attributes_view, context);
+  }
+}
+BENCHMARK(BM_Record_Histogram_Explicit_Exemplar_AlwaysOn);
+
+void BM_Record_Histogram_Base2Expo_Exemplar_AlwaysOff(benchmark::State &state)
+{
+  BenchmarkProvider provider;
+  provider.AddView(metrics_sdk::InstrumentType::kHistogram, "benchmark_histogram",
+                   metrics_sdk::AggregationType::kBase2ExponentialHistogram);
+  provider.sdk_meter_provider->SetExemplarFilter(metrics_sdk::ExemplarFilterType::kAlwaysOff);
+  auto histogram                = provider.meter->CreateDoubleHistogram("benchmark_histogram");
+  const AttributeMap attributes = MakeAttributes(kNominalAttributeCount);
+  const AttributesView attributes_view(attributes);
+  auto context =
+      MakeContext(opentelemetry::trace::TraceFlags{opentelemetry::trace::TraceFlags::kIsSampled});
+  const auto values = MakeRecordingValues();
+  std::size_t index = 0;
+  for (auto _ : state)
+  {
+    benchmark::DoNotOptimize(histogram);
+    histogram->Record(values[index++ % values.size()], attributes_view, context);
+  }
+}
+BENCHMARK(BM_Record_Histogram_Base2Expo_Exemplar_AlwaysOff);
+
+void BM_Record_Histogram_Base2Expo_Exemplar_AlwaysOn(benchmark::State &state)
+{
+  BenchmarkProvider provider;
+  provider.AddView(metrics_sdk::InstrumentType::kHistogram, "benchmark_histogram",
+                   metrics_sdk::AggregationType::kBase2ExponentialHistogram);
+  provider.sdk_meter_provider->SetExemplarFilter(metrics_sdk::ExemplarFilterType::kAlwaysOn);
+  auto histogram                = provider.meter->CreateDoubleHistogram("benchmark_histogram");
+  const AttributeMap attributes = MakeAttributes(kNominalAttributeCount);
+  const AttributesView attributes_view(attributes);
+  auto context =
+      MakeContext(opentelemetry::trace::TraceFlags{opentelemetry::trace::TraceFlags::kIsSampled});
+  const auto values = MakeRecordingValues();
+  std::size_t index = 0;
+  for (auto _ : state)
+  {
+    benchmark::DoNotOptimize(histogram);
+    histogram->Record(values[index++ % values.size()], attributes_view, context);
+  }
+}
+BENCHMARK(BM_Record_Histogram_Base2Expo_Exemplar_AlwaysOn);
 
 #endif  // ENABLE_METRICS_EXEMPLAR_PREVIEW
 
@@ -876,69 +946,40 @@ BENCHMARK(BM_Record_Counter_ExemplarFilter_TraceBased_SampledContext);
 
 #ifdef OPENTELEMETRY_HAVE_METRICS_BOUND_INSTRUMENTS_PREVIEW
 
-void BM_Record_BoundCounter_Drop(benchmark::State &state)
+void BM_Record_BoundCounter_Disabled_ByThreads(benchmark::State &state)
 {
-  BenchmarkProvider provider;
-  provider.AddView(metrics_sdk::InstrumentType::kCounter, "counter_bound_drop",
-                   metrics_sdk::AggregationType::kDrop);
-  auto counter    = provider.meter->CreateDoubleCounter("counter_bound_drop");
-  auto attributes = MakeAttributes(kNominalAttributeCount);
-  auto bound      = counter->Bind(AttributesView(attributes));
-  benchmark::DoNotOptimize(bound.get());
+  static BenchmarkProvider provider(false);
+  static auto counter    = provider.meter->CreateDoubleCounter("counter_bound_disabled");
+  static auto attributes = MakeAttributes(kNominalAttributeCount);
+  static auto bound      = counter->Bind(AttributesView(attributes));
   for (auto _ : state)
   {
+    benchmark::DoNotOptimize(bound);
     bound->Add(1.0);
   }
 }
-BENCHMARK(BM_Record_BoundCounter_Drop);
+BENCHMARK(BM_Record_BoundCounter_Disabled_ByThreads)
+    ->ThreadRange(1, static_cast<int>(GetBenchmarkThreads()));
 
-void BM_Record_BoundCounter_Sum(benchmark::State &state)
+void BM_Record_BoundCounter_Drop_ByThreads(benchmark::State &state)
 {
-  BenchmarkProvider provider;
-  auto counter    = provider.meter->CreateDoubleCounter("counter_bound");
-  auto attributes = MakeAttributes(kNominalAttributeCount);
-  auto bound      = counter->Bind(AttributesView(attributes));
-  benchmark::DoNotOptimize(bound.get());
+  static BenchmarkProvider provider = []() -> BenchmarkProvider {
+    BenchmarkProvider p;
+    p.AddView(metrics_sdk::InstrumentType::kCounter, "counter_bound_drop",
+              metrics_sdk::AggregationType::kDrop);
+    return p;
+  }();
+  static auto counter    = provider.meter->CreateDoubleCounter("counter_bound_drop");
+  static auto attributes = MakeAttributes(kNominalAttributeCount);
+  static auto bound      = counter->Bind(AttributesView(attributes));
   for (auto _ : state)
   {
+    benchmark::DoNotOptimize(bound);
     bound->Add(1.0);
   }
 }
-BENCHMARK(BM_Record_BoundCounter_Sum);
-
-void BM_Record_BoundHistogram_Explicit(benchmark::State &state)
-{
-  BenchmarkProvider provider;
-  auto histogram  = provider.meter->CreateDoubleHistogram("histogram_bound");
-  auto attributes = MakeAttributes(kNominalAttributeCount);
-  auto bound      = histogram->Bind(AttributesView(attributes));
-  benchmark::DoNotOptimize(bound.get());
-  const auto values = MakeRecordingValues();
-  std::size_t index = 0;
-  for (auto _ : state)
-  {
-    bound->Record(values[index++ % values.size()]);
-  }
-}
-BENCHMARK(BM_Record_BoundHistogram_Explicit);
-
-void BM_Record_BoundHistogram_Base2Expo(benchmark::State &state)
-{
-  BenchmarkProvider provider;
-  provider.AddView(metrics_sdk::InstrumentType::kHistogram, "histogram_bound_expo",
-                   metrics_sdk::AggregationType::kBase2ExponentialHistogram);
-  auto histogram  = provider.meter->CreateDoubleHistogram("histogram_bound_expo");
-  auto attributes = MakeAttributes(kNominalAttributeCount);
-  auto bound      = histogram->Bind(AttributesView(attributes));
-  benchmark::DoNotOptimize(bound.get());
-  const auto values = MakeRecordingValues();
-  std::size_t index = 0;
-  for (auto _ : state)
-  {
-    bound->Record(values[index++ % values.size()]);
-  }
-}
-BENCHMARK(BM_Record_BoundHistogram_Base2Expo);
+BENCHMARK(BM_Record_BoundCounter_Drop_ByThreads)
+    ->ThreadRange(1, static_cast<int>(GetBenchmarkThreads()));
 
 void BM_Record_BoundCounter_Sum_ByThreads(benchmark::State &state)
 {
@@ -948,10 +989,50 @@ void BM_Record_BoundCounter_Sum_ByThreads(benchmark::State &state)
   static auto bound      = counter->Bind(AttributesView(attributes));
   for (auto _ : state)
   {
+    benchmark::DoNotOptimize(bound);
     bound->Add(1.0);
   }
 }
 BENCHMARK(BM_Record_BoundCounter_Sum_ByThreads)
+    ->ThreadRange(1, static_cast<int>(GetBenchmarkThreads()));
+
+void BM_Record_BoundHistogram_Disabled_ByThreads(benchmark::State &state)
+{
+  static BenchmarkProvider provider(false);
+  static auto histogram  = provider.meter->CreateDoubleHistogram("histogram_bound_disabled");
+  static auto attributes = MakeAttributes(kNominalAttributeCount);
+  static auto bound      = histogram->Bind(AttributesView(attributes));
+  const auto values      = MakeRecordingValues();
+  std::size_t index      = 0;
+  for (auto _ : state)
+  {
+    benchmark::DoNotOptimize(bound);
+    bound->Record(values[index++ % values.size()]);
+  }
+}
+BENCHMARK(BM_Record_BoundHistogram_Disabled_ByThreads)
+    ->ThreadRange(1, static_cast<int>(GetBenchmarkThreads()));
+
+void BM_Record_BoundHistogram_Drop_ByThreads(benchmark::State &state)
+{
+  static BenchmarkProvider provider = []() -> BenchmarkProvider {
+    BenchmarkProvider p;
+    p.AddView(metrics_sdk::InstrumentType::kHistogram, "histogram_bound_drop",
+              metrics_sdk::AggregationType::kDrop);
+    return p;
+  }();
+  static auto histogram  = provider.meter->CreateDoubleHistogram("histogram_bound_drop");
+  static auto attributes = MakeAttributes(kNominalAttributeCount);
+  static auto bound      = histogram->Bind(AttributesView(attributes));
+  const auto values      = MakeRecordingValues();
+  std::size_t index      = 0;
+  for (auto _ : state)
+  {
+    benchmark::DoNotOptimize(bound);
+    bound->Record(values[index++ % values.size()]);
+  }
+}
+BENCHMARK(BM_Record_BoundHistogram_Drop_ByThreads)
     ->ThreadRange(1, static_cast<int>(GetBenchmarkThreads()));
 
 void BM_Record_BoundHistogram_Explicit_ByThreads(benchmark::State &state)
@@ -964,6 +1045,7 @@ void BM_Record_BoundHistogram_Explicit_ByThreads(benchmark::State &state)
   std::size_t index      = 0;
   for (auto _ : state)
   {
+    benchmark::DoNotOptimize(bound);
     bound->Record(values[index++ % values.size()]);
   }
 }
@@ -973,10 +1055,10 @@ BENCHMARK(BM_Record_BoundHistogram_Explicit_ByThreads)
 void BM_Record_BoundHistogram_Base2Expo_ByThreads(benchmark::State &state)
 {
   static auto provider = []() -> BenchmarkProvider {
-    BenchmarkProvider provider;
-    provider.AddView(metrics_sdk::InstrumentType::kHistogram, "histogram_bound_expo_shared",
-                     metrics_sdk::AggregationType::kBase2ExponentialHistogram);
-    return provider;
+    BenchmarkProvider p;
+    p.AddView(metrics_sdk::InstrumentType::kHistogram, "histogram_bound_expo_shared",
+              metrics_sdk::AggregationType::kBase2ExponentialHistogram);
+    return p;
   }();
   static auto histogram  = provider.meter->CreateDoubleHistogram("histogram_bound_expo_shared");
   static auto attributes = MakeAttributes(kNominalAttributeCount);
@@ -985,6 +1067,7 @@ void BM_Record_BoundHistogram_Base2Expo_ByThreads(benchmark::State &state)
   std::size_t index      = 0;
   for (auto _ : state)
   {
+    benchmark::DoNotOptimize(bound);
     bound->Record(values[index++ % values.size()]);
   }
 }

--- a/sdk/test/metrics/sync_instruments_benchmark.cc
+++ b/sdk/test/metrics/sync_instruments_benchmark.cc
@@ -158,7 +158,6 @@
 #include <benchmark/benchmark.h>
 
 #include <chrono>
-#include <cstdint>
 #include <cstdlib>
 #include <map>
 #include <random>
@@ -171,7 +170,6 @@
 #include "opentelemetry/metrics/meter.h"
 #include "opentelemetry/metrics/sync_instruments.h"
 #include "opentelemetry/nostd/shared_ptr.h"
-#include "opentelemetry/nostd/span.h"
 #include "opentelemetry/nostd/string_view.h"
 #include "opentelemetry/nostd/utility.h"
 #include "opentelemetry/sdk/instrumentationscope/scope_configurator.h"
@@ -185,15 +183,19 @@
 #include "opentelemetry/sdk/metrics/view/view.h"
 #include "opentelemetry/sdk/metrics/view/view_registry.h"
 #include "opentelemetry/sdk/resource/resource.h"
-#include "opentelemetry/trace/span_id.h"
-#include "opentelemetry/trace/trace_flags.h"
-#include "opentelemetry/trace/trace_id.h"
+
+#include "opentelemetry/version.h"  // IWYU pragma: keep
 
 #ifdef ENABLE_METRICS_EXEMPLAR_PREVIEW
+#  include <cstdint>
+#  include "opentelemetry/nostd/span.h"
 #  include "opentelemetry/sdk/metrics/exemplar/filter_type.h"
 #  include "opentelemetry/trace/context.h"
 #  include "opentelemetry/trace/default_span.h"
 #  include "opentelemetry/trace/span_context.h"
+#  include "opentelemetry/trace/span_id.h"
+#  include "opentelemetry/trace/trace_flags.h"
+#  include "opentelemetry/trace/trace_id.h"
 #endif
 
 namespace metrics_sdk  = opentelemetry::sdk::metrics;

--- a/sdk/test/metrics/sync_instruments_benchmark.cc
+++ b/sdk/test/metrics/sync_instruments_benchmark.cc
@@ -8,71 +8,8 @@
 //    ENABLE_METRICS_EXEMPLAR_PREVIEW = ON
 //    OPENTELEMETRY_HAVE_METRICS_BOUND_INSTRUMENTS_PREVIEW = OFF
 // *******************************************************************************************************
-// ~/build/sdk/test/metrics/sync_instruments_benchmark
-// 2026-08-21T21:58:43+00:00
-// Running /home/devuser/build/sdk/test/metrics/sync_instruments_benchmark
-// Run on (32 X 800 MHz CPU s)
-// CPU Caches:
-//   L1 Data 48 KiB (x16)
-//   L1 Instruction 32 KiB (x16)
-//   L2 Unified 2048 KiB (x16)
-//   L3 Unified 36864 KiB (x1)
-// Load Average: 6.57, 7.88, 6.02
-// ***WARNING*** ASLR is enabled, the results may have unreproducible noise in them.
-// -------------------------------------------------------------------------------------------------------
-// Benchmark                                                             Time             CPU   Iterations
-// -------------------------------------------------------------------------------------------------------
-// BM_Record_Counter_Drop                                              168 ns          168 ns      3987426
-// BM_Record_Counter_Sum_ByAttributes/0                               13.4 ns         13.4 ns     50673977
-// BM_Record_Counter_Sum_ByAttributes/1                               59.1 ns         59.0 ns     11648365
-// BM_Record_Counter_Sum_ByAttributes/10                               601 ns          600 ns      1152340
-// BM_Record_Counter_Sum_ByAttributes/128                            12258 ns        12257 ns        54263
-// BM_Record_Counter_Sum_ByCardinality/10                              162 ns          162 ns      4166286
-// BM_Record_Counter_Sum_ByCardinality/500                             170 ns          170 ns      3989939
-// BM_Record_Counter_Sum_ByCardinality/2000                            173 ns          173 ns      3909146
-// BM_Record_Counter_Sum_ByCardinality/4000                            184 ns          184 ns      3747914
-// BM_Record_Counter_Sum_ByThreads/threads:1                           162 ns          162 ns      4211788
-// BM_Record_Counter_Sum_ByThreads/threads:2                           278 ns          278 ns      2294024
-// BM_Record_Counter_Sum_ByThreads/threads:4                           645 ns          591 ns      1224916
-// BM_Record_Histogram_Drop                                            168 ns          168 ns      4079689
-// BM_Record_Histogram_ByAttributes/0                                 24.1 ns         24.1 ns     28174246
-// BM_Record_Histogram_ByAttributes/1                                 68.4 ns         68.4 ns      9872132
-// BM_Record_Histogram_ByAttributes/10                                 624 ns          624 ns      1101566
-// BM_Record_Histogram_ByAttributes/128                              10144 ns        10143 ns        54976
-// BM_Record_Histogram_ByCardinality/10                                171 ns          171 ns      4011809
-// BM_Record_Histogram_ByCardinality/500                               183 ns          183 ns      3616072
-// BM_Record_Histogram_ByCardinality/2000                              184 ns          184 ns      3634659
-// BM_Record_Histogram_ByThreads/threads:1                             177 ns          177 ns      3928635
-// BM_Record_Histogram_ByThreads/threads:2                             413 ns          412 ns      1611338
-// BM_Record_Histogram_ByThreads/threads:4                             899 ns          796 ns       879956
-// BM_Record_Histogram_Base2Expo_Drop                                  167 ns          167 ns      4089631
-// BM_Record_Histogram_Base2Expo_ByAttributes/0                       30.5 ns         30.5 ns     26291186
-// BM_Record_Histogram_Base2Expo_ByAttributes/1                       72.0 ns         72.0 ns      9186116
-// BM_Record_Histogram_Base2Expo_ByAttributes/10                       628 ns          628 ns      1106815
-// BM_Record_Histogram_Base2Expo_ByAttributes/128                    11121 ns        11119 ns        60648
-// BM_Record_Histogram_Base2Expo_ByCardinality/10                      179 ns          179 ns      3966895
-// BM_Record_Histogram_Base2Expo_ByCardinality/500                     192 ns          192 ns      3622430
-// BM_Record_Histogram_Base2Expo_ByCardinality/2000                    191 ns          191 ns      3494182
-// BM_Record_Histogram_Base2Expo_ByThreads/threads:1                   177 ns          177 ns      3928414
-// BM_Record_Histogram_Base2Expo_ByThreads/threads:2                   379 ns          378 ns      1500150
-// BM_Record_Histogram_Base2Expo_ByThreads/threads:4                   928 ns          811 ns       872660
-// BM_Record_Histogram_ExemplarFilter_AlwaysOff                        180 ns          180 ns      3828794
-// BM_Record_Histogram_ExemplarFilter_AlwaysOn                         316 ns          316 ns      2151816
-// BM_Record_Histogram_Base2Expo_ExemplarFilter_AlwaysOff              183 ns          183 ns      3808523
-// BM_Record_Histogram_Base2Expo_ExemplarFilter_AlwaysOn               318 ns          318 ns      2167809
-// BM_Record_Counter_ExemplarFilter_AlwaysOff                          170 ns          170 ns      4071325
-// BM_Record_Counter_ExemplarFilter_AlwaysOn                           317 ns          317 ns      2208892
-// BM_Record_Counter_ExemplarFilter_TraceBased_EmptyContext            178 ns          178 ns      3914168
-// BM_Record_Counter_ExemplarFilter_TraceBased_UnsampledContext        183 ns          183 ns      3775693
-// BM_Record_Counter_ExemplarFilter_TraceBased_SampledContext          319 ns          319 ns      2185685
-//
-// *******************************************************************************************************
-// ABIv2 with preview options
-//    ENABLE_METRICS_EXEMPLAR_PREVIEW = ON
-//    OPENTELEMETRY_HAVE_METRICS_BOUND_INSTRUMENTS_PREVIEW = ON
-// *******************************************************************************************************
-// ~/build/sdk/test/metrics/sync_instruments_benchmark
-// 2026-08-21T21:53:56+00:00
+//  ~/build/sdk/test/metrics/sync_instruments_benchmark
+// 2026-08-22T18:29:21+00:00
 // Running /home/devuser/build/sdk/test/metrics/sync_instruments_benchmark
 // Run on (32 X 5700 MHz CPU s)
 // CPU Caches:
@@ -80,78 +17,172 @@
 //   L1 Instruction 32 KiB (x16)
 //   L2 Unified 2048 KiB (x16)
 //   L3 Unified 36864 KiB (x1)
-// Load Average: 3.47, 7.54, 5.41
+// Load Average: 0.31, 1.59, 6.96
 // ***WARNING*** ASLR is enabled, the results may have unreproducible noise in them.
-// -------------------------------------------------------------------------------------------------------
-// Benchmark                                                             Time             CPU   Iterations
-// -------------------------------------------------------------------------------------------------------
-// BM_Record_Counter_Drop                                              272 ns          272 ns      2524674
-// BM_Record_Counter_Sum_ByAttributes/0                               21.4 ns         21.4 ns     32408512
-// BM_Record_Counter_Sum_ByAttributes/1                                101 ns          101 ns      6689829
-// BM_Record_Counter_Sum_ByAttributes/10                               946 ns          946 ns       721512
-// BM_Record_Counter_Sum_ByAttributes/128                            14831 ns        14828 ns        48382
-// BM_Record_Counter_Sum_ByCardinality/10                              263 ns          263 ns      2642020
-// BM_Record_Counter_Sum_ByCardinality/500                             276 ns          275 ns      2460887
-// BM_Record_Counter_Sum_ByCardinality/2000                            280 ns          280 ns      2426883
-// BM_Record_Counter_Sum_ByCardinality/4000                            267 ns          267 ns      2520303
-// BM_Record_Counter_Sum_ByThreads/threads:1                           254 ns          254 ns      2693502
-// BM_Record_Counter_Sum_ByThreads/threads:2                           629 ns          590 ns      1076912
-// BM_Record_Counter_Sum_ByThreads/threads:4                          1378 ns         1132 ns       596732
-// BM_Record_Histogram_Drop                                            272 ns          272 ns      2519934
-// BM_Record_Histogram_ByAttributes/0                                 33.2 ns         33.2 ns     21084946
-// BM_Record_Histogram_ByAttributes/1                                  109 ns          109 ns      6253275
-// BM_Record_Histogram_ByAttributes/10                                1045 ns         1045 ns       663322
-// BM_Record_Histogram_ByAttributes/128                              15644 ns        15642 ns        42846
-// BM_Record_Histogram_ByCardinality/10                                289 ns          289 ns      2468624
-// BM_Record_Histogram_ByCardinality/500                               295 ns          295 ns      2344321
-// BM_Record_Histogram_ByCardinality/2000                              322 ns          322 ns      2256514
-// BM_Record_Histogram_ByThreads/threads:1                             289 ns          289 ns      2418006
-// BM_Record_Histogram_ByThreads/threads:2                             630 ns          620 ns      1038072
-// BM_Record_Histogram_ByThreads/threads:4                            1476 ns         1182 ns       486216
-// BM_Record_Histogram_Base2Expo_Drop                                  290 ns          290 ns      2356193
-// BM_Record_Histogram_Base2Expo_ByAttributes/0                       34.0 ns         34.0 ns     21807161
-// BM_Record_Histogram_Base2Expo_ByAttributes/1                        117 ns          117 ns      5768139
-// BM_Record_Histogram_Base2Expo_ByAttributes/10                      1056 ns         1056 ns       654970
-// BM_Record_Histogram_Base2Expo_ByAttributes/128                    18454 ns        18452 ns        38375
-// BM_Record_Histogram_Base2Expo_ByCardinality/10                      283 ns          283 ns      2445878
-// BM_Record_Histogram_Base2Expo_ByCardinality/500                     314 ns          314 ns      2270390
-// BM_Record_Histogram_Base2Expo_ByCardinality/2000                    308 ns          308 ns      2261228
-// BM_Record_Histogram_Base2Expo_ByThreads/threads:1                   282 ns          282 ns      2485837
-// BM_Record_Histogram_Base2Expo_ByThreads/threads:2                   652 ns          639 ns      1047128
-// BM_Record_Histogram_Base2Expo_ByThreads/threads:4                  1635 ns         1291 ns       396896
-// BM_Record_Gauge_Drop                                                280 ns          280 ns      2488998
-// BM_Record_Gauge_LastValue_ByAttributes/0                           34.1 ns         34.1 ns     20476626
-// BM_Record_Gauge_LastValue_ByAttributes/1                            107 ns          107 ns      6383567
-// BM_Record_Gauge_LastValue_ByAttributes/10                          1019 ns         1019 ns       666139
-// BM_Record_Gauge_LastValue_ByAttributes/128                        15570 ns        15569 ns        43835
-// BM_Record_Gauge_LastValue_ByCardinality/10                          262 ns          262 ns      2633975
-// BM_Record_Gauge_LastValue_ByCardinality/500                         289 ns          289 ns      2423386
-// BM_Record_Gauge_LastValue_ByCardinality/2000                        296 ns          296 ns      2329964
-// BM_Record_Gauge_LastValue_ByThreads/threads:1                       270 ns          270 ns      2593040
-// BM_Record_Gauge_LastValue_ByThreads/threads:2                       550 ns          539 ns      1285084
-// BM_Record_Gauge_LastValue_ByThreads/threads:4                      1393 ns         1124 ns       599968
-// BM_Record_Histogram_ExemplarFilter_AlwaysOff                        288 ns          288 ns      2380934
-// BM_Record_Histogram_ExemplarFilter_AlwaysOn                         440 ns          440 ns      1540212
-// BM_Record_Histogram_Base2Expo_ExemplarFilter_AlwaysOff              298 ns          298 ns      2378637
-// BM_Record_Histogram_Base2Expo_ExemplarFilter_AlwaysOn               433 ns          433 ns      1572360
-// BM_Record_Counter_ExemplarFilter_AlwaysOff                          288 ns          288 ns      2399458
-// BM_Record_Counter_ExemplarFilter_AlwaysOn                           428 ns          428 ns      1606371
-// BM_Record_Counter_ExemplarFilter_TraceBased_EmptyContext            286 ns          286 ns      2369366
-// BM_Record_Counter_ExemplarFilter_TraceBased_UnsampledContext        294 ns          294 ns      2351982
-// BM_Record_Counter_ExemplarFilter_TraceBased_SampledContext          428 ns          428 ns      1601929
-// BM_Record_BoundCounter_Drop                                        5.61 ns         5.60 ns    120495562
-// BM_Record_BoundCounter_Sum                                         9.90 ns         9.90 ns     67730700
-// BM_Record_BoundHistogram_Explicit                                  12.0 ns         12.0 ns     56143923
-// BM_Record_BoundHistogram_Base2Expo                                 17.3 ns         17.3 ns     33561116
-// BM_Record_BoundCounter_Sum_ByThreads/threads:1                     10.3 ns         10.3 ns     67369178
-// BM_Record_BoundCounter_Sum_ByThreads/threads:2                     20.2 ns         11.4 ns     62937932
-// BM_Record_BoundCounter_Sum_ByThreads/threads:4                     74.5 ns         49.4 ns     29200628
-// BM_Record_BoundHistogram_Explicit_ByThreads/threads:1              11.4 ns         11.4 ns     58970940
-// BM_Record_BoundHistogram_Explicit_ByThreads/threads:2              23.4 ns         11.9 ns     59744092
-// BM_Record_BoundHistogram_Explicit_ByThreads/threads:4              38.6 ns         12.5 ns     51175520
-// BM_Record_BoundHistogram_Base2Expo_ByThreads/threads:1             16.7 ns         16.7 ns     41416382
-// BM_Record_BoundHistogram_Base2Expo_ByThreads/threads:2             61.8 ns         52.2 ns     20000000
-// BM_Record_BoundHistogram_Base2Expo_ByThreads/threads:4              134 ns         62.9 ns     12483604
+// -----------------------------------------------------------------------------------------------------
+// Benchmark                                                           Time             CPU   Iterations
+// -----------------------------------------------------------------------------------------------------
+// BM_Record_Counter_Disabled_ByThreads/threads:1                  0.240 ns        0.240 ns   2810278222
+// BM_Record_Counter_Disabled_ByThreads/threads:2                  0.251 ns        0.251 ns   2657675522
+// BM_Record_Counter_Disabled_ByThreads/threads:4                  0.249 ns        0.249 ns   2217318376
+// BM_Record_Counter_Drop_ByThreads/threads:1                        172 ns          172 ns      4061768
+// BM_Record_Counter_Drop_ByThreads/threads:2                        199 ns          199 ns      3502520
+// BM_Record_Counter_Drop_ByThreads/threads:4                        480 ns          451 ns      1460396
+// BM_Record_Counter_Sum_ByAttributes/0                             21.3 ns         21.3 ns     32952539
+// BM_Record_Counter_Sum_ByAttributes/1                             58.9 ns         58.9 ns     11783391
+// BM_Record_Counter_Sum_ByAttributes/10                             622 ns          621 ns      1147270
+// BM_Record_Counter_Sum_ByAttributes/128                          10463 ns        10461 ns        61934
+// BM_Record_Counter_Sum_ByCardinality/10                            167 ns          167 ns      4229155
+// BM_Record_Counter_Sum_ByCardinality/500                           182 ns          182 ns      3887130
+// BM_Record_Counter_Sum_ByCardinality/2000                          184 ns          184 ns      3895325
+// BM_Record_Counter_Sum_ByCardinality/4000                          188 ns          188 ns      3684246
+// BM_Record_Counter_Sum_ByThreads/threads:1                         165 ns          165 ns      4253673
+// BM_Record_Counter_Sum_ByThreads/threads:2                         306 ns          306 ns      2191990
+// BM_Record_Counter_Sum_ByThreads/threads:4                         776 ns          695 ns      1046688
+// BM_Record_Histogram_Disabled_ByThreads/threads:1                0.211 ns        0.211 ns   3317925441
+// BM_Record_Histogram_Disabled_ByThreads/threads:2                0.220 ns        0.220 ns   2448391836
+// BM_Record_Histogram_Disabled_ByThreads/threads:4                0.215 ns        0.215 ns   2565877976
+// BM_Record_Histogram_Drop_ByThreads/threads:1                      168 ns          168 ns      4025374
+// BM_Record_Histogram_Drop_ByThreads/threads:2                      183 ns          183 ns      3715406
+// BM_Record_Histogram_Drop_ByThreads/threads:4                      386 ns          374 ns      1466744
+// BM_Record_Histogram_Explicit_ByAttributes/0                      24.7 ns         24.7 ns     27963357
+// BM_Record_Histogram_Explicit_ByAttributes/1                      68.2 ns         68.2 ns      9980062
+// BM_Record_Histogram_Explicit_ByAttributes/10                      615 ns          615 ns      1116173
+// BM_Record_Histogram_Explicit_ByAttributes/128                   10998 ns        10996 ns        60390
+// BM_Record_Histogram_Explicit_ByCardinality/10                     172 ns          172 ns      3897194
+// BM_Record_Histogram_Explicit_ByCardinality/500                    186 ns          186 ns      3635122
+// BM_Record_Histogram_Explicit_ByCardinality/2000                   189 ns          189 ns      3714421
+// BM_Record_Histogram_Explicit_ByThreads/threads:1                  171 ns          171 ns      4044930
+// BM_Record_Histogram_Explicit_ByThreads/threads:2                  386 ns          384 ns      1623758
+// BM_Record_Histogram_Explicit_ByThreads/threads:4                  895 ns          791 ns       877804
+// BM_Record_Histogram_Base2Expo_ByAttributes/0                     30.4 ns         30.4 ns     25880391
+// BM_Record_Histogram_Base2Expo_ByAttributes/1                     70.5 ns         70.4 ns      9238204
+// BM_Record_Histogram_Base2Expo_ByAttributes/10                     634 ns          634 ns      1091161
+// BM_Record_Histogram_Base2Expo_ByAttributes/128                  11322 ns        11321 ns        59828
+// BM_Record_Histogram_Base2Expo_ByCardinality/10                    188 ns          188 ns      3823091
+// BM_Record_Histogram_Base2Expo_ByCardinality/500                   197 ns          197 ns      3442858
+// BM_Record_Histogram_Base2Expo_ByCardinality/2000                  198 ns          198 ns      3510467
+// BM_Record_Histogram_Base2Expo_ByThreads/threads:1                 187 ns          187 ns      3738470
+// BM_Record_Histogram_Base2Expo_ByThreads/threads:2                 372 ns          372 ns      1751874
+// BM_Record_Histogram_Base2Expo_ByThreads/threads:4                 846 ns          756 ns       900708
+// BM_Record_Counter_Sum_Exemplar_AlwaysOff                          172 ns          172 ns      4053919
+// BM_Record_Counter_Sum_Exemplar_AlwaysOn                           311 ns          311 ns      2222684
+// BM_Record_Counter_Sum_Exemplar_TraceBased_EmptyContext            178 ns          178 ns      3918620
+// BM_Record_Counter_Sum_Exemplar_TraceBased_UnsampledContext        181 ns          181 ns      3802845
+// BM_Record_Counter_Sum_Exemplar_TraceBased_SampledContext          323 ns          323 ns      2180391
+// BM_Record_Histogram_Explicit_Exemplar_AlwaysOff                   182 ns          182 ns      3842404
+// BM_Record_Histogram_Explicit_Exemplar_AlwaysOn                    322 ns          322 ns      2148460
+// BM_Record_Histogram_Base2Expo_Exemplar_AlwaysOff                  191 ns          191 ns      3660302
+// BM_Record_Histogram_Base2Expo_Exemplar_AlwaysOn                   326 ns          326 ns      2160708
+//
+// *******************************************************************************************************
+// ABIv2 with preview options
+//    ENABLE_METRICS_EXEMPLAR_PREVIEW = ON
+//    OPENTELEMETRY_HAVE_METRICS_BOUND_INSTRUMENTS_PREVIEW = ON
+// *******************************************************************************************************
+// ~/build/sdk/test/metrics/sync_instruments_benchmark
+// 2026-08-22T18:35:28+00:00
+// Running /home/devuser/build/sdk/test/metrics/sync_instruments_benchmark
+// Run on (32 X 5700 MHz CPU s)
+// CPU Caches:
+//   L1 Data 48 KiB (x16)
+//   L1 Instruction 32 KiB (x16)
+//   L2 Unified 2048 KiB (x16)
+//   L3 Unified 36864 KiB (x1)
+// Load Average: 1.26, 3.33, 6.24
+// ***WARNING*** ASLR is enabled, the results may have unreproducible noise in them.
+// -----------------------------------------------------------------------------------------------------
+// Benchmark                                                           Time             CPU   Iterations
+// -----------------------------------------------------------------------------------------------------
+// BM_Record_Counter_Disabled_ByThreads/threads:1                  0.244 ns        0.244 ns   2854410569
+// BM_Record_Counter_Disabled_ByThreads/threads:2                  0.246 ns        0.246 ns   2283314028
+// BM_Record_Counter_Disabled_ByThreads/threads:4                  0.259 ns        0.259 ns   2767156460
+// BM_Record_Counter_Drop_ByThreads/threads:1                        280 ns          280 ns      2500556
+// BM_Record_Counter_Drop_ByThreads/threads:2                        504 ns          502 ns      1230074
+// BM_Record_Counter_Drop_ByThreads/threads:4                       1188 ns         1005 ns       693584
+// BM_Record_Counter_Sum_ByAttributes/0                             25.9 ns         25.9 ns     26993356
+// BM_Record_Counter_Sum_ByAttributes/1                              102 ns          102 ns      6857076
+// BM_Record_Counter_Sum_ByAttributes/10                            1047 ns         1047 ns       673706
+// BM_Record_Counter_Sum_ByAttributes/128                          18473 ns        18472 ns        40446
+// BM_Record_Counter_Sum_ByCardinality/10                            264 ns          264 ns      2605094
+// BM_Record_Counter_Sum_ByCardinality/500                           283 ns          282 ns      2415468
+// BM_Record_Counter_Sum_ByCardinality/2000                          288 ns          288 ns      2405574
+// BM_Record_Counter_Sum_ByCardinality/4000                          284 ns          284 ns      2464235
+// BM_Record_Counter_Sum_ByThreads/threads:1                         267 ns          267 ns      2619454
+// BM_Record_Counter_Sum_ByThreads/threads:2                         545 ns          540 ns      1119670
+// BM_Record_Counter_Sum_ByThreads/threads:4                        1382 ns         1143 ns       600404
+// BM_Record_Histogram_Disabled_ByThreads/threads:1                0.230 ns        0.230 ns   3061468421
+// BM_Record_Histogram_Disabled_ByThreads/threads:2                0.226 ns        0.226 ns   2510237466
+// BM_Record_Histogram_Disabled_ByThreads/threads:4                0.227 ns        0.227 ns   2325233576
+// BM_Record_Histogram_Drop_ByThreads/threads:1                      282 ns          282 ns      2483406
+// BM_Record_Histogram_Drop_ByThreads/threads:2                      518 ns          513 ns      1299874
+// BM_Record_Histogram_Drop_ByThreads/threads:4                     1163 ns          986 ns       722172
+// BM_Record_Histogram_Explicit_ByAttributes/0                      34.0 ns         34.0 ns     20597805
+// BM_Record_Histogram_Explicit_ByAttributes/1                       114 ns          114 ns      6252720
+// BM_Record_Histogram_Explicit_ByAttributes/10                     1049 ns         1049 ns       678527
+// BM_Record_Histogram_Explicit_ByAttributes/128                   15747 ns        15744 ns        43593
+// BM_Record_Histogram_Explicit_ByCardinality/10                     278 ns          278 ns      2514763
+// BM_Record_Histogram_Explicit_ByCardinality/500                    309 ns          309 ns      2329567
+// BM_Record_Histogram_Explicit_ByCardinality/2000                   318 ns          318 ns      2247860
+// BM_Record_Histogram_Explicit_ByThreads/threads:1                  280 ns          280 ns      2502514
+// BM_Record_Histogram_Explicit_ByThreads/threads:2                  796 ns          701 ns       993288
+// BM_Record_Histogram_Explicit_ByThreads/threads:4                 1710 ns         1327 ns       419468
+// BM_Record_Histogram_Base2Expo_ByAttributes/0                     36.6 ns         36.6 ns     19063681
+// BM_Record_Histogram_Base2Expo_ByAttributes/1                      115 ns          115 ns      5972985
+// BM_Record_Histogram_Base2Expo_ByAttributes/10                    1040 ns         1040 ns       670899
+// BM_Record_Histogram_Base2Expo_ByAttributes/128                  16436 ns        16435 ns        39525
+// BM_Record_Histogram_Base2Expo_ByCardinality/10                    280 ns          280 ns      2450117
+// BM_Record_Histogram_Base2Expo_ByCardinality/500                   301 ns          301 ns      2191454
+// BM_Record_Histogram_Base2Expo_ByCardinality/2000                  313 ns          312 ns      2204814
+// BM_Record_Histogram_Base2Expo_ByThreads/threads:1                 282 ns          282 ns      2481630
+// BM_Record_Histogram_Base2Expo_ByThreads/threads:2                 645 ns          611 ns       887212
+// BM_Record_Histogram_Base2Expo_ByThreads/threads:4                1651 ns         1314 ns       511640
+// BM_Record_Gauge_Disabled_ByThreads/threads:1                    0.216 ns        0.216 ns   3232809477
+// BM_Record_Gauge_Disabled_ByThreads/threads:2                    0.216 ns        0.216 ns   3244371026
+// BM_Record_Gauge_Disabled_ByThreads/threads:4                    0.223 ns        0.223 ns   2298688384
+// BM_Record_Gauge_Drop_ByThreads/threads:1                          278 ns          278 ns      2532793
+// BM_Record_Gauge_Drop_ByThreads/threads:2                          517 ns          513 ns      1321788
+// BM_Record_Gauge_Drop_ByThreads/threads:4                         1245 ns         1037 ns       696352
+// BM_Record_Gauge_LastValue_ByAttributes/0                         34.9 ns         34.9 ns     19978376
+// BM_Record_Gauge_LastValue_ByAttributes/1                          108 ns          108 ns      6470010
+// BM_Record_Gauge_LastValue_ByAttributes/10                        1039 ns         1039 ns       676449
+// BM_Record_Gauge_LastValue_ByAttributes/128                      17818 ns        17815 ns        37888
+// BM_Record_Gauge_LastValue_ByCardinality/10                        271 ns          271 ns      2582416
+// BM_Record_Gauge_LastValue_ByCardinality/500                       302 ns          302 ns      2359183
+// BM_Record_Gauge_LastValue_ByCardinality/2000                      318 ns          318 ns      2295226
+// BM_Record_Gauge_LastValue_ByThreads/threads:1                     270 ns          270 ns      2573195
+// BM_Record_Gauge_LastValue_ByThreads/threads:2                     784 ns          686 ns       994984
+// BM_Record_Gauge_LastValue_ByThreads/threads:4                    1620 ns         1270 ns       413504
+// BM_Record_Counter_Sum_Exemplar_AlwaysOff                          286 ns          286 ns      2470999
+// BM_Record_Counter_Sum_Exemplar_AlwaysOn                           420 ns          420 ns      1669949
+// BM_Record_Counter_Sum_Exemplar_TraceBased_EmptyContext            290 ns          290 ns      2436719
+// BM_Record_Counter_Sum_Exemplar_TraceBased_UnsampledContext        289 ns          289 ns      2414961
+// BM_Record_Counter_Sum_Exemplar_TraceBased_SampledContext          432 ns          431 ns      1615447
+// BM_Record_Histogram_Explicit_Exemplar_AlwaysOff                   292 ns          292 ns      2407769
+// BM_Record_Histogram_Explicit_Exemplar_AlwaysOn                    435 ns          435 ns      1616356
+// BM_Record_Histogram_Base2Expo_Exemplar_AlwaysOff                  295 ns          295 ns      2347904
+// BM_Record_Histogram_Base2Expo_Exemplar_AlwaysOn                   436 ns          436 ns      1623613
+// BM_Record_BoundCounter_Disabled_ByThreads/threads:1             0.336 ns        0.336 ns   2095049975
+// BM_Record_BoundCounter_Disabled_ByThreads/threads:2             0.292 ns        0.292 ns   2104157288
+// BM_Record_BoundCounter_Disabled_ByThreads/threads:4             0.285 ns        0.285 ns   1865496864
+// BM_Record_BoundCounter_Drop_ByThreads/threads:1                  5.86 ns         5.86 ns    120410059
+// BM_Record_BoundCounter_Drop_ByThreads/threads:2                  10.5 ns         7.56 ns     69726378
+// BM_Record_BoundCounter_Drop_ByThreads/threads:4                   141 ns          131 ns      8562596
+// BM_Record_BoundCounter_Sum_ByThreads/threads:1                   10.2 ns         10.2 ns     68523190
+// BM_Record_BoundCounter_Sum_ByThreads/threads:2                   15.5 ns         10.3 ns     67745558
+// BM_Record_BoundCounter_Sum_ByThreads/threads:4                   31.3 ns         12.4 ns     45178704
+// BM_Record_BoundHistogram_Disabled_ByThreads/threads:1           0.214 ns        0.214 ns   3254335214
+// BM_Record_BoundHistogram_Disabled_ByThreads/threads:2           0.215 ns        0.215 ns   3209349632
+// BM_Record_BoundHistogram_Disabled_ByThreads/threads:4           0.228 ns        0.227 ns   2214249064
+// BM_Record_BoundHistogram_Drop_ByThreads/threads:1                6.17 ns         6.17 ns    113446830
+// BM_Record_BoundHistogram_Drop_ByThreads/threads:2                37.1 ns         35.7 ns     20000000
+// BM_Record_BoundHistogram_Drop_ByThreads/threads:4                 151 ns          149 ns     40000000
+// BM_Record_BoundHistogram_Explicit_ByThreads/threads:1            11.6 ns         11.6 ns     60184742
+// BM_Record_BoundHistogram_Explicit_ByThreads/threads:2            18.9 ns         12.8 ns     48591882
+// BM_Record_BoundHistogram_Explicit_ByThreads/threads:4             106 ns         63.9 ns     36674124
+// BM_Record_BoundHistogram_Base2Expo_ByThreads/threads:1           19.0 ns         19.0 ns     36771009
+// BM_Record_BoundHistogram_Base2Expo_ByThreads/threads:2           83.2 ns         74.1 ns     18307054
+// BM_Record_BoundHistogram_Base2Expo_ByThreads/threads:4           82.0 ns         33.1 ns     31623316
 //
 // clang-format on
 

--- a/sdk/test/metrics/sync_instruments_benchmark.cc
+++ b/sdk/test/metrics/sync_instruments_benchmark.cc
@@ -1,0 +1,998 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+// clang-format off
+//
+// *******************************************************************************************************
+// ABIv1 with preview options
+//    ENABLE_METRICS_EXEMPLAR_PREVIEW = ON
+//    OPENTELEMETRY_HAVE_METRICS_BOUND_INSTRUMENTS_PREVIEW = OFF
+// *******************************************************************************************************
+// ~/build/sdk/test/metrics/sync_instruments_benchmark
+// 2026-08-21T21:58:43+00:00
+// Running /home/devuser/build/sdk/test/metrics/sync_instruments_benchmark
+// Run on (32 X 800 MHz CPU s)
+// CPU Caches:
+//   L1 Data 48 KiB (x16)
+//   L1 Instruction 32 KiB (x16)
+//   L2 Unified 2048 KiB (x16)
+//   L3 Unified 36864 KiB (x1)
+// Load Average: 6.57, 7.88, 6.02
+// ***WARNING*** ASLR is enabled, the results may have unreproducible noise in them.
+// -------------------------------------------------------------------------------------------------------
+// Benchmark                                                             Time             CPU   Iterations
+// -------------------------------------------------------------------------------------------------------
+// BM_Record_Counter_Drop                                              168 ns          168 ns      3987426
+// BM_Record_Counter_Sum_ByAttributes/0                               13.4 ns         13.4 ns     50673977
+// BM_Record_Counter_Sum_ByAttributes/1                               59.1 ns         59.0 ns     11648365
+// BM_Record_Counter_Sum_ByAttributes/10                               601 ns          600 ns      1152340
+// BM_Record_Counter_Sum_ByAttributes/128                            12258 ns        12257 ns        54263
+// BM_Record_Counter_Sum_ByCardinality/10                              162 ns          162 ns      4166286
+// BM_Record_Counter_Sum_ByCardinality/500                             170 ns          170 ns      3989939
+// BM_Record_Counter_Sum_ByCardinality/2000                            173 ns          173 ns      3909146
+// BM_Record_Counter_Sum_ByCardinality/4000                            184 ns          184 ns      3747914
+// BM_Record_Counter_Sum_ByThreads/threads:1                           162 ns          162 ns      4211788
+// BM_Record_Counter_Sum_ByThreads/threads:2                           278 ns          278 ns      2294024
+// BM_Record_Counter_Sum_ByThreads/threads:4                           645 ns          591 ns      1224916
+// BM_Record_Histogram_Drop                                            168 ns          168 ns      4079689
+// BM_Record_Histogram_ByAttributes/0                                 24.1 ns         24.1 ns     28174246
+// BM_Record_Histogram_ByAttributes/1                                 68.4 ns         68.4 ns      9872132
+// BM_Record_Histogram_ByAttributes/10                                 624 ns          624 ns      1101566
+// BM_Record_Histogram_ByAttributes/128                              10144 ns        10143 ns        54976
+// BM_Record_Histogram_ByCardinality/10                                171 ns          171 ns      4011809
+// BM_Record_Histogram_ByCardinality/500                               183 ns          183 ns      3616072
+// BM_Record_Histogram_ByCardinality/2000                              184 ns          184 ns      3634659
+// BM_Record_Histogram_ByThreads/threads:1                             177 ns          177 ns      3928635
+// BM_Record_Histogram_ByThreads/threads:2                             413 ns          412 ns      1611338
+// BM_Record_Histogram_ByThreads/threads:4                             899 ns          796 ns       879956
+// BM_Record_Histogram_Base2Expo_Drop                                  167 ns          167 ns      4089631
+// BM_Record_Histogram_Base2Expo_ByAttributes/0                       30.5 ns         30.5 ns     26291186
+// BM_Record_Histogram_Base2Expo_ByAttributes/1                       72.0 ns         72.0 ns      9186116
+// BM_Record_Histogram_Base2Expo_ByAttributes/10                       628 ns          628 ns      1106815
+// BM_Record_Histogram_Base2Expo_ByAttributes/128                    11121 ns        11119 ns        60648
+// BM_Record_Histogram_Base2Expo_ByCardinality/10                      179 ns          179 ns      3966895
+// BM_Record_Histogram_Base2Expo_ByCardinality/500                     192 ns          192 ns      3622430
+// BM_Record_Histogram_Base2Expo_ByCardinality/2000                    191 ns          191 ns      3494182
+// BM_Record_Histogram_Base2Expo_ByThreads/threads:1                   177 ns          177 ns      3928414
+// BM_Record_Histogram_Base2Expo_ByThreads/threads:2                   379 ns          378 ns      1500150
+// BM_Record_Histogram_Base2Expo_ByThreads/threads:4                   928 ns          811 ns       872660
+// BM_Record_Histogram_ExemplarFilter_AlwaysOff                        180 ns          180 ns      3828794
+// BM_Record_Histogram_ExemplarFilter_AlwaysOn                         316 ns          316 ns      2151816
+// BM_Record_Histogram_Base2Expo_ExemplarFilter_AlwaysOff              183 ns          183 ns      3808523
+// BM_Record_Histogram_Base2Expo_ExemplarFilter_AlwaysOn               318 ns          318 ns      2167809
+// BM_Record_Counter_ExemplarFilter_AlwaysOff                          170 ns          170 ns      4071325
+// BM_Record_Counter_ExemplarFilter_AlwaysOn                           317 ns          317 ns      2208892
+// BM_Record_Counter_ExemplarFilter_TraceBased_EmptyContext            178 ns          178 ns      3914168
+// BM_Record_Counter_ExemplarFilter_TraceBased_UnsampledContext        183 ns          183 ns      3775693
+// BM_Record_Counter_ExemplarFilter_TraceBased_SampledContext          319 ns          319 ns      2185685
+//
+// *******************************************************************************************************
+// ABIv2 with preview options
+//    ENABLE_METRICS_EXEMPLAR_PREVIEW = ON
+//    OPENTELEMETRY_HAVE_METRICS_BOUND_INSTRUMENTS_PREVIEW = ON
+// *******************************************************************************************************
+// ~/build/sdk/test/metrics/sync_instruments_benchmark
+// 2026-08-21T21:53:56+00:00
+// Running /home/devuser/build/sdk/test/metrics/sync_instruments_benchmark
+// Run on (32 X 5700 MHz CPU s)
+// CPU Caches:
+//   L1 Data 48 KiB (x16)
+//   L1 Instruction 32 KiB (x16)
+//   L2 Unified 2048 KiB (x16)
+//   L3 Unified 36864 KiB (x1)
+// Load Average: 3.47, 7.54, 5.41
+// ***WARNING*** ASLR is enabled, the results may have unreproducible noise in them.
+// -------------------------------------------------------------------------------------------------------
+// Benchmark                                                             Time             CPU   Iterations
+// -------------------------------------------------------------------------------------------------------
+// BM_Record_Counter_Drop                                              272 ns          272 ns      2524674
+// BM_Record_Counter_Sum_ByAttributes/0                               21.4 ns         21.4 ns     32408512
+// BM_Record_Counter_Sum_ByAttributes/1                                101 ns          101 ns      6689829
+// BM_Record_Counter_Sum_ByAttributes/10                               946 ns          946 ns       721512
+// BM_Record_Counter_Sum_ByAttributes/128                            14831 ns        14828 ns        48382
+// BM_Record_Counter_Sum_ByCardinality/10                              263 ns          263 ns      2642020
+// BM_Record_Counter_Sum_ByCardinality/500                             276 ns          275 ns      2460887
+// BM_Record_Counter_Sum_ByCardinality/2000                            280 ns          280 ns      2426883
+// BM_Record_Counter_Sum_ByCardinality/4000                            267 ns          267 ns      2520303
+// BM_Record_Counter_Sum_ByThreads/threads:1                           254 ns          254 ns      2693502
+// BM_Record_Counter_Sum_ByThreads/threads:2                           629 ns          590 ns      1076912
+// BM_Record_Counter_Sum_ByThreads/threads:4                          1378 ns         1132 ns       596732
+// BM_Record_Histogram_Drop                                            272 ns          272 ns      2519934
+// BM_Record_Histogram_ByAttributes/0                                 33.2 ns         33.2 ns     21084946
+// BM_Record_Histogram_ByAttributes/1                                  109 ns          109 ns      6253275
+// BM_Record_Histogram_ByAttributes/10                                1045 ns         1045 ns       663322
+// BM_Record_Histogram_ByAttributes/128                              15644 ns        15642 ns        42846
+// BM_Record_Histogram_ByCardinality/10                                289 ns          289 ns      2468624
+// BM_Record_Histogram_ByCardinality/500                               295 ns          295 ns      2344321
+// BM_Record_Histogram_ByCardinality/2000                              322 ns          322 ns      2256514
+// BM_Record_Histogram_ByThreads/threads:1                             289 ns          289 ns      2418006
+// BM_Record_Histogram_ByThreads/threads:2                             630 ns          620 ns      1038072
+// BM_Record_Histogram_ByThreads/threads:4                            1476 ns         1182 ns       486216
+// BM_Record_Histogram_Base2Expo_Drop                                  290 ns          290 ns      2356193
+// BM_Record_Histogram_Base2Expo_ByAttributes/0                       34.0 ns         34.0 ns     21807161
+// BM_Record_Histogram_Base2Expo_ByAttributes/1                        117 ns          117 ns      5768139
+// BM_Record_Histogram_Base2Expo_ByAttributes/10                      1056 ns         1056 ns       654970
+// BM_Record_Histogram_Base2Expo_ByAttributes/128                    18454 ns        18452 ns        38375
+// BM_Record_Histogram_Base2Expo_ByCardinality/10                      283 ns          283 ns      2445878
+// BM_Record_Histogram_Base2Expo_ByCardinality/500                     314 ns          314 ns      2270390
+// BM_Record_Histogram_Base2Expo_ByCardinality/2000                    308 ns          308 ns      2261228
+// BM_Record_Histogram_Base2Expo_ByThreads/threads:1                   282 ns          282 ns      2485837
+// BM_Record_Histogram_Base2Expo_ByThreads/threads:2                   652 ns          639 ns      1047128
+// BM_Record_Histogram_Base2Expo_ByThreads/threads:4                  1635 ns         1291 ns       396896
+// BM_Record_Gauge_Drop                                                280 ns          280 ns      2488998
+// BM_Record_Gauge_LastValue_ByAttributes/0                           34.1 ns         34.1 ns     20476626
+// BM_Record_Gauge_LastValue_ByAttributes/1                            107 ns          107 ns      6383567
+// BM_Record_Gauge_LastValue_ByAttributes/10                          1019 ns         1019 ns       666139
+// BM_Record_Gauge_LastValue_ByAttributes/128                        15570 ns        15569 ns        43835
+// BM_Record_Gauge_LastValue_ByCardinality/10                          262 ns          262 ns      2633975
+// BM_Record_Gauge_LastValue_ByCardinality/500                         289 ns          289 ns      2423386
+// BM_Record_Gauge_LastValue_ByCardinality/2000                        296 ns          296 ns      2329964
+// BM_Record_Gauge_LastValue_ByThreads/threads:1                       270 ns          270 ns      2593040
+// BM_Record_Gauge_LastValue_ByThreads/threads:2                       550 ns          539 ns      1285084
+// BM_Record_Gauge_LastValue_ByThreads/threads:4                      1393 ns         1124 ns       599968
+// BM_Record_Histogram_ExemplarFilter_AlwaysOff                        288 ns          288 ns      2380934
+// BM_Record_Histogram_ExemplarFilter_AlwaysOn                         440 ns          440 ns      1540212
+// BM_Record_Histogram_Base2Expo_ExemplarFilter_AlwaysOff              298 ns          298 ns      2378637
+// BM_Record_Histogram_Base2Expo_ExemplarFilter_AlwaysOn               433 ns          433 ns      1572360
+// BM_Record_Counter_ExemplarFilter_AlwaysOff                          288 ns          288 ns      2399458
+// BM_Record_Counter_ExemplarFilter_AlwaysOn                           428 ns          428 ns      1606371
+// BM_Record_Counter_ExemplarFilter_TraceBased_EmptyContext            286 ns          286 ns      2369366
+// BM_Record_Counter_ExemplarFilter_TraceBased_UnsampledContext        294 ns          294 ns      2351982
+// BM_Record_Counter_ExemplarFilter_TraceBased_SampledContext          428 ns          428 ns      1601929
+// BM_Record_BoundCounter_Drop                                        5.61 ns         5.60 ns    120495562
+// BM_Record_BoundCounter_Sum                                         9.90 ns         9.90 ns     67730700
+// BM_Record_BoundHistogram_Explicit                                  12.0 ns         12.0 ns     56143923
+// BM_Record_BoundHistogram_Base2Expo                                 17.3 ns         17.3 ns     33561116
+// BM_Record_BoundCounter_Sum_ByThreads/threads:1                     10.3 ns         10.3 ns     67369178
+// BM_Record_BoundCounter_Sum_ByThreads/threads:2                     20.2 ns         11.4 ns     62937932
+// BM_Record_BoundCounter_Sum_ByThreads/threads:4                     74.5 ns         49.4 ns     29200628
+// BM_Record_BoundHistogram_Explicit_ByThreads/threads:1              11.4 ns         11.4 ns     58970940
+// BM_Record_BoundHistogram_Explicit_ByThreads/threads:2              23.4 ns         11.9 ns     59744092
+// BM_Record_BoundHistogram_Explicit_ByThreads/threads:4              38.6 ns         12.5 ns     51175520
+// BM_Record_BoundHistogram_Base2Expo_ByThreads/threads:1             16.7 ns         16.7 ns     41416382
+// BM_Record_BoundHistogram_Base2Expo_ByThreads/threads:2             61.8 ns         52.2 ns     20000000
+// BM_Record_BoundHistogram_Base2Expo_ByThreads/threads:4              134 ns         62.9 ns     12483604
+//
+// clang-format on
+
+#include <benchmark/benchmark.h>
+
+#include <chrono>
+#include <cstdint>
+#include <cstdlib>
+#include <map>
+#include <random>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "opentelemetry/common/key_value_iterable_view.h"
+#include "opentelemetry/context/context.h"
+#include "opentelemetry/metrics/meter.h"
+#include "opentelemetry/metrics/sync_instruments.h"
+#include "opentelemetry/nostd/shared_ptr.h"
+#include "opentelemetry/nostd/span.h"
+#include "opentelemetry/nostd/string_view.h"
+#include "opentelemetry/nostd/utility.h"
+#include "opentelemetry/sdk/metrics/aggregation/aggregation_config.h"
+#include "opentelemetry/sdk/metrics/instruments.h"
+#include "opentelemetry/sdk/metrics/meter_provider.h"
+#include "opentelemetry/sdk/metrics/metric_reader.h"
+#include "opentelemetry/sdk/metrics/view/instrument_selector.h"
+#include "opentelemetry/sdk/metrics/view/meter_selector.h"
+#include "opentelemetry/sdk/metrics/view/view.h"
+#include "opentelemetry/trace/span_id.h"
+#include "opentelemetry/trace/trace_flags.h"
+#include "opentelemetry/trace/trace_id.h"
+
+#ifdef ENABLE_METRICS_EXEMPLAR_PREVIEW
+#  include "opentelemetry/sdk/metrics/exemplar/filter_type.h"
+#  include "opentelemetry/trace/context.h"
+#  include "opentelemetry/trace/default_span.h"
+#  include "opentelemetry/trace/span_context.h"
+#endif
+
+namespace metrics_sdk = opentelemetry::sdk::metrics;
+
+namespace
+{
+
+// ---------------------------------------------------------------------------
+// Shared benchmark components
+
+constexpr std::size_t kNominalCardinality    = 10;
+constexpr std::size_t kNominalAttributeCount = 3;
+
+using AttributeMap   = std::map<std::string, std::string>;
+using AttributesView = opentelemetry::common::KeyValueIterableView<AttributeMap>;
+
+class MockMetricExporter : public metrics_sdk::MetricReader
+{
+public:
+  metrics_sdk::AggregationTemporality GetAggregationTemporality(
+      metrics_sdk::InstrumentType) const noexcept override
+  {
+    return metrics_sdk::AggregationTemporality::kCumulative;
+  }
+
+private:
+  bool OnForceFlush(std::chrono::microseconds) noexcept override { return true; }
+  bool OnShutDown(std::chrono::microseconds) noexcept override { return true; }
+  void OnInitialized() noexcept override {}
+};
+
+std::size_t GetBenchmarkThreads()
+{
+  const char *env = std::getenv("BENCHMARK_THREADS");
+  if (env != nullptr && env[0] != '\0')
+  {
+    int val = static_cast<int>(std::strtol(env, nullptr, 10));
+    if (val > 0)
+    {
+      return static_cast<std::size_t>(val);
+    }
+  }
+  return 4;
+}
+
+// Create a set of attributes with a given count
+static AttributeMap MakeAttributes(std::size_t count)
+{
+  AttributeMap attributes;
+  for (std::size_t i = 0; i < count; i++)
+  {
+    attributes["attr_" + std::to_string(i)] = "value_" + std::to_string(i);
+  }
+  return attributes;
+}
+
+// Create attribute sets for a given cardinality target
+static std::vector<AttributeMap> MakeAttributeSets(std::size_t cardinality)
+{
+  std::vector<AttributeMap> sets;
+  sets.reserve(cardinality);
+  for (std::size_t i = 0; i < cardinality; i++)
+  {
+    AttributeMap attrs;
+    for (std::size_t k = 0; k < kNominalAttributeCount; k++)
+    {
+      attrs["key_" + std::to_string(k)] = std::to_string(i);
+    }
+    sets.push_back(std::move(attrs));
+  }
+  return sets;
+}
+
+struct BenchmarkProvider
+{
+  std::shared_ptr<metrics_sdk::MeterProvider> sdk_meter_provider;
+  opentelemetry::nostd::shared_ptr<opentelemetry::metrics::Meter> meter;
+
+  BenchmarkProvider()
+  {
+    sdk_meter_provider = std::make_shared<metrics_sdk::MeterProvider>();
+    sdk_meter_provider->AddMetricReader(std::make_shared<MockMetricExporter>());
+#ifdef ENABLE_METRICS_EXEMPLAR_PREVIEW
+    sdk_meter_provider->SetExemplarFilter(metrics_sdk::ExemplarFilterType::kAlwaysOff);
+#endif
+    meter = sdk_meter_provider->GetMeter("benchmark_meter");
+  }
+
+  void AddView(metrics_sdk::InstrumentType type,
+               const std::string &name,
+               metrics_sdk::AggregationType aggregation_type,
+               const std::string &stream_name = "")
+  {
+    auto instrument_selector = std::make_unique<metrics_sdk::InstrumentSelector>(type, name, "");
+    auto meter_selector = std::make_unique<metrics_sdk::MeterSelector>("benchmark_meter", "", "");
+
+    std::unique_ptr<metrics_sdk::AggregationConfig> aggregation_config{nullptr};
+
+    if (aggregation_type == metrics_sdk::AggregationType::kBase2ExponentialHistogram)
+    {
+      aggregation_config =
+          std::make_unique<metrics_sdk::Base2ExponentialHistogramAggregationConfig>();
+    }
+    else if (aggregation_type == metrics_sdk::AggregationType::kHistogram)
+    {
+      aggregation_config = std::make_unique<metrics_sdk::HistogramAggregationConfig>();
+    }
+
+    auto view = std::make_unique<metrics_sdk::View>(stream_name, "", aggregation_type,
+                                                    std::move(aggregation_config));
+    sdk_meter_provider->AddView(std::move(instrument_selector), std::move(meter_selector),
+                                std::move(view));
+  }
+};
+
+// ---------------------------------------------------------------------------
+// Counter benchmarks
+
+void BM_Record_Counter_Drop(benchmark::State &state)
+{
+  BenchmarkProvider provider;
+  provider.AddView(metrics_sdk::InstrumentType::kCounter, "benchmark_counter",
+                   metrics_sdk::AggregationType::kDrop);
+  auto counter    = provider.meter->CreateDoubleCounter("benchmark_counter");
+  auto attributes = MakeAttributes(kNominalAttributeCount);
+  AttributesView attributes_view(attributes);
+  opentelemetry::context::Context context{};
+  for (auto _ : state)
+  {
+    counter->Add(1.0, attributes_view, context);
+  }
+}
+BENCHMARK(BM_Record_Counter_Drop);
+
+void BM_Record_Counter_Sum_ByAttributes(benchmark::State &state)
+{
+  BenchmarkProvider provider;
+  auto counter    = provider.meter->CreateDoubleCounter("benchmark_counter");
+  auto attributes = MakeAttributes(state.range(0));
+  AttributesView attributes_view(attributes);
+  opentelemetry::context::Context context{};
+  for (auto _ : state)
+  {
+    counter->Add(1.0, attributes_view, context);
+  }
+}
+BENCHMARK(BM_Record_Counter_Sum_ByAttributes)->Arg(0)->Arg(1)->Arg(10)->Arg(128);
+
+void BM_Record_Counter_Sum_ByCardinality(benchmark::State &state)
+{
+  BenchmarkProvider provider;
+  auto counter        = provider.meter->CreateDoubleCounter("benchmark_counter");
+  auto attribute_sets = MakeAttributeSets(state.range(0));
+  std::vector<AttributesView> attribute_views;
+  attribute_views.reserve(attribute_sets.size());
+  for (auto &kv_set : attribute_sets)
+  {
+    attribute_views.emplace_back(kv_set);
+  }
+  opentelemetry::context::Context context{};
+  for (auto &kv_view : attribute_views)
+  {
+    counter->Add(1.0, kv_view, context);
+  }
+  std::size_t index = 0;
+  for (auto _ : state)
+  {
+    counter->Add(1.0, attribute_views[index++ % attribute_views.size()], context);
+  }
+}
+BENCHMARK(BM_Record_Counter_Sum_ByCardinality)
+    ->Arg(10)
+    ->Arg(500)
+    ->Arg(2000)
+    ->Arg(4000);  //< Overflow cardinality limits (default limit is 2000)
+
+void BM_Record_Counter_Sum_ByThreads(benchmark::State &state)
+{
+  static BenchmarkProvider provider;
+  static auto counter = provider.meter->CreateDoubleCounter("benchmark_counter");
+  auto attribute_sets = MakeAttributeSets(kNominalCardinality);
+  std::vector<AttributesView> attribute_views;
+  attribute_views.reserve(attribute_sets.size());
+  for (auto &kv_set : attribute_sets)
+  {
+    attribute_views.emplace_back(kv_set);
+  }
+  opentelemetry::context::Context context{};
+  for (auto &kv_view : attribute_views)
+  {
+    counter->Add(1.0, kv_view, context);
+  }
+  std::size_t index = 0;
+  for (auto _ : state)
+  {
+    counter->Add(1.0, attribute_views[index++ % attribute_views.size()], context);
+  }
+}
+BENCHMARK(BM_Record_Counter_Sum_ByThreads)->ThreadRange(1, static_cast<int>(GetBenchmarkThreads()));
+
+// ---------------------------------------------------------------------------
+// Histogram (Explicit Buckets) benchmarks
+
+static std::vector<double> MakeRecordingValues()
+{
+  static std::mt19937 rng(std::random_device{}());
+  static std::uniform_real_distribution<double> dist(1.0, 10000.0);
+  std::vector<double> values(1024);
+  for (auto &kv_view : values)
+  {
+    kv_view = dist(rng);
+  }
+  return values;
+}
+
+void BM_Record_Histogram_Drop(benchmark::State &state)
+{
+  BenchmarkProvider provider;
+  provider.AddView(metrics_sdk::InstrumentType::kHistogram, "benchmark_histogram",
+                   metrics_sdk::AggregationType::kDrop);
+  auto histogram  = provider.meter->CreateDoubleHistogram("benchmark_histogram");
+  auto attributes = MakeAttributes(kNominalAttributeCount);
+  AttributesView attributes_view(attributes);
+  opentelemetry::context::Context context{};
+  const auto values = MakeRecordingValues();
+  std::size_t index = 0;
+  for (auto _ : state)
+  {
+    histogram->Record(values[index++ % values.size()], attributes_view, context);
+  }
+}
+BENCHMARK(BM_Record_Histogram_Drop);
+
+void BM_Record_Histogram_ByAttributes(benchmark::State &state)
+{
+  BenchmarkProvider provider;
+  auto histogram  = provider.meter->CreateDoubleHistogram("benchmark_histogram");
+  auto attributes = MakeAttributes(state.range(0));
+  AttributesView attributes_view(attributes);
+  opentelemetry::context::Context context{};
+  const auto values = MakeRecordingValues();
+  std::size_t index = 0;
+  for (auto _ : state)
+  {
+    histogram->Record(values[index++ % values.size()], attributes_view, context);
+  }
+}
+BENCHMARK(BM_Record_Histogram_ByAttributes)->Arg(0)->Arg(1)->Arg(10)->Arg(128);
+
+void BM_Record_Histogram_ByCardinality(benchmark::State &state)
+{
+  BenchmarkProvider provider;
+  auto histogram      = provider.meter->CreateDoubleHistogram("benchmark_histogram");
+  auto attribute_sets = MakeAttributeSets(state.range(0));
+  std::vector<AttributesView> attribute_views;
+  attribute_views.reserve(attribute_sets.size());
+  for (auto &kv_set : attribute_sets)
+  {
+    attribute_views.emplace_back(kv_set);
+  }
+  opentelemetry::context::Context context{};
+  const auto values = MakeRecordingValues();
+  std::size_t vidx  = 0;
+  for (auto &kv_view : attribute_views)
+  {
+    histogram->Record(values[vidx++ % values.size()], kv_view, context);
+  }
+  std::size_t index = 0;
+  for (auto _ : state)
+  {
+    const std::size_t i = index++;
+    histogram->Record(values[i % values.size()], attribute_views[i % attribute_views.size()],
+                      context);
+  }
+}
+BENCHMARK(BM_Record_Histogram_ByCardinality)->Arg(10)->Arg(500)->Arg(2000);
+
+void BM_Record_Histogram_ByThreads(benchmark::State &state)
+{
+  static BenchmarkProvider provider;
+  static auto histogram = provider.meter->CreateDoubleHistogram("benchmark_histogram");
+  auto attribute_sets   = MakeAttributeSets(kNominalCardinality);
+  std::vector<AttributesView> attribute_views;
+  attribute_views.reserve(attribute_sets.size());
+  for (auto &kv_set : attribute_sets)
+  {
+    attribute_views.emplace_back(kv_set);
+  }
+  opentelemetry::context::Context context{};
+  const auto values = MakeRecordingValues();
+  std::size_t vidx  = 0;
+  for (auto &kv_view : attribute_views)
+  {
+    histogram->Record(values[vidx++ % values.size()], kv_view, context);
+  }
+  std::size_t index = 0;
+  for (auto _ : state)
+  {
+    const std::size_t i = index++;
+    histogram->Record(values[i % values.size()], attribute_views[i % attribute_views.size()],
+                      context);
+  }
+}
+BENCHMARK(BM_Record_Histogram_ByThreads)->ThreadRange(1, static_cast<int>(GetBenchmarkThreads()));
+
+// ---------------------------------------------------------------------------
+// Histogram (Base2ExponentialHistogram) benchmarks
+
+void BM_Record_Histogram_Base2Expo_Drop(benchmark::State &state)
+{
+  BenchmarkProvider provider;
+  provider.AddView(metrics_sdk::InstrumentType::kHistogram, "benchmark_histogram",
+                   metrics_sdk::AggregationType::kDrop);
+  auto histogram  = provider.meter->CreateDoubleHistogram("benchmark_histogram");
+  auto attributes = MakeAttributes(kNominalAttributeCount);
+  AttributesView attributes_view(attributes);
+  opentelemetry::context::Context context{};
+  const auto values = MakeRecordingValues();
+  std::size_t index = 0;
+  for (auto _ : state)
+  {
+    histogram->Record(values[index++ % values.size()], attributes_view, context);
+  }
+}
+BENCHMARK(BM_Record_Histogram_Base2Expo_Drop);
+
+void BM_Record_Histogram_Base2Expo_ByAttributes(benchmark::State &state)
+{
+  BenchmarkProvider provider;
+  provider.AddView(metrics_sdk::InstrumentType::kHistogram, "benchmark_histogram",
+                   metrics_sdk::AggregationType::kBase2ExponentialHistogram);
+  auto histogram  = provider.meter->CreateDoubleHistogram("benchmark_histogram");
+  auto attributes = MakeAttributes(state.range(0));
+  AttributesView attributes_view(attributes);
+  opentelemetry::context::Context context{};
+  const auto values = MakeRecordingValues();
+  std::size_t index = 0;
+  for (auto _ : state)
+  {
+    histogram->Record(values[index++ % values.size()], attributes_view, context);
+  }
+}
+BENCHMARK(BM_Record_Histogram_Base2Expo_ByAttributes)->Arg(0)->Arg(1)->Arg(10)->Arg(128);
+
+void BM_Record_Histogram_Base2Expo_ByCardinality(benchmark::State &state)
+{
+  BenchmarkProvider provider;
+  provider.AddView(metrics_sdk::InstrumentType::kHistogram, "benchmark_histogram",
+                   metrics_sdk::AggregationType::kBase2ExponentialHistogram);
+  auto histogram      = provider.meter->CreateDoubleHistogram("benchmark_histogram");
+  auto attribute_sets = MakeAttributeSets(state.range(0));
+  std::vector<AttributesView> attribute_views;
+  attribute_views.reserve(attribute_sets.size());
+  for (auto &kv_set : attribute_sets)
+  {
+    attribute_views.emplace_back(kv_set);
+  }
+  opentelemetry::context::Context context{};
+  const auto values = MakeRecordingValues();
+  std::size_t vidx  = 0;
+  for (auto &kv_view : attribute_views)
+  {
+    histogram->Record(values[vidx++ % values.size()], kv_view, context);
+  }
+  std::size_t index = 0;
+  for (auto _ : state)
+  {
+    const std::size_t i = index++;
+    histogram->Record(values[i % values.size()], attribute_views[i % attribute_views.size()],
+                      context);
+  }
+}
+BENCHMARK(BM_Record_Histogram_Base2Expo_ByCardinality)->Arg(10)->Arg(500)->Arg(2000);
+
+void BM_Record_Histogram_Base2Expo_ByThreads(benchmark::State &state)
+{
+  static auto provider = []() -> BenchmarkProvider {
+    BenchmarkProvider provider;
+    provider.AddView(metrics_sdk::InstrumentType::kHistogram, "benchmark_histogram",
+                     metrics_sdk::AggregationType::kBase2ExponentialHistogram);
+    return provider;
+  }();
+  static auto histogram = provider.meter->CreateDoubleHistogram("benchmark_histogram");
+  auto attribute_sets   = MakeAttributeSets(kNominalCardinality);
+  std::vector<AttributesView> attribute_views;
+  attribute_views.reserve(attribute_sets.size());
+  for (auto &kv_set : attribute_sets)
+  {
+    attribute_views.emplace_back(kv_set);
+  }
+  opentelemetry::context::Context context{};
+  const auto values = MakeRecordingValues();
+  std::size_t vidx  = 0;
+  for (auto &kv_view : attribute_views)
+  {
+    histogram->Record(values[vidx++ % values.size()], kv_view, context);
+  }
+  std::size_t index = 0;
+  for (auto _ : state)
+  {
+    const std::size_t i = index++;
+    histogram->Record(values[i % values.size()], attribute_views[i % attribute_views.size()],
+                      context);
+  }
+}
+BENCHMARK(BM_Record_Histogram_Base2Expo_ByThreads)
+    ->ThreadRange(1, static_cast<int>(GetBenchmarkThreads()));
+
+// ---------------------------------------------------------------------------
+// Gauge (LastValue) benchmarks
+
+#if OPENTELEMETRY_ABI_VERSION_NO > 1
+
+void BM_Record_Gauge_Drop(benchmark::State &state)
+{
+  BenchmarkProvider provider;
+  provider.AddView(metrics_sdk::InstrumentType::kGauge, "benchmark_gauge",
+                   metrics_sdk::AggregationType::kDrop);
+  auto gauge      = provider.meter->CreateDoubleGauge("benchmark_gauge");
+  auto attributes = MakeAttributes(kNominalAttributeCount);
+  AttributesView attributes_view(attributes);
+  opentelemetry::context::Context context{};
+  for (auto _ : state)
+  {
+    gauge->Record(1.0, attributes_view, context);
+  }
+}
+BENCHMARK(BM_Record_Gauge_Drop);
+
+void BM_Record_Gauge_LastValue_ByAttributes(benchmark::State &state)
+{
+  BenchmarkProvider provider;
+  auto gauge      = provider.meter->CreateDoubleGauge("benchmark_gauge");
+  auto attributes = MakeAttributes(state.range(0));
+  AttributesView attributes_view(attributes);
+  opentelemetry::context::Context context{};
+  for (auto _ : state)
+  {
+    gauge->Record(1.0, attributes_view, context);
+  }
+}
+BENCHMARK(BM_Record_Gauge_LastValue_ByAttributes)->Arg(0)->Arg(1)->Arg(10)->Arg(128);
+
+void BM_Record_Gauge_LastValue_ByCardinality(benchmark::State &state)
+{
+  BenchmarkProvider provider;
+  auto gauge          = provider.meter->CreateDoubleGauge("benchmark_gauge");
+  auto attribute_sets = MakeAttributeSets(state.range(0));
+  std::vector<AttributesView> attribute_views;
+  attribute_views.reserve(attribute_sets.size());
+  for (auto &kv_set : attribute_sets)
+  {
+    attribute_views.emplace_back(kv_set);
+  }
+  opentelemetry::context::Context context{};
+  for (auto &kv_view : attribute_views)
+  {
+    gauge->Record(1.0, kv_view, context);
+  }
+  std::size_t index = 0;
+  for (auto _ : state)
+  {
+    gauge->Record(1.0, attribute_views[index++ % attribute_views.size()], context);
+  }
+}
+BENCHMARK(BM_Record_Gauge_LastValue_ByCardinality)->Arg(10)->Arg(500)->Arg(2000);
+
+void BM_Record_Gauge_LastValue_ByThreads(benchmark::State &state)
+{
+  static BenchmarkProvider provider;
+  static auto gauge   = provider.meter->CreateDoubleGauge("benchmark_gauge");
+  auto attribute_sets = MakeAttributeSets(kNominalCardinality);
+  std::vector<AttributesView> attribute_views;
+  attribute_views.reserve(attribute_sets.size());
+  for (auto &kv_set : attribute_sets)
+  {
+    attribute_views.emplace_back(kv_set);
+  }
+  opentelemetry::context::Context context{};
+  for (auto &kv_view : attribute_views)
+  {
+    gauge->Record(1.0, kv_view, context);
+  }
+  std::size_t index = 0;
+  for (auto _ : state)
+  {
+    gauge->Record(1.0, attribute_views[index++ % attribute_views.size()], context);
+  }
+}
+BENCHMARK(BM_Record_Gauge_LastValue_ByThreads)
+    ->ThreadRange(1, static_cast<int>(GetBenchmarkThreads()));
+
+#endif  // OPENTELEMETRY_ABI_VERSION_NO > 1
+
+// ---------------------------------------------------------------------------
+// Exemplar filter benchmarks 
+
+#ifdef ENABLE_METRICS_EXEMPLAR_PREVIEW
+
+class RecordingSpan : public opentelemetry::trace::DefaultSpan
+{
+public:
+  RecordingSpan(opentelemetry::trace::TraceFlags flags) : DefaultSpan(MakeSpanContext(flags)) {}
+  bool IsRecording() const noexcept override { return true; }
+
+private:
+  static opentelemetry::trace::SpanContext MakeSpanContext(opentelemetry::trace::TraceFlags flags)
+  {
+    static const uint8_t kTraceBytes[16] = {1};
+    static const uint8_t kSpanBytes[8]   = {1};
+    return opentelemetry::trace::SpanContext{
+        opentelemetry::trace::TraceId{
+            opentelemetry::nostd::span<const uint8_t, 16>{kTraceBytes, 16}},
+        opentelemetry::trace::SpanId{opentelemetry::nostd::span<const uint8_t, 8>{kSpanBytes, 8}},
+        flags, false};
+  }
+};
+
+static opentelemetry::context::Context MakeContext(opentelemetry::trace::TraceFlags flags)
+{
+  auto span    = std::make_shared<RecordingSpan>(flags);
+  auto context = opentelemetry::context::Context{};
+  return opentelemetry::trace::SetSpan(context, {span});
+}
+
+void BM_Record_Histogram_ExemplarFilter_AlwaysOff(benchmark::State &state)
+{
+  BenchmarkProvider provider;
+  provider.sdk_meter_provider->SetExemplarFilter(metrics_sdk::ExemplarFilterType::kAlwaysOff);
+  auto histogram                = provider.meter->CreateDoubleHistogram("benchmark_histogram");
+  const AttributeMap attributes = MakeAttributes(kNominalAttributeCount);
+  const AttributesView attributes_view(attributes);
+  auto context =
+      MakeContext(opentelemetry::trace::TraceFlags{opentelemetry::trace::TraceFlags::kIsSampled});
+  const auto values = MakeRecordingValues();
+  std::size_t index = 0;
+  for (auto _ : state)
+  {
+    histogram->Record(values[index++ % values.size()], attributes_view, context);
+  }
+}
+BENCHMARK(BM_Record_Histogram_ExemplarFilter_AlwaysOff);
+
+void BM_Record_Histogram_ExemplarFilter_AlwaysOn(benchmark::State &state)
+{
+  BenchmarkProvider provider;
+  provider.sdk_meter_provider->SetExemplarFilter(metrics_sdk::ExemplarFilterType::kAlwaysOn);
+  auto histogram                = provider.meter->CreateDoubleHistogram("benchmark_histogram");
+  const AttributeMap attributes = MakeAttributes(kNominalAttributeCount);
+  const AttributesView attributes_view(attributes);
+  auto context =
+      MakeContext(opentelemetry::trace::TraceFlags{opentelemetry::trace::TraceFlags::kIsSampled});
+  const auto values = MakeRecordingValues();
+  std::size_t index = 0;
+  for (auto _ : state)
+  {
+    histogram->Record(values[index++ % values.size()], attributes_view, context);
+  }
+}
+BENCHMARK(BM_Record_Histogram_ExemplarFilter_AlwaysOn);
+
+void BM_Record_Histogram_Base2Expo_ExemplarFilter_AlwaysOff(benchmark::State &state)
+{
+  BenchmarkProvider provider;
+  provider.AddView(metrics_sdk::InstrumentType::kHistogram, "benchmark_histogram",
+                   metrics_sdk::AggregationType::kBase2ExponentialHistogram);
+  provider.sdk_meter_provider->SetExemplarFilter(metrics_sdk::ExemplarFilterType::kAlwaysOff);
+  auto histogram                = provider.meter->CreateDoubleHistogram("benchmark_histogram");
+  const AttributeMap attributes = MakeAttributes(kNominalAttributeCount);
+  const AttributesView attributes_view(attributes);
+  auto context =
+      MakeContext(opentelemetry::trace::TraceFlags{opentelemetry::trace::TraceFlags::kIsSampled});
+  const auto values = MakeRecordingValues();
+  std::size_t index = 0;
+  for (auto _ : state)
+  {
+    histogram->Record(values[index++ % values.size()], attributes_view, context);
+  }
+}
+BENCHMARK(BM_Record_Histogram_Base2Expo_ExemplarFilter_AlwaysOff);
+
+void BM_Record_Histogram_Base2Expo_ExemplarFilter_AlwaysOn(benchmark::State &state)
+{
+  BenchmarkProvider provider;
+  provider.AddView(metrics_sdk::InstrumentType::kHistogram, "benchmark_histogram",
+                   metrics_sdk::AggregationType::kBase2ExponentialHistogram);
+  provider.sdk_meter_provider->SetExemplarFilter(metrics_sdk::ExemplarFilterType::kAlwaysOn);
+  auto histogram                = provider.meter->CreateDoubleHistogram("benchmark_histogram");
+  const AttributeMap attributes = MakeAttributes(kNominalAttributeCount);
+  const AttributesView attributes_view(attributes);
+  auto context =
+      MakeContext(opentelemetry::trace::TraceFlags{opentelemetry::trace::TraceFlags::kIsSampled});
+  const auto values = MakeRecordingValues();
+  std::size_t index = 0;
+  for (auto _ : state)
+  {
+    histogram->Record(values[index++ % values.size()], attributes_view, context);
+  }
+}
+BENCHMARK(BM_Record_Histogram_Base2Expo_ExemplarFilter_AlwaysOn);
+
+void BM_Record_Counter_ExemplarFilter_AlwaysOff(benchmark::State &state)
+{
+  BenchmarkProvider provider;
+  provider.sdk_meter_provider->SetExemplarFilter(metrics_sdk::ExemplarFilterType::kAlwaysOff);
+  auto counter                  = provider.meter->CreateDoubleCounter("benchmark_counter");
+  const AttributeMap attributes = MakeAttributes(kNominalAttributeCount);
+  const AttributesView attributes_view(attributes);
+  auto context =
+      MakeContext(opentelemetry::trace::TraceFlags{opentelemetry::trace::TraceFlags::kIsSampled});
+  for (auto _ : state)
+  {
+    counter->Add(1.0, attributes_view, context);
+  }
+}
+BENCHMARK(BM_Record_Counter_ExemplarFilter_AlwaysOff);
+
+void BM_Record_Counter_ExemplarFilter_AlwaysOn(benchmark::State &state)
+{
+  BenchmarkProvider provider;
+  provider.sdk_meter_provider->SetExemplarFilter(metrics_sdk::ExemplarFilterType::kAlwaysOn);
+  auto counter                  = provider.meter->CreateDoubleCounter("benchmark_counter");
+  const AttributeMap attributes = MakeAttributes(kNominalAttributeCount);
+  const AttributesView attributes_view(attributes);
+  auto context =
+      MakeContext(opentelemetry::trace::TraceFlags{opentelemetry::trace::TraceFlags::kIsSampled});
+  for (auto _ : state)
+  {
+    counter->Add(1.0, attributes_view, context);
+  }
+}
+BENCHMARK(BM_Record_Counter_ExemplarFilter_AlwaysOn);
+
+void BM_Record_Counter_ExemplarFilter_TraceBased_EmptyContext(benchmark::State &state)
+{
+  BenchmarkProvider provider;
+  provider.sdk_meter_provider->SetExemplarFilter(metrics_sdk::ExemplarFilterType::kTraceBased);
+  auto counter                  = provider.meter->CreateDoubleCounter("benchmark_counter");
+  const AttributeMap attributes = MakeAttributes(kNominalAttributeCount);
+  const AttributesView attributes_view(attributes);
+  opentelemetry::context::Context context{};
+  for (auto _ : state)
+  {
+    counter->Add(1.0, attributes_view, context);
+  }
+}
+BENCHMARK(BM_Record_Counter_ExemplarFilter_TraceBased_EmptyContext);
+
+void BM_Record_Counter_ExemplarFilter_TraceBased_UnsampledContext(benchmark::State &state)
+{
+  BenchmarkProvider provider;
+  provider.sdk_meter_provider->SetExemplarFilter(metrics_sdk::ExemplarFilterType::kTraceBased);
+  auto counter                  = provider.meter->CreateDoubleCounter("benchmark_counter");
+  const AttributeMap attributes = MakeAttributes(kNominalAttributeCount);
+  const AttributesView attributes_view(attributes);
+  auto context = MakeContext(opentelemetry::trace::TraceFlags{});
+  for (auto _ : state)
+  {
+    counter->Add(1.0, attributes_view, context);
+  }
+}
+BENCHMARK(BM_Record_Counter_ExemplarFilter_TraceBased_UnsampledContext);
+
+void BM_Record_Counter_ExemplarFilter_TraceBased_SampledContext(benchmark::State &state)
+{
+  BenchmarkProvider provider;
+  provider.sdk_meter_provider->SetExemplarFilter(metrics_sdk::ExemplarFilterType::kTraceBased);
+  auto counter                  = provider.meter->CreateDoubleCounter("benchmark_counter");
+  const AttributeMap attributes = MakeAttributes(kNominalAttributeCount);
+  const AttributesView attributes_view(attributes);
+  auto context =
+      MakeContext(opentelemetry::trace::TraceFlags{opentelemetry::trace::TraceFlags::kIsSampled});
+  for (auto _ : state)
+  {
+    counter->Add(1.0, attributes_view, context);
+  }
+}
+BENCHMARK(BM_Record_Counter_ExemplarFilter_TraceBased_SampledContext);
+
+#endif  // ENABLE_METRICS_EXEMPLAR_PREVIEW
+
+// ---------------------------------------------------------------------------
+// Bound instrument benchmarks
+
+#ifdef OPENTELEMETRY_HAVE_METRICS_BOUND_INSTRUMENTS_PREVIEW
+
+void BM_Record_BoundCounter_Drop(benchmark::State &state)
+{
+  BenchmarkProvider provider;
+  provider.AddView(metrics_sdk::InstrumentType::kCounter, "counter_bound_drop",
+                   metrics_sdk::AggregationType::kDrop);
+  auto counter    = provider.meter->CreateDoubleCounter("counter_bound_drop");
+  auto attributes = MakeAttributes(kNominalAttributeCount);
+  auto bound      = counter->Bind(AttributesView(attributes));
+  benchmark::DoNotOptimize(bound.get());
+  for (auto _ : state)
+  {
+    bound->Add(1.0);
+  }
+}
+BENCHMARK(BM_Record_BoundCounter_Drop);
+
+void BM_Record_BoundCounter_Sum(benchmark::State &state)
+{
+  BenchmarkProvider provider;
+  auto counter    = provider.meter->CreateDoubleCounter("counter_bound");
+  auto attributes = MakeAttributes(kNominalAttributeCount);
+  auto bound      = counter->Bind(AttributesView(attributes));
+  benchmark::DoNotOptimize(bound.get());
+  for (auto _ : state)
+  {
+    bound->Add(1.0);
+  }
+}
+BENCHMARK(BM_Record_BoundCounter_Sum);
+
+void BM_Record_BoundHistogram_Explicit(benchmark::State &state)
+{
+  BenchmarkProvider provider;
+  auto histogram  = provider.meter->CreateDoubleHistogram("histogram_bound");
+  auto attributes = MakeAttributes(kNominalAttributeCount);
+  auto bound      = histogram->Bind(AttributesView(attributes));
+  benchmark::DoNotOptimize(bound.get());
+  const auto values = MakeRecordingValues();
+  std::size_t index = 0;
+  for (auto _ : state)
+  {
+    bound->Record(values[index++ % values.size()]);
+  }
+}
+BENCHMARK(BM_Record_BoundHistogram_Explicit);
+
+void BM_Record_BoundHistogram_Base2Expo(benchmark::State &state)
+{
+  BenchmarkProvider provider;
+  provider.AddView(metrics_sdk::InstrumentType::kHistogram, "histogram_bound_expo",
+                   metrics_sdk::AggregationType::kBase2ExponentialHistogram);
+  auto histogram  = provider.meter->CreateDoubleHistogram("histogram_bound_expo");
+  auto attributes = MakeAttributes(kNominalAttributeCount);
+  auto bound      = histogram->Bind(AttributesView(attributes));
+  benchmark::DoNotOptimize(bound.get());
+  const auto values = MakeRecordingValues();
+  std::size_t index = 0;
+  for (auto _ : state)
+  {
+    bound->Record(values[index++ % values.size()]);
+  }
+}
+BENCHMARK(BM_Record_BoundHistogram_Base2Expo);
+
+void BM_Record_BoundCounter_Sum_ByThreads(benchmark::State &state)
+{
+  static BenchmarkProvider provider;
+  static auto counter    = provider.meter->CreateDoubleCounter("counter_bound_shared");
+  static auto attributes = MakeAttributes(kNominalAttributeCount);
+  static auto bound      = counter->Bind(AttributesView(attributes));
+  for (auto _ : state)
+  {
+    bound->Add(1.0);
+  }
+}
+BENCHMARK(BM_Record_BoundCounter_Sum_ByThreads)
+    ->ThreadRange(1, static_cast<int>(GetBenchmarkThreads()));
+
+void BM_Record_BoundHistogram_Explicit_ByThreads(benchmark::State &state)
+{
+  static BenchmarkProvider provider;
+  static auto histogram  = provider.meter->CreateDoubleHistogram("histogram_bound_shared");
+  static auto attributes = MakeAttributes(kNominalAttributeCount);
+  static auto bound      = histogram->Bind(AttributesView(attributes));
+  const auto values      = MakeRecordingValues();
+  std::size_t index      = 0;
+  for (auto _ : state)
+  {
+    bound->Record(values[index++ % values.size()]);
+  }
+}
+BENCHMARK(BM_Record_BoundHistogram_Explicit_ByThreads)
+    ->ThreadRange(1, static_cast<int>(GetBenchmarkThreads()));
+
+void BM_Record_BoundHistogram_Base2Expo_ByThreads(benchmark::State &state)
+{
+  static auto provider = []() -> BenchmarkProvider {
+    BenchmarkProvider provider;
+    provider.AddView(metrics_sdk::InstrumentType::kHistogram, "histogram_bound_expo_shared",
+                     metrics_sdk::AggregationType::kBase2ExponentialHistogram);
+    return provider;
+  }();
+  static auto histogram  = provider.meter->CreateDoubleHistogram("histogram_bound_expo_shared");
+  static auto attributes = MakeAttributes(kNominalAttributeCount);
+  static auto bound      = histogram->Bind(AttributesView(attributes));
+  const auto values      = MakeRecordingValues();
+  std::size_t index      = 0;
+  for (auto _ : state)
+  {
+    bound->Record(values[index++ % values.size()]);
+  }
+}
+BENCHMARK(BM_Record_BoundHistogram_Base2Expo_ByThreads)
+    ->ThreadRange(1, static_cast<int>(GetBenchmarkThreads()));
+
+#endif  // OPENTELEMETRY_HAVE_METRICS_BOUND_INSTRUMENTS_PREVIEW
+
+}  // namespace
+
+BENCHMARK_MAIN();

--- a/sdk/test/metrics/sync_instruments_benchmark.cc
+++ b/sdk/test/metrics/sync_instruments_benchmark.cc
@@ -256,7 +256,6 @@ namespace
 // ---------------------------------------------------------------------------
 // Shared benchmark components
 
-constexpr std::size_t kNominalCardinality    = 10;
 constexpr std::size_t kNominalAttributeCount = 3;
 
 using AttributeMap   = std::map<std::string, std::string>;

--- a/sdk/test/metrics/sync_instruments_benchmark.cc
+++ b/sdk/test/metrics/sync_instruments_benchmark.cc
@@ -308,7 +308,7 @@ static std::vector<double> MakeRecordingValues()
 }
 
 // Create a set of attributes with a given count
-static AttributeMap MakeAttributes(std::size_t count, std::string value = {})
+static AttributeMap MakeAttributes(std::size_t count, const std::string &value = {})
 {
   AttributeMap attributes;
   for (std::size_t i = 0; i < count; i++)

--- a/sdk/test/metrics/sync_instruments_benchmark.cc
+++ b/sdk/test/metrics/sync_instruments_benchmark.cc
@@ -685,7 +685,7 @@ BENCHMARK(BM_Record_Gauge_LastValue_ByThreads)
 #endif  // OPENTELEMETRY_ABI_VERSION_NO > 1
 
 // ---------------------------------------------------------------------------
-// Exemplar filter benchmarks 
+// Exemplar filter benchmarks
 
 #ifdef ENABLE_METRICS_EXEMPLAR_PREVIEW
 


### PR DESCRIPTION
Contributes to https://github.com/open-telemetry/opentelemetry-cpp/issues/4317 and https://github.com/open-telemetry/opentelemetry-cpp/pull/4416

Adds sync instruments recording benchmarks covering all instrument types and aggregation types. Includes Exemplar filters and bound instruments when enabled. 

## Changes
- Disabled instrument benchmarks (Counter, Histogram, Gauge, and bound variants)
- Counter benchmarks 
   - Drop aggregation
   - Sum aggregation (by attribute count, by cardinality, by thread count)
- Histogram benchmarks
   - Drop aggregation 
   - Explicit bucket and Base2 aggregation  (by attribute count, by cardinality, by thread count)
- Gauge benchmarks 
   - Drop aggregation 
   - Last value aggregation  (by attribute count, by cardinality, by thread count)
- ExemplarFilter
   - Counter with AlwaysOff, AlwaysOn, and TraceBased filters
   - Histogram (Default and Base2Expo) with AlwaysOff and AlwaysOn filters
- Bound instruments (counter and histogram)
   - Drop aggregation 
   - Sum aggregation (by thread count) 
   - Histogram (default and base2) aggregation (by thread count)   

For significant contributions please make sure you have completed the following items:

* [x] `CHANGELOG.md` updated for non-trivial changes
* [ ] Unit tests have been added
* [ ] Changes in public API reviewed