### PR TITLE
[CODE HEALTH] Replace push_back with emplace_back where applicable (#4476)

### DIFF
--- a/.github/workflows/clang-tidy.yaml
+++ b/.github/workflows/clang-tidy.yaml
@@ -17,9 +17,9 @@ jobs:
       matrix:
         include:
           - cmake_options: all-options-abiv1-preview
-            warning_limit: 133
+            warning_limit: 113
           - cmake_options: all-options-abiv2-preview
-            warning_limit: 144
+            warning_limit: 124
     env:
       CC: /usr/bin/clang-22
       CXX: /usr/bin/clang++-22

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,6 +65,10 @@ Increment the:
   in the value as-is rather than dropping the attribute.
   [#1536](https://github.com/open-telemetry/opentelemetry-cpp/issues/1536)
 
+* [CLEANUP] Replace `push_back` with `emplace_back` where applicable to
+  construct objects in-place, avoiding unnecessary temporaries.
+  [#4476](https://github.com/open-telemetry/opentelemetry-cpp/pull/4476)
+
 * [BUG] Fix `MultiSpanProcessor` and `MultiLogRecordProcessor` not reporting
   failures from `ForceFlush` and `Shutdown` when a child processor failed.
   [#4472](https://github.com/open-telemetry/opentelemetry-cpp/pull/4472)

--- a/api/test/baggage/propagation/baggage_propagator_test.cc
+++ b/api/test/baggage/propagation/baggage_propagator_test.cc
@@ -87,7 +87,7 @@ TEST(BaggagePropagatorTest, ExtractAndInjectBaggage)
 
     std::vector<std::string> fields;
     format.Fields([&fields](nostd::string_view field) {
-      fields.push_back(field.data());
+      fields.emplace_back(field.data());
       return true;
     });
     EXPECT_EQ(fields.size(), 1);

--- a/api/test/context/propagation/composite_propagator_test.cc
+++ b/api/test/context/propagation/composite_propagator_test.cc
@@ -142,7 +142,7 @@ TEST_F(CompositePropagatorTest, Inject)
 
   std::vector<std::string> fields;
   composite_propagator_->Fields([&fields](nostd::string_view field) {
-    fields.push_back(field.data());
+    fields.emplace_back(field.data());
     return true;
   });
   EXPECT_EQ(fields.size(), 3);

--- a/api/test/context/runtime_context_test.cc
+++ b/api/test/context/runtime_context_test.cc
@@ -124,7 +124,7 @@ TEST(RuntimeContextTest, DetachOutOfOrder)
   contexts.reserve(indices.size());
   for (auto i : indices)
   {
-    contexts.push_back(context::Context("index", static_cast<int64_t>(i)));
+    contexts.emplace_back("index", static_cast<int64_t>(i));
   }
 
   do

--- a/api/test/nostd/shared_ptr_test.cc
+++ b/api/test/nostd/shared_ptr_test.cc
@@ -221,7 +221,7 @@ static void SharedPtrTest_Sort(size_t size = 10)
 
   for (int i = static_cast<int>(size); i > 0; i--)
   {
-    nums.push_back(shared_ptr<int>(new int(i)));
+    nums.emplace_back(new int(i));
   }
 
   auto nums2 = nums;

--- a/api/test/trace/propagation/http_text_format_test.cc
+++ b/api/test/trace/propagation/http_text_format_test.cc
@@ -262,7 +262,7 @@ TEST(GlobalPropagator, SetAndGet)
 
   std::vector<std::string> fields;
   propagator->Fields([&fields](nostd::string_view field) {
-    fields.push_back(field.data());
+    fields.emplace_back(field.data());
     return true;
   });
   EXPECT_EQ(fields.size(), 2);

--- a/api/test/trace/propagation/jaeger_propagation_test.cc
+++ b/api/test/trace/propagation/jaeger_propagation_test.cc
@@ -191,7 +191,7 @@ TEST(JaegerPropagatorTest, InjectsContext)
 
   std::vector<std::string> fields;
   format.Fields([&fields](nostd::string_view field) {
-    fields.push_back(field.data());
+    fields.emplace_back(field.data());
     return true;
   });
   EXPECT_EQ(fields.size(), 1);

--- a/examples/multithreaded/main.cc
+++ b/examples/multithreaded/main.cc
@@ -60,11 +60,11 @@ void run_threads()
   {
     // This shows how one can effectively use Scope objects to correctly
     // parent spans across threads.
-    threads.push_back(std::thread([=] {
+    threads.emplace_back([=] {
       trace_api::Scope scope(thread_span);
       auto thread_span_2 =
           get_tracer()->StartSpan(std::string("thread ") + std::to_string(thread_num));
-    }));
+    });
   }
 
   std::for_each(threads.begin(), threads.end(), [](std::thread &th) { th.join(); });

--- a/exporters/otlp/src/otlp_file_client.cc
+++ b/exporters/otlp/src/otlp_file_client.cc
@@ -565,17 +565,17 @@ public:
             }
             else
             {
-              out.push_back(token);
+              out.emplace_back(token);
             }
           }
           else if (0 != std::strcmp(".", token))
           {
-            out.push_back(token);
+            out.emplace_back(token);
           }
         }
         else
         {
-          out.push_back(token);
+          out.emplace_back(token);
         }
       }
       token = SAFE_STRTOK_S(nullptr, "\\/", &saveptr);

--- a/ext/include/opentelemetry/ext/http/server/http_server.h
+++ b/ext/include/opentelemetry/ext/http/server/http_server.h
@@ -223,7 +223,7 @@ public:
   HttpRequestHandler &addHandler(const std::string &root, HttpRequestCallback &handler)
   {
     // No thread-safety here!
-    m_handlers.push_back({root, &handler});
+    m_handlers.emplace_back(root, &handler);
     LOG_INFO("HttpServer: Added handler for %s", root.c_str());
     return m_handlers.back();
   }
@@ -231,7 +231,7 @@ public:
   HttpRequestHandler &operator[](const std::string &root)
   {
     // No thread-safety here!
-    m_handlers.push_back({root, nullptr});
+    m_handlers.emplace_back(root, nullptr);
     LOG_INFO("HttpServer: Added handler for %s", root.c_str());
     return m_handlers.back();
   }
@@ -239,7 +239,7 @@ public:
   HttpServer &operator+=(std::pair<const std::string &, HttpRequestCallback &> other)
   {
     LOG_INFO("HttpServer: Added handler for %s", other.first.c_str());
-    m_handlers.push_back(HttpRequestHandler(other.first, &other.second));
+    m_handlers.emplace_back(other.first, &other.second);
     return (*this);
   }
 

--- a/ext/include/opentelemetry/ext/http/server/socket_tools.h
+++ b/ext/include/opentelemetry/ext/http/server/socket_tools.h
@@ -626,7 +626,7 @@ public:
         EV_SET(&event, event.ident, EVFILT_WRITE, EV_ADD, 0, 0, NULL);
         kevent(kq, &event, 1, NULL, 0, NULL);
 #endif
-        m_sockets.push_back(SocketData());
+        m_sockets.emplace_back();
         m_sockets.back().socket = socket;
         m_sockets.back().flags  = 0;
         it                      = m_sockets.end() - 1;

--- a/sdk/test/common/random_test.cc
+++ b/sdk/test/common/random_test.cc
@@ -59,7 +59,7 @@ TEST(RandomTest, AtomicFlagMultiThreadTest)
   threads.reserve(10);
   for (int i = 0; i < 10; ++i)
   {
-    threads.push_back(std::thread(doSomethingOnce, &count));
+    threads.emplace_back(doSomethingOnce, &count);
   }
   for (auto &t : threads)
   {

--- a/sdk/test/metrics/attributes_hashmap_benchmark.cc
+++ b/sdk/test/metrics/attributes_hashmap_benchmark.cc
@@ -48,7 +48,7 @@ void BM_AttributseHashMap(benchmark::State &state)
   {
     for (size_t i = 0; i < MAX_THREADS; i++)
     {
-      workers.push_back(std::thread(work, i));
+      workers.emplace_back(work, i);
     }
   }
 

--- a/sdk/test/metrics/measurements_benchmark.cc
+++ b/sdk/test/metrics/measurements_benchmark.cc
@@ -96,7 +96,7 @@ void BM_MeasurementsTest(benchmark::State &state)
     std::atomic<size_t> cur_processed{0};
     for (size_t i = 0; i < NUM_CORES; i++)
     {
-      threads.push_back(std::thread([&h, &cur_processed, &MAX_MEASUREMENTS, &attributes]() {
+      threads.emplace_back([&h, &cur_processed, &MAX_MEASUREMENTS, &attributes]() {
         while (cur_processed++ <= MAX_MEASUREMENTS)
         {
           size_t index = rand() % 1000;
@@ -105,7 +105,7 @@ void BM_MeasurementsTest(benchmark::State &state)
                      attributes[index]),
                  opentelemetry::context::Context{});
         }
-      }));
+      });
     }
     for (auto &thread : threads)
     {
@@ -141,7 +141,7 @@ void BM_MeasurementsThreadsShareCounterTest(benchmark::State &state)
     std::atomic<size_t> cur_processed{0};
     for (size_t i = 0; i < NUM_CORES; i++)
     {
-      threads.push_back(std::thread(
+      threads.emplace_back(
           [&h, &cur_processed, &MAX_MEASUREMENTS, &attributes](size_t /*thread_id*/) {
             while (cur_processed++ <= MAX_MEASUREMENTS)
             {
@@ -152,7 +152,7 @@ void BM_MeasurementsThreadsShareCounterTest(benchmark::State &state)
                      opentelemetry::context::Context{});
             }
           },
-          i));
+          i);
     }
     for (auto &thread : threads)
     {
@@ -187,7 +187,7 @@ void BM_MeasurementsPerThreadCounterTest(benchmark::State &state)
     std::atomic<size_t> cur_processed{0};
     for (size_t i = 0; i < NUM_CORES; i++)
     {
-      threads.push_back(std::thread(
+      threads.emplace_back(
           [&m, &cur_processed, &MAX_MEASUREMENTS, &attributes](size_t thread_id) {
             // Each thread creates its own counter with the same name but a unique description
             // encoding the thread id, ensuring no shared underlying storage.
@@ -204,7 +204,7 @@ void BM_MeasurementsPerThreadCounterTest(benchmark::State &state)
                   opentelemetry::context::Context{});
             }
           },
-          i));
+          i);
     }
     for (auto &thread : threads)
     {

--- a/sdk/test/metrics/meter_test.cc
+++ b/sdk/test/metrics/meter_test.cc
@@ -109,7 +109,7 @@ public:
     if (LogLevel::Warning == level)
     {
       std::cout << msg << "\n";
-      warnings.push_back(msg);
+      warnings.emplace_back(msg);
     }
   }
 


### PR DESCRIPTION
Use `emplace_back` instead of `push_back` to construct objects in-place, avoiding unnecessary temporary object creation and copy/move operations. Changes span test files, examples, exporters, and ext headers.

Fixes #4476

## Changes
- Test files: Use `emplace_back` for `std::string`, `context::Context`, `shared_ptr`, and `std::thread` construction
- `otlp_file_client.cc`: Use `emplace_back` for string tokens
- `http_server.h`: Use `emplace_back` for `HttpRequestHandler` construction
- `socket_tools.h`: Use `emplace_back()` for default-constructed `SocketData`
- Benchmark files: Use `emplace_back` for `std::thread` with lambda arguments

## Checklist
- [x] `CHANGELOG.md` updated for non-trivial changes
- [x] Unit tests have been added (existing tests cover all affected code — no new tests needed for this refactoring)
- [x] Changes in public API reviewed (no public API changes)