### PR TITLE
[CONFIGURATION] Internal logging cleanup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,9 @@ Increment the:
   resource detectors
   [#4412](https://github.com/open-telemetry/opentelemetry-cpp/issues/4412)
 
+* [CONFIGURATION] Internal logging cleanup
+  [#4479](https://github.com/open-telemetry/opentelemetry-cpp/pull/4479)
+
 * [CONFIGURATION] Add support for composable sampler extensions.
   [#4409](https://github.com/open-telemetry/opentelemetry-cpp/issues/4409)
 

--- a/examples/configuration/CMakeLists.txt
+++ b/examples/configuration/CMakeLists.txt
@@ -78,15 +78,15 @@ if(BUILD_TESTING)
      AND OTELCPP_WITH_PROMETHEUS
      AND OTELCPP_WITH_RESOURCE_DETECTORS_PREVIEW)
     add_test(NAME examples.example_yaml_kitchen_sink
-             COMMAND $<TARGET_FILE:example_yaml> --test --yaml
+             COMMAND $<TARGET_FILE:example_yaml> --debug --yaml
                      ${CMAKE_CURRENT_SOURCE_DIR}/kitchen-sink.yaml)
   endif()
 
   add_test(NAME examples.example_yaml_extensions
-           COMMAND $<TARGET_FILE:example_yaml> --test --yaml
+           COMMAND $<TARGET_FILE:example_yaml> --debug --yaml
                    ${CMAKE_CURRENT_SOURCE_DIR}/extensions.yaml)
 
   add_test(NAME examples.example_yaml_sdk_default
-           COMMAND $<TARGET_FILE:example_yaml> --test --yaml
+           COMMAND $<TARGET_FILE:example_yaml> --debug --yaml
                    ${CMAKE_CURRENT_SOURCE_DIR}/sdk-default.yaml)
 endif()

--- a/examples/configuration/custom_log_record_exporter.cc
+++ b/examples/configuration/custom_log_record_exporter.cc
@@ -20,18 +20,18 @@ opentelemetry::sdk::common::ExportResult CustomLogRecordExporter::Export(
     const opentelemetry::nostd::span<std::unique_ptr<opentelemetry::sdk::logs::Recordable>>
         & /* records */) noexcept
 {
-  OTEL_INTERNAL_LOG_ERROR("CustomLogRecordExporter::Export(): YOUR CODE HERE");
+  OTEL_INTERNAL_LOG_INFO("CustomLogRecordExporter::Export(): YOUR CODE HERE");
   return opentelemetry::sdk::common::ExportResult::kSuccess;
 }
 
 bool CustomLogRecordExporter::ForceFlush(std::chrono::microseconds /* timeout */) noexcept
 {
-  OTEL_INTERNAL_LOG_ERROR("CustomLogRecordExporter::ForceFlush(): YOUR CODE HERE");
-  return false;
+  OTEL_INTERNAL_LOG_INFO("CustomLogRecordExporter::ForceFlush(): YOUR CODE HERE");
+  return true;
 }
 
 bool CustomLogRecordExporter::Shutdown(std::chrono::microseconds /* timeout */) noexcept
 {
-  OTEL_INTERNAL_LOG_ERROR("CustomLogRecordExporter::Shutdown(): YOUR CODE HERE");
-  return false;
+  OTEL_INTERNAL_LOG_INFO("CustomLogRecordExporter::Shutdown(): YOUR CODE HERE");
+  return true;
 }

--- a/examples/configuration/custom_log_record_processor.cc
+++ b/examples/configuration/custom_log_record_processor.cc
@@ -20,18 +20,18 @@ CustomLogRecordProcessor::MakeRecordable() noexcept
 void CustomLogRecordProcessor::OnEmit(
     std::unique_ptr<opentelemetry::sdk::logs::Recordable> &&span) noexcept
 {
-  OTEL_INTERNAL_LOG_ERROR("CustomLogRecordProcessor::OnEnd(): YOUR CODE HERE");
+  OTEL_INTERNAL_LOG_INFO("CustomLogRecordProcessor::OnEmit(): YOUR CODE HERE");
   auto unused = std::move(span);
 }
 
 bool CustomLogRecordProcessor::ForceFlush(std::chrono::microseconds /* timeout */) noexcept
 {
-  OTEL_INTERNAL_LOG_ERROR("CustomLogRecordProcessor::ForceFlush(): YOUR CODE HERE");
-  return false;
+  OTEL_INTERNAL_LOG_INFO("CustomLogRecordProcessor::ForceFlush(): YOUR CODE HERE");
+  return true;
 }
 
 bool CustomLogRecordProcessor::Shutdown(std::chrono::microseconds /* timeout */) noexcept
 {
-  OTEL_INTERNAL_LOG_ERROR("CustomLogRecordProcessor::Shutdown(): YOUR CODE HERE");
-  return false;
+  OTEL_INTERNAL_LOG_INFO("CustomLogRecordProcessor::Shutdown(): YOUR CODE HERE");
+  return true;
 }

--- a/examples/configuration/custom_pull_metric_exporter.cc
+++ b/examples/configuration/custom_pull_metric_exporter.cc
@@ -10,23 +10,23 @@ opentelemetry::sdk::metrics::AggregationTemporality
 CustomPullMetricExporter::GetAggregationTemporality(
     opentelemetry::sdk::metrics::InstrumentType /* instrument_type */) const noexcept
 {
-  OTEL_INTERNAL_LOG_ERROR("CustomPullMetricExporter::GetAggregationTemporality(): YOUR CODE HERE");
+  OTEL_INTERNAL_LOG_INFO("CustomPullMetricExporter::GetAggregationTemporality(): YOUR CODE HERE");
   return opentelemetry::sdk::metrics::AggregationTemporality::kCumulative;
 }
 
 bool CustomPullMetricExporter::OnForceFlush(std::chrono::microseconds /* timeout */) noexcept
 {
-  OTEL_INTERNAL_LOG_ERROR("CustomPullMetricExporter::OnForceFlush(): YOUR CODE HERE");
+  OTEL_INTERNAL_LOG_INFO("CustomPullMetricExporter::OnForceFlush(): YOUR CODE HERE");
   return true;
 }
 
 bool CustomPullMetricExporter::OnShutDown(std::chrono::microseconds /* timeout */) noexcept
 {
-  OTEL_INTERNAL_LOG_ERROR("CustomPullMetricExporter::OnShutDown(): YOUR CODE HERE");
+  OTEL_INTERNAL_LOG_INFO("CustomPullMetricExporter::OnShutDown(): YOUR CODE HERE");
   return true;
 }
 
 void CustomPullMetricExporter::OnInitialized() noexcept
 {
-  OTEL_INTERNAL_LOG_ERROR("CustomPullMetricExporter::OnInitialized(): YOUR CODE HERE");
+  OTEL_INTERNAL_LOG_INFO("CustomPullMetricExporter::OnInitialized(): YOUR CODE HERE");
 }

--- a/examples/configuration/custom_push_metric_exporter.cc
+++ b/examples/configuration/custom_push_metric_exporter.cc
@@ -10,7 +10,7 @@
 opentelemetry::sdk::common::ExportResult CustomPushMetricExporter::Export(
     const opentelemetry::sdk::metrics::ResourceMetrics & /* data */) noexcept
 {
-  OTEL_INTERNAL_LOG_ERROR("CustomPushMetricExporter::Export(): YOUR CODE HERE");
+  OTEL_INTERNAL_LOG_INFO("CustomPushMetricExporter::Export(): YOUR CODE HERE");
   return opentelemetry::sdk::common::ExportResult::kSuccess;
 }
 
@@ -18,18 +18,18 @@ opentelemetry::sdk::metrics::AggregationTemporality
 CustomPushMetricExporter::GetAggregationTemporality(
     opentelemetry::sdk::metrics::InstrumentType /* instrument_type */) const noexcept
 {
-  OTEL_INTERNAL_LOG_ERROR("CustomPushMetricExporter::GetAggregationTemporality(): YOUR CODE HERE");
+  OTEL_INTERNAL_LOG_INFO("CustomPushMetricExporter::GetAggregationTemporality(): YOUR CODE HERE");
   return opentelemetry::sdk::metrics::AggregationTemporality::kCumulative;
 }
 
 bool CustomPushMetricExporter::ForceFlush(std::chrono::microseconds /* timeout */) noexcept
 {
-  OTEL_INTERNAL_LOG_ERROR("CustomPushMetricExporter::ForceFlush(): YOUR CODE HERE");
+  OTEL_INTERNAL_LOG_INFO("CustomPushMetricExporter::ForceFlush(): YOUR CODE HERE");
   return true;
 }
 
 bool CustomPushMetricExporter::Shutdown(std::chrono::microseconds /* timeout */) noexcept
 {
-  OTEL_INTERNAL_LOG_ERROR("CustomPushMetricExporter::Shutdown(): YOUR CODE HERE");
+  OTEL_INTERNAL_LOG_INFO("CustomPushMetricExporter::Shutdown(): YOUR CODE HERE");
   return true;
 }

--- a/examples/configuration/custom_resource_detector.cc
+++ b/examples/configuration/custom_resource_detector.cc
@@ -11,6 +11,6 @@
 
 opentelemetry::sdk::resource::Resource CustomResourceDetector::Detect() noexcept
 {
-  OTEL_INTERNAL_LOG_ERROR("CustomResourceDetector::Detect(): YOUR CODE HERE");
+  OTEL_INTERNAL_LOG_INFO("CustomResourceDetector::Detect(): YOUR CODE HERE");
   return ResourceDetector::Create({{"custom.comment", comment_}});
 }

--- a/examples/configuration/custom_span_exporter.cc
+++ b/examples/configuration/custom_span_exporter.cc
@@ -19,18 +19,18 @@ opentelemetry::sdk::common::ExportResult CustomSpanExporter::Export(
     const opentelemetry::nostd::span<std::unique_ptr<opentelemetry::sdk::trace::Recordable>>
         & /* spans */) noexcept
 {
-  OTEL_INTERNAL_LOG_ERROR("CustomSpanExporter::Export(): YOUR CODE HERE");
+  OTEL_INTERNAL_LOG_INFO("CustomSpanExporter::Export(): YOUR CODE HERE");
   return opentelemetry::sdk::common::ExportResult::kSuccess;
 }
 
 bool CustomSpanExporter::ForceFlush(std::chrono::microseconds /* timeout */) noexcept
 {
-  OTEL_INTERNAL_LOG_ERROR("CustomSpanExporter::ForceFlush(): YOUR CODE HERE");
-  return false;
+  OTEL_INTERNAL_LOG_INFO("CustomSpanExporter::ForceFlush(): YOUR CODE HERE");
+  return true;
 }
 
 bool CustomSpanExporter::Shutdown(std::chrono::microseconds /* timeout */) noexcept
 {
-  OTEL_INTERNAL_LOG_ERROR("CustomSpanExporter::Shutdown(): YOUR CODE HERE");
-  return false;
+  OTEL_INTERNAL_LOG_INFO("CustomSpanExporter::Shutdown(): YOUR CODE HERE");
+  return true;
 }

--- a/examples/configuration/custom_span_processor.cc
+++ b/examples/configuration/custom_span_processor.cc
@@ -21,24 +21,24 @@ void CustomSpanProcessor::OnStart(
     opentelemetry::sdk::trace::Recordable & /* span */,
     const opentelemetry::trace::SpanContext & /* parent_context */) noexcept
 {
-  OTEL_INTERNAL_LOG_ERROR("CustomSpanProcessor::OnStart(): YOUR CODE HERE");
+  OTEL_INTERNAL_LOG_INFO("CustomSpanProcessor::OnStart(): YOUR CODE HERE");
 }
 
 void CustomSpanProcessor::OnEnd(
     std::unique_ptr<opentelemetry::sdk::trace::Recordable> &&span) noexcept
 {
-  OTEL_INTERNAL_LOG_ERROR("CustomSpanProcessor::OnEnd(): YOUR CODE HERE");
+  OTEL_INTERNAL_LOG_INFO("CustomSpanProcessor::OnEnd(): YOUR CODE HERE");
   auto unused = std::move(span);
 }
 
 bool CustomSpanProcessor::ForceFlush(std::chrono::microseconds /* timeout */) noexcept
 {
-  OTEL_INTERNAL_LOG_ERROR("CustomSpanProcessor::ForceFlush(): YOUR CODE HERE");
-  return false;
+  OTEL_INTERNAL_LOG_INFO("CustomSpanProcessor::ForceFlush(): YOUR CODE HERE");
+  return true;
 }
 
 bool CustomSpanProcessor::Shutdown(std::chrono::microseconds /* timeout */) noexcept
 {
-  OTEL_INTERNAL_LOG_ERROR("CustomSpanProcessor::Shutdown(): YOUR CODE HERE");
-  return false;
+  OTEL_INTERNAL_LOG_INFO("CustomSpanProcessor::Shutdown(): YOUR CODE HERE");
+  return true;
 }

--- a/examples/configuration/extensions.yaml
+++ b/examples/configuration/extensions.yaml
@@ -9,6 +9,9 @@ file_format: "1.1"
 # If omitted or null, false is used.
 disabled: false
 
+# Configure the internal log level for the SDK.
+log_level: debug
+
 # Configure text map context propagators.
 # If omitted, a noop propagator is used.
 propagator:

--- a/examples/configuration/kitchen-sink.yaml
+++ b/examples/configuration/kitchen-sink.yaml
@@ -17,7 +17,7 @@ file_format: "1.1"
 disabled: false
 # Configure the log level of the internal logger used by the SDK.
 # If omitted, info is used.
-log_level: info
+log_level: debug
 # Configure general attribute limits. See also tracer_provider.limits, logger_provider.limits.
 attribute_limits:
   # Configure max attribute value size.
@@ -1006,6 +1006,8 @@ resource:
   attributes:
     - name: service.name
       value: unknown_service
+    - name: service.version
+      value: null
     - name: string_key
       value: value
       type: string
@@ -1074,6 +1076,18 @@ resource:
   # Configure resource schema URL.
   # If omitted or null, no schema URL is used.
   schema_url: https://opentelemetry.io/schemas/1.16.0
+
+# Configure distribution.
+# Defines configuration parameters specific to a particular OpenTelemetry distribution or vendor.
+# This section provides a standardized location for distribution-specific settings
+# that are not part of the OpenTelemetry configuration model.
+# It allows vendors to expose their own extensions and general configuration options.
+# If omitted, distribution defaults are used.
+distribution:
+  # Configure distribution-specific configuration options.
+  # Vendors may define their own configuration options here.
+  example:
+    property: "value"
 # Configure instrumentation.
 # This type is in development and subject to breaking changes in minor versions.
 instrumentation/development:

--- a/examples/configuration/main.cc
+++ b/examples/configuration/main.cc
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include <cstdio>
-#include <cstdlib>
 #include <cstring>
 #include <string>
 
@@ -16,6 +15,10 @@
 #include "opentelemetry/sdk/configuration/registry.h"
 #include "opentelemetry/sdk/configuration/registry_factory.h"
 #include "opentelemetry/sdk/configuration/yaml_configuration_parser.h"
+
+#include "opentelemetry/sdk/logs/logger_provider.h"
+#include "opentelemetry/sdk/metrics/meter_provider.h"
+#include "opentelemetry/sdk/trace/tracer_provider.h"
 
 #include "custom_log_record_exporter_builder.h"
 #include "custom_log_record_processor_builder.h"
@@ -73,6 +76,15 @@ static std::unique_ptr<opentelemetry::sdk::configuration::ConfiguredSdk> sdk;
 
 namespace
 {
+enum class ReturnCode : std::uint8_t
+{
+  kSuccess          = 0,
+  kYamlParseError   = 1,
+  kSdkCreationError = 2,
+  kSdkInitError     = 3,
+  kSdkCleanupError  = 4,
+  kInvalidArguments = 5,
+};
 
 class CheckerLogHandler : public opentelemetry::sdk::common::internal_log::LogHandler
 {
@@ -129,7 +141,6 @@ void PrintModelParsedForTesting(bool pass)
     else
     {
       std::fprintf(stdout, "FAILED TO PARSE MODEL\n");
-      std::exit(1);
     }
   }
 }
@@ -145,7 +156,6 @@ void PrintSdkCreatedForTesting(bool pass)
     else
     {
       std::fprintf(stdout, "FAILED TO CREATE SDK\n");
-      std::exit(2);
     }
   }
 }
@@ -161,7 +171,7 @@ void SetSilentLoggerForTesting()
   }
 }
 
-void InitOtel(const std::string &config_file)
+ReturnCode InitOtel(const std::string &config_file)
 {
   auto level = opentelemetry::sdk::common::internal_log::LogLevel::Info;
 
@@ -251,6 +261,11 @@ void InitOtel(const std::string &config_file)
   // Functional test helpers, ignore.
   PrintModelParsedForTesting(model != nullptr);
 
+  if (model == nullptr)
+  {
+    return ReturnCode::kYamlParseError;
+  }
+
   /* 5 - Build the SDK from the parsed config.yaml */
 
   sdk = opentelemetry::sdk::configuration::ConfiguredSdk::Create(registry, model);
@@ -258,21 +273,47 @@ void InitOtel(const std::string &config_file)
   // Functional test helpers, ignore.
   PrintSdkCreatedForTesting(sdk != nullptr);
 
+  if (sdk == nullptr)
+  {
+    return ReturnCode::kSdkCreationError;
+  }
+
   /* 6 - Deploy the SDK */
 
   if (sdk != nullptr)
   {
     sdk->Install();
   }
+
+  return ReturnCode::kSuccess;
 }
 
-void CleanupOtel()
+ReturnCode CleanupOtel()
 {
+  bool success = true;
+
   if (sdk != nullptr)
   {
+    if (sdk->tracer_provider != nullptr)
+    {
+      success = success && sdk->tracer_provider->ForceFlush();
+      success = success && sdk->tracer_provider->Shutdown();
+    }
+    if (sdk->meter_provider != nullptr)
+    {
+      success = success && sdk->meter_provider->ForceFlush();
+      success = success && sdk->meter_provider->Shutdown();
+    }
+    if (sdk->logger_provider != nullptr)
+    {
+      success = success && sdk->logger_provider->ForceFlush();
+      success = success && sdk->logger_provider->Shutdown();
+    }
     sdk->UnInstall();
   }
   sdk.reset(nullptr);
+
+  return success ? ReturnCode::kSuccess : ReturnCode::kSdkCleanupError;
 }
 }  // namespace
 
@@ -375,19 +416,23 @@ int main(int argc, char *argv[])
   if (rc != 0)
   {
     usage(stderr);
-    return 1;
+    return static_cast<int>(ReturnCode::kInvalidArguments);
   }
 
   if (opt_help)
   {
     usage(stdout);
-    return 0;
+    return static_cast<int>(ReturnCode::kSuccess);
   }
 
   // Functional test helpers, ignore.
   SetLoggerForTesting();
 
-  InitOtel(yaml_file_path);
+  auto return_code = InitOtel(yaml_file_path);
+  if (return_code != ReturnCode::kSuccess)
+  {
+    return static_cast<int>(return_code);
+  }
 
   // Functional test helpers, ignore.
   SetSilentLoggerForTesting();
@@ -397,6 +442,6 @@ int main(int argc, char *argv[])
   foo_library::observable_counter_example("yaml");
   foo_library::histogram_example("yaml");
 
-  CleanupOtel();
-  return 0;
+  return_code = CleanupOtel();
+  return static_cast<int>(return_code);
 }

--- a/examples/configuration/main.cc
+++ b/examples/configuration/main.cc
@@ -1,6 +1,7 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
+#include <cstdint>
 #include <cstdio>
 #include <cstring>
 #include <string>

--- a/examples/configuration/sdk-default.yaml
+++ b/examples/configuration/sdk-default.yaml
@@ -13,6 +13,7 @@
 
 file_format: "1.1"
 disabled: false
+log_level: debug
 
 # --- Logs ---
 logger_provider:

--- a/exporters/ostream/src/console_push_metric_builder.cc
+++ b/exporters/ostream/src/console_push_metric_builder.cc
@@ -10,6 +10,7 @@
 #include "opentelemetry/sdk/common/global_log_handler.h"
 #include "opentelemetry/sdk/configuration/console_push_metric_exporter_builder.h"
 #include "opentelemetry/sdk/configuration/console_push_metric_exporter_configuration.h"
+#include "opentelemetry/sdk/configuration/default_histogram_aggregation.h"
 #include "opentelemetry/sdk/configuration/registry.h"
 #include "opentelemetry/sdk/configuration/temporality_preference.h"
 #include "opentelemetry/sdk/metrics/instruments.h"
@@ -31,6 +32,14 @@ void ConsolePushMetricBuilder::Register(opentelemetry::sdk::configuration::Regis
 std::unique_ptr<opentelemetry::sdk::metrics::PushMetricExporter> ConsolePushMetricBuilder::Build(
     const opentelemetry::sdk::configuration::ConsolePushMetricExporterConfiguration *model) const
 {
+  // FIXME-SDK: default_histogram_aggregation is parsed but not implemented by the SDK.
+  if (model->default_histogram_aggregation !=
+      opentelemetry::sdk::configuration::DefaultHistogramAggregation::explicit_bucket_histogram)
+  {
+    OTEL_INTERNAL_LOG_WARN(
+        "[Console Exporter] default_histogram_aggregation is not supported and will be ignored");
+  }
+
   sdk::metrics::AggregationTemporality aggregation_temporality{
       sdk::metrics::AggregationTemporality::kUnspecified};
 

--- a/exporters/otlp/src/otlp_builder_utils.cc
+++ b/exporters/otlp/src/otlp_builder_utils.cc
@@ -130,6 +130,12 @@ bool OtlpBuilderUtils::GrpcUseSsl(
 
   if (endpoint.substr(0, 5) == "http:")
   {
+    if (tls && !tls->insecure)
+    {
+      OTEL_INTERNAL_LOG_WARN(
+          "[Otlp Grpc Exporter] endpoint is http but tls.insecure is false: using insecure "
+          "connection");
+    }
     return false;
   }
 
@@ -138,6 +144,10 @@ bool OtlpBuilderUtils::GrpcUseSsl(
     return !tls->insecure;
   }
 
+  OTEL_INTERNAL_LOG_DEBUG(
+      "[Otlp Grpc Exporter] endpoint does not specify http or https and tls is not configured. "
+      "Using secure connection by default. To use an insecure connection, set tls.insecure to "
+      "true.");
   return true;
 }
 

--- a/exporters/otlp/src/otlp_file_log_record_builder.cc
+++ b/exporters/otlp/src/otlp_file_log_record_builder.cc
@@ -2,12 +2,15 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include <memory>
+#include <string>
 #include <utility>
 
 #include "opentelemetry/exporters/otlp/otlp_file_log_record_builder.h"
 #include "opentelemetry/exporters/otlp/otlp_file_log_record_exporter_factory.h"
 #include "opentelemetry/exporters/otlp/otlp_file_log_record_exporter_options.h"
+#include "opentelemetry/sdk/common/global_log_handler.h"
 #include "opentelemetry/sdk/configuration/otlp_file_log_record_exporter_builder.h"
+#include "opentelemetry/sdk/configuration/otlp_file_log_record_exporter_configuration.h"
 #include "opentelemetry/sdk/configuration/registry.h"
 #include "opentelemetry/sdk/logs/exporter.h"
 #include "opentelemetry/version.h"
@@ -25,12 +28,15 @@ void OtlpFileLogRecordBuilder::Register(opentelemetry::sdk::configuration::Regis
 }
 
 std::unique_ptr<opentelemetry::sdk::logs::LogRecordExporter> OtlpFileLogRecordBuilder::Build(
-    const opentelemetry::sdk::configuration::OtlpFileLogRecordExporterConfiguration * /* model */)
-    const
+    const opentelemetry::sdk::configuration::OtlpFileLogRecordExporterConfiguration *model) const
 {
   OtlpFileLogRecordExporterOptions options;
 
   // FIXME: unclear how to map model->output_stream to a OtlpFileClientBackendOptions
+  if (!model->output_stream.empty())
+  {
+    OTEL_INTERNAL_LOG_WARN("[Otlp File Exporter] output_stream is not yet supported, ignoring");
+  }
 
   return OtlpFileLogRecordExporterFactory::Create(options);
 }

--- a/exporters/otlp/src/otlp_file_push_metric_builder.cc
+++ b/exporters/otlp/src/otlp_file_push_metric_builder.cc
@@ -2,12 +2,15 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include <memory>
+#include <string>
 #include <utility>
 
 #include "opentelemetry/exporters/otlp/otlp_builder_utils.h"
 #include "opentelemetry/exporters/otlp/otlp_file_metric_exporter_factory.h"
 #include "opentelemetry/exporters/otlp/otlp_file_metric_exporter_options.h"
 #include "opentelemetry/exporters/otlp/otlp_file_push_metric_builder.h"
+#include "opentelemetry/sdk/common/global_log_handler.h"
+#include "opentelemetry/sdk/configuration/default_histogram_aggregation.h"
 #include "opentelemetry/sdk/configuration/otlp_file_push_metric_exporter_builder.h"
 #include "opentelemetry/sdk/configuration/otlp_file_push_metric_exporter_configuration.h"
 #include "opentelemetry/sdk/configuration/registry.h"
@@ -29,9 +32,22 @@ void OtlpFilePushMetricBuilder::Register(opentelemetry::sdk::configuration::Regi
 std::unique_ptr<opentelemetry::sdk::metrics::PushMetricExporter> OtlpFilePushMetricBuilder::Build(
     const opentelemetry::sdk::configuration::OtlpFilePushMetricExporterConfiguration *model) const
 {
+  // FIXME-SDK: default_histogram_aggregation is parsed but not implemented by the SDK.
+  if (model->default_histogram_aggregation !=
+      opentelemetry::sdk::configuration::DefaultHistogramAggregation::explicit_bucket_histogram)
+  {
+    OTEL_INTERNAL_LOG_WARN(
+        "[Otlp File Exporter] default_histogram_aggregation is not supported and will be "
+        "ignored");
+  }
+
   OtlpFileMetricExporterOptions options;
 
   // FIXME: unclear how to map model->output_stream to a OtlpFileClientBackendOptions
+  if (!model->output_stream.empty())
+  {
+    OTEL_INTERNAL_LOG_WARN("[Otlp File Exporter] output_stream is not yet supported, ignoring");
+  }
 
   options.aggregation_temporality =
       OtlpBuilderUtils::ConvertTemporalityPreference(model->temporality_preference);

--- a/exporters/otlp/src/otlp_file_span_builder.cc
+++ b/exporters/otlp/src/otlp_file_span_builder.cc
@@ -2,12 +2,15 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include <memory>
+#include <string>
 #include <utility>
 
 #include "opentelemetry/exporters/otlp/otlp_file_exporter_factory.h"
 #include "opentelemetry/exporters/otlp/otlp_file_exporter_options.h"
 #include "opentelemetry/exporters/otlp/otlp_file_span_builder.h"
+#include "opentelemetry/sdk/common/global_log_handler.h"
 #include "opentelemetry/sdk/configuration/otlp_file_span_exporter_builder.h"
+#include "opentelemetry/sdk/configuration/otlp_file_span_exporter_configuration.h"
 #include "opentelemetry/sdk/configuration/registry.h"
 #include "opentelemetry/sdk/trace/exporter.h"
 #include "opentelemetry/version.h"
@@ -25,11 +28,15 @@ void OtlpFileSpanBuilder::Register(opentelemetry::sdk::configuration::Registry *
 }
 
 std::unique_ptr<opentelemetry::sdk::trace::SpanExporter> OtlpFileSpanBuilder::Build(
-    const opentelemetry::sdk::configuration::OtlpFileSpanExporterConfiguration * /* model */) const
+    const opentelemetry::sdk::configuration::OtlpFileSpanExporterConfiguration *model) const
 {
   OtlpFileExporterOptions options;
 
   // FIXME: unclear how to map model->output_stream to a OtlpFileClientBackendOptions
+  if (!model->output_stream.empty())
+  {
+    OTEL_INTERNAL_LOG_WARN("[Otlp File Exporter] output_stream is not yet supported, ignoring");
+  }
 
   return OtlpFileExporterFactory::Create(options);
 }

--- a/exporters/otlp/src/otlp_grpc_log_record_builder.cc
+++ b/exporters/otlp/src/otlp_grpc_log_record_builder.cc
@@ -17,6 +17,10 @@
 #include "opentelemetry/sdk/logs/exporter.h"
 #include "opentelemetry/version.h"
 
+#ifndef ENABLE_OTLP_GRPC_SSL_MTLS_PREVIEW
+#  include "opentelemetry/sdk/common/global_log_handler.h"
+#endif
+
 OPENTELEMETRY_BEGIN_NAMESPACE
 namespace exporter
 {
@@ -46,6 +50,13 @@ std::unique_ptr<opentelemetry::sdk::logs::LogRecordExporter> OtlpGrpcLogRecordBu
 #ifdef ENABLE_OTLP_GRPC_SSL_MTLS_PREVIEW
     options.ssl_client_key_path  = tls->key_file;
     options.ssl_client_cert_path = tls->cert_file;
+#else
+    if (!tls->key_file.empty() || !tls->cert_file.empty())
+    {
+      OTEL_INTERNAL_LOG_WARN(
+          "[Otlp Grpc Exporter] mTLS client key/cert configured but the SDK was built without "
+          "ENABLE_OTLP_GRPC_SSL_MTLS_PREVIEW: tls.cert_file and tls.key_file will be ignored");
+    }
 #endif
   }
 

--- a/exporters/otlp/src/otlp_grpc_push_metric_builder.cc
+++ b/exporters/otlp/src/otlp_grpc_push_metric_builder.cc
@@ -10,6 +10,8 @@
 #include "opentelemetry/exporters/otlp/otlp_grpc_metric_exporter_factory.h"
 #include "opentelemetry/exporters/otlp/otlp_grpc_metric_exporter_options.h"
 #include "opentelemetry/exporters/otlp/otlp_grpc_push_metric_builder.h"
+#include "opentelemetry/sdk/common/global_log_handler.h"
+#include "opentelemetry/sdk/configuration/default_histogram_aggregation.h"
 #include "opentelemetry/sdk/configuration/grpc_tls_configuration.h"
 #include "opentelemetry/sdk/configuration/otlp_grpc_push_metric_exporter_builder.h"
 #include "opentelemetry/sdk/configuration/otlp_grpc_push_metric_exporter_configuration.h"
@@ -32,6 +34,15 @@ void OtlpGrpcPushMetricBuilder::Register(opentelemetry::sdk::configuration::Regi
 std::unique_ptr<opentelemetry::sdk::metrics::PushMetricExporter> OtlpGrpcPushMetricBuilder::Build(
     const opentelemetry::sdk::configuration::OtlpGrpcPushMetricExporterConfiguration *model) const
 {
+  // FIXME-SDK: default_histogram_aggregation is parsed but not implemented by the SDK.
+  if (model->default_histogram_aggregation !=
+      opentelemetry::sdk::configuration::DefaultHistogramAggregation::explicit_bucket_histogram)
+  {
+    OTEL_INTERNAL_LOG_WARN(
+        "[Otlp Grpc Exporter] default_histogram_aggregation is not supported and will be "
+        "ignored");
+  }
+
   OtlpGrpcMetricExporterOptions options(nullptr);
 
   const auto *tls = model->tls.get();
@@ -46,6 +57,13 @@ std::unique_ptr<opentelemetry::sdk::metrics::PushMetricExporter> OtlpGrpcPushMet
 #ifdef ENABLE_OTLP_GRPC_SSL_MTLS_PREVIEW
     options.ssl_client_key_path  = tls->key_file;
     options.ssl_client_cert_path = tls->cert_file;
+#else
+    if (!tls->key_file.empty() || !tls->cert_file.empty())
+    {
+      OTEL_INTERNAL_LOG_WARN(
+          "[Otlp Grpc Exporter] mTLS client key/cert configured but the SDK was built without "
+          "ENABLE_OTLP_GRPC_SSL_MTLS_PREVIEW: tls.cert_file and tls.key_file will be ignored");
+    }
 #endif
   }
 

--- a/exporters/otlp/src/otlp_grpc_span_builder.cc
+++ b/exporters/otlp/src/otlp_grpc_span_builder.cc
@@ -17,6 +17,10 @@
 #include "opentelemetry/sdk/trace/exporter.h"
 #include "opentelemetry/version.h"
 
+#ifndef ENABLE_OTLP_GRPC_SSL_MTLS_PREVIEW
+#  include "opentelemetry/sdk/common/global_log_handler.h"
+#endif
+
 OPENTELEMETRY_BEGIN_NAMESPACE
 namespace exporter
 {
@@ -46,6 +50,13 @@ std::unique_ptr<opentelemetry::sdk::trace::SpanExporter> OtlpGrpcSpanBuilder::Bu
 #ifdef ENABLE_OTLP_GRPC_SSL_MTLS_PREVIEW
     options.ssl_client_key_path  = tls->key_file;
     options.ssl_client_cert_path = tls->cert_file;
+#else
+    if (!tls->key_file.empty() || !tls->cert_file.empty())
+    {
+      OTEL_INTERNAL_LOG_WARN(
+          "[Otlp Grpc Exporter] mTLS client key/cert configured but the SDK was built without "
+          "ENABLE_OTLP_GRPC_SSL_MTLS_PREVIEW: tls.cert_file and tls.key_file will be ignored");
+    }
 #endif
   }
 

--- a/exporters/otlp/src/otlp_http_push_metric_builder.cc
+++ b/exporters/otlp/src/otlp_http_push_metric_builder.cc
@@ -11,6 +11,8 @@
 #include "opentelemetry/exporters/otlp/otlp_http_metric_exporter_factory.h"
 #include "opentelemetry/exporters/otlp/otlp_http_metric_exporter_options.h"
 #include "opentelemetry/exporters/otlp/otlp_http_push_metric_builder.h"
+#include "opentelemetry/sdk/common/global_log_handler.h"
+#include "opentelemetry/sdk/configuration/default_histogram_aggregation.h"
 #include "opentelemetry/sdk/configuration/http_tls_configuration.h"
 #include "opentelemetry/sdk/configuration/otlp_http_push_metric_exporter_builder.h"
 #include "opentelemetry/sdk/configuration/otlp_http_push_metric_exporter_configuration.h"
@@ -33,6 +35,15 @@ void OtlpHttpPushMetricBuilder::Register(opentelemetry::sdk::configuration::Regi
 std::unique_ptr<opentelemetry::sdk::metrics::PushMetricExporter> OtlpHttpPushMetricBuilder::Build(
     const opentelemetry::sdk::configuration::OtlpHttpPushMetricExporterConfiguration *model) const
 {
+  // FIXME-SDK: default_histogram_aggregation is parsed but not implemented by the SDK.
+  if (model->default_histogram_aggregation !=
+      opentelemetry::sdk::configuration::DefaultHistogramAggregation::explicit_bucket_histogram)
+  {
+    OTEL_INTERNAL_LOG_WARN(
+        "[Otlp Http Exporter] default_histogram_aggregation is not supported and will be "
+        "ignored");
+  }
+
   OtlpHttpMetricExporterOptions options(nullptr);
 
   const auto *tls = model->tls.get();

--- a/install/test/cmake/examples_test/CMakeLists.txt
+++ b/install/test/cmake/examples_test/CMakeLists.txt
@@ -46,6 +46,10 @@ if("exporters_etw" IN_LIST OPENTELEMETRY_CPP_COMPONENTS_INSTALLED)
   set(OTELCPP_WITH_ETW ON)
 endif()
 
+if("resource_detectors" IN_LIST OPENTELEMETRY_CPP_COMPONENTS_INSTALLED)
+  set(OTELCPP_WITH_RESOURCE_DETECTORS ON)
+endif()
+
 # The http example uses the embedded server headers, which the package no longer
 # installs. The ext headers it does use are covered by
 # install/test/src/test_ext_*.cc.

--- a/install/test/src/test_exporters_otlp_file.cc
+++ b/install/test/src/test_exporters_otlp_file.cc
@@ -16,6 +16,10 @@
 #include <opentelemetry/exporters/otlp/otlp_file_push_metric_builder.h>
 #include <opentelemetry/exporters/otlp/otlp_file_span_builder.h>
 
+#include <opentelemetry/sdk/configuration/otlp_file_log_record_exporter_configuration.h>
+#include <opentelemetry/sdk/configuration/otlp_file_push_metric_exporter_configuration.h>
+#include <opentelemetry/sdk/configuration/otlp_file_span_exporter_configuration.h>
+
 TEST(ExportersOtlpFileInstall, OtlpFileExporter)
 {
   auto options  = opentelemetry::exporter::otlp::OtlpFileExporterOptions();
@@ -41,7 +45,9 @@ TEST(ExportersOtlpFileBuilderInstall, OtlpFileSpanBuilder)
 {
   auto builder = std::make_unique<opentelemetry::exporter::otlp::OtlpFileSpanBuilder>();
   ASSERT_TRUE(builder != nullptr);
-  auto exporter = builder->Build(nullptr);
+
+  opentelemetry::sdk::configuration::OtlpFileSpanExporterConfiguration model;
+  auto exporter = builder->Build(&model);
   ASSERT_TRUE(exporter != nullptr);
 }
 
@@ -62,6 +68,8 @@ TEST(ExportersOtlpFileBuilderInstall, OtlpFileLogRecordBuilder)
 {
   auto builder = std::make_unique<opentelemetry::exporter::otlp::OtlpFileLogRecordBuilder>();
   ASSERT_TRUE(builder != nullptr);
-  auto exporter = builder->Build(nullptr);
+
+  opentelemetry::sdk::configuration::OtlpFileLogRecordExporterConfiguration model;
+  auto exporter = builder->Build(&model);
   ASSERT_TRUE(exporter != nullptr);
 }

--- a/sdk/src/configuration/configuration_parser.cc
+++ b/sdk/src/configuration/configuration_parser.cc
@@ -348,7 +348,6 @@ std::unique_ptr<HeadersConfiguration> ConfigurationParser::ParseHeadersConfigura
     name  = name_child->AsString();
     value = value_child->AsString();
 
-    OTEL_INTERNAL_LOG_DEBUG("ParseHeadersConfiguration() name = " << name << ", value = " << value);
     std::pair<std::string, std::string> entry(name, value);
     model->kv_map.insert(entry);
   }
@@ -2627,7 +2626,8 @@ std::unique_ptr<AttributesConfiguration> ConfigurationParser::ParseAttributesCon
     // Per schema nullBehavior: skip entries with a null value.
     if (value_child->IsNull())
     {
-      OTEL_INTERNAL_LOG_DEBUG("Skipping attribute '" << name << "' with null value");
+      OTEL_INTERNAL_LOG_DEBUG("[Config Parser] Skipping attribute '" << name
+                                                                     << "' with null value");
       continue;
     }
 
@@ -2691,7 +2691,8 @@ std::unique_ptr<AttributesConfiguration> ConfigurationParser::ParseAttributesCon
     // var).
     if (value_model == nullptr)
     {
-      OTEL_INTERNAL_LOG_DEBUG("Skipping attribute '" << name << "' with null/empty value");
+      OTEL_INTERNAL_LOG_DEBUG("[Config Parser] Skipping attribute '" << name
+                                                                     << "' with null/empty value");
       continue;
     }
 
@@ -2910,6 +2911,8 @@ std::unique_ptr<Configuration> ConfigurationParser::Parse(std::unique_ptr<Docume
     version_minor_ = minor;
   }
 
+  OTEL_INTERNAL_LOG_DEBUG("[Config Parser] Parsing file with file_format: " << model->file_format);
+
   model->disabled = node->GetBoolean("disabled", false);
 
   const std::string log_level = node->GetString("log_level", "info");
@@ -2953,7 +2956,13 @@ std::unique_ptr<Configuration> ConfigurationParser::Parse(std::unique_ptr<Docume
     model->resource = ParseResourceConfiguration(child);
   }
 
-  // FIXME: instrumentation/development
+  child = node->GetChildNode("instrumentation/development");
+  if (child)
+  {
+    // FIXME-CONFIG: implement the instrumentation/development model
+    OTEL_INTERNAL_LOG_WARN(
+        "[Config Parser] instrumentation/development is not yet supported, ignoring");
+  }
 
   child = node->GetChildNode("distribution");
   if (child)

--- a/sdk/src/configuration/configured_sdk.cc
+++ b/sdk/src/configuration/configured_sdk.cc
@@ -61,8 +61,6 @@ std::unique_ptr<ConfiguredSdk> ConfiguredSdk::Create(
 
 void ConfiguredSdk::Install()
 {
-  opentelemetry::sdk::common::internal_log::GlobalLogHandler::SetLogLevel(log_level);
-
   if (propagator)
   {
     opentelemetry::context::propagation::GlobalTextMapPropagator::SetGlobalPropagator(propagator);

--- a/sdk/src/configuration/ryml_document_node.cc
+++ b/sdk/src/configuration/ryml_document_node.cc
@@ -4,13 +4,12 @@
 #include <cstddef>
 #include <cstdint>
 #include <memory>
-#include <ostream>
+
 #include <ryml.hpp>
 #include <stdexcept>
 #include <string>
 #include <utility>
 
-#include "opentelemetry/sdk/common/global_log_handler.h"
 #include "opentelemetry/sdk/configuration/document_node.h"
 #include "opentelemetry/sdk/configuration/invalid_schema_exception.h"
 #include "opentelemetry/sdk/configuration/ryml_document.h"
@@ -19,6 +18,18 @@
 
 // Local debug, do not use in production
 // #define WITH_DEBUG_NODE
+
+#ifdef WITH_DEBUG_NODE
+#  include <ostream>
+#  include "opentelemetry/sdk/common/global_log_handler.h"
+
+#  define RYML_DOC_LOG_DEBUG(msg) OTEL_INTERNAL_LOG_DEBUG(msg)
+#else
+#  define RYML_DOC_LOG_DEBUG(msg) \
+    do                            \
+    {                             \
+    } while (false)
+#endif
 
 OPENTELEMETRY_BEGIN_NAMESPACE
 namespace sdk
@@ -29,24 +40,24 @@ namespace configuration
 #ifdef WITH_DEBUG_NODE
 static void DebugNode(opentelemetry::nostd::string_view name, ryml::ConstNodeRef node)
 {
-  OTEL_INTERNAL_LOG_DEBUG("Processing: " << name);
-  OTEL_INTERNAL_LOG_DEBUG(" - readable() : " << node.readable());
-  OTEL_INTERNAL_LOG_DEBUG(" - empty() : " << node.empty());
-  OTEL_INTERNAL_LOG_DEBUG(" - is_container() : " << node.is_container());
-  OTEL_INTERNAL_LOG_DEBUG(" - is_map() : " << node.is_map());
-  OTEL_INTERNAL_LOG_DEBUG(" - is_seq() : " << node.is_seq());
-  OTEL_INTERNAL_LOG_DEBUG(" - is_val() : " << node.is_val());
-  OTEL_INTERNAL_LOG_DEBUG(" - is_keyval() : " << node.is_keyval());
-  OTEL_INTERNAL_LOG_DEBUG(" - has_key() : " << node.has_key());
-  OTEL_INTERNAL_LOG_DEBUG(" - has_val() : " << node.has_val());
-  OTEL_INTERNAL_LOG_DEBUG(" - num_children() : " << node.num_children());
+  RYML_DOC_LOG_DEBUG("Processing: " << name);
+  RYML_DOC_LOG_DEBUG(" - readable() : " << node.readable());
+  RYML_DOC_LOG_DEBUG(" - empty() : " << node.empty());
+  RYML_DOC_LOG_DEBUG(" - is_container() : " << node.is_container());
+  RYML_DOC_LOG_DEBUG(" - is_map() : " << node.is_map());
+  RYML_DOC_LOG_DEBUG(" - is_seq() : " << node.is_seq());
+  RYML_DOC_LOG_DEBUG(" - is_val() : " << node.is_val());
+  RYML_DOC_LOG_DEBUG(" - is_keyval() : " << node.is_keyval());
+  RYML_DOC_LOG_DEBUG(" - has_key() : " << node.has_key());
+  RYML_DOC_LOG_DEBUG(" - has_val() : " << node.has_val());
+  RYML_DOC_LOG_DEBUG(" - num_children() : " << node.num_children());
   if (node.has_key())
   {
-    OTEL_INTERNAL_LOG_DEBUG(" - key() : " << node.key());
+    RYML_DOC_LOG_DEBUG(" - key() : " << node.key());
   }
   if (node.has_val())
   {
-    OTEL_INTERNAL_LOG_DEBUG(" - val() : " << node.val());
+    RYML_DOC_LOG_DEBUG(" - val() : " << node.val());
   }
 }
 #endif  // WITH_DEBUG_NODE
@@ -58,7 +69,7 @@ DocumentNodeLocation RymlDocumentNode::Location() const
 
 std::string RymlDocumentNode::Key() const
 {
-  OTEL_INTERNAL_LOG_DEBUG("RymlDocumentNode::Key()");
+  RYML_DOC_LOG_DEBUG("RymlDocumentNode::Key()");
 
   if (!node_.has_key())
   {
@@ -72,7 +83,7 @@ std::string RymlDocumentNode::Key() const
 
 bool RymlDocumentNode::AsBoolean() const
 {
-  OTEL_INTERNAL_LOG_DEBUG("RymlDocumentNode::AsBoolean()");
+  RYML_DOC_LOG_DEBUG("RymlDocumentNode::AsBoolean()");
 
   if (!node_.is_val() && !node_.is_keyval())
   {
@@ -86,7 +97,7 @@ bool RymlDocumentNode::AsBoolean() const
 
 size_t RymlDocumentNode::AsInteger() const
 {
-  OTEL_INTERNAL_LOG_DEBUG("RymlDocumentNode::AsInteger()");
+  RYML_DOC_LOG_DEBUG("RymlDocumentNode::AsInteger()");
 
   if (!node_.is_val() && !node_.is_keyval())
   {
@@ -100,7 +111,7 @@ size_t RymlDocumentNode::AsInteger() const
 
 double RymlDocumentNode::AsDouble() const
 {
-  OTEL_INTERNAL_LOG_DEBUG("RymlDocumentNode::AsDouble()");
+  RYML_DOC_LOG_DEBUG("RymlDocumentNode::AsDouble()");
 
   if (!node_.is_val() && !node_.is_keyval())
   {
@@ -114,7 +125,7 @@ double RymlDocumentNode::AsDouble() const
 
 std::string RymlDocumentNode::AsString() const
 {
-  OTEL_INTERNAL_LOG_DEBUG("RymlDocumentNode::AsString()");
+  RYML_DOC_LOG_DEBUG("RymlDocumentNode::AsString()");
 
   if (!node_.is_val() && !node_.is_keyval())
   {
@@ -128,7 +139,7 @@ std::string RymlDocumentNode::AsString() const
 
 bool RymlDocumentNode::IsNull() const
 {
-  OTEL_INTERNAL_LOG_DEBUG("RymlDocumentNode::IsNull()");
+  RYML_DOC_LOG_DEBUG("RymlDocumentNode::IsNull()");
 
   if (!node_.is_val() && !node_.is_keyval())
   {
@@ -177,8 +188,7 @@ ryml::ConstNodeRef RymlDocumentNode::GetRymlChildNode(const std::string &name) c
 
 std::unique_ptr<DocumentNode> RymlDocumentNode::GetRequiredChildNode(const std::string &name) const
 {
-  OTEL_INTERNAL_LOG_DEBUG("RymlDocumentNode::GetRequiredChildNode(" << depth_ << ", " << name
-                                                                    << ")");
+  RYML_DOC_LOG_DEBUG("RymlDocumentNode::GetRequiredChildNode(" << depth_ << ", " << name << ")");
 
   if (depth_ >= MAX_NODE_DEPTH)
   {
@@ -194,7 +204,7 @@ std::unique_ptr<DocumentNode> RymlDocumentNode::GetRequiredChildNode(const std::
 
 std::unique_ptr<DocumentNode> RymlDocumentNode::GetChildNode(const std::string &name) const
 {
-  OTEL_INTERNAL_LOG_DEBUG("RymlDocumentNode::GetChildNode(" << depth_ << ", " << name << ")");
+  RYML_DOC_LOG_DEBUG("RymlDocumentNode::GetChildNode(" << depth_ << ", " << name << ")");
 
   if (depth_ >= MAX_NODE_DEPTH)
   {
@@ -223,7 +233,7 @@ std::unique_ptr<DocumentNode> RymlDocumentNode::GetChildNode(const std::string &
 
 bool RymlDocumentNode::GetRequiredBoolean(const std::string &name) const
 {
-  OTEL_INTERNAL_LOG_DEBUG("RymlDocumentNode::GetRequiredBoolean(" << name << ")");
+  RYML_DOC_LOG_DEBUG("RymlDocumentNode::GetRequiredBoolean(" << name << ")");
 
   auto ryml_child = GetRequiredRymlChildNode(name);
 
@@ -237,7 +247,7 @@ bool RymlDocumentNode::GetRequiredBoolean(const std::string &name) const
 
 bool RymlDocumentNode::GetBoolean(const std::string &name, bool default_value) const
 {
-  OTEL_INTERNAL_LOG_DEBUG("RymlDocumentNode::GetBoolean(" << name << ", " << default_value << ")");
+  RYML_DOC_LOG_DEBUG("RymlDocumentNode::GetBoolean(" << name << ", " << default_value << ")");
 
   auto ryml_child = GetRymlChildNode(name);
 
@@ -261,7 +271,7 @@ bool RymlDocumentNode::GetBoolean(const std::string &name, bool default_value) c
 
 size_t RymlDocumentNode::GetRequiredInteger(const std::string &name) const
 {
-  OTEL_INTERNAL_LOG_DEBUG("RymlDocumentNode::GetRequiredInteger(" << name << ")");
+  RYML_DOC_LOG_DEBUG("RymlDocumentNode::GetRequiredInteger(" << name << ")");
 
   auto ryml_child = GetRequiredRymlChildNode(name);
 
@@ -275,7 +285,7 @@ size_t RymlDocumentNode::GetRequiredInteger(const std::string &name) const
 
 size_t RymlDocumentNode::GetInteger(const std::string &name, size_t default_value) const
 {
-  OTEL_INTERNAL_LOG_DEBUG("RymlDocumentNode::GetInteger(" << name << ", " << default_value << ")");
+  RYML_DOC_LOG_DEBUG("RymlDocumentNode::GetInteger(" << name << ", " << default_value << ")");
 
   auto ryml_child = GetRymlChildNode(name);
 
@@ -300,8 +310,7 @@ size_t RymlDocumentNode::GetInteger(const std::string &name, size_t default_valu
 std::int64_t RymlDocumentNode::GetSignedInteger(const std::string &name,
                                                 std::int64_t default_value) const
 {
-  OTEL_INTERNAL_LOG_DEBUG("RymlDocumentNode::GetSignedInteger(" << name << ", " << default_value
-                                                                << ")");
+  RYML_DOC_LOG_DEBUG("RymlDocumentNode::GetSignedInteger(" << name << ", " << default_value << ")");
 
   auto ryml_child = GetRymlChildNode(name);
 
@@ -325,7 +334,7 @@ std::int64_t RymlDocumentNode::GetSignedInteger(const std::string &name,
 
 double RymlDocumentNode::GetRequiredDouble(const std::string &name) const
 {
-  OTEL_INTERNAL_LOG_DEBUG("RymlDocumentNode::GetRequiredDouble(" << name << ")");
+  RYML_DOC_LOG_DEBUG("RymlDocumentNode::GetRequiredDouble(" << name << ")");
 
   auto ryml_child = GetRequiredRymlChildNode(name);
 
@@ -339,7 +348,7 @@ double RymlDocumentNode::GetRequiredDouble(const std::string &name) const
 
 double RymlDocumentNode::GetDouble(const std::string &name, double default_value) const
 {
-  OTEL_INTERNAL_LOG_DEBUG("RymlDocumentNode::GetDouble(" << name << ", " << default_value << ")");
+  RYML_DOC_LOG_DEBUG("RymlDocumentNode::GetDouble(" << name << ", " << default_value << ")");
 
   auto ryml_child = GetRymlChildNode(name);
 
@@ -363,7 +372,7 @@ double RymlDocumentNode::GetDouble(const std::string &name, double default_value
 
 std::string RymlDocumentNode::GetRequiredString(const std::string &name) const
 {
-  OTEL_INTERNAL_LOG_DEBUG("RymlDocumentNode::GetRequiredString(" << name << ")");
+  RYML_DOC_LOG_DEBUG("RymlDocumentNode::GetRequiredString(" << name << ")");
 
   ryml::ConstNodeRef ryml_child = GetRequiredRymlChildNode(name);
   ryml::csubstr view            = ryml_child.val();
@@ -384,7 +393,7 @@ std::string RymlDocumentNode::GetRequiredString(const std::string &name) const
 std::string RymlDocumentNode::GetString(const std::string &name,
                                         const std::string &default_value) const
 {
-  OTEL_INTERNAL_LOG_DEBUG("RymlDocumentNode::GetString(" << name << ", " << default_value << ")");
+  RYML_DOC_LOG_DEBUG("RymlDocumentNode::GetString(" << name << ", " << default_value << ")");
 
   ryml::ConstNodeRef ryml_child = GetRymlChildNode(name);
 
@@ -408,7 +417,7 @@ std::string RymlDocumentNode::GetString(const std::string &name,
 
 DocumentNodeConstIterator RymlDocumentNode::begin() const
 {
-  OTEL_INTERNAL_LOG_DEBUG("RymlDocumentNode::begin()");
+  RYML_DOC_LOG_DEBUG("RymlDocumentNode::begin()");
 
 #ifdef WITH_DEBUG_NODE
   DebugNode("::begin()", node_);
@@ -426,7 +435,7 @@ DocumentNodeConstIterator RymlDocumentNode::begin() const
 
 DocumentNodeConstIterator RymlDocumentNode::end() const
 {
-  OTEL_INTERNAL_LOG_DEBUG("RymlDocumentNode::end()");
+  RYML_DOC_LOG_DEBUG("RymlDocumentNode::end()");
 
   auto impl = std::make_unique<RymlDocumentNodeConstIteratorImpl>(doc_, node_, node_.num_children(),
                                                                   depth_);
@@ -449,7 +458,7 @@ std::unique_ptr<DocumentNode> RymlDocumentNode::GetChild(size_t index) const
 
 PropertiesNodeConstIterator RymlDocumentNode::begin_properties() const
 {
-  OTEL_INTERNAL_LOG_DEBUG("RymlDocumentNode::begin_properties()");
+  RYML_DOC_LOG_DEBUG("RymlDocumentNode::begin_properties()");
 
 #ifdef WITH_DEBUG_NODE
   DebugNode("::begin_properties()", node_);
@@ -467,7 +476,7 @@ PropertiesNodeConstIterator RymlDocumentNode::begin_properties() const
 
 PropertiesNodeConstIterator RymlDocumentNode::end_properties() const
 {
-  OTEL_INTERNAL_LOG_DEBUG("RymlDocumentNode::end_properties()");
+  RYML_DOC_LOG_DEBUG("RymlDocumentNode::end_properties()");
 
   auto impl = std::make_unique<RymlPropertiesNodeConstIteratorImpl>(doc_, node_,
                                                                     node_.num_children(), depth_);
@@ -519,7 +528,7 @@ RymlPropertiesNodeConstIteratorImpl::~RymlPropertiesNodeConstIteratorImpl() {}
 
 void RymlPropertiesNodeConstIteratorImpl::Next()
 {
-  OTEL_INTERNAL_LOG_DEBUG("RymlPropertiesNodeConstIteratorImpl::Next()");
+  RYML_DOC_LOG_DEBUG("RymlPropertiesNodeConstIteratorImpl::Next()");
   ++index_;
 }
 
@@ -530,7 +539,7 @@ std::string RymlPropertiesNodeConstIteratorImpl::Name() const
   ryml::csubstr k = ryml_item.key();
   std::string name(k.str, k.len);
 
-  OTEL_INTERNAL_LOG_DEBUG("RymlPropertiesNodeConstIteratorImpl::Name() = " << name);
+  RYML_DOC_LOG_DEBUG("RymlPropertiesNodeConstIteratorImpl::Name() = " << name);
 
   return name;
 }
@@ -542,7 +551,7 @@ std::unique_ptr<DocumentNode> RymlPropertiesNodeConstIteratorImpl::Value() const
   ryml::ConstNodeRef ryml_item = parent_[index_];
   item                         = std::make_unique<RymlDocumentNode>(doc_, ryml_item, depth_ + 1);
 
-  OTEL_INTERNAL_LOG_DEBUG("RymlPropertiesNodeConstIteratorImpl::Value()");
+  RYML_DOC_LOG_DEBUG("RymlPropertiesNodeConstIteratorImpl::Value()");
 
   return item;
 }

--- a/sdk/src/configuration/ryml_document_node.cc
+++ b/sdk/src/configuration/ryml_document_node.cc
@@ -310,7 +310,7 @@ size_t RymlDocumentNode::GetInteger(const std::string &name, size_t default_valu
 
 OptionalValue<std::size_t> RymlDocumentNode::GetOptionalInteger(const std::string &name) const
 {
-  OTEL_INTERNAL_LOG_DEBUG("RymlDocumentNode::GetOptionalInteger(" << name << ")");
+  RYML_DOC_LOG_DEBUG("RymlDocumentNode::GetOptionalInteger(" << name << ")");
 
   auto child = GetChildNode(name);
 

--- a/sdk/src/configuration/sdk_builder.cc
+++ b/sdk/src/configuration/sdk_builder.cc
@@ -418,7 +418,7 @@ public:
         registry_->GetComposableAlwaysOffSamplerBuilder();
     if (builder != nullptr)
     {
-      OTEL_INTERNAL_LOG_DEBUG("VisitComposableAlwaysOff() using registered builder");
+      OTEL_INTERNAL_LOG_DEBUG("[SDK Builder] VisitComposableAlwaysOff() using registered builder");
       sampler = builder->Build(model);
       return;
     }
@@ -434,7 +434,7 @@ public:
         registry_->GetComposableAlwaysOnSamplerBuilder();
     if (builder != nullptr)
     {
-      OTEL_INTERNAL_LOG_DEBUG("VisitComposableAlwaysOn() using registered builder");
+      OTEL_INTERNAL_LOG_DEBUG("[SDK Builder] VisitComposableAlwaysOn() using registered builder");
       sampler = builder->Build(model);
       return;
     }
@@ -450,7 +450,8 @@ public:
         registry_->GetComposableProbabilitySamplerBuilder();
     if (builder != nullptr)
     {
-      OTEL_INTERNAL_LOG_DEBUG("VisitComposableProbability() using registered builder");
+      OTEL_INTERNAL_LOG_DEBUG(
+          "[SDK Builder] VisitComposableProbability() using registered builder");
       sampler = builder->Build(model);
       return;
     }
@@ -484,7 +485,8 @@ public:
         registry_->GetComposableParentThresholdSamplerBuilder();
     if (builder != nullptr)
     {
-      OTEL_INTERNAL_LOG_DEBUG("VisitComposableParentThreshold() using registered builder");
+      OTEL_INTERNAL_LOG_DEBUG(
+          "[SDK Builder] VisitComposableParentThreshold() using registered builder");
       sampler = builder->Build(model, std::move(root));
       return;
     }
@@ -513,7 +515,7 @@ public:
         registry_->GetComposableRuleBasedSamplerBuilder();
     if (builder != nullptr)
     {
-      OTEL_INTERNAL_LOG_DEBUG("VisitComposableRuleBased() using registered builder");
+      OTEL_INTERNAL_LOG_DEBUG("[SDK Builder] VisitComposableRuleBased() using registered builder");
       sampler = builder->Build(model, std::move(rule_samplers));
       return;
     }
@@ -529,7 +531,7 @@ public:
         registry_->GetExtensionComposableSamplerBuilder(model->name);
     if (builder != nullptr)
     {
-      OTEL_INTERNAL_LOG_DEBUG("VisitComposableExtension() using registered builder "
+      OTEL_INTERNAL_LOG_DEBUG("[SDK Builder] VisitComposableExtension() using registered builder "
                               << model->name);
       sampler = builder->Build(model);
       return;
@@ -1062,7 +1064,7 @@ std::unique_ptr<opentelemetry::sdk::trace::Sampler> SdkBuilder::CreateAlwaysOffS
   const AlwaysOffSamplerBuilder *builder = registry_->GetAlwaysOffSamplerBuilder();
   if (builder != nullptr)
   {
-    OTEL_INTERNAL_LOG_DEBUG("CreateAlwaysOffSampler() using registered builder");
+    OTEL_INTERNAL_LOG_DEBUG("[SDK Builder] CreateAlwaysOffSampler() using registered builder");
     return builder->Build(model);
   }
   static const std::string die("No builder for AlwaysOffSampler");
@@ -1075,7 +1077,7 @@ std::unique_ptr<opentelemetry::sdk::trace::Sampler> SdkBuilder::CreateAlwaysOnSa
   const AlwaysOnSamplerBuilder *builder = registry_->GetAlwaysOnSamplerBuilder();
   if (builder != nullptr)
   {
-    OTEL_INTERNAL_LOG_DEBUG("CreateAlwaysOnSampler() using registered builder");
+    OTEL_INTERNAL_LOG_DEBUG("[SDK Builder] CreateAlwaysOnSampler() using registered builder");
     return builder->Build(model);
   }
   static const std::string die("No builder for AlwaysOnSampler");
@@ -1090,7 +1092,7 @@ std::unique_ptr<opentelemetry::sdk::trace::Sampler> SdkBuilder::CreateJaegerRemo
   {
     static const opentelemetry::sdk::configuration::AlwaysOnSamplerConfiguration kAlwaysOn;
     auto initial_sampler = CreateAlwaysOnSampler(&kAlwaysOn);
-    OTEL_INTERNAL_LOG_DEBUG("CreateJaegerRemoteSampler() using registered builder");
+    OTEL_INTERNAL_LOG_DEBUG("[SDK Builder] CreateJaegerRemoteSampler() using registered builder");
     return builder->Build(model, std::move(initial_sampler));
   }
   static const std::string die("No builder for JaegerRemoteSampler");
@@ -1160,7 +1162,7 @@ std::unique_ptr<opentelemetry::sdk::trace::Sampler> SdkBuilder::CreateParentBase
   const ParentBasedSamplerBuilder *builder = registry_->GetParentBasedSamplerBuilder();
   if (builder != nullptr)
   {
-    OTEL_INTERNAL_LOG_DEBUG("CreateParentBasedSampler() using registered builder");
+    OTEL_INTERNAL_LOG_DEBUG("[SDK Builder] CreateParentBasedSampler() using registered builder");
     return builder->Build(model, std::move(root_sdk), std::move(remote_parent_sampled_sdk),
                           std::move(remote_parent_not_sampled_sdk),
                           std::move(local_parent_sampled_sdk),
@@ -1177,7 +1179,7 @@ std::unique_ptr<opentelemetry::sdk::trace::Sampler> SdkBuilder::CreateCompositeS
   const CompositeSamplerBuilder *builder = registry_->GetCompositeSamplerBuilder();
   if (builder != nullptr)
   {
-    OTEL_INTERNAL_LOG_DEBUG("CreateCompositeSampler() using registered builder");
+    OTEL_INTERNAL_LOG_DEBUG("[SDK Builder] CreateCompositeSampler() using registered builder");
     ComposableSamplerBuilder composable_builder(registry_.get(), 1);
     model->Accept(&composable_builder);
     return builder->Build(std::move(composable_builder.sampler));
@@ -1193,7 +1195,7 @@ std::unique_ptr<opentelemetry::sdk::trace::Sampler> SdkBuilder::CreateProbabilit
   const ProbabilitySamplerBuilder *builder = registry_->GetProbabilitySamplerBuilder();
   if (builder != nullptr)
   {
-    OTEL_INTERNAL_LOG_DEBUG("CreateProbabilitySampler() using registered builder");
+    OTEL_INTERNAL_LOG_DEBUG("[SDK Builder] CreateProbabilitySampler() using registered builder");
     return builder->Build(model);
   }
   static const std::string die("No builder for ProbabilitySampler");
@@ -1206,7 +1208,8 @@ std::unique_ptr<opentelemetry::sdk::trace::Sampler> SdkBuilder::CreateTraceIdRat
   const TraceIdRatioBasedSamplerBuilder *builder = registry_->GetTraceIdRatioBasedSamplerBuilder();
   if (builder != nullptr)
   {
-    OTEL_INTERNAL_LOG_DEBUG("CreateTraceIdRatioBasedSampler() using registered builder");
+    OTEL_INTERNAL_LOG_DEBUG(
+        "[SDK Builder] CreateTraceIdRatioBasedSampler() using registered builder");
     return builder->Build(model);
   }
   static const std::string die("No builder for TraceIdRatioBasedSampler");
@@ -1223,7 +1226,8 @@ std::unique_ptr<opentelemetry::sdk::trace::Sampler> SdkBuilder::CreateExtensionS
 
   if (builder != nullptr)
   {
-    OTEL_INTERNAL_LOG_DEBUG("CreateExtensionSampler() using registered builder " << name);
+    OTEL_INTERNAL_LOG_DEBUG("[SDK Builder] CreateExtensionSampler() using registered builder "
+                            << name);
     sdk = builder->Build(model);
     return sdk;
   }
@@ -1252,7 +1256,8 @@ std::unique_ptr<opentelemetry::sdk::trace::SpanExporter> SdkBuilder::CreateOtlpH
   const OtlpHttpSpanExporterBuilder *builder = registry_->GetOtlpHttpSpanBuilder();
   if (builder != nullptr)
   {
-    OTEL_INTERNAL_LOG_DEBUG("CreateOtlpHttpSpanExporter() using registered http builder");
+    OTEL_INTERNAL_LOG_DEBUG(
+        "[SDK Builder] CreateOtlpHttpSpanExporter() using registered http builder");
     sdk = builder->Build(model);
     return sdk;
   }
@@ -1268,7 +1273,8 @@ std::unique_ptr<opentelemetry::sdk::trace::SpanExporter> SdkBuilder::CreateOtlpG
   const OtlpGrpcSpanExporterBuilder *builder = registry_->GetOtlpGrpcSpanBuilder();
   if (builder != nullptr)
   {
-    OTEL_INTERNAL_LOG_DEBUG("CreateOtlpGrpcSpanExporter() using registered grpc builder");
+    OTEL_INTERNAL_LOG_DEBUG(
+        "[SDK Builder] CreateOtlpGrpcSpanExporter() using registered grpc builder");
     sdk = builder->Build(model);
     return sdk;
   }
@@ -1284,7 +1290,8 @@ std::unique_ptr<opentelemetry::sdk::trace::SpanExporter> SdkBuilder::CreateOtlpF
   const OtlpFileSpanExporterBuilder *builder = registry_->GetOtlpFileSpanBuilder();
   if (builder != nullptr)
   {
-    OTEL_INTERNAL_LOG_DEBUG("CreateOtlpFileSpanExporter() using registered file builder");
+    OTEL_INTERNAL_LOG_DEBUG(
+        "[SDK Builder] CreateOtlpFileSpanExporter() using registered file builder");
     sdk = builder->Build(model);
     return sdk;
   }
@@ -1301,7 +1308,7 @@ std::unique_ptr<opentelemetry::sdk::trace::SpanExporter> SdkBuilder::CreateConso
 
   if (builder != nullptr)
   {
-    OTEL_INTERNAL_LOG_DEBUG("CreateConsoleSpanExporter() using registered builder");
+    OTEL_INTERNAL_LOG_DEBUG("[SDK Builder] CreateConsoleSpanExporter() using registered builder");
     sdk = builder->Build(model);
     return sdk;
   }
@@ -1320,7 +1327,8 @@ std::unique_ptr<opentelemetry::sdk::trace::SpanExporter> SdkBuilder::CreateExten
 
   if (builder != nullptr)
   {
-    OTEL_INTERNAL_LOG_DEBUG("CreateExtensionSpanExporter() using registered builder " << name);
+    OTEL_INTERNAL_LOG_DEBUG("[SDK Builder] CreateExtensionSpanExporter() using registered builder "
+                            << name);
     sdk = builder->Build(model);
     return sdk;
   }
@@ -1351,7 +1359,7 @@ std::unique_ptr<opentelemetry::sdk::trace::SpanProcessor> SdkBuilder::CreateBatc
   const BatchSpanProcessorBuilder *builder = registry_->GetBatchSpanProcessorBuilder();
   if (builder != nullptr)
   {
-    OTEL_INTERNAL_LOG_DEBUG("CreateBatchSpanProcessor() using registered builder");
+    OTEL_INTERNAL_LOG_DEBUG("[SDK Builder] CreateBatchSpanProcessor() using registered builder");
     return builder->Build(model, std::move(exporter_sdk));
   }
   static const std::string die("No builder for BatchSpanProcessor");
@@ -1366,7 +1374,7 @@ std::unique_ptr<opentelemetry::sdk::trace::SpanProcessor> SdkBuilder::CreateSimp
   const SimpleSpanProcessorBuilder *builder = registry_->GetSimpleSpanProcessorBuilder();
   if (builder != nullptr)
   {
-    OTEL_INTERNAL_LOG_DEBUG("CreateSimpleSpanProcessor() using registered builder");
+    OTEL_INTERNAL_LOG_DEBUG("[SDK Builder] CreateSimpleSpanProcessor() using registered builder");
     return builder->Build(model, std::move(exporter_sdk));
   }
   static const std::string die("No builder for SimpleSpanProcessor");
@@ -1383,7 +1391,8 @@ std::unique_ptr<opentelemetry::sdk::trace::SpanProcessor> SdkBuilder::CreateExte
 
   if (builder != nullptr)
   {
-    OTEL_INTERNAL_LOG_DEBUG("CreateExtensionSpanProcessor() using registered builder " << name);
+    OTEL_INTERNAL_LOG_DEBUG("[SDK Builder] CreateExtensionSpanProcessor() using registered builder "
+                            << name);
     sdk = builder->Build(model);
     return sdk;
   }
@@ -1414,7 +1423,7 @@ SdkBuilder::CreateTracerConfigurator(
   const TracerConfiguratorBuilder *builder = registry_->GetTracerConfiguratorBuilder();
   if (builder != nullptr)
   {
-    OTEL_INTERNAL_LOG_DEBUG("CreateTracerConfigurator() using registered builder");
+    OTEL_INTERNAL_LOG_DEBUG("[SDK Builder] CreateTracerConfigurator() using registered builder");
     return builder->Build(model.get());
   }
   static const std::string die("No builder for TracerConfigurator");
@@ -1491,7 +1500,8 @@ SdkBuilder::CreateTextMapPropagator(const std::string &name) const
 
   if (builder != nullptr)
   {
-    OTEL_INTERNAL_LOG_DEBUG("CreateTextMapPropagator() using registered builder " << name);
+    OTEL_INTERNAL_LOG_DEBUG("[SDK Builder] CreateTextMapPropagator() using registered builder "
+                            << name);
     sdk = builder->Build();
     return sdk;
   }
@@ -1660,7 +1670,8 @@ SdkBuilder::CreateOtlpHttpPushMetricExporter(
       registry_->GetOtlpHttpPushMetricExporterBuilder();
   if (builder != nullptr)
   {
-    OTEL_INTERNAL_LOG_DEBUG("CreateOtlpHttpPushMetricExporter() using registered http builder");
+    OTEL_INTERNAL_LOG_DEBUG(
+        "[SDK Builder] CreateOtlpHttpPushMetricExporter() using registered http builder");
     sdk = builder->Build(model);
     return sdk;
   }
@@ -1678,7 +1689,8 @@ SdkBuilder::CreateOtlpGrpcPushMetricExporter(
       registry_->GetOtlpGrpcPushMetricExporterBuilder();
   if (builder != nullptr)
   {
-    OTEL_INTERNAL_LOG_DEBUG("CreateOtlpGrpcPushMetricExporter() using registered grpc builder");
+    OTEL_INTERNAL_LOG_DEBUG(
+        "[SDK Builder] CreateOtlpGrpcPushMetricExporter() using registered grpc builder");
     sdk = builder->Build(model);
     return sdk;
   }
@@ -1696,7 +1708,8 @@ SdkBuilder::CreateOtlpFilePushMetricExporter(
       registry_->GetOtlpFilePushMetricExporterBuilder();
   if (builder != nullptr)
   {
-    OTEL_INTERNAL_LOG_DEBUG("CreateOtlpFilePushMetricExporter() using registered file builder");
+    OTEL_INTERNAL_LOG_DEBUG(
+        "[SDK Builder] CreateOtlpFilePushMetricExporter() using registered file builder");
     sdk = builder->Build(model);
     return sdk;
   }
@@ -1716,7 +1729,8 @@ SdkBuilder::CreateConsolePushMetricExporter(
 
   if (builder != nullptr)
   {
-    OTEL_INTERNAL_LOG_DEBUG("CreateConsolePushMetricExporter() using registered builder");
+    OTEL_INTERNAL_LOG_DEBUG(
+        "[SDK Builder] CreateConsolePushMetricExporter() using registered builder");
     sdk = builder->Build(model);
     return sdk;
   }
@@ -1737,8 +1751,8 @@ SdkBuilder::CreateExtensionPushMetricExporter(
 
   if (builder != nullptr)
   {
-    OTEL_INTERNAL_LOG_DEBUG("CreateExtensionPushMetricExporter() using registered builder "
-                            << name);
+    OTEL_INTERNAL_LOG_DEBUG(
+        "[SDK Builder] CreateExtensionPushMetricExporter() using registered builder " << name);
     sdk = builder->Build(model);
     return sdk;
   }
@@ -1759,7 +1773,8 @@ SdkBuilder::CreatePrometheusPullMetricExporter(
 
   if (builder != nullptr)
   {
-    OTEL_INTERNAL_LOG_DEBUG("CreatePrometheusPullMetricExporter() using registered builder");
+    OTEL_INTERNAL_LOG_DEBUG(
+        "[SDK Builder] CreatePrometheusPullMetricExporter() using registered builder");
     sdk = builder->Build(model);
     return sdk;
   }
@@ -1780,8 +1795,8 @@ SdkBuilder::CreateExtensionPullMetricExporter(
 
   if (builder != nullptr)
   {
-    OTEL_INTERNAL_LOG_DEBUG("CreateExtensionPullMetricExporter() using registered builder "
-                            << name);
+    OTEL_INTERNAL_LOG_DEBUG(
+        "[SDK Builder] CreateExtensionPullMetricExporter() using registered builder " << name);
     sdk = builder->Build(model);
     return sdk;
   }
@@ -1827,14 +1842,14 @@ std::unique_ptr<opentelemetry::sdk::metrics::MetricReader> SdkBuilder::CreatePer
 
   if (model->producers.size() > 0)
   {
-    OTEL_INTERNAL_LOG_WARN("metric producer not supported, ignoring");
+    OTEL_INTERNAL_LOG_WARN("[SDK Builder] metric producer is yet not supported, ignoring");
   }
 
   const PeriodicMetricReaderBuilder *builder = registry_->GetPeriodicMetricReaderBuilder();
 
   if (builder != nullptr)
   {
-    OTEL_INTERNAL_LOG_DEBUG("CreatePeriodicMetricReader() using registered builder");
+    OTEL_INTERNAL_LOG_DEBUG("[SDK Builder] CreatePeriodicMetricReader() using registered builder");
     sdk = builder->Build(model, std::move(exporter_sdk));
   }
   else
@@ -1860,7 +1875,7 @@ std::unique_ptr<opentelemetry::sdk::metrics::MetricReader> SdkBuilder::CreatePul
 
   if (model->producers.size() > 0)
   {
-    OTEL_INTERNAL_LOG_WARN("metric producer not supported, ignoring");
+    OTEL_INTERNAL_LOG_WARN("[SDK Builder] metric producer is yet not supported, ignoring");
   }
 
   if (model->cardinality_limits != nullptr)
@@ -2046,7 +2061,6 @@ void SdkBuilder::AddView(
 
     std::unique_ptr<opentelemetry::sdk::metrics::AttributesProcessor> sdk_attribute_processor;
 
-    // FIXME-SDK: The CreateAttributesProcessor method is not implemented yet.
     if (stream->attribute_keys != nullptr)
     {
       sdk_attribute_processor = CreateAttributesProcessor(stream->attribute_keys);
@@ -2089,7 +2103,7 @@ SdkBuilder::CreateMeterConfigurator(
   const MeterConfiguratorBuilder *builder = registry_->GetMeterConfiguratorBuilder();
   if (builder != nullptr)
   {
-    OTEL_INTERNAL_LOG_DEBUG("CreateMeterConfigurator() using registered builder");
+    OTEL_INTERNAL_LOG_DEBUG("[SDK Builder] CreateMeterConfigurator() using registered builder");
     return builder->Build(model.get());
   }
   static const std::string die("No builder for MeterConfigurator");
@@ -2168,7 +2182,8 @@ SdkBuilder::CreateOtlpHttpLogRecordExporter(
   const OtlpHttpLogRecordExporterBuilder *builder = registry_->GetOtlpHttpLogRecordBuilder();
   if (builder != nullptr)
   {
-    OTEL_INTERNAL_LOG_DEBUG("CreateOtlpHttpLogRecordExporter() using registered http builder");
+    OTEL_INTERNAL_LOG_DEBUG(
+        "[SDK Builder] CreateOtlpHttpLogRecordExporter() using registered http builder");
     sdk = builder->Build(model);
     return sdk;
   }
@@ -2185,7 +2200,8 @@ SdkBuilder::CreateOtlpGrpcLogRecordExporter(
   const OtlpGrpcLogRecordExporterBuilder *builder = registry_->GetOtlpGrpcLogRecordBuilder();
   if (builder != nullptr)
   {
-    OTEL_INTERNAL_LOG_DEBUG("CreateOtlpGrpcLogRecordExporter() using registered grpc builder");
+    OTEL_INTERNAL_LOG_DEBUG(
+        "[SDK Builder] CreateOtlpGrpcLogRecordExporter() using registered grpc builder");
     sdk = builder->Build(model);
     return sdk;
   }
@@ -2202,7 +2218,8 @@ SdkBuilder::CreateOtlpFileLogRecordExporter(
   const OtlpFileLogRecordExporterBuilder *builder = registry_->GetOtlpFileLogRecordBuilder();
   if (builder != nullptr)
   {
-    OTEL_INTERNAL_LOG_DEBUG("CreateOtlpFileLogRecordExporter() using registered file builder");
+    OTEL_INTERNAL_LOG_DEBUG(
+        "[SDK Builder] CreateOtlpFileLogRecordExporter() using registered file builder");
     sdk = builder->Build(model);
     return sdk;
   }
@@ -2220,7 +2237,8 @@ SdkBuilder::CreateConsoleLogRecordExporter(
 
   if (builder != nullptr)
   {
-    OTEL_INTERNAL_LOG_DEBUG("CreateConsoleLogRecordExporter() using registered builder");
+    OTEL_INTERNAL_LOG_DEBUG(
+        "[SDK Builder] CreateConsoleLogRecordExporter() using registered builder");
     sdk = builder->Build(model);
     return sdk;
   }
@@ -2241,7 +2259,8 @@ SdkBuilder::CreateExtensionLogRecordExporter(
 
   if (builder != nullptr)
   {
-    OTEL_INTERNAL_LOG_DEBUG("CreateExtensionLogRecordExporter() using registered builder " << name);
+    OTEL_INTERNAL_LOG_DEBUG(
+        "[SDK Builder] CreateExtensionLogRecordExporter() using registered builder " << name);
     sdk = builder->Build(model);
     return sdk;
   }
@@ -2273,7 +2292,8 @@ SdkBuilder::CreateBatchLogRecordProcessor(
   const BatchLogRecordProcessorBuilder *builder = registry_->GetBatchLogRecordProcessorBuilder();
   if (builder != nullptr)
   {
-    OTEL_INTERNAL_LOG_DEBUG("CreateBatchLogRecordProcessor() using registered builder");
+    OTEL_INTERNAL_LOG_DEBUG(
+        "[SDK Builder] CreateBatchLogRecordProcessor() using registered builder");
     return builder->Build(model, std::move(exporter_sdk));
   }
   static const std::string die("No builder for BatchLogRecordProcessor");
@@ -2289,7 +2309,8 @@ SdkBuilder::CreateSimpleLogRecordProcessor(
   const SimpleLogRecordProcessorBuilder *builder = registry_->GetSimpleLogRecordProcessorBuilder();
   if (builder != nullptr)
   {
-    OTEL_INTERNAL_LOG_DEBUG("CreateSimpleLogRecordProcessor() using registered builder");
+    OTEL_INTERNAL_LOG_DEBUG(
+        "[SDK Builder] CreateSimpleLogRecordProcessor() using registered builder");
     return builder->Build(model, std::move(exporter_sdk));
   }
   static const std::string die("No builder for SimpleLogRecordProcessor");
@@ -2308,8 +2329,8 @@ SdkBuilder::CreateExtensionLogRecordProcessor(
 
   if (builder != nullptr)
   {
-    OTEL_INTERNAL_LOG_DEBUG("CreateExtensionLogRecordProcessor() using registered builder "
-                            << name);
+    OTEL_INTERNAL_LOG_DEBUG(
+        "[SDK Builder] CreateExtensionLogRecordProcessor() using registered builder " << name);
     sdk = builder->Build(model);
     return sdk;
   }
@@ -2340,7 +2361,7 @@ SdkBuilder::CreateLoggerConfigurator(
   const LoggerConfiguratorBuilder *builder = registry_->GetLoggerConfiguratorBuilder();
   if (builder != nullptr)
   {
-    OTEL_INTERNAL_LOG_DEBUG("CreateLoggerConfigurator() using registered builder");
+    OTEL_INTERNAL_LOG_DEBUG("[SDK Builder] CreateLoggerConfigurator() using registered builder");
     return builder->Build(model.get());
   }
   static const std::string die("No builder for LoggerConfigurator");
@@ -2395,7 +2416,8 @@ SdkBuilder::CreateContainerResourceDetector(
 
   if (builder != nullptr)
   {
-    OTEL_INTERNAL_LOG_DEBUG("CreateContainerResourceDetector() using registered builder");
+    OTEL_INTERNAL_LOG_DEBUG(
+        "[SDK Builder] CreateContainerResourceDetector() using registered builder");
     return builder->Build(model);
   }
 
@@ -2411,7 +2433,7 @@ SdkBuilder::CreateHostResourceDetector(
 
   if (builder != nullptr)
   {
-    OTEL_INTERNAL_LOG_DEBUG("CreateHostResourceDetector() using registered builder");
+    OTEL_INTERNAL_LOG_DEBUG("[SDK Builder] CreateHostResourceDetector() using registered builder");
     return builder->Build(model);
   }
 
@@ -2427,7 +2449,8 @@ SdkBuilder::CreateProcessResourceDetector(
 
   if (builder != nullptr)
   {
-    OTEL_INTERNAL_LOG_DEBUG("CreateProcessResourceDetector() using registered builder");
+    OTEL_INTERNAL_LOG_DEBUG(
+        "[SDK Builder] CreateProcessResourceDetector() using registered builder");
     return builder->Build(model);
   }
 
@@ -2443,7 +2466,8 @@ SdkBuilder::CreateServiceResourceDetector(
 
   if (builder != nullptr)
   {
-    OTEL_INTERNAL_LOG_DEBUG("CreateServiceResourceDetector() using registered builder");
+    OTEL_INTERNAL_LOG_DEBUG(
+        "[SDK Builder] CreateServiceResourceDetector() using registered builder");
     return builder->Build(model);
   }
 
@@ -2462,7 +2486,8 @@ SdkBuilder::CreateExtensionResourceDetector(
 
   if (builder != nullptr)
   {
-    OTEL_INTERNAL_LOG_DEBUG("CreateExtensionResourceDetector() using registered builder " << name);
+    OTEL_INTERNAL_LOG_DEBUG(
+        "[SDK Builder] CreateExtensionResourceDetector() using registered builder " << name);
     return builder->Build(model);
   }
 
@@ -2562,7 +2587,7 @@ void SdkBuilder::SetResource(
         }
         else
         {
-          OTEL_INTERNAL_LOG_WARN("Found invalid key/value pair in attributes_list");
+          OTEL_INTERNAL_LOG_WARN("[SDK Builder] Found invalid key/value pair in attributes_list");
         }
       }
 
@@ -2648,7 +2673,7 @@ std::unique_ptr<ConfiguredSdk> SdkBuilder::CreateConfiguredSdk(
     {
       // FIXME-SDK: https://github.com/open-telemetry/opentelemetry-cpp/issues/3303
       // FIXME-SDK: Implement attribute limits
-      OTEL_INTERNAL_LOG_WARN("attribute_limits not supported, ignoring");
+      OTEL_INTERNAL_LOG_WARN("[SDK Builder] attribute_limits not supported, ignoring");
     }
 
     if (model->tracer_provider)
@@ -2670,7 +2695,25 @@ std::unique_ptr<ConfiguredSdk> SdkBuilder::CreateConfiguredSdk(
     {
       sdk->logger_provider = CreateLoggerProvider(model->logger_provider, sdk->resource);
     }
+
+    if (model->distribution)
+    {
+      // FIXME-CONFIG: Implement distribution configuration support
+      OTEL_INTERNAL_LOG_WARN("[SDK Builder] the distribution model is not yet supported, ignoring");
+    }
+
+    // FIXME-CONFIG: Implement instrumentation/development support
+    // if(model->instrumentation)
+    // {
+    //   OTEL_INTERNAL_LOG_WARN("[SDK Builder] instrumentation is not yet supported, ignoring");
+    // }
   }
+
+  // Set the log level if the SDK has been created successfully.
+  opentelemetry::sdk::common::internal_log::GlobalLogHandler::SetLogLevel(sdk->log_level);
+
+  OTEL_INTERNAL_LOG_DEBUG("[SDK Builder] Configured SDK is "
+                          << (model->disabled ? "disabled" : "enabled"));
 
   return sdk;
 }


### PR DESCRIPTION
Fixes # (issue)

This PR cleans up internal logging from declarative configuration.

The following use cases are addressed: 
- The internal logger log level is configurable in yaml. The SDK builder should set that log level independent of the providers being installed to the global singletons. 
- If yaml options are configured that the SDK does not yet support the user should see a warning indicating the option is ignored. 
- If the user configures TLS but the SDK (or endpoint) do not support TLS then a warning must be logged. 
- When configuring debug logs the user should see a helpful stream of log lines that indicate important top level configuration options (SDK enabled or disabled) and the builders invoked.  
- As developers we should be able to create an SDK configuration from the kitchen-sink.yaml and see warnings for all the components that still need configuration support. 

## Changes

- set the model configured log_level as soon as the SDK is successfully created
- move ryml document development debug logging to a compile time option
- add warning logs to the exporters when unsupported options are configured and when TLS configuration is not applied as expected. 
- clean up internal logging and testing of the example_yaml project
- enable testing of the yaml example with install tests
- add missing yaml elements to the kitchen-sink.yaml 

For significant contributions please make sure you have completed the following items:

* [x] `CHANGELOG.md` updated for non-trivial changes
* [ ] Unit tests have been added
* [ ] Changes in public API reviewed