### PR TITLE
[CONFIGURATION] Support environment variable substitution for attributes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,10 @@ Increment the:
 
 * [RESOURCE DETECTOR] Add the host resource detector
   [#4413](https://github.com/open-telemetry/opentelemetry-cpp/issues/4413)
+
+* [CONFIGURATION] Support environment variable substitution for attributes
+  [#4474](https://github.com/open-telemetry/opentelemetry-cpp/pull/4474)
+
 * [RESOURCE DETECTOR] Add the service resource detector and builder
   [#4414](https://github.com/open-telemetry/opentelemetry-cpp/issues/4414)
 * [CONFIGURATION] deprecate config builder cmake components

--- a/sdk/include/opentelemetry/sdk/configuration/document_node.h
+++ b/sdk/include/opentelemetry/sdk/configuration/document_node.h
@@ -40,6 +40,7 @@ public:
   virtual std::size_t AsInteger() const = 0;
   virtual double AsDouble() const       = 0;
   virtual std::string AsString() const  = 0;
+  virtual bool IsNull() const           = 0;
 
   virtual std::unique_ptr<DocumentNode> GetRequiredChildNode(const std::string &name) const = 0;
   virtual std::unique_ptr<DocumentNode> GetChildNode(const std::string &name) const         = 0;

--- a/sdk/include/opentelemetry/sdk/configuration/ryml_document_node.h
+++ b/sdk/include/opentelemetry/sdk/configuration/ryml_document_node.h
@@ -40,6 +40,7 @@ public:
   std::size_t AsInteger() const override;
   double AsDouble() const override;
   std::string AsString() const override;
+  bool IsNull() const override;
 
   std::unique_ptr<DocumentNode> GetRequiredChildNode(const std::string &name) const override;
   std::unique_ptr<DocumentNode> GetChildNode(const std::string &name) const override;

--- a/sdk/src/configuration/configuration_parser.cc
+++ b/sdk/src/configuration/configuration_parser.cc
@@ -2477,10 +2477,13 @@ std::unique_ptr<StringAttributeValueConfiguration>
 ConfigurationParser::ParseStringAttributeValueConfiguration(
     const std::unique_ptr<DocumentNode> &node) const
 {
-  auto model = std::make_unique<StringAttributeValueConfiguration>();
-
+  auto model   = std::make_unique<StringAttributeValueConfiguration>();
   model->value = node->AsString();
-
+  // Empty string (YAML null or unset env var) is treated as null per schema nullBehavior.
+  if (model->value.empty())
+  {
+    return nullptr;
+  }
   return model;
 }
 
@@ -2613,6 +2616,21 @@ std::unique_ptr<AttributesConfiguration> ConfigurationParser::ParseAttributesCon
     std::unique_ptr<AttributeValueConfiguration> value_model;
 
     name = name_child->AsString();
+
+    // An empty name is an invalid attribute key per the OTel spec.
+    if (name.empty())
+    {
+      std::string message("Attribute name must not be empty (check for unset env var)");
+      throw InvalidSchemaException(name_child->Location(), message);
+    }
+
+    // Per schema nullBehavior: skip entries with a null value.
+    if (value_child->IsNull())
+    {
+      OTEL_INTERNAL_LOG_DEBUG("Skipping attribute '" << name << "' with null value");
+      continue;
+    }
+
     if (type_child)
     {
       type = type_child->AsString();
@@ -2667,6 +2685,14 @@ std::unique_ptr<AttributesConfiguration> ConfigurationParser::ParseAttributesCon
       std::string message("Illegal attribute type: ");
       message.append(type);
       throw InvalidSchemaException(node->Location(), message);
+    }
+
+    // Per schema nullBehavior: skip entries with a null/empty value (e.g. string from unset env
+    // var).
+    if (value_model == nullptr)
+    {
+      OTEL_INTERNAL_LOG_DEBUG("Skipping attribute '" << name << "' with null/empty value");
+      continue;
     }
 
     std::pair<std::string, std::unique_ptr<AttributeValueConfiguration>> entry(

--- a/sdk/src/configuration/ryml_document_node.cc
+++ b/sdk/src/configuration/ryml_document_node.cc
@@ -80,6 +80,7 @@ bool RymlDocumentNode::AsBoolean() const
   }
   ryml::csubstr view = node_.val();
   std::string value(view.str, view.len);
+  value = DoSubstitution(value);
   return BooleanFromString(value);
 }
 
@@ -93,6 +94,7 @@ size_t RymlDocumentNode::AsInteger() const
   }
   ryml::csubstr view = node_.val();
   std::string value(view.str, view.len);
+  value = DoSubstitution(value);
   return IntegerFromString(value);
 }
 
@@ -106,6 +108,7 @@ double RymlDocumentNode::AsDouble() const
   }
   ryml::csubstr view = node_.val();
   std::string value(view.str, view.len);
+  value = DoSubstitution(value);
   return DoubleFromString(value);
 }
 
@@ -119,7 +122,19 @@ std::string RymlDocumentNode::AsString() const
   }
   ryml::csubstr view = node_.val();
   std::string value(view.str, view.len);
+  value = DoSubstitution(value);
   return value;
+}
+
+bool RymlDocumentNode::IsNull() const
+{
+  OTEL_INTERNAL_LOG_DEBUG("RymlDocumentNode::IsNull()");
+
+  if (!node_.is_val() && !node_.is_keyval())
+  {
+    return false;
+  }
+  return node_.val_is_null();
 }
 
 ryml::ConstNodeRef RymlDocumentNode::GetRequiredRymlChildNode(const std::string &name) const
@@ -382,6 +397,11 @@ std::string RymlDocumentNode::GetString(const std::string &name,
   std::string value(view.str, view.len);
 
   value = DoSubstitution(value);
+
+  if (value.empty())
+  {
+    return default_value;
+  }
 
   return value;
 }

--- a/sdk/src/configuration/sdk_builder.cc
+++ b/sdk/src/configuration/sdk_builder.cc
@@ -2576,7 +2576,12 @@ void SdkBuilder::SetResource(
     {
       for (const auto &kv : opt_model->attributes->kv_map)
       {
-        SetResourceAttribute(sdk_attributes, kv.first, kv.second.get());
+        // kv_map values may be nullptr for programmatically-set null entries.
+        // The default behavior for resource.attributes is to ignore null values.
+        if (kv.second != nullptr)
+        {
+          SetResourceAttribute(sdk_attributes, kv.first, kv.second.get());
+        }
       }
     }
 

--- a/sdk/test/configuration/sdk_builder_test.cc
+++ b/sdk/test/configuration/sdk_builder_test.cc
@@ -1260,18 +1260,24 @@ public:
 class TestExtensionResourceDetectorBuilder : public config_sdk::ExtensionResourceDetectorBuilder
 {
 public:
+  explicit TestExtensionResourceDetectorBuilder(
+      opentelemetry::sdk::resource::ResourceAttributes attributes)
+      : attributes_(std::move(attributes))
+  {}
+
   std::unique_ptr<opentelemetry::sdk::resource::ResourceDetector> Build(
       const config_sdk::ExtensionResourceDetectorConfiguration *model) const override
   {
     called = true;
     name   = model->name;
-    return std::make_unique<TestResourceDetector>(
-        opentelemetry::sdk::resource::ResourceAttributes{{"custom.key", "custom-value"}},
-        std::string{});
+    return std::make_unique<TestResourceDetector>(attributes_, std::string{});
   }
 
   mutable bool called{false};
   mutable std::string name;
+
+private:
+  opentelemetry::sdk::resource::ResourceAttributes attributes_;
 };
 
 std::string GetStringAttribute(const opentelemetry::sdk::resource::Resource &resource,
@@ -1342,8 +1348,9 @@ TEST(SdkBuilder, SetResourceDetectorDispatch)
 
 TEST(SdkBuilder, SetResourceExtensionDetector)
 {
-  auto registry             = RegistryFactory::Create();
-  auto extension_builder    = std::make_unique<TestExtensionResourceDetectorBuilder>();
+  auto registry          = RegistryFactory::Create();
+  auto extension_builder = std::make_unique<TestExtensionResourceDetectorBuilder>(
+      opentelemetry::sdk::resource::ResourceAttributes{{"custom.key", "custom-value"}});
   auto *extension_builder_p = extension_builder.get();
   registry->SetExtensionResourceDetectorBuilder("my_custom_detector", std::move(extension_builder));
   SdkBuilder builder(std::move(registry));
@@ -1471,4 +1478,79 @@ TEST(SdkBuilder, SetResourceFilterAppliesToDetectedAttributesOnly)
   // attributes and attributes_list fields, even when their keys match.
   EXPECT_EQ(GetStringAttribute(resource, "process.pid"), "from-list");
   EXPECT_EQ(GetStringAttribute(resource, "process.command_args"), "from-attributes");
+}
+
+TEST(SdkBuilder, SetResourceNullAttributeValueSkipped)
+{
+  auto registry = RegistryFactory::Create();
+  SdkBuilder builder(std::move(registry));
+
+  auto typed_value   = std::make_unique<config_sdk::StringAttributeValueConfiguration>();
+  typed_value->value = "kept";
+
+  auto model        = std::make_unique<config_sdk::ResourceConfiguration>();
+  model->attributes = std::make_unique<config_sdk::AttributesConfiguration>();
+  model->attributes->kv_map.emplace("present", std::move(typed_value));
+  model->attributes->kv_map.emplace("null-entry", nullptr);  // should be skipped
+
+  auto resource = opentelemetry::sdk::resource::Resource::GetEmpty();
+  builder.SetResource(resource, model);
+
+  EXPECT_EQ(GetStringAttribute(resource, "present"), "kept");
+  const auto &attrs = resource.GetAttributes();
+  EXPECT_EQ(attrs.find("null-entry"), attrs.end());
+}
+
+TEST(SdkBuilder, SetResourceAttributesNullValueSkipped)
+{
+  // The default behavior for the resource.attributes field must skip null values.
+  // This allows optional env values to be set (e.g. OTEL_SERVICE_NAME).
+  // If the env var is not set then the attribute should be ignored.
+
+  // Example config created programmatically below
+  //
+  // resource:
+  //   attributes:
+  //     service.name: ${OTEL_SERVICE_NAME} # env not set
+  //     service.namespace: ${MY_SERVICE_NAMESPACE} # env not set
+  //     service.version: version-from-attributes
+  //   attributes_list: service.name=name-from-list
+  //   detection:
+  //     detectors:
+  //       - test_service_detector  # detects service.{name, version, namespace}
+
+  auto registry     = RegistryFactory::Create();
+  auto ext_detector = std::make_unique<TestExtensionResourceDetectorBuilder>(
+      opentelemetry::sdk::resource::ResourceAttributes{
+          {"service.name", "name-from-detector"},
+          {"service.namespace", "namespace-from-detector"},
+          {"service.version", "version-from-detector"}});
+  registry->SetExtensionResourceDetectorBuilder("test_service_detector", std::move(ext_detector));
+  SdkBuilder builder(std::move(registry));
+
+  auto model            = std::make_unique<config_sdk::ResourceConfiguration>();
+  auto detector_config  = std::make_unique<config_sdk::ExtensionResourceDetectorConfiguration>();
+  detector_config->name = "test_service_detector";
+  model->detection      = std::make_unique<config_sdk::ResourceDetectionConfiguration>();
+  model->detection->detectors.push_back(std::move(detector_config));
+  model->attributes_list = "service.name=name-from-list,service.version=version-from-list";
+
+  // Simulate null values from unset env variables.
+  model->attributes = std::make_unique<config_sdk::AttributesConfiguration>();
+  model->attributes->kv_map.emplace("service.name", nullptr);  // simulate unset OTEL_SERVICE_NAME
+  model->attributes->kv_map.emplace("service.namespace",
+                                    nullptr);  // simulate unset MY_SERVICE_NAMESPACE
+  auto typed_value   = std::make_unique<config_sdk::StringAttributeValueConfiguration>();
+  typed_value->value = "version-from-attributes";
+  model->attributes->kv_map.emplace("service.version", std::move(typed_value));
+
+  auto resource = opentelemetry::sdk::resource::Resource::GetEmpty();
+  builder.SetResource(resource, model);
+
+  // attributes_list wins over detection for service.name; nullptr in attributes doesn't override.
+  EXPECT_EQ(GetStringAttribute(resource, "service.name"), "name-from-list");
+  // detected value survives for service.namespace (no attributes_list entry, nullptr skipped).
+  EXPECT_EQ(GetStringAttribute(resource, "service.namespace"), "namespace-from-detector");
+  // attribute value for service.version overrides both list and detection.
+  EXPECT_EQ(GetStringAttribute(resource, "service.version"), "version-from-attributes");
 }

--- a/sdk/test/configuration/sdk_builder_test.cc
+++ b/sdk/test/configuration/sdk_builder_test.cc
@@ -1511,10 +1511,13 @@ TEST(SdkBuilder, SetResourceAttributesNullValueSkipped)
   //
   // resource:
   //   attributes:
-  //     service.name: ${OTEL_SERVICE_NAME} # env not set
-  //     service.namespace: ${MY_SERVICE_NAMESPACE} # env not set
-  //     service.version: version-from-attributes
-  //   attributes_list: service.name=name-from-list
+  //     -name: service.name
+  //      value: ${OTEL_SERVICE_NAME} # env not set
+  //     -name: service.namespace
+  //      value: ${MY_SERVICE_NAMESPACE} # env not set
+  //     -name: service.version
+  //      value: version-from-attributes
+  //   attributes_list: "service.name=name-from-list"
   //   detection:
   //     detectors:
   //       - test_service_detector  # detects service.{name, version, namespace}

--- a/sdk/test/configuration/yaml_resource_test.cc
+++ b/sdk/test/configuration/yaml_resource_test.cc
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include <gtest/gtest.h>
-#include <cstddef>
 #include <cstdint>
 #include <cstdlib>
 #include <map>

--- a/sdk/test/configuration/yaml_resource_test.cc
+++ b/sdk/test/configuration/yaml_resource_test.cc
@@ -4,6 +4,7 @@
 #include <gtest/gtest.h>
 #include <cstddef>
 #include <cstdint>
+#include <cstdlib>
 #include <map>
 #include <memory>
 #include <string>
@@ -11,16 +12,31 @@
 
 #include "opentelemetry/sdk/configuration/attribute_value_configuration.h"
 #include "opentelemetry/sdk/configuration/attributes_configuration.h"
+#include "opentelemetry/sdk/configuration/boolean_array_attribute_value_configuration.h"
+#include "opentelemetry/sdk/configuration/boolean_attribute_value_configuration.h"
 #include "opentelemetry/sdk/configuration/configuration.h"
+#include "opentelemetry/sdk/configuration/double_array_attribute_value_configuration.h"
+#include "opentelemetry/sdk/configuration/double_attribute_value_configuration.h"
 #include "opentelemetry/sdk/configuration/extension_resource_detector_configuration.h"
 #include "opentelemetry/sdk/configuration/include_exclude_configuration.h"
+#include "opentelemetry/sdk/configuration/integer_array_attribute_value_configuration.h"
+#include "opentelemetry/sdk/configuration/integer_attribute_value_configuration.h"
 #include "opentelemetry/sdk/configuration/resource_configuration.h"
 #include "opentelemetry/sdk/configuration/resource_detection_configuration.h"
 #include "opentelemetry/sdk/configuration/resource_detector_configuration.h"
 #include "opentelemetry/sdk/configuration/resource_detector_configuration_visitor.h"
+#include "opentelemetry/sdk/configuration/string_array_attribute_value_configuration.h"
 #include "opentelemetry/sdk/configuration/string_array_configuration.h"
 #include "opentelemetry/sdk/configuration/string_attribute_value_configuration.h"
 #include "opentelemetry/sdk/configuration/yaml_configuration_parser.h"
+
+#if defined(_MSC_VER)
+#  include "opentelemetry/sdk/common/env_variables.h"
+using opentelemetry::sdk::common::setenv;
+using opentelemetry::sdk::common::unsetenv;
+#endif
+
+namespace config_sdk = opentelemetry::sdk::configuration;
 
 static std::unique_ptr<opentelemetry::sdk::configuration::Configuration> DoParse(
     const std::string &yaml)
@@ -189,6 +205,40 @@ resource:
   ASSERT_NE(config, nullptr);
   ASSERT_NE(config->resource, nullptr);
   ASSERT_EQ(config->resource->attributes_list, "foo=1234,bar=5678");
+}
+
+TEST(YamlResource, attributes_list_substitution)
+{
+  setenv("TEST_ENV_NAME", "foo=1234,bar=5678", 1);
+
+  std::string yaml = R"(
+file_format: "1.0-resource"
+resource:
+  attributes_list: ${TEST_ENV_NAME}
+)";
+
+  auto config = DoParse(yaml);
+  ASSERT_NE(config, nullptr);
+  ASSERT_NE(config->resource, nullptr);
+  ASSERT_EQ(config->resource->attributes_list, "foo=1234,bar=5678");
+
+  unsetenv("TEST_ENV_NAME");
+}
+
+TEST(YamlResource, attributes_list_substitution_fallback)
+{
+  unsetenv("TEST_ENV_NAME");
+
+  std::string yaml = R"(
+file_format: "1.0-resource"
+resource:
+  attributes_list: ${TEST_ENV_NAME:-service.name=fallback}
+)";
+
+  auto config = DoParse(yaml);
+  ASSERT_NE(config, nullptr);
+  ASSERT_NE(config->resource, nullptr);
+  ASSERT_EQ(config->resource->attributes_list, "service.name=fallback");
 }
 
 TEST(YamlResource, both_0_10)
@@ -447,4 +497,359 @@ resource:
   ASSERT_EQ(config->resource->detection->attributes->included->string_array.size(), 1);
   ASSERT_EQ(config->resource->detection->attributes->included->string_array[0], "container.*");
   ASSERT_EQ(config->resource->detection->detectors.size(), 2);
+}
+
+TEST(YamlResource, string_attribute_substitution)
+{
+  setenv("TEST_ENV_NAME", "my-service", 1);
+
+  std::string yaml = R"(
+file_format: "1.0-resource"
+resource:
+  attributes:
+    - name: service.name
+      value: ${TEST_ENV_NAME}
+)";
+
+  auto config = DoParse(yaml);
+  ASSERT_NE(config, nullptr);
+  ASSERT_NE(config->resource, nullptr);
+  ASSERT_NE(config->resource->attributes, nullptr);
+  auto &kv = config->resource->attributes->kv_map;
+  ASSERT_EQ(kv.count("service.name"), 1u);
+  auto *val =
+      static_cast<config_sdk::StringAttributeValueConfiguration *>(kv.at("service.name").get());
+  ASSERT_EQ(val->value, "my-service");
+
+  unsetenv("TEST_ENV_NAME");
+}
+
+TEST(YamlResource, string_attribute_substitution_fallback_empty)
+{
+  unsetenv("TEST_ENV_NAME");
+
+  std::string yaml = R"(
+file_format: "1.0-resource"
+resource:
+  attributes:
+    - name: service.name
+      value: ${TEST_ENV_NAME:-fallback-name}
+)";
+
+  auto config = DoParse(yaml);
+  ASSERT_NE(config, nullptr);
+  ASSERT_NE(config->resource, nullptr);
+  ASSERT_NE(config->resource->attributes, nullptr);
+  auto &kv = config->resource->attributes->kv_map;
+  ASSERT_EQ(kv.count("service.name"), 1u);
+  auto *val =
+      static_cast<config_sdk::StringAttributeValueConfiguration *>(kv.at("service.name").get());
+  ASSERT_EQ(val->value, "fallback-name");
+}
+
+TEST(YamlResource, boolean_attribute_substitution)
+{
+  setenv("TEST_ENV_NAME", "true", 1);
+
+  std::string yaml = R"(
+file_format: "1.0-resource"
+resource:
+  attributes:
+    - name: flag
+      value: ${TEST_ENV_NAME}
+      type: bool
+)";
+
+  auto config = DoParse(yaml);
+  ASSERT_NE(config, nullptr);
+  ASSERT_NE(config->resource, nullptr);
+  ASSERT_NE(config->resource->attributes, nullptr);
+  auto &kv = config->resource->attributes->kv_map;
+  ASSERT_EQ(kv.count("flag"), 1u);
+  auto *val = static_cast<config_sdk::BooleanAttributeValueConfiguration *>(kv.at("flag").get());
+  ASSERT_EQ(val->value, true);
+
+  unsetenv("TEST_ENV_NAME");
+}
+
+TEST(YamlResource, boolean_attribute_substitution_fallback)
+{
+  unsetenv("TEST_ENV_NAME");
+
+  std::string yaml = R"(
+file_format: "1.0-resource"
+resource:
+  attributes:
+    - name: flag
+      value: ${TEST_ENV_NAME:-false}
+      type: bool
+)";
+
+  auto config = DoParse(yaml);
+  ASSERT_NE(config, nullptr);
+  ASSERT_NE(config->resource, nullptr);
+  ASSERT_NE(config->resource->attributes, nullptr);
+  auto &kv = config->resource->attributes->kv_map;
+  ASSERT_EQ(kv.count("flag"), 1u);
+  auto *val = static_cast<config_sdk::BooleanAttributeValueConfiguration *>(kv.at("flag").get());
+  ASSERT_EQ(val->value, false);
+}
+
+TEST(YamlResource, integer_attribute_substitution)
+{
+  setenv("TEST_ENV_NAME", "42", 1);
+
+  std::string yaml = R"(
+file_format: "1.0-resource"
+resource:
+  attributes:
+    - name: count
+      value: ${TEST_ENV_NAME}
+      type: int
+)";
+
+  auto config = DoParse(yaml);
+  ASSERT_NE(config, nullptr);
+  ASSERT_NE(config->resource, nullptr);
+  ASSERT_NE(config->resource->attributes, nullptr);
+  auto &kv = config->resource->attributes->kv_map;
+  ASSERT_EQ(kv.count("count"), 1u);
+  auto *val = static_cast<config_sdk::IntegerAttributeValueConfiguration *>(kv.at("count").get());
+  ASSERT_EQ(val->value, 42);
+
+  unsetenv("TEST_ENV_NAME");
+}
+
+TEST(YamlResource, integer_attribute_substitution_fallback)
+{
+  unsetenv("TEST_ENV_NAME");
+
+  std::string yaml = R"(
+file_format: "1.0-resource"
+resource:
+  attributes:
+    - name: count
+      value: ${TEST_ENV_NAME:-99}
+      type: int
+)";
+
+  auto config = DoParse(yaml);
+  ASSERT_NE(config, nullptr);
+  ASSERT_NE(config->resource, nullptr);
+  ASSERT_NE(config->resource->attributes, nullptr);
+  auto &kv = config->resource->attributes->kv_map;
+  ASSERT_EQ(kv.count("count"), 1u);
+  auto *val = static_cast<config_sdk::IntegerAttributeValueConfiguration *>(kv.at("count").get());
+  ASSERT_EQ(val->value, 99);
+}
+
+TEST(YamlResource, double_attribute_substitution)
+{
+  setenv("TEST_ENV_NAME", "3.14", 1);
+
+  std::string yaml = R"(
+file_format: "1.0-resource"
+resource:
+  attributes:
+    - name: ratio
+      value: ${TEST_ENV_NAME}
+      type: double
+)";
+
+  auto config = DoParse(yaml);
+  ASSERT_NE(config, nullptr);
+  ASSERT_NE(config->resource, nullptr);
+  ASSERT_NE(config->resource->attributes, nullptr);
+  auto &kv = config->resource->attributes->kv_map;
+  ASSERT_EQ(kv.count("ratio"), 1u);
+  auto *val = static_cast<config_sdk::DoubleAttributeValueConfiguration *>(kv.at("ratio").get());
+  ASSERT_DOUBLE_EQ(val->value, 3.14);
+
+  unsetenv("TEST_ENV_NAME");
+}
+
+TEST(YamlResource, double_attribute_substitution_fallback)
+{
+  unsetenv("TEST_ENV_NAME");
+
+  std::string yaml = R"(
+file_format: "1.0-resource"
+resource:
+  attributes:
+    - name: ratio
+      value: ${TEST_ENV_NAME:-2.71}
+      type: double
+)";
+
+  auto config = DoParse(yaml);
+  ASSERT_NE(config, nullptr);
+  ASSERT_NE(config->resource, nullptr);
+  ASSERT_NE(config->resource->attributes, nullptr);
+  auto &kv = config->resource->attributes->kv_map;
+  ASSERT_EQ(kv.count("ratio"), 1u);
+  auto *val = static_cast<config_sdk::DoubleAttributeValueConfiguration *>(kv.at("ratio").get());
+  ASSERT_DOUBLE_EQ(val->value, 2.71);
+}
+
+TEST(YamlResource, string_array_attribute_substitution)
+{
+  setenv("TEST_ENV_NAME", "hello", 1);
+
+  std::string yaml = R"(
+file_format: "1.0-resource"
+resource:
+  attributes:
+    - name: tags
+      value:
+        - ${TEST_ENV_NAME}
+        - world
+      type: string_array
+)";
+
+  auto config = DoParse(yaml);
+  ASSERT_NE(config, nullptr);
+  ASSERT_NE(config->resource, nullptr);
+  ASSERT_NE(config->resource->attributes, nullptr);
+  auto &kv = config->resource->attributes->kv_map;
+  ASSERT_EQ(kv.count("tags"), 1u);
+  auto *val =
+      static_cast<config_sdk::StringArrayAttributeValueConfiguration *>(kv.at("tags").get());
+  ASSERT_EQ(val->value.size(), 2u);
+  ASSERT_EQ(val->value[0], "hello");
+  ASSERT_EQ(val->value[1], "world");
+
+  unsetenv("TEST_ENV_NAME");
+}
+
+TEST(YamlResource, integer_array_attribute_substitution)
+{
+  setenv("TEST_ENV_NAME", "7", 1);
+
+  std::string yaml = R"(
+file_format: "1.0-resource"
+resource:
+  attributes:
+    - name: ids
+      value:
+        - ${TEST_ENV_NAME}
+        - 8
+      type: int_array
+)";
+
+  auto config = DoParse(yaml);
+  ASSERT_NE(config, nullptr);
+  ASSERT_NE(config->resource, nullptr);
+  ASSERT_NE(config->resource->attributes, nullptr);
+  auto &kv = config->resource->attributes->kv_map;
+  ASSERT_EQ(kv.count("ids"), 1u);
+  auto *val =
+      static_cast<config_sdk::IntegerArrayAttributeValueConfiguration *>(kv.at("ids").get());
+  ASSERT_EQ(val->value.size(), 2u);
+  ASSERT_EQ(val->value[0], 7u);
+  ASSERT_EQ(val->value[1], 8u);
+
+  unsetenv("TEST_ENV_NAME");
+}
+
+TEST(YamlResource, double_array_attribute_substitution)
+{
+  setenv("TEST_ENV_NAME", "1.5", 1);
+
+  std::string yaml = R"(
+file_format: "1.0-resource"
+resource:
+  attributes:
+    - name: scores
+      value:
+        - ${TEST_ENV_NAME}
+        - 2.5
+      type: double_array
+)";
+
+  auto config = DoParse(yaml);
+  ASSERT_NE(config, nullptr);
+  ASSERT_NE(config->resource, nullptr);
+  ASSERT_NE(config->resource->attributes, nullptr);
+  auto &kv = config->resource->attributes->kv_map;
+  ASSERT_EQ(kv.count("scores"), 1u);
+  auto *val =
+      static_cast<config_sdk::DoubleArrayAttributeValueConfiguration *>(kv.at("scores").get());
+  ASSERT_EQ(val->value.size(), 2u);
+  ASSERT_DOUBLE_EQ(val->value[0], 1.5);
+  ASSERT_DOUBLE_EQ(val->value[1], 2.5);
+
+  unsetenv("TEST_ENV_NAME");
+}
+
+TEST(YamlResource, boolean_array_attribute_substitution)
+{
+  setenv("TEST_ENV_NAME", "true", 1);
+
+  std::string yaml = R"(
+file_format: "1.0-resource"
+resource:
+  attributes:
+    - name: flags
+      value:
+        - ${TEST_ENV_NAME}
+        - false
+      type: bool_array
+)";
+
+  auto config = DoParse(yaml);
+  ASSERT_NE(config, nullptr);
+  ASSERT_NE(config->resource, nullptr);
+  ASSERT_NE(config->resource->attributes, nullptr);
+  auto &kv = config->resource->attributes->kv_map;
+  ASSERT_EQ(kv.count("flags"), 1u);
+  auto *val =
+      static_cast<config_sdk::BooleanArrayAttributeValueConfiguration *>(kv.at("flags").get());
+  ASSERT_EQ(val->value.size(), 2u);
+  ASSERT_EQ(val->value[0], true);
+  ASSERT_EQ(val->value[1], false);
+
+  unsetenv("TEST_ENV_NAME");
+}
+
+TEST(YamlResource, null_attribute_value_skipped)
+{
+  // YAML null value (value:) must be skipped per schema nullBehavior.
+  std::string yaml = R"(
+file_format: "1.0-resource"
+resource:
+  attributes:
+    - name: service.name
+      value:
+    - name: host.name
+      value: "my-host"
+)";
+
+  auto config = DoParse(yaml);
+  ASSERT_NE(config, nullptr);
+  ASSERT_NE(config->resource, nullptr);
+  ASSERT_NE(config->resource->attributes, nullptr);
+  const auto &kv = config->resource->attributes->kv_map;
+  // null value entry must be absent
+  ASSERT_EQ(kv.count("service.name"), 0u);
+  // non-null entry must be present
+  ASSERT_EQ(kv.count("host.name"), 1u);
+}
+
+TEST(YamlResource, empty_name_attribute_parse_error)
+{
+  // An empty attribute name (e.g. from an unset env var) is an invalid config.
+  unsetenv("TEST_ENV_NAME");
+
+  std::string yaml = R"(
+file_format: "1.0-resource"
+resource:
+  attributes:
+    - name: ${TEST_ENV_NAME}
+      value: "some-value"
+    - name: host.name
+      value: "my-host"
+)";
+
+  auto config = DoParse(yaml);
+  ASSERT_EQ(config, nullptr);
 }

--- a/sdk/test/configuration/yaml_resource_test.cc
+++ b/sdk/test/configuration/yaml_resource_test.cc
@@ -834,6 +834,50 @@ resource:
   ASSERT_EQ(kv.count("host.name"), 1u);
 }
 
+TEST(YamlResource, null_tilde_attribute_value_skipped)
+{
+  // value: ~ is the YAML tilde form of null — also skipped.
+  std::string yaml = R"(
+file_format: "1.0-resource"
+resource:
+  attributes:
+    - name: service.name
+      value: ~
+    - name: host.name
+      value: "my-host"
+)";
+
+  auto config = DoParse(yaml);
+  ASSERT_NE(config, nullptr);
+  ASSERT_NE(config->resource, nullptr);
+  ASSERT_NE(config->resource->attributes, nullptr);
+  const auto &kv = config->resource->attributes->kv_map;
+  ASSERT_EQ(kv.count("service.name"), 0u);
+  ASSERT_EQ(kv.count("host.name"), 1u);
+}
+
+TEST(YamlResource, null_keyword_attribute_value_skipped)
+{
+  // value: null is the YAML keyword form of null — also skipped.
+  std::string yaml = R"(
+file_format: "1.0-resource"
+resource:
+  attributes:
+    - name: service.name
+      value: null
+    - name: host.name
+      value: "my-host"
+)";
+
+  auto config = DoParse(yaml);
+  ASSERT_NE(config, nullptr);
+  ASSERT_NE(config->resource, nullptr);
+  ASSERT_NE(config->resource->attributes, nullptr);
+  const auto &kv = config->resource->attributes->kv_map;
+  ASSERT_EQ(kv.count("service.name"), 0u);
+  ASSERT_EQ(kv.count("host.name"), 1u);
+}
+
 TEST(YamlResource, empty_name_attribute_parse_error)
 {
   // An empty attribute name (e.g. from an unset env var) is an invalid config.

--- a/sdk/test/configuration/yaml_test.cc
+++ b/sdk/test/configuration/yaml_test.cc
@@ -8,6 +8,7 @@
 
 #include "opentelemetry/sdk/configuration/attribute_limits_configuration.h"
 #include "opentelemetry/sdk/configuration/configuration.h"
+#include "opentelemetry/sdk/configuration/severity_number.h"
 #include "opentelemetry/sdk/configuration/trace_id_ratio_based_sampler_configuration.h"
 #include "opentelemetry/sdk/configuration/tracer_provider_configuration.h"
 #include "opentelemetry/sdk/configuration/yaml_configuration_parser.h"
@@ -757,3 +758,66 @@ tracer_provider:
   auto config = DoParse(yaml);
   ASSERT_EQ(config, nullptr);
 }
+
+// --- empty env var with :- fallback tests ---
+
+TEST(Yaml, empty_string_substitution_with_fallback)
+{
+  setenv("ENV_NAME", "", 1);
+
+  std::string yaml = R"(
+file_format: ${ENV_NAME:-1.0}
+)";
+
+  auto config = DoParse(yaml);
+  ASSERT_NE(config, nullptr);
+  ASSERT_EQ(config->file_format, "1.0");
+}
+
+TEST(Yaml, empty_boolean_substitution_with_fallback)
+{
+  setenv("ENV_NAME", "", 1);
+
+  std::string yaml = R"(
+file_format: "1.0"
+disabled: ${ENV_NAME:-true}
+)";
+
+  auto config = DoParse(yaml);
+  ASSERT_NE(config, nullptr);
+  ASSERT_EQ(config->disabled, true);
+}
+
+// --- GetString default-on-empty tests ---
+
+TEST(Yaml, optional_string_unset_env_var_uses_default)
+{
+  // An unset env var in an optional string field must produce the declared default,
+  // not an empty string that fails downstream parsing.
+  unsetenv("ENV_NAME");
+
+  std::string yaml = R"(
+file_format: "1.0"
+log_level: ${ENV_NAME}
+)";
+
+  auto config = DoParse(yaml);
+  ASSERT_NE(config, nullptr);
+  // default log_level is "info" -> SeverityNumber::info
+  ASSERT_EQ(config->log_level, opentelemetry::sdk::configuration::SeverityNumber::info);
+}
+
+TEST(Yaml, optional_string_set_env_var_uses_value)
+{
+  setenv("ENV_NAME", "debug", 1);
+
+  std::string yaml = R"(
+file_format: "1.0"
+log_level: ${ENV_NAME}
+)";
+
+  auto config = DoParse(yaml);
+  ASSERT_NE(config, nullptr);
+  ASSERT_EQ(config->log_level, opentelemetry::sdk::configuration::SeverityNumber::debug);
+}
+

--- a/sdk/test/configuration/yaml_test.cc
+++ b/sdk/test/configuration/yaml_test.cc
@@ -820,4 +820,3 @@ log_level: ${ENV_NAME}
   ASSERT_NE(config, nullptr);
   ASSERT_EQ(config->log_level, opentelemetry::sdk::configuration::SeverityNumber::debug);
 }
-


### PR DESCRIPTION
Fixes #4473

## Changes

- Add null value detection to the ryml document 
- Add env var substitution to all attribute value type parsing methods
- Add unit tests and a programmatic test for the use case in the linked issue

For significant contributions please make sure you have completed the following items:

* [ ] `CHANGELOG.md` updated for non-trivial changes
* [ ] Unit tests have been added
* [ ] Changes in public API reviewed