### PR TITLE
[CONFIGURATION] Update registry factory to return a unique_ptr

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,9 @@ Increment the:
   when building the SDK, with exclude patterns taking precedence.
   [#3546](https://github.com/open-telemetry/opentelemetry-cpp/issues/3546)
 
+* [CONFIGURATION] Update registry factory to return a unique_ptr
+  [#4487](https://github.com/open-telemetry/opentelemetry-cpp/pull/4487)
+
 * [CONFIGURATION] Add support for the composite sampler configuration
   (programmatic and from yaml)
   ([#4366](https://github.com/open-telemetry/opentelemetry-cpp/pull/4366))

--- a/install/test/src/test_sdk.cc
+++ b/install/test/src/test_sdk.cc
@@ -601,7 +601,7 @@ TEST_F(SdkInstallTest, ConfigurationCoreCheck)
   {
     const std::string propagator_name{"noop"};
 
-    auto registry = config_sdk::RegistryFactory::Create();
+    std::shared_ptr<config_sdk::Registry> registry = config_sdk::RegistryFactory::Create();
     registry->SetConsoleSpanBuilder(std::make_unique<NoopConsoleSpanBuilder>());
     registry->SetConsoleLogRecordBuilder(std::make_unique<NoopConsoleLogRecordBuilder>());
     registry->SetConsolePushMetricExporterBuilder(std::make_unique<NoopConsolePushMetricBuilder>());

--- a/sdk/include/opentelemetry/sdk/configuration/registry_factory.h
+++ b/sdk/include/opentelemetry/sdk/configuration/registry_factory.h
@@ -18,7 +18,7 @@ class RegistryFactory
 {
 public:
   // Returns a Registry pre-populated with all default signal builders.
-  static std::shared_ptr<Registry> Create();
+  static std::unique_ptr<Registry> Create();
 };
 
 }  // namespace configuration

--- a/sdk/src/configuration/registry_factory.cc
+++ b/sdk/src/configuration/registry_factory.cc
@@ -16,9 +16,9 @@ namespace sdk
 namespace configuration
 {
 
-std::shared_ptr<Registry> RegistryFactory::Create()
+std::unique_ptr<Registry> RegistryFactory::Create()
 {
-  auto registry = std::make_shared<Registry>();
+  auto registry = std::make_unique<Registry>();
   RegisterDefaultTraceBuilders(registry.get());
   RegisterDefaultMetricsBuilders(registry.get());
   RegisterDefaultLogsBuilders(registry.get());


### PR DESCRIPTION
Followup from https://github.com/open-telemetry/opentelemetry-cpp/pull/4367#discussion_r3753974075

## Changes

- Configuration `RegistryFactory::Create` returns a unique_ptr 

For significant contributions please make sure you have completed the following items:

* [x] `CHANGELOG.md` updated for non-trivial changes
* [ ] Unit tests have been added
* [ ] Changes in public API reviewed