### PR TITLE
[CODE HEALTH] Fix cppcoreguidelines-pro-type-const-cast for multi observer metrics.

### DIFF
--- a/sdk/include/opentelemetry/sdk/metrics/async_instruments.h
+++ b/sdk/include/opentelemetry/sdk/metrics/async_instruments.h
@@ -37,9 +37,9 @@ public:
   void RemoveCallback(opentelemetry::metrics::ObservableCallbackPtr callback,
                       void *state) noexcept override;
 
-  const InstrumentDescriptor &GetInstrumentDescriptor();
+  const InstrumentDescriptor &GetInstrumentDescriptor() const;
 
-  AsyncWritableMetricStorage *GetMetricStorage();
+  AsyncWritableMetricStorage *GetMetricStorage() const;
 
 private:
   InstrumentDescriptor instrument_descriptor_;

--- a/sdk/include/opentelemetry/sdk/metrics/multi_observer_result.h
+++ b/sdk/include/opentelemetry/sdk/metrics/multi_observer_result.h
@@ -27,7 +27,7 @@ public:
   size_t InstrumentCount() const;
   bool HasInstrument(const opentelemetry::metrics::ObservableInstrument *instrument) const;
   void GetInstruments(
-      nostd::function_ref<void(opentelemetry::metrics::ObservableInstrument *)> callback);
+      nostd::function_ref<void(const opentelemetry::metrics::ObservableInstrument *)> callback);
   void Reset();
   void StoreResults(opentelemetry::common::SystemTimestamp collection_ts);
 
@@ -43,7 +43,7 @@ private:
   // This allows us to avoid an unnecessary layer of indirection and a bunch of allocations.
   using ObserverResultDirect =
       nostd::variant<nostd::monostate, ObserverResultT<double>, ObserverResultT<int64_t>>;
-  std::unordered_map<opentelemetry::metrics::ObservableInstrument *, ObserverResultDirect>
+  std::unordered_map<const opentelemetry::metrics::ObservableInstrument *, ObserverResultDirect>
       observer_results_;
 };
 }  // namespace metrics

--- a/sdk/src/metrics/async_instruments.cc
+++ b/sdk/src/metrics/async_instruments.cc
@@ -43,12 +43,12 @@ void ObservableInstrument::RemoveCallback(opentelemetry::metrics::ObservableCall
   observable_registry_->RemoveCallback(callback, state, this);
 }
 
-const InstrumentDescriptor &ObservableInstrument::GetInstrumentDescriptor()
+const InstrumentDescriptor &ObservableInstrument::GetInstrumentDescriptor() const
 {
   return instrument_descriptor_;
 }
 
-AsyncWritableMetricStorage *ObservableInstrument::GetMetricStorage()
+AsyncWritableMetricStorage *ObservableInstrument::GetMetricStorage() const
 {
   return storage_.get();
 }

--- a/sdk/src/metrics/multi_observer_result.cc
+++ b/sdk/src/metrics/multi_observer_result.cc
@@ -65,12 +65,11 @@ size_t MultiObserverResult::InstrumentCount() const
 bool MultiObserverResult::HasInstrument(
     const opentelemetry::metrics::ObservableInstrument *instrument) const
 {
-  return observer_results_.find(const_cast<opentelemetry::metrics::ObservableInstrument *>(
-             instrument)) != observer_results_.end();
+  return observer_results_.find(instrument) != observer_results_.end();
 }
 
 void MultiObserverResult::GetInstruments(
-    nostd::function_ref<void(opentelemetry::metrics::ObservableInstrument *)> callback)
+    nostd::function_ref<void(const opentelemetry::metrics::ObservableInstrument *)> callback)
 {
   for (auto &el : observer_results_)
   {
@@ -93,7 +92,7 @@ void MultiObserverResult::StoreResults(opentelemetry::common::SystemTimestamp co
     auto *instrument = el.first;
     auto &result     = el.second;
 
-    auto storage = static_cast<opentelemetry::sdk::metrics::ObservableInstrument *>(instrument)
+    auto storage = static_cast<const opentelemetry::sdk::metrics::ObservableInstrument *>(instrument)
                        ->GetMetricStorage();
     nostd::visit(StoreResultVisitor{storage, collection_ts}, result);
   }
@@ -103,10 +102,7 @@ opentelemetry::metrics::ObserverResultT<double> &MultiObserverResult::ForInstrum
     const opentelemetry::metrics::ObservableInstrument *instrument)
 {
   static opentelemetry::sdk::metrics::ObserverResultT<double> null_result;
-  // const_cast is appropriate here, because we're _not_ modifying the passed-in pointer;
-  // we just need to make it non-const to be able to look it up in our map.
-  auto it = observer_results_.find(
-      const_cast<opentelemetry::metrics::ObservableInstrument *>(instrument));
+  auto it = observer_results_.find(instrument);
   if (it == observer_results_.end())
   {
     OTEL_INTERNAL_LOG_ERROR("[MultiObserverResult::ForInstrumentDouble]"
@@ -128,8 +124,7 @@ opentelemetry::metrics::ObserverResultT<int64_t> &MultiObserverResult::ForInstru
     const opentelemetry::metrics::ObservableInstrument *instrument)
 {
   static opentelemetry::sdk::metrics::ObserverResultT<int64_t> null_result;
-  auto it = observer_results_.find(
-      const_cast<opentelemetry::metrics::ObservableInstrument *>(instrument));
+  auto it = observer_results_.find(instrument);
   if (it == observer_results_.end())
   {
     OTEL_INTERNAL_LOG_ERROR("[MultiObserverResult::ForInstrumentInt64]"

--- a/sdk/src/metrics/multi_observer_result.cc
+++ b/sdk/src/metrics/multi_observer_result.cc
@@ -92,8 +92,9 @@ void MultiObserverResult::StoreResults(opentelemetry::common::SystemTimestamp co
     auto *instrument = el.first;
     auto &result     = el.second;
 
-    auto storage = static_cast<const opentelemetry::sdk::metrics::ObservableInstrument *>(instrument)
-                       ->GetMetricStorage();
+    auto storage =
+        static_cast<const opentelemetry::sdk::metrics::ObservableInstrument *>(instrument)
+            ->GetMetricStorage();
     nostd::visit(StoreResultVisitor{storage, collection_ts}, result);
   }
 }

--- a/sdk/src/metrics/state/observable_registry.cc
+++ b/sdk/src/metrics/state/observable_registry.cc
@@ -162,9 +162,9 @@ struct InvokeCallbackVisitor
   void operator()(const opentelemetry::metrics::ObservableCallbackPtr &callback)
   {
     record->observable_result.GetInstruments(
-        [&](opentelemetry::metrics::ObservableInstrument *instrument) {
+        [&](const opentelemetry::metrics::ObservableInstrument *instrument) {
           auto value_type =
-              static_cast<opentelemetry::sdk::metrics::ObservableInstrument *>(instrument)
+              static_cast<const opentelemetry::sdk::metrics::ObservableInstrument *>(instrument)
                   ->GetInstrumentDescriptor()
                   .value_type_;
           if (value_type == InstrumentValueType::kDouble)
@@ -185,7 +185,7 @@ struct InvokeCallbackVisitor
   template <typename T>
   void invoke_single_instrument_callback(
       const opentelemetry::metrics::ObservableCallbackPtr &callback,
-      opentelemetry::metrics::ObservableInstrument *instrument)
+      const opentelemetry::metrics::ObservableInstrument *instrument)
   {
     // This is all a bit strangely shaped, but it's in the name of back-compat.
     // The signature of ObservableCallbackPtr is that it takes a nostd::shared_ptr to


### PR DESCRIPTION
Fixes # (issue)

## Changes

Please provide a brief description of the changes here.

* Resolved `cppcoreguidelines-pro-type-const-cast` warnings in the multi observer code.
* Changed the observer result map to keep `const` instruments instead of non const objects.
* Adjusted the code accordingly.

For significant contributions please make sure you have completed the following items:

* [ ] `CHANGELOG.md` updated for non-trivial changes
* [ ] Unit tests have been added
* [ ] Changes in public API reviewed