### PR TITLE
[CODE HEALTH] Use uint16_t for port numbers in ext/http/server

### DIFF
--- a/ext/include/opentelemetry/ext/http/server/http_server.h
+++ b/ext/include/opentelemetry/ext/http/server/http_server.h
@@ -173,7 +173,7 @@ public:
         m_maxRequestContentSize(2 * 1024 * 1024)
   {}
 
-  HttpServer(const std::string &serverHost, int port = 30000) : HttpServer()
+  HttpServer(const std::string &serverHost, uint16_t port = 30000) : HttpServer()
   {
     std::ostringstream os;
     os << serverHost << ":" << port;
@@ -202,7 +202,7 @@ public:
 
   void setServerName(std::string const &name) { m_serverHost = name; }
 
-  int addListeningPort(int port)
+  int addListeningPort(uint16_t port)
   {
     SocketTools::Socket socket(AF_INET, SOCK_STREAM, IPPROTO_TCP);
     socket.setNonBlocking();

--- a/ext/include/opentelemetry/ext/http/server/socket_tools.h
+++ b/ext/include/opentelemetry/ext/http/server/socket_tools.h
@@ -236,7 +236,7 @@ struct SocketAddr
           ok = false;
           break;
         }
-        unsigned int const digit = static_cast<unsigned int>(*p - '0');
+        const uint16_t digit = static_cast<uint16_t>(*p - '0');
         if (port > (65535u - digit) / 10u)
         {
           ok = false;  // would exceed 65535

--- a/ext/include/opentelemetry/ext/http/server/socket_tools.h
+++ b/ext/include/opentelemetry/ext/http/server/socket_tools.h
@@ -175,11 +175,11 @@ struct SocketAddr
   /// <returns>SocketAddr</returns>
   SocketAddr() {}
 
-  SocketAddr(u_long addr, int port)
+  SocketAddr(u_long addr, uint16_t port)
   {
     sockaddr_in &inet4    = reinterpret_cast<sockaddr_in &>(m_data);
     inet4.sin_family      = AF_INET;
-    inet4.sin_port        = htons(static_cast<uint16_t>(port));
+    inet4.sin_port        = htons(port);
     inet4.sin_addr.s_addr = htonl(addr);
   }
 
@@ -223,8 +223,8 @@ struct SocketAddr
     // accept a leading sign or whitespace and depend on the locale.
     if (ok && colon)
     {
-      char const *p     = colon + 1;
-      unsigned int port = 0;
+      char const *p = colon + 1;
+      uint16_t port = 0;
       if (*p == '\0')
       {
         ok = false;  // empty port, e.g. "127.0.0.1:"
@@ -247,7 +247,7 @@ struct SocketAddr
       }
       if (ok)
       {
-        parsed.sin_port = htons(static_cast<uint16_t>(port));
+        parsed.sin_port = htons(port);
       }
     }
 


### PR DESCRIPTION
Fixes #4305

## Changes

Please provide a brief description of the changes here.

* Code cleanup, use uint16_t for port numbers, in ext/http/server

For significant contributions please make sure you have completed the following items:

* [ ] `CHANGELOG.md` updated for non-trivial changes
* [ ] Unit tests have been added
* [ ] Changes in public API reviewed