### PR TITLE
[METRICS SDK] Drop aggregation behaves as a no-op

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,10 @@ Increment the:
   `noexcept` function.
   [#4439](https://github.com/open-telemetry/opentelemetry-cpp/issues/4439)
 
+* [METRICS SDK] Drop aggregation behaves as a no-op, prevent duplicate metric recording
+  from conflicting streams, and warn if stream conflicts were configured
+  [#4515](https://github.com/open-telemetry/opentelemetry-cpp/pull/4515)
+
 * [CONFIGURATION] Apply general `attribute_limits` per individual limit field.
   If a model-specific limit is set it is used, otherwise the matching general
   limit, otherwise the model-specific default. Limit fields on

--- a/sdk/include/opentelemetry/sdk/metrics/instruments.h
+++ b/sdk/include/opentelemetry/sdk/metrics/instruments.h
@@ -157,6 +157,31 @@ struct InstrumentDescriptorUtil
   }
 };
 
+struct AggregationUtil
+{
+  static opentelemetry::nostd::string_view GetAggregationTypeString(
+      AggregationType aggregation_type) noexcept
+  {
+    switch (aggregation_type)
+    {
+      case AggregationType::kDrop:
+        return "Drop";
+      case AggregationType::kHistogram:
+        return "Histogram";
+      case AggregationType::kLastValue:
+        return "LastValue";
+      case AggregationType::kSum:
+        return "Sum";
+      case AggregationType::kDefault:
+        return "Default";
+      case AggregationType::kBase2ExponentialHistogram:
+        return "Base2ExponentialHistogram";
+      default:
+        return "Unknown";
+    }
+  }
+};
+
 struct InstrumentEqualNameCaseInsensitive
 {
   bool operator()(const InstrumentDescriptor &lhs, const InstrumentDescriptor &rhs) const noexcept

--- a/sdk/include/opentelemetry/sdk/metrics/meter.h
+++ b/sdk/include/opentelemetry/sdk/metrics/meter.h
@@ -190,6 +190,11 @@ private:
   static void WarnOnNameCaseConflict(const sdk::instrumentationscope::InstrumentationScope *scope,
                                      const InstrumentDescriptor &existing_instrument,
                                      const InstrumentDescriptor &new_instrument);
+
+  // Emits a warning that the view will create a semantic error and is skipped.
+  static void WarnOnViewSemanticError(const sdk::instrumentationscope::InstrumentationScope *scope,
+                                      const InstrumentDescriptor &existing_instrument,
+                                      const View &view);
 };
 }  // namespace metrics
 }  // namespace sdk

--- a/sdk/include/opentelemetry/sdk/metrics/state/multi_metric_storage.h
+++ b/sdk/include/opentelemetry/sdk/metrics/state/multi_metric_storage.h
@@ -29,8 +29,21 @@ namespace metrics
 class SyncMultiMetricStorage : public SyncWritableMetricStorage
 {
 public:
+  bool HasStorage(const std::shared_ptr<SyncWritableMetricStorage> &storage) const
+  {
+    if (!storage || storages_.empty())
+    {
+      return false;
+    }
+    return std::find(storages_.begin(), storages_.end(), storage) != storages_.end();
+  }
+
   void AddStorage(const std::shared_ptr<SyncWritableMetricStorage> &storage)
   {
+    if (!storage || HasStorage(storage))
+    {
+      return;
+    }
     storages_.push_back(storage);
   }
 
@@ -82,8 +95,21 @@ private:
 class AsyncMultiMetricStorage : public AsyncWritableMetricStorage
 {
 public:
+  bool HasStorage(const std::shared_ptr<AsyncWritableMetricStorage> &storage) const
+  {
+    if (!storage || storages_.empty())
+    {
+      return false;
+    }
+    return std::find(storages_.begin(), storages_.end(), storage) != storages_.end();
+  }
+
   void AddStorage(const std::shared_ptr<AsyncWritableMetricStorage> &storage)
   {
+    if (!storage || HasStorage(storage))
+    {
+      return;
+    }
     storages_.push_back(storage);
   }
 

--- a/sdk/include/opentelemetry/sdk/metrics/state/multi_metric_storage.h
+++ b/sdk/include/opentelemetry/sdk/metrics/state/multi_metric_storage.h
@@ -29,22 +29,14 @@ namespace metrics
 class SyncMultiMetricStorage : public SyncWritableMetricStorage
 {
 public:
-  bool HasStorage(const std::shared_ptr<SyncWritableMetricStorage> &storage) const
-  {
-    if (!storage || storages_.empty())
-    {
-      return false;
-    }
-    return std::find(storages_.begin(), storages_.end(), storage) != storages_.end();
-  }
-
-  void AddStorage(const std::shared_ptr<SyncWritableMetricStorage> &storage)
+  bool AddStorage(const std::shared_ptr<SyncWritableMetricStorage> &storage)
   {
     if (!storage || HasStorage(storage))
     {
-      return;
+      return false;
     }
     storages_.push_back(storage);
+    return true;
   }
 
   void RecordLong(int64_t value, const opentelemetry::context::Context &context) noexcept override
@@ -89,13 +81,7 @@ public:
 #endif
 
 private:
-  std::vector<std::shared_ptr<SyncWritableMetricStorage>> storages_;
-};
-
-class AsyncMultiMetricStorage : public AsyncWritableMetricStorage
-{
-public:
-  bool HasStorage(const std::shared_ptr<AsyncWritableMetricStorage> &storage) const
+  bool HasStorage(const std::shared_ptr<SyncWritableMetricStorage> &storage) const
   {
     if (!storage || storages_.empty())
     {
@@ -104,13 +90,20 @@ public:
     return std::find(storages_.begin(), storages_.end(), storage) != storages_.end();
   }
 
-  void AddStorage(const std::shared_ptr<AsyncWritableMetricStorage> &storage)
+  std::vector<std::shared_ptr<SyncWritableMetricStorage>> storages_;
+};
+
+class AsyncMultiMetricStorage : public AsyncWritableMetricStorage
+{
+public:
+  bool AddStorage(const std::shared_ptr<AsyncWritableMetricStorage> &storage)
   {
     if (!storage || HasStorage(storage))
     {
-      return;
+      return false;
     }
     storages_.push_back(storage);
+    return true;
   }
 
   void RecordLong(
@@ -134,6 +127,15 @@ public:
   }
 
 private:
+  bool HasStorage(const std::shared_ptr<AsyncWritableMetricStorage> &storage) const
+  {
+    if (!storage || storages_.empty())
+    {
+      return false;
+    }
+    return std::find(storages_.begin(), storages_.end(), storage) != storages_.end();
+  }
+
   std::vector<std::shared_ptr<AsyncWritableMetricStorage>> storages_;
 };
 

--- a/sdk/src/metrics/meter.cc
+++ b/sdk/src/metrics/meter.cc
@@ -60,6 +60,11 @@ struct InstrumentDescriptorLogStreamable
   std::reference_wrapper<const opentelemetry::sdk::metrics::InstrumentDescriptor> instrument;
 };
 
+struct ViewLogStreamable
+{
+  std::reference_wrapper<const opentelemetry::sdk::metrics::View> view;
+};
+
 std::ostream &operator<<(std::ostream &os,
                          const InstrumentationScopeLogStreamable &streamable) noexcept
 {
@@ -80,6 +85,27 @@ std::ostream &operator<<(std::ostream &os,
      << opentelemetry::sdk::metrics::InstrumentDescriptorUtil::GetInstrumentTypeString(
             streamable.instrument.get().type_)
      << "\"";
+  return os;
+}
+
+std::ostream &operator<<(std::ostream &os, const ViewLogStreamable &streamable) noexcept
+{
+  using opentelemetry::sdk::metrics::AggregationUtil;
+  auto aggregation_type          = streamable.view.get().GetAggregationType();
+  const auto *aggregation_config = streamable.view.get().GetAggregationConfig();
+
+  os << "\n  name=\"" << streamable.view.get().GetName() << "\"" << "\n  description=\""
+     << streamable.view.get().GetDescription() << "\"" << "\n  aggregation_type=\""
+     << AggregationUtil::GetAggregationTypeString(aggregation_type) << "\""
+     << "\n  aggregation_config={\""
+     << (aggregation_config
+             ? AggregationUtil::GetAggregationTypeString(aggregation_config->GetType())
+             : "null")
+     << "\""
+     << (aggregation_config
+             ? ", cardinality_limit=" + std::to_string(aggregation_config->cardinality_limit_)
+             : "")
+     << "}";
   return os;
 }
 
@@ -519,6 +545,17 @@ std::unique_ptr<SyncWritableMetricStorage> Meter::RegisterSyncMetricStorage(
        exemplar_filter_type
 #endif
   ](const View &view) {
+        OTEL_INTERNAL_LOG_DEBUG("[Meter::RegisterSyncMetricStorage] View matched."
+                                << "\nInstrumentationScope: "
+                                << InstrumentationScopeLogStreamable{*GetInstrumentationScope()}
+                                << "\nInstrument: "
+                                << InstrumentDescriptorLogStreamable{instrument_descriptor}
+                                << "\nView: " << ViewLogStreamable{view});
+
+        if (view.GetAggregationType() == AggregationType::kDrop)
+        {
+          return true;
+        }
         auto view_instr_desc = instrument_descriptor;
         if (!view.GetName().empty())
         {
@@ -552,6 +589,11 @@ std::unique_ptr<SyncWritableMetricStorage> Meter::RegisterSyncMetricStorage(
           storage_registry_.insert({view_instr_desc, sync_storage});
         }
         auto sync_multi_storage = static_cast<SyncMultiMetricStorage *>(storages.get());
+        if (sync_multi_storage->HasStorage(sync_storage))
+        {
+          WarnOnViewSemanticError(GetInstrumentationScope(), instrument_descriptor, view);
+          return true;
+        }
         sync_multi_storage->AddStorage(sync_storage);
         return true;
       });
@@ -592,6 +634,16 @@ std::unique_ptr<AsyncWritableMetricStorage> Meter::RegisterAsyncMetricStorage(
        exemplar_filter_type
 #endif
   ](const View &view) {
+        OTEL_INTERNAL_LOG_DEBUG("[Meter::RegisterAsyncMetricStorage] View matched."
+                                << "\nInstrumentationScope: "
+                                << InstrumentationScopeLogStreamable{*GetInstrumentationScope()}
+                                << "\nInstrument: "
+                                << InstrumentDescriptorLogStreamable{instrument_descriptor}
+                                << "\nView: " << ViewLogStreamable{view});
+        if (view.GetAggregationType() == AggregationType::kDrop)
+        {
+          return true;
+        }
         auto view_instr_desc = instrument_descriptor;
         if (!view.GetName().empty())
         {
@@ -625,6 +677,11 @@ std::unique_ptr<AsyncWritableMetricStorage> Meter::RegisterAsyncMetricStorage(
           storage_registry_.insert({view_instr_desc, async_storage});
         }
         auto async_multi_storage = static_cast<AsyncMultiMetricStorage *>(storages.get());
+        if (async_multi_storage->HasStorage(async_storage))
+        {
+          WarnOnViewSemanticError(GetInstrumentationScope(), instrument_descriptor, view);
+          return true;
+        }
         async_multi_storage->AddStorage(async_storage);
         return true;
       });
@@ -746,6 +803,21 @@ void Meter::WarnOnNameCaseConflict(const sdk::instrumentationscope::Instrumentat
         << "\nExisting instrument: " << InstrumentDescriptorLogStreamable{existing_instrument}
         << "\nDuplicate instrument: " << InstrumentDescriptorLogStreamable{new_instrument});
   }
+}
+
+// Implementation of the log message recommended by the SDK specification for semantic errors caused
+// by a View configuration. See
+// https://github.com/open-telemetry/opentelemetry-specification/blob/v1.60.0/specification/metrics/sdk.md?plain=1#L438
+void Meter::WarnOnViewSemanticError(const sdk::instrumentationscope::InstrumentationScope *scope,
+                                    const InstrumentDescriptor &existing_instrument,
+                                    const View &view)
+{
+  OTEL_INTERNAL_LOG_WARN(
+      "[Meter::WarnOnViewSemanticError] The matched View may cause a semantic error in "
+      "the data exported from this meter by configuring a conflicting metric and is not applied."
+      << "\nScope: " << InstrumentationScopeLogStreamable{*scope}
+      << "\nInstrument: " << InstrumentDescriptorLogStreamable{existing_instrument}
+      << "\nView: " << ViewLogStreamable{view});
 }
 
 }  // namespace metrics

--- a/sdk/src/metrics/meter.cc
+++ b/sdk/src/metrics/meter.cc
@@ -21,6 +21,7 @@
 #include "opentelemetry/sdk/common/global_log_handler.h"
 #include "opentelemetry/sdk/instrumentationscope/instrumentation_scope.h"
 #include "opentelemetry/sdk/instrumentationscope/scope_configurator.h"
+#include "opentelemetry/sdk/metrics/aggregation/aggregation_config.h"
 #include "opentelemetry/sdk/metrics/async_instruments.h"
 #include "opentelemetry/sdk/metrics/data/metric_data.h"
 #include "opentelemetry/sdk/metrics/instruments.h"

--- a/sdk/src/metrics/meter.cc
+++ b/sdk/src/metrics/meter.cc
@@ -590,12 +590,11 @@ std::unique_ptr<SyncWritableMetricStorage> Meter::RegisterSyncMetricStorage(
           storage_registry_.insert({view_instr_desc, sync_storage});
         }
         auto sync_multi_storage = static_cast<SyncMultiMetricStorage *>(storages.get());
-        if (sync_multi_storage->HasStorage(sync_storage))
+        if (!sync_multi_storage->AddStorage(sync_storage))
         {
           WarnOnViewSemanticError(GetInstrumentationScope(), instrument_descriptor, view);
           return true;
         }
-        sync_multi_storage->AddStorage(sync_storage);
         return true;
       });
 
@@ -678,12 +677,12 @@ std::unique_ptr<AsyncWritableMetricStorage> Meter::RegisterAsyncMetricStorage(
           storage_registry_.insert({view_instr_desc, async_storage});
         }
         auto async_multi_storage = static_cast<AsyncMultiMetricStorage *>(storages.get());
-        if (async_multi_storage->HasStorage(async_storage))
+        if (!async_multi_storage->AddStorage(async_storage))
         {
           WarnOnViewSemanticError(GetInstrumentationScope(), instrument_descriptor, view);
           return true;
         }
-        async_multi_storage->AddStorage(async_storage);
+
         return true;
       });
   if (!success)

--- a/sdk/test/metrics/meter_test.cc
+++ b/sdk/test/metrics/meter_test.cc
@@ -114,21 +114,20 @@ public:
     {
       case LogLevel::Warning: {
         warnings.emplace_back(msg);
-        std::cout << "[Warning] " << msg << std::endl;
         break;
       }
       case LogLevel::Error: {
         errors.emplace_back(msg);
-        std::cout << "[Error] " << msg << std::endl;
         break;
       }
       case LogLevel::None:
       case LogLevel::Info:
       case LogLevel::Debug:
       default:
-        std::cout << "[" << LevelToString(level) << "] " << msg << std::endl;
         break;
     }
+
+    std::cout << "[" << LevelToString(level) << "] " << msg << "\n";
   }
 
   bool HasNameCaseConflictWarning() const

--- a/sdk/test/metrics/meter_test.cc
+++ b/sdk/test/metrics/meter_test.cc
@@ -620,7 +620,7 @@ TEST_F(MeterCreateInstrumentTest, IdenticalSyncInstruments)
   counter1->Add(1.0, {{"key", "value1"}});
   counter2->Add(2.5, {{"key", "value2"}});
 
-  metric_reader_ptr_->Collect([this](ResourceMetrics &metric_data) {
+  metric_reader_ptr_->Collect([](ResourceMetrics &metric_data) {
     const auto &data = metric_data.scope_metric_data_.at(0).metric_data_;
     EXPECT_EQ(data.size(), 1);
     InstrumentDescriptor descriptor{"my_counter", "desc", "unit", InstrumentType::kCounter,
@@ -642,7 +642,7 @@ TEST_F(MeterCreateInstrumentTest, NameCaseConflictSyncInstruments)
   counter1->Add(1);
   counter2->Add(2);
 
-  metric_reader_ptr_->Collect([this](ResourceMetrics &metric_data) {
+  metric_reader_ptr_->Collect([](ResourceMetrics &metric_data) {
     const auto &data = metric_data.scope_metric_data_.at(0).metric_data_;
     EXPECT_EQ(data.size(), 1);
     InstrumentDescriptor descriptor{"My_CountER", "desc", "unit", InstrumentType::kCounter,
@@ -672,7 +672,7 @@ TEST_F(MeterCreateInstrumentTest, ViewCorrectedNameCaseConflictSyncInstruments)
   counter1->Add(1);
   counter2->Add(2);
 
-  metric_reader_ptr_->Collect([this](ResourceMetrics &metric_data) {
+  metric_reader_ptr_->Collect([](ResourceMetrics &metric_data) {
     const auto &data = metric_data.scope_metric_data_.at(0).metric_data_;
     EXPECT_EQ(data.size(), 1);
     InstrumentDescriptor descriptor{"my_counter", "desc", "unit", InstrumentType::kCounter,
@@ -694,7 +694,7 @@ TEST_F(MeterCreateInstrumentTest, DuplicateSyncInstrumentsByKind)
   counter1->Add(1, {{"key", "value1"}});
   counter2->Add(1, {{"key", "value2"}});
 
-  metric_reader_ptr_->Collect([this](ResourceMetrics &metric_data) {
+  metric_reader_ptr_->Collect([](ResourceMetrics &metric_data) {
     const auto &data = metric_data.scope_metric_data_.at(0).metric_data_;
     EXPECT_EQ(data.size(), 2);
     InstrumentDescriptor double_descriptor{"my_counter", "desc", "unit", InstrumentType::kCounter,
@@ -721,7 +721,7 @@ TEST_F(MeterCreateInstrumentTest, DuplicateSyncInstrumentsByUnits)
   counter1->Add(1, {{"key", "value1"}});
   counter2->Add(1, {{"key", "value2"}});
 
-  metric_reader_ptr_->Collect([this](ResourceMetrics &metric_data) {
+  metric_reader_ptr_->Collect([](ResourceMetrics &metric_data) {
     const auto &data = metric_data.scope_metric_data_.at(0).metric_data_;
     EXPECT_EQ(data.size(), 2);
     InstrumentDescriptor unit_descriptor{"my_counter", "desc", "unit", InstrumentType::kCounter,
@@ -749,7 +749,7 @@ TEST_F(MeterCreateInstrumentTest, DuplicateSyncInstrumentsByDescription)
   counter1->Add(1, {{"key", "value1"}});
   counter2->Add(1, {{"key", "value2"}});
 
-  metric_reader_ptr_->Collect([this](ResourceMetrics &metric_data) {
+  metric_reader_ptr_->Collect([](ResourceMetrics &metric_data) {
     const auto &data = metric_data.scope_metric_data_.at(0).metric_data_;
     EXPECT_EQ(data.size(), 2);
     InstrumentDescriptor desc_descriptor{"my_counter", "desc", "unit", InstrumentType::kCounter,
@@ -782,7 +782,7 @@ TEST_F(MeterCreateInstrumentTest, ViewCorrectedDuplicateSyncInstrumentsByDescrip
   counter1->Add(1, {{"key", "value1"}});
   counter2->Add(1, {{"key", "value2"}});
 
-  metric_reader_ptr_->Collect([this](ResourceMetrics &metric_data) {
+  metric_reader_ptr_->Collect([](ResourceMetrics &metric_data) {
     // only one metric_data object expected after correction with the view
     const auto &data = metric_data.scope_metric_data_.at(0).metric_data_;
     EXPECT_EQ(data.size(), 1);
@@ -808,7 +808,7 @@ TEST_F(MeterCreateInstrumentTest, SyncInstrumentWithDropAggregation)
   counter1->Add(1, {{"key", "value1"}});
   counter2->Add(1, {{"key", "value2"}});
 
-  metric_reader_ptr_->Collect([this](ResourceMetrics &metric_data) {
+  metric_reader_ptr_->Collect([](ResourceMetrics &metric_data) {
     const auto &data = metric_data.scope_metric_data_.at(0).metric_data_;
     EXPECT_EQ(data.size(), 1);
     InstrumentDescriptor dropped_descriptor{"counter_one", "desc", "unit", InstrumentType::kCounter,
@@ -839,7 +839,7 @@ TEST_F(MeterCreateInstrumentTest, SyncInstrumentWithCatchAllDropAggregation)
   counter1->Add(1, {{"key", "value1"}});
   counter2->Add(1, {{"key", "value2"}});
 
-  metric_reader_ptr_->Collect([this](ResourceMetrics &metric_data) {
+  metric_reader_ptr_->Collect([](ResourceMetrics &metric_data) {
     const auto &data = metric_data.scope_metric_data_.at(0).metric_data_;
     EXPECT_EQ(data.size(), 1);
     InstrumentDescriptor dropped_descriptor{"counter_two", "desc", "unit", InstrumentType::kCounter,
@@ -867,7 +867,7 @@ TEST_F(MeterCreateInstrumentTest, SyncInstrumentWithConflictingAggregation)
 
   counter1->Add(1, {{"key", "value1"}});
 
-  metric_reader_ptr_->Collect([this](ResourceMetrics &metric_data) {
+  metric_reader_ptr_->Collect([](ResourceMetrics &metric_data) {
     const auto &data = metric_data.scope_metric_data_.at(0).metric_data_;
     EXPECT_EQ(data.size(), 1);
     InstrumentDescriptor descriptor{"counter_one", "desc", "unit", InstrumentType::kCounter,
@@ -896,7 +896,7 @@ TEST_F(MeterCreateInstrumentTest, SyncInstrumentWithMultipleAggregations)
   counter1->Add(1, {{"key", "value1"}});
   counter1->Add(4, {{"key", "value2"}});
 
-  metric_reader_ptr_->Collect([this](ResourceMetrics &metric_data) {
+  metric_reader_ptr_->Collect([](ResourceMetrics &metric_data) {
     const auto &data = metric_data.scope_metric_data_.at(0).metric_data_;
     EXPECT_EQ(data.size(), 2);
     InstrumentDescriptor descriptor_default{"counter_one", "desc", "unit", InstrumentType::kCounter,
@@ -926,7 +926,7 @@ TEST_F(MeterCreateInstrumentTest, IdenticalAsyncInstruments)
   observable_counter1->AddCallback(ObservableResultDouble::Callback, &callback1);
   observable_counter2->AddCallback(ObservableResultDouble::Callback, &callback2);
 
-  metric_reader_ptr_->Collect([this](ResourceMetrics &metric_data) {
+  metric_reader_ptr_->Collect([](ResourceMetrics &metric_data) {
     const auto &data = metric_data.scope_metric_data_.at(0).metric_data_;
     EXPECT_EQ(data.size(), 1);
     InstrumentDescriptor descriptor{"observable_counter", "desc", "unit",
@@ -954,7 +954,7 @@ TEST_F(MeterCreateInstrumentTest, NameCaseConflictAsyncInstruments)
   observable_counter1->AddCallback(ObservableResultDouble::Callback, &callback1);
   observable_counter2->AddCallback(ObservableResultDouble::Callback, &callback2);
 
-  metric_reader_ptr_->Collect([this](ResourceMetrics &metric_data) {
+  metric_reader_ptr_->Collect([](ResourceMetrics &metric_data) {
     const auto &data = metric_data.scope_metric_data_.at(0).metric_data_;
     EXPECT_EQ(data.size(), 1);
     InstrumentDescriptor descriptor{"OBServable_CounTER", "desc", "unit",
@@ -986,7 +986,7 @@ TEST_F(MeterCreateInstrumentTest, ViewCorrectedNameCaseConflictAsyncInstruments)
   observable_counter1->AddCallback(ObservableResultDouble::Callback, &callback1);
   observable_counter2->AddCallback(ObservableResultDouble::Callback, &callback2);
 
-  metric_reader_ptr_->Collect([this](ResourceMetrics &metric_data) {
+  metric_reader_ptr_->Collect([](ResourceMetrics &metric_data) {
     const auto &data = metric_data.scope_metric_data_.at(0).metric_data_;
     EXPECT_EQ(data.size(), 1);
     InstrumentDescriptor descriptor{"observable_counter", "desc", "unit",
@@ -1013,7 +1013,7 @@ TEST_F(MeterCreateInstrumentTest, DuplicateAsyncInstrumentsByKind)
   observable_counter1->AddCallback(ObservableResultDouble::Callback, &callback1);
   observable_counter2->AddCallback(ObservableResultDouble::Callback, &callback2);
 
-  metric_reader_ptr_->Collect([this](ResourceMetrics &metric_data) {
+  metric_reader_ptr_->Collect([](ResourceMetrics &metric_data) {
     const auto &data = metric_data.scope_metric_data_.at(0).metric_data_;
     EXPECT_EQ(data.size(), 2);
     InstrumentDescriptor counter_descriptor{"observable_counter", "", "",
@@ -1047,7 +1047,7 @@ TEST_F(MeterCreateInstrumentTest, DuplicateAsyncInstrumentsByUnits)
   observable_counter1->AddCallback(ObservableResultDouble::Callback, &callback1);
   observable_counter2->AddCallback(ObservableResultDouble::Callback, &callback2);
 
-  metric_reader_ptr_->Collect([this](ResourceMetrics &metric_data) {
+  metric_reader_ptr_->Collect([](ResourceMetrics &metric_data) {
     const auto &data = metric_data.scope_metric_data_.at(0).metric_data_;
     EXPECT_EQ(data.size(), 2);
     InstrumentDescriptor unit_descriptor{"observable_counter", "desc", "unit",
@@ -1081,7 +1081,7 @@ TEST_F(MeterCreateInstrumentTest, DuplicateAsyncInstrumentsByDescription)
   observable_counter1->AddCallback(ObservableResultDouble::Callback, &callback1);
   observable_counter2->AddCallback(ObservableResultDouble::Callback, &callback2);
 
-  metric_reader_ptr_->Collect([this](ResourceMetrics &metric_data) {
+  metric_reader_ptr_->Collect([](ResourceMetrics &metric_data) {
     const auto &data = metric_data.scope_metric_data_.at(0).metric_data_;
     EXPECT_EQ(data.size(), 2);
     InstrumentDescriptor desc_descriptor{"observable_counter", "desc", "unit",
@@ -1121,7 +1121,7 @@ TEST_F(MeterCreateInstrumentTest, ViewCorrectedDuplicateAsyncInstrumentsByDescri
   observable_counter1->AddCallback(ObservableResultDouble::Callback, &callback1);
   observable_counter2->AddCallback(ObservableResultDouble::Callback, &callback2);
 
-  metric_reader_ptr_->Collect([this](ResourceMetrics &metric_data) {
+  metric_reader_ptr_->Collect([](ResourceMetrics &metric_data) {
     const auto &data = metric_data.scope_metric_data_.at(0).metric_data_;
     EXPECT_EQ(data.size(), 1);
     InstrumentDescriptor descriptor{"observable_counter", "desc", "unit",
@@ -1153,7 +1153,7 @@ TEST_F(MeterCreateInstrumentTest, AsyncInstrumentWithDropAggregation)
   observable_counter1->AddCallback(ObservableResultDouble::Callback, &callback1);
   observable_counter2->AddCallback(ObservableResultDouble::Callback, &callback2);
 
-  metric_reader_ptr_->Collect([this](ResourceMetrics &metric_data) {
+  metric_reader_ptr_->Collect([](ResourceMetrics &metric_data) {
     const auto &data = metric_data.scope_metric_data_.at(0).metric_data_;
     EXPECT_EQ(data.size(), 1);
     InstrumentDescriptor dropped_descriptor{"observable_counter_one", "desc", "unit",
@@ -1192,7 +1192,7 @@ TEST_F(MeterCreateInstrumentTest, ASyncInstrumentWithCatchAllDropAggregation)
   observable_counter1->AddCallback(ObservableResultDouble::Callback, &callback1);
   observable_counter2->AddCallback(ObservableResultDouble::Callback, &callback2);
 
-  metric_reader_ptr_->Collect([this](ResourceMetrics &metric_data) {
+  metric_reader_ptr_->Collect([](ResourceMetrics &metric_data) {
     const auto &data = metric_data.scope_metric_data_.at(0).metric_data_;
     EXPECT_EQ(data.size(), 1);
     InstrumentDescriptor descriptor_kept{"observable_counter_one", "desc", "unit",
@@ -1226,7 +1226,7 @@ TEST_F(MeterCreateInstrumentTest, ASyncInstrumentWithConflictingAggregation)
 
   observable_counter1->AddCallback(ObservableResultDouble::Callback, &callback1);
 
-  metric_reader_ptr_->Collect([this](ResourceMetrics &metric_data) {
+  metric_reader_ptr_->Collect([](ResourceMetrics &metric_data) {
     const auto &data = metric_data.scope_metric_data_.at(0).metric_data_;
     EXPECT_EQ(data.size(), 1);
     InstrumentDescriptor descriptor{"observable_counter_one", "desc", "unit",
@@ -1259,7 +1259,7 @@ TEST_F(MeterCreateInstrumentTest, ASyncInstrumentWithMultipleAggregations)
 
   observable_counter1->AddCallback(ObservableResultDouble::Callback, &callback1);
 
-  metric_reader_ptr_->Collect([this](ResourceMetrics &metric_data) {
+  metric_reader_ptr_->Collect([](ResourceMetrics &metric_data) {
     const auto &data = metric_data.scope_metric_data_.at(0).metric_data_;
     EXPECT_EQ(data.size(), 2);
     InstrumentDescriptor descriptor_default{"observable_counter", "desc", "unit",

--- a/sdk/test/metrics/meter_test.cc
+++ b/sdk/test/metrics/meter_test.cc
@@ -7,15 +7,17 @@
 #include <chrono>
 #include <cstddef>
 #include <cstdint>
+#include <functional>
 #include <initializer_list>  // IWYU pragma: keep
 #include <iostream>
+#include <map>
 #include <string>
 #include <thread>
 #include <utility>
 #include <vector>
+
 #include "common.h"
 
-#include <functional>
 #include "opentelemetry/context/context.h"  // IWYU pragma: keep
 #include "opentelemetry/metrics/async_instruments.h"
 #include "opentelemetry/metrics/meter.h"
@@ -25,10 +27,12 @@
 #include "opentelemetry/nostd/function_ref.h"
 #include "opentelemetry/nostd/shared_ptr.h"
 #include "opentelemetry/nostd/string_view.h"
+#include "opentelemetry/nostd/utility.h"
 #include "opentelemetry/nostd/variant.h"
 #include "opentelemetry/sdk/common/global_log_handler.h"
 #include "opentelemetry/sdk/instrumentationscope/instrumentation_scope.h"
 #include "opentelemetry/sdk/instrumentationscope/scope_configurator.h"
+#include "opentelemetry/sdk/metrics/aggregation/aggregation_config.h"
 #include "opentelemetry/sdk/metrics/data/exemplar_data.h"  // IWYU pragma: keep
 #include "opentelemetry/sdk/metrics/data/metric_data.h"
 #include "opentelemetry/sdk/metrics/data/point_data.h"

--- a/sdk/test/metrics/meter_test.cc
+++ b/sdk/test/metrics/meter_test.cc
@@ -106,10 +106,24 @@ public:
               const sdk::common::AttributeMap & /*attributes*/) noexcept override
 
   {
-    if (LogLevel::Warning == level)
+    switch (level)
     {
-      std::cout << msg << "\n";
-      warnings.emplace_back(msg);
+      case LogLevel::Warning: {
+        warnings.emplace_back(msg);
+        std::cout << "[Warning] " << msg << std::endl;
+        break;
+      }
+      case LogLevel::Error: {
+        errors.emplace_back(msg);
+        std::cout << "[Error] " << msg << std::endl;
+        break;
+      }
+      case LogLevel::None:
+      case LogLevel::Info:
+      case LogLevel::Debug:
+      default:
+        std::cout << "[" << LevelToString(level) << "] " << msg << std::endl;
+        break;
     }
   }
 
@@ -127,8 +141,19 @@ public:
     });
   }
 
+  bool HasSemanticErrorWarning() const
+  {
+    return std::any_of(warnings.begin(), warnings.end(), [](const std::string &warning) {
+      return warning.find("WarnOnViewSemanticError") != std::string::npos;
+    });
+  }
+
+  bool HasErrors() const { return !errors.empty(); }
+  bool HasWarnings() const { return !warnings.empty(); }
+
 private:
   std::vector<std::string> warnings;
+  std::vector<std::string> errors;
 };
 
 class MeterCreateInstrumentTest : public ::testing::Test
@@ -140,7 +165,7 @@ protected:
     ASSERT_TRUE(metric_reader_ptr_ != nullptr);
     ASSERT_TRUE(provider_ != nullptr);
     GlobalLogHandler::SetLogHandler(std::static_pointer_cast<LogHandler>(log_handler_));
-    GlobalLogHandler::SetLogLevel(LogLevel::Warning);
+    GlobalLogHandler::SetLogLevel(LogLevel::Debug);
 
     provider_->AddMetricReader(metric_reader_ptr_);
     meter_ = provider_->GetMeter("test_meter");
@@ -178,6 +203,102 @@ protected:
     provider_->AddView(std::move(instrument_selector), std::move(meter_selector),
                        std::move(corrective_view));
   }
+
+  void AddView(const std::string &name,
+               const std::string &unit,
+               InstrumentType type,
+               const std::string &new_name,
+               AggregationType new_aggregation_type,
+               const std::shared_ptr<AggregationConfig> &new_aggregation_config = nullptr)
+  {
+    std::unique_ptr<View> view{
+        new View(new_name, "", new_aggregation_type, new_aggregation_config)};
+    std::unique_ptr<InstrumentSelector> instrument_selector{
+        new InstrumentSelector(type, name, unit)};
+
+    std::unique_ptr<MeterSelector> meter_selector{new MeterSelector("test_meter", "", "")};
+
+    provider_->AddView(std::move(instrument_selector), std::move(meter_selector), std::move(view));
+  }
+
+  static size_t CountPointData(const std::vector<MetricData> &data,
+                               const InstrumentDescriptor &descriptor,
+                               bool expected_match = true)
+  {
+    size_t match_count = 0;
+    size_t point_count = 0;
+    for (const auto &md : data)
+    {
+      if (md.instrument_descriptor.name_ == descriptor.name_ &&
+          md.instrument_descriptor.unit_ == descriptor.unit_ &&
+          md.instrument_descriptor.description_ == descriptor.description_ &&
+          md.instrument_descriptor.type_ == descriptor.type_ &&
+          md.instrument_descriptor.value_type_ == descriptor.value_type_)
+      {
+        match_count++;
+        point_count = md.point_data_attr_.size();
+      }
+    }
+    EXPECT_EQ(match_count, expected_match ? 1 : 0);
+    return point_count;
+  }
+
+  static double SumPointData(const std::vector<MetricData> &data,
+                             const InstrumentDescriptor &descriptor)
+  {
+    auto value_to_double = [](const ValueType &value) {
+      return nostd::holds_alternative<double>(value)
+                 ? nostd::get<double>(value)
+                 : static_cast<double>(nostd::get<int64_t>(value));
+    };
+
+    double total = 0;
+    for (const auto &md : data)
+    {
+      if (md.instrument_descriptor.name_ != descriptor.name_ ||
+          md.instrument_descriptor.unit_ != descriptor.unit_ ||
+          md.instrument_descriptor.description_ != descriptor.description_ ||
+          md.instrument_descriptor.type_ != descriptor.type_ ||
+          md.instrument_descriptor.value_type_ != descriptor.value_type_)
+      {
+        continue;
+      }
+      for (const auto &point_data_attr : md.point_data_attr_)
+      {
+        if (auto *sum_point_data =
+                nostd::get_if<sdk::metrics::SumPointData>(&point_data_attr.point_data))
+        {
+          total += value_to_double(sum_point_data->value_);
+        }
+        else if (auto *histogram_point_data =
+                     nostd::get_if<sdk::metrics::HistogramPointData>(&point_data_attr.point_data))
+        {
+          total += value_to_double(histogram_point_data->sum_);
+        }
+        else if (auto *last_value_point_data =
+                     nostd::get_if<sdk::metrics::LastValuePointData>(&point_data_attr.point_data))
+        {
+          total += value_to_double(last_value_point_data->value_);
+        }
+      }
+    }
+    return total;
+  }
+
+protected:
+  struct ObservableResultDouble
+  {
+    double value{};
+    std::map<std::string, std::string> attributes{};
+
+    static void Callback(opentelemetry::metrics::ObserverResult observer, void *state)
+    {
+      auto *self = static_cast<ObservableResultDouble *>(state);
+      auto observer_double =
+          nostd::get<nostd::shared_ptr<opentelemetry::metrics::ObserverResultT<double>>>(observer);
+      observer_double->Observe(self->value, self->attributes);
+    }
+  };
 
   std::shared_ptr<sdk::metrics::MeterProvider> provider_{new sdk::metrics::MeterProvider()};
   std::shared_ptr<TestLogHandler> log_handler_{new TestLogHandler()};
@@ -497,24 +618,17 @@ TEST_F(MeterCreateInstrumentTest, IdenticalSyncInstruments)
   counter2->Add(2.5, {{"key", "value2"}});
 
   metric_reader_ptr_->Collect([this](ResourceMetrics &metric_data) {
-    EXPECT_EQ(metric_data.scope_metric_data_.size(), 1);
-    EXPECT_EQ(metric_data.scope_metric_data_[0].metric_data_.size(), 1);
-    EXPECT_EQ(metric_data.scope_metric_data_[0].metric_data_[0].point_data_attr_.size(), 2);
-    auto &point_data1 =
-        metric_data.scope_metric_data_[0].metric_data_[0].point_data_attr_[0].point_data;
-    auto &point_data2 =
-        metric_data.scope_metric_data_[0].metric_data_[0].point_data_attr_[1].point_data;
-
-    auto sum_point_data1 = nostd::get<sdk::metrics::SumPointData>(point_data1);
-    auto sum_point_data2 = nostd::get<sdk::metrics::SumPointData>(point_data2);
-
-    const double sum =
-        nostd::get<double>(sum_point_data1.value_) + nostd::get<double>(sum_point_data2.value_);
-    EXPECT_DOUBLE_EQ(sum, 3.5);
-    EXPECT_FALSE(log_handler_->HasDuplicateInstrumentWarning());
-    EXPECT_FALSE(log_handler_->HasNameCaseConflictWarning());
+    const auto &data = metric_data.scope_metric_data_.at(0).metric_data_;
+    EXPECT_EQ(data.size(), 1);
+    InstrumentDescriptor descriptor{"my_counter", "desc", "unit", InstrumentType::kCounter,
+                                    InstrumentValueType::kDouble};
+    EXPECT_EQ(CountPointData(data, descriptor), 2u);
+    EXPECT_DOUBLE_EQ(SumPointData(data, descriptor), 3.5);
     return true;
   });
+
+  EXPECT_FALSE(log_handler_->HasErrors());
+  EXPECT_FALSE(log_handler_->HasWarnings());
 }
 
 TEST_F(MeterCreateInstrumentTest, NameCaseConflictSyncInstruments)
@@ -526,18 +640,18 @@ TEST_F(MeterCreateInstrumentTest, NameCaseConflictSyncInstruments)
   counter2->Add(2);
 
   metric_reader_ptr_->Collect([this](ResourceMetrics &metric_data) {
-    EXPECT_EQ(metric_data.scope_metric_data_.size(), 1);
-    EXPECT_EQ(metric_data.scope_metric_data_[0].metric_data_.size(), 1);
-    EXPECT_EQ(metric_data.scope_metric_data_[0].metric_data_[0].point_data_attr_.size(), 1);
-    auto &point_data =
-        metric_data.scope_metric_data_[0].metric_data_[0].point_data_attr_[0].point_data;
-    auto sum_point_data = nostd::get<sdk::metrics::SumPointData>(point_data);
-    const auto sum      = nostd::get<int64_t>(sum_point_data.value_);
-    EXPECT_EQ(sum, 3);
-    EXPECT_FALSE(log_handler_->HasDuplicateInstrumentWarning());
-    EXPECT_TRUE(log_handler_->HasNameCaseConflictWarning());
+    const auto &data = metric_data.scope_metric_data_.at(0).metric_data_;
+    EXPECT_EQ(data.size(), 1);
+    InstrumentDescriptor descriptor{"My_CountER", "desc", "unit", InstrumentType::kCounter,
+                                    InstrumentValueType::kLong};
+    EXPECT_EQ(CountPointData(data, descriptor), 1u);
+    EXPECT_DOUBLE_EQ(SumPointData(data, descriptor), 3);
     return true;
   });
+
+  EXPECT_FALSE(log_handler_->HasErrors());
+  EXPECT_TRUE(log_handler_->HasNameCaseConflictWarning());
+  EXPECT_FALSE(log_handler_->HasDuplicateInstrumentWarning());
 }
 
 TEST_F(MeterCreateInstrumentTest, ViewCorrectedNameCaseConflictSyncInstruments)
@@ -556,19 +670,17 @@ TEST_F(MeterCreateInstrumentTest, ViewCorrectedNameCaseConflictSyncInstruments)
   counter2->Add(2);
 
   metric_reader_ptr_->Collect([this](ResourceMetrics &metric_data) {
-    EXPECT_EQ(metric_data.scope_metric_data_.size(), 1);
-    EXPECT_EQ(metric_data.scope_metric_data_[0].metric_data_.size(), 1);
-    EXPECT_EQ(metric_data.scope_metric_data_[0].metric_data_[0].point_data_attr_.size(), 1);
-    auto &point_data =
-        metric_data.scope_metric_data_[0].metric_data_[0].point_data_attr_[0].point_data;
-    auto sum_point_data = nostd::get<sdk::metrics::SumPointData>(point_data);
-    const auto sum      = nostd::get<int64_t>(sum_point_data.value_);
-    EXPECT_EQ(sum, 3);
-    // no warnings expected after correction with the view
-    EXPECT_FALSE(log_handler_->HasDuplicateInstrumentWarning());
-    EXPECT_FALSE(log_handler_->HasNameCaseConflictWarning());
+    const auto &data = metric_data.scope_metric_data_.at(0).metric_data_;
+    EXPECT_EQ(data.size(), 1);
+    InstrumentDescriptor descriptor{"my_counter", "desc", "unit", InstrumentType::kCounter,
+                                    InstrumentValueType::kLong};
+    EXPECT_EQ(CountPointData(data, descriptor), 1u);
+    EXPECT_DOUBLE_EQ(SumPointData(data, descriptor), 3);
     return true;
   });
+
+  EXPECT_FALSE(log_handler_->HasErrors());
+  EXPECT_FALSE(log_handler_->HasWarnings());
 }
 
 TEST_F(MeterCreateInstrumentTest, DuplicateSyncInstrumentsByKind)
@@ -580,14 +692,22 @@ TEST_F(MeterCreateInstrumentTest, DuplicateSyncInstrumentsByKind)
   counter2->Add(1, {{"key", "value2"}});
 
   metric_reader_ptr_->Collect([this](ResourceMetrics &metric_data) {
-    EXPECT_EQ(metric_data.scope_metric_data_.size(), 1);
-    EXPECT_EQ(metric_data.scope_metric_data_[0].metric_data_.size(), 2);
-    EXPECT_EQ(metric_data.scope_metric_data_[0].metric_data_[0].point_data_attr_.size(), 1);
-    EXPECT_EQ(metric_data.scope_metric_data_[0].metric_data_[1].point_data_attr_.size(), 1);
-    EXPECT_TRUE(log_handler_->HasDuplicateInstrumentWarning());
-    EXPECT_FALSE(log_handler_->HasNameCaseConflictWarning());
+    const auto &data = metric_data.scope_metric_data_.at(0).metric_data_;
+    EXPECT_EQ(data.size(), 2);
+    InstrumentDescriptor double_descriptor{"my_counter", "desc", "unit", InstrumentType::kCounter,
+                                           InstrumentValueType::kDouble};
+    InstrumentDescriptor long_descriptor{"my_counter", "desc", "unit", InstrumentType::kCounter,
+                                         InstrumentValueType::kLong};
+    EXPECT_EQ(CountPointData(data, double_descriptor), 1u);
+    EXPECT_DOUBLE_EQ(SumPointData(data, double_descriptor), 1);
+    EXPECT_EQ(CountPointData(data, long_descriptor), 1u);
+    EXPECT_DOUBLE_EQ(SumPointData(data, long_descriptor), 1);
     return true;
   });
+
+  EXPECT_FALSE(log_handler_->HasErrors());
+  EXPECT_TRUE(log_handler_->HasDuplicateInstrumentWarning());
+  EXPECT_FALSE(log_handler_->HasNameCaseConflictWarning());
 }
 
 TEST_F(MeterCreateInstrumentTest, DuplicateSyncInstrumentsByUnits)
@@ -599,14 +719,23 @@ TEST_F(MeterCreateInstrumentTest, DuplicateSyncInstrumentsByUnits)
   counter2->Add(1, {{"key", "value2"}});
 
   metric_reader_ptr_->Collect([this](ResourceMetrics &metric_data) {
-    EXPECT_EQ(metric_data.scope_metric_data_.size(), 1);
-    EXPECT_EQ(metric_data.scope_metric_data_[0].metric_data_.size(), 2);
-    EXPECT_EQ(metric_data.scope_metric_data_[0].metric_data_[0].point_data_attr_.size(), 1);
-    EXPECT_EQ(metric_data.scope_metric_data_[0].metric_data_[1].point_data_attr_.size(), 1);
-    EXPECT_TRUE(log_handler_->HasDuplicateInstrumentWarning());
-    EXPECT_FALSE(log_handler_->HasNameCaseConflictWarning());
+    const auto &data = metric_data.scope_metric_data_.at(0).metric_data_;
+    EXPECT_EQ(data.size(), 2);
+    InstrumentDescriptor unit_descriptor{"my_counter", "desc", "unit", InstrumentType::kCounter,
+                                         InstrumentValueType::kDouble};
+    InstrumentDescriptor another_unit_descriptor{"my_counter", "desc", "another_unit",
+                                                 InstrumentType::kCounter,
+                                                 InstrumentValueType::kDouble};
+    EXPECT_EQ(CountPointData(data, unit_descriptor), 1u);
+    EXPECT_DOUBLE_EQ(SumPointData(data, unit_descriptor), 1);
+    EXPECT_EQ(CountPointData(data, another_unit_descriptor), 1u);
+    EXPECT_DOUBLE_EQ(SumPointData(data, another_unit_descriptor), 1);
     return true;
   });
+
+  EXPECT_FALSE(log_handler_->HasErrors());
+  EXPECT_TRUE(log_handler_->HasDuplicateInstrumentWarning());
+  EXPECT_FALSE(log_handler_->HasNameCaseConflictWarning());
 }
 
 TEST_F(MeterCreateInstrumentTest, DuplicateSyncInstrumentsByDescription)
@@ -618,14 +747,23 @@ TEST_F(MeterCreateInstrumentTest, DuplicateSyncInstrumentsByDescription)
   counter2->Add(1, {{"key", "value2"}});
 
   metric_reader_ptr_->Collect([this](ResourceMetrics &metric_data) {
-    EXPECT_EQ(metric_data.scope_metric_data_.size(), 1);
-    EXPECT_EQ(metric_data.scope_metric_data_[0].metric_data_.size(), 2);
-    EXPECT_EQ(metric_data.scope_metric_data_[0].metric_data_[0].point_data_attr_.size(), 1);
-    EXPECT_EQ(metric_data.scope_metric_data_[0].metric_data_[1].point_data_attr_.size(), 1);
-    EXPECT_TRUE(log_handler_->HasDuplicateInstrumentWarning());
-    EXPECT_FALSE(log_handler_->HasNameCaseConflictWarning());
+    const auto &data = metric_data.scope_metric_data_.at(0).metric_data_;
+    EXPECT_EQ(data.size(), 2);
+    InstrumentDescriptor desc_descriptor{"my_counter", "desc", "unit", InstrumentType::kCounter,
+                                         InstrumentValueType::kDouble};
+    InstrumentDescriptor another_desc_descriptor{"my_counter", "another_desc", "unit",
+                                                 InstrumentType::kCounter,
+                                                 InstrumentValueType::kDouble};
+    EXPECT_EQ(CountPointData(data, desc_descriptor), 1u);
+    EXPECT_DOUBLE_EQ(SumPointData(data, desc_descriptor), 1);
+    EXPECT_EQ(CountPointData(data, another_desc_descriptor), 1u);
+    EXPECT_DOUBLE_EQ(SumPointData(data, another_desc_descriptor), 1);
     return true;
   });
+
+  EXPECT_FALSE(log_handler_->HasErrors());
+  EXPECT_TRUE(log_handler_->HasDuplicateInstrumentWarning());
+  EXPECT_FALSE(log_handler_->HasNameCaseConflictWarning());
 }
 
 TEST_F(MeterCreateInstrumentTest, ViewCorrectedDuplicateSyncInstrumentsByDescription)
@@ -642,58 +780,162 @@ TEST_F(MeterCreateInstrumentTest, ViewCorrectedDuplicateSyncInstrumentsByDescrip
   counter2->Add(1, {{"key", "value2"}});
 
   metric_reader_ptr_->Collect([this](ResourceMetrics &metric_data) {
-    EXPECT_EQ(metric_data.scope_metric_data_.size(), 1);
     // only one metric_data object expected after correction with the view
-    EXPECT_EQ(metric_data.scope_metric_data_[0].metric_data_.size(), 1);
-    EXPECT_EQ(metric_data.scope_metric_data_[0].metric_data_[0].point_data_attr_.size(), 2);
-    // no warnings expected after correction with the view
-    EXPECT_FALSE(log_handler_->HasDuplicateInstrumentWarning());
-    EXPECT_FALSE(log_handler_->HasNameCaseConflictWarning());
+    const auto &data = metric_data.scope_metric_data_.at(0).metric_data_;
+    EXPECT_EQ(data.size(), 1);
+    InstrumentDescriptor descriptor{"my_counter", "desc", "unit", InstrumentType::kCounter,
+                                    InstrumentValueType::kDouble};
+    EXPECT_EQ(CountPointData(data, descriptor), 2u);
+    EXPECT_DOUBLE_EQ(SumPointData(data, descriptor), 2);
     return true;
   });
+
+  // no warnings expected after correction with the view
+  EXPECT_FALSE(log_handler_->HasErrors());
+  EXPECT_FALSE(log_handler_->HasWarnings());
+}
+
+TEST_F(MeterCreateInstrumentTest, SyncInstrumentWithDropAggregation)
+{
+  AddView("counter_one", "", InstrumentType::kCounter, "", AggregationType::kDrop);
+
+  auto counter1 = meter_->CreateUInt64Counter("counter_one", "desc", "unit");
+  auto counter2 = meter_->CreateUInt64Counter("counter_two", "desc", "unit");
+
+  counter1->Add(1, {{"key", "value1"}});
+  counter2->Add(1, {{"key", "value2"}});
+
+  metric_reader_ptr_->Collect([this](ResourceMetrics &metric_data) {
+    const auto &data = metric_data.scope_metric_data_.at(0).metric_data_;
+    EXPECT_EQ(data.size(), 1);
+    InstrumentDescriptor dropped_descriptor{"counter_one", "desc", "unit", InstrumentType::kCounter,
+                                            InstrumentValueType::kLong};
+    InstrumentDescriptor kept_descriptor{"counter_two", "desc", "unit", InstrumentType::kCounter,
+                                         InstrumentValueType::kLong};
+    EXPECT_EQ(CountPointData(data, dropped_descriptor, false), 0u);
+    EXPECT_EQ(CountPointData(data, kept_descriptor), 1u);
+    EXPECT_DOUBLE_EQ(SumPointData(data, kept_descriptor), 1);
+    return true;
+  });
+
+  EXPECT_FALSE(log_handler_->HasErrors());
+  EXPECT_FALSE(log_handler_->HasWarnings());
+}
+
+TEST_F(MeterCreateInstrumentTest, SyncInstrumentWithCatchAllDropAggregation)
+{
+  // Catch-all drop view
+  AddView("*", "", InstrumentType::kCounter, "", AggregationType::kDrop);
+
+  // Specific view for counter_one
+  AddView("counter_one", "", InstrumentType::kCounter, "", AggregationType::kSum);
+
+  auto counter1 = meter_->CreateUInt64Counter("counter_one", "desc", "unit");
+  auto counter2 = meter_->CreateUInt64Counter("counter_two", "desc", "unit");
+
+  counter1->Add(1, {{"key", "value1"}});
+  counter2->Add(1, {{"key", "value2"}});
+
+  metric_reader_ptr_->Collect([this](ResourceMetrics &metric_data) {
+    const auto &data = metric_data.scope_metric_data_.at(0).metric_data_;
+    EXPECT_EQ(data.size(), 1);
+    InstrumentDescriptor dropped_descriptor{"counter_two", "desc", "unit", InstrumentType::kCounter,
+                                            InstrumentValueType::kLong};
+    InstrumentDescriptor kept_descriptor{"counter_one", "desc", "unit", InstrumentType::kCounter,
+                                         InstrumentValueType::kLong};
+    EXPECT_EQ(CountPointData(data, dropped_descriptor, false), 0u);
+    EXPECT_EQ(CountPointData(data, kept_descriptor), 1u);
+    EXPECT_DOUBLE_EQ(SumPointData(data, kept_descriptor), 1);
+    return true;
+  });
+  EXPECT_FALSE(log_handler_->HasErrors());
+  EXPECT_FALSE(log_handler_->HasWarnings());
+}
+
+TEST_F(MeterCreateInstrumentTest, SyncInstrumentWithConflictingAggregation)
+{
+  // Specific view for counter_one
+  AddView("counter_one", "", InstrumentType::kCounter, "", AggregationType::kSum);
+
+  // Catch-all view
+  AddView("*", "", InstrumentType::kCounter, "", AggregationType::kSum);
+
+  auto counter1 = meter_->CreateUInt64Counter("counter_one", "desc", "unit");
+
+  counter1->Add(1, {{"key", "value1"}});
+
+  metric_reader_ptr_->Collect([this](ResourceMetrics &metric_data) {
+    const auto &data = metric_data.scope_metric_data_.at(0).metric_data_;
+    EXPECT_EQ(data.size(), 1);
+    InstrumentDescriptor descriptor{"counter_one", "desc", "unit", InstrumentType::kCounter,
+                                    InstrumentValueType::kLong};
+    EXPECT_EQ(CountPointData(data, descriptor), 1u);
+    EXPECT_DOUBLE_EQ(SumPointData(data, descriptor), 1);
+    return true;
+  });
+  EXPECT_FALSE(log_handler_->HasErrors());
+  EXPECT_TRUE(log_handler_->HasSemanticErrorWarning());
+}
+
+TEST_F(MeterCreateInstrumentTest, SyncInstrumentWithMultipleAggregations)
+{
+  // Specific view for counter_one to add histogram aggregation
+  AddView("counter_one", "", InstrumentType::kCounter, "counter_one_as_histogram",
+          AggregationType::kHistogram);
+
+  // Another view that matches counter_one with default aggregation and a cardinality limit
+  auto aggregation_config                = std::make_shared<sdk::metrics::AggregationConfig>();
+  aggregation_config->cardinality_limit_ = 100;
+  AddView("*", "", InstrumentType::kCounter, "", AggregationType::kDefault, aggregation_config);
+
+  auto counter1 = meter_->CreateUInt64Counter("counter_one", "desc", "unit");
+
+  counter1->Add(1, {{"key", "value1"}});
+  counter1->Add(4, {{"key", "value2"}});
+
+  metric_reader_ptr_->Collect([this](ResourceMetrics &metric_data) {
+    const auto &data = metric_data.scope_metric_data_.at(0).metric_data_;
+    EXPECT_EQ(data.size(), 2);
+    InstrumentDescriptor descriptor_default{"counter_one", "desc", "unit", InstrumentType::kCounter,
+                                            InstrumentValueType::kLong};
+    InstrumentDescriptor descriptor_histogram{"counter_one_as_histogram", "desc", "unit",
+                                              InstrumentType::kCounter, InstrumentValueType::kLong};
+    EXPECT_EQ(CountPointData(data, descriptor_default), 2u);
+    EXPECT_DOUBLE_EQ(SumPointData(data, descriptor_default), 5);
+    EXPECT_EQ(CountPointData(data, descriptor_histogram), 2u);
+    EXPECT_DOUBLE_EQ(SumPointData(data, descriptor_histogram), 5);
+    return true;
+  });
+  EXPECT_FALSE(log_handler_->HasErrors());
+  EXPECT_FALSE(log_handler_->HasWarnings());
 }
 
 TEST_F(MeterCreateInstrumentTest, IdenticalAsyncInstruments)
 {
   auto observable_counter1 =
-      meter_->CreateInt64ObservableCounter("observable_counter", "desc", "unit");
+      meter_->CreateDoubleObservableCounter("observable_counter", "desc", "unit");
   auto observable_counter2 =
-      meter_->CreateInt64ObservableCounter("observable_counter", "desc", "unit");
+      meter_->CreateDoubleObservableCounter("observable_counter", "desc", "unit");
 
-  auto callback1 = [](opentelemetry::metrics::ObserverResult observer, void * /* state */) {
-    auto observer_long =
-        nostd::get<nostd::shared_ptr<opentelemetry::metrics::ObserverResultT<int64_t>>>(observer);
-    observer_long->Observe(12, {{"key", "value1"}});
-  };
+  auto callback1 = ObservableResultDouble{22.2, {{"key", "value1"}}};
+  auto callback2 = ObservableResultDouble{55.5, {{"key", "value2"}}};
 
-  auto callback2 = [](opentelemetry::metrics::ObserverResult observer, void * /* state */) {
-    auto observer_long =
-        nostd::get<nostd::shared_ptr<opentelemetry::metrics::ObserverResultT<int64_t>>>(observer);
-    observer_long->Observe(2, {{"key", "value2"}});
-  };
-
-  observable_counter1->AddCallback(callback1, nullptr);
-  observable_counter2->AddCallback(callback2, nullptr);
+  observable_counter1->AddCallback(ObservableResultDouble::Callback, &callback1);
+  observable_counter2->AddCallback(ObservableResultDouble::Callback, &callback2);
 
   metric_reader_ptr_->Collect([this](ResourceMetrics &metric_data) {
-    EXPECT_EQ(metric_data.scope_metric_data_.size(), 1);
-    EXPECT_EQ(metric_data.scope_metric_data_[0].metric_data_.size(), 1);
-    auto &point_data_attr = metric_data.scope_metric_data_[0].metric_data_[0].point_data_attr_;
-    EXPECT_EQ(point_data_attr.size(), 2);
-
-    auto &point_data1 = point_data_attr[0].point_data;
-    auto &point_data2 = point_data_attr[1].point_data;
-
-    auto sum_point_data1 = nostd::get<sdk::metrics::SumPointData>(point_data1);
-    auto sum_point_data2 = nostd::get<sdk::metrics::SumPointData>(point_data2);
-
-    int64_t sum =
-        nostd::get<int64_t>(sum_point_data1.value_) + nostd::get<int64_t>(sum_point_data2.value_);
-    EXPECT_EQ(sum, 14);
-    EXPECT_FALSE(log_handler_->HasDuplicateInstrumentWarning());
-    EXPECT_FALSE(log_handler_->HasNameCaseConflictWarning());
+    const auto &data = metric_data.scope_metric_data_.at(0).metric_data_;
+    EXPECT_EQ(data.size(), 1);
+    InstrumentDescriptor descriptor{"observable_counter", "desc", "unit",
+                                    InstrumentType::kObservableCounter,
+                                    InstrumentValueType::kDouble};
+    EXPECT_EQ(CountPointData(data, descriptor), 2u);
+    EXPECT_DOUBLE_EQ(SumPointData(data, descriptor), 77.7);
     return true;
   });
+
+  EXPECT_FALSE(log_handler_->HasErrors());
+  EXPECT_FALSE(log_handler_->HasWarnings());
 }
 
 TEST_F(MeterCreateInstrumentTest, NameCaseConflictAsyncInstruments)
@@ -703,39 +945,26 @@ TEST_F(MeterCreateInstrumentTest, NameCaseConflictAsyncInstruments)
   auto observable_counter2 =
       meter_->CreateDoubleObservableCounter("observable_counter", "desc", "unit");
 
-  auto callback1 = [](opentelemetry::metrics::ObserverResult observer, void * /* state */) {
-    auto observer_double =
-        nostd::get<nostd::shared_ptr<opentelemetry::metrics::ObserverResultT<double>>>(observer);
-    observer_double->Observe(22.22, {{"key", "value1"}});
-  };
+  auto callback1 = ObservableResultDouble{22.2, {{"key", "value1"}}};
+  auto callback2 = ObservableResultDouble{55.5, {{"key", "value2"}}};
 
-  auto callback2 = [](opentelemetry::metrics::ObserverResult observer, void * /* state */) {
-    auto observer_double =
-        nostd::get<nostd::shared_ptr<opentelemetry::metrics::ObserverResultT<double>>>(observer);
-    observer_double->Observe(55.55, {{"key", "value2"}});
-  };
-
-  observable_counter1->AddCallback(callback1, nullptr);
-  observable_counter2->AddCallback(callback2, nullptr);
+  observable_counter1->AddCallback(ObservableResultDouble::Callback, &callback1);
+  observable_counter2->AddCallback(ObservableResultDouble::Callback, &callback2);
 
   metric_reader_ptr_->Collect([this](ResourceMetrics &metric_data) {
-    EXPECT_EQ(metric_data.scope_metric_data_.size(), 1);
-    EXPECT_EQ(metric_data.scope_metric_data_[0].metric_data_.size(), 1);
-    auto &point_data_attr = metric_data.scope_metric_data_[0].metric_data_[0].point_data_attr_;
-    EXPECT_EQ(point_data_attr.size(), 2);
-
-    auto &point_data1    = point_data_attr[0].point_data;
-    auto &point_data2    = point_data_attr[1].point_data;
-    auto sum_point_data1 = nostd::get<sdk::metrics::SumPointData>(point_data1);
-    auto sum_point_data2 = nostd::get<sdk::metrics::SumPointData>(point_data2);
-
-    const double sum =
-        nostd::get<double>(sum_point_data1.value_) + nostd::get<double>(sum_point_data2.value_);
-    EXPECT_DOUBLE_EQ(sum, 77.77);
-    EXPECT_FALSE(log_handler_->HasDuplicateInstrumentWarning());
-    EXPECT_TRUE(log_handler_->HasNameCaseConflictWarning());
+    const auto &data = metric_data.scope_metric_data_.at(0).metric_data_;
+    EXPECT_EQ(data.size(), 1);
+    InstrumentDescriptor descriptor{"OBServable_CounTER", "desc", "unit",
+                                    InstrumentType::kObservableCounter,
+                                    InstrumentValueType::kDouble};
+    EXPECT_EQ(CountPointData(data, descriptor), 2u);
+    EXPECT_DOUBLE_EQ(SumPointData(data, descriptor), 77.7);
     return true;
   });
+
+  EXPECT_FALSE(log_handler_->HasErrors());
+  EXPECT_FALSE(log_handler_->HasDuplicateInstrumentWarning());
+  EXPECT_TRUE(log_handler_->HasNameCaseConflictWarning());
 }
 
 TEST_F(MeterCreateInstrumentTest, ViewCorrectedNameCaseConflictAsyncInstruments)
@@ -748,40 +977,26 @@ TEST_F(MeterCreateInstrumentTest, ViewCorrectedNameCaseConflictAsyncInstruments)
   auto observable_counter2 =
       meter_->CreateDoubleObservableCounter("observable_counter", "desc", "unit");
 
-  auto callback1 = [](opentelemetry::metrics::ObserverResult observer, void * /* state */) {
-    auto observer_double =
-        nostd::get<nostd::shared_ptr<opentelemetry::metrics::ObserverResultT<double>>>(observer);
-    observer_double->Observe(22.22, {{"key", "value1"}});
-  };
+  auto callback1 = ObservableResultDouble{22.2, {{"key", "value1"}}};
+  auto callback2 = ObservableResultDouble{55.5, {{"key", "value2"}}};
 
-  auto callback2 = [](opentelemetry::metrics::ObserverResult observer, void * /* state */) {
-    auto observer_double =
-        nostd::get<nostd::shared_ptr<opentelemetry::metrics::ObserverResultT<double>>>(observer);
-    observer_double->Observe(55.55, {{"key", "value2"}});
-  };
-
-  observable_counter1->AddCallback(callback1, nullptr);
-  observable_counter2->AddCallback(callback2, nullptr);
+  observable_counter1->AddCallback(ObservableResultDouble::Callback, &callback1);
+  observable_counter2->AddCallback(ObservableResultDouble::Callback, &callback2);
 
   metric_reader_ptr_->Collect([this](ResourceMetrics &metric_data) {
-    EXPECT_EQ(metric_data.scope_metric_data_.size(), 1);
-    EXPECT_EQ(metric_data.scope_metric_data_[0].metric_data_.size(), 1);
-    auto &point_data_attr = metric_data.scope_metric_data_[0].metric_data_[0].point_data_attr_;
-    EXPECT_EQ(point_data_attr.size(), 2);
-
-    auto &point_data1    = point_data_attr[0].point_data;
-    auto &point_data2    = point_data_attr[1].point_data;
-    auto sum_point_data1 = nostd::get<sdk::metrics::SumPointData>(point_data1);
-    auto sum_point_data2 = nostd::get<sdk::metrics::SumPointData>(point_data2);
-
-    const double sum =
-        nostd::get<double>(sum_point_data1.value_) + nostd::get<double>(sum_point_data2.value_);
-    EXPECT_DOUBLE_EQ(sum, 77.77);
-    // no warnings expected after correction with the view
-    EXPECT_FALSE(log_handler_->HasDuplicateInstrumentWarning());
-    EXPECT_FALSE(log_handler_->HasNameCaseConflictWarning());
+    const auto &data = metric_data.scope_metric_data_.at(0).metric_data_;
+    EXPECT_EQ(data.size(), 1);
+    InstrumentDescriptor descriptor{"observable_counter", "desc", "unit",
+                                    InstrumentType::kObservableCounter,
+                                    InstrumentValueType::kDouble};
+    EXPECT_EQ(CountPointData(data, descriptor), 2u);
+    EXPECT_DOUBLE_EQ(SumPointData(data, descriptor), 77.7);
     return true;
   });
+
+  // no warnings expected after correction with the view
+  EXPECT_FALSE(log_handler_->HasErrors());
+  EXPECT_FALSE(log_handler_->HasWarnings());
 }
 
 TEST_F(MeterCreateInstrumentTest, DuplicateAsyncInstrumentsByKind)
@@ -789,17 +1004,31 @@ TEST_F(MeterCreateInstrumentTest, DuplicateAsyncInstrumentsByKind)
   auto observable_counter1 = meter_->CreateDoubleObservableCounter("observable_counter");
   auto observable_counter2 = meter_->CreateDoubleObservableGauge("observable_counter");
 
-  observable_counter1->AddCallback(asyc_generate_measurements_double, nullptr);
-  observable_counter2->AddCallback(asyc_generate_measurements_double, nullptr);
+  auto callback1 = ObservableResultDouble{22.2, {{"key", "value1"}}};
+  auto callback2 = ObservableResultDouble{55.5, {{"key", "value2"}}};
+
+  observable_counter1->AddCallback(ObservableResultDouble::Callback, &callback1);
+  observable_counter2->AddCallback(ObservableResultDouble::Callback, &callback2);
 
   metric_reader_ptr_->Collect([this](ResourceMetrics &metric_data) {
-    EXPECT_EQ(metric_data.scope_metric_data_.size(), 1);
-    EXPECT_EQ(metric_data.scope_metric_data_[0].metric_data_.size(), 2);
-    EXPECT_EQ(metric_data.scope_metric_data_[0].metric_data_[0].point_data_attr_.size(), 1);
-    EXPECT_TRUE(log_handler_->HasDuplicateInstrumentWarning());
-    EXPECT_FALSE(log_handler_->HasNameCaseConflictWarning());
+    const auto &data = metric_data.scope_metric_data_.at(0).metric_data_;
+    EXPECT_EQ(data.size(), 2);
+    InstrumentDescriptor counter_descriptor{"observable_counter", "", "",
+                                            InstrumentType::kObservableCounter,
+                                            InstrumentValueType::kDouble};
+    InstrumentDescriptor gauge_descriptor{"observable_counter", "", "",
+                                          InstrumentType::kObservableGauge,
+                                          InstrumentValueType::kDouble};
+    EXPECT_EQ(CountPointData(data, counter_descriptor), 1u);
+    EXPECT_DOUBLE_EQ(SumPointData(data, counter_descriptor), 22.2);
+    EXPECT_EQ(CountPointData(data, gauge_descriptor), 1u);
+    EXPECT_DOUBLE_EQ(SumPointData(data, gauge_descriptor), 55.5);
     return true;
   });
+
+  EXPECT_FALSE(log_handler_->HasErrors());
+  EXPECT_TRUE(log_handler_->HasDuplicateInstrumentWarning());
+  EXPECT_FALSE(log_handler_->HasNameCaseConflictWarning());
 }
 
 TEST_F(MeterCreateInstrumentTest, DuplicateAsyncInstrumentsByUnits)
@@ -809,17 +1038,31 @@ TEST_F(MeterCreateInstrumentTest, DuplicateAsyncInstrumentsByUnits)
   auto observable_counter2 =
       meter_->CreateDoubleObservableCounter("observable_counter", "desc", "another_unit");
 
-  observable_counter1->AddCallback(asyc_generate_measurements_double, nullptr);
-  observable_counter2->AddCallback(asyc_generate_measurements_double, nullptr);
+  auto callback1 = ObservableResultDouble{22.2, {{"key", "value1"}}};
+  auto callback2 = ObservableResultDouble{55.5, {{"key", "value2"}}};
+
+  observable_counter1->AddCallback(ObservableResultDouble::Callback, &callback1);
+  observable_counter2->AddCallback(ObservableResultDouble::Callback, &callback2);
 
   metric_reader_ptr_->Collect([this](ResourceMetrics &metric_data) {
-    EXPECT_EQ(metric_data.scope_metric_data_.size(), 1);
-    EXPECT_EQ(metric_data.scope_metric_data_[0].metric_data_.size(), 2);
-    EXPECT_EQ(metric_data.scope_metric_data_[0].metric_data_[0].point_data_attr_.size(), 1);
-    EXPECT_TRUE(log_handler_->HasDuplicateInstrumentWarning());
-    EXPECT_FALSE(log_handler_->HasNameCaseConflictWarning());
+    const auto &data = metric_data.scope_metric_data_.at(0).metric_data_;
+    EXPECT_EQ(data.size(), 2);
+    InstrumentDescriptor unit_descriptor{"observable_counter", "desc", "unit",
+                                         InstrumentType::kObservableCounter,
+                                         InstrumentValueType::kDouble};
+    InstrumentDescriptor another_unit_descriptor{"observable_counter", "desc", "another_unit",
+                                                 InstrumentType::kObservableCounter,
+                                                 InstrumentValueType::kDouble};
+    EXPECT_EQ(CountPointData(data, unit_descriptor), 1u);
+    EXPECT_DOUBLE_EQ(SumPointData(data, unit_descriptor), 22.2);
+    EXPECT_EQ(CountPointData(data, another_unit_descriptor), 1u);
+    EXPECT_DOUBLE_EQ(SumPointData(data, another_unit_descriptor), 55.5);
     return true;
   });
+
+  EXPECT_FALSE(log_handler_->HasErrors());
+  EXPECT_TRUE(log_handler_->HasDuplicateInstrumentWarning());
+  EXPECT_FALSE(log_handler_->HasNameCaseConflictWarning());
 }
 
 TEST_F(MeterCreateInstrumentTest, DuplicateAsyncInstrumentsByDescription)
@@ -829,17 +1072,31 @@ TEST_F(MeterCreateInstrumentTest, DuplicateAsyncInstrumentsByDescription)
   auto observable_counter2 =
       meter_->CreateDoubleObservableCounter("observable_counter", "another_desc", "unit");
 
-  observable_counter1->AddCallback(asyc_generate_measurements_double, nullptr);
-  observable_counter2->AddCallback(asyc_generate_measurements_double, nullptr);
+  auto callback1 = ObservableResultDouble{22.2, {{"key", "value1"}}};
+  auto callback2 = ObservableResultDouble{55.5, {{"key", "value2"}}};
+
+  observable_counter1->AddCallback(ObservableResultDouble::Callback, &callback1);
+  observable_counter2->AddCallback(ObservableResultDouble::Callback, &callback2);
 
   metric_reader_ptr_->Collect([this](ResourceMetrics &metric_data) {
-    EXPECT_EQ(metric_data.scope_metric_data_.size(), 1);
-    EXPECT_EQ(metric_data.scope_metric_data_[0].metric_data_.size(), 2);
-    EXPECT_EQ(metric_data.scope_metric_data_[0].metric_data_[0].point_data_attr_.size(), 1);
-    EXPECT_TRUE(log_handler_->HasDuplicateInstrumentWarning());
-    EXPECT_FALSE(log_handler_->HasNameCaseConflictWarning());
+    const auto &data = metric_data.scope_metric_data_.at(0).metric_data_;
+    EXPECT_EQ(data.size(), 2);
+    InstrumentDescriptor desc_descriptor{"observable_counter", "desc", "unit",
+                                         InstrumentType::kObservableCounter,
+                                         InstrumentValueType::kDouble};
+    InstrumentDescriptor another_desc_descriptor{"observable_counter", "another_desc", "unit",
+                                                 InstrumentType::kObservableCounter,
+                                                 InstrumentValueType::kDouble};
+    EXPECT_EQ(CountPointData(data, desc_descriptor), 1u);
+    EXPECT_DOUBLE_EQ(SumPointData(data, desc_descriptor), 22.2);
+    EXPECT_EQ(CountPointData(data, another_desc_descriptor), 1u);
+    EXPECT_DOUBLE_EQ(SumPointData(data, another_desc_descriptor), 55.5);
     return true;
   });
+
+  EXPECT_FALSE(log_handler_->HasErrors());
+  EXPECT_TRUE(log_handler_->HasDuplicateInstrumentWarning());
+  EXPECT_FALSE(log_handler_->HasNameCaseConflictWarning());
 }
 
 TEST_F(MeterCreateInstrumentTest, ViewCorrectedDuplicateAsyncInstrumentsByDescription)
@@ -855,18 +1112,167 @@ TEST_F(MeterCreateInstrumentTest, ViewCorrectedDuplicateAsyncInstrumentsByDescri
   auto observable_counter2 =
       meter_->CreateDoubleObservableCounter(descriptor.name_, "another_desc", descriptor.unit_);
 
-  observable_counter1->AddCallback(asyc_generate_measurements_double, nullptr);
-  observable_counter2->AddCallback(asyc_generate_measurements_double, nullptr);
+  auto callback1 = ObservableResultDouble{22.2, {{"key", "value1"}}};
+  auto callback2 = ObservableResultDouble{55.5, {{"key", "value2"}}};
+
+  observable_counter1->AddCallback(ObservableResultDouble::Callback, &callback1);
+  observable_counter2->AddCallback(ObservableResultDouble::Callback, &callback2);
 
   metric_reader_ptr_->Collect([this](ResourceMetrics &metric_data) {
-    EXPECT_EQ(metric_data.scope_metric_data_.size(), 1);
-    EXPECT_EQ(metric_data.scope_metric_data_[0].metric_data_.size(), 1);
-    EXPECT_EQ(metric_data.scope_metric_data_[0].metric_data_[0].point_data_attr_.size(), 1);
-    // no warnings expected after correction with the view
-    EXPECT_FALSE(log_handler_->HasDuplicateInstrumentWarning());
-    EXPECT_FALSE(log_handler_->HasNameCaseConflictWarning());
+    const auto &data = metric_data.scope_metric_data_.at(0).metric_data_;
+    EXPECT_EQ(data.size(), 1);
+    InstrumentDescriptor descriptor{"observable_counter", "desc", "unit",
+                                    InstrumentType::kObservableCounter,
+                                    InstrumentValueType::kDouble};
+    EXPECT_EQ(CountPointData(data, descriptor), 2u);
+    EXPECT_DOUBLE_EQ(SumPointData(data, descriptor), 77.7);
     return true;
   });
+
+  // no warnings expected after correction with the view
+  EXPECT_FALSE(log_handler_->HasErrors());
+  EXPECT_FALSE(log_handler_->HasWarnings());
+}
+
+TEST_F(MeterCreateInstrumentTest, AsyncInstrumentWithDropAggregation)
+{
+  AddView("observable_counter_one", "", InstrumentType::kObservableCounter, "",
+          AggregationType::kDrop);
+
+  auto observable_counter1 =
+      meter_->CreateDoubleObservableCounter("observable_counter_one", "desc", "unit");
+  auto observable_counter2 =
+      meter_->CreateDoubleObservableCounter("observable_counter_two", "desc", "unit");
+
+  auto callback1 = ObservableResultDouble{22.2, {{"key", "value1"}}};
+  auto callback2 = ObservableResultDouble{55.5, {{"key", "value2"}}};
+
+  observable_counter1->AddCallback(ObservableResultDouble::Callback, &callback1);
+  observable_counter2->AddCallback(ObservableResultDouble::Callback, &callback2);
+
+  metric_reader_ptr_->Collect([this](ResourceMetrics &metric_data) {
+    const auto &data = metric_data.scope_metric_data_.at(0).metric_data_;
+    EXPECT_EQ(data.size(), 1);
+    InstrumentDescriptor dropped_descriptor{"observable_counter_one", "desc", "unit",
+                                            InstrumentType::kObservableCounter,
+                                            InstrumentValueType::kDouble};
+    InstrumentDescriptor kept_descriptor{"observable_counter_two", "desc", "unit",
+                                         InstrumentType::kObservableCounter,
+                                         InstrumentValueType::kDouble};
+    EXPECT_EQ(CountPointData(data, dropped_descriptor, false), 0u);
+    EXPECT_EQ(CountPointData(data, kept_descriptor), 1u);
+    EXPECT_DOUBLE_EQ(SumPointData(data, kept_descriptor), 55.5);
+    return true;
+  });
+
+  EXPECT_FALSE(log_handler_->HasErrors());
+  EXPECT_FALSE(log_handler_->HasWarnings());
+}
+
+TEST_F(MeterCreateInstrumentTest, ASyncInstrumentWithCatchAllDropAggregation)
+{
+  // Specific view for counter_one
+  AddView("observable_counter_one", "", InstrumentType::kObservableCounter, "",
+          AggregationType::kSum);
+
+  // Catch-all drop view
+  AddView("*", "", InstrumentType::kObservableCounter, "", AggregationType::kDrop);
+
+  auto observable_counter1 =
+      meter_->CreateDoubleObservableCounter("observable_counter_one", "desc", "unit");
+  auto observable_counter2 =
+      meter_->CreateDoubleObservableCounter("observable_counter_two", "desc", "unit");
+
+  auto callback1 = ObservableResultDouble{22.2, {{"key", "value1"}}};
+  auto callback2 = ObservableResultDouble{55.5, {{"key", "value2"}}};
+
+  observable_counter1->AddCallback(ObservableResultDouble::Callback, &callback1);
+  observable_counter2->AddCallback(ObservableResultDouble::Callback, &callback2);
+
+  metric_reader_ptr_->Collect([this](ResourceMetrics &metric_data) {
+    const auto &data = metric_data.scope_metric_data_.at(0).metric_data_;
+    EXPECT_EQ(data.size(), 1);
+    InstrumentDescriptor descriptor_kept{"observable_counter_one", "desc", "unit",
+                                         InstrumentType::kObservableCounter,
+                                         InstrumentValueType::kDouble};
+    InstrumentDescriptor descriptor_dropped{"observable_counter_two", "desc", "unit",
+                                            InstrumentType::kObservableCounter,
+                                            InstrumentValueType::kDouble};
+    EXPECT_EQ(CountPointData(data, descriptor_dropped, false), 0u);
+    EXPECT_EQ(CountPointData(data, descriptor_kept), 1u);
+    EXPECT_DOUBLE_EQ(SumPointData(data, descriptor_kept), 22.2);
+    return true;
+  });
+  EXPECT_FALSE(log_handler_->HasErrors());
+  EXPECT_FALSE(log_handler_->HasWarnings());
+}
+
+TEST_F(MeterCreateInstrumentTest, ASyncInstrumentWithConflictingAggregation)
+{
+  // Specific view for counter_one
+  AddView("observable_counter_one", "", InstrumentType::kObservableCounter, "",
+          AggregationType::kSum);
+
+  // Catch-all non-drop view
+  AddView("*", "", InstrumentType::kObservableCounter, "", AggregationType::kSum);
+
+  auto observable_counter1 =
+      meter_->CreateDoubleObservableCounter("observable_counter_one", "desc", "unit");
+
+  auto callback1 = ObservableResultDouble{22.2, {{"key", "value1"}}};
+
+  observable_counter1->AddCallback(ObservableResultDouble::Callback, &callback1);
+
+  metric_reader_ptr_->Collect([this](ResourceMetrics &metric_data) {
+    const auto &data = metric_data.scope_metric_data_.at(0).metric_data_;
+    EXPECT_EQ(data.size(), 1);
+    InstrumentDescriptor descriptor{"observable_counter_one", "desc", "unit",
+                                    InstrumentType::kObservableCounter,
+                                    InstrumentValueType::kDouble};
+    EXPECT_EQ(CountPointData(data, descriptor), 1u);
+    EXPECT_DOUBLE_EQ(SumPointData(data, descriptor), 22.2);
+    return true;
+  });
+  EXPECT_FALSE(log_handler_->HasErrors());
+  EXPECT_TRUE(log_handler_->HasSemanticErrorWarning());
+}
+
+TEST_F(MeterCreateInstrumentTest, ASyncInstrumentWithMultipleAggregations)
+{
+  // Specific view for counter_one to add histogram aggregation
+  AddView("observable_counter", "", InstrumentType::kObservableCounter,
+          "observable_counter_as_histogram", AggregationType::kHistogram);
+
+  // Catch-all to set the default aggregation and a cardinality limit
+  auto aggregation_config                = std::make_shared<sdk::metrics::AggregationConfig>();
+  aggregation_config->cardinality_limit_ = 100;
+  AddView("*", "", InstrumentType::kObservableCounter, "", AggregationType::kDefault,
+          aggregation_config);
+
+  auto observable_counter1 =
+      meter_->CreateDoubleObservableCounter("observable_counter", "desc", "unit");
+
+  auto callback1 = ObservableResultDouble{55.5};
+
+  observable_counter1->AddCallback(ObservableResultDouble::Callback, &callback1);
+
+  metric_reader_ptr_->Collect([this](ResourceMetrics &metric_data) {
+    const auto &data = metric_data.scope_metric_data_.at(0).metric_data_;
+    EXPECT_EQ(data.size(), 2);
+    InstrumentDescriptor descriptor_default{"observable_counter", "desc", "unit",
+                                            InstrumentType::kObservableCounter,
+                                            InstrumentValueType::kDouble};
+    InstrumentDescriptor descriptor_histogram{"observable_counter_as_histogram", "desc", "unit",
+                                              InstrumentType::kObservableCounter,
+                                              InstrumentValueType::kDouble};
+    EXPECT_EQ(CountPointData(data, descriptor_default), 1u);
+    EXPECT_DOUBLE_EQ(SumPointData(data, descriptor_default), 55.5);
+    EXPECT_EQ(CountPointData(data, descriptor_histogram), 1u);
+    EXPECT_DOUBLE_EQ(SumPointData(data, descriptor_histogram), 55.5);
+    return true;
+  });
+  EXPECT_FALSE(log_handler_->HasErrors());
+  EXPECT_FALSE(log_handler_->HasWarnings());
 }
 
 TEST(MeterTest, RecordAfterProviderDestructionWithCustomProcessor_NoResetInMain)

--- a/sdk/test/metrics/meter_test.cc
+++ b/sdk/test/metrics/meter_test.cc
@@ -33,6 +33,7 @@
 #include "opentelemetry/sdk/instrumentationscope/instrumentation_scope.h"
 #include "opentelemetry/sdk/instrumentationscope/scope_configurator.h"
 #include "opentelemetry/sdk/metrics/aggregation/aggregation_config.h"
+#include "opentelemetry/sdk/metrics/aggregation/default_aggregation.h"
 #include "opentelemetry/sdk/metrics/data/exemplar_data.h"  // IWYU pragma: keep
 #include "opentelemetry/sdk/metrics/data/metric_data.h"
 #include "opentelemetry/sdk/metrics/data/point_data.h"
@@ -224,9 +225,9 @@ protected:
     provider_->AddView(std::move(instrument_selector), std::move(meter_selector), std::move(view));
   }
 
-  static size_t CountPointData(const std::vector<MetricData> &data,
-                               const InstrumentDescriptor &descriptor,
-                               bool expected_match = true)
+  static size_t GetPointDataSize(const std::vector<MetricData> &data,
+                                 const InstrumentDescriptor &descriptor,
+                                 bool expected_match = true)
   {
     size_t match_count = 0;
     size_t point_count = 0;
@@ -246,16 +247,64 @@ protected:
     return point_count;
   }
 
-  static double SumPointData(const std::vector<MetricData> &data,
-                             const InstrumentDescriptor &descriptor)
+  static double GetPointDataTotalSum(const std::vector<MetricData> &data,
+                                     const InstrumentDescriptor &descriptor,
+                                     AggregationType aggregation_type = AggregationType::kDefault,
+                                     std::size_t expected_conflict_count = 0)
   {
-    auto value_to_double = [](const ValueType &value) {
+    auto value_to_double = [](const ValueType &value) -> double {
       return nostd::holds_alternative<double>(value)
                  ? nostd::get<double>(value)
                  : static_cast<double>(nostd::get<int64_t>(value));
     };
 
-    double total = 0;
+    struct PointDataSum
+    {
+      AggregationType type = AggregationType::kDefault;
+      double sum           = 0;
+    };
+
+    auto get_point_data_sum = [&value_to_double](const PointType &point_data) -> PointDataSum {
+      if (auto *sum_point_data = nostd::get_if<sdk::metrics::SumPointData>(&point_data))
+      {
+        return PointDataSum{AggregationType::kSum, value_to_double(sum_point_data->value_)};
+      }
+      else if (auto *histogram_point_data =
+                   nostd::get_if<sdk::metrics::HistogramPointData>(&point_data))
+      {
+        return PointDataSum{AggregationType::kHistogram,
+                            value_to_double(histogram_point_data->sum_)};
+      }
+      else if (auto *last_value_point_data =
+                   nostd::get_if<sdk::metrics::LastValuePointData>(&point_data))
+      {
+        return PointDataSum{AggregationType::kLastValue,
+                            value_to_double(last_value_point_data->value_)};
+      }
+      else if (auto *base2_exponential_histogram_point_data =
+                   nostd::get_if<sdk::metrics::Base2ExponentialHistogramPointData>(&point_data))
+      {
+        return PointDataSum{AggregationType::kBase2ExponentialHistogram,
+                            value_to_double(base2_exponential_histogram_point_data->sum_)};
+      }
+      else if (auto *drop_point_data = nostd::get_if<sdk::metrics::DropPointData>(&point_data))
+      {
+        (void)drop_point_data;
+        return PointDataSum{AggregationType::kDrop, 0};
+      }
+      return PointDataSum{AggregationType::kDefault, 0};
+    };
+
+    if (aggregation_type == AggregationType::kDefault)
+    {
+      bool is_monotonic{};
+      aggregation_type = opentelemetry::sdk::metrics::DefaultAggregation::GetDefaultAggregationType(
+          descriptor.type_, is_monotonic);
+    }
+
+    double expected_total   = 0;
+    double unexpected_total = 0;
+
     for (const auto &md : data)
     {
       if (md.instrument_descriptor.name_ != descriptor.name_ ||
@@ -268,24 +317,24 @@ protected:
       }
       for (const auto &point_data_attr : md.point_data_attr_)
       {
-        if (auto *sum_point_data =
-                nostd::get_if<sdk::metrics::SumPointData>(&point_data_attr.point_data))
+        auto point_data_sum = get_point_data_sum(point_data_attr.point_data);
+        if (point_data_sum.type == aggregation_type)
         {
-          total += value_to_double(sum_point_data->value_);
+          expected_total += point_data_sum.sum;
         }
-        else if (auto *histogram_point_data =
-                     nostd::get_if<sdk::metrics::HistogramPointData>(&point_data_attr.point_data))
+        else
         {
-          total += value_to_double(histogram_point_data->sum_);
-        }
-        else if (auto *last_value_point_data =
-                     nostd::get_if<sdk::metrics::LastValuePointData>(&point_data_attr.point_data))
-        {
-          total += value_to_double(last_value_point_data->value_);
+          std::cout << "Unexpected aggregation type found for instrument " << descriptor.name_
+                    << ": "
+                    << ", expected: " << AggregationUtil::GetAggregationTypeString(aggregation_type)
+                    << ", actual: "
+                    << AggregationUtil::GetAggregationTypeString(point_data_sum.type) << "\n";
+          unexpected_total += point_data_sum.sum;
         }
       }
     }
-    return total;
+    EXPECT_EQ(unexpected_total, expected_conflict_count);
+    return expected_total;
   }
 
 protected:
@@ -625,8 +674,8 @@ TEST_F(MeterCreateInstrumentTest, IdenticalSyncInstruments)
     EXPECT_EQ(data.size(), 1);
     InstrumentDescriptor descriptor{"my_counter", "desc", "unit", InstrumentType::kCounter,
                                     InstrumentValueType::kDouble};
-    EXPECT_EQ(CountPointData(data, descriptor), 2u);
-    EXPECT_DOUBLE_EQ(SumPointData(data, descriptor), 3.5);
+    EXPECT_EQ(GetPointDataSize(data, descriptor), 2u);
+    EXPECT_DOUBLE_EQ(GetPointDataTotalSum(data, descriptor), 3.5);
     return true;
   });
 
@@ -647,8 +696,8 @@ TEST_F(MeterCreateInstrumentTest, NameCaseConflictSyncInstruments)
     EXPECT_EQ(data.size(), 1);
     InstrumentDescriptor descriptor{"My_CountER", "desc", "unit", InstrumentType::kCounter,
                                     InstrumentValueType::kLong};
-    EXPECT_EQ(CountPointData(data, descriptor), 1u);
-    EXPECT_DOUBLE_EQ(SumPointData(data, descriptor), 3);
+    EXPECT_EQ(GetPointDataSize(data, descriptor), 1u);
+    EXPECT_DOUBLE_EQ(GetPointDataTotalSum(data, descriptor), 3);
     return true;
   });
 
@@ -677,8 +726,8 @@ TEST_F(MeterCreateInstrumentTest, ViewCorrectedNameCaseConflictSyncInstruments)
     EXPECT_EQ(data.size(), 1);
     InstrumentDescriptor descriptor{"my_counter", "desc", "unit", InstrumentType::kCounter,
                                     InstrumentValueType::kLong};
-    EXPECT_EQ(CountPointData(data, descriptor), 1u);
-    EXPECT_DOUBLE_EQ(SumPointData(data, descriptor), 3);
+    EXPECT_EQ(GetPointDataSize(data, descriptor), 1u);
+    EXPECT_DOUBLE_EQ(GetPointDataTotalSum(data, descriptor), 3);
     return true;
   });
 
@@ -701,10 +750,10 @@ TEST_F(MeterCreateInstrumentTest, DuplicateSyncInstrumentsByKind)
                                            InstrumentValueType::kDouble};
     InstrumentDescriptor long_descriptor{"my_counter", "desc", "unit", InstrumentType::kCounter,
                                          InstrumentValueType::kLong};
-    EXPECT_EQ(CountPointData(data, double_descriptor), 1u);
-    EXPECT_DOUBLE_EQ(SumPointData(data, double_descriptor), 1);
-    EXPECT_EQ(CountPointData(data, long_descriptor), 1u);
-    EXPECT_DOUBLE_EQ(SumPointData(data, long_descriptor), 1);
+    EXPECT_EQ(GetPointDataSize(data, double_descriptor), 1u);
+    EXPECT_DOUBLE_EQ(GetPointDataTotalSum(data, double_descriptor), 1);
+    EXPECT_EQ(GetPointDataSize(data, long_descriptor), 1u);
+    EXPECT_DOUBLE_EQ(GetPointDataTotalSum(data, long_descriptor), 1);
     return true;
   });
 
@@ -729,10 +778,10 @@ TEST_F(MeterCreateInstrumentTest, DuplicateSyncInstrumentsByUnits)
     InstrumentDescriptor another_unit_descriptor{"my_counter", "desc", "another_unit",
                                                  InstrumentType::kCounter,
                                                  InstrumentValueType::kDouble};
-    EXPECT_EQ(CountPointData(data, unit_descriptor), 1u);
-    EXPECT_DOUBLE_EQ(SumPointData(data, unit_descriptor), 1);
-    EXPECT_EQ(CountPointData(data, another_unit_descriptor), 1u);
-    EXPECT_DOUBLE_EQ(SumPointData(data, another_unit_descriptor), 1);
+    EXPECT_EQ(GetPointDataSize(data, unit_descriptor), 1u);
+    EXPECT_DOUBLE_EQ(GetPointDataTotalSum(data, unit_descriptor), 1);
+    EXPECT_EQ(GetPointDataSize(data, another_unit_descriptor), 1u);
+    EXPECT_DOUBLE_EQ(GetPointDataTotalSum(data, another_unit_descriptor), 1);
     return true;
   });
 
@@ -757,10 +806,10 @@ TEST_F(MeterCreateInstrumentTest, DuplicateSyncInstrumentsByDescription)
     InstrumentDescriptor another_desc_descriptor{"my_counter", "another_desc", "unit",
                                                  InstrumentType::kCounter,
                                                  InstrumentValueType::kDouble};
-    EXPECT_EQ(CountPointData(data, desc_descriptor), 1u);
-    EXPECT_DOUBLE_EQ(SumPointData(data, desc_descriptor), 1);
-    EXPECT_EQ(CountPointData(data, another_desc_descriptor), 1u);
-    EXPECT_DOUBLE_EQ(SumPointData(data, another_desc_descriptor), 1);
+    EXPECT_EQ(GetPointDataSize(data, desc_descriptor), 1u);
+    EXPECT_DOUBLE_EQ(GetPointDataTotalSum(data, desc_descriptor), 1);
+    EXPECT_EQ(GetPointDataSize(data, another_desc_descriptor), 1u);
+    EXPECT_DOUBLE_EQ(GetPointDataTotalSum(data, another_desc_descriptor), 1);
     return true;
   });
 
@@ -788,8 +837,8 @@ TEST_F(MeterCreateInstrumentTest, ViewCorrectedDuplicateSyncInstrumentsByDescrip
     EXPECT_EQ(data.size(), 1);
     InstrumentDescriptor descriptor{"my_counter", "desc", "unit", InstrumentType::kCounter,
                                     InstrumentValueType::kDouble};
-    EXPECT_EQ(CountPointData(data, descriptor), 2u);
-    EXPECT_DOUBLE_EQ(SumPointData(data, descriptor), 2);
+    EXPECT_EQ(GetPointDataSize(data, descriptor), 2u);
+    EXPECT_DOUBLE_EQ(GetPointDataTotalSum(data, descriptor), 2);
     return true;
   });
 
@@ -815,9 +864,9 @@ TEST_F(MeterCreateInstrumentTest, SyncInstrumentWithDropAggregation)
                                             InstrumentValueType::kLong};
     InstrumentDescriptor kept_descriptor{"counter_two", "desc", "unit", InstrumentType::kCounter,
                                          InstrumentValueType::kLong};
-    EXPECT_EQ(CountPointData(data, dropped_descriptor, false), 0u);
-    EXPECT_EQ(CountPointData(data, kept_descriptor), 1u);
-    EXPECT_DOUBLE_EQ(SumPointData(data, kept_descriptor), 1);
+    EXPECT_EQ(GetPointDataSize(data, dropped_descriptor, false), 0u);
+    EXPECT_EQ(GetPointDataSize(data, kept_descriptor), 1u);
+    EXPECT_DOUBLE_EQ(GetPointDataTotalSum(data, kept_descriptor), 1);
     return true;
   });
 
@@ -846,16 +895,16 @@ TEST_F(MeterCreateInstrumentTest, SyncInstrumentWithCatchAllDropAggregation)
                                             InstrumentValueType::kLong};
     InstrumentDescriptor kept_descriptor{"counter_one", "desc", "unit", InstrumentType::kCounter,
                                          InstrumentValueType::kLong};
-    EXPECT_EQ(CountPointData(data, dropped_descriptor, false), 0u);
-    EXPECT_EQ(CountPointData(data, kept_descriptor), 1u);
-    EXPECT_DOUBLE_EQ(SumPointData(data, kept_descriptor), 1);
+    EXPECT_EQ(GetPointDataSize(data, dropped_descriptor, false), 0u);
+    EXPECT_EQ(GetPointDataSize(data, kept_descriptor), 1u);
+    EXPECT_DOUBLE_EQ(GetPointDataTotalSum(data, kept_descriptor), 1);
     return true;
   });
   EXPECT_FALSE(log_handler_->HasErrors());
   EXPECT_FALSE(log_handler_->HasWarnings());
 }
 
-TEST_F(MeterCreateInstrumentTest, SyncInstrumentWithConflictingAggregation)
+TEST_F(MeterCreateInstrumentTest, SyncInstrumentWithDuplicateAggregation)
 {
   // Specific view for counter_one
   AddView("counter_one", "", InstrumentType::kCounter, "", AggregationType::kSum);
@@ -872,8 +921,34 @@ TEST_F(MeterCreateInstrumentTest, SyncInstrumentWithConflictingAggregation)
     EXPECT_EQ(data.size(), 1);
     InstrumentDescriptor descriptor{"counter_one", "desc", "unit", InstrumentType::kCounter,
                                     InstrumentValueType::kLong};
-    EXPECT_EQ(CountPointData(data, descriptor), 1u);
-    EXPECT_DOUBLE_EQ(SumPointData(data, descriptor), 1);
+    EXPECT_EQ(GetPointDataSize(data, descriptor), 1u);
+    EXPECT_DOUBLE_EQ(GetPointDataTotalSum(data, descriptor), 1);
+    return true;
+  });
+  EXPECT_FALSE(log_handler_->HasErrors());
+  EXPECT_TRUE(log_handler_->HasSemanticErrorWarning());
+}
+
+TEST_F(MeterCreateInstrumentTest, SyncInstrumentWithConflictingAggregation)
+{
+  // Specific view for counter_one
+  AddView("counter_one", "", InstrumentType::kCounter, "", AggregationType::kHistogram);
+
+  // Catch-all view
+  AddView("*", "", InstrumentType::kCounter, "", AggregationType::kSum);
+
+  auto counter1 = meter_->CreateUInt64Counter("counter_one", "desc", "unit");
+
+  counter1->Add(1, {{"key", "value1"}});
+
+  metric_reader_ptr_->Collect([](ResourceMetrics &metric_data) {
+    const auto &data = metric_data.scope_metric_data_.at(0).metric_data_;
+    EXPECT_EQ(data.size(), 1);
+    InstrumentDescriptor descriptor{"counter_one", "desc", "unit", InstrumentType::kCounter,
+                                    InstrumentValueType::kLong};
+    EXPECT_EQ(GetPointDataSize(data, descriptor), 1u);
+    EXPECT_DOUBLE_EQ(GetPointDataTotalSum(data, descriptor, AggregationType::kHistogram, 0), 1);
+    EXPECT_DOUBLE_EQ(GetPointDataTotalSum(data, descriptor, AggregationType::kSum, 1), 0);
     return true;
   });
   EXPECT_FALSE(log_handler_->HasErrors());
@@ -903,10 +978,11 @@ TEST_F(MeterCreateInstrumentTest, SyncInstrumentWithMultipleAggregations)
                                             InstrumentValueType::kLong};
     InstrumentDescriptor descriptor_histogram{"counter_one_as_histogram", "desc", "unit",
                                               InstrumentType::kCounter, InstrumentValueType::kLong};
-    EXPECT_EQ(CountPointData(data, descriptor_default), 2u);
-    EXPECT_DOUBLE_EQ(SumPointData(data, descriptor_default), 5);
-    EXPECT_EQ(CountPointData(data, descriptor_histogram), 2u);
-    EXPECT_DOUBLE_EQ(SumPointData(data, descriptor_histogram), 5);
+    EXPECT_EQ(GetPointDataSize(data, descriptor_default), 2u);
+    EXPECT_DOUBLE_EQ(GetPointDataTotalSum(data, descriptor_default, AggregationType::kSum), 5);
+    EXPECT_EQ(GetPointDataSize(data, descriptor_histogram), 2u);
+    EXPECT_DOUBLE_EQ(GetPointDataTotalSum(data, descriptor_histogram, AggregationType::kHistogram),
+                     5);
     return true;
   });
   EXPECT_FALSE(log_handler_->HasErrors());
@@ -932,8 +1008,8 @@ TEST_F(MeterCreateInstrumentTest, IdenticalAsyncInstruments)
     InstrumentDescriptor descriptor{"observable_counter", "desc", "unit",
                                     InstrumentType::kObservableCounter,
                                     InstrumentValueType::kDouble};
-    EXPECT_EQ(CountPointData(data, descriptor), 2u);
-    EXPECT_DOUBLE_EQ(SumPointData(data, descriptor), 77.7);
+    EXPECT_EQ(GetPointDataSize(data, descriptor), 2u);
+    EXPECT_DOUBLE_EQ(GetPointDataTotalSum(data, descriptor), 77.7);
     return true;
   });
 
@@ -960,8 +1036,8 @@ TEST_F(MeterCreateInstrumentTest, NameCaseConflictAsyncInstruments)
     InstrumentDescriptor descriptor{"OBServable_CounTER", "desc", "unit",
                                     InstrumentType::kObservableCounter,
                                     InstrumentValueType::kDouble};
-    EXPECT_EQ(CountPointData(data, descriptor), 2u);
-    EXPECT_DOUBLE_EQ(SumPointData(data, descriptor), 77.7);
+    EXPECT_EQ(GetPointDataSize(data, descriptor), 2u);
+    EXPECT_DOUBLE_EQ(GetPointDataTotalSum(data, descriptor), 77.7);
     return true;
   });
 
@@ -992,8 +1068,8 @@ TEST_F(MeterCreateInstrumentTest, ViewCorrectedNameCaseConflictAsyncInstruments)
     InstrumentDescriptor descriptor{"observable_counter", "desc", "unit",
                                     InstrumentType::kObservableCounter,
                                     InstrumentValueType::kDouble};
-    EXPECT_EQ(CountPointData(data, descriptor), 2u);
-    EXPECT_DOUBLE_EQ(SumPointData(data, descriptor), 77.7);
+    EXPECT_EQ(GetPointDataSize(data, descriptor), 2u);
+    EXPECT_DOUBLE_EQ(GetPointDataTotalSum(data, descriptor), 77.7);
     return true;
   });
 
@@ -1022,10 +1098,10 @@ TEST_F(MeterCreateInstrumentTest, DuplicateAsyncInstrumentsByKind)
     InstrumentDescriptor gauge_descriptor{"observable_counter", "", "",
                                           InstrumentType::kObservableGauge,
                                           InstrumentValueType::kDouble};
-    EXPECT_EQ(CountPointData(data, counter_descriptor), 1u);
-    EXPECT_DOUBLE_EQ(SumPointData(data, counter_descriptor), 22.2);
-    EXPECT_EQ(CountPointData(data, gauge_descriptor), 1u);
-    EXPECT_DOUBLE_EQ(SumPointData(data, gauge_descriptor), 55.5);
+    EXPECT_EQ(GetPointDataSize(data, counter_descriptor), 1u);
+    EXPECT_DOUBLE_EQ(GetPointDataTotalSum(data, counter_descriptor), 22.2);
+    EXPECT_EQ(GetPointDataSize(data, gauge_descriptor), 1u);
+    EXPECT_DOUBLE_EQ(GetPointDataTotalSum(data, gauge_descriptor), 55.5);
     return true;
   });
 
@@ -1056,10 +1132,10 @@ TEST_F(MeterCreateInstrumentTest, DuplicateAsyncInstrumentsByUnits)
     InstrumentDescriptor another_unit_descriptor{"observable_counter", "desc", "another_unit",
                                                  InstrumentType::kObservableCounter,
                                                  InstrumentValueType::kDouble};
-    EXPECT_EQ(CountPointData(data, unit_descriptor), 1u);
-    EXPECT_DOUBLE_EQ(SumPointData(data, unit_descriptor), 22.2);
-    EXPECT_EQ(CountPointData(data, another_unit_descriptor), 1u);
-    EXPECT_DOUBLE_EQ(SumPointData(data, another_unit_descriptor), 55.5);
+    EXPECT_EQ(GetPointDataSize(data, unit_descriptor), 1u);
+    EXPECT_DOUBLE_EQ(GetPointDataTotalSum(data, unit_descriptor), 22.2);
+    EXPECT_EQ(GetPointDataSize(data, another_unit_descriptor), 1u);
+    EXPECT_DOUBLE_EQ(GetPointDataTotalSum(data, another_unit_descriptor), 55.5);
     return true;
   });
 
@@ -1090,10 +1166,10 @@ TEST_F(MeterCreateInstrumentTest, DuplicateAsyncInstrumentsByDescription)
     InstrumentDescriptor another_desc_descriptor{"observable_counter", "another_desc", "unit",
                                                  InstrumentType::kObservableCounter,
                                                  InstrumentValueType::kDouble};
-    EXPECT_EQ(CountPointData(data, desc_descriptor), 1u);
-    EXPECT_DOUBLE_EQ(SumPointData(data, desc_descriptor), 22.2);
-    EXPECT_EQ(CountPointData(data, another_desc_descriptor), 1u);
-    EXPECT_DOUBLE_EQ(SumPointData(data, another_desc_descriptor), 55.5);
+    EXPECT_EQ(GetPointDataSize(data, desc_descriptor), 1u);
+    EXPECT_DOUBLE_EQ(GetPointDataTotalSum(data, desc_descriptor), 22.2);
+    EXPECT_EQ(GetPointDataSize(data, another_desc_descriptor), 1u);
+    EXPECT_DOUBLE_EQ(GetPointDataTotalSum(data, another_desc_descriptor), 55.5);
     return true;
   });
 
@@ -1127,8 +1203,8 @@ TEST_F(MeterCreateInstrumentTest, ViewCorrectedDuplicateAsyncInstrumentsByDescri
     InstrumentDescriptor descriptor{"observable_counter", "desc", "unit",
                                     InstrumentType::kObservableCounter,
                                     InstrumentValueType::kDouble};
-    EXPECT_EQ(CountPointData(data, descriptor), 2u);
-    EXPECT_DOUBLE_EQ(SumPointData(data, descriptor), 77.7);
+    EXPECT_EQ(GetPointDataSize(data, descriptor), 2u);
+    EXPECT_DOUBLE_EQ(GetPointDataTotalSum(data, descriptor), 77.7);
     return true;
   });
 
@@ -1162,9 +1238,9 @@ TEST_F(MeterCreateInstrumentTest, AsyncInstrumentWithDropAggregation)
     InstrumentDescriptor kept_descriptor{"observable_counter_two", "desc", "unit",
                                          InstrumentType::kObservableCounter,
                                          InstrumentValueType::kDouble};
-    EXPECT_EQ(CountPointData(data, dropped_descriptor, false), 0u);
-    EXPECT_EQ(CountPointData(data, kept_descriptor), 1u);
-    EXPECT_DOUBLE_EQ(SumPointData(data, kept_descriptor), 55.5);
+    EXPECT_EQ(GetPointDataSize(data, dropped_descriptor, false), 0u);
+    EXPECT_EQ(GetPointDataSize(data, kept_descriptor), 1u);
+    EXPECT_DOUBLE_EQ(GetPointDataTotalSum(data, kept_descriptor), 55.5);
     return true;
   });
 
@@ -1201,16 +1277,16 @@ TEST_F(MeterCreateInstrumentTest, ASyncInstrumentWithCatchAllDropAggregation)
     InstrumentDescriptor descriptor_dropped{"observable_counter_two", "desc", "unit",
                                             InstrumentType::kObservableCounter,
                                             InstrumentValueType::kDouble};
-    EXPECT_EQ(CountPointData(data, descriptor_dropped, false), 0u);
-    EXPECT_EQ(CountPointData(data, descriptor_kept), 1u);
-    EXPECT_DOUBLE_EQ(SumPointData(data, descriptor_kept), 22.2);
+    EXPECT_EQ(GetPointDataSize(data, descriptor_dropped, false), 0u);
+    EXPECT_EQ(GetPointDataSize(data, descriptor_kept), 1u);
+    EXPECT_DOUBLE_EQ(GetPointDataTotalSum(data, descriptor_kept), 22.2);
     return true;
   });
   EXPECT_FALSE(log_handler_->HasErrors());
   EXPECT_FALSE(log_handler_->HasWarnings());
 }
 
-TEST_F(MeterCreateInstrumentTest, ASyncInstrumentWithConflictingAggregation)
+TEST_F(MeterCreateInstrumentTest, ASyncInstrumentWithDuplicateAggregation)
 {
   // Specific view for counter_one
   AddView("observable_counter_one", "", InstrumentType::kObservableCounter, "",
@@ -1232,8 +1308,38 @@ TEST_F(MeterCreateInstrumentTest, ASyncInstrumentWithConflictingAggregation)
     InstrumentDescriptor descriptor{"observable_counter_one", "desc", "unit",
                                     InstrumentType::kObservableCounter,
                                     InstrumentValueType::kDouble};
-    EXPECT_EQ(CountPointData(data, descriptor), 1u);
-    EXPECT_DOUBLE_EQ(SumPointData(data, descriptor), 22.2);
+    EXPECT_EQ(GetPointDataSize(data, descriptor), 1u);
+    EXPECT_DOUBLE_EQ(GetPointDataTotalSum(data, descriptor), 22.2);
+    return true;
+  });
+  EXPECT_FALSE(log_handler_->HasErrors());
+  EXPECT_TRUE(log_handler_->HasSemanticErrorWarning());
+}
+
+TEST_F(MeterCreateInstrumentTest, ASyncInstrumentWithConflictingAggregation)
+{
+  // Specific view for counter_one
+  AddView("observable_counter_one", "", InstrumentType::kObservableCounter, "",
+          AggregationType::kSum);
+
+  // Catch-all non-drop view
+  AddView("*", "", InstrumentType::kObservableCounter, "", AggregationType::kLastValue);
+
+  auto observable_counter1 =
+      meter_->CreateDoubleObservableCounter("observable_counter_one", "desc", "unit");
+
+  auto callback1 = ObservableResultDouble{22.2, {{"key", "value1"}}};
+
+  observable_counter1->AddCallback(ObservableResultDouble::Callback, &callback1);
+
+  metric_reader_ptr_->Collect([](ResourceMetrics &metric_data) {
+    const auto &data = metric_data.scope_metric_data_.at(0).metric_data_;
+    EXPECT_EQ(data.size(), 1);
+    InstrumentDescriptor descriptor{"observable_counter_one", "desc", "unit",
+                                    InstrumentType::kObservableCounter,
+                                    InstrumentValueType::kDouble};
+    EXPECT_EQ(GetPointDataSize(data, descriptor), 1u);
+    EXPECT_DOUBLE_EQ(GetPointDataTotalSum(data, descriptor), 22.2);
     return true;
   });
   EXPECT_FALSE(log_handler_->HasErrors());
@@ -1249,7 +1355,7 @@ TEST_F(MeterCreateInstrumentTest, ASyncInstrumentWithMultipleAggregations)
   // Catch-all to set the default aggregation and a cardinality limit
   auto aggregation_config                = std::make_shared<sdk::metrics::AggregationConfig>();
   aggregation_config->cardinality_limit_ = 100;
-  AddView("*", "", InstrumentType::kObservableCounter, "", AggregationType::kDefault,
+  AddView("*", "", InstrumentType::kObservableCounter, "", AggregationType::kSum,
           aggregation_config);
 
   auto observable_counter1 =
@@ -1268,10 +1374,11 @@ TEST_F(MeterCreateInstrumentTest, ASyncInstrumentWithMultipleAggregations)
     InstrumentDescriptor descriptor_histogram{"observable_counter_as_histogram", "desc", "unit",
                                               InstrumentType::kObservableCounter,
                                               InstrumentValueType::kDouble};
-    EXPECT_EQ(CountPointData(data, descriptor_default), 1u);
-    EXPECT_DOUBLE_EQ(SumPointData(data, descriptor_default), 55.5);
-    EXPECT_EQ(CountPointData(data, descriptor_histogram), 1u);
-    EXPECT_DOUBLE_EQ(SumPointData(data, descriptor_histogram), 55.5);
+    EXPECT_EQ(GetPointDataSize(data, descriptor_default), 1u);
+    EXPECT_DOUBLE_EQ(GetPointDataTotalSum(data, descriptor_default, AggregationType::kSum), 55.5);
+    EXPECT_EQ(GetPointDataSize(data, descriptor_histogram), 1u);
+    EXPECT_DOUBLE_EQ(GetPointDataTotalSum(data, descriptor_histogram, AggregationType::kHistogram),
+                     55.5);
     return true;
   });
   EXPECT_FALSE(log_handler_->HasErrors());

--- a/sdk/test/metrics/sync_instruments_benchmark.cc
+++ b/sdk/test/metrics/sync_instruments_benchmark.cc
@@ -25,8 +25,8 @@
 //    ENABLE_METRICS_EXEMPLAR_PREVIEW = ON
 //    OPENTELEMETRY_HAVE_METRICS_BOUND_INSTRUMENTS_PREVIEW = OFF
 // -------------------------------------------------------------------------------------------------------
-//  ~/build/sdk/test/metrics/sync_instruments_benchmark
-// 2026-08-22T20:05:18+00:00
+// ~/build/sdk/test/metrics/sync_instruments_benchmark
+// 2026-09-02T04:44:52+00:00
 // Running /home/devuser/build/sdk/test/metrics/sync_instruments_benchmark
 // Run on (32 X 5700 MHz CPU s)
 // CPU Caches:
@@ -34,63 +34,63 @@
 //   L1 Instruction 32 KiB (x16)
 //   L2 Unified 2048 KiB (x16)
 //   L3 Unified 36864 KiB (x1)
-// Load Average: 2.11, 4.01, 3.82
+// Load Average: 1.28, 3.38, 2.89
 // ***WARNING*** ASLR is enabled, the results may have unreproducible noise in them.
 // -----------------------------------------------------------------------------------------------------
 // Benchmark                                                           Time             CPU   Iterations
 // -----------------------------------------------------------------------------------------------------
-// BM_Record_Counter_Disabled_ByThreads/threads:1                  0.223 ns        0.223 ns   3149132264
-// BM_Record_Counter_Disabled_ByThreads/threads:2                  0.334 ns        0.334 ns   2424266898
-// BM_Record_Counter_Disabled_ByThreads/threads:4                  0.335 ns        0.335 ns   1860780336
-// BM_Record_Counter_Drop_ByThreads/threads:1                        181 ns          181 ns      3883111
-// BM_Record_Counter_Drop_ByThreads/threads:2                        336 ns          336 ns      3412070
-// BM_Record_Counter_Drop_ByThreads/threads:4                        548 ns          519 ns      1265888
-// BM_Record_Counter_Sum_ByThreads/threads:1                         183 ns          183 ns      3725731
-// BM_Record_Counter_Sum_ByThreads/threads:2                         313 ns          313 ns      1731700
-// BM_Record_Counter_Sum_ByThreads/threads:4                         658 ns          605 ns      1074776
-// BM_Record_Counter_Sum_ByAttributes/0                             21.7 ns         21.7 ns     32259034
-// BM_Record_Counter_Sum_ByAttributes/1                             63.7 ns         63.7 ns     11103173
-// BM_Record_Counter_Sum_ByAttributes/10                             665 ns          665 ns      1067127
-// BM_Record_Counter_Sum_ByAttributes/128                          11495 ns        11495 ns        58949
-// BM_Record_Counter_Sum_ByCardinality/10                            189 ns          189 ns      3620079
-// BM_Record_Counter_Sum_ByCardinality/500                           187 ns          187 ns      3732425
-// BM_Record_Counter_Sum_ByCardinality/2000                          185 ns          185 ns      3746437
-// BM_Record_Counter_Sum_ByCardinality/4000                          195 ns          195 ns      3587680
-// BM_Record_Histogram_Disabled_ByThreads/threads:1                0.215 ns        0.215 ns   3245684429
-// BM_Record_Histogram_Disabled_ByThreads/threads:2                0.215 ns        0.215 ns   3219420938
-// BM_Record_Histogram_Disabled_ByThreads/threads:4                0.227 ns        0.227 ns   2728839212
-// BM_Record_Histogram_Drop_ByThreads/threads:1                      180 ns          180 ns      3891143
-// BM_Record_Histogram_Drop_ByThreads/threads:2                      198 ns          198 ns      3255264
-// BM_Record_Histogram_Drop_ByThreads/threads:4                      556 ns          515 ns      1294128
-// BM_Record_Histogram_Explicit_ByThreads/threads:1                  192 ns          192 ns      3652980
-// BM_Record_Histogram_Explicit_ByThreads/threads:2                  473 ns          471 ns      1458558
-// BM_Record_Histogram_Explicit_ByThreads/threads:4                  910 ns          806 ns       840420
-// BM_Record_Histogram_Explicit_ByAttributes/0                      25.4 ns         25.4 ns     27240860
-// BM_Record_Histogram_Explicit_ByAttributes/1                      73.7 ns         73.7 ns      9490681
-// BM_Record_Histogram_Explicit_ByAttributes/10                      662 ns          662 ns      1069361
-// BM_Record_Histogram_Explicit_ByAttributes/128                   10666 ns        10665 ns        65408
-// BM_Record_Histogram_Explicit_ByCardinality/10                     202 ns          202 ns      3515610
-// BM_Record_Histogram_Explicit_ByCardinality/500                    202 ns          202 ns      3499771
-// BM_Record_Histogram_Explicit_ByCardinality/2000                   205 ns          205 ns      3499176
-// BM_Record_Histogram_Base2Expo_ByThreads/threads:1                 209 ns          209 ns      3356693
-// BM_Record_Histogram_Base2Expo_ByThreads/threads:2                 378 ns          378 ns      1566898
-// BM_Record_Histogram_Base2Expo_ByThreads/threads:4                 884 ns          786 ns       881608
-// BM_Record_Histogram_Base2Expo_ByAttributes/0                     27.4 ns         27.4 ns     23210481
-// BM_Record_Histogram_Base2Expo_ByAttributes/1                     72.1 ns         72.1 ns      9380658
-// BM_Record_Histogram_Base2Expo_ByAttributes/10                     662 ns          662 ns      1060240
-// BM_Record_Histogram_Base2Expo_ByAttributes/128                  10619 ns        10618 ns        57887
-// BM_Record_Histogram_Base2Expo_ByCardinality/10                    207 ns          207 ns      3466383
-// BM_Record_Histogram_Base2Expo_ByCardinality/500                   203 ns          203 ns      3436550
-// BM_Record_Histogram_Base2Expo_ByCardinality/2000                  206 ns          206 ns      3400210
-// BM_Record_Counter_Sum_Exemplar_AlwaysOff                          181 ns          181 ns      3876313
-// BM_Record_Counter_Sum_Exemplar_AlwaysOn                           331 ns          331 ns      2119737
-// BM_Record_Counter_Sum_Exemplar_TraceBased_EmptyContext            188 ns          188 ns      3748573
-// BM_Record_Counter_Sum_Exemplar_TraceBased_UnsampledContext        191 ns          191 ns      3628388
-// BM_Record_Counter_Sum_Exemplar_TraceBased_SampledContext          341 ns          341 ns      2064088
-// BM_Record_Histogram_Explicit_Exemplar_AlwaysOff                   191 ns          191 ns      3657244
-// BM_Record_Histogram_Explicit_Exemplar_AlwaysOn                    339 ns          339 ns      2063476
-// BM_Record_Histogram_Base2Expo_Exemplar_AlwaysOff                  190 ns          190 ns      3650174
-// BM_Record_Histogram_Base2Expo_Exemplar_AlwaysOn                   343 ns          343 ns      2076733
+// BM_Record_Counter_Disabled_ByThreads/threads:1                  0.219 ns        0.219 ns   3178418618
+// BM_Record_Counter_Disabled_ByThreads/threads:2                  0.220 ns        0.220 ns   3107456060
+// BM_Record_Counter_Disabled_ByThreads/threads:4                  0.228 ns        0.227 ns   2777031836
+// BM_Record_Counter_Drop_ByThreads/threads:1                       2.29 ns         2.29 ns    305338324
+// BM_Record_Counter_Drop_ByThreads/threads:2                       2.29 ns         2.29 ns    269371614
+// BM_Record_Counter_Drop_ByThreads/threads:4                       2.35 ns         2.35 ns    240692852
+// BM_Record_Counter_Sum_ByThreads/threads:1                         173 ns          173 ns      4033669
+// BM_Record_Counter_Sum_ByThreads/threads:2                         263 ns          263 ns      2105922
+// BM_Record_Counter_Sum_ByThreads/threads:4                         820 ns          728 ns       932456
+// BM_Record_Counter_Sum_ByAttributes/0                             21.7 ns         21.7 ns     32237207
+// BM_Record_Counter_Sum_ByAttributes/1                             59.0 ns         59.0 ns     11865426
+// BM_Record_Counter_Sum_ByAttributes/10                             615 ns          615 ns      1132969
+// BM_Record_Counter_Sum_ByAttributes/128                          10473 ns        10471 ns        61260
+// BM_Record_Counter_Sum_ByCardinality/10                            178 ns          178 ns      3741926
+// BM_Record_Counter_Sum_ByCardinality/500                           178 ns          178 ns      3875935
+// BM_Record_Counter_Sum_ByCardinality/2000                          180 ns          180 ns      3765961
+// BM_Record_Counter_Sum_ByCardinality/4000                          187 ns          187 ns      3731380
+// BM_Record_Histogram_Disabled_ByThreads/threads:1                0.213 ns        0.213 ns   3288043694
+// BM_Record_Histogram_Disabled_ByThreads/threads:2                0.214 ns        0.214 ns   3239303644
+// BM_Record_Histogram_Disabled_ByThreads/threads:4                0.219 ns        0.219 ns   2444940680
+// BM_Record_Histogram_Drop_ByThreads/threads:1                     2.50 ns         2.50 ns    279768220
+// BM_Record_Histogram_Drop_ByThreads/threads:2                     2.52 ns         2.52 ns    231723630
+// BM_Record_Histogram_Drop_ByThreads/threads:4                     2.56 ns         2.56 ns    230104300
+// BM_Record_Histogram_Explicit_ByThreads/threads:1                  184 ns          184 ns      3795006
+// BM_Record_Histogram_Explicit_ByThreads/threads:2                  459 ns          458 ns      1409266
+// BM_Record_Histogram_Explicit_ByThreads/threads:4                  989 ns          873 ns       767192
+// BM_Record_Histogram_Explicit_ByAttributes/0                      25.5 ns         25.5 ns     27761752
+// BM_Record_Histogram_Explicit_ByAttributes/1                      68.1 ns         68.0 ns     10269587
+// BM_Record_Histogram_Explicit_ByAttributes/10                      616 ns          616 ns      1137361
+// BM_Record_Histogram_Explicit_ByAttributes/128                   11633 ns        11631 ns        59646
+// BM_Record_Histogram_Explicit_ByCardinality/10                     187 ns          187 ns      3740950
+// BM_Record_Histogram_Explicit_ByCardinality/500                    193 ns          193 ns      3644548
+// BM_Record_Histogram_Explicit_ByCardinality/2000                   197 ns          197 ns      3590726
+// BM_Record_Histogram_Base2Expo_ByThreads/threads:1                 186 ns          186 ns      3695842
+// BM_Record_Histogram_Base2Expo_ByThreads/threads:2                 306 ns          306 ns      2236848
+// BM_Record_Histogram_Base2Expo_ByThreads/threads:4                 724 ns          654 ns       967532
+// BM_Record_Histogram_Base2Expo_ByAttributes/0                     29.6 ns         29.6 ns     22206631
+// BM_Record_Histogram_Base2Expo_ByAttributes/1                     75.2 ns         75.2 ns      9902341
+// BM_Record_Histogram_Base2Expo_ByAttributes/10                     653 ns          653 ns      1089054
+// BM_Record_Histogram_Base2Expo_ByAttributes/128                  10788 ns        10788 ns        65623
+// BM_Record_Histogram_Base2Expo_ByCardinality/10                    194 ns          194 ns      3329016
+// BM_Record_Histogram_Base2Expo_ByCardinality/500                   198 ns          198 ns      3574653
+// BM_Record_Histogram_Base2Expo_ByCardinality/2000                  197 ns          197 ns      3499208
+// BM_Record_Counter_Sum_Exemplar_AlwaysOff                          173 ns          173 ns      4040048
+// BM_Record_Counter_Sum_Exemplar_AlwaysOn                           320 ns          320 ns      2235414
+// BM_Record_Counter_Sum_Exemplar_TraceBased_EmptyContext            181 ns          181 ns      3851898
+// BM_Record_Counter_Sum_Exemplar_TraceBased_UnsampledContext        186 ns          186 ns      3714975
+// BM_Record_Counter_Sum_Exemplar_TraceBased_SampledContext          323 ns          323 ns      2173860
+// BM_Record_Histogram_Explicit_Exemplar_AlwaysOff                   182 ns          182 ns      3824218
+// BM_Record_Histogram_Explicit_Exemplar_AlwaysOn                    324 ns          324 ns      2166338
+// BM_Record_Histogram_Base2Expo_Exemplar_AlwaysOff                  182 ns          182 ns      3739049
+// BM_Record_Histogram_Base2Expo_Exemplar_AlwaysOn                   326 ns          326 ns      2165242
 //
 // *******************************************************************************************************
 // ABIv2 with preview options
@@ -98,7 +98,7 @@
 //    OPENTELEMETRY_HAVE_METRICS_BOUND_INSTRUMENTS_PREVIEW = ON
 // -------------------------------------------------------------------------------------------------------
 // ~/build/sdk/test/metrics/sync_instruments_benchmark
-// 2026-08-22T19:58:12+00:00
+// 2026-09-02T04:38:03+00:00
 // Running /home/devuser/build/sdk/test/metrics/sync_instruments_benchmark
 // Run on (32 X 5700 MHz CPU s)
 // CPU Caches:
@@ -106,100 +106,100 @@
 //   L1 Instruction 32 KiB (x16)
 //   L2 Unified 2048 KiB (x16)
 //   L3 Unified 36864 KiB (x1)
-// Load Average: 1.76, 4.54, 3.46
+// Load Average: 0.22, 1.44, 1.97
 // ***WARNING*** ASLR is enabled, the results may have unreproducible noise in them.
 // -----------------------------------------------------------------------------------------------------
 // Benchmark                                                           Time             CPU   Iterations
 // -----------------------------------------------------------------------------------------------------
-// BM_Record_Counter_Disabled_ByThreads/threads:1                  0.225 ns        0.225 ns   3106874136
-// BM_Record_Counter_Disabled_ByThreads/threads:2                  0.235 ns        0.235 ns   2399463178
-// BM_Record_Counter_Disabled_ByThreads/threads:4                  0.235 ns        0.235 ns   3078807728
-// BM_Record_Counter_Drop_ByThreads/threads:1                        291 ns          291 ns      2434016
-// BM_Record_Counter_Drop_ByThreads/threads:2                        545 ns          536 ns      1124740
-// BM_Record_Counter_Drop_ByThreads/threads:4                       1222 ns         1021 ns       646440
-// BM_Record_Counter_Sum_ByThreads/threads:1                         293 ns          293 ns      2380047
-// BM_Record_Counter_Sum_ByThreads/threads:2                         546 ns          541 ns      1106950
-// BM_Record_Counter_Sum_ByThreads/threads:4                        1372 ns         1130 ns       480448
-// BM_Record_Counter_Sum_ByAttributes/0                             26.3 ns         26.3 ns     26542376
-// BM_Record_Counter_Sum_ByAttributes/1                              102 ns          102 ns      6829105
-// BM_Record_Counter_Sum_ByAttributes/10                            1086 ns         1086 ns       638378
-// BM_Record_Counter_Sum_ByAttributes/128                          17152 ns        17151 ns        41400
-// BM_Record_Counter_Sum_ByCardinality/10                            296 ns          296 ns      2372167
-// BM_Record_Counter_Sum_ByCardinality/500                           293 ns          293 ns      2327678
-// BM_Record_Counter_Sum_ByCardinality/2000                          308 ns          308 ns      2324245
-// BM_Record_Counter_Sum_ByCardinality/4000                          285 ns          285 ns      2494418
-// BM_Record_Histogram_Disabled_ByThreads/threads:1                0.219 ns        0.219 ns   3091515656
-// BM_Record_Histogram_Disabled_ByThreads/threads:2                0.220 ns        0.220 ns   3112553734
-// BM_Record_Histogram_Disabled_ByThreads/threads:4                0.228 ns        0.228 ns   3084546480
-// BM_Record_Histogram_Drop_ByThreads/threads:1                      288 ns          288 ns      2422775
-// BM_Record_Histogram_Drop_ByThreads/threads:2                      540 ns          535 ns      1184022
-// BM_Record_Histogram_Drop_ByThreads/threads:4                     1423 ns         1175 ns       453324
-// BM_Record_Histogram_Explicit_ByThreads/threads:1                  297 ns          297 ns      2348315
-// BM_Record_Histogram_Explicit_ByThreads/threads:2                  746 ns          683 ns       960462
-// BM_Record_Histogram_Explicit_ByThreads/threads:4                 1759 ns         1392 ns       396388
-// BM_Record_Histogram_Explicit_ByAttributes/0                      34.0 ns         34.0 ns     20428456
-// BM_Record_Histogram_Explicit_ByAttributes/1                       113 ns          113 ns      6214071
-// BM_Record_Histogram_Explicit_ByAttributes/10                     1078 ns         1077 ns       650557
-// BM_Record_Histogram_Explicit_ByAttributes/128                   17187 ns        17185 ns        41086
-// BM_Record_Histogram_Explicit_ByCardinality/10                     305 ns          305 ns      2279601
-// BM_Record_Histogram_Explicit_ByCardinality/500                    313 ns          313 ns      2186641
-// BM_Record_Histogram_Explicit_ByCardinality/2000                   332 ns          332 ns      2170545
-// BM_Record_Histogram_Base2Expo_ByThreads/threads:1                 300 ns          300 ns      2344747
-// BM_Record_Histogram_Base2Expo_ByThreads/threads:2                 588 ns          582 ns      1194796
-// BM_Record_Histogram_Base2Expo_ByThreads/threads:4                1500 ns         1196 ns       518668
-// BM_Record_Histogram_Base2Expo_ByAttributes/0                     39.3 ns         39.3 ns     19087472
-// BM_Record_Histogram_Base2Expo_ByAttributes/1                      115 ns          115 ns      5936592
-// BM_Record_Histogram_Base2Expo_ByAttributes/10                    1067 ns         1067 ns       656089
-// BM_Record_Histogram_Base2Expo_ByAttributes/128                  18242 ns        18241 ns        38268
-// BM_Record_Histogram_Base2Expo_ByCardinality/10                    313 ns          313 ns      2235656
-// BM_Record_Histogram_Base2Expo_ByCardinality/500                   317 ns          317 ns      2232139
-// BM_Record_Histogram_Base2Expo_ByCardinality/2000                  331 ns          331 ns      2086932
-// BM_Record_Gauge_Disabled_ByThreads/threads:1                    0.219 ns        0.219 ns   3205741054
-// BM_Record_Gauge_Disabled_ByThreads/threads:2                    0.223 ns        0.223 ns   2690301556
-// BM_Record_Gauge_Disabled_ByThreads/threads:4                    0.229 ns        0.229 ns   2606758588
-// BM_Record_Gauge_Drop_ByThreads/threads:1                          286 ns          286 ns      2439706
-// BM_Record_Gauge_Drop_ByThreads/threads:2                          546 ns          539 ns      1177080
-// BM_Record_Gauge_Drop_ByThreads/threads:4                         1200 ns         1012 ns       497924
-// BM_Record_Gauge_LastValue_ByThreads/threads:1                     293 ns          293 ns      2371945
-// BM_Record_Gauge_LastValue_ByThreads/threads:2                     564 ns          559 ns      1232712
-// BM_Record_Gauge_LastValue_ByThreads/threads:4                    1513 ns         1214 ns       520464
-// BM_Record_Gauge_LastValue_ByAttributes/0                         37.1 ns         37.1 ns     18902040
-// BM_Record_Gauge_LastValue_ByAttributes/1                          108 ns          108 ns      6302008
-// BM_Record_Gauge_LastValue_ByAttributes/10                        1092 ns         1092 ns       647118
-// BM_Record_Gauge_LastValue_ByAttributes/128                      16605 ns        16604 ns        41995
-// BM_Record_Gauge_LastValue_ByCardinality/10                        298 ns          298 ns      2289380
-// BM_Record_Gauge_LastValue_ByCardinality/500                       309 ns          309 ns      2298937
-// BM_Record_Gauge_LastValue_ByCardinality/2000                      318 ns          318 ns      2242299
-// BM_Record_Counter_Sum_Exemplar_AlwaysOff                          296 ns          295 ns      2395056
-// BM_Record_Counter_Sum_Exemplar_AlwaysOn                           437 ns          437 ns      1585966
-// BM_Record_Counter_Sum_Exemplar_TraceBased_EmptyContext            302 ns          302 ns      2365598
-// BM_Record_Counter_Sum_Exemplar_TraceBased_UnsampledContext        303 ns          303 ns      2348573
-// BM_Record_Counter_Sum_Exemplar_TraceBased_SampledContext          450 ns          450 ns      1557082
-// BM_Record_Histogram_Explicit_Exemplar_AlwaysOff                   301 ns          301 ns      2266520
-// BM_Record_Histogram_Explicit_Exemplar_AlwaysOn                    453 ns          453 ns      1573692
-// BM_Record_Histogram_Base2Expo_Exemplar_AlwaysOff                  303 ns          303 ns      2274437
-// BM_Record_Histogram_Base2Expo_Exemplar_AlwaysOn                   453 ns          453 ns      1550092
-// BM_Record_BoundCounter_Disabled_ByThreads/threads:1             0.221 ns        0.221 ns   3142560276
-// BM_Record_BoundCounter_Disabled_ByThreads/threads:2             0.222 ns        0.222 ns   2660334766
-// BM_Record_BoundCounter_Disabled_ByThreads/threads:4             0.226 ns        0.226 ns   2861051432
-// BM_Record_BoundCounter_Drop_ByThreads/threads:1                  5.81 ns         5.81 ns    120342496
-// BM_Record_BoundCounter_Drop_ByThreads/threads:2                  34.8 ns         33.5 ns     20000000
-// BM_Record_BoundCounter_Drop_ByThreads/threads:4                   123 ns          112 ns      6062044
-// BM_Record_BoundCounter_Sum_ByThreads/threads:1                   10.7 ns         10.7 ns     65164652
-// BM_Record_BoundCounter_Sum_ByThreads/threads:2                   19.6 ns         13.2 ns     48429404
-// BM_Record_BoundCounter_Sum_ByThreads/threads:4                   73.4 ns         41.7 ns     32971620
-// BM_Record_BoundHistogram_Disabled_ByThreads/threads:1           0.214 ns        0.214 ns   3277171217
-// BM_Record_BoundHistogram_Disabled_ByThreads/threads:2           0.214 ns        0.214 ns   2444610710
-// BM_Record_BoundHistogram_Disabled_ByThreads/threads:4           0.224 ns        0.224 ns   2556315680
-// BM_Record_BoundHistogram_Drop_ByThreads/threads:1                6.19 ns         6.19 ns    113761230
-// BM_Record_BoundHistogram_Drop_ByThreads/threads:2                32.6 ns         29.9 ns     61564776
-// BM_Record_BoundHistogram_Drop_ByThreads/threads:4                 155 ns          145 ns     42223756
-// BM_Record_BoundHistogram_Explicit_ByThreads/threads:1            11.8 ns         11.8 ns     59006925
-// BM_Record_BoundHistogram_Explicit_ByThreads/threads:2            23.6 ns         13.5 ns     44770066
-// BM_Record_BoundHistogram_Explicit_ByThreads/threads:4             196 ns          133 ns      9838224
-// BM_Record_BoundHistogram_Base2Expo_ByThreads/threads:1           19.3 ns         19.3 ns     37052293
-// BM_Record_BoundHistogram_Base2Expo_ByThreads/threads:2           32.8 ns         21.5 ns     35315540
-// BM_Record_BoundHistogram_Base2Expo_ByThreads/threads:4           67.1 ns         25.8 ns     31687100
+// BM_Record_Counter_Disabled_ByThreads/threads:1                  0.222 ns        0.222 ns   3157611074
+// BM_Record_Counter_Disabled_ByThreads/threads:2                  0.228 ns        0.228 ns   2317559982
+// BM_Record_Counter_Disabled_ByThreads/threads:4                  0.224 ns        0.224 ns   2449047760
+// BM_Record_Counter_Drop_ByThreads/threads:1                       1.75 ns         1.75 ns    398352965
+// BM_Record_Counter_Drop_ByThreads/threads:2                       1.77 ns         1.77 ns    395926306
+// BM_Record_Counter_Drop_ByThreads/threads:4                       1.80 ns         1.80 ns    385184052
+// BM_Record_Counter_Sum_ByThreads/threads:1                         290 ns          290 ns      2411526
+// BM_Record_Counter_Sum_ByThreads/threads:2                         524 ns          519 ns      1299874
+// BM_Record_Counter_Sum_ByThreads/threads:4                        1337 ns         1107 ns       637784
+// BM_Record_Counter_Sum_ByAttributes/0                             26.3 ns         26.3 ns     26555865
+// BM_Record_Counter_Sum_ByAttributes/1                              104 ns          104 ns      6677963
+// BM_Record_Counter_Sum_ByAttributes/10                            1061 ns         1061 ns       666984
+// BM_Record_Counter_Sum_ByAttributes/128                          16510 ns        16509 ns        42555
+// BM_Record_Counter_Sum_ByCardinality/10                            305 ns          305 ns      2273336
+// BM_Record_Counter_Sum_ByCardinality/500                           309 ns          309 ns      2362157
+// BM_Record_Counter_Sum_ByCardinality/2000                          306 ns          306 ns      2259027
+// BM_Record_Counter_Sum_ByCardinality/4000                          282 ns          282 ns      2441950
+// BM_Record_Histogram_Disabled_ByThreads/threads:1                0.237 ns        0.237 ns   3065761938
+// BM_Record_Histogram_Disabled_ByThreads/threads:2                0.230 ns        0.230 ns   2427449390
+// BM_Record_Histogram_Disabled_ByThreads/threads:4                0.233 ns        0.233 ns   2243067152
+// BM_Record_Histogram_Drop_ByThreads/threads:1                     2.12 ns         2.12 ns    330519632
+// BM_Record_Histogram_Drop_ByThreads/threads:2                     2.16 ns         2.16 ns    326855378
+// BM_Record_Histogram_Drop_ByThreads/threads:4                     2.16 ns         2.16 ns    285233320
+// BM_Record_Histogram_Explicit_ByThreads/threads:1                  303 ns          303 ns      2305548
+// BM_Record_Histogram_Explicit_ByThreads/threads:2                  584 ns          583 ns      1179140
+// BM_Record_Histogram_Explicit_ByThreads/threads:4                 1474 ns         1210 ns       478800
+// BM_Record_Histogram_Explicit_ByAttributes/0                      34.0 ns         34.0 ns     20382028
+// BM_Record_Histogram_Explicit_ByAttributes/1                       116 ns          116 ns      6048721
+// BM_Record_Histogram_Explicit_ByAttributes/10                     1135 ns         1135 ns       615638
+// BM_Record_Histogram_Explicit_ByAttributes/128                   18457 ns        18457 ns        36005
+// BM_Record_Histogram_Explicit_ByCardinality/10                     318 ns          318 ns      2152688
+// BM_Record_Histogram_Explicit_ByCardinality/500                    312 ns          312 ns      2213058
+// BM_Record_Histogram_Explicit_ByCardinality/2000                   327 ns          327 ns      2140112
+// BM_Record_Histogram_Base2Expo_ByThreads/threads:1                 308 ns          308 ns      2273908
+// BM_Record_Histogram_Base2Expo_ByThreads/threads:2                 801 ns          722 ns       919292
+// BM_Record_Histogram_Base2Expo_ByThreads/threads:4                1710 ns         1357 ns       467556
+// BM_Record_Histogram_Base2Expo_ByAttributes/0                     32.4 ns         32.4 ns     19635763
+// BM_Record_Histogram_Base2Expo_ByAttributes/1                      117 ns          117 ns      5991477
+// BM_Record_Histogram_Base2Expo_ByAttributes/10                    1070 ns         1070 ns       649709
+// BM_Record_Histogram_Base2Expo_ByAttributes/128                  18389 ns        18388 ns        36322
+// BM_Record_Histogram_Base2Expo_ByCardinality/10                    317 ns          317 ns      2225556
+// BM_Record_Histogram_Base2Expo_ByCardinality/500                   315 ns          315 ns      2219892
+// BM_Record_Histogram_Base2Expo_ByCardinality/2000                  344 ns          344 ns      2133056
+// BM_Record_Gauge_Disabled_ByThreads/threads:1                    0.231 ns        0.230 ns   2985182463
+// BM_Record_Gauge_Disabled_ByThreads/threads:2                    0.258 ns        0.258 ns   2535349748
+// BM_Record_Gauge_Disabled_ByThreads/threads:4                    0.263 ns        0.263 ns   2058977740
+// BM_Record_Gauge_Drop_ByThreads/threads:1                         1.77 ns         1.77 ns    396510306
+// BM_Record_Gauge_Drop_ByThreads/threads:2                         1.76 ns         1.76 ns    396203792
+// BM_Record_Gauge_Drop_ByThreads/threads:4                         1.88 ns         1.88 ns    378999736
+// BM_Record_Gauge_LastValue_ByThreads/threads:1                     301 ns          301 ns      2322567
+// BM_Record_Gauge_LastValue_ByThreads/threads:2                     684 ns          627 ns      1054172
+// BM_Record_Gauge_LastValue_ByThreads/threads:4                    1454 ns         1180 ns       485272
+// BM_Record_Gauge_LastValue_ByAttributes/0                         36.4 ns         36.4 ns     19232981
+// BM_Record_Gauge_LastValue_ByAttributes/1                          112 ns          112 ns      6230722
+// BM_Record_Gauge_LastValue_ByAttributes/10                        1091 ns         1090 ns       644785
+// BM_Record_Gauge_LastValue_ByAttributes/128                      19942 ns        19941 ns        35750
+// BM_Record_Gauge_LastValue_ByCardinality/10                        310 ns          310 ns      2220110
+// BM_Record_Gauge_LastValue_ByCardinality/500                       310 ns          310 ns      2273872
+// BM_Record_Gauge_LastValue_ByCardinality/2000                      315 ns          315 ns      2176490
+// BM_Record_Counter_Sum_Exemplar_AlwaysOff                          297 ns          297 ns      2346887
+// BM_Record_Counter_Sum_Exemplar_AlwaysOn                           437 ns          437 ns      1607196
+// BM_Record_Counter_Sum_Exemplar_TraceBased_EmptyContext            304 ns          304 ns      2307315
+// BM_Record_Counter_Sum_Exemplar_TraceBased_UnsampledContext        303 ns          303 ns      2307124
+// BM_Record_Counter_Sum_Exemplar_TraceBased_SampledContext          449 ns          449 ns      1569626
+// BM_Record_Histogram_Explicit_Exemplar_AlwaysOff                   307 ns          307 ns      2287304
+// BM_Record_Histogram_Explicit_Exemplar_AlwaysOn                    443 ns          443 ns      1578995
+// BM_Record_Histogram_Base2Expo_Exemplar_AlwaysOff                  310 ns          310 ns      2219974
+// BM_Record_Histogram_Base2Expo_Exemplar_AlwaysOn                   448 ns          448 ns      1564477
+// BM_Record_BoundCounter_Disabled_ByThreads/threads:1             0.225 ns        0.225 ns   3109199368
+// BM_Record_BoundCounter_Disabled_ByThreads/threads:2             0.221 ns        0.221 ns   3139159388
+// BM_Record_BoundCounter_Disabled_ByThreads/threads:4             0.230 ns        0.230 ns   2444090640
+// BM_Record_BoundCounter_Drop_ByThreads/threads:1                  1.14 ns         1.14 ns    602944599
+// BM_Record_BoundCounter_Drop_ByThreads/threads:2                  1.16 ns         1.16 ns    582566836
+// BM_Record_BoundCounter_Drop_ByThreads/threads:4                  1.20 ns         1.20 ns    527738312
+// BM_Record_BoundCounter_Sum_ByThreads/threads:1                   15.7 ns         15.7 ns     44638005
+// BM_Record_BoundCounter_Sum_ByThreads/threads:2                    487 ns          487 ns      1730740
+// BM_Record_BoundCounter_Sum_ByThreads/threads:4                    334 ns          288 ns      3176988
+// BM_Record_BoundHistogram_Disabled_ByThreads/threads:1           0.225 ns        0.225 ns   3074007094
+// BM_Record_BoundHistogram_Disabled_ByThreads/threads:2           0.298 ns        0.298 ns   2348095536
+// BM_Record_BoundHistogram_Disabled_ByThreads/threads:4           0.267 ns        0.267 ns   1925459520
+// BM_Record_BoundHistogram_Drop_ByThreads/threads:1                1.76 ns         1.76 ns    397471719
+// BM_Record_BoundHistogram_Drop_ByThreads/threads:2                1.76 ns         1.76 ns    391899074
+// BM_Record_BoundHistogram_Drop_ByThreads/threads:4                1.79 ns         1.79 ns    357721228
+// BM_Record_BoundHistogram_Explicit_ByThreads/threads:1            16.6 ns         16.6 ns     42000966
+// BM_Record_BoundHistogram_Explicit_ByThreads/threads:2             237 ns          230 ns      3395654
+// BM_Record_BoundHistogram_Explicit_ByThreads/threads:4             473 ns          394 ns      2378376
+// BM_Record_BoundHistogram_Base2Expo_ByThreads/threads:1           23.9 ns         23.9 ns     28651138
+// BM_Record_BoundHistogram_Base2Expo_ByThreads/threads:2            489 ns          489 ns      2000000
+// BM_Record_BoundHistogram_Base2Expo_ByThreads/threads:4            590 ns          494 ns      1754400
 //
 // clang-format on
 


### PR DESCRIPTION
Fixes #4514 

When a view configures drop aggregation for an instrument (sync or async) the meter should not create a storage for that view. 

When multiple views are configured for an instrument (a catch-all view and an instrument specific view), the SDK should detect semantic errors and prevent conflicting metrics. 

> Producers SHOULD prevent the presence of multiple Metric identities for a given name with the same Resource and Scope attributes. Producers are expected to aggregate data for identical Metric objects as a basic feature, so the appearance of multiple Metric, considered a “semantic error”, generally requires duplicate conflicting instrument registration to have occurred somewhere.

https://opentelemetry.io/docs/specs/otel/metrics/data-model/#opentelemetry-protocol-data-model-producer-recommendations

## Changes

- Check if a view configures drop aggregation before creating storage
- Log a warning if the views will create duplicate conflicting metric storage objects. 
- Fix bugs that allowed the meter to add the same storage multiple times to a single instrument. This would cause unexpected results when multiple views match the same instrument/stream.
- Update meter test to verify drop aggregation (including catch-all view cases) and general cleanup/enhancement. 
- Updates sync instruments benchmark results

For significant contributions please make sure you have completed the following items:

* [x] `CHANGELOG.md` updated for non-trivial changes
* [x] Unit tests have been added
* [ ] Changes in public API reviewed