### PR TITLE
[CODE HEALTH] Resolve multiple clang tidy warnings

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -10,6 +10,7 @@ Checks: >
   -portability-avoid-pragma-once,
   abseil-*,
   -abseil-string-find-str-contains,
+  -abseil-string-find-startswith,
   bugprone-*,
   -bugprone-easily-swappable-parameters,
   -bugprone-implicit-widening-of-multiplication-result,

--- a/.github/workflows/clang-tidy.yaml
+++ b/.github/workflows/clang-tidy.yaml
@@ -17,9 +17,9 @@ jobs:
       matrix:
         include:
           - cmake_options: all-options-abiv1-preview
-            warning_limit: 113
+            warning_limit: 83
           - cmake_options: all-options-abiv2-preview
-            warning_limit: 124
+            warning_limit: 86
     env:
       CC: /usr/bin/clang-22
       CXX: /usr/bin/clang++-22

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,9 @@ Increment the:
 * [CONFIGURATION/BUILD] Add resource detector targets and README
   [#4430](https://github.com/open-telemetry/opentelemetry-cpp/pull/4430)
 
+* [CODE HEALTH] Resolve multiple clang tidy warnings
+  [#4492](https://github.com/open-telemetry/opentelemetry-cpp/pull/4492)
+
 * [SDK] `OTELResourceDetector` now percent-decodes values parsed from the
   `OTEL_RESOURCE_ATTRIBUTES` environment variable, per the W3C Baggage value
   grammar the resource spec defers to. A malformed escape sequence is left

--- a/api/include/opentelemetry/common/attribute_value.h
+++ b/api/include/opentelemetry/common/attribute_value.h
@@ -58,9 +58,9 @@ using AttributeValue =
                    nostd::span<const uint8_t>>;
 
 #if OPENTELEMETRY_ABI_VERSION_NO >= 2
-enum AttributeType : std::uint8_t
+enum class AttributeType : std::uint8_t
 #else
-enum AttributeType  // NOLINT(performance-enum-size)
+enum AttributeType  // NOLINT(performance-enum-size,cppcoreguidelines-use-enum-class)
 #endif
 {
   kTypeBool,

--- a/api/include/opentelemetry/common/attribute_value.h
+++ b/api/include/opentelemetry/common/attribute_value.h
@@ -58,7 +58,7 @@ using AttributeValue =
                    nostd::span<const uint8_t>>;
 
 #if OPENTELEMETRY_ABI_VERSION_NO >= 2
-enum class AttributeType : std::uint8_t
+enum AttributeType : std::uint8_t  // NOLINT(cppcoreguidelines-use-enum-class)
 #else
 enum AttributeType  // NOLINT(performance-enum-size,cppcoreguidelines-use-enum-class)
 #endif

--- a/api/include/opentelemetry/nostd/string_view.h
+++ b/api/include/opentelemetry/nostd/string_view.h
@@ -37,7 +37,7 @@ using Traits = std::char_traits<char>;
 class string_view
 {
 public:
-  typedef std::size_t size_type;
+  using size_type = std::size_t;
 
   static constexpr size_type npos = static_cast<size_type>(-1);
 

--- a/api/include/opentelemetry/version.h
+++ b/api/include/opentelemetry/version.h
@@ -34,6 +34,9 @@
 // Experimental: bound synchronous metric instruments (Counter, Histogram).
 // This public API is available only in ABI v2 preview builds. Guard bound
 // instrument code with OPENTELEMETRY_HAVE_METRICS_BOUND_INSTRUMENTS_PREVIEW.
+
+// NOLINTBEGIN(cppcoreguidelines-macro-to-enum)
 #if OPENTELEMETRY_ABI_VERSION_NO >= 2 && defined(ENABLE_METRICS_BOUND_INSTRUMENTS_PREVIEW)
 #  define OPENTELEMETRY_HAVE_METRICS_BOUND_INSTRUMENTS_PREVIEW 1
 #endif
+// NOLINTEND(cppcoreguidelines-macro-to-enum)

--- a/examples/multi_processor/main.cc
+++ b/examples/multi_processor/main.cc
@@ -4,7 +4,6 @@
 #include <iostream>
 #include <memory>
 #include <string>
-#include <type_traits>
 #include <utility>
 #include <vector>
 
@@ -65,6 +64,38 @@ void CleanupTracer()
   trace_sdk::Provider::SetTracerProvider(none);
 }
 
+opentelemetry::nostd::string_view SpanKindToString(trace_api::SpanKind kind)
+{
+  switch (kind)
+  {
+    case trace_api::SpanKind::kInternal:
+      return "Internal";
+    case trace_api::SpanKind::kServer:
+      return "Server";
+    case trace_api::SpanKind::kClient:
+      return "Client";
+    case trace_api::SpanKind::kProducer:
+      return "Producer";
+    case trace_api::SpanKind::kConsumer:
+      return "Consumer";
+  }
+  return "Unknown";
+}
+
+opentelemetry::nostd::string_view StatusCodeToString(trace_api::StatusCode code)
+{
+  switch (code)
+  {
+    case trace_api::StatusCode::kUnset:
+      return "Unset";
+    case trace_api::StatusCode::kOk:
+      return "Ok";
+    case trace_api::StatusCode::kError:
+      return "Error";
+  }
+  return "Unknown";
+}
+
 void dumpSpans(std::vector<std::unique_ptr<trace_sdk::SpanData>> &spans)
 {
   char span_buf[trace_api::SpanId::kSize * 2];
@@ -85,14 +116,8 @@ void dumpSpans(std::vector<std::unique_ptr<trace_sdk::SpanData>> &spans)
               << '\n';
 
     std::cout << "\t\tDescription: " << span->GetDescription() << '\n';
-    std::cout << "\t\tSpan kind:"
-              << static_cast<typename std::underlying_type<trace_api::SpanKind>::type>(
-                     span->GetSpanKind())
-              << '\n';
-    std::cout << "\t\tSpan Status: "
-              << static_cast<typename std::underlying_type<trace_api::StatusCode>::type>(
-                     span->GetStatus())
-              << '\n';
+    std::cout << "\t\tSpan kind: " << SpanKindToString(span->GetSpanKind()) << '\n';
+    std::cout << "\t\tSpan Status: " << StatusCodeToString(span->GetStatus()) << '\n';
   }
 }
 }  // namespace

--- a/exporters/otlp/test/otlp_grpc_exporter_test.cc
+++ b/exporters/otlp/test/otlp_grpc_exporter_test.cc
@@ -126,8 +126,12 @@ public:
     OtlpMockTraceServiceStub *stub_;
   };
 
+#  if defined(GRPC_CPP_VERSION_MAJOR) && \
+      (GRPC_CPP_VERSION_MAJOR * 1000 + GRPC_CPP_VERSION_MINOR) >= 1039
   async_interface_base *async() override { return &async_interface_; }
-  async_interface_base *experimental_async() { return &async_interface_; }
+#  else
+  async_interface_base *experimental_async() override { return &async_interface_; }
+#  endif
 
   ::grpc::Status GetLastAsyncStatus() const noexcept { return last_async_status_; }
 

--- a/exporters/otlp/test/otlp_grpc_exporter_test.cc
+++ b/exporters/otlp/test/otlp_grpc_exporter_test.cc
@@ -56,6 +56,12 @@ using opentelemetry::sdk::common::setenv;
 using opentelemetry::sdk::common::unsetenv;
 #  endif
 
+#  if defined(GRPC_CPP_VERSION_MAJOR) &&                                      \
+          (GRPC_CPP_VERSION_MAJOR * 1000 + GRPC_CPP_VERSION_MINOR) >= 1039 || \
+      defined(GRPC_CALLBACK_API_NONEXPERIMENTAL)
+#    define OTELCPP_GRPC_ASYNC_API_IS_STABLE
+#  endif
+
 using namespace testing;
 
 OPENTELEMETRY_BEGIN_NAMESPACE
@@ -70,8 +76,7 @@ class OtlpMockTraceServiceStub : public proto::collector::trace::v1::MockTraceSe
 {
 public:
 // Some old toolchains can only use gRPC 1.33 and it's experimental.
-#  if defined(GRPC_CPP_VERSION_MAJOR) && \
-      (GRPC_CPP_VERSION_MAJOR * 1000 + GRPC_CPP_VERSION_MINOR) >= 1039
+#  if defined(OTELCPP_GRPC_ASYNC_API_IS_STABLE)
   using async_interface_base =
       proto::collector::trace::v1::TraceService::StubInterface::async_interface;
 #  else
@@ -104,9 +109,7 @@ public:
     }
 
 // Some old toolchains can only use gRPC 1.33 and it's experimental.
-#  if defined(GRPC_CPP_VERSION_MAJOR) &&                                      \
-          (GRPC_CPP_VERSION_MAJOR * 1000 + GRPC_CPP_VERSION_MINOR) >= 1039 || \
-      defined(GRPC_CALLBACK_API_NONEXPERIMENTAL)
+#  if defined(OTELCPP_GRPC_ASYNC_API_IS_STABLE)
     void Export(
         ::grpc::ClientContext * /*context*/,
         const ::opentelemetry::proto::collector::trace::v1::ExportTraceServiceRequest * /*request*/,
@@ -126,8 +129,7 @@ public:
     OtlpMockTraceServiceStub *stub_;
   };
 
-#  if defined(GRPC_CPP_VERSION_MAJOR) && \
-      (GRPC_CPP_VERSION_MAJOR * 1000 + GRPC_CPP_VERSION_MINOR) >= 1039
+#  if defined(OTELCPP_GRPC_ASYNC_API_IS_STABLE)
   async_interface_base *async() override { return &async_interface_; }
 #  else
   async_interface_base *experimental_async() override { return &async_interface_; }

--- a/exporters/otlp/test/otlp_grpc_log_record_exporter_test.cc
+++ b/exporters/otlp/test/otlp_grpc_log_record_exporter_test.cc
@@ -128,8 +128,12 @@ public:
     OtlpMockTraceServiceStub *stub_;
   };
 
+#if defined(GRPC_CPP_VERSION_MAJOR) && \
+    (GRPC_CPP_VERSION_MAJOR * 1000 + GRPC_CPP_VERSION_MINOR) >= 1039
   async_interface_base *async() override { return &async_interface_; }
-  async_interface_base *experimental_async() { return &async_interface_; }
+#else
+  async_interface_base *experimental_async() override { return &async_interface_; }
+#endif
 
   ::grpc::Status GetLastAsyncStatus() const noexcept { return last_async_status_; }
 
@@ -189,8 +193,12 @@ public:
     OtlpMockLogsServiceStub *stub_;
   };
 
+#if defined(GRPC_CPP_VERSION_MAJOR) && \
+    (GRPC_CPP_VERSION_MAJOR * 1000 + GRPC_CPP_VERSION_MINOR) >= 1039
   async_interface_base *async() override { return &async_interface_; }
-  async_interface_base *experimental_async() { return &async_interface_; }
+#else
+  async_interface_base *experimental_async() override { return &async_interface_; }
+#endif
 
   ::grpc::Status GetLastAsyncStatus() const noexcept { return last_async_status_; }
 

--- a/exporters/otlp/test/otlp_grpc_log_record_exporter_test.cc
+++ b/exporters/otlp/test/otlp_grpc_log_record_exporter_test.cc
@@ -67,6 +67,12 @@ using opentelemetry::sdk::common::setenv;
 using opentelemetry::sdk::common::unsetenv;
 #endif
 
+#if defined(GRPC_CPP_VERSION_MAJOR) &&                                      \
+        (GRPC_CPP_VERSION_MAJOR * 1000 + GRPC_CPP_VERSION_MINOR) >= 1039 || \
+    defined(GRPC_CALLBACK_API_NONEXPERIMENTAL)
+#  define OTELCPP_GRPC_ASYNC_API_IS_STABLE
+#endif
+
 using namespace testing;
 
 OPENTELEMETRY_BEGIN_NAMESPACE
@@ -80,8 +86,7 @@ namespace
 class OtlpMockTraceServiceStub : public proto::collector::trace::v1::MockTraceServiceStub
 {
 public:
-#if defined(GRPC_CPP_VERSION_MAJOR) && \
-    (GRPC_CPP_VERSION_MAJOR * 1000 + GRPC_CPP_VERSION_MINOR) >= 1039
+#if defined(OTELCPP_GRPC_ASYNC_API_IS_STABLE)
   using async_interface_base =
       proto::collector::trace::v1::TraceService::StubInterface::async_interface;
 #else
@@ -106,9 +111,7 @@ public:
       callback(stub_->last_async_status_);
     }
 
-#if defined(GRPC_CPP_VERSION_MAJOR) &&                                      \
-        (GRPC_CPP_VERSION_MAJOR * 1000 + GRPC_CPP_VERSION_MINOR) >= 1039 || \
-    defined(GRPC_CALLBACK_API_NONEXPERIMENTAL)
+#if defined(OTELCPP_GRPC_ASYNC_API_IS_STABLE)
     void Export(
         ::grpc::ClientContext * /*context*/,
         const ::opentelemetry::proto::collector::trace::v1::ExportTraceServiceRequest * /*request*/,
@@ -128,8 +131,7 @@ public:
     OtlpMockTraceServiceStub *stub_;
   };
 
-#if defined(GRPC_CPP_VERSION_MAJOR) && \
-    (GRPC_CPP_VERSION_MAJOR * 1000 + GRPC_CPP_VERSION_MINOR) >= 1039
+#if defined(OTELCPP_GRPC_ASYNC_API_IS_STABLE)
   async_interface_base *async() override { return &async_interface_; }
 #else
   async_interface_base *experimental_async() override { return &async_interface_; }
@@ -145,8 +147,7 @@ private:
 class OtlpMockLogsServiceStub : public proto::collector::logs::v1::MockLogsServiceStub
 {
 public:
-#if defined(GRPC_CPP_VERSION_MAJOR) && \
-    (GRPC_CPP_VERSION_MAJOR * 1000 + GRPC_CPP_VERSION_MINOR) >= 1039
+#if defined(OTELCPP_GRPC_ASYNC_API_IS_STABLE)
   using async_interface_base =
       proto::collector::logs::v1::LogsService::StubInterface::async_interface;
 #else
@@ -171,9 +172,7 @@ public:
       callback(stub_->last_async_status_);
     }
 
-#if defined(GRPC_CPP_VERSION_MAJOR) &&                                      \
-        (GRPC_CPP_VERSION_MAJOR * 1000 + GRPC_CPP_VERSION_MINOR) >= 1039 || \
-    defined(GRPC_CALLBACK_API_NONEXPERIMENTAL)
+#if defined(OTELCPP_GRPC_ASYNC_API_IS_STABLE)
     void Export(
         ::grpc::ClientContext * /*context*/,
         const ::opentelemetry::proto::collector::logs::v1::ExportLogsServiceRequest * /*request*/,
@@ -193,8 +192,7 @@ public:
     OtlpMockLogsServiceStub *stub_;
   };
 
-#if defined(GRPC_CPP_VERSION_MAJOR) && \
-    (GRPC_CPP_VERSION_MAJOR * 1000 + GRPC_CPP_VERSION_MINOR) >= 1039
+#if defined(OTELCPP_GRPC_ASYNC_API_IS_STABLE)
   async_interface_base *async() override { return &async_interface_; }
 #else
   async_interface_base *experimental_async() override { return &async_interface_; }

--- a/ext/include/opentelemetry/ext/http/server/http_server.h
+++ b/ext/include/opentelemetry/ext/http/server/http_server.h
@@ -101,7 +101,7 @@ protected:
     SocketTools::Socket socket;
     std::string receiveBuffer;
     std::string sendBuffer;
-    enum : std::uint8_t
+    enum : std::uint8_t  // NOLINT(cppcoreguidelines-use-enum-class)
     {
       Idle,
       ReceivingHeaders,

--- a/ext/include/opentelemetry/ext/http/server/socket_tools.h
+++ b/ext/include/opentelemetry/ext/http/server/socket_tools.h
@@ -326,10 +326,10 @@ static_assert(sizeof(SocketAddr) == sizeof(sockaddr),
 struct Socket
 {
 #ifdef _WIN32
-  typedef SOCKET Type;
+  using Type                = SOCKET;
   static Type const Invalid = INVALID_SOCKET;
 #else
-  typedef int Type;
+  using Type                = int;
   static Type const Invalid = -1;
 #endif
 

--- a/ext/include/opentelemetry/ext/http/server/socket_tools.h
+++ b/ext/include/opentelemetry/ext/http/server/socket_tools.h
@@ -465,7 +465,7 @@ struct Socket
 #endif
   }
 
-  enum  // NOLINT(performance-enum-size)
+  enum  // NOLINT(performance-enum-size,cppcoreguidelines-use-enum-class)
   {
 #ifdef _WIN32
     ErrorWouldBlock = WSAEWOULDBLOCK
@@ -474,7 +474,7 @@ struct Socket
 #endif
   };
 
-  enum  // NOLINT(performance-enum-size)
+  enum  // NOLINT(performance-enum-size,cppcoreguidelines-use-enum-class)
   {
 #ifdef _WIN32
     ShutdownReceive = SD_RECEIVE,
@@ -527,7 +527,7 @@ struct Reactor : protected common::Thread
   /// <summary>
   /// Socket State
   /// </summary>
-  enum State : std::uint8_t
+  enum State : std::uint8_t  // NOLINT(cppcoreguidelines-use-enum-class)
   {
     Readable   = 1,
     Writable   = 2,

--- a/functional/otlp/func_grpc_main.cc
+++ b/functional/otlp/func_grpc_main.cc
@@ -318,7 +318,7 @@ static int parse_args(int argc, char *argv[])
   return 0;
 }
 
-typedef int (*test_func_t)();
+using test_func_t = int (*)();
 
 struct test_case
 {

--- a/functional/otlp/func_http_main.cc
+++ b/functional/otlp/func_http_main.cc
@@ -40,7 +40,7 @@ const int TEST_FAILED = 1;
 
 namespace
 {
-enum test_mode : std::uint8_t
+enum test_mode : std::uint8_t  // NOLINT(cppcoreguidelines-use-enum-class)
 {
   MODE_NONE,
   MODE_HTTP,

--- a/functional/otlp/func_http_main.cc
+++ b/functional/otlp/func_http_main.cc
@@ -335,7 +335,7 @@ static int parse_args(int argc, char *argv[])
   return 0;
 }
 
-typedef int (*test_func_t)();
+using test_func_t = int (*)();
 
 struct test_case
 {

--- a/resource_detectors/test/service_detector_utils_test.cc
+++ b/resource_detectors/test/service_detector_utils_test.cc
@@ -42,14 +42,15 @@ TEST(ServiceDetectorUtilsTest, GetServiceNameFallbackUsesUnknownServicePrefix)
 {
   unsetenv(kOtelServiceName);
 
-  const std::string service_name = detail::GetServiceName();
-  if (service_name.rfind("unknown_service:", 0) == 0)
+  const std::string service_name           = detail::GetServiceName();
+  const std::string unknown_service_prefix = "unknown_service:";
+  if (service_name.substr(0, unknown_service_prefix.size()) == unknown_service_prefix)
   {
-    EXPECT_GT(service_name.size(), std::string{"unknown_service:"}.size());
+    EXPECT_GT(service_name.size(), unknown_service_prefix.size());
   }
   else
   {
-    EXPECT_EQ(service_name, std::string{"unknown_service"});
+    EXPECT_EQ(service_name, "unknown_service");
   }
 }
 

--- a/sdk/include/opentelemetry/sdk/common/attribute_utils.h
+++ b/sdk/include/opentelemetry/sdk/common/attribute_utils.h
@@ -57,7 +57,7 @@ using OwnedAttributeValue = nostd::variant<bool,
                                            std::vector<uint64_t>,
                                            std::vector<uint8_t>>;
 
-enum OwnedAttributeType : std::uint8_t
+enum class OwnedAttributeType : std::uint8_t
 {
   kTypeBool,
   kTypeInt,

--- a/sdk/include/opentelemetry/sdk/common/attribute_utils.h
+++ b/sdk/include/opentelemetry/sdk/common/attribute_utils.h
@@ -57,7 +57,7 @@ using OwnedAttributeValue = nostd::variant<bool,
                                            std::vector<uint64_t>,
                                            std::vector<uint8_t>>;
 
-enum class OwnedAttributeType : std::uint8_t
+enum OwnedAttributeType : std::uint8_t  // NOLINT(cppcoreguidelines-use-enum-class)
 {
   kTypeBool,
   kTypeInt,

--- a/sdk/include/opentelemetry/sdk/metrics/exemplar/reservoir_cell.h
+++ b/sdk/include/opentelemetry/sdk/metrics/exemplar/reservoir_cell.h
@@ -149,8 +149,8 @@ private:
   friend class ReservoirCellTestPeer;
 };
 
-typedef std::shared_ptr<ExemplarData> (ReservoirCell::*MapAndResetCellType)(
-    const MetricAttributes &);
+using MapAndResetCellType =
+    std::shared_ptr<ExemplarData> (ReservoirCell::*)(const MetricAttributes &);
 
 }  // namespace metrics
 }  // namespace sdk

--- a/sdk/include/opentelemetry/sdk/metrics/state/sync_metric_storage.h
+++ b/sdk/include/opentelemetry/sdk/metrics/state/sync_metric_storage.h
@@ -122,7 +122,7 @@ public:
 #ifdef OPENTELEMETRY_HAVE_METRICS_BOUND_INSTRUMENTS_PREVIEW
     // Resolve via the unified cardinality policy so unbound and bound paths
     // share one combined limit (see ResolveCardinality()).
-    MetricAttributes resolved = ResolveCardinality(std::move(attr));
+    MetricAttributes resolved = ResolveCardinality(attr);
     // cppcheck-suppress accessMoved
     attributes_hashmap_->GetOrSetDefault(std::move(resolved), create_default_aggregation_)
         ->Aggregate(value);
@@ -176,7 +176,7 @@ public:
     MetricAttributes attr{attributes, attributes_processor_.get()};
     std::lock_guard<std::mutex> guard(attribute_hashmap_lock_);
 #ifdef OPENTELEMETRY_HAVE_METRICS_BOUND_INSTRUMENTS_PREVIEW
-    MetricAttributes resolved = ResolveCardinality(std::move(attr));
+    MetricAttributes resolved = ResolveCardinality(attr);
     // cppcheck-suppress accessMoved
     attributes_hashmap_->GetOrSetDefault(std::move(resolved), create_default_aggregation_)
         ->Aggregate(value);

--- a/sdk/include/opentelemetry/sdk/metrics/view/attributes_processor.h
+++ b/sdk/include/opentelemetry/sdk/metrics/view/attributes_processor.h
@@ -24,11 +24,10 @@ namespace metrics
 
 using MetricAttributes = opentelemetry::sdk::metrics::FilteredOrderedAttributeMap;
 
-typedef std::unordered_map<std::string,
-                           bool,
-                           opentelemetry::sdk::common::StringViewHash,
-                           opentelemetry::sdk::common::StringViewEqual>
-    FilterAttributeMap;
+using FilterAttributeMap = std::unordered_map<std::string,
+                                              bool,
+                                              opentelemetry::sdk::common::StringViewHash,
+                                              opentelemetry::sdk::common::StringViewEqual>;
 
 /**
  * The AttributesProcessor is responsible for customizing which

--- a/sdk/src/resource/resource_detector.cc
+++ b/sdk/src/resource/resource_detector.cc
@@ -12,7 +12,7 @@
 
 #include "opentelemetry/nostd/variant.h"
 
-#include <stddef.h>
+#include <cstddef>
 #include <sstream>
 #include <string>
 

--- a/sdk/test/common/circular_buffer_benchmark.cc
+++ b/sdk/test/common/circular_buffer_benchmark.cc
@@ -55,7 +55,8 @@ static uint64_t ConsumeBufferNumbers(CircularBuffer<uint64_t> &buffer) noexcept
 template <class Buffer>
 static void GenerateNumbersForThread(Buffer &buffer, int n, std::atomic<uint64_t> &sum) noexcept
 {
-  static thread_local std::mt19937_64 random_number_generator{std::random_device{}()};
+  // NOLINTNEXTLINE(bugprone-random-generator-seed)
+  static thread_local std::mt19937_64 random_number_generator{1234};
   for (int i = 0; i < n; ++i)
   {
     auto x = random_number_generator();

--- a/sdk/test/common/random_benchmark.cc
+++ b/sdk/test/common/random_benchmark.cc
@@ -21,7 +21,7 @@ BENCHMARK(BM_RandomIdGeneration);
 
 void BM_RandomIdStdGeneration(benchmark::State &state)
 {
-  std::mt19937_64 generator{0};
+  std::mt19937_64 generator{std::random_device{}()};
   while (state.KeepRunning())
   {
     benchmark::DoNotOptimize(generator());

--- a/sdk/test/common/random_benchmark.cc
+++ b/sdk/test/common/random_benchmark.cc
@@ -21,7 +21,8 @@ BENCHMARK(BM_RandomIdGeneration);
 
 void BM_RandomIdStdGeneration(benchmark::State &state)
 {
-  std::mt19937_64 generator{std::random_device{}()};
+  // NOLINTNEXTLINE(bugprone-random-generator-seed)
+  std::mt19937_64 generator{1234};
   while (state.KeepRunning())
   {
     benchmark::DoNotOptimize(generator());

--- a/sdk/test/configuration/yaml_metrics_test.cc
+++ b/sdk/test/configuration/yaml_metrics_test.cc
@@ -1406,8 +1406,11 @@ meter_provider:
   ASSERT_EQ(view->stream->attribute_keys->excluded->string_array[1], "bar.ex");
 }
 
+namespace
+{
 class YamlMetricsEmptyIncluded : public ::testing::TestWithParam<const char *>
 {};
+}  // namespace
 
 TEST_P(YamlMetricsEmptyIncluded, RetainsAllAttributes)
 {

--- a/sdk/test/metrics/base2_exponential_histogram_indexer_benchmark.cc
+++ b/sdk/test/metrics/base2_exponential_histogram_indexer_benchmark.cc
@@ -15,7 +15,7 @@ namespace
 void BM_NewIndexer(benchmark::State &state)
 {
   std::array<int, 1000> batch{};
-  std::default_random_engine generator;
+  std::default_random_engine generator{std::random_device{}()};
   std::uniform_int_distribution<int> distribution(1, 32);
 
   while (state.KeepRunningBatch(static_cast<benchmark::IterationCount>(batch.size())))
@@ -39,7 +39,7 @@ BENCHMARK(BM_NewIndexer);
 void BM_ComputeIndex(benchmark::State &state)
 {
   std::array<double, 1000> batch{};
-  std::default_random_engine generator;
+  std::default_random_engine generator{std::random_device{}()};
   std::uniform_real_distribution<double> distribution(0, 1000);
   Base2ExponentialHistogramIndexer indexer(static_cast<int32_t>(state.range(0)));
 

--- a/sdk/test/metrics/base2_exponential_histogram_indexer_benchmark.cc
+++ b/sdk/test/metrics/base2_exponential_histogram_indexer_benchmark.cc
@@ -15,7 +15,8 @@ namespace
 void BM_NewIndexer(benchmark::State &state)
 {
   std::array<int, 1000> batch{};
-  std::default_random_engine generator{std::random_device{}()};
+  std::mt19937 generator(
+      1234);  // NOLINT(cert-msc32-c,cert-msc51-cpp,bugprone-random-generator-seed)
   std::uniform_int_distribution<int> distribution(1, 32);
 
   while (state.KeepRunningBatch(static_cast<benchmark::IterationCount>(batch.size())))
@@ -39,7 +40,8 @@ BENCHMARK(BM_NewIndexer);
 void BM_ComputeIndex(benchmark::State &state)
 {
   std::array<double, 1000> batch{};
-  std::default_random_engine generator{std::random_device{}()};
+  std::mt19937 generator(
+      1234);  // NOLINT(cert-msc32-c,cert-msc51-cpp,bugprone-random-generator-seed)
   std::uniform_real_distribution<double> distribution(0, 1000);
   Base2ExponentialHistogramIndexer indexer(static_cast<int32_t>(state.range(0)));
 

--- a/sdk/test/metrics/base2_exponential_histogram_indexer_benchmark.cc
+++ b/sdk/test/metrics/base2_exponential_histogram_indexer_benchmark.cc
@@ -15,8 +15,8 @@ namespace
 void BM_NewIndexer(benchmark::State &state)
 {
   std::array<int, 1000> batch{};
-  std::mt19937 generator(
-      1234);  // NOLINT(cert-msc32-c,cert-msc51-cpp,bugprone-random-generator-seed)
+  // NOLINTNEXTLINE(bugprone-random-generator-seed)
+  std::mt19937 generator(1234);
   std::uniform_int_distribution<int> distribution(1, 32);
 
   while (state.KeepRunningBatch(static_cast<benchmark::IterationCount>(batch.size())))
@@ -40,8 +40,8 @@ BENCHMARK(BM_NewIndexer);
 void BM_ComputeIndex(benchmark::State &state)
 {
   std::array<double, 1000> batch{};
-  std::mt19937 generator(
-      1234);  // NOLINT(cert-msc32-c,cert-msc51-cpp,bugprone-random-generator-seed)
+  // NOLINTNEXTLINE(bugprone-random-generator-seed)
+  std::mt19937 generator(1234);
   std::uniform_real_distribution<double> distribution(0, 1000);
   Base2ExponentialHistogramIndexer indexer(static_cast<int32_t>(state.range(0)));
 

--- a/sdk/test/metrics/exemplar/aligned_histogram_bucket_exemplar_reservoir_test.cc
+++ b/sdk/test/metrics/exemplar/aligned_histogram_bucket_exemplar_reservoir_test.cc
@@ -4,7 +4,7 @@
 #ifdef ENABLE_METRICS_EXEMPLAR_PREVIEW
 
 #  include <gtest/gtest.h>
-#  include <stdint.h>
+#  include <cstdint>
 #  include <memory>
 #  include <string>
 #  include <vector>

--- a/sdk/test/metrics/exemplar/filter_predicate_test.cc
+++ b/sdk/test/metrics/exemplar/filter_predicate_test.cc
@@ -4,7 +4,7 @@
 #ifdef ENABLE_METRICS_EXEMPLAR_PREVIEW
 
 #  include <gtest/gtest.h>
-#  include <stdint.h>
+#  include <cstdint>
 #  include <string>
 
 #  include "opentelemetry/context/context.h"

--- a/sdk/test/metrics/exemplar/no_exemplar_reservoir_test.cc
+++ b/sdk/test/metrics/exemplar/no_exemplar_reservoir_test.cc
@@ -4,7 +4,7 @@
 #ifdef ENABLE_METRICS_EXEMPLAR_PREVIEW
 
 #  include <gtest/gtest.h>
-#  include <stdint.h>
+#  include <cstdint>
 #  include <memory>
 #  include <string>
 #  include <vector>

--- a/sdk/test/metrics/histogram_aggregation_benchmark.cc
+++ b/sdk/test/metrics/histogram_aggregation_benchmark.cc
@@ -54,7 +54,7 @@ void HistogramAggregation(benchmark::State &state, std::unique_ptr<ViewRegistry>
   std::shared_ptr<MetricReader> reader{new MockMetricReader(std::move(exporter))};
   mp.AddMetricReader(reader);
   auto h = m->CreateDoubleHistogram("histogram1", "histogram1_description", "histogram1_unit");
-  std::default_random_engine generator;
+  std::default_random_engine generator{std::random_device{}()};
   std::uniform_int_distribution<int> distribution(0, 1000000);
   // Generate 100000 measurements
   constexpr size_t TOTAL_MEASUREMENTS = 100000;

--- a/sdk/test/metrics/histogram_aggregation_benchmark.cc
+++ b/sdk/test/metrics/histogram_aggregation_benchmark.cc
@@ -54,7 +54,8 @@ void HistogramAggregation(benchmark::State &state, std::unique_ptr<ViewRegistry>
   std::shared_ptr<MetricReader> reader{new MockMetricReader(std::move(exporter))};
   mp.AddMetricReader(reader);
   auto h = m->CreateDoubleHistogram("histogram1", "histogram1_description", "histogram1_unit");
-  std::default_random_engine generator{std::random_device{}()};
+  std::mt19937 generator(
+      1234);  // NOLINT(cert-msc32-c,cert-msc51-cpp,bugprone-random-generator-seed)
   std::uniform_int_distribution<int> distribution(0, 1000000);
   // Generate 100000 measurements
   constexpr size_t TOTAL_MEASUREMENTS = 100000;

--- a/sdk/test/metrics/histogram_aggregation_benchmark.cc
+++ b/sdk/test/metrics/histogram_aggregation_benchmark.cc
@@ -54,8 +54,8 @@ void HistogramAggregation(benchmark::State &state, std::unique_ptr<ViewRegistry>
   std::shared_ptr<MetricReader> reader{new MockMetricReader(std::move(exporter))};
   mp.AddMetricReader(reader);
   auto h = m->CreateDoubleHistogram("histogram1", "histogram1_description", "histogram1_unit");
-  std::mt19937 generator(
-      1234);  // NOLINT(cert-msc32-c,cert-msc51-cpp,bugprone-random-generator-seed)
+  // NOLINTNEXTLINE(bugprone-random-generator-seed)
+  std::mt19937 generator(1234);
   std::uniform_int_distribution<int> distribution(0, 1000000);
   // Generate 100000 measurements
   constexpr size_t TOTAL_MEASUREMENTS = 100000;

--- a/sdk/test/metrics/measurements_benchmark.cc
+++ b/sdk/test/metrics/measurements_benchmark.cc
@@ -7,6 +7,7 @@
 #include <cstdint>
 #include <cstdlib>
 #include <map>
+#include <random>
 #include <string>
 #include <thread>
 #include <vector>
@@ -97,9 +98,11 @@ void BM_MeasurementsTest(benchmark::State &state)
     for (size_t i = 0; i < NUM_CORES; i++)
     {
       threads.emplace_back([&h, &cur_processed, &MAX_MEASUREMENTS, &attributes]() {
+        std::mt19937 rng{std::random_device{}()};
+        std::uniform_int_distribution<size_t> dist(0, 999);
         while (cur_processed++ <= MAX_MEASUREMENTS)
         {
-          size_t index = rand() % 1000;
+          size_t index = dist(rng);
           h->Add(1.0,
                  opentelemetry::common::KeyValueIterableView<std::map<std::string, uint32_t>>(
                      attributes[index]),
@@ -143,9 +146,11 @@ void BM_MeasurementsThreadsShareCounterTest(benchmark::State &state)
     {
       threads.emplace_back(
           [&h, &cur_processed, &MAX_MEASUREMENTS, &attributes](size_t /*thread_id*/) {
+            std::mt19937 rng{std::random_device{}()};
+            std::uniform_int_distribution<size_t> dist(0, 999);
             while (cur_processed++ <= MAX_MEASUREMENTS)
             {
-              size_t index = rand() % 1000;
+              size_t index = dist(rng);
               h->Add(1.0,
                      opentelemetry::common::KeyValueIterableView<std::map<std::string, uint32_t>>(
                          attributes[index]),
@@ -194,9 +199,11 @@ void BM_MeasurementsPerThreadCounterTest(benchmark::State &state)
             std::string description = "counter1_description_thread_" + std::to_string(thread_id);
             auto per_thread_counter =
                 m->CreateDoubleCounter("counter1", description, "counter1_unit");
+            std::mt19937 rng{std::random_device{}()};
+            std::uniform_int_distribution<size_t> dist(0, 999);
             while (cur_processed++ <= MAX_MEASUREMENTS)
             {
-              size_t index = rand() % 1000;
+              size_t index = dist(rng);
               per_thread_counter->Add(
                   1.0,
                   opentelemetry::common::KeyValueIterableView<std::map<std::string, uint32_t>>(

--- a/sdk/test/metrics/measurements_benchmark.cc
+++ b/sdk/test/metrics/measurements_benchmark.cc
@@ -98,7 +98,8 @@ void BM_MeasurementsTest(benchmark::State &state)
     for (size_t i = 0; i < NUM_CORES; i++)
     {
       threads.emplace_back([&h, &cur_processed, &MAX_MEASUREMENTS, &attributes]() {
-        std::mt19937 rng{std::random_device{}()};
+        // NOLINTNEXTLINE(bugprone-random-generator-seed)
+        std::mt19937 rng{1234};
         std::uniform_int_distribution<size_t> dist(0, 999);
         while (cur_processed++ <= MAX_MEASUREMENTS)
         {
@@ -146,7 +147,8 @@ void BM_MeasurementsThreadsShareCounterTest(benchmark::State &state)
     {
       threads.emplace_back(
           [&h, &cur_processed, &MAX_MEASUREMENTS, &attributes](size_t /*thread_id*/) {
-            std::mt19937 rng{std::random_device{}()};
+            // NOLINTNEXTLINE(bugprone-random-generator-seed)
+            std::mt19937 rng{1234};
             std::uniform_int_distribution<size_t> dist(0, 999);
             while (cur_processed++ <= MAX_MEASUREMENTS)
             {
@@ -199,7 +201,8 @@ void BM_MeasurementsPerThreadCounterTest(benchmark::State &state)
             std::string description = "counter1_description_thread_" + std::to_string(thread_id);
             auto per_thread_counter =
                 m->CreateDoubleCounter("counter1", description, "counter1_unit");
-            std::mt19937 rng{std::random_device{}()};
+            // NOLINTNEXTLINE(bugprone-random-generator-seed)
+            std::mt19937 rng{1234};
             std::uniform_int_distribution<size_t> dist(0, 999);
             while (cur_processed++ <= MAX_MEASUREMENTS)
             {

--- a/sdk/test/metrics/meter_provider_sdk_test.cc
+++ b/sdk/test/metrics/meter_provider_sdk_test.cc
@@ -328,7 +328,7 @@ TEST(MeterProvider, GetMeterAbiv2)
     EXPECT_EQ(opentelemetry::nostd::get<int>(attr->second), 42);
   }
 
-  typedef std::pair<opentelemetry::nostd::string_view, opentelemetry::common::AttributeValue> KV;
+  using KV = std::pair<opentelemetry::nostd::string_view, opentelemetry::common::AttributeValue>;
 
   std::initializer_list<KV> attrs7 = {{"foo", 3.14}, {"bar", "2"}};
   auto m7                          = mp.GetMeter("name7", "version7", "url7", attrs7);

--- a/sdk/test/metrics/sum_aggregation_benchmark.cc
+++ b/sdk/test/metrics/sum_aggregation_benchmark.cc
@@ -41,7 +41,8 @@ void BM_SumAggregation(benchmark::State &state)
   std::shared_ptr<MetricReader> reader{new MockMetricReader(std::move(exporter))};
   mp.AddMetricReader(reader);
   auto h = m->CreateDoubleCounter("counter1", "counter1_description", "counter1_unit");
-  std::default_random_engine generator{std::random_device{}()};
+  std::mt19937 generator(
+      1234);  // NOLINT(cert-msc32-c,cert-msc51-cpp,bugprone-random-generator-seed)
   std::uniform_int_distribution<int> distribution(0, 1000000);
   // Generate 100000 measurements
   constexpr size_t TOTAL_MEASUREMENTS = 100000;

--- a/sdk/test/metrics/sum_aggregation_benchmark.cc
+++ b/sdk/test/metrics/sum_aggregation_benchmark.cc
@@ -41,8 +41,8 @@ void BM_SumAggregation(benchmark::State &state)
   std::shared_ptr<MetricReader> reader{new MockMetricReader(std::move(exporter))};
   mp.AddMetricReader(reader);
   auto h = m->CreateDoubleCounter("counter1", "counter1_description", "counter1_unit");
-  std::mt19937 generator(
-      1234);  // NOLINT(cert-msc32-c,cert-msc51-cpp,bugprone-random-generator-seed)
+  // NOLINTNEXTLINE(bugprone-random-generator-seed)
+  std::mt19937 generator(1234);
   std::uniform_int_distribution<int> distribution(0, 1000000);
   // Generate 100000 measurements
   constexpr size_t TOTAL_MEASUREMENTS = 100000;

--- a/sdk/test/metrics/sum_aggregation_benchmark.cc
+++ b/sdk/test/metrics/sum_aggregation_benchmark.cc
@@ -41,7 +41,7 @@ void BM_SumAggregation(benchmark::State &state)
   std::shared_ptr<MetricReader> reader{new MockMetricReader(std::move(exporter))};
   mp.AddMetricReader(reader);
   auto h = m->CreateDoubleCounter("counter1", "counter1_description", "counter1_unit");
-  std::default_random_engine generator;
+  std::default_random_engine generator{std::random_device{}()};
   std::uniform_int_distribution<int> distribution(0, 1000000);
   // Generate 100000 measurements
   constexpr size_t TOTAL_MEASUREMENTS = 100000;

--- a/sdk/test/metrics/sync_instruments_benchmark.cc
+++ b/sdk/test/metrics/sync_instruments_benchmark.cc
@@ -297,7 +297,8 @@ static std::vector<double> MakeRecordingValues()
   constexpr double kMinValue       = 1.0;
   constexpr double kMaxValue       = 10000.0;
 
-  thread_local std::mt19937 rng(std::random_device{}());
+  // NOLINTNEXTLINE(bugprone-random-generator-seed)
+  thread_local std::mt19937 rng(1234);
   thread_local std::uniform_real_distribution<double> dist(kMinValue, kMaxValue);
   std::vector<double> values(kNumValues);
   for (auto &val : values)

--- a/sdk/test/trace/tracer_provider_test.cc
+++ b/sdk/test/trace/tracer_provider_test.cc
@@ -268,7 +268,7 @@ TEST(TracerProvider, GetTracerAbiv2)
     EXPECT_EQ(opentelemetry::nostd::get<int>(attr->second), 42);
   }
 
-  typedef std::pair<opentelemetry::nostd::string_view, opentelemetry::common::AttributeValue> KV;
+  using KV = std::pair<opentelemetry::nostd::string_view, opentelemetry::common::AttributeValue>;
 
   std::initializer_list<KV> attrs7 = {{"foo", 3.14}, {"bar", "2"}};
   auto t7                          = tp.GetTracer("name7", "version7", "url7", attrs7);


### PR DESCRIPTION
Contributes to #2053 

## Changes

resolves the following warnings: 
- `modernize-use-using` - 8  warnings	
- `cppcoreguidelines-use-enum-class` - 7 warnings
- `bugprone-random-generator-seed` - 5 warnings
- `modernize-deprecated-headers`  - 4 warnings
- `misc-predictable-rand` - 3 warnings
- `bugprone-derived-method-shadowing-base-method` - 3 warnings
- `bugprone-unintended-char-ostream-output` - 2 warnings
- `performance-move-const-arg`  - 2 warnings
- `cppcoreguidelines-macro-to-enum`  - 2 warnings
- `abseil-string-find-startswith` - 1 warning
- `misc-use-internal-linkage` - 1 warning

For significant contributions please make sure you have completed the following items:

* [x] `CHANGELOG.md` updated for non-trivial changes
* [ ] Unit tests have been added
* [ ] Changes in public API reviewed