### PR TITLE
[DOC] Fix and clarify StartSpanOptions documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,9 @@ Increment the:
 
 ## [Unreleased]
 
+* [DOC] Fix and clarify the `StartSpanOptions` documentation
+  [#4526](https://github.com/open-telemetry/opentelemetry-cpp/pull/4526)
+
 * [EXPORTER] Fix the Elasticsearch log exporter aborting the process when a log
   record's body or attributes contain bytes that are not valid UTF-8. The
   exporter now substitutes the replacement character for the invalid bytes

--- a/api/include/opentelemetry/trace/span_startoptions.h
+++ b/api/include/opentelemetry/trace/span_startoptions.h
@@ -35,14 +35,14 @@ struct StartSpanOptions
    * Explicitly sets the parent of the Span.
    *
    * A valid `SpanContext` identifies the parent directly. An invalid
-  * `SpanContext` falls back to the currently active Span, if one exists;
-  * otherwise, the new Span is created as a root Span.
+   * `SpanContext` falls back to the currently active Span, if one exists;
+   * otherwise, the new Span is created as a root Span.
    *
    * When a `context::Context` is provided, a valid Span in that Context is used
    * as the parent. Otherwise, if the Context contains `is_root_span` set to
    * `true`, the new Span is created without a parent. If neither is present,
-  * the currently active Span is used as the parent, if one exists; otherwise,
-  * the new Span is created as a root Span.
+   * the currently active Span is used as the parent, if one exists; otherwise,
+   * the new Span is created as a root Span.
    *
    * Example:
    * ```cpp

--- a/api/include/opentelemetry/trace/span_startoptions.h
+++ b/api/include/opentelemetry/trace/span_startoptions.h
@@ -35,12 +35,14 @@ struct StartSpanOptions
    * Explicitly sets the parent of the Span.
    *
    * A valid `SpanContext` identifies the parent directly. An invalid
-   * `SpanContext` falls back to the currently active Span.
+    * `SpanContext` falls back to the currently active Span, if one exists;
+    * otherwise, the new Span is created as a root Span.
    *
    * When a `context::Context` is provided, a valid Span in that Context is used
    * as the parent. Otherwise, if the Context contains `is_root_span` set to
    * `true`, the new Span is created without a parent. If neither is present,
-   * the currently active Span is used as the parent, if one exists.
+    * the currently active Span is used as the parent, if one exists; otherwise,
+    * the new Span is created as a root Span.
    *
    * Example:
    * ```cpp

--- a/api/include/opentelemetry/trace/span_startoptions.h
+++ b/api/include/opentelemetry/trace/span_startoptions.h
@@ -35,14 +35,14 @@ struct StartSpanOptions
    * Explicitly sets the parent of the Span.
    *
    * A valid `SpanContext` identifies the parent directly. An invalid
-    * `SpanContext` falls back to the currently active Span, if one exists;
-    * otherwise, the new Span is created as a root Span.
+  * `SpanContext` falls back to the currently active Span, if one exists;
+  * otherwise, the new Span is created as a root Span.
    *
    * When a `context::Context` is provided, a valid Span in that Context is used
    * as the parent. Otherwise, if the Context contains `is_root_span` set to
    * `true`, the new Span is created without a parent. If neither is present,
-    * the currently active Span is used as the parent, if one exists; otherwise,
-    * the new Span is created as a root Span.
+  * the currently active Span is used as the parent, if one exists; otherwise,
+  * the new Span is created as a root Span.
    *
    * Example:
    * ```cpp

--- a/api/include/opentelemetry/trace/span_startoptions.h
+++ b/api/include/opentelemetry/trace/span_startoptions.h
@@ -15,55 +15,44 @@ namespace trace
 {
 
 /**
- * StartSpanOptions provides options to set properties of a Span at the time of
- * its creation
+ * Provides options for creating a Span.
  */
 struct StartSpanOptions
 {
-  // Optionally sets the start time of a Span.
-  //
-  // If the start time of a Span is set, timestamps from both the system clock
-  // and steady clock must be provided.
-  //
-  // Timestamps from the steady clock can be used to most accurately measure a
-  // Span's duration, while timestamps from the system clock can be used to most
-  // accurately place a Span's
-  // time point relative to other Spans collected across a distributed system.
+  /**
+   * Optionally sets the system-clock start time of the Span.
+   *
+   * If a start time is set, both the system-clock and steady-clock timestamps
+   * must be provided. The system clock places the Span relative to Spans from
+   * other systems, while the steady clock measures its duration accurately.
+   */
   common::SystemTimestamp start_system_time;
+
+  /** The steady-clock start time corresponding to start_system_time. */
   common::SteadyTimestamp start_steady_time;
 
-  // Explicitly set the parent of a Span.
-  //
-  // The `parent` field is designed to establish  parent-child relationships
-  // in tracing spans. It can be set to either a `SpanContext` or a
-  // `context::Context` object.
-  //
-  // - When set to valid `SpanContext`, it directly assigns a specific Span as the parent
-  // of the newly created Span.
-  //
-  // - Alternatively, setting the `parent` field to a `context::Context` allows for
-  // more nuanced parent identification:
-  //   1. If the `Context` contains a Span object, this Span is treated as the parent.
-  //   2. If the `Context` contains the boolean flag `is_root_span` set to `true`,
-  //      it indicates that the new Span should be treated as a root Span, i.e., it
-  //      does not have a parent Span.
-  //   Example Usage:
-  //   ```cpp
-  //   trace_api::StartSpanOptions options;
-  //   opentelemetry::context::Context root;
-  //   root                    = root.SetValue(kIsRootSpanKey, true);
-  //   options.parent = root;
-  //   auto root_span = tracer->StartSpan("span root", options);
-  //  ```
-  //
-  // - If the `parent` field is not set, the newly created Span will inherit the
-  // parent of the currently active Span (if any) in the current context.
-  //
+  /**
+   * Explicitly sets the parent of the Span.
+   *
+   * A valid `SpanContext` identifies the parent directly. An invalid
+   * `SpanContext` falls back to the currently active Span.
+   *
+   * When a `context::Context` is provided, a valid Span in that Context is used
+   * as the parent. Otherwise, if the Context contains `is_root_span` set to
+   * `true`, the new Span is created without a parent. If neither is present,
+   * the currently active Span is used as the parent, if one exists.
+   *
+   * Example:
+   * ```cpp
+   * opentelemetry::trace::StartSpanOptions options;
+   * options.parent = opentelemetry::context::Context{
+   *     opentelemetry::trace::kIsRootSpanKey, true};
+   * auto root_span = tracer->StartSpan("span root", options);
+   * ```
+   */
   nostd::variant<SpanContext, context::Context> parent = context::Context{};
 
-  // TODO:
-  // SpanContext remote_parent;
-  // Links
+  /** The role of the Span in a trace. */
   SpanKind kind = SpanKind::kInternal;
 };
 


### PR DESCRIPTION
Fixes # (issue)

## Changes

The doc comment on StartSpanOptions::parent described the default case
backwards, and none of the member comments reached the generated API
docs because they used `//` while Doxygen runs with EXTRACT_ALL = NO.

For significant contributions please make sure you have completed the following items:

* [x] `CHANGELOG.md` updated for non-trivial changes
* [ ] Unit tests have been added
* [ ] Changes in public API reviewed