### PR TITLE
[TEST] Make OTLP gRPC functional teardown deterministic

### DIFF
--- a/functional/otlp/func_grpc_main.cc
+++ b/functional/otlp/func_grpc_main.cc
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include <chrono>
+#include <grpc/grpc.h>
 #include <cstdint>
 #include <cstdio>
 #include <cstring>
@@ -434,7 +435,16 @@ int main(int argc, char *argv[])
   internal_log::GlobalLogHandler::SetLogHandler(log_handler);
   internal_log::GlobalLogHandler::SetLogLevel(internal_log::LogLevel::Debug);
 
+  // Keep one explicit gRPC runtime reference for the lifetime of the functional test.
+  // Channel construction owns additional references internally, but their final release may
+  // start asynchronous global teardown just as this short-lived process is returning. The TLS
+  // failure cases exercise gRPC background work heavily enough that this has intermittently
+  // raced process exit in CI. Holding our own reference lets us destroy every OpenTelemetry/gRPC
+  // object first, then wait for the final gRPC teardown to complete before leaving main().
+  grpc_init();
   rc = run_test_case(opt_test_name);
+  grpc_shutdown_blocking();
+
   return rc;
 }
 

--- a/functional/otlp/func_grpc_main.cc
+++ b/functional/otlp/func_grpc_main.cc
@@ -1,8 +1,8 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-#include <chrono>
 #include <grpc/grpc.h>
+#include <chrono>
 #include <cstdint>
 #include <cstdio>
 #include <cstring>


### PR DESCRIPTION
Contributes to #4489.

## Problem

`func_otlp_grpc` intermittently exits with SIGSEGV / heap-corruption signatures during TLS failure cases after the normal ctest suite has already passed. The failure still reproduces with gRPC 1.83.1, so the earlier OpenSSL `NO_ATEXIT` explanation is not sufficient on its own.

## Hypothesis

The functional binary is short-lived. C++ channel wrappers release their own gRPC runtime references as the OpenTelemetry exporter/provider is destroyed, and the last release can initiate asynchronous gRPC global teardown immediately before `main()` returns. TLS failure cases leave enough EventEngine/background teardown work to expose that race intermittently.

## Change

- hold one explicit `grpc_init()` reference for the functional-test invocation;
- after the test has destroyed its OpenTelemetry/gRPC objects, release that final reference with `grpc_shutdown_blocking()`;
- keep the change scoped to the functional test binary; no exporter/runtime production behavior changes.

This is intentionally a draft while CI and maintainer review validate whether the teardown barrier removes the intermittent failure. If the hypothesis is wrong, I will not promote this as a fix.

## Validation target

The important signal is repeated maintainer-mode CMake coverage of the TLS functional cases, especially the paths that have previously failed with exit 134/139.
