### PR TITLE
[TEST] Time only the quit in ElegantQuitQuick, and bound it where the two outcomes are

### DIFF
--- a/ext/test/http/curl_http_test.cc
+++ b/ext/test/http/curl_http_test.cc
@@ -926,8 +926,12 @@ TEST_F(BasicCurlHttpTests, FinishInAsyncCallback)
   }
 }
 
+// Destroying the client wakes the polling background thread instead of letting it sleep out
+// scheduled_delay_milliseconds_. A missed wakeup is slow rather than wrong, so the bound is the
+// assertion: measured, the quit is under a millisecond and a slept out poll is 256 ms.
 TEST_F(BasicCurlHttpTests, ElegantQuitQuick)
 {
+  received_requests_.clear();
   auto http_client = std::make_shared<http_client::curl::HttpCurlClientFactory>()->Create();
   std::static_pointer_cast<curl::HttpClient>(http_client)->MaybeSpawnBackgroundThread();
   // start background first, then test it could wakeup
@@ -936,19 +940,22 @@ TEST_F(BasicCurlHttpTests, ElegantQuitQuick)
   request->SetUri("get/");
   auto handler = std::make_shared<GetEventHandler>();
   session->SendRequest(handler);
-  std::this_thread::sleep_for(std::chrono::milliseconds{10});  // let it enter poll state
+
+  // Sending is not what is timed, so a slow request must not read as a slow quit.
+  ASSERT_TRUE(waitForRequests(30, 1));
+  session->FinishSession();
+  ASSERT_TRUE(handler->is_called_.load(std::memory_order_acquire));
+  ASSERT_TRUE(handler->got_response_.load(std::memory_order_acquire));
+
   auto beg = std::chrono::system_clock::now();
   http_client->FinishAllSessions();
   http_client.reset();
-  // when background_thread_wait_for_ is used, it should have no side effect on elegant quit
-  // wait should be less than scheduled_delay_milliseconds_
-  // Due to load on CI hosts (some take 10ms), we assert it is less than 20ms
   auto cost = std::chrono::system_clock::now() - beg;
-  ASSERT_TRUE(cost < std::chrono::milliseconds{20})
+
+  // background_thread_wait_for_ keeps the thread alive here and must not delay the quit.
+  ASSERT_TRUE(cost < std::chrono::milliseconds{100})
       << "cost ms: " << std::chrono::duration_cast<std::chrono::milliseconds>(cost).count()
       << " libcurl version: 0x" << std::hex << LIBCURL_VERSION_NUM;
-  ASSERT_TRUE(handler->is_called_);
-  ASSERT_TRUE(handler->got_response_);
 }
 
 TEST_F(BasicCurlHttpTests, BackgroundThreadWaitMore)


### PR DESCRIPTION
Fixes #4265.

The two failures reported on that issue are not the same failure, and only one of them is the test's fault.

## What the case is measuring

`ElegantQuitQuick` destroys the client while its background thread is polling, and checks that the destructor woke the thread rather than letting it sleep out `scheduled_delay_milliseconds_`, which is 256 ms. A missed wakeup makes the quit slow rather than wrong, so a duration is the only thing there is to assert.

I measured both outcomes on this branch before changing anything. 24 runs of each, same binary, idle host:

| | runs | under 20 ms | 20 to 100 ms | over 100 ms |
| --- | --- | --- | --- | --- |
| as it is | 24 | 24 | 0 | 0 |
| with `curl_multi_wakeup` removed | 24 | 5 | **0** | 19 |

The working quit costs 0.1 to 0.5 ms. A quit that waited the poll out costs 256.5 to 256.9 ms. Nothing lands between them.

## Why 20 ms is the wrong bound and 100 ms is not just a larger one

The bound sat 20 ms above an operation that takes half a millisecond. A host that adds scheduling delay to that operation trips it while the wakeup is working perfectly. That is the `cost ms: 21` in the issue.

`cost ms: 247` is the other one. It matches the measured missed wakeup exactly, so the case was right that time, and disabling it would drop a signal it has already produced once.

100 ms was chosen from the gap rather than by doubling. Both bounds partition those 48 measurements identically, so the wider one gives up no detection while removing the class of false alarm that 20 ms invites. I would rather not raise it further: 256 ms is what it has to stay under.

It is still costing runs. `Bazel asan config` on #4337 failed at this line on 31 August, and #4337 changes five files that are all under `exporters/elasticsearch/`. `bazel query "somepath(//ext/test/http:curl_http_test, //exporters/elasticsearch/...)"` returns an empty result, so nothing in it reaches that binary, and the same job is green on the `main` commit it is rebased onto. That is one unrelated pull request going red in a run with nothing else wrong with it.

## What else changed

The timed window used to open before `FinishAllSessions()` with the request still going, after a fixed `sleep_for(10ms)` that was standing in for the request completing. The window now covers the quit alone, and the request is finished first through `waitForRequests()`, which this file already uses for the same purpose in `SendGetRequest`. That removes the sleep as well.

The two response assertions moved above the window, where they now guard it rather than trail it.

## Checks

`curl_http_test` passes 26 of 26.

Measured again under `--config=asan`, since that is the configuration that goes red and the one where a wall clock bound is most fragile. Options copied from `ci/do_ci.sh bazel.asan`, thirty runs per arm, `--local_test_jobs=1` so the runs do not race each other for port 19000:

| arm | failing runs |
| --- | --- |
| this branch, idle | 0 of 30 |
| this branch, 32 busy loops on 32 cores | 0 of 30 |
| `main`'s 20 ms bound, 32 busy loops on 32 cores | 0 of 30 |

The third row is a negative result and I would rather report it than leave it out. This host does not reproduce the failure that CI produced this morning, so the fail before evidence here is CI's own red rather than anything I can show locally. A 32 core host recovers from a scheduling delay faster than a shared two core runner does, which is the same reason the bound is a bad fit for CI in the first place.

An earlier attempt at this measurement used `--runs_per_test=30` without serialising and reported 18 of 30 failing. Those failed at `waitForRequests`, each after the full 30 seconds, because thirty copies of the test were competing for port 19000 and only one of them had a server. It measured the harness.

Removing `curl_multi_wakeup` still turns the case red, at `cost ms: 256`. It is worth saying that this catches it 19 times in 24 rather than every time: with the wakeup gone, the poll is sometimes broken by the cancelled transfer instead. That was true of the old bound too, and it is why the failure on CI is intermittent rather than constant.

## One thing this does not fix

It does not explain why the wakeup was missed on the run that produced 247 ms. `wakeupBackgroundThread()` is called more than once on the destruction path, and libcurl documents that "multiple calls to this function wake up the same waiting operation", so two wakeups collapsing into one while two poll iterations remain would produce exactly this. That is a hypothesis, not a measurement, and it belongs to the transport work in #4448 rather than to a test fix.

## Landing next to the other curl changes

`ext/test/http/curl_http_test.cc` is also touched by #4395, #4405, #4406, #4431 and #4457, so this conflicts with each of them in that file. This is the smallest of the six and changes one case, so it is the cheapest to take first and rebase the others onto. Whichever order suits you, I rebase the rest.

For significant contributions please make sure you have completed the following items:

* [ ] `CHANGELOG.md` updated for non-trivial changes - N/A, test only, no behaviour change
* [x] Unit tests have been added
* [x] Changes in public API reviewed - N/A, no API change

