### PR TITLE
[RESOURCE DETECTOR] Container ID detection from `/proc/self/mountinfo`

### DIFF
--- a/resource_detectors/README.md
+++ b/resource_detectors/README.md
@@ -60,9 +60,9 @@ Limitations:
 Limitation: this detector depends on Linux `/proc` data and may return no value
 outside containers or when neither source contains the container ID. On cgroup
 v2 hosts with a private cgroup namespace `/proc/self/cgroup` does not contain
-the ID, so detection relies on the container runtime bind mounting
-`/etc/hostname`, `/etc/hosts` or `/etc/resolv.conf` from a path containing the
-container ID.
+the ID, so detection relies on the container runtime bind mounting files (such
+as `/etc/hostname` or `/run/secrets`) from a `.../containers/<id>/...` path, as
+Docker, Podman and CRI-O do.
 
 ### Host Resource Detector
 

--- a/resource_detectors/README.md
+++ b/resource_detectors/README.md
@@ -55,10 +55,14 @@ Limitations:
 
 | Attribute | Description | Linux | macOS | Windows |
 | --- | --- | --- | --- | --- |
-| `container.id` | Container ID from `/proc/self/cgroup` | Yes | No | No |
+| `container.id` | Container ID from `/proc/self/cgroup`, falling back to container runtime bind mount paths in `/proc/self/mountinfo` | Yes | No | No |
 
-Limitation: this detector depends on Linux cgroup data and may return no value
-outside containers or when cgroup data is unavailable.
+Limitation: this detector depends on Linux `/proc` data and may return no value
+outside containers or when neither source contains the container ID. On cgroup
+v2 hosts with a private cgroup namespace `/proc/self/cgroup` does not contain
+the ID, so detection relies on the container runtime bind mounting
+`/etc/hostname`, `/etc/hosts` or `/etc/resolv.conf` from a path containing the
+container ID.
 
 ### Host Resource Detector
 

--- a/resource_detectors/include/opentelemetry/resource_detectors/container_detector.h
+++ b/resource_detectors/include/opentelemetry/resource_detectors/container_detector.h
@@ -12,8 +12,9 @@ namespace resource_detector
 
 /**
  * ContainerResourceDetector to detect resource attributes when running inside a containerized
- * environment. This detector extracts metadata such as container ID from cgroup information and
- * sets attributes like container.id following the OpenTelemetry semantic conventions.
+ * environment. This detector extracts metadata such as container ID from cgroup information
+ * (/proc/self/cgroup on cgroup v1, /proc/self/mountinfo on cgroup v2) and sets attributes like
+ * container.id following the OpenTelemetry semantic conventions.
  */
 class ContainerResourceDetector : public opentelemetry::sdk::resource::ResourceDetector
 {

--- a/resource_detectors/include/opentelemetry/resource_detectors/container_detector.h
+++ b/resource_detectors/include/opentelemetry/resource_detectors/container_detector.h
@@ -12,9 +12,9 @@ namespace resource_detector
 
 /**
  * ContainerResourceDetector to detect resource attributes when running inside a containerized
- * environment. This detector extracts metadata such as container ID from cgroup information
- * (/proc/self/cgroup on cgroup v1, /proc/self/mountinfo on cgroup v2) and sets attributes like
- * container.id following the OpenTelemetry semantic conventions.
+ * environment. This detector extracts the container ID from /proc/self/cgroup, falling back to
+ * container runtime bind mount paths in /proc/self/mountinfo, and sets the container.id attribute
+ * following the OpenTelemetry semantic conventions.
  */
 class ContainerResourceDetector : public opentelemetry::sdk::resource::ResourceDetector
 {

--- a/resource_detectors/include/opentelemetry/resource_detectors/detail/container_detector_utils.h
+++ b/resource_detectors/include/opentelemetry/resource_detectors/detail/container_detector_utils.h
@@ -15,7 +15,7 @@ namespace detail
 {
 
 /**
- * Reads the container.id from /proc/self/cgroup file (cgroup v1).
+ * Reads the container.id from /proc/self/cgroup file.
  * @param file_path file path of cgroup
  * @return container.id as string or an empty string if not found on error
  */
@@ -29,7 +29,9 @@ std::string GetContainerIDFromCgroup(const char *file_path);
 std::string ExtractContainerIDFromLine(nostd::string_view line);
 
 /**
- * Reads the container.id from /proc/self/mountinfo file (cgroup v2).
+ * Reads the container.id from container runtime bind mount paths in /proc/self/mountinfo.
+ * Used as a fallback when /proc/self/cgroup does not contain the id (e.g. cgroup v2 with a
+ * private cgroup namespace).
  * @param file_path file path of mountinfo
  * @return container.id as string or an empty string if not found on error
  */

--- a/resource_detectors/include/opentelemetry/resource_detectors/detail/container_detector_utils.h
+++ b/resource_detectors/include/opentelemetry/resource_detectors/detail/container_detector_utils.h
@@ -31,15 +31,16 @@ std::string ExtractContainerIDFromLine(nostd::string_view line);
 /**
  * Reads the container.id from container runtime bind mount paths in /proc/self/mountinfo.
  * Used as a fallback when /proc/self/cgroup does not contain the id (e.g. cgroup v2 with a
- * private cgroup namespace).
+ * private cgroup namespace). When several distinct ids are present (Kubernetes pod sandbox and
+ * application container) the last one found is returned and a warning is logged.
  * @param file_path file path of mountinfo
  * @return container.id as string or an empty string if not found on error
  */
 std::string GetContainerIDFromMountInfo(const char *file_path);
 
 /**
- * Extracts container.id from a mountinfo line by looking for a 64 character hexadecimal
- * path segment on lines that reference "containers" or "hostname".
+ * Extracts container.id from a mountinfo line whose mount root contains "/containers/"
+ * followed by a 64 character hexadecimal id.
  * @param line a single line of text, typically from the /proc/self/mountinfo file
  * @return matched id or empty string
  */

--- a/resource_detectors/include/opentelemetry/resource_detectors/detail/container_detector_utils.h
+++ b/resource_detectors/include/opentelemetry/resource_detectors/detail/container_detector_utils.h
@@ -15,7 +15,7 @@ namespace detail
 {
 
 /**
- * Reads the container.id from /proc/self/cgroup file.
+ * Reads the container.id from /proc/self/cgroup file (cgroup v1).
  * @param file_path file path of cgroup
  * @return container.id as string or an empty string if not found on error
  */
@@ -27,6 +27,21 @@ std::string GetContainerIDFromCgroup(const char *file_path);
  * @return matched id or empty string
  */
 std::string ExtractContainerIDFromLine(nostd::string_view line);
+
+/**
+ * Reads the container.id from /proc/self/mountinfo file (cgroup v2).
+ * @param file_path file path of mountinfo
+ * @return container.id as string or an empty string if not found on error
+ */
+std::string GetContainerIDFromMountInfo(const char *file_path);
+
+/**
+ * Extracts container.id from a mountinfo line by looking for a 64 character hexadecimal
+ * path segment on lines that reference "containers" or "hostname".
+ * @param line a single line of text, typically from the /proc/self/mountinfo file
+ * @return matched id or empty string
+ */
+std::string ExtractContainerIDFromMountInfoLine(nostd::string_view line);
 
 }  // namespace detail
 }  // namespace resource_detector

--- a/resource_detectors/src/container_detector.cc
+++ b/resource_detectors/src/container_detector.cc
@@ -20,12 +20,13 @@ namespace resource_detector
 {
 
 /**
- * This is the file path from where we can get container.id on cgroup v1
+ * This is the file path from where we can get container.id from cgroup paths
  */
 constexpr const char *kCGroupPath = "/proc/self/cgroup";
 
 /**
- * This is the file path from where we can get container.id on cgroup v2
+ * Fallback file path from where we can get container.id from container runtime bind mount paths
+ * (needed on cgroup v2 with a private cgroup namespace, where /proc/self/cgroup is just "0::/")
  */
 constexpr const char *kMountInfoPath = "/proc/self/mountinfo";
 

--- a/resource_detectors/src/container_detector.cc
+++ b/resource_detectors/src/container_detector.cc
@@ -17,14 +17,24 @@ namespace resource_detector
 {
 
 /**
- * This is the file path from where we can get container.id
+ * This is the file path from where we can get container.id on cgroup v1
  */
 constexpr const char *kCGroupPath = "/proc/self/cgroup";
+
+/**
+ * This is the file path from where we can get container.id on cgroup v2
+ */
+constexpr const char *kMountInfoPath = "/proc/self/mountinfo";
 
 opentelemetry::sdk::resource::Resource ContainerResourceDetector::Detect() noexcept
 {
   std::string container_id =
       opentelemetry::resource_detector::detail::GetContainerIDFromCgroup(kCGroupPath);
+  if (container_id.empty())
+  {
+    container_id =
+        opentelemetry::resource_detector::detail::GetContainerIDFromMountInfo(kMountInfoPath);
+  }
   if (container_id.empty())
   {
     return ResourceDetector::Create({});

--- a/resource_detectors/src/container_detector.cc
+++ b/resource_detectors/src/container_detector.cc
@@ -4,11 +4,14 @@
 #include "opentelemetry/resource_detectors/container_detector.h"
 #include "opentelemetry/nostd/variant.h"
 #include "opentelemetry/resource_detectors/detail/container_detector_utils.h"
+#include "opentelemetry/sdk/common/global_log_handler.h"
 #include "opentelemetry/sdk/resource/resource.h"
 #include "opentelemetry/sdk/resource/resource_detector.h"
 #include "opentelemetry/semconv/incubating/container_attributes.h"
 #include "opentelemetry/version.h"
 
+#include <exception>
+#include <ostream>
 #include <string>
 #include <utility>
 
@@ -28,13 +31,34 @@ constexpr const char *kMountInfoPath = "/proc/self/mountinfo";
 
 opentelemetry::sdk::resource::Resource ContainerResourceDetector::Detect() noexcept
 {
-  std::string container_id =
-      opentelemetry::resource_detector::detail::GetContainerIDFromCgroup(kCGroupPath);
+  std::string container_id;
+
+  try
+  {
+    container_id = opentelemetry::resource_detector::detail::GetContainerIDFromCgroup(kCGroupPath);
+  }
+  catch (const std::exception &ex)
+  {
+    OTEL_INTERNAL_LOG_ERROR("[Container Resource Detector] "
+                            << "Error extracting the container id from " << kCGroupPath << ": "
+                            << ex.what());
+  }
+
   if (container_id.empty())
   {
-    container_id =
-        opentelemetry::resource_detector::detail::GetContainerIDFromMountInfo(kMountInfoPath);
+    try
+    {
+      container_id =
+          opentelemetry::resource_detector::detail::GetContainerIDFromMountInfo(kMountInfoPath);
+    }
+    catch (const std::exception &ex)
+    {
+      OTEL_INTERNAL_LOG_ERROR("[Container Resource Detector] "
+                              << "Error extracting the container id from " << kMountInfoPath << ": "
+                              << ex.what());
+    }
   }
+
   if (container_id.empty())
   {
     return ResourceDetector::Create({});

--- a/resource_detectors/src/container_detector_utils.cc
+++ b/resource_detectors/src/container_detector_utils.cc
@@ -55,6 +55,44 @@ std::string ExtractContainerIDFromLine(nostd::string_view line)
   return std::string();
 }
 
+std::string GetContainerIDFromMountInfo(const char *file_path)
+{
+  std::ifstream mountinfo_file(file_path);
+  std::string line;
+
+  while (std::getline(mountinfo_file, line))
+  {
+    std::string container_id = ExtractContainerIDFromMountInfoLine(line);
+    if (!container_id.empty())
+    {
+      return container_id;
+    }
+  }
+  return std::string();
+}
+
+std::string ExtractContainerIDFromMountInfoLine(nostd::string_view line)
+{
+  /**
+   * This regex is designed to extract container IDs from /proc/self/mountinfo file lines.
+   * On cgroup v2 hosts the container id is present in the bind mount source paths of
+   * /etc/hostname, /etc/hosts and /etc/resolv.conf, e.g.:
+   * /docker/containers/e9974a495c2e01d17b9c71d4469cd6636ca733cd514e6ee49e1435fc03a93592/hostname
+   * The line must contain "containers" or "hostname" and the id is a 64 character hex path
+   * segment delimited by '/' on both sides (or end of path).
+   */
+  static const std::regex container_id_regex(
+      R"(^(?=.*(?:containers|hostname)).*?/([0-9a-f]{64})(?:/|\s|$))");
+  std::match_results<const char *> match;
+
+  if (std::regex_search(line.data(), line.data() + line.size(), match, container_id_regex))
+  {
+    return match.str(1);
+  }
+
+  return std::string();
+}
+
 }  // namespace detail
 }  // namespace resource_detector
 OPENTELEMETRY_END_NAMESPACE

--- a/resource_detectors/src/container_detector_utils.cc
+++ b/resource_detectors/src/container_detector_utils.cc
@@ -3,10 +3,14 @@
 
 #include "opentelemetry/resource_detectors/detail/container_detector_utils.h"
 #include "opentelemetry/nostd/string_view.h"
+#include "opentelemetry/sdk/common/global_log_handler.h"
 
+#include <algorithm>
 #include <fstream>
 #include <regex>
 #include <string>
+#include <utility>
+#include <vector>
 
 #include "opentelemetry/version.h"
 
@@ -59,16 +63,32 @@ std::string GetContainerIDFromMountInfo(const char *file_path)
 {
   std::ifstream mountinfo_file(file_path);
   std::string line;
+  std::vector<std::string> container_ids;
 
+  // In Kubernetes the pod sandbox container's files are mounted first (e.g. /etc/hostname), and
+  // the application container's own mounts (e.g. /run/secrets) come later, so the last id wins.
   while (std::getline(mountinfo_file, line))
   {
-    std::string container_id = ExtractContainerIDFromMountInfoLine(line);
-    if (!container_id.empty())
+    std::string id = ExtractContainerIDFromMountInfoLine(line);
+    if (!id.empty() &&
+        std::find(container_ids.begin(), container_ids.end(), id) == container_ids.end())
     {
-      return container_id;
+      container_ids.push_back(std::move(id));
     }
   }
-  return std::string();
+
+  if (container_ids.empty())
+  {
+    return std::string();
+  }
+
+  if (container_ids.size() > 1)
+  {
+    OTEL_INTERNAL_LOG_WARN("[Container Resource Detector] Multiple container ids found in "
+                           << file_path << ", using the last one: " << container_ids.back());
+  }
+
+  return container_ids.back();
 }
 
 std::string ExtractContainerIDFromMountInfoLine(nostd::string_view line)
@@ -76,14 +96,16 @@ std::string ExtractContainerIDFromMountInfoLine(nostd::string_view line)
   /**
    * This regex is designed to extract container IDs from /proc/self/mountinfo file lines.
    * When /proc/self/cgroup does not contain the id (e.g. cgroup v2 with a private cgroup
-   * namespace) the container id is still present in the bind mount source paths of
-   * /etc/hostname, /etc/hosts and /etc/resolv.conf, e.g.:
-   * /docker/containers/e9974a495c2e01d17b9c71d4469cd6636ca733cd514e6ee49e1435fc03a93592/hostname
-   * The line must contain "containers" or "hostname" and the id is a 64 character hex path
-   * segment delimited by '/' on both sides (or end of path).
+   * namespace) the container id is still present in the source paths of files the container
+   * runtime bind mounts into the container. The mountinfo fields are:
+   *   <mount id> <parent id> <major:minor> <root> <mount point> <options> ...
+   * and <root> must contain "/containers/" followed by a 64 character hex id. Examples:
+   * - docker: /docker/containers/<id>/hostname /etc/hostname
+   * - podman: /containers/overlay-containers/<id>/userdata/resolv.conf /etc/resolv.conf
+   * - cri-o:  /containers/storage/overlay-containers/<id>/userdata/run/secrets /run/secrets
    */
   static const std::regex container_id_regex(
-      R"(^(?=.*(?:containers|hostname)).*?/([0-9a-f]{64})(?:/|\s|$))");
+      R"(^\d+\s+\d+\s+\d+:\d+\s+\S*/containers/(?:\S*?/)?([0-9a-f]{64})(?:/|\s|$))");
   std::match_results<const char *> match;
 
   if (std::regex_search(line.data(), line.data() + line.size(), match, container_id_regex))

--- a/resource_detectors/src/container_detector_utils.cc
+++ b/resource_detectors/src/container_detector_utils.cc
@@ -75,7 +75,8 @@ std::string ExtractContainerIDFromMountInfoLine(nostd::string_view line)
 {
   /**
    * This regex is designed to extract container IDs from /proc/self/mountinfo file lines.
-   * On cgroup v2 hosts the container id is present in the bind mount source paths of
+   * When /proc/self/cgroup does not contain the id (e.g. cgroup v2 with a private cgroup
+   * namespace) the container id is still present in the bind mount source paths of
    * /etc/hostname, /etc/hosts and /etc/resolv.conf, e.g.:
    * /docker/containers/e9974a495c2e01d17b9c71d4469cd6636ca733cd514e6ee49e1435fc03a93592/hostname
    * The line must contain "containers" or "hostname" and the id is a 64 character hex path

--- a/resource_detectors/test/container_detector_test.cc
+++ b/resource_detectors/test/container_detector_test.cc
@@ -67,37 +67,101 @@ TEST(ContainerIdDetectorTest, ReturnsEmptyOnFileFailingToOpen)
   EXPECT_EQ(id, std::string{""});
 }
 
+// The following tests are based on the opentelemetry-java-instrumentation test cases for docker,
+// podman, and cri-o mountinfo files:
+// https://github.com/open-telemetry/opentelemetry-java-instrumentation/blob/3eafaa0539f1e38aae788d7c7fc60c74ad0d7290/instrumentation/resources/library/src/test/resources/podman_proc_self_mountinfo1
+// https://github.com/open-telemetry/opentelemetry-java-instrumentation/blob/3eafaa0539f1e38aae788d7c7fc60c74ad0d7290/instrumentation/resources/library/src/test/resources/crio_proc_self_mountinfo
 TEST(ContainerIdDetectorTest, ExtractValidContainerIdFromMountInfoLine)
 {
-  std::string line =
-      "9266 6084 259:5 "
-      "/docker/containers/e9974a495c2e01d17b9c71d4469cd6636ca733cd514e6ee49e1435fc03a93592/"
-      "hostname /etc/hostname rw,relatime - ext4 /dev/nvme1n1p3 rw";
-  std::string extracted_id =
-      opentelemetry::resource_detector::detail::ExtractContainerIDFromMountInfoLine(line);
-  EXPECT_EQ(std::string{"e9974a495c2e01d17b9c71d4469cd6636ca733cd514e6ee49e1435fc03a93592"},
-            extracted_id);
+  const std::string expected_id =
+      "1aac2bcc27c4f738c1a176cb71b47527fe73e26f80980a8f99275c93afe4d21a";
+
+  const char *lines[] = {
+      // docker
+      "9408 9397 259:5 "
+      "/docker/containers/1aac2bcc27c4f738c1a176cb71b47527fe73e26f80980a8f99275c93afe4d21a/"
+      "resolv.conf /etc/resolv.conf rw,relatime - ext4 /dev/nvme1n1p3 rw",
+      "9409 9397 259:5 "
+      "/docker/containers/1aac2bcc27c4f738c1a176cb71b47527fe73e26f80980a8f99275c93afe4d21a/"
+      "hostname /etc/hostname rw,relatime - ext4 /dev/nvme1n1p3 rw",
+      "9410 9397 259:5 "
+      "/docker/containers/1aac2bcc27c4f738c1a176cb71b47527fe73e26f80980a8f99275c93afe4d21a/"
+      "hosts /etc/hosts rw,relatime - ext4 /dev/nvme1n1p3 rw",
+      // podman rootless, root relative to the tmpfs mount (java: podman_proc_self_mountinfo1)
+      "981 961 0:56 "
+      "/containers/overlay-containers/"
+      "1aac2bcc27c4f738c1a176cb71b47527fe73e26f80980a8f99275c93afe4d21a/"
+      "userdata/resolv.conf /etc/resolv.conf ro,nosuid,nodev,noexec,relatime - tmpfs tmpfs "
+      "rw,size=783888k,nr_inodes=195972,mode=700,uid=2024,gid=2024,inode64",
+      // podman / cri-o
+      "1120 1118 0:42 /run/containers/storage/overlay-containers/"
+      "1aac2bcc27c4f738c1a176cb71b47527fe73e26f80980a8f99275c93afe4d21a/userdata/resolv.conf "
+      "/etc/resolv.conf rw,nodev,relatime - ext4 /dev/sda1 rw",
+      // cri-o application container secrets mount (java: crio_proc_self_mountinfo)
+      "10316 10303 0:25 /containers/storage/overlay-containers/"
+      "1aac2bcc27c4f738c1a176cb71b47527fe73e26f80980a8f99275c93afe4d21a/userdata/run/secrets "
+      "/run/secrets rw,nosuid,nodev - tmpfs tmpfs "
+      "rw,seclabel,size=6416204k,nr_inodes=819200,mode=755,inode64",
+  };
+
+  for (const char *line : lines)
+  {
+    EXPECT_EQ(opentelemetry::resource_detector::detail::ExtractContainerIDFromMountInfoLine(line),
+              expected_id)
+        << line;
+  }
 }
 
-TEST(ContainerIdDetectorTest, DoesNotExtractFromMountInfoLineWithoutKeywords)
+// containerd mounts /etc/hostname from the pod sandbox, which is not the container id.
+// This case is taken from the opentelemetry-java-instrumentation test:
+// https://github.com/open-telemetry/opentelemetry-java-instrumentation/blob/3eafaa0539f1e38aae788d7c7fc60c74ad0d7290/instrumentation/resources/library/src/test/resources/containerd_proc_self_mountinfo
+TEST(ContainerIdDetectorTest, DoesNotExtractSandboxIdFromContainerdMountInfoLine)
 {
   std::string line =
-      "8248 6084 259:5 "
-      "/docker/other/e9974a495c2e01d17b9c71d4469cd6636ca733cd514e6ee49e1435fc03a93592/"
-      "resolv.conf /etc/resolv.conf rw,relatime - ext4 /dev/nvme1n1p3 rw";
-  std::string id =
-      opentelemetry::resource_detector::detail::ExtractContainerIDFromMountInfoLine(line);
-  EXPECT_EQ(id, std::string{""});
+      "2023 2002 253:1 /var/lib/containerd/io.containerd.grpc.v1.cri/sandboxes/"
+      "b136f3d296b4c2024b3e7ad816f2a804a47cf1acc3d445075c6d78cf159ef58d/hostname /etc/hostname "
+      "rw,relatime - xfs /dev/mapper/ubuntu--vg-root "
+      "rw,attr2,inode64,logbufs=8,logbsize=32k,noquota";
+  EXPECT_EQ(opentelemetry::resource_detector::detail::ExtractContainerIDFromMountInfoLine(line),
+            std::string{""});
+}
+
+// The overlay line is taken from the opentelemetry-java-instrumentation test:
+// https://github.com/open-telemetry/opentelemetry-java-instrumentation/blob/3eafaa0539f1e38aae788d7c7fc60c74ad0d7290/instrumentation/resources/library/src/test/resources/docker_proc_self_mountinfo
+TEST(ContainerIdDetectorTest, DoesNotExtractIdFromMountInfoOptionsField)
+{
+  std::string line =
+      "9408 9397 259:5 /tmp/random_mount /etc/resolv.conf rw,namespace=/docker/containers/"
+      "1aac2bcc27c4f738c1a176cb71b47527fe73e26f80980a8f99275c93afe4d21a/resolv.conf - ext4 "
+      "/dev/nvme1n1p3 rw";
+  EXPECT_EQ(opentelemetry::resource_detector::detail::ExtractContainerIDFromMountInfoLine(line),
+            std::string{""});
+
+  // 64 hex overlay layer ids in lowerdir/upperdir must not be picked up either.
+  std::string overlay =
+      "456 375 0:143 / / rw,relatime master:175 - overlay overlay "
+      "rw,lowerdir=/var/lib/docker/overlay2/l/CBPR2ETR4Z3UMOOGIIRDVT2P27,"
+      "upperdir=/var/lib/docker/overlay2/"
+      "3ef3e5a1a87b4e220c1da9a7901654e945b0ef5398e1b67fccb42fdb7750829e/diff";
+  EXPECT_EQ(opentelemetry::resource_detector::detail::ExtractContainerIDFromMountInfoLine(overlay),
+            std::string{""});
 }
 
 TEST(ContainerIdDetectorTest, DoesNotExtractNonHexOrWrongLengthFromMountInfoLine)
 {
   std::string wrong_length =
-      "9266 6084 259:5 /docker/containers/abcdef0123456789/hostname /etc/hostname rw - ext4 "
-      "/dev/sda1 rw";
+      "9408 9397 259:5 /docker/containers/1aac2bcc27c4f/resolv.conf /etc/resolv.conf rw,relatime "
+      "- ext4 /dev/nvme1n1p3 rw";
   EXPECT_EQ(
       opentelemetry::resource_detector::detail::ExtractContainerIDFromMountInfoLine(wrong_length),
       std::string{""});
+
+  std::string too_long =
+      "9408 9397 259:5 "
+      "/docker/containers/1aac2bcc27c4f738c1a176cb71b47527fe73e26f80980a8f99275c93afe4d21a0/"
+      "resolv.conf /etc/resolv.conf rw,relatime - ext4 /dev/nvme1n1p3 rw";
+  EXPECT_EQ(opentelemetry::resource_detector::detail::ExtractContainerIDFromMountInfoLine(too_long),
+            std::string{""});
 
   std::string non_hex =
       "9266 6084 259:5 "
@@ -128,6 +192,32 @@ TEST(ContainerIdDetectorTest, ExtractIdFromMockUpMountInfoFile)
       opentelemetry::resource_detector::detail::GetContainerIDFromMountInfo(filename);
   EXPECT_EQ(container_id,
             std::string{"e9974a495c2e01d17b9c71d4469cd6636ca733cd514e6ee49e1435fc03a93592"});
+
+  std::remove(filename);
+}
+
+// In Kubernetes /etc/hostname comes from the pod sandbox container while /run/secrets comes
+// from the application container, whose id must be returned.
+// This case is taken from the opentelemetry-java-instrumentation tests:
+// https://github.com/open-telemetry/opentelemetry-java-instrumentation/blob/3eafaa0539f1e38aae788d7c7fc60c74ad0d7290/instrumentation/resources/library/src/test/resources/crio_proc_self_mountinfo
+TEST(ContainerIdDetectorTest, ExtractLastIdFromKubernetesCrioMountInfoFile)
+{
+  const char *filename = "test_crio_mountinfo.txt";
+
+  {
+    std::ofstream outfile(filename);
+    outfile << "10312 10303 0:25 /containers/storage/overlay-containers/"
+               "2ac4c84cb0d3c3beb04beeef6ccf71c17b5fdd0252ce3a2b66bc2fdd0aaa1814/userdata/"
+               "hostname /etc/hostname rw,nosuid,nodev master:15 - tmpfs tmpfs rw\n";
+    outfile << "10316 10303 0:25 /containers/storage/overlay-containers/"
+               "a8f62e52ed7c2cd85242dcf0eb1d727b643540ceca7f328ad7d2f31aedf07731/userdata/run/"
+               "secrets /run/secrets rw,nosuid,nodev - tmpfs tmpfs rw\n";
+  }
+
+  std::string container_id =
+      opentelemetry::resource_detector::detail::GetContainerIDFromMountInfo(filename);
+  EXPECT_EQ(container_id,
+            std::string{"a8f62e52ed7c2cd85242dcf0eb1d727b643540ceca7f328ad7d2f31aedf07731"});
 
   std::remove(filename);
 }

--- a/resource_detectors/test/container_detector_test.cc
+++ b/resource_detectors/test/container_detector_test.cc
@@ -66,3 +66,91 @@ TEST(ContainerIdDetectorTest, ReturnsEmptyOnFileFailingToOpen)
   std::string id = opentelemetry::resource_detector::detail::GetContainerIDFromCgroup(filename);
   EXPECT_EQ(id, std::string{""});
 }
+
+TEST(ContainerIdDetectorTest, ExtractValidContainerIdFromMountInfoLine)
+{
+  std::string line =
+      "9266 6084 259:5 "
+      "/docker/containers/e9974a495c2e01d17b9c71d4469cd6636ca733cd514e6ee49e1435fc03a93592/"
+      "hostname /etc/hostname rw,relatime - ext4 /dev/nvme1n1p3 rw";
+  std::string extracted_id =
+      opentelemetry::resource_detector::detail::ExtractContainerIDFromMountInfoLine(line);
+  EXPECT_EQ(std::string{"e9974a495c2e01d17b9c71d4469cd6636ca733cd514e6ee49e1435fc03a93592"},
+            extracted_id);
+}
+
+TEST(ContainerIdDetectorTest, DoesNotExtractFromMountInfoLineWithoutKeywords)
+{
+  std::string line =
+      "8248 6084 259:5 "
+      "/docker/other/e9974a495c2e01d17b9c71d4469cd6636ca733cd514e6ee49e1435fc03a93592/"
+      "resolv.conf /etc/resolv.conf rw,relatime - ext4 /dev/nvme1n1p3 rw";
+  std::string id =
+      opentelemetry::resource_detector::detail::ExtractContainerIDFromMountInfoLine(line);
+  EXPECT_EQ(id, std::string{""});
+}
+
+TEST(ContainerIdDetectorTest, DoesNotExtractNonHexOrWrongLengthFromMountInfoLine)
+{
+  std::string wrong_length =
+      "9266 6084 259:5 /docker/containers/abcdef0123456789/hostname /etc/hostname rw - ext4 "
+      "/dev/sda1 rw";
+  EXPECT_EQ(
+      opentelemetry::resource_detector::detail::ExtractContainerIDFromMountInfoLine(wrong_length),
+      std::string{""});
+
+  std::string non_hex =
+      "9266 6084 259:5 "
+      "/docker/containers/g9974a495c2e01d17b9c71d4469cd6636ca733cd514e6ee49e1435fc03a93592/"
+      "hostname /etc/hostname rw - ext4 /dev/sda1 rw";
+  EXPECT_EQ(opentelemetry::resource_detector::detail::ExtractContainerIDFromMountInfoLine(non_hex),
+            std::string{""});
+}
+
+TEST(ContainerIdDetectorTest, ExtractIdFromMockUpMountInfoFile)
+{
+  const char *filename = "test_mountinfo.txt";
+
+  {
+    std::ofstream outfile(filename);
+    outfile << "6084 6083 0:100 / / rw,relatime - overlay overlay rw,lowerdir=/var/lib/docker\n";
+    outfile
+        << "8248 6084 259:5 "
+           "/docker/containers/e9974a495c2e01d17b9c71d4469cd6636ca733cd514e6ee49e1435fc03a93592/"
+           "resolv.conf /etc/resolv.conf rw,relatime - ext4 /dev/nvme1n1p3 rw\n";
+    outfile
+        << "9266 6084 259:5 "
+           "/docker/containers/e9974a495c2e01d17b9c71d4469cd6636ca733cd514e6ee49e1435fc03a93592/"
+           "hostname /etc/hostname rw,relatime - ext4 /dev/nvme1n1p3 rw\n";
+  }
+
+  std::string container_id =
+      opentelemetry::resource_detector::detail::GetContainerIDFromMountInfo(filename);
+  EXPECT_EQ(container_id,
+            std::string{"e9974a495c2e01d17b9c71d4469cd6636ca733cd514e6ee49e1435fc03a93592"});
+
+  std::remove(filename);
+}
+
+TEST(ContainerIdDetectorTest, ReturnsEmptyOnMountInfoNoMatch)
+{
+  const char *filename = "test_empty_mountinfo.txt";
+
+  {
+    std::ofstream outfile(filename);
+    outfile << "6084 6083 0:100 / / rw,relatime - overlay overlay rw\n";
+  }
+
+  std::string id = opentelemetry::resource_detector::detail::GetContainerIDFromMountInfo(filename);
+  EXPECT_EQ(id, std::string{""});
+
+  std::remove(filename);
+}
+
+TEST(ContainerIdDetectorTest, ReturnsEmptyOnMountInfoFileFailingToOpen)
+{
+  const char *filename = "test_invalid_mountinfo.txt";
+
+  std::string id = opentelemetry::resource_detector::detail::GetContainerIDFromMountInfo(filename);
+  EXPECT_EQ(id, std::string{""});
+}


### PR DESCRIPTION
Fixes # (issue)

Add container detector support for parsing container id from `/proc/self/mountinfo` as a fallback to when it is not contained in `/proc/self/cgroup`. 

This follows the pattern used in [opentelemetry/instrumentation/resources/CgroupV2ContainerIdExtractor.java](https://github.com/open-telemetry/opentelemetry-java-instrumentation/blob/3eafaa0539f1e38aae788d7c7fc60c74ad0d7290/instrumentation/resources/library/src/main/java/io/opentelemetry/instrumentation/resources/CgroupV2ContainerIdExtractor.java)

## Changes

- Adds a new regex and private utility function to parse the container id
- Adds exception handling to the container detector
- Adds test for the new id parsing method
- Verified the container id is now added to the resource when running the container detector with the `example_yaml` exe inside the devcontainer. The container id is not detected when the example is built from `main`. 

For significant contributions please make sure you have completed the following items:

* [ ] `CHANGELOG.md` updated for non-trivial changes
* [x] Unit tests have been added
* [ ] Changes in public API reviewed