### PR TITLE
[CMAKE] Fix missing version properties on configuration_core

### DIFF
--- a/sdk/src/configuration/CMakeLists.txt
+++ b/sdk/src/configuration/CMakeLists.txt
@@ -18,6 +18,8 @@ add_library(
 set_target_properties(opentelemetry_configuration_core
                       PROPERTIES EXPORT_NAME configuration_core)
 
+set_target_version(opentelemetry_configuration_core)
+
 target_include_directories(
   opentelemetry_configuration_core
   PUBLIC "$<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/sdk/include>"


### PR DESCRIPTION
Fixes # (issue)

## Changes

- Call `set_target_version` on configuration_core

For significant contributions please make sure you have completed the following items:

* [ ] `CHANGELOG.md` updated for non-trivial changes
* [ ] Unit tests have been added
* [ ] Changes in public API reviewed