### PR TITLE
feat: support general attribute limits

### DIFF
--- a/sdk/include/opentelemetry/sdk/configuration/attribute_limits_configuration.h
+++ b/sdk/include/opentelemetry/sdk/configuration/attribute_limits_configuration.h
@@ -23,6 +23,9 @@ public:
       (std::numeric_limits<std::size_t>::max)();
   static constexpr std::size_t kDefaultAttributeCountLimit = 128;
 
+  bool has_attribute_value_length_limit{false};
+  bool has_attribute_count_limit{false};
+
   std::size_t attribute_value_length_limit{kDefaultAttributeValueLengthLimit};
   std::size_t attribute_count_limit{kDefaultAttributeCountLimit};
 };

--- a/sdk/include/opentelemetry/sdk/configuration/log_record_limits_configuration.h
+++ b/sdk/include/opentelemetry/sdk/configuration/log_record_limits_configuration.h
@@ -23,6 +23,9 @@ public:
       (std::numeric_limits<std::size_t>::max)();
   static constexpr std::size_t kDefaultAttributeCountLimit = 128;
 
+  bool has_attribute_value_length_limit{false};
+  bool has_attribute_count_limit{false};
+
   std::size_t attribute_value_length_limit{kDefaultAttributeValueLengthLimit};
   std::size_t attribute_count_limit{kDefaultAttributeCountLimit};
 };

--- a/sdk/include/opentelemetry/sdk/configuration/sdk_builder.h
+++ b/sdk/include/opentelemetry/sdk/configuration/sdk_builder.h
@@ -161,7 +161,9 @@ public:
 
   std::unique_ptr<opentelemetry::sdk::trace::TracerProvider> CreateTracerProvider(
       const std::unique_ptr<opentelemetry::sdk::configuration::TracerProviderConfiguration> &model,
-      const opentelemetry::sdk::resource::Resource &resource) const;
+      const opentelemetry::sdk::resource::Resource &resource,
+      const opentelemetry::sdk::configuration::AttributeLimitsConfiguration *attribute_limits =
+          nullptr) const;
 
   std::unique_ptr<opentelemetry::context::propagation::TextMapPropagator> CreateTextMapPropagator(
       const std::string &name) const;
@@ -286,7 +288,9 @@ public:
 
   std::unique_ptr<opentelemetry::sdk::logs::LoggerProvider> CreateLoggerProvider(
       const std::unique_ptr<opentelemetry::sdk::configuration::LoggerProviderConfiguration> &model,
-      const opentelemetry::sdk::resource::Resource &resource) const;
+      const opentelemetry::sdk::resource::Resource &resource,
+      const opentelemetry::sdk::configuration::AttributeLimitsConfiguration *attribute_limits =
+          nullptr) const;
 
   std::unique_ptr<opentelemetry::sdk::resource::ResourceDetector> CreateContainerResourceDetector(
       const opentelemetry::sdk::configuration::ContainerResourceDetectorConfiguration *model) const;

--- a/sdk/include/opentelemetry/sdk/configuration/span_limits_configuration.h
+++ b/sdk/include/opentelemetry/sdk/configuration/span_limits_configuration.h
@@ -27,6 +27,9 @@ public:
   static constexpr std::uint32_t kDefaultEventAttributeCountLimit = 128;
   static constexpr std::uint32_t kDefaultLinkAttributeCountLimit  = 128;
 
+  bool has_attribute_value_length_limit{false};
+  bool has_attribute_count_limit{false};
+
   std::size_t attribute_value_length_limit{kDefaultAttributeValueLengthLimit};
   std::uint32_t attribute_count_limit{kDefaultAttributeCountLimit};
   std::uint32_t event_count_limit{kDefaultEventCountLimit};

--- a/sdk/src/configuration/configuration_parser.cc
+++ b/sdk/src/configuration/configuration_parser.cc
@@ -363,6 +363,21 @@ ConfigurationParser::ParseAttributeLimitsConfiguration(
   using Config = AttributeLimitsConfiguration;
   auto model   = std::make_unique<AttributeLimitsConfiguration>();
 
+  if (auto child = node->GetChildNode("attribute_value_length_limit"))
+  {
+    if (!child->IsNull())
+    {
+      model->has_attribute_value_length_limit = true;
+    }
+  }
+  if (auto child = node->GetChildNode("attribute_count_limit"))
+  {
+    if (!child->IsNull())
+    {
+      model->has_attribute_count_limit = true;
+    }
+  }
+
   model->attribute_value_length_limit =
       node->GetInteger("attribute_value_length_limit", Config::kDefaultAttributeValueLengthLimit);
   model->attribute_count_limit =
@@ -642,6 +657,21 @@ ConfigurationParser::ParseLogRecordLimitsConfiguration(
 {
   using Config = LogRecordLimitsConfiguration;
   auto model   = std::make_unique<LogRecordLimitsConfiguration>();
+
+  if (auto child = node->GetChildNode("attribute_value_length_limit"))
+  {
+    if (!child->IsNull())
+    {
+      model->has_attribute_value_length_limit = true;
+    }
+  }
+  if (auto child = node->GetChildNode("attribute_count_limit"))
+  {
+    if (!child->IsNull())
+    {
+      model->has_attribute_count_limit = true;
+    }
+  }
 
   model->attribute_value_length_limit =
       node->GetInteger("attribute_value_length_limit", Config::kDefaultAttributeValueLengthLimit);
@@ -1685,6 +1715,21 @@ std::unique_ptr<SpanLimitsConfiguration> ConfigurationParser::ParseSpanLimitsCon
     }
     return static_cast<uint32_t>(value);
   };
+
+  if (auto child = node->GetChildNode("attribute_value_length_limit"))
+  {
+    if (!child->IsNull())
+    {
+      model->has_attribute_value_length_limit = true;
+    }
+  }
+  if (auto child = node->GetChildNode("attribute_count_limit"))
+  {
+    if (!child->IsNull())
+    {
+      model->has_attribute_count_limit = true;
+    }
+  }
 
   model->attribute_value_length_limit =
       node->GetInteger("attribute_value_length_limit", Config::kDefaultAttributeValueLengthLimit);

--- a/sdk/src/configuration/sdk_builder.cc
+++ b/sdk/src/configuration/sdk_builder.cc
@@ -1423,7 +1423,8 @@ SdkBuilder::CreateTracerConfigurator(
 
 std::unique_ptr<opentelemetry::sdk::trace::TracerProvider> SdkBuilder::CreateTracerProvider(
     const std::unique_ptr<opentelemetry::sdk::configuration::TracerProviderConfiguration> &model,
-    const opentelemetry::sdk::resource::Resource &resource) const
+    const opentelemetry::sdk::resource::Resource &resource,
+    const opentelemetry::sdk::configuration::AttributeLimitsConfiguration *attribute_limits) const
 {
   std::unique_ptr<opentelemetry::sdk::trace::TracerProvider> sdk;
 
@@ -1451,14 +1452,33 @@ std::unique_ptr<opentelemetry::sdk::trace::TracerProvider> SdkBuilder::CreateTra
   }
 
   opentelemetry::sdk::trace::SpanLimits span_limits;
+  if (attribute_limits)
+  {
+    if (attribute_limits->has_attribute_value_length_limit || !model->limits)
+    {
+      span_limits.attribute_value_length_limit = attribute_limits->attribute_value_length_limit;
+    }
+    if (attribute_limits->has_attribute_count_limit || !model->limits)
+    {
+      span_limits.attribute_count_limit =
+          static_cast<std::uint32_t>(attribute_limits->attribute_count_limit);
+    }
+  }
+
   if (model->limits)
   {
-    span_limits.attribute_value_length_limit = model->limits->attribute_value_length_limit;
-    span_limits.attribute_count_limit        = model->limits->attribute_count_limit;
-    span_limits.event_count_limit            = model->limits->event_count_limit;
-    span_limits.link_count_limit             = model->limits->link_count_limit;
-    span_limits.event_attribute_count_limit  = model->limits->event_attribute_count_limit;
-    span_limits.link_attribute_count_limit   = model->limits->link_attribute_count_limit;
+    if (model->limits->has_attribute_value_length_limit || !attribute_limits)
+    {
+      span_limits.attribute_value_length_limit = model->limits->attribute_value_length_limit;
+    }
+    if (model->limits->has_attribute_count_limit || !attribute_limits)
+    {
+      span_limits.attribute_count_limit = model->limits->attribute_count_limit;
+    }
+    span_limits.event_count_limit           = model->limits->event_count_limit;
+    span_limits.link_count_limit            = model->limits->link_count_limit;
+    span_limits.event_attribute_count_limit = model->limits->event_attribute_count_limit;
+    span_limits.link_attribute_count_limit  = model->limits->link_attribute_count_limit;
   }
 
   if (model->tracer_configurator)
@@ -2349,7 +2369,8 @@ SdkBuilder::CreateLoggerConfigurator(
 
 std::unique_ptr<opentelemetry::sdk::logs::LoggerProvider> SdkBuilder::CreateLoggerProvider(
     const std::unique_ptr<opentelemetry::sdk::configuration::LoggerProviderConfiguration> &model,
-    const opentelemetry::sdk::resource::Resource &resource) const
+    const opentelemetry::sdk::resource::Resource &resource,
+    const opentelemetry::sdk::configuration::AttributeLimitsConfiguration *attribute_limits) const
 {
   std::unique_ptr<opentelemetry::sdk::logs::LoggerProvider> sdk;
 
@@ -2361,10 +2382,29 @@ std::unique_ptr<opentelemetry::sdk::logs::LoggerProvider> SdkBuilder::CreateLogg
   }
 
   opentelemetry::sdk::logs::LogRecordLimits log_record_limits;
+  if (attribute_limits)
+  {
+    if (attribute_limits->has_attribute_value_length_limit || !model->limits)
+    {
+      log_record_limits.attribute_value_length_limit =
+          attribute_limits->attribute_value_length_limit;
+    }
+    if (attribute_limits->has_attribute_count_limit || !model->limits)
+    {
+      log_record_limits.attribute_count_limit = attribute_limits->attribute_count_limit;
+    }
+  }
+
   if (model->limits)
   {
-    log_record_limits.attribute_value_length_limit = model->limits->attribute_value_length_limit;
-    log_record_limits.attribute_count_limit        = model->limits->attribute_count_limit;
+    if (model->limits->has_attribute_value_length_limit || !attribute_limits)
+    {
+      log_record_limits.attribute_value_length_limit = model->limits->attribute_value_length_limit;
+    }
+    if (model->limits->has_attribute_count_limit || !attribute_limits)
+    {
+      log_record_limits.attribute_count_limit = model->limits->attribute_count_limit;
+    }
   }
 
   std::unique_ptr<opentelemetry::sdk::instrumentationscope::ScopeConfigurator<
@@ -2644,16 +2684,10 @@ std::unique_ptr<ConfiguredSdk> SdkBuilder::CreateConfiguredSdk(
   {
     SetResource(sdk->resource, model->resource);
 
-    if (model->attribute_limits)
-    {
-      // FIXME-SDK: https://github.com/open-telemetry/opentelemetry-cpp/issues/3303
-      // FIXME-SDK: Implement attribute limits
-      OTEL_INTERNAL_LOG_WARN("attribute_limits not supported, ignoring");
-    }
-
     if (model->tracer_provider)
     {
-      sdk->tracer_provider = CreateTracerProvider(model->tracer_provider, sdk->resource);
+      sdk->tracer_provider = CreateTracerProvider(
+          model->tracer_provider, sdk->resource, model->attribute_limits.get());
     }
 
     if (model->propagator)
@@ -2668,7 +2702,8 @@ std::unique_ptr<ConfiguredSdk> SdkBuilder::CreateConfiguredSdk(
 
     if (model->logger_provider)
     {
-      sdk->logger_provider = CreateLoggerProvider(model->logger_provider, sdk->resource);
+      sdk->logger_provider = CreateLoggerProvider(
+          model->logger_provider, sdk->resource, model->attribute_limits.get());
     }
   }
 

--- a/sdk/test/configuration/programmatic_configuration_test.cc
+++ b/sdk/test/configuration/programmatic_configuration_test.cc
@@ -42,6 +42,7 @@
 
 #include "opentelemetry/sdk/configuration/aggregation_configuration.h"
 #include "opentelemetry/sdk/configuration/always_off_sampler_configuration.h"
+#include "opentelemetry/sdk/configuration/attribute_limits_configuration.h"
 #include "opentelemetry/sdk/configuration/base2_exponential_bucket_histogram_aggregation_configuration.h"
 #include "opentelemetry/sdk/configuration/batch_log_record_processor_builder.h"
 #include "opentelemetry/sdk/configuration/batch_log_record_processor_configuration.h"
@@ -331,6 +332,239 @@ TEST_F(ProgrammaticConfigTest, LoggerProviderWithLogRecordLimits)
   {
     EXPECT_EQ(nostd::get<std::string>(attr.second).size(), limits.attribute_value_length_limit);
   }
+}
+
+TEST_F(ProgrammaticConfigTest, LoggerProviderWithGeneralAttributeLimits)
+{
+  auto attr_limits = std::make_unique<config_sdk::AttributeLimitsConfiguration>();
+  attr_limits->attribute_count_limit        = 2;
+  attr_limits->attribute_value_length_limit = 5;
+  attr_limits->has_attribute_count_limit    = true;
+  attr_limits->has_attribute_value_length_limit = true;
+
+  auto logger_provider_config = MakeLoggerProviderConfig();
+  logger_provider_config->limits = nullptr;
+
+  auto model             = std::make_unique<config_sdk::Configuration>();
+  model->attribute_limits = std::move(attr_limits);
+  model->logger_provider = std::move(logger_provider_config);
+
+  CreateAndInstallSdk(model);
+  ASSERT_NE(sdk_->logger_provider, nullptr);
+
+  auto logger = logs::Provider::GetLoggerProvider()->GetLogger("test");
+  logger->EmitLogRecord(
+      logs::Severity::kInfo, nostd::string_view("test-message"),
+      common::MakeAttributes({{"key1", "value1"}, {"key2", "value2"}, {"key3", "value3"}}));
+
+  ASSERT_TRUE(sdk_->logger_provider->ForceFlush(std::chrono::milliseconds(kProcessTimeout)));
+  ASSERT_TRUE(sdk_->logger_provider->Shutdown(std::chrono::milliseconds(kProcessTimeout)));
+
+  EXPECT_EQ(log_buffer_->size(), 1);
+  auto *record = log_buffer_->front().get();
+  EXPECT_EQ(nostd::get<std::string>(record->GetBody()), "test-message");
+  const auto &attributes = record->GetAttributes();
+  EXPECT_EQ(attributes.size(), 2u);
+  for (const auto &attr : attributes)
+  {
+    EXPECT_EQ(nostd::get<std::string>(attr.second).size(), 5u);
+  }
+}
+
+TEST_F(ProgrammaticConfigTest, LoggerProviderWithGeneralAttributeLimitsOverridden)
+{
+  auto attr_limits = std::make_unique<config_sdk::AttributeLimitsConfiguration>();
+  attr_limits->attribute_count_limit        = 10;
+  attr_limits->attribute_value_length_limit = 20;
+  attr_limits->has_attribute_count_limit    = true;
+  attr_limits->has_attribute_value_length_limit = true;
+
+  config_sdk::LogRecordLimitsConfiguration limits;
+  limits.attribute_count_limit        = 2;
+  limits.attribute_value_length_limit = 5;
+  limits.has_attribute_count_limit    = true;
+  limits.has_attribute_value_length_limit = true;
+
+  auto logger_provider_config = MakeLoggerProviderConfig();
+  logger_provider_config->limits =
+      std::make_unique<config_sdk::LogRecordLimitsConfiguration>(limits);
+
+  auto model             = std::make_unique<config_sdk::Configuration>();
+  model->attribute_limits = std::move(attr_limits);
+  model->logger_provider = std::move(logger_provider_config);
+
+  CreateAndInstallSdk(model);
+  ASSERT_NE(sdk_->logger_provider, nullptr);
+
+  auto logger = logs::Provider::GetLoggerProvider()->GetLogger("test");
+  logger->EmitLogRecord(
+      logs::Severity::kInfo, nostd::string_view("test-message"),
+      common::MakeAttributes({{"key1", "value1"}, {"key2", "value2"}, {"key3", "value3"}}));
+
+  ASSERT_TRUE(sdk_->logger_provider->ForceFlush(std::chrono::milliseconds(kProcessTimeout)));
+  ASSERT_TRUE(sdk_->logger_provider->Shutdown(std::chrono::milliseconds(kProcessTimeout)));
+
+  EXPECT_EQ(log_buffer_->size(), 1);
+  auto *record = log_buffer_->front().get();
+  const auto &attributes = record->GetAttributes();
+  EXPECT_EQ(attributes.size(), 2u);
+  for (const auto &attr : attributes)
+  {
+    EXPECT_EQ(nostd::get<std::string>(attr.second).size(), 5u);
+  }
+}
+
+TEST_F(ProgrammaticConfigTest, LoggerProviderWithGeneralAttributeLimitsPartialOverride)
+{
+  auto attr_limits = std::make_unique<config_sdk::AttributeLimitsConfiguration>();
+  attr_limits->attribute_count_limit        = 10;
+  attr_limits->attribute_value_length_limit = 5;
+  attr_limits->has_attribute_count_limit    = true;
+  attr_limits->has_attribute_value_length_limit = true;
+
+  config_sdk::LogRecordLimitsConfiguration limits;
+  limits.attribute_count_limit        = 2;
+  limits.has_attribute_count_limit    = true;
+  limits.has_attribute_value_length_limit = false;
+
+  auto logger_provider_config = MakeLoggerProviderConfig();
+  logger_provider_config->limits =
+      std::make_unique<config_sdk::LogRecordLimitsConfiguration>(limits);
+
+  auto model             = std::make_unique<config_sdk::Configuration>();
+  model->attribute_limits = std::move(attr_limits);
+  model->logger_provider = std::move(logger_provider_config);
+
+  CreateAndInstallSdk(model);
+  ASSERT_NE(sdk_->logger_provider, nullptr);
+
+  auto logger = logs::Provider::GetLoggerProvider()->GetLogger("test");
+  logger->EmitLogRecord(
+      logs::Severity::kInfo, nostd::string_view("test-message"),
+      common::MakeAttributes({{"key1", "value1"}, {"key2", "value2"}, {"key3", "value3"}}));
+
+  ASSERT_TRUE(sdk_->logger_provider->ForceFlush(std::chrono::milliseconds(kProcessTimeout)));
+  ASSERT_TRUE(sdk_->logger_provider->Shutdown(std::chrono::milliseconds(kProcessTimeout)));
+
+  EXPECT_EQ(log_buffer_->size(), 1);
+  auto *record = log_buffer_->front().get();
+  const auto &attributes = record->GetAttributes();
+  EXPECT_EQ(attributes.size(), 2u);
+  for (const auto &attr : attributes)
+  {
+    EXPECT_EQ(nostd::get<std::string>(attr.second).size(), 5u);
+  }
+}
+
+TEST_F(ProgrammaticConfigTest, TracerProviderWithGeneralAttributeLimits)
+{
+  auto attr_limits = std::make_unique<config_sdk::AttributeLimitsConfiguration>();
+  attr_limits->attribute_count_limit        = 50;
+  attr_limits->attribute_value_length_limit = 1000;
+  attr_limits->has_attribute_count_limit    = true;
+  attr_limits->has_attribute_value_length_limit = true;
+
+  auto tracer_provider_config = MakeTracerProviderConfig();
+  tracer_provider_config->limits = nullptr;
+
+  auto model             = std::make_unique<config_sdk::Configuration>();
+  model->attribute_limits = std::move(attr_limits);
+  model->tracer_provider = std::move(tracer_provider_config);
+
+  CreateAndInstallSdk(model);
+  ASSERT_NE(sdk_->tracer_provider, nullptr);
+
+  const auto span_limits = sdk_->tracer_provider->GetSpanLimits();
+  EXPECT_EQ(span_limits.attribute_count_limit, 50u);
+  EXPECT_EQ(span_limits.attribute_value_length_limit, 1000u);
+}
+
+TEST_F(ProgrammaticConfigTest, TracerProviderWithGeneralAttributeLimitsOverridden)
+{
+  auto attr_limits = std::make_unique<config_sdk::AttributeLimitsConfiguration>();
+  attr_limits->attribute_count_limit        = 50;
+  attr_limits->attribute_value_length_limit = 1000;
+  attr_limits->has_attribute_count_limit    = true;
+  attr_limits->has_attribute_value_length_limit = true;
+
+  config_sdk::SpanLimitsConfiguration limits;
+  limits.attribute_count_limit        = 20;
+  limits.attribute_value_length_limit = 500;
+  limits.has_attribute_count_limit    = true;
+  limits.has_attribute_value_length_limit = true;
+
+  auto tracer_provider_config = MakeTracerProviderConfig();
+  tracer_provider_config->limits =
+      std::make_unique<config_sdk::SpanLimitsConfiguration>(limits);
+
+  auto model             = std::make_unique<config_sdk::Configuration>();
+  model->attribute_limits = std::move(attr_limits);
+  model->tracer_provider = std::move(tracer_provider_config);
+
+  CreateAndInstallSdk(model);
+  ASSERT_NE(sdk_->tracer_provider, nullptr);
+
+  const auto span_limits = sdk_->tracer_provider->GetSpanLimits();
+  EXPECT_EQ(span_limits.attribute_count_limit, 20u);
+  EXPECT_EQ(span_limits.attribute_value_length_limit, 500u);
+}
+
+TEST_F(ProgrammaticConfigTest, TracerProviderWithGeneralAttributeLimitsPartialOverrideCount)
+{
+  auto attr_limits = std::make_unique<config_sdk::AttributeLimitsConfiguration>();
+  attr_limits->attribute_count_limit        = 50;
+  attr_limits->attribute_value_length_limit = 1000;
+  attr_limits->has_attribute_count_limit    = true;
+  attr_limits->has_attribute_value_length_limit = true;
+
+  config_sdk::SpanLimitsConfiguration limits;
+  limits.attribute_count_limit        = 20;
+  limits.has_attribute_count_limit    = true;
+  limits.has_attribute_value_length_limit = false;
+
+  auto tracer_provider_config = MakeTracerProviderConfig();
+  tracer_provider_config->limits =
+      std::make_unique<config_sdk::SpanLimitsConfiguration>(limits);
+
+  auto model             = std::make_unique<config_sdk::Configuration>();
+  model->attribute_limits = std::move(attr_limits);
+  model->tracer_provider = std::move(tracer_provider_config);
+
+  CreateAndInstallSdk(model);
+  ASSERT_NE(sdk_->tracer_provider, nullptr);
+
+  const auto span_limits = sdk_->tracer_provider->GetSpanLimits();
+  EXPECT_EQ(span_limits.attribute_count_limit, 20u);
+  EXPECT_EQ(span_limits.attribute_value_length_limit, 1000u);
+}
+
+TEST_F(ProgrammaticConfigTest, TracerProviderWithGeneralAttributeLimitsPartialOverrideLength)
+{
+  auto attr_limits = std::make_unique<config_sdk::AttributeLimitsConfiguration>();
+  attr_limits->attribute_count_limit        = 50;
+  attr_limits->attribute_value_length_limit = 1000;
+  attr_limits->has_attribute_count_limit    = true;
+  attr_limits->has_attribute_value_length_limit = true;
+
+  config_sdk::SpanLimitsConfiguration limits;
+  limits.attribute_value_length_limit = 500;
+  limits.has_attribute_value_length_limit = true;
+  limits.has_attribute_count_limit    = false;
+
+  auto tracer_provider_config = MakeTracerProviderConfig();
+  tracer_provider_config->limits =
+      std::make_unique<config_sdk::SpanLimitsConfiguration>(limits);
+
+  auto model             = std::make_unique<config_sdk::Configuration>();
+  model->attribute_limits = std::move(attr_limits);
+  model->tracer_provider = std::move(tracer_provider_config);
+
+  CreateAndInstallSdk(model);
+  ASSERT_NE(sdk_->tracer_provider, nullptr);
+
+  const auto span_limits = sdk_->tracer_provider->GetSpanLimits();
+  EXPECT_EQ(span_limits.attribute_count_limit, 50u);
+  EXPECT_EQ(span_limits.attribute_value_length_limit, 500u);
 }
 
 TEST_F(ProgrammaticConfigTest, LoggerProviderWithLoggerConfigurator)

--- a/sdk/test/configuration/sdk_builder_test.cc
+++ b/sdk/test/configuration/sdk_builder_test.cc
@@ -28,6 +28,7 @@
 #include "opentelemetry/sdk/configuration/aggregation_configuration.h"
 #include "opentelemetry/sdk/configuration/always_off_sampler_configuration.h"
 #include "opentelemetry/sdk/configuration/always_on_sampler_configuration.h"
+#include "opentelemetry/sdk/configuration/attribute_limits_configuration.h"
 #include "opentelemetry/sdk/configuration/attribute_value_configuration.h"
 #include "opentelemetry/sdk/configuration/attributes_configuration.h"
 #include "opentelemetry/sdk/configuration/cardinality_limits_configuration.h"
@@ -53,7 +54,9 @@
 #include "opentelemetry/sdk/configuration/instrument_type.h"
 #include "opentelemetry/sdk/configuration/logger_config_configuration.h"
 #include "opentelemetry/sdk/configuration/logger_configurator_configuration.h"
+#include "opentelemetry/sdk/configuration/log_record_limits_configuration.h"
 #include "opentelemetry/sdk/configuration/logger_matcher_and_config_configuration.h"
+#include "opentelemetry/sdk/configuration/logger_provider_configuration.h"
 #include "opentelemetry/sdk/configuration/parent_based_sampler_configuration.h"
 #include "opentelemetry/sdk/configuration/periodic_metric_reader_builder.h"
 #include "opentelemetry/sdk/configuration/periodic_metric_reader_configuration.h"
@@ -83,7 +86,9 @@
 #include "opentelemetry/nostd/variant.h"
 #include "opentelemetry/sdk/instrumentationscope/instrumentation_scope.h"
 #include "opentelemetry/sdk/instrumentationscope/scope_configurator.h"
+#include "opentelemetry/sdk/logs/log_record_limits.h"
 #include "opentelemetry/sdk/logs/logger_config.h"
+#include "opentelemetry/sdk/logs/logger_provider.h"
 #include "opentelemetry/sdk/metrics/aggregation/aggregation.h"
 #include "opentelemetry/sdk/metrics/aggregation/aggregation_config.h"
 #include "opentelemetry/sdk/metrics/aggregation/default_aggregation.h"
@@ -259,6 +264,171 @@ TEST(SdkBuilder, SpanLimitsConfiguration)
   EXPECT_EQ(limits.link_count_limit, model->limits->link_count_limit);
   EXPECT_EQ(limits.event_attribute_count_limit, model->limits->event_attribute_count_limit);
   EXPECT_EQ(limits.link_attribute_count_limit, model->limits->link_attribute_count_limit);
+}
+
+TEST(SdkBuilder, GeneralAttributeLimitsTracerAndLogger)
+{
+  config_sdk::AttributeLimitsConfiguration attr_limits;
+  attr_limits.attribute_count_limit        = 50;
+  attr_limits.attribute_value_length_limit = 1000;
+  attr_limits.has_attribute_count_limit    = true;
+  attr_limits.has_attribute_value_length_limit = true;
+
+  auto tracer_model    = std::make_unique<config_sdk::TracerProviderConfiguration>();
+  tracer_model->limits = nullptr;
+
+  auto logger_model    = std::make_unique<config_sdk::LoggerProviderConfiguration>();
+  logger_model->limits = nullptr;
+
+  SdkBuilder builder(RegistryFactory::Create());
+  auto resource = opentelemetry::sdk::resource::Resource::Create({});
+
+  auto tracer_provider = builder.CreateTracerProvider(tracer_model, resource, &attr_limits);
+  ASSERT_NE(tracer_provider, nullptr);
+  const auto span_limits = tracer_provider->GetSpanLimits();
+  EXPECT_EQ(span_limits.attribute_count_limit, 50u);
+  EXPECT_EQ(span_limits.attribute_value_length_limit, 1000u);
+  EXPECT_EQ(span_limits.event_count_limit, 128u);
+
+  auto logger_provider = builder.CreateLoggerProvider(logger_model, resource, &attr_limits);
+  ASSERT_NE(logger_provider, nullptr);
+}
+
+TEST(SdkBuilder, GeneralAttributeLimitsTracerOverride)
+{
+  config_sdk::AttributeLimitsConfiguration attr_limits;
+  attr_limits.attribute_count_limit        = 50;
+  attr_limits.attribute_value_length_limit = 1000;
+  attr_limits.has_attribute_count_limit    = true;
+  attr_limits.has_attribute_value_length_limit = true;
+
+  auto tracer_model                           = std::make_unique<config_sdk::TracerProviderConfiguration>();
+  tracer_model->limits                        = std::make_unique<config_sdk::SpanLimitsConfiguration>();
+  tracer_model->limits->attribute_count_limit = 20;
+  tracer_model->limits->attribute_value_length_limit = 500;
+  tracer_model->limits->has_attribute_count_limit = true;
+  tracer_model->limits->has_attribute_value_length_limit = true;
+
+  SdkBuilder builder(RegistryFactory::Create());
+  auto resource = opentelemetry::sdk::resource::Resource::Create({});
+
+  auto tracer_provider = builder.CreateTracerProvider(tracer_model, resource, &attr_limits);
+  ASSERT_NE(tracer_provider, nullptr);
+  const auto span_limits = tracer_provider->GetSpanLimits();
+  EXPECT_EQ(span_limits.attribute_count_limit, 20u);
+  EXPECT_EQ(span_limits.attribute_value_length_limit, 500u);
+}
+
+TEST(SdkBuilder, GeneralAttributeLimitsTracerPartialOverrideCount)
+{
+  config_sdk::AttributeLimitsConfiguration attr_limits;
+  attr_limits.attribute_count_limit        = 50;
+  attr_limits.attribute_value_length_limit = 1000;
+  attr_limits.has_attribute_count_limit    = true;
+  attr_limits.has_attribute_value_length_limit = true;
+
+  auto tracer_model                           = std::make_unique<config_sdk::TracerProviderConfiguration>();
+  tracer_model->limits                        = std::make_unique<config_sdk::SpanLimitsConfiguration>();
+  tracer_model->limits->attribute_count_limit = 20;
+  tracer_model->limits->has_attribute_count_limit = true;
+  tracer_model->limits->has_attribute_value_length_limit = false;
+
+  SdkBuilder builder(RegistryFactory::Create());
+  auto resource = opentelemetry::sdk::resource::Resource::Create({});
+
+  auto tracer_provider = builder.CreateTracerProvider(tracer_model, resource, &attr_limits);
+  ASSERT_NE(tracer_provider, nullptr);
+  const auto span_limits = tracer_provider->GetSpanLimits();
+  EXPECT_EQ(span_limits.attribute_count_limit, 20u);
+  EXPECT_EQ(span_limits.attribute_value_length_limit, 1000u);
+}
+
+TEST(SdkBuilder, GeneralAttributeLimitsTracerPartialOverrideLength)
+{
+  config_sdk::AttributeLimitsConfiguration attr_limits;
+  attr_limits.attribute_count_limit        = 50;
+  attr_limits.attribute_value_length_limit = 1000;
+  attr_limits.has_attribute_count_limit    = true;
+  attr_limits.has_attribute_value_length_limit = true;
+
+  auto tracer_model                                  = std::make_unique<config_sdk::TracerProviderConfiguration>();
+  tracer_model->limits                               = std::make_unique<config_sdk::SpanLimitsConfiguration>();
+  tracer_model->limits->attribute_value_length_limit = 500;
+  tracer_model->limits->has_attribute_value_length_limit = true;
+  tracer_model->limits->has_attribute_count_limit = false;
+
+  SdkBuilder builder(RegistryFactory::Create());
+  auto resource = opentelemetry::sdk::resource::Resource::Create({});
+
+  auto tracer_provider = builder.CreateTracerProvider(tracer_model, resource, &attr_limits);
+  ASSERT_NE(tracer_provider, nullptr);
+  const auto span_limits = tracer_provider->GetSpanLimits();
+  EXPECT_EQ(span_limits.attribute_count_limit, 50u);
+  EXPECT_EQ(span_limits.attribute_value_length_limit, 500u);
+}
+
+TEST(SdkBuilder, GeneralAttributeLimitsLoggerOverride)
+{
+  config_sdk::AttributeLimitsConfiguration attr_limits;
+  attr_limits.attribute_count_limit        = 50;
+  attr_limits.attribute_value_length_limit = 1000;
+  attr_limits.has_attribute_count_limit    = true;
+  attr_limits.has_attribute_value_length_limit = true;
+
+  auto logger_model                           = std::make_unique<config_sdk::LoggerProviderConfiguration>();
+  logger_model->limits                        = std::make_unique<config_sdk::LogRecordLimitsConfiguration>();
+  logger_model->limits->attribute_count_limit = 20;
+  logger_model->limits->attribute_value_length_limit = 500;
+  logger_model->limits->has_attribute_count_limit = true;
+  logger_model->limits->has_attribute_value_length_limit = true;
+
+  SdkBuilder builder(RegistryFactory::Create());
+  auto resource = opentelemetry::sdk::resource::Resource::Create({});
+
+  auto logger_provider = builder.CreateLoggerProvider(logger_model, resource, &attr_limits);
+  ASSERT_NE(logger_provider, nullptr);
+}
+
+TEST(SdkBuilder, GeneralAttributeLimitsLoggerPartialOverrideCount)
+{
+  config_sdk::AttributeLimitsConfiguration attr_limits;
+  attr_limits.attribute_count_limit        = 50;
+  attr_limits.attribute_value_length_limit = 1000;
+  attr_limits.has_attribute_count_limit    = true;
+  attr_limits.has_attribute_value_length_limit = true;
+
+  auto logger_model                           = std::make_unique<config_sdk::LoggerProviderConfiguration>();
+  logger_model->limits                        = std::make_unique<config_sdk::LogRecordLimitsConfiguration>();
+  logger_model->limits->attribute_count_limit = 20;
+  logger_model->limits->has_attribute_count_limit = true;
+  logger_model->limits->has_attribute_value_length_limit = false;
+
+  SdkBuilder builder(RegistryFactory::Create());
+  auto resource = opentelemetry::sdk::resource::Resource::Create({});
+
+  auto logger_provider = builder.CreateLoggerProvider(logger_model, resource, &attr_limits);
+  ASSERT_NE(logger_provider, nullptr);
+}
+
+TEST(SdkBuilder, GeneralAttributeLimitsLoggerPartialOverrideLength)
+{
+  config_sdk::AttributeLimitsConfiguration attr_limits;
+  attr_limits.attribute_count_limit        = 50;
+  attr_limits.attribute_value_length_limit = 1000;
+  attr_limits.has_attribute_count_limit    = true;
+  attr_limits.has_attribute_value_length_limit = true;
+
+  auto logger_model                                  = std::make_unique<config_sdk::LoggerProviderConfiguration>();
+  logger_model->limits                               = std::make_unique<config_sdk::LogRecordLimitsConfiguration>();
+  logger_model->limits->attribute_value_length_limit = 500;
+  logger_model->limits->has_attribute_value_length_limit = true;
+  logger_model->limits->has_attribute_count_limit = false;
+
+  SdkBuilder builder(RegistryFactory::Create());
+  auto resource = opentelemetry::sdk::resource::Resource::Create({});
+
+  auto logger_provider = builder.CreateLoggerProvider(logger_model, resource, &attr_limits);
+  ASSERT_NE(logger_provider, nullptr);
 }
 
 #if defined(ENABLE_METRICS_EXEMPLAR_PREVIEW) && !defined(NO_GETENV)

--- a/sdk/test/configuration/yaml_logs_test.cc
+++ b/sdk/test/configuration/yaml_logs_test.cc
@@ -489,6 +489,78 @@ logger_provider:
   ASSERT_EQ(config->logger_provider->limits->attribute_count_limit, 2222);
 }
 
+TEST(YamlLogs, limits_partial_count)
+{
+  std::string yaml = R"(
+file_format: "1.0-logs"
+logger_provider:
+  processors:
+    - simple:
+        exporter:
+          console:
+  limits:
+    attribute_count_limit: 2222
+)";
+
+  auto config = DoParse(yaml);
+  ASSERT_NE(config, nullptr);
+  ASSERT_NE(config->logger_provider, nullptr);
+  ASSERT_NE(config->logger_provider->limits, nullptr);
+  EXPECT_TRUE(config->logger_provider->limits->has_attribute_count_limit);
+  EXPECT_FALSE(config->logger_provider->limits->has_attribute_value_length_limit);
+  EXPECT_EQ(config->logger_provider->limits->attribute_count_limit, 2222u);
+  EXPECT_EQ(config->logger_provider->limits->attribute_value_length_limit,
+            opentelemetry::sdk::configuration::LogRecordLimitsConfiguration::kDefaultAttributeValueLengthLimit);
+}
+
+TEST(YamlLogs, limits_partial_length)
+{
+  std::string yaml = R"(
+file_format: "1.0-logs"
+logger_provider:
+  processors:
+    - simple:
+        exporter:
+          console:
+  limits:
+    attribute_value_length_limit: 1111
+)";
+
+  auto config = DoParse(yaml);
+  ASSERT_NE(config, nullptr);
+  ASSERT_NE(config->logger_provider, nullptr);
+  ASSERT_NE(config->logger_provider->limits, nullptr);
+  EXPECT_FALSE(config->logger_provider->limits->has_attribute_count_limit);
+  EXPECT_TRUE(config->logger_provider->limits->has_attribute_value_length_limit);
+  EXPECT_EQ(config->logger_provider->limits->attribute_count_limit, 128u);
+  EXPECT_EQ(config->logger_provider->limits->attribute_value_length_limit, 1111u);
+}
+
+TEST(YamlLogs, limits_null_values)
+{
+  std::string yaml = R"(
+file_format: "1.0-logs"
+logger_provider:
+  processors:
+    - simple:
+        exporter:
+          console:
+  limits:
+    attribute_value_length_limit:
+    attribute_count_limit:
+)";
+
+  auto config = DoParse(yaml);
+  ASSERT_NE(config, nullptr);
+  ASSERT_NE(config->logger_provider, nullptr);
+  ASSERT_NE(config->logger_provider->limits, nullptr);
+  EXPECT_FALSE(config->logger_provider->limits->has_attribute_count_limit);
+  EXPECT_FALSE(config->logger_provider->limits->has_attribute_value_length_limit);
+  EXPECT_EQ(config->logger_provider->limits->attribute_count_limit, 128u);
+  EXPECT_EQ(config->logger_provider->limits->attribute_value_length_limit,
+            opentelemetry::sdk::configuration::LogRecordLimitsConfiguration::kDefaultAttributeValueLengthLimit);
+}
+
 TEST(YamlLogs, no_logger_configurator)
 {
   std::string yaml = R"(

--- a/sdk/test/configuration/yaml_test.cc
+++ b/sdk/test/configuration/yaml_test.cc
@@ -200,6 +200,60 @@ attribute_limits:
   ASSERT_EQ(config->attribute_limits->attribute_count_limit, 5678);
 }
 
+TEST(Yaml, attribute_limits_partial_count)
+{
+  std::string yaml = R"(
+file_format: "1.0"
+attribute_limits:
+  attribute_count_limit: 5678
+)";
+
+  auto config = DoParse(yaml);
+  ASSERT_NE(config, nullptr);
+  ASSERT_NE(config->attribute_limits, nullptr);
+  EXPECT_TRUE(config->attribute_limits->has_attribute_count_limit);
+  EXPECT_FALSE(config->attribute_limits->has_attribute_value_length_limit);
+  EXPECT_EQ(config->attribute_limits->attribute_count_limit, 5678u);
+  EXPECT_EQ(config->attribute_limits->attribute_value_length_limit,
+            opentelemetry::sdk::configuration::AttributeLimitsConfiguration::kDefaultAttributeValueLengthLimit);
+}
+
+TEST(Yaml, attribute_limits_partial_length)
+{
+  std::string yaml = R"(
+file_format: "1.0"
+attribute_limits:
+  attribute_value_length_limit: 1234
+)";
+
+  auto config = DoParse(yaml);
+  ASSERT_NE(config, nullptr);
+  ASSERT_NE(config->attribute_limits, nullptr);
+  EXPECT_FALSE(config->attribute_limits->has_attribute_count_limit);
+  EXPECT_TRUE(config->attribute_limits->has_attribute_value_length_limit);
+  EXPECT_EQ(config->attribute_limits->attribute_count_limit, 128u);
+  EXPECT_EQ(config->attribute_limits->attribute_value_length_limit, 1234u);
+}
+
+TEST(Yaml, attribute_limits_null_values)
+{
+  std::string yaml = R"(
+file_format: "1.0"
+attribute_limits:
+  attribute_value_length_limit:
+  attribute_count_limit:
+)";
+
+  auto config = DoParse(yaml);
+  ASSERT_NE(config, nullptr);
+  ASSERT_NE(config->attribute_limits, nullptr);
+  EXPECT_FALSE(config->attribute_limits->has_attribute_count_limit);
+  EXPECT_FALSE(config->attribute_limits->has_attribute_value_length_limit);
+  EXPECT_EQ(config->attribute_limits->attribute_count_limit, 128u);
+  EXPECT_EQ(config->attribute_limits->attribute_value_length_limit,
+            opentelemetry::sdk::configuration::AttributeLimitsConfiguration::kDefaultAttributeValueLengthLimit);
+}
+
 TEST(Yaml, no_optional_boolean)
 {
   std::string yaml = R"(

--- a/sdk/test/configuration/yaml_trace_test.cc
+++ b/sdk/test/configuration/yaml_trace_test.cc
@@ -645,6 +645,78 @@ tracer_provider:
   ASSERT_EQ(config->tracer_provider->limits->link_attribute_count_limit, 6666);
 }
 
+TEST(YamlTrace, limits_partial_count)
+{
+  std::string yaml = R"(
+file_format: "1.0-trace"
+tracer_provider:
+  processors:
+    - simple:
+        exporter:
+          console:
+  limits:
+    attribute_count_limit: 2222
+)";
+
+  auto config = DoParse(yaml);
+  ASSERT_NE(config, nullptr);
+  ASSERT_NE(config->tracer_provider, nullptr);
+  ASSERT_NE(config->tracer_provider->limits, nullptr);
+  EXPECT_TRUE(config->tracer_provider->limits->has_attribute_count_limit);
+  EXPECT_FALSE(config->tracer_provider->limits->has_attribute_value_length_limit);
+  EXPECT_EQ(config->tracer_provider->limits->attribute_count_limit, 2222u);
+  EXPECT_EQ(config->tracer_provider->limits->attribute_value_length_limit,
+            opentelemetry::sdk::configuration::SpanLimitsConfiguration::kDefaultAttributeValueLengthLimit);
+}
+
+TEST(YamlTrace, limits_partial_length)
+{
+  std::string yaml = R"(
+file_format: "1.0-trace"
+tracer_provider:
+  processors:
+    - simple:
+        exporter:
+          console:
+  limits:
+    attribute_value_length_limit: 1111
+)";
+
+  auto config = DoParse(yaml);
+  ASSERT_NE(config, nullptr);
+  ASSERT_NE(config->tracer_provider, nullptr);
+  ASSERT_NE(config->tracer_provider->limits, nullptr);
+  EXPECT_FALSE(config->tracer_provider->limits->has_attribute_count_limit);
+  EXPECT_TRUE(config->tracer_provider->limits->has_attribute_value_length_limit);
+  EXPECT_EQ(config->tracer_provider->limits->attribute_count_limit, 128u);
+  EXPECT_EQ(config->tracer_provider->limits->attribute_value_length_limit, 1111u);
+}
+
+TEST(YamlTrace, limits_null_values)
+{
+  std::string yaml = R"(
+file_format: "1.0-trace"
+tracer_provider:
+  processors:
+    - simple:
+        exporter:
+          console:
+  limits:
+    attribute_value_length_limit:
+    attribute_count_limit:
+)";
+
+  auto config = DoParse(yaml);
+  ASSERT_NE(config, nullptr);
+  ASSERT_NE(config->tracer_provider, nullptr);
+  ASSERT_NE(config->tracer_provider->limits, nullptr);
+  EXPECT_FALSE(config->tracer_provider->limits->has_attribute_count_limit);
+  EXPECT_FALSE(config->tracer_provider->limits->has_attribute_value_length_limit);
+  EXPECT_EQ(config->tracer_provider->limits->attribute_count_limit, 128u);
+  EXPECT_EQ(config->tracer_provider->limits->attribute_value_length_limit,
+            opentelemetry::sdk::configuration::SpanLimitsConfiguration::kDefaultAttributeValueLengthLimit);
+}
+
 TEST(YamlTrace, limits_with_invalid_values)
 {
   std::string invalid_attribute_count_yaml = R"(


### PR DESCRIPTION
## Changes

Adds support for configuring general `attribute_limits` and propagating them to tracer and logger providers.

### Implementation

- Added general attribute limit propagation to `TracerProvider` and `LoggerProvider`.
- Added provider-specific override support.
- Added partial override handling for attribute count and value length limits.
- Preserved existing provider-specific limits and defaults.
- Updated YAML parsing to distinguish configured values from omitted/null values.

### Tests

Added coverage for:

- General attribute limits
- Provider-specific overrides
- Partial count overrides
- Partial value-length overrides
- YAML partial configurations
- YAML null values
- Programmatic tracer/logger configuration

### Verification

- `git diff --check` passes
- Build succeeds
- Targeted configuration tests: 75/75 passed
- Full test suite: 986/986 passed