### PR TITLE
[EXPORTER] Fix Elasticsearch log exporter Export blocking forever on a non-responding client

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,15 @@ Increment the:
 
 ## [Unreleased]
 
+* [EXPORTER] Fix the Elasticsearch log exporter's synchronous export path
+  waiting with no deadline of its own, trusting an injected `HttpClient` to
+  always eventually deliver a terminal event. A client that accepts a
+  request and never calls back (a dead thread, a reused socket, a swallowed
+  error) left `Export()` blocked for the life of the process. The wait now
+  has its own deadline derived from the configured response timeout, so a
+  non-responding client fails the export instead of hanging it.
+  [#4362](https://github.com/open-telemetry/opentelemetry-cpp/issues/4362)
+
 * [DOC] Fix and clarify the `StartSpanOptions` documentation
   [#4526](https://github.com/open-telemetry/opentelemetry-cpp/pull/4526)
 

--- a/exporters/elasticsearch/src/es_log_record_exporter.cc
+++ b/exporters/elasticsearch/src/es_log_record_exporter.cc
@@ -110,15 +110,22 @@ public:
 
   /**
    * A method the user calls to block their thread until the request has either produced a
-   * response or failed. The longest duration is the timeout of the request, set by
-   * SetTimeoutMs(), which arrives here as a TimedOut session event.
+   * response or failed, or until the given deadline passes. Ordinarily the request's own
+   * timeout (set by SetTimeoutMs()) arrives here first, as a TimedOut session event. But that
+   * guarantee belongs to the injected HttpClient, not to this exporter: a client that accepts
+   * a handler and never delivers a terminal event (a dead thread, a reused socket, a swallowed
+   * error) would otherwise leave this wait blocked for the life of the process. The deadline is
+   * this exporter's own backstop, independent of whether the client honors its side of the
+   * contract.
    */
-  bool waitForResponse()
+  bool waitForResponse(std::chrono::steady_clock::time_point deadline)
   {
     std::unique_lock<std::mutex> lk(mutex_);
     // Waiting on a predicate rather than bare: the completion may already have been recorded
     // before this thread got here, in which case there is no notification left to receive.
-    cv_.wait(lk, [this] { return completion_ != CompletionState::Pending; });
+    // A deadline that passes without a terminal event leaves completion_ at Pending, which
+    // reads as failure below, the same outcome a terminal error event would have produced.
+    cv_.wait_until(lk, deadline, [this] { return completion_ != CompletionState::Pending; });
     return completion_ == CompletionState::Success;
   }
 
@@ -470,6 +477,10 @@ sdk::common::ExportResult ElasticsearchLogRecordExporter::Export(
 #else
   // Send the request
   auto handler = std::make_shared<ResponseHandler>(options_.console_debug_);
+  // Captured before SendRequest() so the deadline reflects this exporter's own timeout budget,
+  // not whatever the injected HttpClient decides to do with it (see waitForResponse()).
+  auto deadline =
+      std::chrono::steady_clock::now() + std::chrono::seconds(options_.response_timeout_);
   session->SendRequest(handler);
 
   // Wait for the response to be received
@@ -478,7 +489,7 @@ sdk::common::ExportResult ElasticsearchLogRecordExporter::Export(
     OTEL_INTERNAL_LOG_DEBUG("[ES Log Exporter] waiting for response from Elasticsearch (timeout = "
                             << options_.response_timeout_ << " seconds)");
   }
-  bool write_successful = handler->waitForResponse();
+  bool write_successful = handler->waitForResponse(deadline);
 
   // End the session
   session->FinishSession();

--- a/exporters/elasticsearch/test/es_log_record_exporter_test.cc
+++ b/exporters/elasticsearch/test/es_log_record_exporter_test.cc
@@ -120,6 +120,45 @@ public:
   void SetMaxSessionsPerConnection(std::size_t) noexcept override {}
 };
 
+// A session that accepts a handler and never calls back into it, at all: no OnResponse, no
+// OnEvent. Nothing in the HttpClient interface promises a terminal event, so a client built
+// this way (a dead thread, a reused socket, a swallowed error) is a legal implementation, not
+// a broken one. The exporter's own wait has to have a backstop independent of this.
+//
+// Only meaningful against the synchronous Export() path: under ENABLE_ASYNC_EXPORT, Export()
+// hands the request to the client and returns success without waiting on anything, by design,
+// so a silent client changes nothing observable there.
+#ifndef ENABLE_ASYNC_EXPORT
+class SilentSession final : public http_client::Session
+{
+public:
+  std::shared_ptr<http_client::Request> CreateRequest() noexcept override
+  {
+    return std::make_shared<FakeRequest>();
+  }
+
+  void SendRequest(std::shared_ptr<http_client::EventHandler>) noexcept override {}
+
+  bool IsSessionActive() noexcept override { return true; }
+  bool CancelSession() noexcept override { return true; }
+  bool FinishSession() noexcept override { return true; }
+};
+
+class SilentHttpClient final : public http_client::HttpClient
+{
+public:
+  std::shared_ptr<http_client::Session> CreateSession(
+      opentelemetry::nostd::string_view) noexcept override
+  {
+    return std::make_shared<SilentSession>();
+  }
+
+  bool CancelAllSessions() noexcept override { return true; }
+  bool FinishAllSessions() noexcept override { return true; }
+  void SetMaxSessionsPerConnection(std::size_t) noexcept override {}
+};
+#endif  // !ENABLE_ASYNC_EXPORT
+
 }  // namespace
 
 namespace sdklogs       = opentelemetry::sdk::logs;
@@ -156,6 +195,32 @@ TEST(ElasticsearchLogsExporterTests, CustomClientConstructionSucceeds)
       new logs_exporter::ElasticsearchLogRecordExporter(opts));
   ASSERT_NE(exporter, nullptr);
 }
+
+// Regression test: the synchronous export path used to wait on its response condition variable
+// with no deadline of its own, trusting the injected HttpClient to eventually deliver a terminal
+// event. SilentHttpClient never does, by design, so before the fix this test would hang forever.
+// The 1-second response_timeout_ keeps the test itself fast while still exercising the real
+// deadline path end to end, rather than a mocked-out clock.
+//
+// Synchronous-path-only: under ENABLE_ASYNC_EXPORT, Export() never waits at all (it hands the
+// request off and returns success unconditionally), so there is nothing here to regress against.
+#ifndef ENABLE_ASYNC_EXPORT
+TEST(ElasticsearchLogsExporterTests, ExportReturnsOnTimeoutWhenClientNeverResponds)
+{
+  logs_exporter::ElasticsearchExporterOptions options("localhost", 9200, "logs",
+                                                      /*response_timeout=*/1);
+  auto http_client = std::make_shared<SilentHttpClient>();
+  auto exporter    = std::unique_ptr<sdklogs::LogRecordExporter>(
+      new logs_exporter::ElasticsearchLogRecordExporter(options, http_client));
+
+  auto record = exporter->MakeRecordable();
+  record->SetBody("this export should time out, not hang");
+
+  auto result = exporter->Export(nostd::span<std::unique_ptr<sdklogs::Recordable>>(&record, 1));
+
+  EXPECT_EQ(result, opentelemetry::sdk::common::ExportResult::kFailure);
+}
+#endif  // !ENABLE_ASYNC_EXPORT
 
 // Attempt to write a log to an invalid host/port, test that the Export() returns failure
 TEST(DISABLED_ElasticsearchLogsExporterTests, InvalidEndpoint)


### PR DESCRIPTION
Fixes #4362.

The synchronous export path waited on its response condition variable with no deadline of its own, trusting the injected `HttpClient` to always eventually deliver a terminal event via `OnResponse` or `OnEvent`. Nothing in the `HttpClient` interface actually guarantees that: a client is a supported public surface, not a test seam, and one that accepts a request and never calls back (a dead thread, a reused socket, a swallowed error) left `Export()` blocked for the life of the process, with no way for a caller's `Shutdown()` to release it either.

## Changes

- `waitForResponse()` now takes an absolute `std::chrono::steady_clock::time_point` deadline instead of waiting unconditionally, via `cv_.wait_until()` in place of `cv_.wait()`.
- The deadline is derived from the exporter's own configured `response_timeout_` and captured before `SendRequest()` is called, so it reflects this exporter's own timeout budget rather than whatever the client does with it.
- A deadline that passes without a terminal event leaves the completion state at `Pending`, which reads as failure, the same outcome a terminal error event already produces today. No successful path changes.

## Testing

Added `SilentHttpClient`/`SilentSession` test doubles whose `SendRequest()` never calls back into the handler at all (no `OnResponse`, no `OnEvent`), the exact scenario the issue describes. `ExportReturnsOnTimeoutWhenClientNeverResponds` constructs the exporter with a 1 second `response_timeout_` and this client, and asserts `Export()` returns `kFailure` rather than hanging.

Verified the test actually catches the regression: reverted the fix locally (kept the test) and reran under a `timeout` wrapper, the test hung and was killed at exit code 124 instead of passing vacuously. Restored the fix and confirmed all four tests in the file pass, total runtime 1 second (the deadline in the new test), not 30 (the default `response_timeout_`).