### PR TITLE
[BUG] Rewind the curl request body with a seek callback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,11 @@ Increment the:
 
 ## [Unreleased]
 
+* [BUG] Install a curl seek callback so an OTLP/HTTP export body can be rewound
+  when libcurl restarts an upload, instead of failing with
+  `CURLE_SEND_FAIL_REWIND` and dropping the batch
+  ([#4549](https://github.com/open-telemetry/opentelemetry-cpp/issues/4549))
+
 * [DOC] Fix and clarify the `StartSpanOptions` documentation
   [#4526](https://github.com/open-telemetry/opentelemetry-cpp/pull/4526)
 

--- a/ext/include/opentelemetry/ext/http/client/curl/http_operation_curl.h
+++ b/ext/include/opentelemetry/ext/http/client/curl/http_operation_curl.h
@@ -385,6 +385,7 @@ private:
     std::future<CURLcode> result_future;
   };
   friend class HttpOperationAccessor;
+  friend class HttpOperationTestPeer;
   std::unique_ptr<AsyncData> async_data_;
 };
 }  // namespace curl

--- a/ext/include/opentelemetry/ext/http/client/curl/http_operation_curl.h
+++ b/ext/include/opentelemetry/ext/http/client/curl/http_operation_curl.h
@@ -115,6 +115,20 @@ private:
 
   static size_t ReadMemoryCallback(char *buffer, size_t size, size_t nitems, void *userp);
 
+  /**
+   * Reposition the request body for libcurl.
+   *
+   * libcurl calls this when it has to restart an upload it already began, for example after a
+   * connection it had reused was closed before the response arrived. Without it libcurl has no way
+   * to rewind the body and fails the transfer with CURLE_SEND_FAIL_REWIND.
+   *
+   * @param userp The HttpOperation, set through CURLOPT_SEEKDATA
+   * @param offset Byte offset to seek to, interpreted relative to origin
+   * @param origin One of SEEK_SET, SEEK_CUR or SEEK_END
+   * @return CURL_SEEKFUNC_OK on success, CURL_SEEKFUNC_CANTSEEK to tell libcurl to find another way
+   */
+  static int SeekCallback(void *userp, curl_off_t offset, int origin);
+
   static int CurlLoggerCallback(const CURL * /* handle */,
                                 curl_infotype type,
                                 const char *data,

--- a/ext/src/http/client/curl/http_operation_curl.cc
+++ b/ext/src/http/client/curl/http_operation_curl.cc
@@ -13,6 +13,7 @@
 #include <chrono>
 #include <cmath>
 #include <cstdint>
+#include <cstdio>
 #include <cstring>
 #include <functional>
 #include <future>
@@ -332,6 +333,27 @@ size_t HttpOperation::ReadMemoryCallback(char *buffer, size_t size, size_t nitem
   std::memcpy(buffer, &self->request_body_[self->request_nwrite_], nwrite);
   self->request_nwrite_ += nwrite;
   return nwrite;
+}
+
+int HttpOperation::SeekCallback(void *userp, curl_off_t offset, int origin)
+{
+  HttpOperation *self = reinterpret_cast<HttpOperation *>(userp);
+  if (nullptr == self)
+  {
+    return CURL_SEEKFUNC_CANTSEEK;
+  }
+
+  // The body is a fully buffered span owned by the caller, so an absolute seek inside it is just a
+  // move of the read cursor. Anything else is refused rather than approximated, because reporting
+  // success without repositioning would resume the upload from the wrong offset and send a
+  // truncated or misaligned body.
+  if (origin != SEEK_SET || offset < 0 || static_cast<size_t>(offset) > self->request_body_.size())
+  {
+    return CURL_SEEKFUNC_CANTSEEK;
+  }
+
+  self->request_nwrite_ = static_cast<size_t>(offset);
+  return CURL_SEEKFUNC_OK;
 }
 
 #if LIBCURL_VERSION_NUM >= 0x075000
@@ -1332,6 +1354,19 @@ CURLcode HttpOperation::Setup()
     }
 
     rc = SetCurlPtrOption(CURLOPT_READDATA, this);
+    if (rc != CURLE_OK)
+    {
+      return rc;
+    }
+
+    rc = SetCurlPtrOption(CURLOPT_SEEKFUNCTION,
+                          reinterpret_cast<void *>(&HttpOperation::SeekCallback));
+    if (rc != CURLE_OK)
+    {
+      return rc;
+    }
+
+    rc = SetCurlPtrOption(CURLOPT_SEEKDATA, this);
     if (rc != CURLE_OK)
     {
       return rc;

--- a/ext/test/http/curl_http_test.cc
+++ b/ext/test/http/curl_http_test.cc
@@ -58,6 +58,27 @@ class HttpClientTestPeer
 public:
   static void ResetMultiHandle(HttpClient &client) { client.resetMultiHandle(); }
 };
+
+class HttpOperationTestPeer
+{
+public:
+  static int Seek(HttpOperation &operation, curl_off_t offset, int origin)
+  {
+    return HttpOperation::SeekCallback(&operation, offset, origin);
+  }
+
+  static int SeekNullUserData(curl_off_t offset, int origin)
+  {
+    return HttpOperation::SeekCallback(nullptr, offset, origin);
+  }
+
+  static size_t ReadCursor(const HttpOperation &operation) { return operation.request_nwrite_; }
+
+  static void SetReadCursor(HttpOperation &operation, size_t value)
+  {
+    operation.request_nwrite_ = value;
+  }
+};
 }  // namespace curl
 }  // namespace client
 }  // namespace http
@@ -449,6 +470,48 @@ TEST_F(BasicCurlHttpTests, SendPostRequestWithMultiChunkBody)
 
   session_manager->CancelAllSessions();
   session_manager->FinishAllSessions();
+}
+
+// libcurl calls the seek callback when it has to restart an upload it already began. The body is a
+// fully buffered span, so an absolute seek inside it repositions the read cursor, and anything the
+// callback cannot honour is refused so libcurl fails rather than resuming from the wrong offset.
+TEST_F(BasicCurlHttpTests, SeekCallbackRepositionsTheRequestBody)
+{
+  CustomEventHandler handler;
+  http_client::HttpSslOptions no_ssl;
+  http_client::Headers headers;
+  const char *payload    = "0123456789";
+  http_client::Body body = {payload, payload + std::strlen(payload)};
+
+  curl::HttpOperation operation(http_client::Method::Post, "http://127.0.0.1:19000/post/", no_ssl,
+                                &handler, headers, body, http_client::Compression::kNone, false,
+                                curl::kDefaultHttpConnTimeout);
+
+  using Peer = curl::HttpOperationTestPeer;
+
+  // An absolute seek inside the body moves the cursor.
+  Peer::SetReadCursor(operation, 10);
+  EXPECT_EQ(CURL_SEEKFUNC_OK, Peer::Seek(operation, 4, SEEK_SET));
+  EXPECT_EQ(4u, Peer::ReadCursor(operation));
+
+  // Rewinding to the start is the case libcurl actually asks for.
+  EXPECT_EQ(CURL_SEEKFUNC_OK, Peer::Seek(operation, 0, SEEK_SET));
+  EXPECT_EQ(0u, Peer::ReadCursor(operation));
+
+  // Seeking to exactly the end is in range and leaves nothing left to send.
+  EXPECT_EQ(CURL_SEEKFUNC_OK, Peer::Seek(operation, 10, SEEK_SET));
+  EXPECT_EQ(10u, Peer::ReadCursor(operation));
+
+  // Everything below is refused, and must leave the cursor where it was.
+  Peer::SetReadCursor(operation, 3);
+
+  EXPECT_EQ(CURL_SEEKFUNC_CANTSEEK, Peer::Seek(operation, 11, SEEK_SET));
+  EXPECT_EQ(CURL_SEEKFUNC_CANTSEEK, Peer::Seek(operation, -1, SEEK_SET));
+  EXPECT_EQ(CURL_SEEKFUNC_CANTSEEK, Peer::Seek(operation, 0, SEEK_CUR));
+  EXPECT_EQ(CURL_SEEKFUNC_CANTSEEK, Peer::Seek(operation, 0, SEEK_END));
+  EXPECT_EQ(3u, Peer::ReadCursor(operation));
+
+  EXPECT_EQ(CURL_SEEKFUNC_CANTSEEK, Peer::SeekNullUserData(0, SEEK_SET));
 }
 
 TEST_F(BasicCurlHttpTests, RequestTimeout)

--- a/ext/test/http/curl_http_test.cc
+++ b/ext/test/http/curl_http_test.cc
@@ -428,10 +428,9 @@ TEST_F(BasicCurlHttpTests, SendPostRequest)
   session_manager->FinishAllSessions();
 }
 
-// The request body is uploaded through CURLOPT_READFUNCTION, and CURLOPT_SEEKFUNCTION is
-// registered alongside it so libcurl can rewind the body when it restarts an upload. Send a body
-// large enough to span several read callbacks and check it arrives whole, so a mistake in either
-// option shows up as a corrupted or short upload rather than silently.
+// Send a body large enough to span several read callbacks and check it arrives whole, so a mistake
+// in either CURLOPT_READFUNCTION or the seek callback registered beside it shows up as a corrupted
+// or short upload.
 TEST_F(BasicCurlHttpTests, SendPostRequestWithMultiChunkBody)
 {
   received_requests_.clear();
@@ -473,9 +472,7 @@ TEST_F(BasicCurlHttpTests, SendPostRequestWithMultiChunkBody)
   session_manager->FinishAllSessions();
 }
 
-// libcurl calls the seek callback when it has to restart an upload it already began. The body is a
-// fully buffered span, so an absolute seek inside it repositions the read cursor, and anything the
-// callback cannot honour is refused so libcurl fails rather than resuming from the wrong offset.
+// Cover both halves of the callback contract, the seeks it honours and the ones it refuses.
 TEST_F(BasicCurlHttpTests, SeekCallbackRepositionsTheRequestBody)
 {
   CustomEventHandler handler;
@@ -490,7 +487,6 @@ TEST_F(BasicCurlHttpTests, SeekCallbackRepositionsTheRequestBody)
 
   using Peer = curl::HttpOperationTestPeer;
 
-  // An absolute seek inside the body moves the cursor.
   Peer::SetReadCursor(operation, 10);
   EXPECT_EQ(CURL_SEEKFUNC_OK, Peer::Seek(operation, 4, SEEK_SET));
   EXPECT_EQ(4u, Peer::ReadCursor(operation));

--- a/ext/test/http/curl_http_test.cc
+++ b/ext/test/http/curl_http_test.cc
@@ -13,6 +13,7 @@
 #  include <numeric>
 #endif  // ENABLE_OTLP_COMPRESSION_PREVIEW
 
+#include <algorithm>
 #include <atomic>
 #include <chrono>
 #include <condition_variable>
@@ -400,6 +401,51 @@ TEST_F(BasicCurlHttpTests, SendPostRequest)
   session->FinishSession();
   ASSERT_TRUE(handler->is_called_.load(std::memory_order_acquire));
   ASSERT_TRUE(handler->got_response_.load(std::memory_order_acquire));
+
+  session_manager->CancelAllSessions();
+  session_manager->FinishAllSessions();
+}
+
+// The request body is uploaded through CURLOPT_READFUNCTION, and CURLOPT_SEEKFUNCTION is
+// registered alongside it so libcurl can rewind the body when it restarts an upload. Send a body
+// large enough to span several read callbacks and check it arrives whole, so a mistake in either
+// option shows up as a corrupted or short upload rather than silently.
+TEST_F(BasicCurlHttpTests, SendPostRequestWithMultiChunkBody)
+{
+  received_requests_.clear();
+  auto session_manager = std::make_shared<http_client::curl::HttpCurlClientFactory>()->Create();
+  EXPECT_TRUE(session_manager != nullptr);
+
+  auto session = session_manager->CreateSession("http://127.0.0.1:19000");
+  auto request = session->CreateRequest();
+  request->SetUri("post/");
+  request->SetMethod(http_client::Method::Post);
+
+  // Not a round number, so an off-by-one in the read cursor cannot land on a chunk boundary.
+  constexpr size_t kBodySize = 257u * 1024u + 7u;
+  http_client::Body body(kBodySize);
+  for (size_t i = 0; i < kBodySize; ++i)
+  {
+    body[i] = static_cast<http_client::Byte>('a' + (i % 26));
+  }
+  const http_client::Body expected = body;
+
+  request->SetBody(body);
+  request->AddHeader("Content-Type", "application/octet-stream");
+  auto handler = std::make_shared<PostEventHandler>();
+  session->SendRequest(handler);
+  ASSERT_TRUE(waitForRequests(30, 1));
+  session->FinishSession();
+  ASSERT_TRUE(handler->is_called_.load(std::memory_order_acquire));
+  ASSERT_TRUE(handler->got_response_.load(std::memory_order_acquire));
+
+  {
+    std::unique_lock<std::mutex> lk(mtx_requests);
+    ASSERT_EQ(received_requests_.size(), 1u);
+    const auto &received = received_requests_[0].content;
+    ASSERT_EQ(received.size(), expected.size());
+    EXPECT_TRUE(std::equal(expected.begin(), expected.end(), received.begin()));
+  }
 
   session_manager->CancelAllSessions();
   session_manager->FinishAllSessions();

--- a/ext/test/http/curl_http_test.cc
+++ b/ext/test/http/curl_http_test.cc
@@ -1,11 +1,11 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
+#include <curl/curl.h>
 #include <curl/curlver.h>
 #include "gtest/gtest.h"
 
 #ifdef ENABLE_OTLP_RETRY_PREVIEW
-#  include <curl/curl.h>
 #  include "gmock/gmock.h"
 #endif  // ENABLE_OTLP_RETRY_PREVIEW
 
@@ -17,6 +17,7 @@
 #include <atomic>
 #include <chrono>
 #include <condition_variable>
+#include <cstdio>
 #include <cstring>
 #include <map>
 #include <memory>


### PR DESCRIPTION
Fixes #4549

## Changes

The curl client sets `CURLOPT_READFUNCTION` but never `CURLOPT_SEEKFUNCTION`. When libcurl restarts an upload it has already begun, it asks the application to rewind the body, and with no seek callback it cannot, so the transfer ends in `CURLE_SEND_FAIL_REWIND` (65). `IsRetryable()` requires `last_curl_result_ == CURLE_OK` (`http_operation_curl.cc:602`), so the operation falls through to `Cleanup()` at `:1631-1635` and the export batch is gone.

This registers a seek callback next to `CURLOPT_READDATA` in the POST branch, which is the only branch that installs a read callback.

`request_body_` is a `const Body &` (`http_operation_curl.h:338`) and `ReadMemoryCallback` copies out of it while advancing `request_nwrite_` (`:321-334`), so the body is fully buffered and an absolute seek is a move of the read cursor. Other origins, a negative offset, or an offset past the end return `CURL_SEEKFUNC_CANTSEEK` rather than being approximated, so libcurl fails cleanly instead of resuming from the wrong place and sending a truncated body.

This is the first of the two fixes the issue describes. The `IsRetryable()` gate is deliberately not touched here, because widening the set of `CURLcode`s that may be replayed on a non-idempotent POST is a policy decision that deserves its own thread.

## Testing

`SendPostRequestWithMultiChunkBody` sends a 263,175 byte body, not a round number so an off-by-one in the read cursor cannot land on a chunk boundary, and asserts the server received it byte for byte. It guards the read and seek registration: with a one byte corruption injected into `ReadMemoryCallback` the test fails, without it the suite is 27 of 27 green.

It does not exercise the rewind path itself, and I would rather say so than imply otherwise. Reaching that path needs a peer that accepts one request on a connection and then half closes the reused connection on the next, which the in-tree test server cannot do, and `CURLOPT_FOLLOWLOCATION` is never set so a redirect cannot be used to force a rewind either.

@meastp built a deterministic reproducer for exactly this and measured error 65 at 3 of 8 requests with connection reuse and 0 of 8 without, against an unmodified library. He has offered to run it against this branch and to contribute it as a functional test. That seems the better home for it than this PR.

* [x] `CHANGELOG.md` updated for non-trivial changes
* [x] Unit tests have been added
* [ ] Changes in public API reviewed (no public API change, the callback is a private static and the new options are internal to `Setup()`)
